### PR TITLE
Delta per ntp v1

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -329,10 +329,10 @@ ss::future<std::error_code> controller_backend::create_partition(
     if (likely(_partition_manager.local().get(ntp).get() == nullptr)) {
         // we use offset as an ntp_id as it is always increasing and it
         // increases while ntp is being created again
-        auto ntp_id = storage::ntp_config::ntp_id(offset());
+        auto rev = model::revision_id(offset());
         f = _partition_manager.local()
               .manage(
-                cfg->make_ntp_config(_data_directory, ntp.tp.partition, ntp_id),
+                cfg->make_ntp_config(_data_directory, ntp.tp.partition, rev),
                 group_id,
                 std::move(members))
               .discard_result();

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -81,6 +81,8 @@ struct errc_category final : public std::error_category {
             return "Invalid topic name";
         case errc::partition_not_exists:
             return "Requested partition does not exists";
+        case errc::not_leader:
+            return "Current node is not a leader for partition";
         case errc::partition_already_exists:
             return "Requested partition already exists";
         case errc::waiting_for_recovery:

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -32,7 +32,9 @@ enum class errc {
     topic_not_exists,
     invalid_topic_name,
     partition_not_exists,
-    not_leader
+    not_leader,
+    partition_already_exists,
+    waiting_for_recovery,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -79,6 +81,10 @@ struct errc_category final : public std::error_category {
             return "Invalid topic name";
         case errc::partition_not_exists:
             return "Requested partition does not exists";
+        case errc::partition_already_exists:
+            return "Requested partition already exists";
+        case errc::waiting_for_recovery:
+            return "Waiting for partition to recover";
         default:
             return "cluster::errc::unknown";
         }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -112,6 +112,10 @@ public:
 
     partition_probe& probe() { return _probe; }
 
+    model::revision_id get_revision_id() const {
+        return _raft->log_config().get_revision();
+    }
+
 private:
     friend partition_manager;
 

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -23,15 +23,19 @@ create_allocation_node(model::node_id nid, uint32_t cores) {
 }
 
 static void validate_delta(
-  const cluster::topic_table::delta& d,
-  int new_topics,
+  const std::vector<cluster::topic_table::delta>& d,
   int new_partitions,
-  int removed_topics,
   int removed_partitions) {
-    BOOST_REQUIRE_EQUAL(d.partitions.additions.size(), new_partitions);
-    BOOST_REQUIRE_EQUAL(d.partitions.deletions.size(), removed_partitions);
-    BOOST_REQUIRE_EQUAL(d.topics.additions.size(), new_topics);
-    BOOST_REQUIRE_EQUAL(d.topics.deletions.size(), removed_topics);
+    size_t additions = std::count_if(
+      d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
+          return d.type == cluster::topic_table::delta::op_type::add;
+      });
+    size_t deletions = std::count_if(
+      d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
+          return d.type == cluster::topic_table::delta::op_type::del;
+      });
+    BOOST_REQUIRE_EQUAL(additions, new_partitions);
+    BOOST_REQUIRE_EQUAL(deletions, removed_partitions);
 }
 
 struct topic_table_fixture {

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -36,10 +36,7 @@ FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
     // check delta
     auto d = table.local().wait_for_changes(as).get0();
 
-    BOOST_REQUIRE_EQUAL(d.size(), 3);
-    validate_delta(d[0], 1, 1, 0, 0);
-    validate_delta(d[1], 1, 12, 0, 0);
-    validate_delta(d[2], 1, 8, 0, 0);
+    validate_delta(d, 21, 0);
 }
 
 FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
@@ -67,9 +64,7 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
     // check delta
     auto d = table.local().wait_for_changes(as).get0();
 
-    BOOST_REQUIRE_EQUAL(d.size(), 2);
-    validate_delta(d[0], 0, 0, 1, 12);
-    validate_delta(d[1], 0, 0, 1, 8);
+    validate_delta(d, 0, 20);
 }
 
 FIXTURE_TEST(test_conflicts, topic_table_fixture) {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -34,16 +34,21 @@ class topic_table {
 public:
     // delta propagated to backend
     struct delta {
-        explicit delta(model::offset o)
-          : offset(o) {}
-        using partition
-          = std::pair<model::topic_namespace, partition_assignment>;
+        enum class op_type { add, del, update };
 
-        patch<partition> partitions;
-        patch<topic_configuration> topics;
+        delta(
+          model::ntp, cluster::partition_assignment, model::offset, op_type);
+        model::ntp ntp;
+        cluster::partition_assignment p_as;
         model::offset offset;
+        op_type type;
 
-        bool empty() const;
+        model::topic_namespace_view tp_ns() const {
+            return model::topic_namespace_view(ntp);
+        }
+
+        friend std::ostream& operator<<(std::ostream&, const delta&);
+        friend std::ostream& operator<<(std::ostream&, const op_type&);
     };
 
     bool is_batch_applicable(const model::record_batch& b) const {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -110,6 +110,16 @@ std::ostream& operator<<(std::ostream& o, const configuration_invariants& c) {
       c.core_count);
     return o;
 }
+
+std::ostream& operator<<(std::ostream& o, const partition_assignment& p_as) {
+    fmt::print(
+      o,
+      "{{ id: {}, group_id: {}, replicas: {} }}",
+      p_as.id,
+      p_as.group,
+      p_as.replicas);
+    return o;
+}
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -31,7 +31,7 @@ topic_configuration::topic_configuration(
 storage::ntp_config topic_configuration::make_ntp_config(
   const ss::sstring& work_dir,
   model::partition_id p_id,
-  storage::ntp_config::ntp_id version) const {
+  model::revision_id rev) const {
     auto has_overrides = cleanup_policy_bitflags || compaction_strategy
                          || segment_size || retention_bytes.has_value()
                          || retention_bytes.is_disabled()
@@ -52,7 +52,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
       model::ntp(tp_ns.ns, tp_ns.tp, p_id),
       work_dir,
       std::move(overrides),
-      version);
+      rev);
 }
 
 model::topic_metadata topic_configuration_assignment::get_metadata() const {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -82,7 +82,7 @@ struct topic_configuration {
     storage::ntp_config make_ntp_config(
       const ss::sstring&,
       model::partition_id,
-      storage::ntp_config::ntp_id) const;
+      model::revision_id) const;
 
     model::topic_namespace tp_ns;
     // using signed integer because Kafka protocol defines it as signed int

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -68,6 +68,8 @@ struct partition_assignment {
         p_md.replicas = replicas;
         return p_md;
     }
+
+    friend std::ostream& operator<<(std::ostream&, const partition_assignment&);
 };
 
 // Structure holding topic configuration, optionals will be replaced by broker
@@ -80,9 +82,7 @@ struct topic_configuration {
       int16_t replication_factor);
 
     storage::ntp_config make_ntp_config(
-      const ss::sstring&,
-      model::partition_id,
-      model::revision_id) const;
+      const ss::sstring&, model::partition_id, model::revision_id) const;
 
     model::topic_namespace tp_ns;
     // using signed integer because Kafka protocol defines it as signed int

--- a/src/v/coproc/tests/read_materialized_topic_test.cc
+++ b/src/v/coproc/tests/read_materialized_topic_test.cc
@@ -102,7 +102,7 @@ FIXTURE_TEST(
         using namespace storage;
         storage::disk_log_builder builder(log_config);
         storage::ntp_config ntp_cfg(
-          ntp, log_config.base_dir, nullptr, storage::ntp_config::ntp_id(2));
+          ntp, log_config.base_dir, nullptr, model::revision_id(2));
         builder | start(std::move(ntp_cfg)) | add_segment(model::offset(0))
           | add_random_batch(
             model::offset(0),

--- a/src/v/kafka/tests/fetch_test.cc
+++ b/src/v/kafka/tests/fetch_test.cc
@@ -197,7 +197,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
         return resp;
     };
     wait_for_controller_leadership().get0();
-    auto ntp = make_data(storage::ntp_config::ntp_id(2));
+    auto ntp = make_data(model::revision_id(2));
 
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
@@ -230,7 +230,7 @@ FIXTURE_TEST(fetch_one, redpanda_thread_fixture) {
         using namespace storage;
         storage::disk_log_builder builder(log_config);
         storage::ntp_config ntp_cfg(
-          ntp, log_config.base_dir, nullptr, storage::ntp_config::ntp_id(2));
+          ntp, log_config.base_dir, nullptr, model::revision_id(2));
         builder | start(std::move(ntp_cfg)) | add_segment(model::offset(0))
           | add_random_batch(model::offset(0), 10, maybe_compress_batches::yes)
           | stop();

--- a/src/v/kafka/tests/list_offsets_test.cc
+++ b/src/v/kafka/tests/list_offsets_test.cc
@@ -22,7 +22,7 @@ using namespace std::chrono_literals;
 FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
     wait_for_controller_leadership().get0();
     auto query_ts = model::timestamp::now();
-    auto ntp = make_data(storage::ntp_config::ntp_id(2));
+    auto ntp = make_data(model::revision_id(2));
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(
@@ -65,7 +65,7 @@ FIXTURE_TEST(list_offsets, redpanda_thread_fixture) {
 
 FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
     wait_for_controller_leadership().get0();
-    auto ntp = make_data(storage::ntp_config::ntp_id(2));
+    auto ntp = make_data(model::revision_id(2));
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(
@@ -100,7 +100,7 @@ FIXTURE_TEST(list_offsets_earliest, redpanda_thread_fixture) {
 
 FIXTURE_TEST(list_offsets_latest, redpanda_thread_fixture) {
     wait_for_controller_leadership().get0();
-    auto ntp = make_data(storage::ntp_config::ntp_id(2));
+    auto ntp = make_data(model::revision_id(2));
     auto shard = app.shard_table.local().shard_for(ntp);
     tests::cooperative_spin_wait_with_timeout(10s, [this, shard, ntp = ntp] {
         return app.partition_manager.invoke_on(

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -29,7 +29,11 @@
 
 namespace model {
 using node_id = named_type<int32_t, struct node_id_model_type>;
-
+/**
+ * We use revision_id to identify entities evolution in time. f.e. NTP that was
+ * first created and then removed, raft configuration
+ */
+using revision_id = named_type<int64_t, struct revision_id_model_type>;
 struct broker_properties {
     uint32_t cores;
     uint32_t available_memory;

--- a/src/v/pandaproxy/client/test/fetch.cc
+++ b/src/v/pandaproxy/client/test/fetch.cc
@@ -54,7 +54,7 @@ FIXTURE_TEST(pandaproxy_fetch, ppc_test_fixture) {
     }
 
     info("Adding known topic");
-    auto ntp = make_data(storage::ntp_config::ntp_id(2));
+    auto ntp = make_data(model::revision_id(2));
     auto shard = app.shard_table.local().shard_for(ntp);
     {
         info("Waiting for topic leader");

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -150,7 +150,7 @@ public:
           });
     }
 
-    model::ntp make_data(storage::ntp_config::ntp_id version) {
+    model::ntp make_data(model::revision_id rev) {
         auto topic_name = fmt::format("my_topic_{}", 0);
         model::ntp ntp(
           cluster::kafka_namespace,
@@ -158,7 +158,7 @@ public:
           model::partition_id(0));
 
         storage::ntp_config ntp_cfg(
-          ntp, lconf().data_directory().as_sstring(), nullptr, version);
+          ntp, lconf().data_directory().as_sstring(), nullptr, rev);
 
         storage::disk_log_builder builder(make_default_config());
         using namespace storage; // NOLINT

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "tristate.h"
 
 #include <seastar/core/sstring.hh>
@@ -20,7 +21,6 @@
 namespace storage {
 class ntp_config {
 public:
-    using ntp_id = named_type<int64_t, struct ntp_id_tag>;
     struct default_overrides {
         // if not set use the log_manager's configuration
         std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -46,20 +46,25 @@ public:
       ss::sstring base_dir,
       std::unique_ptr<default_overrides> overrides) noexcept
       : ntp_config(
-        std::move(n), std::move(base_dir), std::move(overrides), ntp_id(0)) {}
+        std::move(n),
+        std::move(base_dir),
+        std::move(overrides),
+        model::revision_id(0)) {}
 
     ntp_config(
       model::ntp n,
       ss::sstring base_dir,
       std::unique_ptr<default_overrides> overrides,
-      ntp_id id) noexcept
+      model::revision_id id) noexcept
       : _ntp(std::move(n))
       , _base_dir(std::move(base_dir))
       , _overrides(std::move(overrides))
-      , _ntp_id(id) {}
+      , _revision_id(id) {}
 
     const model::ntp& ntp() const { return _ntp; }
     model::ntp& ntp() { return _ntp; }
+
+    model::revision_id get_revision() const { return _revision_id; }
 
     const ss::sstring& base_directory() const { return _base_dir; }
     ss::sstring& base_directory() { return _base_dir; }
@@ -90,7 +95,7 @@ public:
     }
 
     ss::sstring work_directory() const {
-        return fmt::format("{}/{}_{}", _base_dir, _ntp.path(), _ntp_id);
+        return fmt::format("{}/{}_{}", _base_dir, _ntp.path(), _revision_id);
     }
 
     std::filesystem::path topic_directory() const {
@@ -110,7 +115,7 @@ private:
      * A number indicating an id of the NTP in case it was created more
      * than once (i.e. created, deleted and then created again)
      */
-    ntp_id _ntp_id{0};
+    model::revision_id _revision_id{0};
 
     // in storage/types.cc
     friend std::ostream& operator<<(std::ostream&, const ntp_config&);


### PR DESCRIPTION
This patch series simplifies handling of NTP deltas in controller. Previously we had delta that could contain multiple NTP information. Changed this to have exactly one delta per NTP. This enables compaction of NTP deltas while being processed by the controller backend. Also each NTP can be processed in parallel by controller backend.

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
