### PR TITLE
coproc: add 766 permission to rpk wasm generate

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -13,8 +13,9 @@ import (
 )
 
 type genFile struct {
-	name    string
-	content string
+	name       string
+	content    string
+	permission os.FileMode
 }
 
 var manifest = func() map[string][]genFile {
@@ -24,7 +25,7 @@ var manifest = func() map[string][]genFile {
 		"": {
 			genFile{name: "vectorized.js", content: template.GetVectorizedDependency()},
 			genFile{name: "package.json", content: template.GetPackageJson()},
-			genFile{name: "webpack.js", content: template.GetWebpack()},
+			genFile{name: "webpack.js", content: template.GetWebpack(), permission: 0766},
 		},
 	}
 }
@@ -97,6 +98,12 @@ func executeGenerate(fs afero.Fs, path string) error {
 			_, err = utils.WriteBytes(fs, []byte(templateFile.content), filePath)
 			if err != nil {
 				return err
+			}
+			if templateFile.permission > 0 {
+				err = fs.Chmod(filePath, templateFile.permission)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/src/go/rpk/pkg/cli/cmd/wasm_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm_test.go
@@ -94,6 +94,14 @@ func TestWasmCommand(t *testing.T) {
 			},
 			expectedErrMsg: fmt.Sprintf("The directory %s/existFolder/"+
 				" contains files that could conflict: \n package.json", path),
+		}, {
+			name: "should create webpack file with executable permission",
+			args: []string{"generate"},
+			check: func(fs afero.Fs, t *testing.T) {
+				dir := filepath.Join(path, "wasm", "webpack.js")
+				info, _ := fs.Stat(dir)
+				require.True(t, info.Mode() == 0766)
+			},
 		},
 	}
 


### PR DESCRIPTION
coproc: add 766 permission to RPK wasm generate

this permission is necessary when someone needs to run `npm run build`
on wasm generated folder by `rpk wasm generate`
