### PR TITLE
Delta per ntp v1

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -321,10 +321,10 @@ ss::future<std::error_code> controller_backend::create_partition(
     if (likely(_partition_manager.local().get(ntp).get() == nullptr)) {
         // we use offset as an ntp_id as it is always increasing and it
         // increases while ntp is being created again
-        auto ntp_id = storage::ntp_config::ntp_id(offset());
+        auto rev = model::revision_id(offset());
         f = _partition_manager.local()
               .manage(
-                cfg->make_ntp_config(_data_directory, ntp.tp.partition, ntp_id),
+                cfg->make_ntp_config(_data_directory, ntp.tp.partition, rev),
                 group_id,
                 std::move(members))
               .discard_result();

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -59,24 +59,27 @@ ss::future<> controller_backend::start() {
     return ss::now();
 }
 
+ss::future<> controller_backend::fetch_deltas() {
+    return _topics.local()
+      .wait_for_changes(_as.local())
+      .then([this](deltas_t deltas) {
+          return ss::with_semaphore(
+            _topics_sem, 1, [this, deltas = std::move(deltas)]() mutable {
+                for (auto& d : deltas) {
+                    auto ntp = d.ntp;
+                    _topic_deltas[ntp].push_back(std::move(d));
+                }
+            });
+      });
+}
+
 void controller_backend::start_topics_reconciliation_loop() {
     (void)ss::with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _as.local().abort_requested(); },
           [this] {
-              return _topics.local()
-                .wait_for_changes(_as.local())
-                .then([this](std::vector<topic_table::delta> deltas) {
-                    return ss::with_semaphore(
-                      _topics_sem,
-                      1,
-                      [this, deltas = std::move(deltas)]() mutable {
-                          for (auto& d : deltas) {
-                              _topic_deltas.emplace_back(std::move(d));
-                          }
-                          return reconcile_topics();
-                      });
-                })
+              return fetch_deltas()
+                .then([this] { return reconcile_topics(); })
                 .handle_exception([](const std::exception_ptr& e) {
                     vlog(
                       clusterlog.error,
@@ -89,30 +92,61 @@ void controller_backend::start_topics_reconciliation_loop() {
 
 void controller_backend::housekeeping() {
     if (!_topic_deltas.empty() && _topics_sem.available_units() > 0) {
-        (void)ss::with_gate(_gate, [this] {
-            return ss::with_semaphore(
-              _topics_sem, 1, [this] { return reconcile_topics(); });
-        });
+        (void)ss::with_gate(_gate, [this] { return reconcile_topics(); });
     }
+}
+
+ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
+    return ss::do_with(
+      bool{false},
+      deltas.cbegin(),
+      [this, &deltas](bool& stop, deltas_t::const_iterator& it) {
+          return ss::do_until(
+                   [&stop, &it, &deltas] {
+                       return stop || it == deltas.cend();
+                   },
+                   [this, &it, &stop] {
+                       return execute_partitition_op(*it).then(
+                         [&it, &stop](std::error_code ec) {
+                             if (ec) {
+                                 stop = true;
+                                 return;
+                             }
+                             it++;
+                         });
+                   })
+            .then([&deltas, &it] {
+                // remove finished tasks
+                deltas.erase(deltas.cbegin(), it);
+            });
+      });
 }
 
 // caller must hold _topics_sem lock
 ss::future<> controller_backend::reconcile_topics() {
-    using meta_t = task_meta<topic_table::delta>;
-    // _topic_deltas are chronologically ordered, we cannot reorder applying
-    // them, hence we have to use `ss::do_for_each`
-    return ss::do_for_each(
-             std::begin(_topic_deltas),
-             std::end(_topic_deltas),
-             [this](meta_t& task) { return do_reconcile_topic(task); })
-      .then([this] {
-          // remove finished tasks
-          auto it = std::stable_partition(
-            std::begin(_topic_deltas),
-            std::end(_topic_deltas),
-            [](meta_t& task) { return task.finished; });
-          _topic_deltas.erase(_topic_deltas.begin(), it);
-      });
+    return ss::with_semaphore(_topics_sem, 1, [this] {
+        if (_topic_deltas.empty()) {
+            return ss::now();
+        }
+        // reconcile NTPs in parallel
+        return ss::parallel_for_each(
+                 _topic_deltas.begin(),
+                 _topic_deltas.end(),
+                 [this](underlying_t::value_type& ntp_deltas) {
+                     return reconcile_ntp(ntp_deltas.second);
+                 })
+          .then([this] {
+              // cleanup empty NTP keys
+              for (auto it = _topic_deltas.cbegin();
+                   it != _topic_deltas.cend();) {
+                  if (it->second.empty()) {
+                      _topic_deltas.erase(it++);
+                  } else {
+                      ++it;
+                  }
+              }
+          });
+    });
 }
 
 bool has_local_replicas(
@@ -146,78 +180,45 @@ std::vector<model::broker> create_brokers_set(
     return brokers;
 }
 
-controller_backend::results_t join_results(
-  controller_backend::results_t prev_results,
-  controller_backend::results_t new_results) {
-    std::move(
-      new_results.begin(), new_results.end(), std::back_inserter(prev_results));
-    return prev_results;
-}
-
-ss::future<>
-controller_backend::do_reconcile_topic(task_meta<topic_table::delta>& task) {
+ss::future<std::error_code>
+controller_backend::execute_partitition_op(const topic_table::delta& delta) {
+    /**
+     * Revision is derived from delta offset, i.e. offset of a command that
+     * the delta is derived from. The offset is always monotonically
+     * increasing together with cluster state evelotion hence it is perfect
+     * as a source of revision_id
+     */
+    vlog(clusterlog.trace, "Executing operation: {}", delta);
+    model::revision_id rev(delta.offset());
     // new partitions
-    auto f = ssx::parallel_transform(
-      task.delta.partitions.additions,
-      [this, o = task.delta.offset](topic_table::delta::partition p) {
-          // only create partitions for this backend
-          // partitions created on current shard at this node
-          if (!has_local_replicas(_self, p.second.replicas)) {
-              return ss::make_ready_future<std::error_code>(errc::success);
-          }
-          return create_partition(
-            model::ntp(p.first.ns, p.first.tp, p.second.id),
-            p.second.group,
-            o,
-            create_brokers_set(p.second.replicas, _members_table.local()));
-      });
 
-    // delete partitions
-    f = f.then([this, &task](results_t results) {
-        return ssx::parallel_transform(
-                 task.delta.partitions.deletions,
-                 [this](const topic_table::delta::partition& p) {
-                     return delete_partition(
-                       model::ntp(p.first.ns, p.first.tp, p.second.id));
-                 })
-          .then([results = std::move(results)](results_t new_results) mutable {
-              return join_results(std::move(results), std::move(new_results));
-          });
-    });
-
-    // partition updates
-    f = f.then([this, &task](results_t results) {
-        return ssx::parallel_transform(
-                 task.delta.partitions.updates,
-                 [this, o = task.delta.offset](
-                   const topic_table::delta::partition& p) {
-                     return process_partition_update(p, o);
-                 })
-          .then([results = std::move(results)](results_t new_res) mutable {
-              return join_results(std::move(results), std::move(new_res));
-          });
-    });
-
-    return f.then([&task](results_t all_results) {
-        auto success = std::all_of(
-          std::cbegin(all_results),
-          std::cend(all_results),
-          [](std::error_code ec) { return !ec; });
-        // only mark task as finished if all operations are successfull
-        if (success) {
-            task.finished = true;
+    // only create partitions for this backend
+    // partitions created on current shard at this node
+    auto f = ss::make_ready_future<std::error_code>(errc::success);
+    switch (delta.type) {
+    case topic_table::delta::op_type::add:
+        if (!has_local_replicas(_self, delta.p_as.replicas)) {
+            return ss::make_ready_future<std::error_code>(errc::success);
         }
-    });
+        return create_partition(
+          delta.ntp,
+          delta.p_as.group,
+          rev,
+          create_brokers_set(delta.p_as.replicas, _members_table.local()));
+    case topic_table::delta::op_type::del:
+        return delete_partition(delta.ntp, rev);
+    case topic_table::delta::op_type::update:
+        return process_partition_update(delta.ntp, delta.p_as, rev);
+    }
 }
 
 ss::future<std::error_code> controller_backend::process_partition_update(
-  const topic_table::delta::partition& p, model::offset offset) {
-    model::ntp ntp(p.first.ns, p.first.tp, p.second.id);
+  model::ntp ntp, const partition_assignment& p_as, model::revision_id rev) {
     // if there is no local replica in replica set but,
     // partition with requested ntp exists on this broker core
     // it has to be removed after new configuration is stable
     auto partition = _partition_manager.local().get(ntp);
-    if (!has_local_replicas(_self, p.second.replicas)) {
+    if (!has_local_replicas(_self, p_as.replicas)) {
         // we do not have local replicas and partition does not
         // exists, it is ok
         if (!partition) {
@@ -225,10 +226,10 @@ ss::future<std::error_code> controller_backend::process_partition_update(
         }
         // this partition has to be removed eventually
 
-        return update_partition_replica_set(ntp, p.second.replicas)
-          .then([this, ntp](std::error_code ec) {
+        return update_partition_replica_set(ntp, p_as.replicas)
+          .then([this, ntp, rev](std::error_code ec) {
               if (!ec) {
-                  return delete_partition(ntp);
+                  return delete_partition(ntp, rev);
               }
               return ss::make_ready_future<std::error_code>(ec);
           });
@@ -236,11 +237,11 @@ ss::future<std::error_code> controller_backend::process_partition_update(
 
     // partition already exists, update configuration
     if (partition) {
-        return update_partition_replica_set(ntp, p.second.replicas);
+        return update_partition_replica_set(ntp, p_as.replicas);
     }
     // create partition with empty configuration. Configuration
     // will be populated during node recovery
-    return create_partition(ntp, p.second.group, offset, {});
+    return create_partition(ntp, p_as.group, rev, {});
 }
 
 bool is_configuration_up_to_date(
@@ -307,7 +308,7 @@ ss::future<> controller_backend::add_to_shard_table(
 ss::future<std::error_code> controller_backend::create_partition(
   model::ntp ntp,
   raft::group_id group_id,
-  model::offset offset,
+  model::revision_id rev,
   std::vector<model::broker> members) {
     auto cfg = _topics.local().get_topic_cfg(model::topic_namespace_view(ntp));
 
@@ -321,7 +322,6 @@ ss::future<std::error_code> controller_backend::create_partition(
     if (likely(_partition_manager.local().get(ntp).get() == nullptr)) {
         // we use offset as an ntp_id as it is always increasing and it
         // increases while ntp is being created again
-        auto rev = model::revision_id(offset());
         f = _partition_manager.local()
               .manage(
                 cfg->make_ntp_config(_data_directory, ntp.tp.partition, rev),
@@ -340,9 +340,13 @@ ss::future<std::error_code> controller_backend::create_partition(
 }
 
 ss::future<std::error_code>
-controller_backend::delete_partition(model::ntp ntp) {
+controller_backend::delete_partition(model::ntp ntp, model::revision_id rev) {
     auto part = _partition_manager.local().get(ntp);
     if (unlikely(part.get() == nullptr)) {
+        return ss::make_ready_future<std::error_code>(errc::success);
+    }
+    // partition was already recreated with greater rev, do nothing
+    if (unlikely(part->get_revision_id() > rev)) {
         return ss::make_ready_future<std::error_code>(errc::success);
     }
     auto group_id = part->group();

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -30,26 +30,26 @@ public:
     ss::future<> start();
 
 private:
-    template<typename T>
-    struct task_meta {
-        explicit task_meta(T t)
-          : delta(std::move(t)) {}
-
-        bool finished = false;
-        T delta;
-    };
-
+    using deltas_t = std::vector<topic_table::delta>;
+    using underlying_t = absl::flat_hash_map<model::ntp, deltas_t>;
     // Topics
     void start_topics_reconciliation_loop();
     ss::future<> reconcile_topics();
-    ss::future<> do_reconcile_topic(task_meta<topic_table::delta>&);
+    ss::future<std::error_code>
+    execute_partitition_op(const topic_table::delta&);
     ss::future<std::error_code> create_partition(
-      model::ntp, raft::group_id, model::offset, std::vector<model::broker>);
+      model::ntp,
+      raft::group_id,
+      model::revision_id,
+      std::vector<model::broker>);
     ss::future<> add_to_shard_table(model::ntp, raft::group_id, ss::shard_id);
     ss::future<std::error_code> process_partition_update(
-      const topic_table::delta::partition&, model::offset);
+      model::ntp, const partition_assignment&, model::revision_id);
+    ss::future<> fetch_deltas();
+    ss::future<> reconcile_ntp(deltas_t&);
 
-    ss::future<std::error_code> delete_partition(model::ntp);
+    ss::future<std::error_code>
+      delete_partition(model::ntp, model::revision_id);
     ss::future<std::error_code> update_partition_replica_set(
       const model::ntp&, const std::vector<model::broker_shard>&);
 
@@ -63,7 +63,7 @@ private:
     model::node_id _self;
     ss::sstring _data_directory;
     ss::sharded<ss::abort_source>& _as;
-    std::vector<task_meta<topic_table::delta>> _topic_deltas;
+    underlying_t _topic_deltas;
     ss::timer<> _housekeeping_timer;
     ss::semaphore _topics_sem{1};
     ss::gate _gate;

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -22,7 +22,9 @@ enum class errc {
     topic_not_exists,
     invalid_topic_name,
     partition_not_exists,
-    not_leader
+    not_leader,
+    partition_already_exists,
+    waiting_for_recovery,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -69,6 +71,10 @@ struct errc_category final : public std::error_category {
             return "Invalid topic name";
         case errc::partition_not_exists:
             return "Requested partition does not exists";
+        case errc::partition_already_exists:
+            return "Requested partition already exists";
+        case errc::waiting_for_recovery:
+            return "Waiting for partition to recover";
         default:
             return "cluster::errc::unknown";
         }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -102,6 +102,10 @@ public:
 
     partition_probe& probe() { return _probe; }
 
+    model::revision_id get_revision_id() const {
+        return _raft->log_config().get_revision();
+    }
+
 private:
     friend partition_manager;
 

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -12,15 +12,19 @@ create_allocation_node(model::node_id nid, uint32_t cores) {
 }
 
 static void validate_delta(
-  const cluster::topic_table::delta& d,
-  int new_topics,
+  const std::vector<cluster::topic_table::delta>& d,
   int new_partitions,
-  int removed_topics,
   int removed_partitions) {
-    BOOST_REQUIRE_EQUAL(d.partitions.additions.size(), new_partitions);
-    BOOST_REQUIRE_EQUAL(d.partitions.deletions.size(), removed_partitions);
-    BOOST_REQUIRE_EQUAL(d.topics.additions.size(), new_topics);
-    BOOST_REQUIRE_EQUAL(d.topics.deletions.size(), removed_topics);
+    size_t additions = std::count_if(
+      d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
+          return d.type == cluster::topic_table::delta::op_type::add;
+      });
+    size_t deletions = std::count_if(
+      d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
+          return d.type == cluster::topic_table::delta::op_type::del;
+      });
+    BOOST_REQUIRE_EQUAL(additions, new_partitions);
+    BOOST_REQUIRE_EQUAL(deletions, removed_partitions);
 }
 
 struct topic_table_fixture {

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -27,10 +27,7 @@ FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
     // check delta
     auto d = table.local().wait_for_changes(as).get0();
 
-    BOOST_REQUIRE_EQUAL(d.size(), 3);
-    validate_delta(d[0], 1, 1, 0, 0);
-    validate_delta(d[1], 1, 12, 0, 0);
-    validate_delta(d[2], 1, 8, 0, 0);
+    validate_delta(d, 21, 0);
 }
 
 FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
@@ -58,9 +55,7 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
     // check delta
     auto d = table.local().wait_for_changes(as).get0();
 
-    BOOST_REQUIRE_EQUAL(d.size(), 2);
-    validate_delta(d[0], 0, 0, 1, 12);
-    validate_delta(d[1], 0, 0, 1, 8);
+    validate_delta(d, 0, 20);
 }
 
 FIXTURE_TEST(test_conflicts, topic_table_fixture) {

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -1,7 +1,9 @@
 
 #include "cluster/topic_table.h"
 
+#include "cluster/logger.h"
 #include "cluster/types.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 
 namespace cluster {
@@ -21,6 +23,16 @@ topic_table::transform_topics(Func&& f) const {
     return ret;
 }
 
+topic_table::delta::delta(
+  model::ntp ntp,
+  cluster::partition_assignment p_as,
+  model::offset o,
+  op_type tp)
+  : ntp(std::move(ntp))
+  , p_as(std::move(p_as))
+  , offset(o)
+  , type(tp) {}
+
 ss::future<std::error_code>
 topic_table::apply(create_topic_cmd cmd, model::offset offset) {
     if (_topics.contains(cmd.key)) {
@@ -29,12 +41,11 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
           errc::topic_already_exists);
     }
     // calculate delta
-    delta d(offset);
-    d.topics.additions.push_back(cmd.value.cfg);
     for (auto& pas : cmd.value.assignments) {
-        d.partitions.additions.emplace_back(cmd.value.cfg.tp_ns, pas);
+        auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, pas.id);
+        _pending_deltas.emplace_back(
+          std::move(ntp), pas, offset, delta::op_type::add);
     }
-    _pending_deltas.push_back(std::move(d));
 
     _topics.insert({cmd.key, std::move(cmd.value)});
     notify_waiters();
@@ -51,12 +62,11 @@ ss::future<> topic_table::stop() {
 ss::future<std::error_code>
 topic_table::apply(delete_topic_cmd cmd, model::offset offset) {
     if (auto tp = _topics.find(cmd.value); tp != _topics.end()) {
-        delta d(offset);
-        d.topics.deletions.push_back(tp->second.cfg);
         for (auto& p : tp->second.assignments) {
-            d.partitions.deletions.emplace_back(tp->first, p);
+            auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, p.id);
+            _pending_deltas.emplace_back(
+              std::move(ntp), std::move(p), offset, delta::op_type::del);
         }
-        _pending_deltas.push_back(std::move(d));
         _topics.erase(tp);
         notify_waiters();
         return ss::make_ready_future<std::error_code>(errc::success);
@@ -86,9 +96,10 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
     current_assignment_it->replicas = cmd.value;
 
     // calculate deleta for backend
-    delta d(o);
-    d.partitions.updates.emplace_back(tp->first, *current_assignment_it);
-    _pending_deltas.push_back(std::move(d));
+    model::ntp ntp(tp->first.ns, tp->first.tp, current_assignment_it->id);
+    _pending_deltas.emplace_back(
+      std::move(ntp), *current_assignment_it, o, delta::op_type::update);
+
     notify_waiters();
 
     return ss::make_ready_future<std::error_code>(errc::success);
@@ -140,10 +151,6 @@ topic_table::wait_for_changes(ss::abort_source& as) {
     return f;
 }
 
-bool topic_table::delta::empty() const {
-    return partitions.empty() && topics.empty();
-}
-
 std::vector<model::topic_namespace> topic_table::all_topics() const {
     return transform_topics(
       [](const topic_configuration_assignment& td) { return td.cfg.tp_ns; });
@@ -189,6 +196,30 @@ bool topic_table::contains(
           [&pid](const partition_assignment& pas) { return pas.id == pid; });
     }
     return false;
+}
+
+std::ostream&
+operator<<(std::ostream& o, const topic_table::delta::op_type& tp) {
+    switch (tp) {
+    case topic_table::delta::op_type::add:
+        return o << "addition";
+    case topic_table::delta::op_type::del:
+        return o << "deletion";
+    case topic_table::delta::op_type::update:
+        return o << "update";
+    }
+}
+
+std::ostream& operator<<(std::ostream& o, const topic_table::delta& d) {
+    fmt::print(
+      o,
+      "{{type: {}, ntp: {}, offset: {}, assignment: {}}}",
+      d.type,
+      d.ntp,
+      d.offset,
+      d.p_as);
+
+    return o;
 }
 
 } // namespace cluster

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -23,16 +23,21 @@ class topic_table {
 public:
     // delta propagated to backend
     struct delta {
-        explicit delta(model::offset o)
-          : offset(o) {}
-        using partition
-          = std::pair<model::topic_namespace, partition_assignment>;
+        enum class op_type { add, del, update };
 
-        patch<partition> partitions;
-        patch<topic_configuration> topics;
+        delta(
+          model::ntp, cluster::partition_assignment, model::offset, op_type);
+        model::ntp ntp;
+        cluster::partition_assignment p_as;
         model::offset offset;
+        op_type type;
 
-        bool empty() const;
+        model::topic_namespace_view tp_ns() const {
+            return model::topic_namespace_view(ntp);
+        }
+
+        friend std::ostream& operator<<(std::ostream&, const delta&);
+        friend std::ostream& operator<<(std::ostream&, const op_type&);
     };
 
     bool is_batch_applicable(const model::record_batch& b) const {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -22,7 +22,7 @@ topic_configuration::topic_configuration(
 storage::ntp_config topic_configuration::make_ntp_config(
   const ss::sstring& work_dir,
   model::partition_id p_id,
-  storage::ntp_config::ntp_id version) const {
+  model::revision_id rev) const {
     auto has_overrides = cleanup_policy_bitflags || compaction_strategy
                          || segment_size || retention_bytes.has_value()
                          || retention_bytes.is_disabled()
@@ -43,7 +43,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
       model::ntp(tp_ns.ns, tp_ns.tp, p_id),
       work_dir,
       std::move(overrides),
-      version);
+      rev);
 }
 
 model::topic_metadata topic_configuration_assignment::get_metadata() const {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -101,6 +101,16 @@ std::ostream& operator<<(std::ostream& o, const configuration_invariants& c) {
       c.core_count);
     return o;
 }
+
+std::ostream& operator<<(std::ostream& o, const partition_assignment& p_as) {
+    fmt::print(
+      o,
+      "{{ id: {}, group_id: {}, replicas: {} }}",
+      p_as.id,
+      p_as.group,
+      p_as.replicas);
+    return o;
+}
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -71,7 +71,7 @@ struct topic_configuration {
     storage::ntp_config make_ntp_config(
       const ss::sstring&,
       model::partition_id,
-      storage::ntp_config::ntp_id) const;
+      model::revision_id) const;
 
     model::topic_namespace tp_ns;
     // using signed integer because Kafka protocol defines it as signed int

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -57,6 +57,8 @@ struct partition_assignment {
         p_md.replicas = replicas;
         return p_md;
     }
+
+    friend std::ostream& operator<<(std::ostream&, const partition_assignment&);
 };
 
 // Structure holding topic configuration, optionals will be replaced by broker
@@ -69,9 +71,7 @@ struct topic_configuration {
       int16_t replication_factor);
 
     storage::ntp_config make_ntp_config(
-      const ss::sstring&,
-      model::partition_id,
-      model::revision_id) const;
+      const ss::sstring&, model::partition_id, model::revision_id) const;
 
     model::topic_namespace tp_ns;
     // using signed integer because Kafka protocol defines it as signed int

--- a/src/v/kafka/tests/fetch_test.cc
+++ b/src/v/kafka/tests/fetch_test.cc
@@ -187,7 +187,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
         return resp;
     };
     wait_for_controller_leadership().get0();
-    auto ntp = make_data(storage::ntp_config::ntp_id(2));
+    auto ntp = make_data(model::revision_id(2));
 
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
@@ -220,7 +220,7 @@ FIXTURE_TEST(fetch_one, redpanda_thread_fixture) {
         using namespace storage;
         storage::disk_log_builder builder(log_config);
         storage::ntp_config ntp_cfg(
-          ntp, log_config.base_dir, nullptr, storage::ntp_config::ntp_id(2));
+          ntp, log_config.base_dir, nullptr, model::revision_id(2));
         builder | start(std::move(ntp_cfg)) | add_segment(model::offset(0))
           | add_random_batch(model::offset(0), 10, maybe_compress_batches::yes)
           | stop();

--- a/src/v/kafka/tests/list_offsets_test.cc
+++ b/src/v/kafka/tests/list_offsets_test.cc
@@ -13,7 +13,7 @@ using namespace std::chrono_literals;
 FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
     wait_for_controller_leadership().get0();
     auto query_ts = model::timestamp::now();
-    auto ntp = make_data(storage::ntp_config::ntp_id(2));
+    auto ntp = make_data(model::revision_id(2));
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(
@@ -56,7 +56,7 @@ FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
 
 FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
     wait_for_controller_leadership().get0();
-    auto ntp = make_data(storage::ntp_config::ntp_id(2));
+    auto ntp = make_data(model::revision_id(2));
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(
@@ -91,7 +91,7 @@ FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
 
 FIXTURE_TEST(list_offsets_latest, redpanda_thread_fixture) {
     wait_for_controller_leadership().get0();
-    auto ntp = make_data(storage::ntp_config::ntp_id(2));
+    auto ntp = make_data(model::revision_id(2));
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -18,7 +18,11 @@
 
 namespace model {
 using node_id = named_type<int32_t, struct node_id_model_type>;
-
+/**
+ * We use revision_id to identify entities evolution in time. f.e. NTP that was
+ * first created and then removed, raft configuration
+ */
+using revision_id = named_type<int64_t, struct revision_id_model_type>;
 struct broker_properties {
     uint32_t cores;
     uint32_t available_memory;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -119,7 +119,7 @@ public:
           });
     }
 
-    model::ntp make_data(storage::ntp_config::ntp_id version) {
+    model::ntp make_data(model::revision_id version) {
         auto topic_name = fmt::format("my_topic_{}", 0);
         model::ntp ntp(
           cluster::kafka_namespace,

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "tristate.h"
 
 #include <seastar/core/sstring.hh>
@@ -9,7 +10,6 @@
 namespace storage {
 class ntp_config {
 public:
-    using ntp_id = named_type<int64_t, struct ntp_id_tag>;
     struct default_overrides {
         // if not set use the log_manager's configuration
         std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -35,20 +35,25 @@ public:
       ss::sstring base_dir,
       std::unique_ptr<default_overrides> overrides) noexcept
       : ntp_config(
-        std::move(n), std::move(base_dir), std::move(overrides), ntp_id(0)) {}
+        std::move(n),
+        std::move(base_dir),
+        std::move(overrides),
+        model::revision_id(0)) {}
 
     ntp_config(
       model::ntp n,
       ss::sstring base_dir,
       std::unique_ptr<default_overrides> overrides,
-      ntp_id id) noexcept
+      model::revision_id id) noexcept
       : _ntp(std::move(n))
       , _base_dir(std::move(base_dir))
       , _overrides(std::move(overrides))
-      , _ntp_id(id) {}
+      , _revision_id(id) {}
 
     const model::ntp& ntp() const { return _ntp; }
     model::ntp& ntp() { return _ntp; }
+
+    model::revision_id get_revision() const { return _revision_id; }
 
     const ss::sstring& base_directory() const { return _base_dir; }
     ss::sstring& base_directory() { return _base_dir; }
@@ -79,7 +84,7 @@ public:
     }
 
     ss::sstring work_directory() const {
-        return fmt::format("{}/{}_{}", _base_dir, _ntp.path(), _ntp_id);
+        return fmt::format("{}/{}_{}", _base_dir, _ntp.path(), _revision_id);
     }
 
     std::filesystem::path topic_directory() const {
@@ -99,7 +104,7 @@ private:
      * A number indicating an id of the NTP in case it was created more
      * than once (i.e. created, deleted and then created again)
      */
-    ntp_id _ntp_id{0};
+    model::revision_id _revision_id{0};
 
     // in storage/types.cc
     friend std::ostream& operator<<(std::ostream&, const ntp_config&);


### PR DESCRIPTION
This patch series simplifies handling of NTP deltas in controller. Previously we had delta that could contain multiple NTP information. Changed this to have exactly one delta per NTP. This enables compaction of NTP deltas while being processed by the controller backend. Also each NTP can be processed in parallel by controller backend.