### PR TITLE
validate response codes on enable and disable coprocessor

### DIFF
--- a/src/js/modules/supervisors/FileManager.ts
+++ b/src/js/modules/supervisors/FileManager.ts
@@ -18,6 +18,10 @@ import { Coprocessor, PolicyInjection } from "../public/Coprocessor";
 import { Script_ManagerClient as ManagementClient } from "../rpc/serverAndClients/server";
 import * as path from "path";
 import { hash64 } from "xxhash";
+import {
+  validateDisableResponseCode,
+  validateEnableResponseCode,
+} from "./HandleError";
 
 /**
  * FileManager class is an inotify implementation, it receives a
@@ -157,33 +161,17 @@ class FileManager {
    *
    * Possible coprocessor statuses:
    *   0 = success
-   *   1 = topic never enabled
-   *   2 = invalid coprocessor
-   *   3 = materialized coprocessor
-   *   4 = internal error
-   * @param coprocessor
-   * @param validateNeverEnabled
+   *   1 = internal error
+   *   2 = script doesn't exist
+   * @param coprocessors
    */
-  disableCoprocessors(
-    coprocessor: Coprocessor[],
-    validateNeverEnabled = true
-  ): Promise<void> {
+  disableCoprocessors(coprocessors: Coprocessor[]): Promise<void> {
     return this.managementClient
-      .disable_copros({ inputs: coprocessor.map((coproc) => coproc.globalId) })
-      .then((disableResponse) => {
-        const isValid = (condition: (n: number) => boolean) =>
-          disableResponse.inputs.find(condition);
-        const condition = validateNeverEnabled
-          ? (coproc) => coproc > 0
-          : (coproc) => coproc > 1;
-        const invalidCoprocessor = isValid(condition);
-        if (invalidCoprocessor > 0) {
-          return Promise.reject(
-            new Error(
-              "Is not possible to disable coprocessors with ids: " +
-                invalidCoprocessor
-            )
-          );
+      .disable_copros({ inputs: coprocessors.map((coproc) => coproc.globalId) })
+      .then((response) => {
+        const errors = validateDisableResponseCode(response, coprocessors);
+        if (errors.length > 0) {
+          return Promise.reject(errors);
         } else {
           return Promise.resolve();
         }
@@ -197,18 +185,15 @@ class FileManager {
    *
    * Possible topic statuses:
    *   0 = success
-   *   1 = topic already enabled
-   *   2 = topic does not exist
-   *   3 = invalid coprocessor
-   *   4 = materialized coprocessor
-   *   5 = internal error
+   *   1 = internal error
+   *   2 = invalid ingestion policy
+   *   3 = script id already exist
+   *   4 = topic doesn't exist
+   *   5 = invalid topic
+   *   6 = materialized topic
    * @param coprocessors
-   * @param validateAlreadyEnabled
    */
-  enableCoprocessor(
-    coprocessors: Coprocessor[],
-    validateAlreadyEnabled = false
-  ): Promise<void> {
+  enableCoprocessor(coprocessors: Coprocessor[]): Promise<void> {
     if (coprocessors.length == 0) {
       return Promise.resolve();
     } else {
@@ -223,21 +208,9 @@ class FileManager {
           })),
         })
         .then((enableResponse) => {
-          const isValid = (condition: (n: number) => boolean) =>
-            enableResponse.inputs.filter((coprocessorStatus) =>
-              coprocessorStatus.response.find(condition)
-            );
-          const condition = validateAlreadyEnabled
-            ? (coproc) => coproc > 0
-            : (coproc) => coproc > 2;
-          const invalidCoprocessor = isValid(condition);
-          if (invalidCoprocessor.length > 0) {
-            return Promise.reject(
-              new Error(
-                `Is not possible to enable coprocessors with ids:` +
-                  invalidCoprocessor.join(", ")
-              )
-            );
+          const errors = validateEnableResponseCode(enableResponse);
+          if (errors.find((errors) => errors.length > 0)) {
+            return Promise.reject(errors.flat());
           } else {
             return Promise.resolve();
           }

--- a/src/js/modules/supervisors/HandleError.ts
+++ b/src/js/modules/supervisors/HandleError.ts
@@ -1,0 +1,90 @@
+import {
+  DisableCoprosReply,
+  EnableCoprosReply,
+} from "../domain/generatedRpc/enableDisableCoprocClasses";
+import { Coprocessor } from "../public/Coprocessor";
+
+export enum EnableResponseCode {
+  success,
+  internalError,
+  invalidIngestionPolicy,
+  scriptIdAlreadyExist,
+  topicDoesNotExist,
+  invalidTopic,
+  materializedTopic,
+}
+
+export enum DisableResponseCode {
+  success,
+  internalError,
+  scriptDoesNotExist,
+}
+
+export const validateDisableResponseCode = (
+  responses: DisableCoprosReply,
+  coprocessor: Coprocessor[]
+): Error[] => {
+  return responses.inputs.reduceRight<Error[]>((errors, code, index) => {
+    switch (code) {
+      case DisableResponseCode.internalError: {
+        errors.push(
+          new Error(
+            `internal error: wasm function ID: ${coprocessor[index].globalId}`
+          )
+        );
+        break;
+      }
+      case DisableResponseCode.scriptDoesNotExist: {
+        errors.push(
+          new Error(
+            `error: script with ID ${coprocessor[index].globalId}` +
+              "doesn't exist."
+          )
+        );
+      }
+    }
+    return errors;
+  }, []);
+};
+
+export const validateEnableResponseCode = (
+  responses: EnableCoprosReply
+): Error[][] => {
+  return responses.inputs.map((response) => {
+    const { id, response: codes } = response;
+    return codes.reduceRight<Error[]>((errors, code) => {
+      switch (code) {
+        case EnableResponseCode.internalError: {
+          errors.push(new Error(`internal error: wasm id function: ${id}`));
+          break;
+        }
+        case EnableResponseCode.invalidIngestionPolicy: {
+          errors.push(new Error(`error: invalid ingestion policy`));
+          break;
+        }
+        case EnableResponseCode.invalidTopic: {
+          errors.push(new Error(`error: invalid topic`));
+          break;
+        }
+        case EnableResponseCode.topicDoesNotExist: {
+          errors.push(new Error(`error: invalid doesn't exist`));
+          break;
+        }
+        case EnableResponseCode.scriptIdAlreadyExist: {
+          errors.push(new Error(`error: wasm function already register`));
+          break;
+        }
+        case EnableResponseCode.materializedTopic: {
+          errors.push(new Error(`error: materialized topic`));
+          break;
+        }
+        case EnableResponseCode.success: {
+          break;
+        }
+        default:
+          break;
+      }
+      return errors;
+    }, []);
+  });
+};

--- a/src/js/test/supervisors/HandleError.test.ts
+++ b/src/js/test/supervisors/HandleError.test.ts
@@ -1,0 +1,109 @@
+import {
+  DisableResponseCode,
+  EnableResponseCode,
+  validateDisableResponseCode,
+  validateEnableResponseCode,
+} from "../../modules/supervisors/HandleError";
+import * as assert from "assert";
+import { createMockCoprocessor } from "../testUtilities";
+
+describe("handle error enable and disable coprocessor", () => {
+  [
+    {
+      codes: [EnableResponseCode.internalError],
+      errorNumber: 1,
+    },
+    {
+      codes: [EnableResponseCode.materializedTopic],
+      errorNumber: 1,
+    },
+    {
+      codes: [EnableResponseCode.scriptIdAlreadyExist],
+      errorNumber: 1,
+    },
+    {
+      codes: [EnableResponseCode.invalidTopic],
+      errorNumber: 1,
+    },
+    {
+      codes: [EnableResponseCode.invalidIngestionPolicy],
+      errorNumber: 1,
+    },
+    {
+      codes: [EnableResponseCode.topicDoesNotExist],
+      errorNumber: 1,
+    },
+    {
+      codes: [EnableResponseCode.success],
+      errorNumber: 0,
+    },
+    {
+      codes: [
+        EnableResponseCode.topicDoesNotExist,
+        EnableResponseCode.invalidTopic,
+      ],
+      errorNumber: 2,
+    },
+    {
+      codes: [
+        EnableResponseCode.topicDoesNotExist,
+        EnableResponseCode.internalError,
+      ],
+      errorNumber: 2,
+    },
+  ].forEach(({ codes, errorNumber }) => {
+    it(
+      `should validateEnableCodeResponse returns an array with ` +
+        `${errorNumber} errors, when it receives ${codes} enable ` +
+        `response code`,
+      function () {
+        const [errors] = validateEnableResponseCode({
+          inputs: [
+            {
+              id: BigInt(1),
+              response: codes,
+            },
+          ],
+        });
+        assert.ok(errors.length === errorNumber);
+      }
+    );
+  });
+
+  [
+    {
+      codes: [DisableResponseCode.internalError],
+      errorNumber: 1,
+    },
+    {
+      codes: [DisableResponseCode.scriptDoesNotExist],
+      errorNumber: 1,
+    },
+    {
+      codes: [DisableResponseCode.success],
+      errorNumber: 0,
+    },
+    {
+      codes: [
+        DisableResponseCode.internalError,
+        DisableResponseCode.scriptDoesNotExist,
+      ],
+      errorNumber: 2,
+    },
+  ].forEach(({ codes, errorNumber }) => {
+    it(
+      `should validateDisableCodeResponse returns an array with ` +
+        `${errorNumber} errors, when it receives ${codes} disable ` +
+        `response code`,
+      function () {
+        const errors = validateDisableResponseCode(
+          {
+            inputs: codes,
+          },
+          [createMockCoprocessor(BigInt(1)), createMockCoprocessor(BigInt(2))]
+        );
+        assert.ok(errors.length === errorNumber);
+      }
+    );
+  });
+});


### PR DESCRIPTION
add validateDisableResponseCode and validateEnableResponseCode functions, those ones validate the response codes on `enable` and `disable` request, this function is going to find the code different to 0 (success case), and make an array with error messages, those errors depended on the response code like (1) `internal error` or (3) `script doesn't exist`