### PR TITLE
k/fetch_request: do not send message_too_large response

### DIFF
--- a/src/v/kafka/requests/fetch_request.cc
+++ b/src/v/kafka/requests/fetch_request.cc
@@ -461,12 +461,11 @@ static ss::future<> fetch_topic_partition(
     auto& topic = *p.topic;
     auto& part = *p.partition;
 
-    // if over budget create placeholder response
+    // if over budget skip the fetch.
     if (octx.bytes_left <= 0) {
-        resp_it.set(make_partition_response_error(
-          part.id, error_code::message_too_large));
         return ss::now();
     }
+
     // if we already have data in response for this partition skip it
     if (!octx.initial_fetch) {
         auto& partition_response = resp_it->partition_response;


### PR DESCRIPTION
We shouldn't send message_to_large error code as a part of send response
as this error code is not expected by the clients. Instead we can just
skip the fetch.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
