### PR TITLE
s/e2e_tests: fixed assertion checking if segment sizes are unique

### DIFF
--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1059,9 +1059,10 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
         auto& segs = get_disk_log(l)->segments();
         sizes.push_back((*segs.begin())->size_bytes());
     }
-    std::sort(sizes.begin(), sizes.end());
-    auto end = std::unique(sizes.begin(), sizes.end());
-    auto unique_cnt = std::distance(sizes.begin(), end);
-    // check if all logs have unique segment size
-    BOOST_REQUIRE_EQUAL(unique_cnt, sizes.size());
+    BOOST_REQUIRE_EQUAL(
+      std::all_of(
+        sizes.begin(),
+        sizes.end(),
+        [size = sizes[0]](auto other) { return size == other; }),
+      false);
 }


### PR DESCRIPTION
It may happen that two segments have the same size even though we
randomize its size.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
