### PR TITLE
add sasl-related kafka request handling with default behavior

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -22,6 +22,7 @@ set(request_srcs
   requests/alter_configs_request.cc
   requests/describe_groups_request.cc
   requests/sasl_handshake_request.cc
+  requests/sasl_authenticate_request.cc
   requests/topics/types.cc
   requests/topics/topic_utils.cc)
 

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -21,6 +21,7 @@ set(request_srcs
   requests/delete_topics_request.cc
   requests/alter_configs_request.cc
   requests/describe_groups_request.cc
+  requests/sasl_handshake_request.cc
   requests/topics/types.cc
   requests/topics/topic_utils.cc)
 

--- a/src/v/kafka/requests/api_versions_request.cc
+++ b/src/v/kafka/requests/api_versions_request.cc
@@ -29,6 +29,7 @@
 #include "kafka/requests/requests.h"
 #include "kafka/requests/response.h"
 #include "kafka/requests/response_writer.h"
+#include "kafka/requests/sasl_authenticate_request.h"
 #include "kafka/requests/sasl_handshake_request.h"
 #include "kafka/requests/sync_group_request.h"
 
@@ -65,7 +66,8 @@ using request_types = make_request_types<
   alter_configs_api,
   delete_topics_api,
   describe_groups_api,
-  sasl_handshake_api>;
+  sasl_handshake_api,
+  sasl_authenticate_api>;
 
 template<typename RequestType>
 static auto make_api() {

--- a/src/v/kafka/requests/api_versions_request.cc
+++ b/src/v/kafka/requests/api_versions_request.cc
@@ -29,6 +29,7 @@
 #include "kafka/requests/requests.h"
 #include "kafka/requests/response.h"
 #include "kafka/requests/response_writer.h"
+#include "kafka/requests/sasl_handshake_request.h"
 #include "kafka/requests/sync_group_request.h"
 
 namespace kafka {
@@ -63,7 +64,8 @@ using request_types = make_request_types<
   describe_configs_api,
   alter_configs_api,
   delete_topics_api,
-  describe_groups_api>;
+  describe_groups_api,
+  sasl_handshake_api>;
 
 template<typename RequestType>
 static auto make_api() {

--- a/src/v/kafka/requests/find_coordinator_request.h
+++ b/src/v/kafka/requests/find_coordinator_request.h
@@ -96,7 +96,7 @@ struct find_coordinator_response final {
     }
 };
 
-static inline std::ostream&
+inline std::ostream&
 operator<<(std::ostream& os, const find_coordinator_response& r) {
     return os << r.data;
 }

--- a/src/v/kafka/requests/requests.cc
+++ b/src/v/kafka/requests/requests.cc
@@ -27,6 +27,7 @@
 #include "kafka/requests/offset_fetch_request.h"
 #include "kafka/requests/produce_request.h"
 #include "kafka/requests/request_context.h"
+#include "kafka/requests/sasl_handshake_request.h"
 #include "kafka/requests/sync_group_request.h"
 #include "utils/to_string.h"
 #include "vlog.h"
@@ -126,6 +127,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<delete_topics_api>(std::move(ctx), g);
     case describe_groups_api::key:
         return do_process<describe_groups_api>(std::move(ctx), g);
+    case sasl_handshake_api::key:
+        return do_process<sasl_handshake_api>(std::move(ctx), g);
     };
     return ss::make_exception_future<response_ptr>(
       std::runtime_error(fmt::format("Unsupported API {}", ctx.header().key)));

--- a/src/v/kafka/requests/requests.cc
+++ b/src/v/kafka/requests/requests.cc
@@ -27,6 +27,7 @@
 #include "kafka/requests/offset_fetch_request.h"
 #include "kafka/requests/produce_request.h"
 #include "kafka/requests/request_context.h"
+#include "kafka/requests/sasl_authenticate_request.h"
 #include "kafka/requests/sasl_handshake_request.h"
 #include "kafka/requests/sync_group_request.h"
 #include "utils/to_string.h"
@@ -129,6 +130,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<describe_groups_api>(std::move(ctx), g);
     case sasl_handshake_api::key:
         return do_process<sasl_handshake_api>(std::move(ctx), g);
+    case sasl_authenticate_api::key:
+        return do_process<sasl_authenticate_api>(std::move(ctx), g);
     };
     return ss::make_exception_future<response_ptr>(
       std::runtime_error(fmt::format("Unsupported API {}", ctx.header().key)));

