### PR TITLE
Increasing Gobekli consistency checking accuracy

### DIFF
--- a/src/consistency-testing/chaostest/chaostest/kafka_cluster.py
+++ b/src/consistency-testing/chaostest/chaostest/kafka_cluster.py
@@ -15,7 +15,7 @@ import sys
 import asyncio
 import aiohttp
 
-from gobekli.kvapi import KVNode, RequestTimedout, RequestCanceled
+from gobekli.kvapi import KVNode, RequestTimedout, RequestCanceled, RequestViolated
 from gobekli.logging import m
 import logging
 import jinja2
@@ -355,6 +355,8 @@ class KafkaCluster:
                     m(f"put request to {address} timed out").with_time())
                 pass
             except RequestCanceled:
+                pass
+            except RequestViolated:
                 pass
             await kv.close_aio()
             if is_ok:

--- a/src/consistency-testing/chaostest/chaostest/kvell_cluster.py
+++ b/src/consistency-testing/chaostest/chaostest/kvell_cluster.py
@@ -10,7 +10,7 @@
 from sh import ssh
 import sh
 
-from gobekli.kvapi import KVNode, RequestTimedout, RequestCanceled
+from gobekli.kvapi import KVNode, RequestTimedout, RequestCanceled, RequestViolated
 from gobekli.logging import m
 import logging
 import asyncio
@@ -199,9 +199,10 @@ class KvelldbCluster:
                 await kv.put_aio("test", "value1", "wid1")
                 is_ok = True
             except RequestTimedout:
-                # TODO add logging
                 pass
             except RequestCanceled:
+                pass
+            except RequestViolated:
                 pass
             await kv.close_aio()
             if is_ok:

--- a/src/consistency-testing/chaostest/chaostest/redpanda_cluster.py
+++ b/src/consistency-testing/chaostest/chaostest/redpanda_cluster.py
@@ -16,7 +16,7 @@ import asyncio
 import aiohttp
 import uuid
 
-from gobekli.kvapi import KVNode, RequestTimedout, RequestCanceled
+from gobekli.kvapi import KVNode, RequestTimedout, RequestCanceled, RequestViolated
 from gobekli.logging import m
 import logging
 
@@ -242,9 +242,10 @@ class RedpandaCluster:
                 await kv.put_aio("test", "value1", "wid1")
                 is_ok = True
             except RequestTimedout:
-                # TODO add logging
                 pass
             except RequestCanceled:
+                pass
+            except RequestViolated:
                 pass
             await kv.close_aio()
             if is_ok:

--- a/src/consistency-testing/gobekli/gobekli/chaos/main.py
+++ b/src/consistency-testing/gobekli/gobekli/chaos/main.py
@@ -20,7 +20,6 @@ import traceback
 import pathlib
 from datetime import datetime
 
-from gobekli.kvapi import KVNode
 from gobekli.workloads.symmetrical_mrsw import MRSWWorkload
 from gobekli.logging import (init_logs, m)
 

--- a/src/consistency-testing/gobekli/gobekli/kvapi.py
+++ b/src/consistency-testing/gobekli/gobekli/kvapi.py
@@ -28,6 +28,12 @@ class RequestCanceled(Exception):
     pass
 
 
+class RequestViolated(Exception):
+    def __init__(self, info):
+        self.info = info
+        super().__init__()
+
+
 Record = namedtuple('Record', ['write_id', 'value'])
 Response = namedtuple('Response', ['record', 'metrics'])
 
@@ -78,6 +84,8 @@ class KVNode:
             raise RequestTimedout()
         elif data["status"] == "fail":
             raise RequestCanceled()
+        elif data["status"] == "violation":
+            raise RequestViolated(data["info"])
         else:
             raise Exception(f"Unknown status: {data['status']}")
         return Response(record, data["metrics"])
@@ -125,6 +133,8 @@ class KVNode:
             raise RequestTimedout()
         elif data["status"] == "fail":
             raise RequestCanceled()
+        elif data["status"] == "violation":
+            raise RequestViolated(data["info"])
         else:
             raise Exception(f"Unknown status: {data['status']}")
         return Response(record, data["metrics"])
@@ -173,6 +183,8 @@ class KVNode:
             raise RequestTimedout()
         elif data["status"] == "fail":
             raise RequestCanceled()
+        elif data["status"] == "violation":
+            raise RequestViolated(data["info"])
         else:
             raise Exception(f"Unknown status: {data['status']}")
         return Response(record, data["metrics"])


### PR DESCRIPTION
Consistency validation works only with key/value interface but redpanda and kafka is a log so in order to check consistency we treat it as a tx log and fetch and apply the txes to the in-memory cache. We fetch only the difference between the last cache update and the offset of the currently inserted txes so we may not notice if we start losing the head of the log.
    
This commit adds a background replay of the all log to check that there is no data loss.