### PR TITLE
ci/rpk: Fix release jobs

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -87,6 +87,8 @@ jobs:
         release_name: ${{ github.ref }}
         draft: true
         prerelease: false
+    outputs:
+      urload_url: ${{ steps.create_rpk_release.outputs.upload_url }
 
   publish-release-artifacts:
     name: Publish release
@@ -105,7 +107,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_rpk_release.outputs.upload_url }} 
+        upload_url: ${{ needs.create-release.outputs.upload_url }} 
         asset_path: rpk-archives/rpk-${{ matrix.os }}-amd64.zip
         asset_name: rpk-${{ matrix.os }}-amd64.zip
         asset_content_type: application/zip


### PR DESCRIPTION
Fix the `upload_url` value source in the rpk release jobs.
