### PR TITLE
Gobekli reporting granularity

### DIFF
--- a/src/consistency-testing/chaostest/chaostest/kafka_cluster.py
+++ b/src/consistency-testing/chaostest/chaostest/kafka_cluster.py
@@ -346,7 +346,7 @@ class KafkaCluster:
             host = endpoint["host"]
             port = endpoint["httpport"]
             address = f"{host}:{port}"
-            kv = KVNode(address, address)
+            kv = KVNode(endpoint["idx"], address, address)
             try:
                 await kv.put_aio("test", "value1", "wid1")
                 is_ok = True

--- a/src/consistency-testing/chaostest/chaostest/kvell_cluster.py
+++ b/src/consistency-testing/chaostest/chaostest/kvell_cluster.py
@@ -194,7 +194,7 @@ class KvelldbCluster:
             host = endpoint["host"]
             port = endpoint["httpport"]
             address = f"{host}:{port}"
-            kv = KVNode(address, address)
+            kv = KVNode(endpoint["idx"], address, address)
             try:
                 await kv.put_aio("test", "value1", "wid1")
                 is_ok = True

--- a/src/consistency-testing/chaostest/chaostest/redpanda_cluster.py
+++ b/src/consistency-testing/chaostest/chaostest/redpanda_cluster.py
@@ -237,7 +237,7 @@ class RedpandaCluster:
             host = endpoint["host"]
             port = endpoint["httpport"]
             address = f"{host}:{port}"
-            kv = KVNode(address, address)
+            kv = KVNode(endpoint["idx"], address, address)
             try:
                 await kv.put_aio("test", "value1", "wid1")
                 is_ok = True

