### PR TITLE
coproc: redefine calculateRecordBatchSize function

### DIFF
--- a/src/js/modules/public/Utils.ts
+++ b/src/js/modules/public/Utils.ts
@@ -133,11 +133,18 @@ export const calculateRecordLength = (record: Record): number => {
   size += varintZigzagSize(BigInt(record.valueLen));
   size += record.value.length;
   size += varintZigzagSize(BigInt(record.headers.length));
-  size += varintZigzagSize(BigInt(size));
   return size;
 };
 
 export const calculateRecordBatchSize = (records: Record[]): number => {
-  // 61 is the header batch bytes size
-  return 61 + records.reduce((p, r) => p + r.length, 0);
+  const headerBytesSize = 57;
+  const arrayBytesSize = 4;
+  return (
+    headerBytesSize +
+    records.reduce(
+      (p, r) => p + r.length + varintZigzagSize(BigInt(r.length)),
+      0
+    ) +
+    arrayBytesSize
+  );
 };

--- a/src/js/test/public/util.test.ts
+++ b/src/js/test/public/util.test.ts
@@ -20,20 +20,30 @@ describe("Public utils functions", function () {
 
   it("should calculateRecordLength", function () {
     const value = Buffer.from("Test");
+    /**
+     * value (4 bytes)
+     * header (1 byte)
+     * key (0 byte)
+     * offsetDelta (1 byte)
+     * timestampDelta (1 byte)
+     * keyLength (1 byte)
+     * attributes (1 byte)
+     * valueLen (1 byte)
+     * Total = 10 bytes
+     */
     const record: Record = {
-      value: value, // 4  |
-      headers: [], // 1  |
-      key: Buffer.from(""), // 0  |
-      offsetDelta: 0, // 1  |
-      timestampDelta: BigInt(0), // 1  |
-      keyLength: 0, // 1  |
-      attributes: 0, // 1  |
-      length: 0, // 1  |
-      valueLen: value.length, // 1 => 11
+      value: value,
+      headers: [],
+      key: Buffer.from(""),
+      offsetDelta: 0,
+      timestampDelta: BigInt(0),
+      keyLength: 0,
+      attributes: 0,
+      valueLen: value.length,
+      length: 0,
     };
-    console.log(record);
     const size = calculateRecordLength(record);
-    assert.strictEqual(size, 11);
+    assert.strictEqual(size, 10);
   });
 
   it("should calculate record batch size", function () {
@@ -46,7 +56,7 @@ describe("Public utils functions", function () {
       timestampDelta: BigInt(0),
       keyLength: 0,
       attributes: 0,
-      length: 11,
+      length: 10,
       valueLen: value.length,
     };
     const size = calculateRecordBatchSize([record]);


### PR DESCRIPTION
before just use 61 + sum(records.size), now we use:
57 for header size
4  for array size
per record in records => (record)=> sum(record.size) + varint(record.lenght)

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