--- a/src/v/kafka/requests/sasl_authenticate_request.cc
+++ b/src/v/kafka/requests/sasl_authenticate_request.cc
@@ -1,0 +1,25 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/requests/sasl_authenticate_request.h"
+
+#include "kafka/errors.h"
+
+namespace kafka {
+
+ss::future<response_ptr> sasl_authenticate_api::process(
+  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+    sasl_authenticate_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    return ctx.respond(sasl_authenticate_response(
+      error_code::illegal_sasl_state,
+      "SASL authenticate request received after successful authentication"));
+}
+
+} // namespace kafka

--- a/src/v/kafka/requests/sasl_authenticate_request.h
+++ b/src/v/kafka/requests/sasl_authenticate_request.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "kafka/requests/request_context.h"
+#include "kafka/requests/response.h"
+#include "kafka/requests/schemata/sasl_authenticate_request.h"
+#include "kafka/requests/schemata/sasl_authenticate_response.h"
+#include "kafka/types.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+namespace kafka {
+
+struct sasl_authenticate_response;
+
+class sasl_authenticate_api final {
+public:
+    using response_type = sasl_authenticate_response;
+
+    static constexpr const char* name = "sasl authenticate";
+    static constexpr api_key key = api_key(36);
+    static constexpr api_version min_supported = api_version(0);
+    static constexpr api_version max_supported = api_version(1);
+
+    static ss::future<response_ptr>
+    process(request_context&&, ss::smp_service_group);
+};
+
+struct sasl_authenticate_request final {
+    using api_type = sasl_authenticate_api;
+
+    sasl_authenticate_request_data data;
+
+    sasl_authenticate_request() = default;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const sasl_authenticate_request& r) {
+    return os << r.data;
+}
+
+struct sasl_authenticate_response final {
+    using api_type = sasl_authenticate_api;
+
+    sasl_authenticate_response_data data;
+
+    explicit sasl_authenticate_response(
+      error_code error, ss::sstring error_msg) {
+        data.error_code = error;
+        data.error_message = std::move(error_msg);
+    }
+
+    void encode(const request_context& ctx, response& resp) {
+        data.encode(resp.writer(), ctx.header().version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const sasl_authenticate_response& r) {
+    return os << r.data;
+}
+
+} // namespace kafka

--- a/src/v/kafka/requests/sasl_handshake_request.cc
+++ b/src/v/kafka/requests/sasl_handshake_request.cc
@@ -1,0 +1,23 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/requests/sasl_handshake_request.h"
+
+#include "kafka/errors.h"
+
+namespace kafka {
+
+ss::future<response_ptr> sasl_handshake_api::process(
+  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+    sasl_handshake_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    return ctx.respond(sasl_handshake_response(error_code::illegal_sasl_state));
+}
+
+} // namespace kafka

--- a/src/v/kafka/requests/sasl_handshake_request.h
+++ b/src/v/kafka/requests/sasl_handshake_request.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "kafka/requests/request_context.h"
+#include "kafka/requests/response.h"
+#include "kafka/requests/schemata/sasl_handshake_request.h"
+#include "kafka/requests/schemata/sasl_handshake_response.h"
+#include "kafka/types.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+namespace kafka {
+
+struct sasl_handshake_response;
+
+class sasl_handshake_api final {
+public:
+    using response_type = sasl_handshake_response;
+
+    static constexpr const char* name = "sasl handshake";
+    static constexpr api_key key = api_key(17);
+    static constexpr api_version min_supported = api_version(1);
+    static constexpr api_version max_supported = api_version(1);
+
+    static ss::future<response_ptr>
+    process(request_context&&, ss::smp_service_group);
+};
+
+struct sasl_handshake_request final {
+    using api_type = sasl_handshake_api;
+
+    sasl_handshake_request_data data;
+
+    sasl_handshake_request() = default;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const sasl_handshake_request& r) {
+    return os << r.data;
+}
+
+struct sasl_handshake_response final {
+    using api_type = sasl_handshake_api;
+
+    sasl_handshake_response_data data;
+
+    explicit sasl_handshake_response(error_code error) {
+        data.error_code = error;
+    }
+
+    void encode(const request_context& ctx, response& resp) {
+        data.encode(resp.writer(), ctx.header().version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const sasl_handshake_response& r) {
+    return os << r.data;
+}
+
+} // namespace kafka

--- a/src/v/kafka/requests/schemata/CMakeLists.txt
+++ b/src/v/kafka/requests/schemata/CMakeLists.txt
@@ -30,7 +30,9 @@ set(schemata
   describe_groups_request.json
   describe_groups_response.json
   create_topics_request.json
-  create_topics_response.json)
+  create_topics_response.json
+  sasl_handshake_request.json
+  sasl_handshake_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/requests/schemata/CMakeLists.txt
+++ b/src/v/kafka/requests/schemata/CMakeLists.txt
@@ -32,7 +32,9 @@ set(schemata
   create_topics_request.json
   create_topics_response.json
   sasl_handshake_request.json
-  sasl_handshake_response.json)
+  sasl_handshake_response.json
+  sasl_authenticate_request.json
+  sasl_authenticate_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/requests/schemata/generator.py
+++ b/src/v/kafka/requests/schemata/generator.py
@@ -706,12 +706,12 @@ writer.write({{ fname }});
 namespace kafka {
 
 {%- if struct.fields %}
-void {{ struct.name }}::encode(response_writer& writer, api_version version) {
+void {{ struct.name }}::encode(response_writer& writer, [[maybe_unused]] api_version version) {
 {{- struct_serde(struct, field_encoder) | indent }}
 }
 
 {%- if op_type == "request" %}
-void {{ struct.name }}::decode(request_reader& reader, api_version version) {
+void {{ struct.name }}::decode(request_reader& reader, [[maybe_unused]] api_version version) {
 {{- struct_serde(struct, field_decoder) | indent }}
 }
 {%- else %}

--- a/src/v/kafka/requests/schemata/sasl_authenticate_request.json
+++ b/src/v/kafka/requests/schemata/sasl_authenticate_request.json
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 36,
+  "type": "request",
+  "name": "SaslAuthenticateRequest",
+  // Version 1 is the same as version 0.
+  "validVersions": "0-1",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "AuthBytes", "type": "bytes", "versions": "0+",
+      "about": "The SASL authentication bytes from the client, as defined by the SASL mechanism." }
+  ]
+}

--- a/src/v/kafka/requests/schemata/sasl_authenticate_response.json
+++ b/src/v/kafka/requests/schemata/sasl_authenticate_response.json
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 36,
+  "type": "response",
+  "name": "SaslAuthenticateResponse",
+  // Version 1 adds the session lifetime.
+  "validVersions": "0-1",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The error message, or null if there was no error." },
+    { "name": "AuthBytes", "type": "bytes", "versions": "0+",
+      "about": "The SASL authentication bytes from the server, as defined by the SASL mechanism." },
+    { "name": "SessionLifetimeMs", "type": "int64", "versions": "1+", "default": "0",
+      "about": "The SASL authentication bytes from the server, as defined by the SASL mechanism." }
+  ]
+}

--- a/src/v/kafka/requests/schemata/sasl_handshake_request.json
+++ b/src/v/kafka/requests/schemata/sasl_handshake_request.json
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 17,
+  "type": "request",
+  "name": "SaslHandshakeRequest",
+  // Version 1 supports SASL_AUTHENTICATE.
+  "validVersions": "0-1",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "Mechanism", "type": "string", "versions": "0+",
+      "about": "The SASL mechanism chosen by the client." }
+  ]
+}

--- a/src/v/kafka/requests/schemata/sasl_handshake_response.json
+++ b/src/v/kafka/requests/schemata/sasl_handshake_response.json
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 17,
+  "type": "response",
+  "name": "SaslHandshakeResponse",
+  // Version 1 is the same as version 0.
+  "validVersions": "0-1",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "Mechanisms", "type": "[]string", "versions": "0+",
+      "about": "The mechanisms enabled in the server." }
+  ]
+}


### PR DESCRIPTION
Adds SASL handlers with default behavior which will be used to authenticate clients for ACL.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
