### PR TITLE
coproc: change wasm.js generated example by rpk wasm generate

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/template/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/template/wasm.go
@@ -9,26 +9,39 @@
 
 package template
 
-const wasmJs = `const { SimpleTransform, PolicyError } = require("@vectorizedio/wasm-api");
+const wasmJs = `const {
+  SimpleTransform,
+  PolicyError,
+} = require("@vectorizedio/wasm-api");
 const transform = new SimpleTransform();
 /* Topics that fire the transform function */
-transform.subscribe([
-  /*\"input topics\"*/
-]);
+transform.subscribe(["produce"]);
 /* The strategy the transform engine will use when handling errors */
 transform.errorHandler(PolicyError.SkipOnFailure);
+/* Auxiliar transform function for records */
+const uppercase = (record) => {
+  const newRecord = {
+    ...record,
+    value: record.value.map((char) => {
+      if (char > 97 && char < 122) {
+        return char - 32;
+      } else {
+        return char;
+      }
+    }),
+  };
+  return newRecord;
+}
 /* Transform function */
 transform.processRecord((recordBatch) => {
-  /* Custom logic */
   const result = new Map();
-  const transformedRecord = recordBatch.map(({ header, records }) => ({
-    header,
-    records: records.map((record) => ({
-      ...record,
-      value: Buffer.from("Change Record"),
-    })),
-  }));
-  result.set("topic", transformedRecord);
+  const transformedRecord = recordBatch.map(({ header, records }) => {
+    return {
+      header,
+      records: records.map(uppercase),
+    };
+  });
+  result.set("result", transformedRecord);
   return result;
 });
 exports["default"] = transform;

--- a/src/go/rpk/pkg/cli/cmd/wasm/template/wasm_test_case.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/template/wasm_test_case.go
@@ -13,16 +13,16 @@ const wasmTestJS = `const transform = require("../src/wasm");
 const { createRecordBatch } = require("@vectorizedio/wasm-api");
 const assert = require("assert");
 
-const record = createRecordBatch();
+const record = createRecordBatch({records: [{value: Buffer.from("test")}]});
 
 describe("transform", () => {
   it("should apply function", function() {
     const result = transform.default.apply(record);
     assert.strictEqual(result.size, 1);
-    assert(result.get("topic"));
+    assert(result.get("result"));
     assert(!result.get("unExpectedTopic"));
-    result.get("topic").records.forEach(record => {
-      assert.strictEqual(record.value, Buffer.from("Changed"))
+    result.get("result").records.forEach(record => {
+      assert.deepStrictEqual(record.value, Buffer.from("TEST"))
     })
   });
 });`


### PR DESCRIPTION
change wasm generated, the new example shows to user a simple case
where it takes a records and transform all letter on uppercase.
Also update the test generated file.

coproc: record => "test" to "TEST"

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
