### PR TITLE
coproc: capture copy from local binding

### DIFF
--- a/src/v/coproc/tests/router_test_fixture.cc
+++ b/src/v/coproc/tests/router_test_fixture.cc
@@ -31,7 +31,7 @@ void router_test_fixture::validate_result(
     for (const auto& ack : reply.acks) {
         const auto& [sid, topic_acks] = ack;
         const auto found = std::find_if(
-          layout.cbegin(), layout.cend(), [&](const auto& data_e) {
+          layout.cbegin(), layout.cend(), [sid = sid](const auto& data_e) {
               return data_e.id == sid;
           });
         vassert(found != layout.end(), "Missing script id: {}", sid);


### PR DESCRIPTION
lambda captures variables, but local bindings are not names of
variables, so make a copy to fix gcc error.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
