### PR TITLE
Learners promotion v2

### DIFF
--- a/src/v/raft/configuration.cc
+++ b/src/v/raft/configuration.cc
@@ -20,6 +20,14 @@
 #include <optional>
 
 namespace raft {
+bool group_nodes::contains(model::node_id id) const {
+    auto v_it = std::find(std::cbegin(voters), std::cend(voters), id);
+    if (v_it != voters.cend()) {
+        return true;
+    }
+    auto l_it = std::find(std::cbegin(learners), std::cend(learners), id);
+    return l_it != learners.cend();
+}
 
 group_configuration::group_configuration(std::vector<model::broker> brokers)
   : _brokers(std::move(brokers)) {
@@ -141,10 +149,9 @@ void group_configuration::add(std::vector<model::broker> brokers) {
         }
     }
 
-    // FIXME: add to learners when we will implement learners promotion
     _old = _current;
     for (auto& b : brokers) {
-        _current.voters.push_back(b.id());
+        _current.learners.push_back(b.id());
         _brokers.push_back(std::move(b));
     }
 }
@@ -176,24 +183,61 @@ void group_configuration::remove(const std::vector<model::node_id>& ids) {
 }
 
 void group_configuration::replace(std::vector<model::broker> brokers) {
-    vassert(
-      !_old, "can not remove broker from joint configuration - {}", *this);
+    vassert(!_old, "can not replace joint configuration - {}", *this);
 
-    // add missing brokers, brokers have to contain both the new and old nodes
+    /**
+     * If configurations are identical do nothing. For identical configuration
+     * we assume that brokers list hasn't changed (1) and current configuration
+     * contains all brokers in either voters of learners (2).
+     */
+    // check list of brokers (1)
+    if (brokers == _brokers) {
+        // check if all brokers are assigned to current configuration (2)
+        bool has_all = std::all_of(
+          brokers.begin(), brokers.end(), [this](model::broker& b) {
+              return _current.contains(b.id());
+          });
+        // configurations are identical, do nothing
+        if (has_all) {
+            return;
+        }
+    }
+
     _old = _current;
     _current.learners.clear();
     _current.voters.clear();
-    std::transform(
-      std::cbegin(brokers),
-      std::cend(brokers),
-      std::back_inserter(_current.voters),
-      [](const model::broker& broker) { return broker.id(); });
+
+    for (auto& br : brokers) {
+        auto was_voter = std::find(
+                           std::cbegin(_old->voters),
+                           std::cend(_old->voters),
+                           br.id())
+                         != std::cend(_old->voters);
+
+        if (was_voter) {
+            _current.voters.push_back(br.id());
+        } else {
+            _current.learners.push_back(br.id());
+        }
+    }
 
     for (auto& b : brokers) {
         if (!contains_broker(b.id())) {
             _brokers.push_back(std::move(b));
         }
     }
+}
+
+void group_configuration::promote_to_voter(model::node_id id) {
+    auto it = std::find(
+      std::cbegin(_current.learners), std::cend(_current.learners), id);
+    // do nothing
+    if (it == _current.learners.end()) {
+        return;
+    }
+    // add to voters
+    _current.learners.erase(it);
+    _current.voters.push_back(id);
 }
 
 void group_configuration::discard_old_config() {

--- a/src/v/raft/configuration.h
+++ b/src/v/raft/configuration.h
@@ -28,6 +28,7 @@ struct group_nodes {
     std::vector<model::node_id> voters;
     std::vector<model::node_id> learners;
 
+    bool contains(model::node_id id) const;
     friend std::ostream& operator<<(std::ostream&, const group_nodes&);
     friend bool operator==(const group_nodes&, const group_nodes&);
 };
@@ -134,6 +135,8 @@ public:
     bool majority(Predicate&& f) const;
 
     int8_t version() const { return _version; }
+
+    void promote_to_voter(model::node_id id);
 
     friend bool
     operator==(const group_configuration&, const group_configuration&);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -307,6 +307,7 @@ private:
     ss::future<std::error_code> change_configuration(Func&&);
 
     ss::future<> maybe_commit_configuration(ss::semaphore_units<>);
+    void maybe_promote_to_voter(model::node_id);
 
     ss::future<model::record_batch_reader>
       do_make_reader(storage::log_reader_config);

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -31,7 +31,8 @@ enum class errc {
     node_does_not_exists,
     leadership_transfer_in_progress,
     node_already_exists,
-    invalid_configuration_update
+    invalid_configuration_update,
+    not_voter
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "raft::errc"; }
@@ -70,6 +71,8 @@ struct errc_category final : public std::error_category {
             return "Node does already exists in configuration";
         case errc::invalid_configuration_update:
             return "Configuration resulting from the update is invalid";
+        case errc::not_voter:
+            return "Requested node is not a voter";
         default:
             return "raft::errc::unknown";
         }

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -29,7 +29,7 @@ recovery_stm::recovery_stm(
   : _ptr(p)
   , _node_id(node_id)
   , _prio(prio)
-  , _ctxlog(_ptr->group(), _ptr->ntp()) {}
+  , _ctxlog(_ptr->_ctxlog) {}
 
 ss::future<> recovery_stm::do_recover() {
     // We have to send all the records that leader have, event those that are

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -245,7 +245,7 @@ replicate_entries_stm::replicate_entries_stm(
   , _req(std::move(r))
   , _followers_seq(std::move(seqs))
   , _share_sem(1)
-  , _ctxlog(_ptr->group(), _ptr->ntp()) {}
+  , _ctxlog(_ptr->_ctxlog) {}
 
 replicate_entries_stm::~replicate_entries_stm() {
     vassert(

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -36,7 +36,7 @@ std::ostream& operator<<(std::ostream& o, const vote_stm::vmeta& m) {
 vote_stm::vote_stm(consensus* p)
   : _ptr(p)
   , _sem(0)
-  , _ctxlog(_ptr->group(), _ptr->ntp()) {}
+  , _ctxlog(_ptr->_ctxlog) {}
 
 vote_stm::~vote_stm() {
     vassert(


### PR DESCRIPTION
Implemented learners promotion feature in repdanda Raft. In order to not disturb the cluster nodes when first joining raft group will be added as a learners. When learner if fully caught up with the leader it is promoted to become a voter.

Changes since v1:
- not allowing leadership transfer to learner

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
