### PR TITLE
rpk/config: Add tests for missing advertised_* fields

### DIFF
--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -111,14 +111,12 @@ func DefaultConfig() Config {
 	return Config{
 		ConfigFile: "/etc/redpanda/redpanda.yaml",
 		Redpanda: &RedpandaConfig{
-			Directory:          "/var/lib/redpanda/data",
-			RPCServer:          SocketAddress{"0.0.0.0", 33145},
-			AdvertisedRPCAPI:   &SocketAddress{"0.0.0.0", 33145},
-			KafkaApi:           SocketAddress{"0.0.0.0", 9092},
-			AdvertisedKafkaApi: &SocketAddress{"0.0.0.0", 9092},
-			AdminApi:           SocketAddress{"0.0.0.0", 9644},
-			Id:                 0,
-			SeedServers:        []*SeedServer{},
+			Directory:   "/var/lib/redpanda/data",
+			RPCServer:   SocketAddress{"0.0.0.0", 33145},
+			KafkaApi:    SocketAddress{"0.0.0.0", 9092},
+			AdminApi:    SocketAddress{"0.0.0.0", 9644},
+			Id:          0,
+			SeedServers: []*SeedServer{},
 		},
 		Rpk: &RpkConfig{
 			CoredumpDir: "/var/lib/redpanda/coredump",


### PR DESCRIPTION
Adds regression unit tests for when a config object's `redpanda.advertised_*` fields are nil.