### PR TITLE
Last visible offset based on max offset replicated by majority

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -127,6 +127,7 @@ ss::future<> consensus::stop() {
     _vote_timeout.cancel();
     _as.request_abort();
     _commit_index_updated.broken();
+    _disk_append.broken();
 
     return _event_manager.stop()
       .then([this] { return _bg.close(); })
@@ -1419,6 +1420,7 @@ consensus::disk_append(model::record_batch_reader&& reader) {
              _log.make_appender(cfg),
              cfg.timeout)
       .then([this](std::tuple<ret_t, std::vector<offset_configuration>> t) {
+          _disk_append.broadcast();
           auto& [ret, configurations] = t;
           _has_pending_flushes = true;
           // TODO

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -293,6 +293,7 @@ void consensus::process_append_entries_reply(
     auto is_success = update_follower_index(node, std::move(r), seq_id);
     if (is_success) {
         maybe_promote_to_voter(node);
+        maybe_update_majority_replicated_index();
         maybe_update_leader_commit_idx();
     }
 }
@@ -383,8 +384,10 @@ consensus::replicate(model::record_batch_reader&& rdr, replicate_options opts) {
                                details::term_assigning_reader>(
                                std::move(rdr), model::term_id(_term)))
             .then([this](storage::append_result res) {
-                // update last_visible_index immediately after append succeed
-                maybe_update_last_visible_index(res.last_offset);
+                // for relaxed consistency mode update visibility upper bound
+                // with last offset appended to the log
+                _visibility_upper_bound_index = std::max(
+                  _visibility_upper_bound_index, res.last_offset);
                 return result<replicate_result>(
                   replicate_result{.last_offset = res.last_offset});
             });
@@ -409,13 +412,13 @@ void consensus::dispatch_flush_with_lock() {
 model::offset consensus::last_stable_offset() const {
     // TODO: handle transactions, when we implement them, for now LSO is simply
     // equal to max consumable offset
-    return _last_visible_index;
+    return _majority_replicated_index;
 }
 
 ss::future<model::record_batch_reader>
 consensus::do_make_reader(storage::log_reader_config config) {
     // limit to last visible index
-    config.max_offset = std::min(config.max_offset, _last_visible_index);
+    config.max_offset = std::min(config.max_offset, last_visible_index());
     return _log.make_reader(config);
 }
 
@@ -428,7 +431,10 @@ ss::future<model::record_batch_reader> consensus::make_reader(
     }
 
     return _consumable_offset_monitor
-      .wait(details::next_offset(_last_visible_index), *debounce_timeout, _as)
+      .wait(
+        details::next_offset(_majority_replicated_index),
+        *debounce_timeout,
+        _as)
       .then([this, config]() mutable { return do_make_reader(config); });
 }
 
@@ -708,7 +714,7 @@ ss::future<> consensus::start() {
               auto last_applied = read_last_applied();
               if (last_applied > _commit_index) {
                   _commit_index = last_applied;
-                  _last_visible_index = last_applied;
+                  maybe_update_last_visible_index(_commit_index);
                   vlog(
                     _ctxlog.trace, "Recovered commit_index: {}", _commit_index);
               }
@@ -1021,8 +1027,10 @@ consensus::do_append_entries(append_entries_request&& r) {
             return ss::make_ready_future<append_entries_reply>(
               std::move(reply));
         }
-        maybe_update_last_visible_index(
-          std::min(lstats.dirty_offset, r.meta.last_visible_index));
+        auto last_visible = std::min(
+          lstats.dirty_offset, r.meta.last_visible_index);
+        // on the follower leader control visibility of entries in the log
+        maybe_update_last_visible_index(last_visible);
         return maybe_update_follower_commit_idx(
                  model::offset(r.meta.commit_index))
           .then([reply = std::move(reply)]() mutable {
@@ -1094,8 +1102,8 @@ consensus::do_append_entries(append_entries_request&& r) {
           if (flush) {
               f = f.then([this] { return flush_log(); });
           }
-          maybe_update_last_visible_index(
-            std::min(ofs.last_offset, m.last_visible_index));
+          auto last_visible = std::min(ofs.last_offset, m.last_visible_index);
+          maybe_update_last_visible_index(last_visible);
           return f.then(
             [this, m = std::move(m), ofs = std::move(ofs)]() mutable {
                 return maybe_update_follower_commit_idx(
@@ -1590,7 +1598,6 @@ consensus::maybe_update_follower_commit_idx(model::offset request_commit_idx) {
               _ctxlog.trace, "Follower commit index updated {}", _commit_index);
             _commit_index_updated.broadcast();
             _event_manager.notify_commit_index(_commit_index);
-            maybe_update_last_visible_index(_commit_index);
         }
     }
     return ss::make_ready_future<>();
@@ -1880,8 +1887,22 @@ ss::future<> consensus::remove_persistent_state() {
 }
 
 void consensus::maybe_update_last_visible_index(model::offset offset) {
-    _last_visible_index = std::max(_last_visible_index, offset);
-    _consumable_offset_monitor.notify(_last_visible_index);
+    _visibility_upper_bound_index = std::max(
+      _visibility_upper_bound_index, offset);
+    _majority_replicated_index = std::max(_majority_replicated_index, offset);
+    _consumable_offset_monitor.notify(last_visible_index());
 }
 
+void consensus::maybe_update_majority_replicated_index() {
+    auto majority_match = config().quorum_match([this](model::node_id id) {
+        if (id == _self) {
+            return _log.offsets().dirty_offset;
+        }
+        return _fstats.get(id).last_dirty_log_index;
+    });
+
+    _majority_replicated_index = std::max(
+      _majority_replicated_index, majority_match);
+    _consumable_offset_monitor.notify(last_visible_index());
+}
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -372,6 +372,8 @@ private:
     configuration_manager _configuration_manager;
     model::offset _last_visible_index;
     offset_monitor _consumable_offset_monitor;
+    ss::condition_variable _disk_append;
+
     friend std::ostream& operator<<(std::ostream&, const consensus&);
 };
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -377,6 +377,13 @@ private:
     configuration_manager _configuration_manager;
     model::offset _majority_replicated_index;
     model::offset _visibility_upper_bound_index;
+    /**
+     * We keep an idex of the most recent entry replicated with quorum
+     * consistency level to make sure that all requests replicated with quorum
+     * consistency level will not be visible before they are committed by
+     * majority.
+     */
+    model::offset _last_quorum_replicated_index;
     offset_monitor _consumable_offset_monitor;
     ss::condition_variable _disk_append;
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -105,7 +105,7 @@ public:
           .term = _term,
           .prev_log_index = lstats.dirty_offset,
           .prev_log_term = lstats.dirty_offset_term,
-          .last_visible_index = _last_visible_index};
+          .last_visible_index = last_visible_index()};
     }
     raft::group_id group() const { return _group; }
     model::term_id term() const { return _term; }
@@ -152,13 +152,17 @@ public:
      * Last visible offset is updated in two scenarios
      *
      * - commited offset is updated (consistency_level=quorum)
-     * - when batch with was appended to the leader log with relaxed consistency
+     * - when batch that was appendend to the leader log is safely replicated on
+     *   majority of nodes
      *
      * We always update last visible index with std::max(prev,
      * possible_value) to guarantee its monotonicity.
      *
      */
-    model::offset last_visible_index() const { return _last_visible_index; };
+    model::offset last_visible_index() const {
+        return std::min(
+          _majority_replicated_index, _visibility_upper_bound_index);
+    };
 
     ss::future<offset_configuration>
     wait_for_config_change(model::offset last_seen, ss::abort_source& as) {
@@ -315,6 +319,7 @@ private:
     bytes last_applied_key() const;
 
     void maybe_update_last_visible_index(model::offset);
+    void maybe_update_majority_replicated_index();
     // args
     model::node_id _self;
     raft::group_id _group;
@@ -370,7 +375,8 @@ private:
     model::offset _last_snapshot_index;
     model::term_id _last_snapshot_term;
     configuration_manager _configuration_manager;
-    model::offset _last_visible_index;
+    model::offset _majority_replicated_index;
+    model::offset _visibility_upper_bound_index;
     offset_monitor _consumable_offset_monitor;
     ss::condition_variable _disk_append;
 

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -370,7 +370,8 @@ bool recovery_stm::is_recovery_finished() {
       max_offset);
 
     bool is_up_to_date = meta.value()->match_index == max_offset;
-    bool quorum_writes = _ptr->_last_visible_index <= _ptr->_commit_index;
+    bool quorum_writes = _ptr->_visibility_upper_bound_index
+                         <= _ptr->_commit_index;
     /**
      * We do not stop recovery for relaxed consistency recoveries as we want
      * recoveries to be send immediately after leader disk append. For low

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -45,6 +45,7 @@ private:
     model::offset _base_batch_offset;
     model::offset _last_batch_offset;
     model::offset _committed_offset;
+    model::term_id _term;
     ss::io_priority_class _prio;
     ctx_log _ctxlog;
     // tracking follower snapshot delivery

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -130,7 +130,8 @@ replicate_entries_stm::append_to_self() {
           vlog(_ctxlog.trace, "Self append entries - {}", req.meta);
           return _ptr->disk_append(std::move(req.batches));
       })
-      .then([](storage::append_result res) {
+      .then([this](storage::append_result res) {
+          _ptr->_last_quorum_replicated_index = res.last_offset;
           return result<storage::append_result>(std::move(res));
       })
       .handle_exception([this](const std::exception_ptr& e) {


### PR DESCRIPTION
Based last visible offset on largest offset successfully replicated on majority of nodes.  This prevents consumers from seeing data that may be truncated during leader election

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
Fixes #65
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
