### PR TITLE
rpk: Fix rpk check configFile

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,3 +3,4 @@
 --------
 
 * fixed duplicated partitions & topics in fetch response #82 #89
+* fixed config file lookup for rpk check

--- a/src/go/rpk/pkg/cli/cmd/check.go
+++ b/src/go/rpk/pkg/cli/cmd/check.go
@@ -72,7 +72,7 @@ func executeCheck(fs afero.Fs, configFile string, timeout time.Duration) error {
 		return err
 	}
 	config.CheckAndPrintNotice(conf.LicenseKey)
-	results, err := tuners.Check(fs, configFile, conf, timeout)
+	results, err := tuners.Check(fs, conf, timeout)
 	if err != nil {
 		return err
 	}

--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -458,7 +458,7 @@ func check(
 	checkFailedActions map[tuners.CheckerID]checkFailedAction,
 ) ([]api.CheckPayload, error) {
 	payloads := make([]api.CheckPayload, 0)
-	results, err := tuners.Check(fs, conf.ConfigFile, conf, timeout)
+	results, err := tuners.Check(fs, conf, timeout)
 	if err != nil {
 		return payloads, err
 	}

--- a/src/go/rpk/pkg/tuners/check.go
+++ b/src/go/rpk/pkg/tuners/check.go
@@ -21,10 +21,10 @@ import (
 )
 
 func Check(
-	fs afero.Fs, configFile string, conf *config.Config, timeout time.Duration,
+	fs afero.Fs, conf *config.Config, timeout time.Duration,
 ) ([]CheckResult, error) {
 	var results []CheckResult
-	ioConfigFile := redpanda.GetIOConfigPath(filepath.Dir(configFile))
+	ioConfigFile := redpanda.GetIOConfigPath(filepath.Dir(conf.ConfigFile))
 	checkersMap, err := RedpandaCheckers(fs, ioConfigFile, conf, timeout)
 	if err != nil {
 		return results, err


### PR DESCRIPTION
`configFile` was passed as the empty string.
The path is in the config, so don't pass pass the path.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
