### PR TITLE
forcing colours in gcc/clang output by default even with ninja

### DIFF
--- a/cmake/diagnostic_colors.cmake
+++ b/cmake/diagnostic_colors.cmake
@@ -1,0 +1,13 @@
+if(NOT REDPANDA_NO_COLORS_IN_OUTPUT)
+  # Force colored output from compilers even when output is piped (not a tty)
+  # as is the case when building with ninja. For reference see these 2 issues:
+  # https://github.com/ninja-build/ninja/issues/174
+  # https://github.com/ninja-build/ninja/issues/814
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    list(APPEND BASE_C_FLAGS_LIST -fdiagnostics-color=always)
+    list(APPEND BASE_CXX_FLAGS_LIST -fdiagnostics-color=always)
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    list(APPEND BASE_C_FLAGS_LIST -fcolor-diagnostics)
+    list(APPEND BASE_CXX_FLAGS_LIST -fcolor-diagnostics)
+  endif()
+endif()

--- a/cmake/main.cmake
+++ b/cmake/main.cmake
@@ -41,6 +41,9 @@ if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
             )
 endif()
 
+# included here because it modifies the BASE_*_FLAGS_LIST variables used below
+include(diagnostic_colors)
+
 # join flag lists
 string(JOIN " " BASE_C_FLAGS ${BASE_C_FLAGS_LIST})
 string(JOIN " " BASE_CXX_FLAGS ${BASE_CXX_FLAGS_LIST})


### PR DESCRIPTION
As we discussed in #91 I factored this change into a separate PR and added a guard around the colour forcing so that it can be disabled if necessary. PR #91 has been updated and there's a change to `build.sh` that allows for flags to be forwarded to CMake => disabling colours will entail calling `./build.sh -DRP_NO_COLOURS_IN_OUTPUT=ON` and that automatically gets cached for subsequent runs.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant
