### PR TITLE
rpk/container: Limit node core count

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,3 +4,4 @@
 
 * fixed duplicated partitions & topics in fetch response #82 #89
 * fixed config file lookup for rpk check
+* rpk container - divide the host cores across the nodes

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -13,6 +13,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"runtime"
 	"sync"
 	"vectorized/pkg/cli/cmd/container/common"
 	"vectorized/pkg/cli/ui"
@@ -145,6 +147,8 @@ func startCluster(fs afero.Fs, c common.Client, n uint) error {
 		return err
 	}
 
+	coreCount := int(math.Max(1, float64(runtime.NumCPU()) / float64(n)))
+
 	log.Info("Starting cluster")
 	seedIP, seedKafkaPort, err := startNode(
 		fs,
@@ -156,6 +160,7 @@ func startCluster(fs afero.Fs, c common.Client, n uint) error {
 		seedState.ContainerID,
 		seedState.ContainerIP,
 		"",
+		coreCount,
 	)
 	if err != nil {
 		return err
@@ -200,6 +205,7 @@ func startCluster(fs afero.Fs, c common.Client, n uint) error {
 				state.ContainerID,
 				state.ContainerIP,
 				seedState.ContainerIP,
+				coreCount,
 			)
 			if err != nil {
 				return err
@@ -296,9 +302,9 @@ func startNode(
 	fs afero.Fs,
 	c common.Client,
 	nodeID, kafkaPort, rpcPort, seedRPCPort uint,
-	containerID, ip, seedIP string,
+	containerID, ip, seedIP string, cores int,
 ) (string, uint, error) {
-	conf, err := writeNodeConfig(fs, nodeID, kafkaPort, rpcPort, seedRPCPort, ip, seedIP, common.ConfPath(nodeID))
+	conf, err := writeNodeConfig(fs, nodeID, kafkaPort, rpcPort, seedRPCPort, ip, seedIP, common.ConfPath(nodeID), cores)
 	if err != nil {
 		return "", 0, err
 	}
@@ -311,7 +317,7 @@ func startNode(
 func writeNodeConfig(
 	fs afero.Fs,
 	nodeID, kafkaPort, rpcPort, seedRPCPort uint,
-	ip, seedIP, path string,
+	ip, seedIP, path string, cores int,
 ) (*config.Config, error) {
 	localhost := "127.0.0.1"
 	conf := config.DefaultConfig()
@@ -340,6 +346,7 @@ func writeNodeConfig(
 	}
 
 	conf.Rpk.Overprovisioned = true
+	conf.Rpk.SMP = &cores 
 	conf.Redpanda.DeveloperMode = true
 
 	return &conf, config.WriteConfig(fs, &conf, path)


### PR DESCRIPTION
Share the host cores across the number of nodes to reduce the amount of overprovisioning.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
