### PR TITLE
Feature/pr read big payload v2

### DIFF
--- a/tools/ts-generator/package-lock.json
+++ b/tools/ts-generator/package-lock.json
@@ -4,6 +4,51 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
+      "integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.2.12",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
@@ -20,6 +65,21 @@
       "version": "14.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.2.tgz",
       "integrity": "sha512-onlIwbaeqvZyniGPfdw/TEhKIh79pz66L1q06WUQqJLnAb6wbjvOtepLYTGHTqzdXgBYIE3ZdmqHDGsRsbBz7A=="
+    },
+    "@types/sinon": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.8.tgz",
+      "integrity": "sha512-IVnI820FZFMGI+u1R+2VdRaD/82YIQTdqLYC9DLPszZuynAJDtCvCtCs3bmyL66s7FqRM3+LPX7DhHnVTaagDw==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+      "dev": true
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -552,6 +612,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -568,6 +634,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -582,6 +654,12 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "log-symbols": {
@@ -665,6 +743,19 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-addon-api": {
       "version": "1.7.2",
@@ -767,6 +858,15 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -811,6 +911,44 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "sinon": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.1.tgz",
+      "integrity": "sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.2.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/tools/ts-generator/package.json
+++ b/tools/ts-generator/package.json
@@ -14,6 +14,8 @@
     "xxhash": "^0.3.0"
   },
   "devDependencies": {
+    "sinon": "^9.2.1",
+    "@types/sinon": "^9.0.8",
     "@types/chai": "^4.2.12",
     "@types/mocha": "^8.0.3",
     "typescript": "^4.0.2",

--- a/tools/ts-generator/rpc/example/generatedType.ts
+++ b/tools/ts-generator/rpc/example/generatedType.ts
@@ -27,47 +27,55 @@ export class RpcHeader {
    * @param buffer is the place where the binary data is stored
    * @param offset is the position where the function will start to
    *        read into buffer
-   * @return a tuple, where first element is a RpcHeader and second
-   *        one is the read last position in the buffer
+   * @return a tuple, where first element is a RpcHeader and
+   *        second one is the read last position in the buffer
    */
   static fromBytes(buffer: Buffer, offset = 0): [RpcHeader, number] {
+    const version = (() => {
+      const [value, newOffset] = BF.readUInt8LE(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const headerChecksum = (() => {
+      const [value, newOffset] = BF.readUInt32LE(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const compression = (() => {
+      const [value, newOffset] = BF.readInt8LE(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const payloadSize = (() => {
+      const [value, newOffset] = BF.readUInt32LE(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const meta = (() => {
+      const [value, newOffset] = BF.readUInt32LE(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const correlationId = (() => {
+      const [value, newOffset] = BF.readUInt32LE(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const payloadChecksum = (() => {
+      const [value, newOffset] = BF.readUInt64LE(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+
     return [
       {
-        version: (() => {
-          const [value, newOffset] = BF.readUInt8LE(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        headerChecksum: (() => {
-          const [value, newOffset] = BF.readUInt32LE(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        compression: (() => {
-          const [value, newOffset] = BF.readInt8LE(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        payloadSize: (() => {
-          const [value, newOffset] = BF.readUInt32LE(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        meta: (() => {
-          const [value, newOffset] = BF.readUInt32LE(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        correlationId: (() => {
-          const [value, newOffset] = BF.readUInt32LE(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        payloadChecksum: (() => {
-          const [value, newOffset] = BF.readUInt64LE(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
+        version,
+        headerChecksum,
+        compression,
+        payloadSize,
+        meta,
+        correlationId,
+        payloadChecksum,
       },
       offset,
     ];
@@ -109,46 +117,53 @@ export class MetadataInfo {
    * @param buffer is the place where the binary data is stored
    * @param offset is the position where the function will start to
    *        read into buffer
-   * @return a tuple, where first element is a MetadataInfo and second
-   *        one is the read last position in the buffer
+   * @return a tuple, where first element is a MetadataInfo and
+   *        second one is the read last position in the buffer
    */
   static fromBytes(buffer: Buffer, offset = 0): [MetadataInfo, number] {
+    const inputs = (() => {
+      const [array, newOffset] = BF.readArray()(
+        buffer,
+        offset,
+        (auxBuffer, auxOffset) => BF.readString(auxBuffer, auxOffset)
+      );
+      offset = newOffset;
+      return array;
+    })();
+    const name = (() => {
+      const [value, newOffset] = BF.readString(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const age = (() => {
+      const [value, newOffset] = BF.readInt8LE(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const isCool = (() => {
+      const [value, newOffset] = BF.readBoolean(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const id = (() => {
+      const [value, newOffset] = BF.readVarint(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+    const data = (() => {
+      const [value, newOffset] = BF.readBuffer(buffer, offset);
+      offset = newOffset;
+      return value;
+    })();
+
     return [
       {
-        inputs: (() => {
-          const [array, newOffset] = BF.readArray(
-            buffer,
-            offset,
-            (auxBuffer, auxOffset) => BF.readString(auxBuffer, auxOffset)
-          );
-          offset = newOffset;
-          return array;
-        })(),
-        name: (() => {
-          const [value, newOffset] = BF.readString(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        age: (() => {
-          const [value, newOffset] = BF.readInt8LE(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        isCool: (() => {
-          const [value, newOffset] = BF.readBoolean(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        id: (() => {
-          const [value, newOffset] = BF.readVarint(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
-        data: (() => {
-          const [value, newOffset] = BF.readBuffer(buffer, offset);
-          offset = newOffset;
-          return value;
-        })(),
+        inputs,
+        name,
+        age,
+        isCool,
+        id,
+        data,
       },
       offset,
     ];
@@ -167,7 +182,7 @@ export class MetadataInfo {
   static toBytes(value: MetadataInfo, buffer: IOBuf): number {
     let wroteBytes = 0;
 
-    wroteBytes += BF.writeArray(value.inputs, buffer, (item, auxBuffer) =>
+    wroteBytes += BF.writeArray(true)(value.inputs, buffer, (item, auxBuffer) =>
       BF.writeString(item, auxBuffer)
     );
     wroteBytes += BF.writeString(value.name, buffer);
@@ -187,21 +202,23 @@ export class EnableTopicsReply {
    * @param buffer is the place where the binary data is stored
    * @param offset is the position where the function will start to
    *        read into buffer
-   * @return a tuple, where first element is a EnableTopicsReply and second
-   *        one is the read last position in the buffer
+   * @return a tuple, where first element is a EnableTopicsReply and
+   *        second one is the read last position in the buffer
    */
   static fromBytes(buffer: Buffer, offset = 0): [EnableTopicsReply, number] {
+    const inputs = (() => {
+      const [array, newOffset] = BF.readArray()(
+        buffer,
+        offset,
+        (auxBuffer, auxOffset) => BF.readInt8LE(auxBuffer, auxOffset)
+      );
+      offset = newOffset;
+      return array;
+    })();
+
     return [
       {
-        inputs: (() => {
-          const [array, newOffset] = BF.readArray(
-            buffer,
-            offset,
-            (auxBuffer, auxOffset) => BF.readInt8LE(auxBuffer, auxOffset)
-          );
-          offset = newOffset;
-          return array;
-        })(),
+        inputs,
       },
       offset,
     ];
@@ -220,7 +237,7 @@ export class EnableTopicsReply {
   static toBytes(value: EnableTopicsReply, buffer: IOBuf): number {
     let wroteBytes = 0;
 
-    wroteBytes += BF.writeArray(value.inputs, buffer, (item, auxBuffer) =>
+    wroteBytes += BF.writeArray(true)(value.inputs, buffer, (item, auxBuffer) =>
       BF.writeInt8LE(item, auxBuffer)
     );
     return wroteBytes;
@@ -235,21 +252,23 @@ export class DisableTopicsReply {
    * @param buffer is the place where the binary data is stored
    * @param offset is the position where the function will start to
    *        read into buffer
-   * @return a tuple, where first element is a DisableTopicsReply and second
-   *        one is the read last position in the buffer
+   * @return a tuple, where first element is a DisableTopicsReply and
+   *        second one is the read last position in the buffer
    */
   static fromBytes(buffer: Buffer, offset = 0): [DisableTopicsReply, number] {
+    const inputs = (() => {
+      const [array, newOffset] = BF.readArray()(
+        buffer,
+        offset,
+        (auxBuffer, auxOffset) => BF.readInt8LE(auxBuffer, auxOffset)
+      );
+      offset = newOffset;
+      return array;
+    })();
+
     return [
       {
-        inputs: (() => {
-          const [array, newOffset] = BF.readArray(
-            buffer,
-            offset,
-            (auxBuffer, auxOffset) => BF.readInt8LE(auxBuffer, auxOffset)
-          );
-          offset = newOffset;
-          return array;
-        })(),
+        inputs,
       },
       offset,
     ];
@@ -268,7 +287,7 @@ export class DisableTopicsReply {
   static toBytes(value: DisableTopicsReply, buffer: IOBuf): number {
     let wroteBytes = 0;
 
-    wroteBytes += BF.writeArray(value.inputs, buffer, (item, auxBuffer) =>
+    wroteBytes += BF.writeArray(true)(value.inputs, buffer, (item, auxBuffer) =>
       BF.writeInt8LE(item, auxBuffer)
     );
     return wroteBytes;

--- a/tools/ts-generator/rpc/rpc.test.ts
+++ b/tools/ts-generator/rpc/rpc.test.ts
@@ -1,0 +1,111 @@
+import {
+  RegistrationClient,
+  RegistrationServer,
+} from "./example/generatedServer";
+import { reset, spy } from "sinon";
+import assert = require("assert");
+
+let server: RegistrationServer;
+let client: RegistrationClient;
+
+describe("rpc generator", function () {
+  beforeEach(function () {
+    reset();
+    server = new RegistrationServer();
+    server.listen(8003);
+    client = new RegistrationClient(8003);
+  });
+
+  afterEach(async () => {
+    client.close();
+    await server.closeConnection();
+  });
+
+  it("should send a record between server and client", function (done) {
+    // override server method
+    server.enable_topics = (_) => Promise.resolve({ inputs: [0] });
+    client
+      .enable_topics({
+        inputs: ["1"],
+        age: 1,
+        data: Buffer.from(""),
+        id: BigInt(1),
+        isCool: true,
+        name: "vectorized",
+      })
+      .then((response) => {
+        assert.strictEqual(response.inputs.length, 1);
+        assert.deepStrictEqual(response.inputs, [0]);
+        done();
+      });
+  });
+
+  it("should server method calls with client request", function (done) {
+    // override server method
+    server.enable_topics = (_) => Promise.resolve({ inputs: [0] });
+    const serverSpy = spy(server, "enable_topics");
+
+    const request = {
+      inputs: ["1"],
+      age: 1,
+      data: Buffer.from(""),
+      id: BigInt(1),
+      isCool: true,
+      name: "vectorized",
+    };
+
+    client.enable_topics(request).then((response) => {
+      assert.deepStrictEqual(serverSpy.firstCall.firstArg, request);
+      assert.deepStrictEqual(
+        serverSpy.firstCall.returnValue,
+        Promise.resolve(response)
+      );
+      done();
+    });
+  });
+
+  it("should server support big payload ( > 65Kb )", function (done) {
+    server.enable_topics = (_) => Promise.resolve({ inputs: [0] });
+    const serverSpy = spy(server, "process");
+    // make request bigger than 65kb (500029)
+    const request = {
+      inputs: "1,".repeat(100000).split(","),
+      age: 1,
+      data: Buffer.from(""),
+      id: BigInt(1),
+      isCool: true,
+      name: "vectorized",
+    };
+
+    client.enable_topics(request).then((_) => {
+      const rpc = serverSpy.firstCall.args[0];
+      assert.strictEqual(rpc.payloadSize > 66000, true);
+      done();
+    });
+  });
+
+  it("should server support small payload ( < 65Kb )", function (done) {
+    server.enable_topics = (_) => Promise.resolve({ inputs: [0] });
+    const serverSpy = spy(server, "process");
+    const request = {
+      inputs: "1,".repeat(100).split(","),
+      age: 1,
+      data: Buffer.from(""),
+      id: BigInt(1),
+      isCool: true,
+      name: "vectorized",
+    };
+
+    client.enable_topics(request).then((_) => {
+      const rpc = serverSpy.firstCall.args[0];
+      assert.strictEqual(rpc.payloadSize < 65000, true);
+      done();
+    });
+
+    client.enable_topics(request).then((_) => {
+      const rpc = serverSpy.firstCall.args[0];
+      assert.strictEqual(rpc.payloadSize < 65000, true);
+      done();
+    });
+  });
+});

--- a/tools/ts-generator/rpc/rpc_gen_js.py
+++ b/tools/ts-generator/rpc/rpc_gen_js.py
@@ -38,6 +38,9 @@ import {
   RpcHeader
 } from "{{js_include}}"
 
+const rpcHeaderSize = 26;
+type ApplyFn = (rpcH: RpcHeader, buf: Buffer, socket: Socket) => void
+
 function createCrc32(buffer: Buffer, start, end): number {
   return calculate(buffer.subarray(start, end));
 }
@@ -79,6 +82,76 @@ function generateRpcHeader(
     RpcHeader.toBytes(rpc, reserve);
 }
 
+const startReadRequest = (fn: ApplyFn) => (socket: Socket): void => {
+  socket.once("data", (data) => readRequestBuffer(data, fn, socket));
+};
+
+/**
+ * given a buffer with request, it read a rpc header and rpc header payload size
+ * if the buffer has a complete payload size it return buffer, Otherwise, it
+ * waits for n "data" events with necessary data for complete payload size.
+ * @param buffer
+ * @param fn
+ * @param socket
+ */
+const readRequestBuffer = (buffer: Buffer, fn: ApplyFn, socket: Socket) => {
+  const [rpcHeader, crcValidation, crc32] = validateRpcHeader(
+    buffer.slice(0, rpcHeaderSize)
+  );
+  if (!crcValidation) {
+    throw (
+      `Crc32 inconsistent, expect: ${rpcHeader.headerChecksum} ` +
+      `generated: ${crc32}`
+    );
+  } else {
+    const size = rpcHeader.payloadSize;
+    if (buffer.length - rpcHeaderSize >= size) {
+      const result = buffer.slice(rpcHeaderSize, size + rpcHeaderSize);
+      startReadRequest(fn)(socket)
+      return fn(rpcHeader, result, socket);
+    } else {
+      const bytesForReading = size - (buffer.length - rpcHeaderSize);
+      return readNextChunk(socket, bytesForReading, fn)
+        .then((nextBuffer) =>
+          Buffer.concat([buffer.slice(rpcHeaderSize), nextBuffer])
+        )
+        .then((result) => fn(rpcHeader, result, socket));
+    }
+  }
+};
+
+/**
+ * given payload size, it waits for n "data" events until have the complete data
+ * size.
+ * @param socket
+ * @param size
+ * @param fn
+ */
+const readNextChunk = (
+  socket: Socket,
+  size: number,
+  fn: ApplyFn
+): Promise<Buffer> => {
+  return new Promise<Buffer>((resolve) => {
+    socket.once("data", (data) => {
+      if (data.length >= size) {
+        if (data.length - size > 0) {
+          readRequestBuffer(data.slice(size), fn, socket);
+        } else {
+          startReadRequest(fn)(socket);
+        }
+        return resolve(data.slice(0, size));
+      } else {
+        return readNextChunk(
+          socket,
+          size - data.length,
+          fn
+        ).then((nextBuffer) => resolve(Buffer.concat([data, nextBuffer])));
+      }
+    });
+  });
+};
+
 """
 
 server_template = """
@@ -86,65 +159,58 @@ export class {{service_name.title()}}Server {
   constructor() {
     this.server = createServer(this.executeMethod.bind(this));
     this.handleNewConnection()
+    this.process = this.process.bind(this)
   }
   
   listen(port: number){
     this.server.listen(port)
   }
   
-  executeMethod(socket: Socket) {
-    socket.on("readable", () => {
-      if (socket.readableLength > 26) {
-        const [rpcHeader, crc32Validation, crc32] =
-          validateRpcHeader(socket.read(26));
-        if (!crc32Validation){
-          throw(`Crc32 inconsistent, expect: ${rpcHeader.headerChecksum}`+
-            `generated: ${crc32}`
-          )
-        } else {
-          switch (rpcHeader.meta) {
-            {%- for method in methods %}
-            case {{method.id}}: {
-              const [value] = {{method.input_ts}}
-                .fromBytes(socket.read(rpcHeader.payloadSize))
-              this.{{method.name}}(value)
-                .then((output: {{method.output_ts}}) => {
-                    const buffer = new IOBuf();
-                    const rpcHeaderReserve = buffer.getReserve(26)
-                    const size = {{method.output_ts}}
-                      .toBytes(output, buffer)
-                    generateRpcHeader(
-                      buffer,
-                      rpcHeaderReserve,
-                      size,
-                      200,
-                      rpcHeader.correlationId
-                    )
-                    buffer.forEach((fragment =>
-                        socket.write(fragment.buffer.slice(0, fragment.used))
-                    ));
-                })
-              break;
-            }
-            {%- endfor %}
-            default: {
-              const buffer = new IOBuf();
-              const rpcHeaderReserve = buffer.getReserve(26);
-              generateRpcHeader(
-                buffer,
-                rpcHeaderReserve,
-                0,
-                404,
-                rpcHeader.correlationId
-              );
-              buffer.forEach((fragment =>
-                socket.write(fragment.buffer.slice(0, fragment.used))
-              ));
-            }
-          }
+  process(rpcHeader: RpcHeader, payload: Buffer, socket: Socket) {
+      switch (rpcHeader.meta) {
+        {%- for method in methods %}
+        case {{method.id}}: {
+          const [value] = {{method.input_ts}}
+            .fromBytes(payload)
+          this.{{method.name}}(value)
+            .then((output: {{method.output_ts}}) => {
+                const buffer = new IOBuf();
+                const rpcHeaderReserve = buffer.getReserve(26)
+                const size = {{method.output_ts}}
+                  .toBytes(output, buffer)
+                generateRpcHeader(
+                  buffer,
+                  rpcHeaderReserve,
+                  size,
+                  200,
+                  rpcHeader.correlationId
+                )
+                buffer.forEach((fragment =>
+                    socket.write(fragment.buffer.slice(0, fragment.used))
+                ));
+            })
+          break;
         }
-      }
-    })
+        {%- endfor %}
+        default: {
+          const buffer = new IOBuf();
+          const rpcHeaderReserve = buffer.getReserve(26);
+          generateRpcHeader(
+            buffer,
+            rpcHeaderReserve,
+            0,
+            404,
+            rpcHeader.correlationId
+          );
+          buffer.forEach((fragment =>
+            socket.write(fragment.buffer.slice(0, fragment.used))
+          ));
+        }
+        }
+  }
+  
+  executeMethod(socket: Socket) {
+    startReadRequest(this.process)(socket)
   }
   
   {% for method in methods %}
@@ -185,14 +251,16 @@ export class {{service_name.title()}}Server {
 client_template = """
 export class {{service_name.title()}}Client {
   constructor(port: number) {
+    this.process = this.process.bind(this)
     this.client = createConnection({ port }, () => {
     console.log("Established connection with redpanda");
-    this.client.on("data", data => {
-      const [rpc] = RpcHeader.fromBytes(data, 0);
-        this.responseHandlers.get(rpc.correlationId)(data)
-      });
+    startReadRequest(this.process)(this.client);
     })
   }
+  
+  process(rpcHeader: RpcHeader, payload: Buffer, socket: Socket) {
+    this.responseHandlers.get(rpcHeader.correlationId)(payload);
+  }  
     
   send(buffer: IOBuf, headerReserve: IOBuf, size: number, meta: number): number{
     const correlationId = ++this.correlationId;
@@ -217,15 +285,7 @@ export class {{service_name.title()}}Client {
         );
         this.responseHandlers.set(correlationId, (data: Buffer) => {
           try {
-            const [rpcHeader, crc32Validation, crc32] =
-              validateRpcHeader(data)
-            if(!crc32Validation){
-              throw(`Crc32 inconsistent, expect: ${rpcHeader.headerChecksum}`+
-                `generated: ${crc32}`
-              )
-            } else {
-              resolve({{method.output_ts}}.fromBytes(data, 26)[0])
-            }
+              resolve({{method.output_ts}}.fromBytes(data)[0])
             } catch(e) {reject(e)}
           }
         )} catch(e){ reject(e) }


### PR DESCRIPTION
coproc: read big payload on RPC generated server (Nodejs)

When NodeJS receives a big payload (> 65kb), this payload splitting on
differents chunk that will be passed to server on different "data" events, for
this reason it's necessary to add some function to the RPC server in order to
wait for having RPC payload size and after that, apply to process batch
logic.

---since v1:
  - clean code
  - reuse readRequestBuffer
  - add new test for payloads < 65kb