### PR TITLE
Sign rpk for macOS on release

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -65,10 +65,56 @@ jobs:
         name: rpk-archives
         path: |
           src/go/rpk/rpk-*.zip
+  
+  sign-darwin:
+    name: Sign and notarize the darwin release_name
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/release-')
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download zip
+        uses: actions/download-artifact@v2
+        with:
+          name: rpk-archives
+          path: zip/
+
+      - name: Unzip darwin build
+        working-directory: zip/
+        run: |
+          unzip rpk-darwin-amd64.zip
+          rm rpk-darwin-amd64.zip
+
+      - name: Import Code-Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v1
+        with:
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+
+      - name: Install gon via HomeBrew for code signing and app notarization
+        run: |
+          brew tap mitchellh/gon
+          brew install mitchellh/gon/gon
+
+      - name: Sign the mac binaries with Gon
+        working-directory: zip/
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+        run: |
+          gon -log-level=info ../src/go/rpk/gon.json
+      
+      - name: Upload signed Package
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpk-archives
+          path: zip/rpk-darwin-amd64.zip
 
   create-release:
     name: Create release
-    needs: build
+    needs: [build, sign-darwin]
     if: startsWith(github.ref, 'refs/tags/release-')
     runs-on: ubuntu-latest
     steps:

--- a/src/go/rpk/gon.json
+++ b/src/go/rpk/gon.json
@@ -1,0 +1,10 @@
+{
+    "source" : ["./rpk"],
+    "bundle_id" : "io.vectorized.redpanda",
+    "sign" :{
+        "application_identity" : "Developer ID Application: Vectorized, Inc."
+    },
+    "zip" :{
+        "output_path" : "rpk-darwin-amd64.zip"
+    }
+}


### PR DESCRIPTION
When making a release, for the macOS binary use gon to sign the package
and get it notarized.

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
