### PR TITLE
coproc: modify readActiveCoprocessor -> readCoprocessorFolder

### DIFF
--- a/src/js/test/rpc/server.test.ts
+++ b/src/js/test/rpc/server.test.ts
@@ -28,7 +28,11 @@ let client: SupervisorClient;
 let manageServer: ManagementServer;
 
 const createStubs = (sandbox: SinonSandbox) => {
-  sandbox.stub(FileManager.prototype, "readActiveCoprocessor");
+  const readCoprocessorFolder = sandbox.stub(
+    FileManager.prototype,
+    "readCoprocessorFolder"
+  );
+  readCoprocessorFolder.returns(Promise.resolve());
   sandbox.stub(FileManager.prototype, "updateRepositoryOnNewFile");
   sandbox.stub(INotifyWait.prototype);
   const spyFireExceptionServer = sandbox.stub(


### PR DESCRIPTION
Add folder attribute to readCoprocessorFolder, which makes it
possible to define from which folder it reads the coprocessor
definition. Also use this function to read the submit folder
after reading the active folder.
