### PR TITLE
Fixed duplicated entries in fetch response

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -1,0 +1,5 @@
+>=20.11.2
+
+--------
+
+* fixed duplicated partitions & topics in fetch response #82 #89

--- a/src/v/coproc/tests/read_materialized_topic_test.cc
+++ b/src/v/coproc/tests/read_materialized_topic_test.cc
@@ -145,7 +145,7 @@ FIXTURE_TEST(
     // Connect a kafka client to the expected output topic
     kafka::fetch_request req;
     req.max_bytes = std::numeric_limits<int32_t>::max();
-    req.min_bytes = min_expected_bytes; // At LEAST 'bytes_written' in src topic
+    req.min_bytes = 1; // At LEAST 'bytes_written' in src topic
     req.max_wait_time = 2s;
     req.topics = {
       {.name = materialized_topic,

--- a/src/v/kafka/requests/fetch_request.cc
+++ b/src/v/kafka/requests/fetch_request.cc
@@ -428,18 +428,68 @@ handle_ntp_fetch(op_context& octx, model::ntp ntp, fetch_config config) {
           try {
               auto response = f.get0();
               response.id = p_id;
-              octx.add_partition_response(std::move(response));
+              octx.set_partition_response(std::move(response));
           } catch (...) {
               /*
                * TODO: this is where we will want to handle any storage
                * specific errors and translate them into kafka response
                * error codes.
                */
-              octx.response_error = true;
-              octx.add_partition_response(make_partition_response_error(
+              octx.set_partition_response(make_partition_response_error(
                 error_code::unknown_server_error));
           }
       });
+}
+
+static ss::future<> fetch_topic_partition(
+  op_context& octx, const fetch_request::const_iterator::value_type& p) {
+    /*
+     * the next topic-partition to fetch
+     */
+    auto& topic = *p.topic;
+    auto& part = *p.partition;
+    if (p.new_topic && octx.initial_fetch) {
+        octx.start_response_topic(topic);
+    }
+
+    if (
+      model::timeout_clock::now() > octx.deadline.value_or(model::no_timeout)) {
+        octx.set_partition_response(
+          make_partition_response_error(error_code::request_timed_out));
+        return ss::now();
+    }
+
+    // if over budget create placeholder response
+    if (octx.bytes_left <= 0) {
+        octx.set_partition_response(
+          make_partition_response_error(error_code::message_too_large));
+        return ss::now();
+    }
+    // if we already have data in response for this partition skip it
+    if (!octx.initial_fetch) {
+        auto& partition_response = octx.response_iterator->partition_response;
+
+        /**
+         * do not try to fetch again if partition response already contains an
+         * error or it is not empty and we are already over the min bytes
+         * threshold.
+         */
+        if (
+          partition_response->has_error()
+          || (!partition_response->record_set->empty() && octx.over_min_bytes())) {
+            return ss::now();
+        }
+    }
+
+    auto ntp = model::ntp(cluster::kafka_namespace, topic.name, part.id);
+
+    fetch_config config{
+      .start_offset = part.fetch_offset,
+      .max_bytes = std::min(octx.bytes_left, size_t(part.partition_max_bytes)),
+      .timeout = octx.deadline.value_or(model::no_timeout),
+      .strict_max_bytes = octx.response_size > 0,
+    };
+    return handle_ntp_fetch(octx, std::move(ntp), config);
 }
 
 /**
@@ -448,72 +498,46 @@ handle_ntp_fetch(op_context& octx, model::ntp ntp, fetch_config config) {
  * Each request is handled serially in the order they appear in the request.
  * There are a couple reasons why we are not **yet** processing these in
  * parallel. First, Kafka expects to some extent that the order of the
- * partitions in the request is an implicit priority on which partitions to read
- * from. This is closely related to the request budget limits specified in terms
- * of maximum bytes and maximum time delay.
+ * partitions in the request is an implicit priority on which partitions to
+ * read from. This is closely related to the request budget limits specified
+ * in terms of maximum bytes and maximum time delay.
  *
  * Once we start processing requests in parallel we'll have to work through
  * various challenges. First, once we dispatch in parallel, we'll need to
- * develop heuristics for dealing with the implicit priority order. We'll also
- * need to develop techniques and heuristics for dealing with budgets since
- * global budgets aren't trivially divisible onto each core when partition
- * requests may produce non-uniform amounts of data.
+ * develop heuristics for dealing with the implicit priority order. We'll
+ * also need to develop techniques and heuristics for dealing with budgets
+ * since global budgets aren't trivially divisible onto each core when
+ * partition requests may produce non-uniform amounts of data.
  *
  * w.r.t. what is needed to parallelize this, there are no data dependencies
- * between partition requests within the fetch request, and so they can be run
- * fully in parallel. The only dependency that exists is that the response must
- * be reassembled such that the responses appear in these order as the
- * partitions in the request.
+ * between partition requests within the fetch request, and so they can be
+ * run fully in parallel. The only dependency that exists is that the
+ * response must be reassembled such that the responses appear in these
+ * order as the partitions in the request.
  */
 static ss::future<> fetch_topic_partitions(op_context& octx) {
     return ss::do_for_each(
-      octx.request.cbegin(),
-      octx.request.cend(),
-      [&octx](const fetch_request::const_iterator::value_type& p) {
-          /*
-           * the next topic-partition to fetch
-           */
-          auto& topic = *p.topic;
-          auto& part = *p.partition;
-
-          if (p.new_topic) {
-              octx.start_response_topic(topic);
-          }
-
-          // if over budget create placeholder response
-          if (
-            octx.bytes_left == 0
-            || model::timeout_clock::now()
-                 > octx.deadline.value_or(model::no_timeout)) {
-              octx.add_partition_response(
-                make_partition_response_error(error_code::message_too_large));
-              return ss::make_ready_future<>();
-          }
-
-          auto ntp = model::ntp(cluster::kafka_namespace, topic.name, part.id);
-
-          fetch_config config{
-            .start_offset = part.fetch_offset,
-            .max_bytes = std::min(
-              octx.bytes_left, size_t(part.partition_max_bytes)),
-            .timeout = octx.deadline.value_or(model::no_timeout),
-            .strict_max_bytes = octx.response_size > 0,
-          };
-
-          return handle_ntp_fetch(octx, std::move(ntp), config);
-      });
+             octx.request.cbegin(),
+             octx.request.cend(),
+             [&octx](const fetch_request::const_iterator::value_type& p) {
+                 return fetch_topic_partition(octx, p).then([&octx] {
+                     if (!octx.initial_fetch) {
+                         octx.response_iterator++;
+                     }
+                 });
+             })
+      .then([&octx] { octx.reset_context(); });
 }
 
 ss::future<response_ptr>
 fetch_api::process(request_context&& rctx, ss::smp_service_group ssg) {
     return ss::do_with(op_context(std::move(rctx), ssg), [](op_context& octx) {
-        // top-level error is used for session-level errors, but we do not yet
-        // implement session management.
+        // top-level error is used for session-level errors, but we do
+        // not yet implement session management.
         octx.response.error = error_code::none;
         // first fetch, do not wait
         return fetch_topic_partitions(octx)
           .then([&octx] {
-              octx.initial_fetch = false;
               return ss::do_until(
                 [&octx] { return octx.should_stop_fetch(); },
                 [&octx] { return fetch_topic_partitions(octx); });

--- a/src/v/kafka/requests/fetch_request.cc
+++ b/src/v/kafka/requests/fetch_request.cc
@@ -315,7 +315,7 @@ static ss::future<fetch_response::partition_response> read_from_partition(
                 };
             });
       })
-      .handle_exception_type([](const ss::timed_out_error&) {
+      .handle_exception_type([](const raft::offset_monitor::wait_aborted&) {
           // no data are returned
           return fetch_response::partition_response{
             .error = error_code::none,

--- a/src/v/kafka/requests/fetch_request.h
+++ b/src/v/kafka/requests/fetch_request.h
@@ -83,6 +83,18 @@ struct fetch_request final {
         }
     }
 
+    /**
+     * return empty if request doesn't contain any topics or all topics are
+     * empty
+     */
+    bool empty() const {
+        return topics.empty()
+               || std::all_of(
+                 topics.cbegin(), topics.cend(), [](const topic& t) {
+                     return t.partitions.empty();
+                 });
+    }
+
     /*
      * iterator over request partitions. this adapter iterator is used because
      * the partitions are decoded off the wire directly into a hierarhical

--- a/src/v/kafka/requests/fetch_request.h
+++ b/src/v/kafka/requests/fetch_request.h
@@ -390,7 +390,7 @@ struct op_context {
     bool should_stop_fetch() const {
         return !request.debounce_delay()
                || static_cast<int32_t>(response_size) >= request.min_bytes
-               || request.topics.empty() || response_error;
+               || request.empty() || response_error;
     }
 };
 

--- a/src/v/kafka/tests/produce_consume_test.cc
+++ b/src/v/kafka/tests/produce_consume_test.cc
@@ -105,7 +105,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         kafka::fetch_request req;
         req.min_bytes = 1;
         req.max_bytes = 10_MiB;
-        req.max_wait_time = 100ms;
+        req.max_wait_time = 1000ms;
         req.topics.push_back(std::move(topic));
 
         return consumer->dispatch(std::move(req), kafka::api_version(4))

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -111,9 +111,10 @@ public:
           storage::debug_sanitize_files::yes);
     }
 
-    ss::future<> add_topic(model::topic_namespace_view tp_ns) {
+    ss::future<>
+    add_topic(model::topic_namespace_view tp_ns, int partitions = 1) {
         std::vector<cluster::topic_configuration> cfgs{
-          cluster::topic_configuration(tp_ns.ns, tp_ns.tp, 1, 1)};
+          cluster::topic_configuration(tp_ns.ns, tp_ns.tp, partitions, 1)};
         return app.controller->get_topics_frontend()
           .local()
           .create_topics(std::move(cfgs), model::no_timeout)


### PR DESCRIPTION
Fixed fetch request debouncing leading to duplicated partition responses. 
Fixes #82 

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