--- a/src/consistency-testing/chaostest/example.kafka.comrmw.json
+++ b/src/consistency-testing/chaostest/example.kafka.comrmw.json
@@ -3,17 +3,20 @@
         {
             "host": "427.0.0.1",
             "httpport": 8888,
-            "id": "endpoint0"
+            "id": "endpoint0",
+            "idx": 0
         },
         {
             "host": "427.0.0.2",
             "httpport": 8888,
-            "id": "endpoint1"
+            "id": "endpoint1",
+            "idx": 1
         },
         {
             "host": "427.0.0.3",
             "httpport": 8888,
-            "id": "endpoint2"
+            "id": "endpoint2",
+            "idx": 2
         }
     ],
     "nodes": [

--- a/src/consistency-testing/chaostest/example.kafka.comrmw.json
+++ b/src/consistency-testing/chaostest/example.kafka.comrmw.json
@@ -185,7 +185,7 @@
     "cluster_warmup": 30,
     "exploitation": 60,
     "cooldown": 120,
-    "ss_metrics": [],
+    "ss_metrics": ["send_us", "catchup_us"],
     "cmd_log": "cmd.log",
     "latency_log": "lat.log",
     "availability_log": "1s.log",

--- a/src/consistency-testing/chaostest/example.kafka.mrsw.json
+++ b/src/consistency-testing/chaostest/example.kafka.mrsw.json
@@ -3,17 +3,20 @@
         {
             "host": "427.0.0.1",
             "httpport": 8888,
-            "id": "endpoint0"
+            "id": "endpoint0",
+            "idx": 0
         },
         {
             "host": "427.0.0.2",
             "httpport": 8888,
-            "id": "endpoint1"
+            "id": "endpoint1",
+            "idx": 1
         },
         {
             "host": "427.0.0.3",
             "httpport": 8888,
-            "id": "endpoint2"
+            "id": "endpoint2",
+            "idx": 2
         }
     ],
     "nodes": [

--- a/src/consistency-testing/chaostest/example.kafka.mrsw.json
+++ b/src/consistency-testing/chaostest/example.kafka.mrsw.json
@@ -184,7 +184,7 @@
     "cluster_warmup": 30,
     "exploitation": 60,
     "cooldown": 120,
-    "ss_metrics": [],
+    "ss_metrics": ["send_us", "catchup_us"],
     "cmd_log": "cmd.log",
     "latency_log": "lat.log",
     "availability_log": "1s.log",

--- a/src/consistency-testing/chaostest/example.kvelldb.comrmw.json
+++ b/src/consistency-testing/chaostest/example.kvelldb.comrmw.json
@@ -3,17 +3,20 @@
         {
             "host": "427.0.0.1",
             "httpport": 9092,
-            "id": "node0"
+            "id": "node0",
+            "idx": 0
         },
         {
             "host": "427.0.0.2",
             "httpport": 9092,
-            "id": "node1"
+            "id": "node1",
+            "idx": 1
         },
         {
             "host": "427.0.0.3",
             "httpport": 9092,
-            "id": "node2"
+            "id": "node2",
+            "idx": 2
         }
     ],
     "nodes": [

--- a/src/consistency-testing/chaostest/example.kvelldb.mrsw.json
+++ b/src/consistency-testing/chaostest/example.kvelldb.mrsw.json
@@ -3,17 +3,20 @@
         {
             "host": "427.0.0.1",
             "httpport": 9092,
-            "id": "node0"
+            "id": "node0",
+            "idx": 0
         },
         {
             "host": "427.0.0.2",
             "httpport": 9092,
-            "id": "node1"
+            "id": "node1",
+            "idx": 1
         },
         {
             "host": "427.0.0.3",
             "httpport": 9092,
-            "id": "node2"
+            "id": "node2",
+            "idx": 2
         }
     ],
     "nodes": [

--- a/src/consistency-testing/chaostest/example.redpanda.comrmw.json
+++ b/src/consistency-testing/chaostest/example.redpanda.comrmw.json
@@ -3,17 +3,20 @@
         {
             "host": "427.0.0.1",
             "httpport": 8888,
-            "id": "endpoint0"
+            "id": "endpoint0",
+            "idx": 0
         },
         {
             "host": "427.0.0.2",
             "httpport": 8888,
-            "id": "endpoint1"
+            "id": "endpoint1",
+            "idx": 1
         },
         {
             "host": "427.0.0.3",
             "httpport": 8888,
-            "id": "endpoint2"
+            "id": "endpoint2",
+            "idx": 2
         }
     ],
     "nodes": [

--- a/src/consistency-testing/chaostest/example.redpanda.comrmw.json
+++ b/src/consistency-testing/chaostest/example.redpanda.comrmw.json
@@ -125,7 +125,7 @@
     "cluster_warmup": 30,
     "exploitation": 60,
     "cooldown": 120,
-    "ss_metrics": [],
+    "ss_metrics": ["send_us", "catchup_us"],
     "cmd_log": "cmd.log",
     "latency_log": "lat.log",
     "availability_log": "1s.log",

--- a/src/consistency-testing/chaostest/example.redpanda.mrsw.json
+++ b/src/consistency-testing/chaostest/example.redpanda.mrsw.json
@@ -3,17 +3,20 @@
         {
             "host": "427.0.0.1",
             "httpport": 8888,
-            "id": "endpoint0"
+            "id": "endpoint0",
+            "idx": 0
         },
         {
             "host": "427.0.0.2",
             "httpport": 8888,
-            "id": "endpoint1"
+            "id": "endpoint1",
+            "idx": 1
         },
         {
             "host": "427.0.0.3",
             "httpport": 8888,
-            "id": "endpoint2"
+            "id": "endpoint2",
+            "idx": 2
         }
     ],
     "nodes": [

--- a/src/consistency-testing/chaostest/example.redpanda.mrsw.json
+++ b/src/consistency-testing/chaostest/example.redpanda.mrsw.json
@@ -124,7 +124,7 @@
     "cluster_warmup": 30,
     "exploitation": 60,
     "cooldown": 120,
-    "ss_metrics": [],
+    "ss_metrics": ["send_us", "catchup_us"],
     "cmd_log": "cmd.log",
     "latency_log": "lat.log",
     "availability_log": "1s.log",

--- a/src/consistency-testing/chaostest/test-kafka.py
+++ b/src/consistency-testing/chaostest/test-kafka.py
@@ -21,6 +21,8 @@ import argparse
 import json
 import time
 import sys
+import shutil
+from os import path
 
 chaos_event_log = logging.getLogger("chaos-event")
 chaos_stdout = logging.getLogger("chaos-stdout")
@@ -90,10 +92,17 @@ def workload_factory(config):
         raise Exception("Unknown workload: " + config["workload"]["name"])
 
 
-async def run(config, n, overrides):
+async def run(config_json, n, overrides):
     suite_id = int(time.time())
 
+    with open(config_json, "r") as settings_json:
+        config = json.load(settings_json)
+
     init_output(config, suite_id)
+
+    shutil.copyfile(
+        config_json, path.join(config["output"], str(suite_id),
+                               "settings.json"))
 
     if overrides:
         for overide in overrides:
@@ -125,9 +134,4 @@ parser.add_argument('--repeat', type=int, default=1, required=False)
 
 args = parser.parse_args()
 
-config = None
-
-with open(args.config, "r") as settings_json:
-    config = json.load(settings_json)
-
-asyncio.run(run(config, args.repeat, args.override))
+asyncio.run(run(args.config, args.repeat, args.override))

--- a/src/consistency-testing/chaostest/test-kafka.py
+++ b/src/consistency-testing/chaostest/test-kafka.py
@@ -80,7 +80,7 @@ def workload_factory(config):
         host = endpoint["host"]
         port = endpoint["httpport"]
         address = f"{host}:{port}"
-        nodes.append(KVNode(endpoint["id"], address))
+        nodes.append(KVNode(endpoint["idx"], endpoint["id"], address))
     if config["workload"]["name"] == "mrsw":
         return MRSWWorkload(nodes, config["writers"], config["readers"],
                             config["ss_metrics"])

--- a/src/consistency-testing/chaostest/test-kvelldb.py
+++ b/src/consistency-testing/chaostest/test-kvelldb.py
@@ -19,6 +19,8 @@ import logging
 import asyncio
 import argparse
 import json
+import shutil
+from os import path
 
 chaos_event_log = logging.getLogger("chaos-event")
 chaos_stdout = logging.getLogger("chaos-stdout")
@@ -83,10 +85,17 @@ def workload_factory(config):
         raise Exception("Unknown workload: " + config["workload"]["name"])
 
 
-async def run(config, n, overrides):
+async def run(config_json, n, overrides):
     suite_id = int(time.time())
 
+    with open(config_json, "r") as settings_json:
+        config = json.load(settings_json)
+
     init_output(config, suite_id)
+
+    shutil.copyfile(
+        config_json, path.join(config["output"], str(suite_id),
+                               "settings.json"))
 
     if overrides:
         for overide in overrides:
@@ -118,9 +127,4 @@ parser.add_argument('--repeat', type=int, default=1, required=False)
 
 args = parser.parse_args()
 
-config = None
-
-with open(args.config, "r") as settings_json:
-    config = json.load(settings_json)
-
-asyncio.run(run(config, args.repeat, args.override))
+asyncio.run(run(args.config, args.repeat, args.override))

--- a/src/consistency-testing/chaostest/test-kvelldb.py
+++ b/src/consistency-testing/chaostest/test-kvelldb.py
@@ -73,7 +73,7 @@ def workload_factory(config):
         host = endpoint["host"]
         port = endpoint["httpport"]
         address = f"{host}:{port}"
-        nodes.append(KVNode(endpoint["id"], address))
+        nodes.append(KVNode(endpoint["idx"], endpoint["id"], address))
     if config["workload"]["name"] == "mrsw":
         return MRSWWorkload(nodes, config["writers"], config["readers"],
                             config["ss_metrics"])

--- a/src/consistency-testing/chaostest/test-redpanda.py
+++ b/src/consistency-testing/chaostest/test-redpanda.py
@@ -21,6 +21,8 @@ import argparse
 import json
 import time
 import sys
+import shutil
+from os import path
 
 chaos_event_log = logging.getLogger("chaos-event")
 chaos_stdout = logging.getLogger("chaos-stdout")
@@ -90,10 +92,17 @@ def workload_factory(config):
         raise Exception("Unknown workload: " + config["workload"]["name"])
 
 
-async def run(config, n, overrides):
+async def run(config_json, n, overrides):
     suite_id = int(time.time())
 
+    with open(config_json, "r") as settings_json:
+        config = json.load(settings_json)
+
     init_output(config, suite_id)
+
+    shutil.copyfile(
+        config_json, path.join(config["output"], str(suite_id),
+                               "settings.json"))
 
     if overrides:
         for overide in overrides:
@@ -125,9 +134,4 @@ parser.add_argument('--repeat', type=int, default=1, required=False)
 
 args = parser.parse_args()
 
-config = None
-
-with open(args.config, "r") as settings_json:
-    config = json.load(settings_json)
-
-asyncio.run(run(config, args.repeat, args.override))
+asyncio.run(run(args.config, args.repeat, args.override))

--- a/src/consistency-testing/chaostest/test-redpanda.py
+++ b/src/consistency-testing/chaostest/test-redpanda.py
@@ -80,7 +80,7 @@ def workload_factory(config):
         host = endpoint["host"]
         port = endpoint["httpport"]
         address = f"{host}:{port}"
-        nodes.append(KVNode(endpoint["id"], address))
+        nodes.append(KVNode(endpoint["idx"], endpoint["id"], address))
     if config["workload"]["name"] == "mrsw":
         return MRSWWorkload(nodes, config["writers"], config["readers"],
                             config["ss_metrics"])

--- a/src/consistency-testing/gobekli/bin/gobekli-report
+++ b/src/consistency-testing/gobekli/bin/gobekli-report
@@ -8,8 +8,8 @@ from collections import defaultdict
 from pathlib import Path
 
 from gobekli.logging import m
-from gobekli.chaos.analysis import (make_overview_chart,
-                                    make_latency_chart, make_availability_chart,
+from gobekli.chaos.analysis import (make_overview_chart, make_latency_chart,
+                                    make_pdf_latency_chart, make_availability_chart,
                                     analyze_inject_recover_availability)
 
 from os import path
@@ -163,12 +163,6 @@ EXPERIMENT = """
 <html>
     <head></head>
     <body>
-        <a href="overview.png"><img src="overview.png" width="600"/></a>
-
-        <a href="pdf.latency.png"><img src="pdf.latency.png" width="600"/></a>
-
-        <a href="availability.png"><img src="availability.png" width="600"/></a>
-
         <table class="setup">
             <tr>
                 <td class="label">system</td>
@@ -203,28 +197,65 @@ EXPERIMENT = """
                 <td class="value">{{ max_unavailability }}</td>
             </tr>
         </table>
+
+{% for chart in charts %}
+        <div>
+            <h2>{{ chart.title }}</h2>
+
+            <a href="{{ chart.latency }}"><img src="{{ chart.latency }}" width="600"/></a>
+
+            <a href="{{ chart.pdf_latency }}"><img src="{{ chart.pdf_latency }}" width="600"/></a>
+
+            <a href="{{ chart.availability }}"><img src="{{ chart.availability }}" width="600"/></a>        
+        </div>
+{% endfor %}
     </body>
 </html>
 """
 
-def build_charts(root, results, warmup_s, zoom_us):
+def build_charts(config, root, results, warmup_s, zoom_us):
     for result in results:
         path = os.path.join(root, result["path"])
         make_overview_chart(result["title"], path, result["availability_log"], result["latency_log"], warmup_s)
-        make_availability_chart(result["title"], path, result["availability_log"], result["latency_log"], warmup_s)
-        make_latency_chart(result["title"], path, result["availability_log"], result["latency_log"], warmup_s, zoom_us)
+        make_availability_chart(result["title"], None, path, result["availability_log"], result["latency_log"], warmup_s)
+        for endpoint in config["endpoints"]:
+           make_availability_chart(result["title"], endpoint["idx"], path, result["availability_log"], result["latency_log"], warmup_s)
+        make_pdf_latency_chart(result["title"], None, path, result["availability_log"], result["latency_log"], warmup_s, zoom_us)
+        for endpoint in config["endpoints"]:
+            make_pdf_latency_chart(result["title"], endpoint["idx"], path, result["availability_log"], result["latency_log"], warmup_s, zoom_us)
+        for endpoint in config["endpoints"]:
+            make_latency_chart(result["title"], endpoint["idx"], path, result["availability_log"], result["latency_log"], warmup_s)
         came_from = os.getcwd()
         os.chdir(path)
+        gnuplot("pdf.latency.all.gp")
+        rm("pdf.latency.all.gp")
+        rm("pdf.latency.all.log")
+        for endpoint in config["endpoints"]:
+            idx = endpoint["idx"]
+            gnuplot(f"pdf.latency.{idx}.gp")
+            rm(f"pdf.latency.{idx}.gp")
+            rm(f"pdf.latency.{idx}.log")
+        
+        gnuplot("availability.all.gp")
+        rm("availability.all.gp")
+        rm("availability.all.log")
+        for endpoint in config["endpoints"]:
+            idx = endpoint["idx"]
+            gnuplot(f"availability.{idx}.gp")
+            rm(f"availability.{idx}.gp")
+            rm(f"availability.{idx}.log")
+
+        for endpoint in config["endpoints"]:
+            idx = endpoint["idx"]
+            gnuplot(f"latency.{idx}.gp")
+            rm(f"latency.{idx}.gp")
+            rm(f"latency.{idx}.log")
+
         gnuplot("overview.gp")
         rm("overview.gp")
         rm("overview.lat.log")
         rm("overview.1s.log")
-        gnuplot("pdf.latency.gp")
-        rm("pdf.latency.gp")
-        rm("pdf.latency.log")
-        gnuplot("availability.gp")
-        rm("availability.gp")
-        rm("availability.log")
+
         os.chdir(came_from)
 
 def archive_logs(root, results):
@@ -259,13 +290,31 @@ def archive_failed_cmd_log(root, results):
                 for f in cmd_logs:
                     os.remove(path.join(root, result["path"], f))
 
-def build_experiment_index(context, root, result, warmup, zoom_us):
+
+class ChartSet:
+    def __init__(self, title, latency, pdf_latency, availability):
+        self.title = title
+        self.latency = latency
+        self.pdf_latency = pdf_latency
+        self.availability = availability
+
+def build_experiment_index(context, config, root, result, warmup, zoom_us):
     index_path = os.path.join(root, result["path"], "index.html")
+    
+    charts = [
+        ChartSet("Combined", "overview.png", "pdf.latency.all.png", "availability.all.png")
+    ]
+
+    for endpoint in config["endpoints"]:
+        idx = endpoint["idx"]
+        charts.append(ChartSet(endpoint["id"], f"latency.{idx}.png", f"pdf.latency.{idx}.png", f"availability.{idx}.png"))
+    
     with open(index_path, 'w') as html:
         html.write(jinja2.Template(EXPERIMENT).render(
             system = context["system"],
             workload = context["workload"],
             scenario = context["scenario"],
+            charts = charts,
             fault = result["fault"],
             id = result["id"],
             min_lat = result["stat"]["min_lat"],
@@ -295,6 +344,10 @@ def build_alerts(root, results):
         for result in results:
             if result["status"] == "failed":
                 alerts.write(str(m(type="consistency", message=result["error"], id=result["id"])) + "\n")
+
+def load_config(root):
+    with open(path.join(root, "settings.json")) as config_json:
+        return json.load(config_json)
 
 def build_index(context, title, root, results):
     ava_stat = defaultdict(lambda: [])
@@ -357,13 +410,14 @@ def build_index(context, title, root, results):
 def build_report(results_log, warmup_s, zoom_us):
     root = Path(results_log).parent
     context = load_context(root)
+    config = load_config(root)
     results = list(load_results(context, results_log, warmup_s))   
 
-    build_charts(root, results, warmup_s, zoom_us)
+    build_charts(config, root, results, warmup_s, zoom_us)
     archive_failed_cmd_log(root, results)
     
     for result in results:
-        build_experiment_index(context, root, result, warmup_s, zoom_us)
+        build_experiment_index(context, config, root, result, warmup_s, zoom_us)
     
     build_index(context, results_log, root, results)
     build_alerts(root, results)

--- a/src/consistency-testing/gobekli/bin/gobekli-run
+++ b/src/consistency-testing/gobekli/bin/gobekli-run
@@ -15,7 +15,7 @@ async def mrsw_aio(kvs, writers, readers, duration, ss_metrics, cmd_log, latency
     
     nodes = []
     for i in range(0, len(kvs)):
-        nodes.append(KVNode(kvs[i], kvs[i]))
+        nodes.append(KVNode(i, kvs[i], kvs[i]))
     
     await symmetrical_mrsw.start_mrsw_workload_aio(nodes, writers, readers, duration, ss_metrics)
     
@@ -29,7 +29,7 @@ async def comrmw_aio(kvs, writers, readers, duration, ss_metrics, cmd_log, laten
     
     nodes = []
     for i in range(0, len(kvs)):
-        nodes.append(KVNode(kvs[i], kvs[i]))
+        nodes.append(KVNode(i, kvs[i], kvs[i]))
     
     await symmetrical_comrmw.start_comrsw_workload_aio(nodes, writers, readers, duration, ss_metrics)
     

--- a/src/consistency-testing/gobekli/gobekli/chaos/analysis.py
+++ b/src/consistency-testing/gobekli/gobekli/chaos/analysis.py
@@ -16,37 +16,9 @@ import json
 import jinja2
 from pathlib import Path
 
-ALL = """
-set terminal png size 1600,1200
-set output "{{ data }}.png"
-set multiplot
-
-set lmargin 10
-set rmargin 6
-
-set size 1, 0.5
-set origin 0, 0
-
-set yrange [0:{{ maxunava }}]
-set boxwidth 0.5
-plot "{{ data }}.log" using 2:xtic(1) title "unavailability (us)" with boxes fs solid lt rgb "blue"
-
-set yrange [0:{{ maxlat }}]
-set size 1, 0.5
-set origin 0, 0.5
-unset xtics
-
-set title "{{ title }}"
-show title
-
-plot "{{ data }}.log" using 3:xtic(1) title "latency (us)" with boxes fs solid lt rgb "red"
-
-unset multiplot
-"""
-
 PDF_LATENCY = """
 set terminal png size 1600,1200
-set output "pdf.latency.png"
+set output "pdf.latency.{{ endpoint_idx }}.png"
 set multiplot
 set boxwidth {{ step }}
 has(x) = 1
@@ -64,7 +36,7 @@ set border 11
 set xtics nomirror
 unset ytics
 
-plot "pdf.latency.log" using 1:(has($2)) notitle with boxes fs solid
+plot "pdf.latency.{{ endpoint_idx }}.log" using 1:(has($2)) notitle with boxes fs solid
 
 set parametric
 plot [t=0:1] {{ p99 }},t notitle lt rgb "black"
@@ -80,9 +52,9 @@ set border 15
 unset xtics
 set ytics auto
 
-plot "pdf.latency.log" using 1:2 notitle with boxes
+plot "pdf.latency.{{ endpoint_idx }}.log" using 1:2 notitle with boxes
 
-set title "latency (pdf) - {{ title }}"
+set title "[{{ endpoint_idx }}] latency (pdf) - {{ title }}"
 show title
 
 set parametric
@@ -105,7 +77,7 @@ set xtics ("{{ p99 }}" {{ p99 }}, "{{ xrange }}" {{ xrange }})
 unset ytics
 
 set object 1 rectangle from graph 0, graph 0 to graph 1, graph 1 behind fillcolor rgb 'white' fillstyle solid noborder
-plot "pdf.latency.log" using 1:(has($2)) notitle with boxes fs solid
+plot "pdf.latency.{{ endpoint_idx }}.log" using 1:(has($2)) notitle with boxes fs solid
 unset object 1
 set parametric
 plot [t=0:1] {{ p99 }},t notitle lt rgb "black"
@@ -121,7 +93,7 @@ set ytics auto
 unset xtics
 
 set object 2 rectangle from graph 0, graph 0 to graph 1, graph 1 behind fillcolor rgb 'white' fillstyle solid noborder
-plot "pdf.latency.log" using 1:2 notitle with boxes
+plot "pdf.latency.{{ endpoint_idx }}.log" using 1:2 notitle with boxes
 unset object 2
 set parametric
 plot [t=0:{{ yrange }}] {{ p99 }},t notitle lt rgb "black"
@@ -134,7 +106,7 @@ unset multiplot
 
 AVAILABILITY = """
 set terminal png size 1600,1200
-set output "availability.png"
+set output "availability.{{ endpoint_idx }}.png"
 set multiplot
 
 set xrange [0:{{ xrange }}]
@@ -148,7 +120,7 @@ set parametric
 {% endfor %}{% for recovery in recoveries %}plot [t=0:{{ yrange }}] {{ recovery }},t notitle lt rgb "blue"
 {% endfor %}unset parametric
 
-plot "availability.log" using ($1/1000000):2 title "unavailability (us)" w p ls 7
+plot "availability.{{ endpoint_idx }}.log" using ($1/1000000):2 title "unavailability (us)" w p ls 7
 
 unset multiplot
 """
@@ -221,6 +193,59 @@ set parametric
 {% endfor %}unset parametric
 
 plot 'overview.1s.log' using 1:2 title "ops per 1s" with line lt rgb "black"
+
+unset multiplot
+"""
+
+LATENCY = """
+set terminal png size 1600,1200
+set output "latency.{{ endpoint_idx }}.png"
+set multiplot
+
+set lmargin 6
+set rmargin 10
+
+set xrange [0:{{ xrange }}]
+
+set yrange [0:{{ maxminlat }}]
+set pointsize 0.2
+
+set size 1, 0.3
+set origin 0, 0
+unset ytics
+set y2tics {{ minlatstep }}
+
+set parametric
+{% for fault in faults %}plot [t=0:{{ maxminlat }}] {{ fault }},t notitle lt rgb "red"
+{% endfor %}{% for recovery in recoveries %}plot [t=0:{{ maxminlat }}] {{ recovery }},t notitle lt rgb "blue"
+{% endfor %}unset parametric
+
+plot 'latency.{{ endpoint_idx }}.log' using 1:(strcol(3) eq 'ok' ? $2:1/0) title "latency ok (us)" with points lt rgb "black" pt 7,\
+     'latency.{{ endpoint_idx }}.log' using 1:(strcol(3) eq 'err' ? $2:1/0) title "latency err (us)" with points lt rgb "red" pt 7,\
+     'latency.{{ endpoint_idx }}.log' using 1:(strcol(3) eq 'out' ? $2:1/0) title "latency timeout (us)" with points lt rgb "blue" pt 7
+
+set title "{{ title }}"
+show title
+
+set yrange [0:{{ maxmaxx }}]
+set pointsize 0.2
+
+set size 1, 0.65
+set origin 0, 0.3
+unset ytics
+set y2tics auto
+set tmargin 0
+
+plot {{ maxlat }} notitle with lines lt rgb "red"
+
+set parametric
+{% for fault in faults %}plot [t=0:{{ maxmaxx }}] {{ fault }},t notitle lt rgb "red"
+{% endfor %}{% for recovery in recoveries %}plot [t=0:{{ maxmaxx }}] {{ recovery }},t notitle lt rgb "blue"
+{% endfor %}unset parametric
+
+plot 'latency.{{ endpoint_idx }}.log' using 1:(strcol(3) eq 'ok' ? $2:1/0) title "latency ok (us)" with points lt rgb "black" pt 7,\
+     'latency.{{ endpoint_idx }}.log' using 1:(strcol(3) eq 'err' ? $2:1/0) title "latency err (us)" with points lt rgb "red" pt 7,\
+     'latency.{{ endpoint_idx }}.log' using 1:(strcol(3) eq 'out' ? $2:1/0) title "latency timeout (us)" with points lt rgb "blue" pt 7
 
 unset multiplot
 """
@@ -324,8 +349,8 @@ class ExperimentGroup:
         self.experiments = []
 
 
-def make_latency_chart(title, log_dir, availability_log, latency_log, warmup_s,
-                       zoom_range_us):
+def make_pdf_latency_chart(title, endpoint_idx, log_dir, availability_log,
+                           latency_log, warmup_s, zoom_range_us):
     latency_cut_off_us = warmup_s * 1000000
     latencies = []
 
@@ -335,6 +360,10 @@ def make_latency_chart(title, log_dir, availability_log, latency_log, warmup_s,
                 parts = line.rstrip().split("\t")
                 tick = int(parts[0])
                 latency = int(parts[1])
+                idx = int(parts[3])
+                if endpoint_idx != None:
+                    if endpoint_idx != idx:
+                        continue
                 if tick < latency_cut_off_us:
                     continue
                 latencies.append(latency)
@@ -346,7 +375,11 @@ def make_latency_chart(title, log_dir, availability_log, latency_log, warmup_s,
     maxfreq = 0
     step = 1000  #us
 
-    with open(path.join(log_dir, "pdf.latency.log"), "w") as latency_file:
+    if endpoint_idx == None:
+        endpoint_idx = "all"
+
+    with open(path.join(log_dir, f"pdf.latency.{endpoint_idx}.log"),
+              "w") as latency_file:
         offset = 0
         freq = []
 
@@ -383,7 +416,8 @@ def make_latency_chart(title, log_dir, availability_log, latency_log, warmup_s,
             if i >= len(latencies):
                 break
 
-    with open(path.join(log_dir, "pdf.latency.gp"), "w") as latency_file:
+    with open(path.join(log_dir, f"pdf.latency.{endpoint_idx}.gp"),
+              "w") as latency_file:
         latency_file.write(
             jinja2.Template(PDF_LATENCY).render(xrange=maxlat,
                                                 xzrange=min(
@@ -391,39 +425,48 @@ def make_latency_chart(title, log_dir, availability_log, latency_log, warmup_s,
                                                 yrange=1.2 * maxfreq,
                                                 p99=p99,
                                                 step=step,
-                                                title=title))
+                                                title=title,
+                                                endpoint_idx=endpoint_idx))
 
 
-def make_availability_chart(title, log_dir, availability_log, latency_log,
-                            warmup_s):
+def make_availability_chart(title, endpoint_idx, log_dir, availability_log,
+                            latency_log, warmup_s):
     latency_cut_off_us = warmup_s * 1000000
     availability_cut_off_s = warmup_s
 
     maxx = 0
     maxy = 0
-    faults = []
-    recoveries = []
 
-    with open(path.join(log_dir, "availability.log"),
-              "w") as availability_file:
+    if endpoint_idx == None:
+        ava_log = "availability.all.log"
+    else:
+        ava_log = f"availability.{endpoint_idx}.log"
+
+    with open(path.join(log_dir, ava_log), "w") as availability_file:
         with open(path.join(log_dir, latency_log)) as latency_log_file:
             last = None
             for line in latency_log_file:
                 if "ok" in line:
                     parts = line.rstrip().split("\t")
                     tick = int(parts[0])
+                    idx = int(parts[3])
                     if tick < latency_cut_off_us:
                         continue
                     maxx = max(tick / 1000000, maxx)
                     if last == None:
                         last = int(parts[0])
                         continue
+                    if endpoint_idx != None:
+                        if endpoint_idx != idx:
+                            continue
                     delta = tick - last
                     last = tick
                     maxy = max(maxy, delta)
                     availability_file.write(f"{tick}\t{delta}\n")
 
     maxy = int(1.2 * maxy)
+    faults = []
+    recoveries = []
 
     with open(path.join(log_dir, availability_log)) as availability_log_file:
         for line in availability_log_file:
@@ -435,13 +478,18 @@ def make_availability_chart(title, log_dir, availability_log, latency_log,
                 elif entry["type"] == "recovery":
                     recoveries.append(tick)
 
-    with open(path.join(log_dir, "availability.gp"), "w") as availability_file:
+    if endpoint_idx == None:
+        endpoint_idx = "all"
+
+    with open(path.join(log_dir, f"availability.{endpoint_idx}.gp"),
+              "w") as availability_file:
         availability_file.write(
             jinja2.Template(AVAILABILITY).render(xrange=maxx,
                                                  yrange=maxy,
                                                  faults=faults,
                                                  recoveries=recoveries,
-                                                 title=title))
+                                                 title=title,
+                                                 endpoint_idx=endpoint_idx))
 
 
 def make_overview_chart(title, log_dir, availability_log, latency_log,
@@ -522,3 +570,69 @@ def make_overview_chart(title, log_dir, availability_log, latency_log,
                                              faults=faults,
                                              recoveries=recoveries,
                                              title=title))
+
+
+def make_latency_chart(title, endpoint_idx, log_dir, availability_log,
+                       latency_log, warmup_s):
+    latency_cut_off_us = warmup_s * 1000000
+    availability_cut_off_s = warmup_s
+
+    maxtick = 0
+    maxminlat = 0
+    minlatstep = 0
+    maxmaxx = 0
+    maxlat = 0
+    maxthru = 0
+
+    with open(path.join(log_dir, f"latency.{endpoint_idx}.log"),
+              "w") as chart_lat_file:
+        with open(path.join(log_dir, latency_log)) as latency_log_file:
+            mn = sys.maxsize
+            for line in latency_log_file:
+                parts = line.rstrip().split("\t")
+                tick = int(parts[0])
+                if tick < latency_cut_off_us:
+                    continue
+                tick = int(tick / 1000000)
+                lat = int(parts[1])
+                idx = int(parts[3])
+                if idx != endpoint_idx:
+                    continue
+                maxmaxx = max(maxmaxx, lat)
+                if "ok" in line:
+                    maxtick = max(maxtick, tick)
+                    mn = min(mn, lat)
+                    maxlat = max(maxlat, lat)
+                out = f"{tick}\t{lat}"
+                out += "\t" + parts[2]
+                chart_lat_file.write(out + "\n")
+            maxminlat = mn * 3
+            minlatstep = mn
+            maxmaxx = int(1.2 * maxmaxx)
+
+    faults = []
+    recoveries = []
+
+    with open(path.join(log_dir, availability_log)) as availability_log_file:
+        for line in availability_log_file:
+            entry = json.loads(line)
+            tick = int(int(entry["tick"]) / 1000000)
+            if tick >= availability_cut_off_s:
+                if entry["type"] == "fault":
+                    faults.append(tick)
+                elif entry["type"] == "recovery":
+                    recoveries.append(tick)
+
+    with open(path.join(log_dir, f"latency.{endpoint_idx}.gp"),
+              "w") as overview_file:
+        overview_file.write(
+            jinja2.Template(LATENCY).render(xrange=maxtick,
+                                            maxminlat=maxminlat,
+                                            minlatstep=minlatstep,
+                                            maxmaxx=maxmaxx,
+                                            maxlat=maxlat,
+                                            maxthru=maxthru,
+                                            faults=faults,
+                                            recoveries=recoveries,
+                                            title=title,
+                                            endpoint_idx=endpoint_idx))

--- a/src/consistency-testing/gobekli/gobekli/chaos/analysis.py
+++ b/src/consistency-testing/gobekli/gobekli/chaos/analysis.py
@@ -599,8 +599,8 @@ def make_latency_chart(title, endpoint_idx, log_dir, availability_log,
                 if idx != endpoint_idx:
                     continue
                 maxmaxx = max(maxmaxx, lat)
+                maxtick = max(maxtick, tick)
                 if "ok" in line:
-                    maxtick = max(maxtick, tick)
                     mn = min(mn, lat)
                     maxlat = max(maxlat, lat)
                 out = f"{tick}\t{lat}"

--- a/src/consistency-testing/gobekli/gobekli/kvapi.py
+++ b/src/consistency-testing/gobekli/gobekli/kvapi.py
@@ -39,11 +39,12 @@ Response = namedtuple('Response', ['record', 'metrics'])
 
 
 class KVNode:
-    def __init__(self, name, address):
+    def __init__(self, idx, name, address):
         timeout = aiohttp.ClientTimeout(total=10)
         self.session = aiohttp.ClientSession(timeout=timeout)
         self.address = address
         self.name = name
+        self.idx = idx
 
     async def get_aio(self, key, read_id):
         data = None

--- a/src/consistency-testing/gobekli/gobekli/logging.py
+++ b/src/consistency-testing/gobekli/gobekli/logging.py
@@ -77,8 +77,8 @@ def log_violation(pid, message):
 def log_latency(type, time_s, latency_s, endpoint_idx, metrics=None):
     message = f"{int(time_s*1000*1000)}\t{int(latency_s*1000*1000)}\t{type}\t{endpoint_idx}"
     if metrics != None:
-        for key in latency_metrics:
-            message += "\t"
-            if key in metrics:
+        if all(key in metrics for key in latency_metrics):
+            for key in latency_metrics:
+                message += "\t"
                 message += str(metrics[key])
     latlog.info(message)

--- a/src/consistency-testing/gobekli/gobekli/logging.py
+++ b/src/consistency-testing/gobekli/gobekli/logging.py
@@ -74,8 +74,8 @@ def log_violation(pid, message):
           message=message).with_time())
 
 
-def log_latency(type, time_s, latency_s, metrics=None):
-    message = f"{int(time_s*1000*1000)}\t{int(latency_s*1000*1000)}\t{type}"
+def log_latency(type, time_s, latency_s, endpoint_idx, metrics=None):
+    message = f"{int(time_s*1000*1000)}\t{int(latency_s*1000*1000)}\t{type}\t{endpoint_idx}"
     if metrics != None:
         for key in latency_metrics:
             message += "\t"

--- a/src/consistency-testing/gobekli/gobekli/workloads/common.py
+++ b/src/consistency-testing/gobekli/gobekli/workloads/common.py
@@ -237,7 +237,8 @@ class ReaderClient:
                 read = response.record
                 op_ended = loop.time()
                 log_latency("ok", op_ended - self.started_at,
-                            op_ended - op_started, response.metrics)
+                            op_ended - op_started, self.node.idx,
+                            response.metrics)
                 if read == None:
                     cmdlog.info(
                         m(type="read_404",
@@ -263,7 +264,7 @@ class ReaderClient:
                 try:
                     op_ended = loop.time()
                     log_latency("out", op_ended - self.started_at,
-                                op_ended - op_started)
+                                op_ended - op_started, self.node.idx)
                     self.stat.inc(self.node.name + ":out")
                     cmdlog.info(
                         m(type="read_timedout",
@@ -288,7 +289,7 @@ class ReaderClient:
                 try:
                     op_ended = loop.time()
                     log_latency("err", op_ended - self.started_at,
-                                op_ended - op_started)
+                                op_ended - op_started, self.node.idx)
                     self.stat.inc(self.node.name + ".err")
                     cmdlog.info(
                         m(type="read_canceled",

--- a/src/consistency-testing/gobekli/gobekli/workloads/symmetrical_comrmw.py
+++ b/src/consistency-testing/gobekli/gobekli/workloads/symmetrical_comrmw.py
@@ -65,7 +65,7 @@ class MWClient:
             data = response.record
             op_ended = loop.time()
             log_latency("ok", op_ended - self.started_at,
-                        op_ended - op_started, response.metrics)
+                        op_ended - op_started, self.node.idx, response.metrics)
             cmdlog.info(
                 m(type="write_ended",
                   node=self.node.name,
@@ -93,7 +93,7 @@ class MWClient:
                 self.stat.inc(self.node.name + ":out")
                 op_ended = loop.time()
                 log_latency("out", op_ended - self.started_at,
-                            op_ended - op_started)
+                            op_ended - op_started, self.node.idx)
                 cmdlog.info(
                     m(type="write_timedout",
                       node=self.node.name,
@@ -114,7 +114,7 @@ class MWClient:
                 self.stat.inc(self.node.name + ":err")
                 op_ended = loop.time()
                 log_latency("err", op_ended - self.started_at,
-                            op_ended - op_started)
+                            op_ended - op_started, self.node.idx)
                 cmdlog.info(
                     m(type="write_canceled",
                       node=self.node.name,
@@ -185,7 +185,7 @@ class MRClient:
             read = response.record
             op_ended = loop.time()
             log_latency("ok", op_ended - self.started_at,
-                        op_ended - op_started, response.metrics)
+                        op_ended - op_started, self.node.idx, response.metrics)
             if read == None:
                 cmdlog.info(
                     m(type="read_404",
@@ -209,7 +209,7 @@ class MRClient:
             try:
                 op_ended = loop.time()
                 log_latency("out", op_ended - self.started_at,
-                            op_ended - op_started)
+                            op_ended - op_started, self.node.idx)
                 self.stat.inc(self.node.name + ":out")
                 cmdlog.info(
                     m(type="read_timedout",
@@ -229,7 +229,7 @@ class MRClient:
             try:
                 op_ended = loop.time()
                 log_latency("err", op_ended - self.started_at,
-                            op_ended - op_started)
+                            op_ended - op_started, self.node.idx)
                 self.stat.inc(self.node.name + ".err")
                 cmdlog.info(
                     m(type="read_canceled",

--- a/src/consistency-testing/gobekli/gobekli/workloads/symmetrical_mrsw.py
+++ b/src/consistency-testing/gobekli/gobekli/workloads/symmetrical_mrsw.py
@@ -68,7 +68,8 @@ class WriterClient:
                 data = response.record
                 op_ended = loop.time()
                 log_latency("ok", op_ended - self.started_at,
-                            op_ended - op_started, response.metrics)
+                            op_ended - op_started, self.node.idx,
+                            response.metrics)
                 cmdlog.info(
                     m(type="write_ended",
                       node=self.node.name,
@@ -94,7 +95,7 @@ class WriterClient:
                     self.stat.inc(self.node.name + ":out")
                     op_ended = loop.time()
                     log_latency("out", op_ended - self.started_at,
-                                op_ended - op_started)
+                                op_ended - op_started, self.node.idx)
                     cmdlog.info(
                         m(type="write_timedout",
                           node=self.node.name,
@@ -119,7 +120,7 @@ class WriterClient:
                     self.stat.inc(self.node.name + ":err")
                     op_ended = loop.time()
                     log_latency("err", op_ended - self.started_at,
-                                op_ended - op_started)
+                                op_ended - op_started, self.node.idx)
                     cmdlog.info(
                         m(type="write_canceled",
                           node=self.node.name,

--- a/tests/rptest/chaos/redpanda_duck_cluster.py
+++ b/tests/rptest/chaos/redpanda_duck_cluster.py
@@ -12,7 +12,6 @@ import json
 import sys
 import uuid
 
-from gobekli.kvapi import KVNode, RequestTimedout, RequestCanceled
 from gobekli.logging import m
 from rptest.chaos.kafkakv_muservice import KafkaKVMuService
 from rptest.chaos.mount_muservice import MountMuService

--- a/tests/rptest/tests/chaos/chaos_base_test.py
+++ b/tests/rptest/tests/chaos/chaos_base_test.py
@@ -75,9 +75,12 @@ class BaseChaosTest(Test):
 
     def run(self, failure_factory):
         cluster = RedpandaDuckCluster(self.service, self.redpanda_mu)
-        workload_factory = lambda: MRSWWorkload(
-            list(map(lambda x: KVNode(x, x), self.kafkakv_mu.endpoints)), 3, 3,
-            [])
+
+        def workload_factory():
+            nodes = []
+            for x in self.kafkakv_mu.endpoints:
+                nodes.append(KVNode(len(nodes), x, x))
+            return MRSWWorkload(nodes, 3, 3, [])
 
         asyncio.run(
             inject_recover_scenario_aio(BaseChaosTest.PERSISTENT_ROOT,


### PR DESCRIPTION
A fault injection may make different endpoint behave differently and when we track only the overall latency / availability we may loss signals.
    
This change updates gobekli to track latency per endpoint to allow  detailed reports.