### PR TITLE
rpk/container: Log instructions to change cluster size

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -79,6 +79,13 @@ func startCluster(fs afero.Fs, c common.Client, n uint) error {
 	if len(restarted) != 0 {
 		log.Info("\nFound an existing cluster:\n")
 		renderClusterInfo(restarted)
+		if len(restarted) != int(n) {
+			log.Infof(
+				"\nTo change the number of nodes, first purge" +
+					" the existing cluster:\n\n" +
+					"rpk container purge\n",
+			)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Currently, `rpk container` doesn't support resizing existing clusters. However, a user may run `rpk container start` with a different value for `--nodes` in hopes of doing so, so we should tell them what they need to do to achieve something similar. 