### PR TITLE
coproc: add calculateRecordLength and calculateRecordBatchSize to Repository

### DIFF
--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -91,7 +91,7 @@ export class ProcessBatchServer extends SupervisorServer {
    * @param processBatchRequest
    * @param error
    */
-  private handleErrorByPolicy(
+  public handleErrorByPolicy(
     coprocessor: Coprocessor,
     processBatchRequest: ProcessBatchRequestItem,
     error: Error

--- a/src/js/modules/supervisors/Repository.ts
+++ b/src/js/modules/supervisors/Repository.ts
@@ -15,7 +15,11 @@ import {
   ProcessBatchRequestItem,
 } from "../domain/generatedRpc/generatedClasses";
 import { ProcessBatchServer } from "../rpc/server";
-import { createRecordBatch } from "../public";
+import {
+  calculateRecordBatchSize,
+  calculateRecordLength,
+  createRecordBatch,
+} from "../public";
 
 /**
  * Repository is a container for Handles.
@@ -118,6 +122,12 @@ class Repository {
 
             const results: ProcessBatchReplyItem[] = [];
             for (const [key, value] of resultRecordBatch) {
+              value.records = value.records.map((record) => {
+                record.length = calculateRecordLength(record);
+                return record;
+              });
+              value.header.sizeBytes = calculateRecordBatchSize(value.records);
+              value.header.term = recordBatch.header.term;
               results.push({
                 coprocessorId: BigInt(handle.coprocessor.globalId),
                 ntp: {


### PR DESCRIPTION
add calculateRecordLength and calculateRecordBatchSize functions to Repository.ts in order to calculate the `record batch header size` and `record length` attribute after applying coprocessor function to `Record Batch`

**this PR depends on** https://github.com/vectorizedio/redpanda/pull/156