### PR TITLE
Remove assert on detection of coproc no topic

### DIFF
--- a/src/v/coproc/service.cc
+++ b/src/v/coproc/service.cc
@@ -86,6 +86,16 @@ ss::future<enable_copros_reply::ack_id_pair> service::evaluate_topics(
       "topics: {}",
       id,
       topics);
+    if (topics.empty()) {
+        vlog(
+          coproclog.warn,
+          "Request to enable coprocessor {} failed due to empty topics "
+          "list",
+          id);
+        return ss::make_ready_future<enable_copros_reply::ack_id_pair>(
+          std::make_pair(
+            id, std::vector<enable_response_code>{erc::invalid_topic}));
+    }
     return copro_exists(id).then([this, id, topics = std::move(topics)](
                                    bool exists) mutable {
         if (exists) {

--- a/src/v/coproc/service.cc
+++ b/src/v/coproc/service.cc
@@ -22,17 +22,11 @@ service::service(
 
 enable_response_code
 assemble_response(std::vector<enable_response_code> codes) {
-    const bool any_dne = std::all_of(codes.begin(), codes.end(), [](auto x) {
+    const bool all_dne = std::all_of(codes.begin(), codes.end(), [](auto x) {
         return x == erc::topic_does_not_exist;
     });
-    vassert(!any_dne, "Topic was expected to not have existed");
-
-    const bool any_err = std::any_of(codes.begin(), codes.end(), [](auto x) {
-        return x == erc::internal_error;
-    });
-
-    if (any_err) {
-        return erc::internal_error;
+    if (all_dne) {
+        return erc::topic_does_not_exist;
     }
 
     const bool any_double_id = std::any_of(

--- a/src/v/coproc/tests/script_manager_service_test.cc
+++ b/src/v/coproc/tests/script_manager_service_test.cc
@@ -78,6 +78,20 @@ FIXTURE_TEST(test_coproc_topic_dne, script_manager_service_fixture) {
     BOOST_CHECK(resp.acks[0].second[0] == erc::topic_does_not_exist);
 }
 
+FIXTURE_TEST(test_coproc_no_topics, script_manager_service_fixture) {
+    startup({{make_ts("foo"), 5}}, {});
+    auto client = rpc::client<coproc::script_manager_client_protocol>(
+      client_config());
+    client.connect().get();
+    auto dclient = ss::defer([&client] { client.stop().get(); });
+    const auto resp = coproc_register_topics(
+                        client, {make_enable_req(1234, {})})
+                        .get0()
+                        .value()
+                        .data;
+    BOOST_CHECK_EQUAL(resp.acks.size(), 1);
+}
+
 // This test fixture tests the edge cases, i.e. situations that should fail
 FIXTURE_TEST(test_coproc_invalid_topics, script_manager_service_fixture) {
     startup(

--- a/src/v/coproc/tests/script_manager_service_test.cc
+++ b/src/v/coproc/tests/script_manager_service_test.cc
@@ -61,6 +61,23 @@ public:
     }
 };
 
+FIXTURE_TEST(test_coproc_topic_dne, script_manager_service_fixture) {
+    startup({{make_ts("foo"), 5}}, {});
+    auto client = rpc::client<coproc::script_manager_client_protocol>(
+      client_config());
+    client.connect().get();
+    auto dclient = ss::defer([&client] { client.stop().get(); });
+    const auto resp = coproc_register_topics(
+                        client, {make_enable_req(1234, {{"bar", l}})})
+                        .get0()
+                        .value()
+                        .data;
+    BOOST_CHECK_EQUAL(resp.acks.size(), 1);
+    BOOST_CHECK(resp.acks[0].first == coproc::script_id(1234));
+    BOOST_CHECK_EQUAL(resp.acks[0].second.size(), 1);
+    BOOST_CHECK(resp.acks[0].second[0] == erc::topic_does_not_exist);
+}
+
 // This test fixture tests the edge cases, i.e. situations that should fail
 FIXTURE_TEST(test_coproc_invalid_topics, script_manager_service_fixture) {
     startup(


### PR DESCRIPTION
Fix for issue where redpanda throws when the wasm engine attempts to subscribe to a topic that doesn't exist #61
