### PR TITLE
Use viper to manage the configuration

### DIFF
--- a/src/go/rpk/pkg/api/api_test.go
+++ b/src/go/rpk/pkg/api/api_test.go
@@ -47,7 +47,7 @@ func TestSendMetrics(t *testing.T) {
 
 	conf := config.Default()
 	conf.Rpk.EnableUsageStats = true
-	err = sendMetricsToUrl(body, ts.URL, conf)
+	err = sendMetricsToUrl(body, ts.URL, *conf)
 	require.NoError(t, err)
 }
 
@@ -64,7 +64,7 @@ func TestSkipSendMetrics(t *testing.T) {
 
 	conf := config.Default()
 	conf.Rpk.EnableUsageStats = false
-	err := sendMetricsToUrl(metricsBody{}, ts.URL, conf)
+	err := sendMetricsToUrl(metricsBody{}, ts.URL, *conf)
 	require.NoError(t, err)
 }
 
@@ -142,7 +142,7 @@ func TestSendEnvironment(t *testing.T) {
 
 	conf := config.Default()
 	conf.Rpk.EnableUsageStats = true
-	err = sendEnvironmentToUrl(body, ts.URL, conf)
+	err = sendEnvironmentToUrl(body, ts.URL, *conf)
 	require.NoError(t, err)
 }
 
@@ -159,6 +159,6 @@ func TestSkipSendEnvironment(t *testing.T) {
 
 	conf := config.Default()
 	conf.Rpk.EnableUsageStats = false
-	err := sendEnvironmentToUrl(environmentBody{}, ts.URL, conf)
+	err := sendEnvironmentToUrl(environmentBody{}, ts.URL, *conf)
 	require.NoError(t, err)
 }

--- a/src/go/rpk/pkg/api/api_test.go
+++ b/src/go/rpk/pkg/api/api_test.go
@@ -45,7 +45,7 @@ func TestSendMetrics(t *testing.T) {
 		}))
 	defer ts.Close()
 
-	conf := config.DefaultConfig()
+	conf := config.Default()
 	conf.Rpk.EnableUsageStats = true
 	err = sendMetricsToUrl(body, ts.URL, conf)
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestSkipSendMetrics(t *testing.T) {
 	)
 	defer ts.Close()
 
-	conf := config.DefaultConfig()
+	conf := config.Default()
 	conf.Rpk.EnableUsageStats = false
 	err := sendMetricsToUrl(metricsBody{}, ts.URL, conf)
 	require.NoError(t, err)
@@ -140,7 +140,7 @@ func TestSendEnvironment(t *testing.T) {
 	)
 	defer ts.Close()
 
-	conf := config.DefaultConfig()
+	conf := config.Default()
 	conf.Rpk.EnableUsageStats = true
 	err = sendEnvironmentToUrl(body, ts.URL, conf)
 	require.NoError(t, err)
@@ -157,7 +157,7 @@ func TestSkipSendEnvironment(t *testing.T) {
 	)
 	defer ts.Close()
 
-	conf := config.DefaultConfig()
+	conf := config.Default()
 	conf.Rpk.EnableUsageStats = false
 	err := sendEnvironmentToUrl(environmentBody{}, ts.URL, conf)
 	require.NoError(t, err)

--- a/src/go/rpk/pkg/cli/cmd/api.go
+++ b/src/go/rpk/pkg/cli/cmd/api.go
@@ -108,7 +108,7 @@ func findConfigFile(
 						" wasn't passed, using default" +
 						" config",
 				)
-				defaultConf := config.DefaultConfig()
+				defaultConf := config.Default()
 				conf = &defaultConf
 				return conf, nil
 			}

--- a/src/go/rpk/pkg/cli/cmd/api.go
+++ b/src/go/rpk/pkg/cli/cmd/api.go
@@ -108,9 +108,7 @@ func findConfigFile(
 						" wasn't passed, using default" +
 						" config",
 				)
-				defaultConf := config.Default()
-				conf = &defaultConf
-				return conf, nil
+				return config.Default(), nil
 			}
 		}
 		return conf, err

--- a/src/go/rpk/pkg/cli/cmd/api.go
+++ b/src/go/rpk/pkg/cli/cmd/api.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func NewApiCommand(fs afero.Fs) *cobra.Command {
+func NewApiCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
 		brokers    []string
 		configFile string
@@ -66,7 +66,7 @@ func NewApiCommand(fs afero.Fs) *cobra.Command {
 	// closure with references to the required values (the config file
 	// path, the list of brokers passed through --brokers) to deduce the
 	// actual brokers list to be used.
-	configClosure := findConfigFile(fs, &configFile)
+	configClosure := findConfigFile(mgr, &configFile)
 	brokersClosure := deduceBrokers(fs, configClosure, &brokers)
 	producerClosure := createProducer(fs, brokersClosure, configClosure)
 	clientClosure := createClient(fs, brokersClosure, configClosure)
@@ -89,7 +89,7 @@ func NewApiCommand(fs afero.Fs) *cobra.Command {
 // specific path passed with --config. If --config wasn't passed, and the config
 // wasn't found, return the default configuration.
 func findConfigFile(
-	fs afero.Fs, configFile *string,
+	mgr config.Manager, configFile *string,
 ) func() (*config.Config, error) {
 	var conf *config.Config
 	var err error
@@ -97,7 +97,7 @@ func findConfigFile(
 		if conf != nil {
 			return conf, nil
 		}
-		conf, err = config.ReadOrFind(fs, *configFile)
+		conf, err = mgr.ReadOrFind(*configFile)
 		if err == nil {
 			config.CheckAndPrintNotice(conf.LicenseKey)
 		} else {

--- a/src/go/rpk/pkg/cli/cmd/check.go
+++ b/src/go/rpk/pkg/cli/cmd/check.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCheckCommand(fs afero.Fs) *cobra.Command {
+func NewCheckCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
 		configFile string
 		timeout    time.Duration
@@ -34,7 +34,7 @@ func NewCheckCommand(fs afero.Fs) *cobra.Command {
 		Long:         "",
 		SilenceUsage: true,
 		RunE: func(ccmd *cobra.Command, args []string) error {
-			return executeCheck(fs, configFile, timeout)
+			return executeCheck(fs, mgr, configFile, timeout)
 		},
 	}
 	command.Flags().StringVar(
@@ -66,8 +66,10 @@ func appendToTable(t *tablewriter.Table, r tuners.CheckResult) {
 	})
 }
 
-func executeCheck(fs afero.Fs, configFile string, timeout time.Duration) error {
-	conf, err := config.FindOrGenerate(fs, configFile)
+func executeCheck(
+	fs afero.Fs, mgr config.Manager, configFile string, timeout time.Duration,
+) error {
+	conf, err := mgr.FindOrGenerate(configFile)
 	if err != nil {
 		return err
 	}

--- a/src/go/rpk/pkg/cli/cmd/config.go
+++ b/src/go/rpk/pkg/cli/cmd/config.go
@@ -95,7 +95,7 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 			" ones can join later.",
 		Args: cobra.OnlyValidArgs,
 		RunE: func(c *cobra.Command, args []string) error {
-			defaultRpcPort := config.DefaultConfig().Redpanda.RPCServer.Port
+			defaultRpcPort := config.Default().Redpanda.RPCServer.Port
 			conf, err := config.FindOrGenerate(fs, configPath)
 			if err != nil {
 				return errors.New("YAML")

--- a/src/go/rpk/pkg/cli/cmd/config.go
+++ b/src/go/rpk/pkg/cli/cmd/config.go
@@ -121,10 +121,10 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 			conf.Redpanda.RPCServer.Address = ownIp.String()
 			conf.Redpanda.KafkaApi.Address = ownIp.String()
 			conf.Redpanda.AdminApi.Address = ownIp.String()
-			conf.Redpanda.SeedServers = []*config.SeedServer{}
-			seeds := []*config.SeedServer{}
+			conf.Redpanda.SeedServers = []config.SeedServer{}
+			seeds := []config.SeedServer{}
 			for i, ip := range ips {
-				seed := &config.SeedServer{
+				seed := config.SeedServer{
 					Id: i,
 					Host: config.SocketAddress{
 						ip.String(),

--- a/src/go/rpk/pkg/cli/cmd/config.go
+++ b/src/go/rpk/pkg/cli/cmd/config.go
@@ -21,19 +21,19 @@ import (
 
 const configFileFlag = "config"
 
-func NewConfigCommand(fs afero.Fs) *cobra.Command {
+func NewConfigCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "config <command>",
 		Short: "Edit configuration",
 	}
-	root.AddCommand(set(fs))
-	root.AddCommand(bootstrap(fs))
-	root.AddCommand(initNode(fs))
+	root.AddCommand(set(fs, mgr))
+	root.AddCommand(bootstrap(mgr))
+	root.AddCommand(initNode(mgr))
 
 	return root
 }
 
-func set(fs afero.Fs) *cobra.Command {
+func set(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
 		format     string
 		configPath string
@@ -52,7 +52,7 @@ func set(fs afero.Fs) *cobra.Command {
 					return err
 				}
 			}
-			return config.Set(fs, key, value, format, configPath)
+			return mgr.Set(key, value, format, configPath)
 		},
 	}
 	c.Flags().StringVar(&format,
@@ -72,7 +72,7 @@ func set(fs afero.Fs) *cobra.Command {
 	return c
 }
 
-func bootstrap(fs afero.Fs) *cobra.Command {
+func bootstrap(mgr config.Manager) *cobra.Command {
 	var (
 		ips        []string
 		self       string
@@ -96,7 +96,7 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 		Args: cobra.OnlyValidArgs,
 		RunE: func(c *cobra.Command, args []string) error {
 			defaultRpcPort := config.Default().Redpanda.RPCServer.Port
-			conf, err := config.FindOrGenerate(fs, configPath)
+			conf, err := mgr.FindOrGenerate(configPath)
 			if err != nil {
 				return errors.New("YAML")
 			}
@@ -134,7 +134,7 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 				seeds = append(seeds, seed)
 			}
 			conf.Redpanda.SeedServers = seeds
-			return config.WriteConfig(fs, conf, conf.ConfigFile)
+			return mgr.Write(conf)
 		},
 	}
 	c.Flags().StringSliceVar(
@@ -166,7 +166,7 @@ func bootstrap(fs afero.Fs) *cobra.Command {
 	return c
 }
 
-func initNode(fs afero.Fs) *cobra.Command {
+func initNode(mgr config.Manager) *cobra.Command {
 	var (
 		configPath string
 	)
@@ -175,14 +175,13 @@ func initNode(fs afero.Fs) *cobra.Command {
 		Short: "Init the node after install, by setting the node's UUID.",
 		Args:  cobra.OnlyValidArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
-			conf, err := config.FindOrGenerate(fs, configPath)
+			conf, err := mgr.FindOrGenerate(configPath)
 			if err != nil {
 				return err
 			}
 			// Don't reset the node's UUID if it has already been set.
 			if conf.NodeUuid == "" {
-				conf, err = config.GenerateAndWriteNodeUuid(fs, conf)
-				return err
+				return mgr.WriteNodeUUID(conf)
 			}
 			return nil
 		},

--- a/src/go/rpk/pkg/cli/cmd/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/config_test.go
@@ -60,12 +60,7 @@ func TestSet(t *testing.T) {
 			value: `tune_disk_irq: true`,
 			args:  []string{"--format", "yaml"},
 			expected: map[string]interface{}{
-				"enable_usage_stats": false,
-				"tls": map[string]interface{}{
-					"cert_file":       "",
-					"key_file":        "",
-					"truststore_file": "",
-				},
+				"enable_usage_stats":         false,
 				"overprovisioned":            false,
 				"tune_network":               false,
 				"tune_disk_scheduler":        false,

--- a/src/go/rpk/pkg/cli/cmd/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/config_test.go
@@ -135,7 +135,7 @@ func TestSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			conf := config.Default()
-			err := config.WriteConfig(fs, &conf, conf.ConfigFile)
+			err := config.WriteConfig(fs, conf, conf.ConfigFile)
 			require.NoError(t, err)
 
 			c := cmd.NewConfigCommand(fs)
@@ -261,7 +261,7 @@ func TestBootstrap(t *testing.T) {
 func TestInitNode(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	conf := config.Default()
-	err := config.WriteConfig(fs, &conf, conf.ConfigFile)
+	err := config.WriteConfig(fs, conf, conf.ConfigFile)
 	require.NoError(t, err)
 	c := cmd.NewConfigCommand(fs)
 	args := []string{"init"}

--- a/src/go/rpk/pkg/cli/cmd/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/config_test.go
@@ -139,7 +139,7 @@ func TestSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			conf := config.DefaultConfig()
+			conf := config.Default()
 			err := config.WriteConfig(fs, &conf, conf.ConfigFile)
 			require.NoError(t, err)
 
@@ -265,7 +265,7 @@ func TestBootstrap(t *testing.T) {
 
 func TestInitNode(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	conf := config.DefaultConfig()
+	conf := config.Default()
 	err := config.WriteConfig(fs, &conf, conf.ConfigFile)
 	require.NoError(t, err)
 	c := cmd.NewConfigCommand(fs)

--- a/src/go/rpk/pkg/cli/cmd/container.go
+++ b/src/go/rpk/pkg/cli/cmd/container.go
@@ -11,18 +11,19 @@ package cmd
 
 import (
 	"vectorized/pkg/cli/cmd/container"
+	"vectorized/pkg/config"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-func NewContainerCommand(fs afero.Fs) *cobra.Command {
+func NewContainerCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "container",
 		Short: "Manage a local container cluster",
 	}
 
-	command.AddCommand(container.Start(fs))
+	command.AddCommand(container.Start(fs, mgr))
 	command.AddCommand(container.Stop(fs))
 	command.AddCommand(container.Purge(fs))
 

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -124,14 +124,14 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 	}
 
 	hostRPCPort, err := getHostPort(
-		config.DefaultConfig().Redpanda.RPCServer.Port,
+		config.Default().Redpanda.RPCServer.Port,
 		containerJSON,
 	)
 	if err != nil {
 		return nil, err
 	}
 	hostKafkaPort, err := getHostPort(
-		config.DefaultConfig().Redpanda.KafkaApi.Port,
+		config.Default().Redpanda.KafkaApi.Port,
 		containerJSON,
 	)
 	if err != nil {
@@ -213,14 +213,14 @@ func CreateNode(
 ) (*NodeState, error) {
 	rPort, err := nat.NewPort(
 		"tcp",
-		strconv.Itoa(config.DefaultConfig().Redpanda.RPCServer.Port),
+		strconv.Itoa(config.Default().Redpanda.RPCServer.Port),
 	)
 	if err != nil {
 		return nil, err
 	}
 	kPort, err := nat.NewPort(
 		"tcp",
-		strconv.Itoa(config.DefaultConfig().Redpanda.KafkaApi.Port),
+		strconv.Itoa(config.Default().Redpanda.KafkaApi.Port),
 	)
 	if err != nil {
 		return nil, err

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -164,34 +164,37 @@ func CreateNetwork(c Client) (string, error) {
 		return "", err
 	}
 
-	if len(networks) == 0 {
-		log.Debugf(
-			"Docker network '%s' doesn't exist, creating.",
-			redpandaNetwork,
-		)
-		resp, err := c.NetworkCreate(
-			ctx, redpandaNetwork, types.NetworkCreate{
-				Driver: "bridge",
-				IPAM: &network.IPAM{
-					Driver: "default",
-					Config: []network.IPAMConfig{
-						network.IPAMConfig{
-							Subnet:  "172.24.1.0/24",
-							Gateway: "172.24.1.1",
-						},
+	for _, net := range networks {
+		if net.Name == redpandaNetwork {
+			return net.ID, nil
+		}
+	}
+
+	log.Debugf(
+		"Docker network '%s' doesn't exist, creating.",
+		redpandaNetwork,
+	)
+	resp, err := c.NetworkCreate(
+		ctx, redpandaNetwork, types.NetworkCreate{
+			Driver: "bridge",
+			IPAM: &network.IPAM{
+				Driver: "default",
+				Config: []network.IPAMConfig{
+					network.IPAMConfig{
+						Subnet:  "172.24.1.0/24",
+						Gateway: "172.24.1.1",
 					},
 				},
 			},
-		)
-		if err != nil {
-			return "", err
-		}
-		if resp.Warning != "" {
-			log.Debug(resp.Warning)
-		}
-		return resp.ID, nil
+		},
+	)
+	if err != nil {
+		return "", err
 	}
-	return networks[0].ID, nil
+	if resp.Warning != "" {
+		log.Debug(resp.Warning)
+	}
+	return resp.ID, nil
 }
 
 // Delete the Redpanda network if it exists.

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -345,7 +345,7 @@ func writeNodeConfig(
 	}
 
 	if seedIP != "" {
-		conf.Redpanda.SeedServers = []*config.SeedServer{{
+		conf.Redpanda.SeedServers = []config.SeedServer{{
 			Id: 0,
 			Host: config.SocketAddress{
 				Address: seedIP,

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -33,7 +33,7 @@ type node struct {
 	addr string
 }
 
-func Start(fs afero.Fs) *cobra.Command {
+func Start(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
 		nodes uint
 	)
@@ -54,6 +54,7 @@ func Start(fs afero.Fs) *cobra.Command {
 
 			return common.WrapIfConnErr(startCluster(
 				fs,
+				mgr,
 				c,
 				nodes,
 			))
@@ -71,7 +72,9 @@ func Start(fs afero.Fs) *cobra.Command {
 	return command
 }
 
-func startCluster(fs afero.Fs, c common.Client, n uint) error {
+func startCluster(
+	fs afero.Fs, mgr config.Manager, c common.Client, n uint,
+) error {
 	// Check if cluster exists and start it again.
 	restarted, err := restartCluster(fs, c)
 	if err != nil {
@@ -158,7 +161,7 @@ func startCluster(fs afero.Fs, c common.Client, n uint) error {
 
 	log.Info("Starting cluster")
 	seedIP, seedKafkaPort, err := startNode(
-		fs,
+		mgr,
 		c,
 		seedID,
 		seedKafkaPort,
@@ -203,7 +206,7 @@ func startCluster(fs afero.Fs, c common.Client, n uint) error {
 				state.ContainerID,
 			)
 			ip, port, err := startNode(
-				fs,
+				mgr,
 				c,
 				id,
 				kafkaPort,
@@ -306,13 +309,13 @@ func restartCluster(fs afero.Fs, c common.Client) ([]node, error) {
 }
 
 func startNode(
-	fs afero.Fs,
+	mgr config.Manager,
 	c common.Client,
 	nodeID, kafkaPort, rpcPort, seedRPCPort uint,
 	containerID, ip, seedIP string,
 	cores int,
 ) (string, uint, error) {
-	conf, err := writeNodeConfig(fs, nodeID, kafkaPort, rpcPort, seedRPCPort, ip, seedIP, common.ConfPath(nodeID), cores)
+	conf, err := writeNodeConfig(mgr, nodeID, kafkaPort, rpcPort, seedRPCPort, ip, seedIP, common.ConfPath(nodeID), cores)
 	if err != nil {
 		return "", 0, err
 	}
@@ -323,7 +326,7 @@ func startNode(
 }
 
 func writeNodeConfig(
-	fs afero.Fs,
+	mgr config.Manager,
 	nodeID, kafkaPort, rpcPort, seedRPCPort uint,
 	ip, seedIP, path string,
 	cores int,
@@ -331,6 +334,7 @@ func writeNodeConfig(
 	localhost := "127.0.0.1"
 	conf := config.Default()
 	conf.Redpanda.Id = int(nodeID)
+	conf.ConfigFile = path
 
 	conf.Redpanda.KafkaApi.Address = ip
 	conf.Redpanda.RPCServer.Address = ip
@@ -353,12 +357,9 @@ func writeNodeConfig(
 			},
 		}}
 	}
-
-	conf.Rpk.Overprovisioned = true
+	config.SetMode(config.ModeDev, conf)
 	conf.Rpk.SMP = &cores
-	conf.Redpanda.DeveloperMode = true
-
-	return conf, config.WriteConfig(fs, conf, path)
+	return conf, mgr.Write(conf)
 }
 
 func renderClusterInfo(nodes []node) {

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -329,7 +329,7 @@ func writeNodeConfig(
 	cores int,
 ) (*config.Config, error) {
 	localhost := "127.0.0.1"
-	conf := config.DefaultConfig()
+	conf := config.Default()
 	conf.Redpanda.Id = int(nodeID)
 
 	conf.Redpanda.KafkaApi.Address = ip

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -358,7 +358,7 @@ func writeNodeConfig(
 	conf.Rpk.SMP = &cores
 	conf.Redpanda.DeveloperMode = true
 
-	return &conf, config.WriteConfig(fs, &conf, path)
+	return conf, config.WriteConfig(fs, conf, path)
 }
 
 func renderClusterInfo(nodes []node) {

--- a/src/go/rpk/pkg/cli/cmd/container/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start_test.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"testing"
 	"vectorized/pkg/cli/cmd/container/common"
+	"vectorized/pkg/config"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -426,13 +427,14 @@ Please run 'rpk container purge' to delete all remaining data.`,
 		t.Run(tt.name, func(st *testing.T) {
 			var out bytes.Buffer
 			fs := afero.NewMemMapFs()
+			mgr := config.NewManager(fs)
 			if tt.before != nil {
 				require.NoError(st, tt.before(fs))
 			}
 			c, err := tt.client()
 			require.NoError(st, err)
 			logrus.SetOutput(&out)
-			err = startCluster(fs, c, tt.nodes)
+			err = startCluster(fs, mgr, c, tt.nodes)
 			if tt.expectedErrMsg != "" {
 				require.EqualError(st, err, tt.expectedErrMsg)
 			} else {

--- a/src/go/rpk/pkg/cli/cmd/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/generate.go
@@ -11,17 +11,17 @@ package cmd
 
 import (
 	"vectorized/pkg/cli/cmd/generate"
+	"vectorized/pkg/config"
 
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-func NewGenerateCommand(fs afero.Fs) *cobra.Command {
+func NewGenerateCommand(mgr config.Manager) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "generate [template]",
 		Short: "Generate a configuration template for related services.",
 	}
 	command.AddCommand(generate.NewGrafanaDashboardCmd())
-	command.AddCommand(generate.NewPrometheusConfigCmd(fs))
+	command.AddCommand(generate.NewPrometheusConfigCmd(mgr))
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
@@ -87,7 +87,7 @@ especify an arbitrary config file.`,
 A comma-delimited list of the addresses (<host:port>) of all the redpanda nodes
 in a cluster. The port must be the one configured for the nodes' admin API
 (%d by default)`,
-			config.DefaultConfig().Redpanda.AdminApi.Port,
+			config.Default().Redpanda.AdminApi.Port,
 		))
 	command.Flags().StringVar(
 		&seedAddr,

--- a/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
@@ -19,7 +19,6 @@ import (
 	"vectorized/pkg/kafka"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -33,7 +32,7 @@ type StaticConfig struct {
 	Targets []string `yaml:"targets"`
 }
 
-func NewPrometheusConfigCmd(fs afero.Fs) *cobra.Command {
+func NewPrometheusConfigCmd(mgr config.Manager) *cobra.Command {
 	var (
 		jobName    string
 		nodeAddrs  []string
@@ -61,7 +60,7 @@ especify an arbitrary config file.`,
 				log.SetOutput(os.Stdout)
 			}
 			yml, err := executePrometheusConfig(
-				fs,
+				mgr,
 				jobName,
 				nodeAddrs,
 				seedAddr,
@@ -103,7 +102,10 @@ in a cluster. The port must be the one configured for the nodes' admin API
 }
 
 func executePrometheusConfig(
-	fs afero.Fs, jobName string, nodeAddrs []string, seedAddr, configFile string,
+	mgr config.Manager,
+	jobName string,
+	nodeAddrs []string,
+	seedAddr, configFile string,
 ) ([]byte, error) {
 	if len(nodeAddrs) > 0 {
 		return renderConfig(jobName, nodeAddrs)
@@ -122,7 +124,7 @@ func executePrometheusConfig(
 		}
 		return renderConfig(jobName, hosts)
 	}
-	conf, err := config.FindOrGenerate(fs, configFile)
+	conf, err := mgr.FindOrGenerate(configFile)
 	if err != nil {
 		return []byte(""), err
 	}

--- a/src/go/rpk/pkg/cli/cmd/iotune.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune.go
@@ -60,7 +60,7 @@ func NewIoTuneCmd(fs afero.Fs) *cobra.Command {
 	command.Flags().StringVar(
 		&outputFile,
 		"out",
-		filepath.Join(filepath.Dir(config.DefaultConfig().ConfigFile), "io-config.yaml"),
+		filepath.Join(filepath.Dir(config.Default().ConfigFile), "io-config.yaml"),
 		"The file path where the IO config will be written",
 	)
 	command.Flags().StringSliceVar(&directories,

--- a/src/go/rpk/pkg/cli/cmd/iotune.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewIoTuneCmd(fs afero.Fs) *cobra.Command {
+func NewIoTuneCmd(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
 		configFile  string
 		outputFile  string
@@ -33,7 +33,7 @@ func NewIoTuneCmd(fs afero.Fs) *cobra.Command {
 		Short: "Measure filesystem performance and create IO configuration file",
 		RunE: func(ccmd *cobra.Command, args []string) error {
 			timeout += duration
-			conf, err := config.FindOrGenerate(fs, configFile)
+			conf, err := mgr.FindOrGenerate(configFile)
 			if err != nil {
 				return err
 			}

--- a/src/go/rpk/pkg/cli/cmd/iotune_test.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 	"vectorized/pkg/cli/cmd"
+	"vectorized/pkg/config"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -80,9 +81,10 @@ func TestTimeoutDuration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
+			mgr := config.NewManager(fs)
 			err := afero.WriteFile(fs, configPath, []byte(validConfig), 0644)
 			require.NoError(t, err)
-			cmd := cmd.NewIoTuneCmd(fs)
+			cmd := cmd.NewIoTuneCmd(fs, mgr)
 			args := []string{"--config", configPath}
 			args = append(args, tt.args...)
 			cmd.SetArgs(args)

--- a/src/go/rpk/pkg/cli/cmd/mode.go
+++ b/src/go/rpk/pkg/cli/cmd/mode.go
@@ -15,11 +15,10 @@ import (
 	"vectorized/pkg/config"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-func NewModeCommand(fs afero.Fs) *cobra.Command {
+func NewModeCommand(mgr config.Manager) *cobra.Command {
 	var configFile string
 	command := &cobra.Command{
 		Use:   "mode <mode>",
@@ -33,7 +32,7 @@ func NewModeCommand(fs afero.Fs) *cobra.Command {
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			// Safe to access args[0] because it was validated in Args
-			return executeMode(fs, configFile, args[0])
+			return executeMode(mgr, configFile, args[0])
 		},
 	}
 	command.Flags().StringVar(
@@ -46,8 +45,8 @@ func NewModeCommand(fs afero.Fs) *cobra.Command {
 	return command
 }
 
-func executeMode(fs afero.Fs, configFile string, mode string) error {
-	conf, err := config.FindOrGenerate(fs, configFile)
+func executeMode(mgr config.Manager, configFile string, mode string) error {
+	conf, err := mgr.FindOrGenerate(configFile)
 	if err != nil {
 		return err
 	}
@@ -57,5 +56,5 @@ func executeMode(fs afero.Fs, configFile string, mode string) error {
 		return err
 	}
 	log.Infof("Writing '%s' mode defaults to '%s'", mode, conf.ConfigFile)
-	return config.WriteConfig(fs, conf, conf.ConfigFile)
+	return mgr.Write(conf)
 }

--- a/src/go/rpk/pkg/cli/cmd/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/mode_test.go
@@ -23,7 +23,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func fillRpkConfig(path, mode string) config.Config {
+func fillRpkConfig(path, mode string) *config.Config {
 	conf := config.Default()
 	val := mode == config.ModeProd
 	conf.Redpanda.DeveloperMode = !val
@@ -55,7 +55,7 @@ func TestModeCommand(t *testing.T) {
 		name           string
 		args           []string
 		before         func(afero.Fs) (string, error)
-		expectedConfig config.Config
+		expectedConfig *config.Config
 		expectedOutput string
 		expectedErrMsg string
 	}{
@@ -163,7 +163,7 @@ func TestModeCommand(t *testing.T) {
 			require.Contains(t, strings.TrimSpace(output), tt.expectedOutput)
 			conf, err := config.ReadConfigFromPath(fs, path)
 			require.NoError(t, err)
-			require.Exactly(t, tt.expectedConfig, *conf)
+			require.Exactly(t, tt.expectedConfig, conf)
 		})
 	}
 }

--- a/src/go/rpk/pkg/cli/cmd/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/mode_test.go
@@ -27,7 +27,8 @@ func fillRpkConfig(path, mode string) config.Config {
 	conf := config.Default()
 	val := mode == config.ModeProd
 	conf.Redpanda.DeveloperMode = !val
-	conf.Rpk = &config.RpkConfig{
+	conf.Redpanda.SeedServers = []config.SeedServer{}
+	conf.Rpk = config.RpkConfig{
 		TuneNetwork:       val,
 		TuneDiskScheduler: val,
 		TuneNomerges:      val,

--- a/src/go/rpk/pkg/cli/cmd/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/mode_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func fillRpkConfig(path, mode string) config.Config {
-	conf := config.DefaultConfig()
+	conf := config.Default()
 	val := mode == config.ModeProd
 	conf.Redpanda.DeveloperMode = !val
 	conf.Rpk = &config.RpkConfig{

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -12,6 +12,7 @@ package cmd
 import (
 	"os"
 	"vectorized/pkg/cli"
+	"vectorized/pkg/config"
 
 	"github.com/Shopify/sarama"
 	"github.com/fatih/color"
@@ -27,6 +28,7 @@ https://vectorized.io/feedback`
 func Execute() {
 	verbose := false
 	fs := afero.NewOsFs()
+	mgr := config.NewManager(fs)
 
 	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
 		color.NoColor = true
@@ -62,16 +64,16 @@ func Execute() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose",
 		"v", false, "enable verbose logging (default false)")
 
-	rootCmd.AddCommand(NewModeCommand(fs))
-	rootCmd.AddCommand(NewConfigCommand(fs))
-	rootCmd.AddCommand(NewStatusCommand(fs))
-	rootCmd.AddCommand(NewGenerateCommand(fs))
+	rootCmd.AddCommand(NewModeCommand(mgr))
+	rootCmd.AddCommand(NewConfigCommand(fs, mgr))
+	rootCmd.AddCommand(NewStatusCommand(fs, mgr))
+	rootCmd.AddCommand(NewGenerateCommand(mgr))
 	rootCmd.AddCommand(NewVersionCommand())
-	rootCmd.AddCommand(NewApiCommand(fs))
+	rootCmd.AddCommand(NewApiCommand(fs, mgr))
 	rootCmd.AddCommand(NewWasmCommand(fs))
-	rootCmd.AddCommand(NewContainerCommand(fs))
+	rootCmd.AddCommand(NewContainerCommand(fs, mgr))
 
-	addPlatformDependentCmds(fs, rootCmd)
+	addPlatformDependentCmds(fs, mgr, rootCmd)
 
 	err := rootCmd.Execute()
 	if len(os.Args) > 1 {

--- a/src/go/rpk/pkg/cli/cmd/root_darwin.go
+++ b/src/go/rpk/pkg/cli/cmd/root_darwin.go
@@ -10,9 +10,14 @@
 package cmd
 
 import (
+	"vectorized/pkg/config"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
 // On MacOS this is a no-op.
-func addPlatformDependentCmds(fs afero.Fs, cmd *cobra.Command) {}
+func addPlatformDependentCmds(
+	fs afero.Fs, mgr config.Manager, cmd *cobra.Command,
+) {
+}

--- a/src/go/rpk/pkg/cli/cmd/root_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/root_linux.go
@@ -10,14 +10,18 @@
 package cmd
 
 import (
+	"vectorized/pkg/config"
+
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-func addPlatformDependentCmds(fs afero.Fs, cmd *cobra.Command) {
-	cmd.AddCommand(NewTuneCommand(fs))
-	cmd.AddCommand(NewCheckCommand(fs))
-	cmd.AddCommand(NewIoTuneCmd(fs))
-	cmd.AddCommand(NewStartCommand(fs))
-	cmd.AddCommand(NewStopCommand(fs))
+func addPlatformDependentCmds(
+	fs afero.Fs, mgr config.Manager, cmd *cobra.Command,
+) {
+	cmd.AddCommand(NewTuneCommand(fs, mgr))
+	cmd.AddCommand(NewCheckCommand(fs, mgr))
+	cmd.AddCommand(NewIoTuneCmd(fs, mgr))
+	cmd.AddCommand(NewStartCommand(fs, mgr))
+	cmd.AddCommand(NewStopCommand(fs, mgr))
 }

--- a/src/go/rpk/pkg/cli/cmd/status.go
+++ b/src/go/rpk/pkg/cli/cmd/status.go
@@ -35,7 +35,7 @@ type status struct {
 	topics   []*sarama.TopicMetadata
 }
 
-func NewStatusCommand(fs afero.Fs) *cobra.Command {
+func NewStatusCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
 		configFile string
 		send       bool
@@ -47,7 +47,7 @@ func NewStatusCommand(fs afero.Fs) *cobra.Command {
 		Long:         "",
 		SilenceUsage: true,
 		RunE: func(ccmd *cobra.Command, args []string) error {
-			return executeStatus(fs, configFile, timeout, send)
+			return executeStatus(fs, mgr, configFile, timeout, send)
 		},
 	}
 	command.Flags().StringVar(
@@ -75,9 +75,13 @@ func NewStatusCommand(fs afero.Fs) *cobra.Command {
 }
 
 func executeStatus(
-	fs afero.Fs, configFile string, timeout time.Duration, send bool,
+	fs afero.Fs,
+	mgr config.Manager,
+	configFile string,
+	timeout time.Duration,
+	send bool,
 ) error {
-	conf, err := config.FindOrGenerate(fs, configFile)
+	conf, err := mgr.FindOrGenerate(configFile)
 	if err != nil {
 		return err
 	}
@@ -98,8 +102,8 @@ func executeStatus(
 	kafkaRowsCh := make(chan [][]string)
 
 	go getCloudProviderInfo(providerInfoRowsCh)
-	go getMetrics(fs, timeout, *conf, send, metricsRowsCh)
-	go getConf(fs, conf.ConfigFile, confRowsCh)
+	go getMetrics(fs, mgr, timeout, *conf, send, metricsRowsCh)
+	go getConf(mgr, conf.ConfigFile, confRowsCh)
 	go getKafkaInfo(*conf, kafkaRowsCh)
 
 	for _, row := range <-providerInfoRowsCh {
@@ -143,6 +147,7 @@ func getCloudProviderInfo(out chan<- [][]string) {
 
 func getMetrics(
 	fs afero.Fs,
+	mgr config.Manager,
 	timeout time.Duration,
 	conf config.Config,
 	send bool,
@@ -179,13 +184,12 @@ func getMetrics(
 	}
 	if send {
 		if conf.NodeUuid == "" {
-			c, err := config.GenerateAndWriteNodeUuid(fs, &conf)
+			err := mgr.WriteNodeUUID(&conf)
 			if err != nil {
 				log.Info("Error writing the node's UUID: ", err)
 			}
-			conf = *c
 		}
-		err := sendMetrics(fs, conf, m)
+		err := sendMetrics(conf, m)
 		if err != nil {
 			log.Info("Error sending metrics: ", err)
 		}
@@ -193,9 +197,9 @@ func getMetrics(
 	out <- rows
 }
 
-func getConf(fs afero.Fs, configFile string, out chan<- [][]string) {
+func getConf(mgr config.Manager, configFile string, out chan<- [][]string) {
 	rows := [][]string{}
-	props, err := config.ReadFlat(fs, configFile)
+	props, err := mgr.ReadFlat(configFile)
 	if err != nil {
 		log.Info("Error reading or parsing configuration: ", err)
 	} else {
@@ -354,9 +358,7 @@ func getKafkaInfoRows(
 	return rows
 }
 
-func sendMetrics(
-	fs afero.Fs, conf config.Config, metrics *system.Metrics,
-) error {
+func sendMetrics(conf config.Config, metrics *system.Metrics) error {
 	payload := api.MetricsPayload{
 		FreeMemoryMB:  metrics.FreeMemoryMB,
 		FreeSpaceMB:   metrics.FreeSpaceMB,

--- a/src/go/rpk/pkg/cli/cmd/status_test.go
+++ b/src/go/rpk/pkg/cli/cmd/status_test.go
@@ -23,6 +23,7 @@ import (
 func getConfig() *config.Config {
 	conf := config.Default()
 	conf.Rpk.EnableUsageStats = true
+	conf.ConfigFile = "/etc/redpanda/redpanda.yaml"
 	return conf
 }
 
@@ -129,12 +130,13 @@ func TestStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
+			mgr := config.NewManager(fs)
 			if tt.before != nil {
 				err := tt.before(fs)
 				require.NoError(t, err)
 			}
 			var out bytes.Buffer
-			cmd := NewStatusCommand(fs)
+			cmd := NewStatusCommand(fs, mgr)
 			cmd.SetArgs(tt.args)
 			logrus.SetOutput(&out)
 			err := cmd.Execute()

--- a/src/go/rpk/pkg/cli/cmd/status_test.go
+++ b/src/go/rpk/pkg/cli/cmd/status_test.go
@@ -23,8 +23,7 @@ import (
 func getConfig() *config.Config {
 	conf := config.Default()
 	conf.Rpk.EnableUsageStats = true
-	conf.ConfigFile = "/etc/redpanda/redpanda.yaml"
-	return &conf
+	return conf
 }
 
 func writeConfig(fs afero.Fs, conf *config.Config) error {

--- a/src/go/rpk/pkg/cli/cmd/status_test.go
+++ b/src/go/rpk/pkg/cli/cmd/status_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func getConfig() *config.Config {
-	conf := config.DefaultConfig()
+	conf := config.Default()
 	conf.Rpk.EnableUsageStats = true
 	conf.ConfigFile = "/etc/redpanda/redpanda.yaml"
 	return &conf

--- a/src/go/rpk/pkg/cli/cmd/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/stop.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewStopCommand(fs afero.Fs) *cobra.Command {
+func NewStopCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
 		configFile string
 		timeout    time.Duration
@@ -37,7 +37,7 @@ hasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still
 running.`,
 		SilenceUsage: true,
 		RunE: func(ccmd *cobra.Command, args []string) error {
-			return executeStop(fs, configFile, timeout)
+			return executeStop(fs, mgr, configFile, timeout)
 		},
 	}
 	command.Flags().StringVar(
@@ -61,8 +61,10 @@ running.`,
 	return command
 }
 
-func executeStop(fs afero.Fs, configFile string, timeout time.Duration) error {
-	conf, err := config.ReadOrFind(fs, configFile)
+func executeStop(
+	fs afero.Fs, mgr config.Manager, configFile string, timeout time.Duration,
+) error {
+	conf, err := mgr.ReadOrFind(configFile)
 	if err != nil {
 		return err
 	}

--- a/src/go/rpk/pkg/cli/cmd/stop_test.go
+++ b/src/go/rpk/pkg/cli/cmd/stop_test.go
@@ -53,7 +53,7 @@ func TestStopCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			conf := config.DefaultConfig()
+			conf := config.Default()
 			command := baseCommand
 			// trap the signals we want to ignore, to check that the
 			// signal escalation is working.

--- a/src/go/rpk/pkg/cli/cmd/stop_test.go
+++ b/src/go/rpk/pkg/cli/cmd/stop_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestStopCommand(t *testing.T) {
-	const confPath string = "/etc/redpanda/redpanda.yaml"
 	// simulate the redpanda process with an infinite loop.
 	const baseCommand string = "while :; do sleep 1; done"
 	tests := []struct {
@@ -53,6 +52,7 @@ func TestStopCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
+			mgr := config.NewManager(fs)
 			conf := config.Default()
 			command := baseCommand
 			// trap the signals we want to ignore, to check that the
@@ -73,13 +73,12 @@ func TestStopCommand(t *testing.T) {
 				conf.PIDFile(),
 			)
 			require.NoError(t, err)
-
-			err = config.WriteConfig(fs, conf, confPath)
+			err = mgr.Write(conf)
 			require.NoError(t, err)
 
 			var out bytes.Buffer
-			c := cmd.NewStopCommand(fs)
-			args := append([]string{"--config", confPath}, tt.args...)
+			c := cmd.NewStopCommand(fs, mgr)
+			args := append([]string{"--config", conf.ConfigFile}, tt.args...)
 			c.SetArgs(args)
 
 			logrus.SetOutput(&out)

--- a/src/go/rpk/pkg/cli/cmd/stop_test.go
+++ b/src/go/rpk/pkg/cli/cmd/stop_test.go
@@ -74,7 +74,7 @@ func TestStopCommand(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			err = config.WriteConfig(fs, &conf, confPath)
+			err = config.WriteConfig(fs, conf, confPath)
 			require.NoError(t, err)
 
 			var out bytes.Buffer

--- a/src/go/rpk/pkg/cli/cmd/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/tune.go
@@ -105,7 +105,7 @@ Would you like to continue with the default configuration?`,
 				if !confirmed {
 					return nil
 				}
-				defaultConf := config.DefaultConfig()
+				defaultConf := config.Default()
 				conf = &defaultConf
 			}
 			config.CheckAndPrintNotice(conf.LicenseKey)

--- a/src/go/rpk/pkg/cli/cmd/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/tune.go
@@ -39,7 +39,7 @@ type result struct {
 	errMsg    string
 }
 
-func NewTuneCommand(fs afero.Fs) *cobra.Command {
+func NewTuneCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	tunerParams := factory.TunerParams{}
 	var (
 		configFile        string
@@ -88,7 +88,7 @@ func NewTuneCommand(fs afero.Fs) *cobra.Command {
 				return err
 			}
 			tunerParams.CpuMask = cpuMask
-			conf, err := config.FindOrGenerate(fs, configFile)
+			conf, err := mgr.FindOrGenerate(configFile)
 			if err != nil {
 				if !interactive {
 					return err

--- a/src/go/rpk/pkg/cli/cmd/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/tune.go
@@ -105,8 +105,7 @@ Would you like to continue with the default configuration?`,
 				if !confirmed {
 					return nil
 				}
-				defaultConf := config.Default()
-				conf = &defaultConf
+				conf = config.Default()
 			}
 			config.CheckAndPrintNotice(conf.LicenseKey)
 			var tunerFactory factory.TunersFactory

--- a/src/go/rpk/pkg/cli/cmd/tune_test.go
+++ b/src/go/rpk/pkg/cli/cmd/tune_test.go
@@ -52,7 +52,7 @@ func TestInteractive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conf := config.DefaultConfig()
+			conf := config.Default()
 			fs := afero.NewMemMapFs()
 			// Write invalid yaml to simulate an error
 			_, err := utils.WriteBytes(fs, []byte("*asdf&"), conf.ConfigFile)

--- a/src/go/rpk/pkg/cli/cmd/tune_test.go
+++ b/src/go/rpk/pkg/cli/cmd/tune_test.go
@@ -54,6 +54,7 @@ func TestInteractive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := config.Default()
 			fs := afero.NewMemMapFs()
+			mgr := config.NewManager(fs)
 			// Write invalid yaml to simulate an error
 			_, err := utils.WriteBytes(fs, []byte("*asdf&"), conf.ConfigFile)
 			if err != nil {
@@ -65,7 +66,7 @@ func TestInteractive(t *testing.T) {
 			}
 			var out bytes.Buffer
 			in := strings.NewReader(tt.input)
-			cmd := NewTuneCommand(fs)
+			cmd := NewTuneCommand(fs, mgr)
 			cmd.SetArgs([]string{"swappiness", "--interactive"})
 			cmd.SetIn(in)
 			logrus.SetOutput(&out)

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -107,7 +107,7 @@ func (conf *Config) PIDFile() string {
 	return path.Join(conf.Redpanda.Directory, "pid.lock")
 }
 
-func DefaultConfig() Config {
+func Default() Config {
 	return Config{
 		ConfigFile: "/etc/redpanda/redpanda.yaml",
 		Redpanda: &RedpandaConfig{
@@ -231,7 +231,7 @@ func ReadOrGenerate(fs afero.Fs, configFile string) (*Config, error) {
 			"Couldn't find config file at %s. Generating it.",
 			configFile,
 		)
-		conf := DefaultConfig()
+		conf := Default()
 		conf.ConfigFile = configFile
 		err = WriteConfig(fs, &conf, configFile)
 		if err != nil {
@@ -443,7 +443,7 @@ func setDevelopment(conf *Config) *Config {
 	conf.Rpk = &RpkConfig{
 		EnableUsageStats: conf.Rpk.EnableUsageStats,
 		CoredumpDir:      conf.Rpk.CoredumpDir,
-		SMP:              DefaultConfig().Rpk.SMP,
+		SMP:              Default().Rpk.SMP,
 		Overprovisioned:  true,
 	}
 	return conf

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -36,71 +36,71 @@ const (
 )
 
 type Config struct {
-	NodeUuid     string          `yaml:"node_uuid,omitempty" json:"nodeUuid"`
-	Organization string          `yaml:"organization,omitempty" json:"organization"`
-	LicenseKey   string          `yaml:"license_key,omitempty" json:"licenseKey"`
-	ClusterId    string          `yaml:"cluster_id,omitempty" json:"clusterId"`
-	ConfigFile   string          `yaml:"config_file,omitempty" json:"configFile"`
-	Redpanda     *RedpandaConfig `json:"redpanda"`
-	Rpk          *RpkConfig      `yaml:"rpk,omitempty" json:"rpk"`
+	NodeUuid     string          `yaml:"node_uuid,omitempty" mapstructure:"node_uuid,omitempty" json:"nodeUuid"`
+	Organization string          `yaml:"organization,omitempty" mapstructure:"organization,omitempty" json:"organization"`
+	LicenseKey   string          `yaml:"license_key,omitempty" mapstructure:"license_key,omitempty" json:"licenseKey"`
+	ClusterId    string          `yaml:"cluster_id,omitempty" mapstructure:"cluster_id,omitempty" json:"clusterId"`
+	ConfigFile   string          `yaml:"config_file" mapstructure:"config_file" json:"configFile"`
+	Redpanda     *RedpandaConfig `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
+	Rpk          *RpkConfig      `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
 }
 
 type RedpandaConfig struct {
-	Directory          string         `yaml:"data_directory" json:"dataDirectory"`
-	RPCServer          SocketAddress  `yaml:"rpc_server" json:"rpcServer"`
-	AdvertisedRPCAPI   *SocketAddress `yaml:"advertised_rpc_api,omitempty" json:"advertisedRpcApi"`
-	KafkaApi           SocketAddress  `yaml:"kafka_api" json:"kafkaApi"`
-	AdvertisedKafkaApi *SocketAddress `yaml:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi"`
-	KafkaApiTLS        ServerTLS      `yaml:"kafka_api_tls" json:"kafkaApiTls"`
-	AdminApi           SocketAddress  `yaml:"admin" json:"admin"`
-	Id                 int            `yaml:"node_id" json:"id"`
-	SeedServers        []*SeedServer  `yaml:"seed_servers" json:"seedServers"`
-	DeveloperMode      bool           `yaml:"developer_mode" json:"developerMode"`
+	Directory          string         `yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
+	RPCServer          SocketAddress  `yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
+	AdvertisedRPCAPI   *SocketAddress `yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
+	KafkaApi           SocketAddress  `yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
+	AdvertisedKafkaApi *SocketAddress `yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
+	KafkaApiTLS        ServerTLS      `yaml:"kafka_api_tls" mapstructure:"kafka_api_tls" json:"kafkaApiTls"`
+	AdminApi           SocketAddress  `yaml:"admin" mapstructure:"admin" json:"admin"`
+	Id                 int            `yaml:"node_id" mapstructure:"node_id" json:"id"`
+	SeedServers        []*SeedServer  `yaml:"seed_servers,omitempty" mapstructure:"seed_servers,omitempty" json:"seedServers"`
+	DeveloperMode      bool           `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
 }
 
 type SeedServer struct {
-	Host SocketAddress `yaml:"host" json:"host"`
-	Id   int           `yaml:"node_id" json:"id"`
+	Host SocketAddress `yaml:"host" mapstructure:"host" json:"host"`
+	Id   int           `yaml:"node_id" mapstructure:"node_id" json:"id"`
 }
 
 type SocketAddress struct {
-	Address string `yaml:"address" json:"address"`
-	Port    int    `yaml:"port" json:"port"`
+	Address string `yaml:"address" mapstructure:"address" json:"address"`
+	Port    int    `yaml:"port" mapstructure:"port" json:"port"`
 }
 
 type TLS struct {
-	KeyFile        string `yaml:"key_file" json:"keyFile"`
-	CertFile       string `yaml:"cert_file" json:"certFile"`
-	TruststoreFile string `yaml:"truststore_file" json:"truststoreFile"`
+	KeyFile        string `yaml:"key_file" mapstructure:"key_file" json:"keyFile"`
+	CertFile       string `yaml:"cert_file" mapstructure:"cert_file" json:"certFile"`
+	TruststoreFile string `yaml:"truststore_file" mapstructure:"truststore_file" json:"truststoreFile"`
 }
 
 type ServerTLS struct {
-	KeyFile        string `yaml:"key_file" json:"keyFile"`
-	CertFile       string `yaml:"cert_file" json:"certFile"`
-	TruststoreFile string `yaml:"truststore_file" json:"truststoreFile"`
-	Enabled        bool   `yaml:"enabled" json:"enabled"`
+	KeyFile        string `yaml:"key_file" mapstructure:"key_file" json:"keyFile"`
+	CertFile       string `yaml:"cert_file" mapstructure:"cert_file" json:"certFile"`
+	TruststoreFile string `yaml:"truststore_file" mapstructure:"truststore_file" json:"truststoreFile"`
+	Enabled        bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
 }
 
 type RpkConfig struct {
-	TLS                      TLS      `yaml:"tls" json:"tls"`
-	AdditionalStartFlags     []string `yaml:"additional_start_flags,omitempty" json:"additionalStartFlags"`
-	EnableUsageStats         bool     `yaml:"enable_usage_stats" json:"enableUsageStats"`
-	TuneNetwork              bool     `yaml:"tune_network" json:"tuneNetwork"`
-	TuneDiskScheduler        bool     `yaml:"tune_disk_scheduler" json:"tuneDiskScheduler"`
-	TuneNomerges             bool     `yaml:"tune_disk_nomerges" json:"tuneNomerges"`
-	TuneDiskIrq              bool     `yaml:"tune_disk_irq" json:"tuneDiskIrq"`
-	TuneFstrim               bool     `yaml:"tune_fstrim" json:"tuneFstrim"`
-	TuneCpu                  bool     `yaml:"tune_cpu" json:"tuneCpu"`
-	TuneAioEvents            bool     `yaml:"tune_aio_events" json:"tuneAioEvents"`
-	TuneClocksource          bool     `yaml:"tune_clocksource" json:"tuneClocksource"`
-	TuneSwappiness           bool     `yaml:"tune_swappiness" json:"tuneSwappiness"`
-	TuneTransparentHugePages bool     `yaml:"tune_transparent_hugepages" json:"tuneTransparentHugePages"`
-	EnableMemoryLocking      bool     `yaml:"enable_memory_locking" json:"enableMemoryLocking"`
-	TuneCoredump             bool     `yaml:"tune_coredump" json:"tuneCoredump"`
-	CoredumpDir              string   `yaml:"coredump_dir" json:"coredumpDir"`
-	WellKnownIo              string   `yaml:"well_known_io,omitempty" json:"wellKnownIo"`
-	Overprovisioned          bool     `yaml:"overprovisioned", json:"overprovisioned"`
-	SMP                      *int     `yaml:"smp,omitempty", json:"smp,omitempty"`
+	TLS                      TLS      `yaml:"tls" mapstructure:"tls" json:"tls"`
+	AdditionalStartFlags     []string `yaml:"additional_start_flags,omitempty" mapstructure:"additional_start_flags,omitempty" json:"additionalStartFlags"`
+	EnableUsageStats         bool     `yaml:"enable_usage_stats" mapstructure:"enable_usage_stats" json:"enableUsageStats"`
+	TuneNetwork              bool     `yaml:"tune_network" mapstructure:"tune_network" json:"tuneNetwork"`
+	TuneDiskScheduler        bool     `yaml:"tune_disk_scheduler" mapstructure:"tune_disk_scheduler" json:"tuneDiskScheduler"`
+	TuneNomerges             bool     `yaml:"tune_disk_nomerges" mapstructure:"tune_disk_nomerges" json:"tuneNomerges"`
+	TuneDiskIrq              bool     `yaml:"tune_disk_irq" mapstructure:"tune_disk_irq" json:"tuneDiskIrq"`
+	TuneFstrim               bool     `yaml:"tune_fstrim" mapstructure:"tune_fstrim" json:"tuneFstrim"`
+	TuneCpu                  bool     `yaml:"tune_cpu" mapstructure:"tune_cpu" json:"tuneCpu"`
+	TuneAioEvents            bool     `yaml:"tune_aio_events" mapstructure:"tune_aio_events" json:"tuneAioEvents"`
+	TuneClocksource          bool     `yaml:"tune_clocksource" mapstructure:"tune_clocksource" json:"tuneClocksource"`
+	TuneSwappiness           bool     `yaml:"tune_swappiness" mapstructure:"tune_swappiness" json:"tuneSwappiness"`
+	TuneTransparentHugePages bool     `yaml:"tune_transparent_hugepages" mapstructure:"tune_transparent_hugepages" json:"tuneTransparentHugePages"`
+	EnableMemoryLocking      bool     `yaml:"enable_memory_locking" mapstructure:"enable_memory_locking" json:"enableMemoryLocking"`
+	TuneCoredump             bool     `yaml:"tune_coredump" mapstructure:"tune_coredump" json:"tuneCoredump"`
+	CoredumpDir              string   `yaml:"coredump_dir,omitempty" mapstructure:"coredump_dir,omitempty" json:"coredumpDir"`
+	WellKnownIo              string   `yaml:"well_known_io,omitempty" mapstructure:"well_known_io,omitempty" json:"wellKnownIo"`
+	Overprovisioned          bool     `yaml:"overprovisioned" mapstructure:"overprovisioned" json:"overprovisioned"`
+	SMP                      *int     `yaml:"smp,omitempty" mapstructure:"smp,omitempty" json:"smp,omitempty"`
 }
 
 func (conf *Config) PIDFile() string {
@@ -108,18 +108,36 @@ func (conf *Config) PIDFile() string {
 }
 
 func Default() Config {
-	return Config{
-		ConfigFile: "/etc/redpanda/redpanda.yaml",
-		Redpanda: &RedpandaConfig{
-			Directory:   "/var/lib/redpanda/data",
-			RPCServer:   SocketAddress{"0.0.0.0", 33145},
-			KafkaApi:    SocketAddress{"0.0.0.0", 9092},
-			AdminApi:    SocketAddress{"0.0.0.0", 9644},
-			Id:          0,
-			SeedServers: []*SeedServer{},
+	conf := &Config{}
+	err := mapstructure.Decode(defaultMap(), conf)
+	if err != nil {
+		panic(err)
+	}
+	return *conf
+}
+
+func defaultMap() map[string]interface{} {
+	return map[string]interface{}{
+		"config_file": "/etc/redpanda/redpanda.yaml",
+		"redpanda": map[string]interface{}{
+			"data_directory": "/var/lib/redpanda/data",
+			"rpc_server": map[string]interface{}{
+				"address": "0.0.0.0",
+				"port":    33145,
+			},
+			"kafka_api": map[string]interface{}{
+				"address": "0.0.0.0",
+				"port":    9092,
+			},
+			"admin": map[string]interface{}{
+				"address": "0.0.0.0",
+				"port":    9644,
+			},
+			"node_id":      0,
+			"seed_servers": []map[string]interface{}{},
 		},
-		Rpk: &RpkConfig{
-			CoredumpDir: "/var/lib/redpanda/coredump",
+		"rpk": map[string]interface{}{
+			"coredump_dir": "/var/lib/redpanda/coredump",
 		},
 	}
 }

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -34,13 +34,13 @@ const (
 	ModeProd = "prod"
 )
 
-func Default() Config {
+func Default() *Config {
 	conf := &Config{}
 	err := mapstructure.Decode(defaultMap(), conf)
 	if err != nil {
 		panic(err)
 	}
-	return *conf
+	return conf
 }
 
 func defaultMap() map[string]interface{} {
@@ -178,7 +178,7 @@ func ReadOrGenerate(fs afero.Fs, configFile string) (*Config, error) {
 		)
 		conf := Default()
 		conf.ConfigFile = configFile
-		err = WriteConfig(fs, &conf, configFile)
+		err = WriteConfig(fs, conf, configFile)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"Couldn't write config to %s: %v",
@@ -186,7 +186,7 @@ func ReadOrGenerate(fs afero.Fs, configFile string) (*Config, error) {
 				err,
 			)
 		}
-		return &conf, nil
+		return conf, nil
 	}
 	return nil, fmt.Errorf(
 		"An error happened while trying to read %s: %v",

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -54,7 +54,7 @@ type RedpandaConfig struct {
 	KafkaApiTLS        ServerTLS      `yaml:"kafka_api_tls" mapstructure:"kafka_api_tls" json:"kafkaApiTls"`
 	AdminApi           SocketAddress  `yaml:"admin" mapstructure:"admin" json:"admin"`
 	Id                 int            `yaml:"node_id" mapstructure:"node_id" json:"id"`
-	SeedServers        []*SeedServer  `yaml:"seed_servers,omitempty" mapstructure:"seed_servers,omitempty" json:"seedServers"`
+	SeedServers        []SeedServer   `yaml:"seed_servers,omitempty" mapstructure:"seed_servers,omitempty" json:"seedServers"`
 	DeveloperMode      bool           `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
 }
 

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -10,18 +10,12 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"math/big"
 	"os"
 	fp "path/filepath"
-	"strconv"
 	"strings"
-	"vectorized/pkg/utils"
-	vyaml "vectorized/pkg/yaml"
 
-	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -109,68 +103,6 @@ func defaultMap() map[string]interface{} {
 	}
 }
 
-func Set(fs afero.Fs, key, value, format, path string) error {
-	confMap, err := read(fs, path)
-	if err != nil {
-		return err
-	}
-	v := viper.New()
-	v.MergeConfigMap(confMap)
-	var newConfValue interface{}
-	switch strings.ToLower(format) {
-	case "single":
-		v.Set(key, parse(value))
-		err = checkAndWrite(fs, v.AllSettings(), path)
-		if err == nil {
-			checkAndPrintRestartWarning(key)
-		}
-		return err
-	case "yaml":
-		err := yaml.Unmarshal([]byte(value), &newConfValue)
-		if err != nil {
-			return err
-		}
-	case "json":
-		err := json.Unmarshal([]byte(value), &newConfValue)
-		if err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unsupported format %s", format)
-	}
-
-	newV := viper.New()
-	newV.Set(key, newConfValue)
-	v.MergeConfigMap(newV.AllSettings())
-	err = checkAndWrite(fs, v.AllSettings(), path)
-	if err == nil {
-		checkAndPrintRestartWarning(key)
-	}
-	return err
-}
-
-func parse(val string) interface{} {
-	if i, err := strconv.Atoi(val); err == nil {
-		return i
-	}
-	if f, err := strconv.ParseFloat(val, 64); err == nil {
-		return f
-	}
-	if b, err := strconv.ParseBool(val); err == nil {
-		return b
-	}
-	return val
-}
-
-// Checks config and writes it to the given path.
-func WriteConfig(fs afero.Fs, config *Config, path string) error {
-	confMap, err := toMap(config)
-	if err != nil {
-		return err
-	}
-	return checkAndWrite(fs, confMap, path)
-}
-
 func findBackup(fs afero.Fs, dir string) (string, error) {
 	exists, err := afero.Exists(fs, dir)
 	if err != nil {
@@ -189,215 +121,6 @@ func findBackup(fs afero.Fs, dir string) (string, error) {
 		}
 	}
 	return "", nil
-}
-
-func ReadConfigFromPath(fs afero.Fs, path string) (*Config, error) {
-	log.Debugf("Reading Redpanda config file from '%s'", path)
-	config := &Config{}
-	err := vyaml.Read(fs, config, path)
-	if err != nil {
-		return nil, err
-	}
-	config.ConfigFile = path
-	return config, nil
-}
-
-// Tries reading a config file at the given path, or generates a default config
-// and writes it to the path.
-func ReadOrGenerate(fs afero.Fs, configFile string) (*Config, error) {
-	conf, err := ReadConfigFromPath(fs, configFile)
-	if err == nil {
-		// The config file's there, there's nothing to do.
-		return conf, nil
-	}
-	if os.IsNotExist(err) {
-		log.Debug(err)
-		log.Infof(
-			"Couldn't find config file at %s. Generating it.",
-			configFile,
-		)
-		conf := Default()
-		conf.ConfigFile = configFile
-		err = WriteConfig(fs, conf, configFile)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"Couldn't write config to %s: %v",
-				configFile,
-				err,
-			)
-		}
-		return conf, nil
-	}
-	return nil, fmt.Errorf(
-		"An error happened while trying to read %s: %v",
-		configFile,
-		err,
-	)
-}
-
-func ReadOrFind(fs afero.Fs, configFile string) (*Config, error) {
-	var err error
-	if configFile == "" {
-		configFile, err = FindConfigFile(fs)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return ReadConfigFromPath(fs, configFile)
-}
-
-// If configFile is empty, tries to find the file in the default locations.
-// Otherwise, it tries to read the file and load it. If the file doesn't
-// exist, it tries to create it with the default configuration.
-func FindOrGenerate(fs afero.Fs, configFile string) (*Config, error) {
-	var err error
-	if configFile == "" {
-		configFile, err = FindConfigFile(fs)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return ReadOrGenerate(fs, configFile)
-}
-func CheckConfig(config *Config) (bool, []error) {
-	configMap, err := toMap(config)
-	if err != nil {
-		return false, []error{err}
-	}
-	return check(configMap)
-}
-
-func recover(fs afero.Fs, backup, path string, err error) error {
-	log.Infof("Recovering the previous confing from %s", backup)
-	recErr := utils.CopyFile(fs, backup, path)
-	if recErr != nil {
-		msg := "couldn't persist the new config due to '%v'," +
-			" nor recover the backup due to '%v"
-		return fmt.Errorf(msg, err, recErr)
-	}
-	return fmt.Errorf("couldn't persist the new config due to '%v'", err)
-}
-
-func checkAndWrite(
-	fs afero.Fs, conf map[string]interface{}, path string,
-) error {
-	ok, errs := check(conf)
-	if !ok {
-		reasons := []string{}
-		for _, err := range errs {
-			reasons = append(reasons, err.Error())
-		}
-		return errors.New(strings.Join(reasons, ", "))
-	}
-	lastBackupFile, err := findBackup(fs, fp.Dir(path))
-	if err != nil {
-		return err
-	}
-	exists, err := afero.Exists(fs, path)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		// If the config doesn't exist, just write it.
-		return write(fs, conf, path)
-	}
-	// Otherwise, backup the current config file, write the new one, and
-	// try to recover if there's an error.
-	log.Debug("Backing up the current config")
-	backup, err := utils.BackupFile(fs, path)
-	if err != nil {
-		return err
-	}
-	log.Debugf("Backed up the current config to %s", backup)
-	if lastBackupFile != "" && lastBackupFile != backup {
-		log.Debug("Removing previous backup file")
-		err = fs.Remove(lastBackupFile)
-		if err != nil {
-			return err
-		}
-	}
-	currentConf, err := read(fs, path)
-	if err != nil {
-		return recover(fs, backup, path, err)
-	}
-	log.Debugf("Writing the new redpanda config to '%s'", path)
-	if err != nil {
-		return recover(fs, backup, path, err)
-	}
-	merged := merge(currentConf, conf)
-	err = write(fs, merged, path)
-	if err != nil {
-		return recover(fs, backup, path, err)
-	}
-	return nil
-}
-
-func ReadFlat(fs afero.Fs, path string) (map[string]string, error) {
-	v, err := readViper(fs, path)
-	if err != nil {
-		return nil, err
-	}
-	keys := v.AllKeys()
-	flatMap := map[string]string{}
-	compactAddrFields := []string{
-		"redpanda.kafka_api",
-		"redpanda.rpc_server",
-		"redpanda.admin",
-	}
-	unmarshalKey := func(key string, val interface{}) error {
-		return v.UnmarshalKey(
-			key,
-			val,
-			func(c *mapstructure.DecoderConfig) {
-				c.TagName = "yaml"
-			},
-		)
-	}
-	for _, k := range keys {
-		if k == "redpanda.seed_servers" {
-			seeds := &[]SeedServer{}
-			err := unmarshalKey(k, seeds)
-			if err != nil {
-				return nil, err
-			}
-			for _, s := range *seeds {
-				key := fmt.Sprintf("%s.%d", k, s.Id)
-				flatMap[key] = fmt.Sprintf("%s:%d", s.Host.Address, s.Host.Port)
-			}
-			continue
-		}
-		// These fields are added later on as <address>:<port>
-		// instead of
-		// field.address <address>
-		// field.port    <port>
-		if strings.HasSuffix(k, ".port") || strings.HasSuffix(k, ".address") {
-			continue
-		}
-
-		s := v.GetString(k)
-		flatMap[k] = s
-	}
-	for _, k := range compactAddrFields {
-		sa := &SocketAddress{}
-		err := unmarshalKey(k, sa)
-		if err != nil {
-			return nil, err
-		}
-		flatMap[k] = fmt.Sprintf("%s:%d", sa.Address, sa.Port)
-	}
-	return flatMap, nil
-}
-
-func ReadAsJSON(fs afero.Fs, path string) (string, error) {
-	confMap, err := read(fs, path)
-	if err != nil {
-		return "", err
-	}
-	confJSON, err := json.Marshal(confMap)
-	if err != nil {
-		return "", err
-	}
-	return string(confJSON), nil
 }
 
 func SetMode(mode string, conf *Config) (*Config, error) {
@@ -449,15 +172,6 @@ func setProduction(conf *Config) *Config {
 	return conf
 }
 
-func AvailableModes() []string {
-	return []string{
-		ModeDev,
-		"development",
-		ModeProd,
-		"production",
-	}
-}
-
 func NormalizeMode(mode string) (string, error) {
 	switch mode {
 	case "":
@@ -478,62 +192,29 @@ func NormalizeMode(mode string) (string, error) {
 	}
 }
 
-func write(fs afero.Fs, conf map[string]interface{}, path string) error {
-	v := viper.New()
-	v.SetFs(fs)
-	v.MergeConfigMap(conf)
-	err := v.WriteConfigAs(path)
-	if err != nil {
-		return err
+func AvailableModes() []string {
+	return []string{
+		ModeDev,
+		"development",
+		ModeProd,
+		"production",
 	}
-	log.Debugf(
-		"Configuration written to %s.",
-		path,
-	)
-	return nil
 }
 
-func merge(current, new map[string]interface{}) map[string]interface{} {
-	v := viper.New()
-	v.MergeConfigMap(current)
-	v.MergeConfigMap(new)
-	return v.AllSettings()
-}
-
-func read(fs afero.Fs, path string) (map[string]interface{}, error) {
-	v, err := readViper(fs, path)
+func Check(conf *Config) (bool, []error) {
+	configMap, err := toMap(conf)
 	if err != nil {
-		return nil, err
+		return false, []error{err}
 	}
-	return v.AllSettings(), nil
-}
-
-func readViper(fs afero.Fs, path string) (*viper.Viper, error) {
 	v := viper.New()
-	v.SetFs(fs)
-	v.SetConfigFile(path)
-	v.SetConfigType("yaml")
-	err := v.ReadInConfig()
-	return v, err
-}
-
-func toMap(conf *Config) (map[string]interface{}, error) {
-	mapConf := make(map[string]interface{})
-	bs, err := yaml.Marshal(conf)
+	err = v.MergeConfigMap(configMap)
 	if err != nil {
-		return mapConf, err
+		return false, []error{err}
 	}
-	err = yaml.Unmarshal(bs, &mapConf)
-	return mapConf, err
+	return check(v)
 }
 
-func check(conf map[string]interface{}) (bool, []error) {
-	v := viper.New()
-	v.MergeConfigMap(conf)
-	return checkViper(v)
-}
-
-func checkViper(v *viper.Viper) (bool, []error) {
+func check(v *viper.Viper) (bool, []error) {
 	errs := checkRedpandaConfig(v)
 	errs = append(
 		errs,
@@ -545,26 +226,40 @@ func checkViper(v *viper.Viper) (bool, []error) {
 
 func checkRedpandaConfig(v *viper.Viper) []error {
 	errs := []error{}
-	rp := v.Sub("redpanda")
-	if rp == nil {
-		return []error{errors.New("the redpanda config is missing")}
-	}
-	if rp.GetString("data_directory") == "" {
+	if v.GetString("redpanda.data_directory") == "" {
 		errs = append(errs, fmt.Errorf("redpanda.data_directory can't be empty"))
 	}
-	if rp.GetInt("node_id") < 0 {
+	if v.GetInt("redpanda.node_id") < 0 {
 		errs = append(errs, fmt.Errorf("redpanda.node_id can't be a negative integer"))
 	}
-	errs = append(
-		errs,
-		checkSocketAddress(rp.Sub("rpc_server"), "redpanda.rpc_server")...,
-	)
-	errs = append(
-		errs,
-		checkSocketAddress(rp.Sub("kafka_api"), "redpanda.kafka_api")...,
-	)
-	var seedServersSlice []map[string]interface{}
-	err := rp.UnmarshalKey("seed_servers", &seedServersSlice)
+
+	apiConfigKeys := []string{"redpanda.rpc_server", "redpanda.kafka_api"}
+
+	for _, key := range apiConfigKeys {
+		exists := v.Sub(key) != nil
+		if !exists {
+			errs = append(
+				errs,
+				fmt.Errorf("%s missing", key),
+			)
+		} else {
+			socket := &SocketAddress{}
+			err := v.UnmarshalKey(key, socket)
+			if err != nil {
+				errs = append(
+					errs,
+					fmt.Errorf("invalid structure for %s", key),
+				)
+			} else {
+				errs = append(
+					errs,
+					checkSocketAddress(*socket, key)...,
+				)
+			}
+		}
+	}
+	var seedServersSlice []*SeedServer //map[string]interface{}
+	err := v.UnmarshalKey("redpanda.seed_servers", &seedServersSlice)
 	if err != nil {
 		log.Error(err)
 		msg := "redpanda.seed_servers doesn't have the expected structure"
@@ -576,18 +271,6 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 	if len(seedServersSlice) > 0 {
 		seedServersPath := "redpanda.seed_servers"
 		for i, seed := range seedServersSlice {
-			s := viper.New()
-			s.MergeConfigMap(seed)
-			host := s.Sub("host")
-			if host == nil {
-				err := fmt.Errorf(
-					"%s.%d.host can't be empty",
-					seedServersPath,
-					i,
-				)
-				errs = append(errs, err)
-				continue
-			}
 			configPath := fmt.Sprintf(
 				"%s.%d.host",
 				seedServersPath,
@@ -596,7 +279,7 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 			errs = append(
 				errs,
 				checkSocketAddress(
-					host,
+					seed.Host,
 					configPath,
 				)...,
 			)
@@ -605,12 +288,12 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 	return errs
 }
 
-func checkSocketAddress(v *viper.Viper, configPath string) []error {
+func checkSocketAddress(s SocketAddress, configPath string) []error {
 	errs := []error{}
-	if v.GetInt("port") == 0 {
+	if s.Port == 0 {
 		errs = append(errs, fmt.Errorf("%s.port can't be 0", configPath))
 	}
-	if v.GetString("address") == "" {
+	if s.Address == "" {
 		errs = append(errs, fmt.Errorf("%s.address can't be empty", configPath))
 	}
 	return errs
@@ -618,11 +301,7 @@ func checkSocketAddress(v *viper.Viper, configPath string) []error {
 
 func checkRpkConfig(v *viper.Viper) []error {
 	errs := []error{}
-	rpk := v.Sub("rpk")
-	if rpk == nil {
-		return errs
-	}
-	if rpk.GetBool("tune_coredump") && rpk.GetString("coredump_dir") == "" {
+	if v.GetBool("rpk.tune_coredump") && v.GetString("rpk.coredump_dir") == "" {
 		msg := "if rpk.tune_coredump is set to true," +
 			"rpk.coredump_dir can't be empty"
 		errs = append(errs, errors.New(msg))
@@ -630,73 +309,12 @@ func checkRpkConfig(v *viper.Viper) []error {
 	return errs
 }
 
-func GenerateAndWriteNodeUuid(fs afero.Fs, conf *Config) (*Config, error) {
-	id, err := uuid.NewUUID()
+func toMap(conf *Config) (map[string]interface{}, error) {
+	mapConf := make(map[string]interface{})
+	bs, err := yaml.Marshal(conf)
 	if err != nil {
-		return nil, err
+		return mapConf, err
 	}
-	conf.NodeUuid = base58Encode(id.String())
-	err = WriteConfig(fs, conf, conf.ConfigFile)
-	if err != nil {
-		return nil, err
-	}
-	return conf, nil
-}
-
-func stringifyMap(m map[interface{}]interface{}) map[string]interface{} {
-	new := map[string]interface{}{}
-	for k, v := range m {
-		sk := fmt.Sprintf("%v", k)
-		sub, ok := v.(map[interface{}]interface{})
-		if ok {
-			newSub := stringifyMap(sub)
-			new[sk] = newSub
-			continue
-		}
-		new[sk] = v
-	}
-	return new
-}
-
-func base58Encode(s string) string {
-	b := []byte(s)
-
-	alphabet := "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-	alphabetIdx0 := byte('1')
-	bigRadix := big.NewInt(58)
-	bigZero := big.NewInt(0)
-	x := new(big.Int)
-	x.SetBytes(b)
-
-	answer := make([]byte, 0, len(b)*136/100)
-	for x.Cmp(bigZero) > 0 {
-		mod := new(big.Int)
-		x.DivMod(x, bigRadix, mod)
-		answer = append(answer, alphabet[mod.Int64()])
-	}
-
-	// leading zero bytes
-	for _, i := range b {
-		if i != 0 {
-			break
-		}
-		answer = append(answer, alphabetIdx0)
-	}
-
-	// reverse
-	alen := len(answer)
-	for i := 0; i < alen/2; i++ {
-		answer[i], answer[alen-1-i] = answer[alen-1-i], answer[i]
-	}
-
-	return string(answer)
-}
-
-func checkAndPrintRestartWarning(fieldKey string) {
-	if strings.HasPrefix(fieldKey, "redpanda") {
-		log.Info(
-			"If redpanda is running, please restart it for the" +
-				" changes to take effect.",
-		)
-	}
+	err = yaml.Unmarshal(bs, &mapConf)
+	return mapConf, err
 }

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -34,78 +33,6 @@ const (
 	ModeDev  = "dev"
 	ModeProd = "prod"
 )
-
-type Config struct {
-	NodeUuid     string          `yaml:"node_uuid,omitempty" mapstructure:"node_uuid,omitempty" json:"nodeUuid"`
-	Organization string          `yaml:"organization,omitempty" mapstructure:"organization,omitempty" json:"organization"`
-	LicenseKey   string          `yaml:"license_key,omitempty" mapstructure:"license_key,omitempty" json:"licenseKey"`
-	ClusterId    string          `yaml:"cluster_id,omitempty" mapstructure:"cluster_id,omitempty" json:"clusterId"`
-	ConfigFile   string          `yaml:"config_file" mapstructure:"config_file" json:"configFile"`
-	Redpanda     *RedpandaConfig `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
-	Rpk          *RpkConfig      `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
-}
-
-type RedpandaConfig struct {
-	Directory          string         `yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
-	RPCServer          SocketAddress  `yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
-	AdvertisedRPCAPI   *SocketAddress `yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
-	KafkaApi           SocketAddress  `yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
-	AdvertisedKafkaApi *SocketAddress `yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
-	KafkaApiTLS        ServerTLS      `yaml:"kafka_api_tls" mapstructure:"kafka_api_tls" json:"kafkaApiTls"`
-	AdminApi           SocketAddress  `yaml:"admin" mapstructure:"admin" json:"admin"`
-	Id                 int            `yaml:"node_id" mapstructure:"node_id" json:"id"`
-	SeedServers        []SeedServer   `yaml:"seed_servers,omitempty" mapstructure:"seed_servers,omitempty" json:"seedServers"`
-	DeveloperMode      bool           `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
-}
-
-type SeedServer struct {
-	Host SocketAddress `yaml:"host" mapstructure:"host" json:"host"`
-	Id   int           `yaml:"node_id" mapstructure:"node_id" json:"id"`
-}
-
-type SocketAddress struct {
-	Address string `yaml:"address" mapstructure:"address" json:"address"`
-	Port    int    `yaml:"port" mapstructure:"port" json:"port"`
-}
-
-type TLS struct {
-	KeyFile        string `yaml:"key_file" mapstructure:"key_file" json:"keyFile"`
-	CertFile       string `yaml:"cert_file" mapstructure:"cert_file" json:"certFile"`
-	TruststoreFile string `yaml:"truststore_file" mapstructure:"truststore_file" json:"truststoreFile"`
-}
-
-type ServerTLS struct {
-	KeyFile        string `yaml:"key_file" mapstructure:"key_file" json:"keyFile"`
-	CertFile       string `yaml:"cert_file" mapstructure:"cert_file" json:"certFile"`
-	TruststoreFile string `yaml:"truststore_file" mapstructure:"truststore_file" json:"truststoreFile"`
-	Enabled        bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
-}
-
-type RpkConfig struct {
-	TLS                      TLS      `yaml:"tls" mapstructure:"tls" json:"tls"`
-	AdditionalStartFlags     []string `yaml:"additional_start_flags,omitempty" mapstructure:"additional_start_flags,omitempty" json:"additionalStartFlags"`
-	EnableUsageStats         bool     `yaml:"enable_usage_stats" mapstructure:"enable_usage_stats" json:"enableUsageStats"`
-	TuneNetwork              bool     `yaml:"tune_network" mapstructure:"tune_network" json:"tuneNetwork"`
-	TuneDiskScheduler        bool     `yaml:"tune_disk_scheduler" mapstructure:"tune_disk_scheduler" json:"tuneDiskScheduler"`
-	TuneNomerges             bool     `yaml:"tune_disk_nomerges" mapstructure:"tune_disk_nomerges" json:"tuneNomerges"`
-	TuneDiskIrq              bool     `yaml:"tune_disk_irq" mapstructure:"tune_disk_irq" json:"tuneDiskIrq"`
-	TuneFstrim               bool     `yaml:"tune_fstrim" mapstructure:"tune_fstrim" json:"tuneFstrim"`
-	TuneCpu                  bool     `yaml:"tune_cpu" mapstructure:"tune_cpu" json:"tuneCpu"`
-	TuneAioEvents            bool     `yaml:"tune_aio_events" mapstructure:"tune_aio_events" json:"tuneAioEvents"`
-	TuneClocksource          bool     `yaml:"tune_clocksource" mapstructure:"tune_clocksource" json:"tuneClocksource"`
-	TuneSwappiness           bool     `yaml:"tune_swappiness" mapstructure:"tune_swappiness" json:"tuneSwappiness"`
-	TuneTransparentHugePages bool     `yaml:"tune_transparent_hugepages" mapstructure:"tune_transparent_hugepages" json:"tuneTransparentHugePages"`
-	EnableMemoryLocking      bool     `yaml:"enable_memory_locking" mapstructure:"enable_memory_locking" json:"enableMemoryLocking"`
-	TuneCoredump             bool     `yaml:"tune_coredump" mapstructure:"tune_coredump" json:"tuneCoredump"`
-	CoredumpDir              string   `yaml:"coredump_dir,omitempty" mapstructure:"coredump_dir,omitempty" json:"coredumpDir"`
-	WellKnownIo              string   `yaml:"well_known_io,omitempty" mapstructure:"well_known_io,omitempty" json:"wellKnownIo"`
-	Overprovisioned          bool     `yaml:"overprovisioned" mapstructure:"overprovisioned" json:"overprovisioned"`
-	SMP                      *int     `yaml:"smp,omitempty" mapstructure:"smp,omitempty" json:"smp,omitempty"`
-}
-
-func (conf *Config) PIDFile() string {
-	return path.Join(conf.Redpanda.Directory, "pid.lock")
-}
 
 func Default() Config {
 	conf := &Config{}
@@ -458,7 +385,7 @@ func SetMode(mode string, conf *Config) (*Config, error) {
 func setDevelopment(conf *Config) *Config {
 	conf.Redpanda.DeveloperMode = true
 	// Defaults to setting all tuners to false
-	conf.Rpk = &RpkConfig{
+	conf.Rpk = RpkConfig{
 		EnableUsageStats: conf.Rpk.EnableUsageStats,
 		CoredumpDir:      conf.Rpk.CoredumpDir,
 		SMP:              Default().Rpk.SMP,
@@ -469,17 +396,16 @@ func setDevelopment(conf *Config) *Config {
 
 func setProduction(conf *Config) *Config {
 	conf.Redpanda.DeveloperMode = false
-	rpk := conf.Rpk
-	rpk.TuneNetwork = true
-	rpk.TuneDiskScheduler = true
-	rpk.TuneNomerges = true
-	rpk.TuneDiskIrq = true
-	rpk.TuneFstrim = true
-	rpk.TuneCpu = true
-	rpk.TuneAioEvents = true
-	rpk.TuneClocksource = true
-	rpk.TuneSwappiness = true
-	rpk.Overprovisioned = false
+	conf.Rpk.TuneNetwork = true
+	conf.Rpk.TuneDiskScheduler = true
+	conf.Rpk.TuneNomerges = true
+	conf.Rpk.TuneDiskIrq = true
+	conf.Rpk.TuneFstrim = true
+	conf.Rpk.TuneCpu = true
+	conf.Rpk.TuneAioEvents = true
+	conf.Rpk.TuneClocksource = true
+	conf.Rpk.TuneSwappiness = true
+	conf.Rpk.Overprovisioned = false
 	return conf
 }
 

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func getValidConfig() *Config {
 		CoredumpDir:              "/var/lib/redpanda/coredumps",
 		WellKnownIo:              "vendor:vm:storage",
 	}
-	return &conf
+	return conf
 }
 
 func TestSet(t *testing.T) {
@@ -173,7 +173,7 @@ func TestSet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			conf := Default()
-			err := WriteConfig(fs, &conf, conf.ConfigFile)
+			err := WriteConfig(fs, conf, conf.ConfigFile)
 			require.NoError(t, err)
 			err = Set(fs, tt.key, tt.value, tt.format, conf.ConfigFile)
 			if tt.expectErr {
@@ -195,7 +195,7 @@ func TestSet(t *testing.T) {
 
 func TestDefault(t *testing.T) {
 	defaultConfig := Default()
-	expected := Config{
+	expected := &Config{
 		ConfigFile: "/etc/redpanda/redpanda.yaml",
 		Redpanda: RedpandaConfig{
 			Directory: "/var/lib/redpanda/data",
@@ -615,7 +615,7 @@ func TestInitConfig(t *testing.T) {
 			name: "it shouldn't fail if there's a config file already",
 			setup: func(fs afero.Fs) error {
 				conf := Default()
-				return WriteConfig(fs, &conf, conf.ConfigFile)
+				return WriteConfig(fs, conf, conf.ConfigFile)
 			},
 			configFile: Default().ConfigFile,
 		},
@@ -651,7 +651,7 @@ func TestInitConfig(t *testing.T) {
 }
 
 func TestSetMode(t *testing.T) {
-	fillRpkConfig := func(mode string) Config {
+	fillRpkConfig := func(mode string) *Config {
 		conf := Default()
 		val := mode == ModeProd
 		conf.Redpanda.DeveloperMode = !val
@@ -674,7 +674,7 @@ func TestSetMode(t *testing.T) {
 	tests := []struct {
 		name           string
 		mode           string
-		expectedConfig Config
+		expectedConfig *Config
 		expectedErrMsg string
 	}{
 		{
@@ -712,13 +712,13 @@ func TestSetMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(st *testing.T) {
 			defaultConf := Default()
-			conf, err := SetMode(tt.mode, &defaultConf)
+			conf, err := SetMode(tt.mode, defaultConf)
 			if tt.expectedErrMsg != "" {
 				require.EqualError(t, err, tt.expectedErrMsg)
 				return
 			}
 			require.NoError(t, err)
-			require.Exactly(t, tt.expectedConfig, *conf)
+			require.Exactly(t, tt.expectedConfig, conf)
 		})
 	}
 }
@@ -863,7 +863,7 @@ func TestReadAsJSON(t *testing.T) {
 			name: "it should load the config as JSON",
 			before: func(fs afero.Fs) error {
 				conf := Default()
-				return WriteConfig(fs, &conf, conf.ConfigFile)
+				return WriteConfig(fs, conf, conf.ConfigFile)
 			},
 			path:     Default().ConfigFile,
 			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","redpanda":{"admin":{"address":"0.0.0.0","port":9644},"data_directory":"/var/lib/redpanda/data","developer_mode":false,"kafka_api":{"address":"0.0.0.0","port":9092},"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
@@ -929,7 +929,7 @@ func TestReadFlat(t *testing.T) {
 			1001,
 		},
 	}
-	err := WriteConfig(fs, &conf, conf.ConfigFile)
+	err := WriteConfig(fs, conf, conf.ConfigFile)
 	require.NoError(t, err)
 	props, err := ReadFlat(fs, conf.ConfigFile)
 	require.NoError(t, err)

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -33,7 +33,7 @@ func getValidConfig() *Config {
 			2,
 		},
 	}
-	conf.Rpk = &RpkConfig{
+	conf.Rpk = RpkConfig{
 		EnableUsageStats:         true,
 		TuneNetwork:              true,
 		TuneDiskScheduler:        true,
@@ -103,13 +103,8 @@ func TestSet(t *testing.T) {
 			value:  `tune_disk_irq: true`,
 			format: "yaml",
 			expected: map[string]interface{}{
-				"enable_usage_stats": false,
-				"overprovisioned":    false,
-				"tls": map[string]interface{}{
-					"cert_file":       "",
-					"key_file":        "",
-					"truststore_file": "",
-				},
+				"enable_usage_stats":         false,
+				"overprovisioned":            false,
 				"tune_network":               false,
 				"tune_disk_scheduler":        false,
 				"tune_disk_nomerges":         false,
@@ -202,14 +197,14 @@ func TestDefault(t *testing.T) {
 	defaultConfig := Default()
 	expected := Config{
 		ConfigFile: "/etc/redpanda/redpanda.yaml",
-		Redpanda: &RedpandaConfig{
+		Redpanda: RedpandaConfig{
 			Directory: "/var/lib/redpanda/data",
 			RPCServer: SocketAddress{"0.0.0.0", 33145},
 			KafkaApi:  SocketAddress{"0.0.0.0", 9092},
 			AdminApi:  SocketAddress{"0.0.0.0", 9644},
 			Id:        0,
 		},
-		Rpk: &RpkConfig{
+		Rpk: RpkConfig{
 			CoredumpDir: "/var/lib/redpanda/coredump",
 		},
 	}
@@ -280,7 +275,6 @@ func TestWriteConfig(t *testing.T) {
 					"174.32.64.2",
 					33145,
 				}
-				c.Rpk = nil
 				return c
 			},
 			wantErr: false,
@@ -297,11 +291,6 @@ redpanda:
   kafka_api:
     address: 0.0.0.0
     port: 9092
-  kafka_api_tls:
-    cert_file: ""
-    enabled: false
-    key_file: ""
-    truststore_file: ""
   node_id: 0
   rpc_server:
     address: 0.0.0.0
@@ -315,6 +304,23 @@ redpanda:
       address: 127.0.0.1
       port: 33146
     node_id: 2
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
 `,
 		},
 		{
@@ -325,7 +331,6 @@ redpanda:
 					"174.32.64.2",
 					9092,
 				}
-				c.Rpk = nil
 				return c
 			},
 			wantErr: false,
@@ -342,11 +347,6 @@ redpanda:
   kafka_api:
     address: 0.0.0.0
     port: 9092
-  kafka_api_tls:
-    cert_file: ""
-    enabled: false
-    key_file: ""
-    truststore_file: ""
   node_id: 0
   rpc_server:
     address: 0.0.0.0
@@ -360,13 +360,30 @@ redpanda:
       address: 127.0.0.1
       port: 33146
     node_id: 2
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
 `,
 		},
 		{
 			name: "shall write a valid config file without an rpk config object",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.Rpk = nil
+				c.Rpk = RpkConfig{}
 				return c
 			},
 			wantErr: false,
@@ -380,11 +397,6 @@ redpanda:
   kafka_api:
     address: 0.0.0.0
     port: 9092
-  kafka_api_tls:
-    cert_file: ""
-    enabled: false
-    key_file: ""
-    truststore_file: ""
   node_id: 0
   rpc_server:
     address: 0.0.0.0
@@ -398,6 +410,21 @@ redpanda:
       address: 127.0.0.1
       port: 33146
     node_id: 2
+rpk:
+  enable_memory_locking: false
+  enable_usage_stats: false
+  overprovisioned: false
+  tune_aio_events: false
+  tune_clocksource: false
+  tune_coredump: false
+  tune_cpu: false
+  tune_disk_irq: false
+  tune_disk_nomerges: false
+  tune_disk_scheduler: false
+  tune_fstrim: false
+  tune_network: false
+  tune_swappiness: false
+  tune_transparent_hugepages: false
 `,
 		},
 		{
@@ -430,11 +457,6 @@ redpanda:
   kafka_api:
     address: 0.0.0.0
     port: 9092
-  kafka_api_tls:
-    cert_file: ""
-    enabled: false
-    key_file: ""
-    truststore_file: ""
   node_id: 0
   rpc_server:
     address: 0.0.0.0
@@ -453,10 +475,6 @@ rpk:
   enable_memory_locking: true
   enable_usage_stats: true
   overprovisioned: false
-  tls:
-    cert_file: ""
-    key_file: ""
-    truststore_file: ""
   tune_aio_events: true
   tune_clocksource: true
   tune_coredump: true
@@ -515,11 +533,6 @@ redpanda:
   kafka_api:
     address: 0.0.0.0
     port: 9092
-  kafka_api_tls:
-    cert_file: ""
-    enabled: false
-    key_file: ""
-    truststore_file: ""
   node_id: 0
   rpc_server:
     address: 0.0.0.0
@@ -539,10 +552,6 @@ rpk:
   enable_memory_locking: true
   enable_usage_stats: true
   overprovisioned: false
-  tls:
-    cert_file: ""
-    key_file: ""
-    truststore_file: ""
   tune_aio_events: true
   tune_clocksource: true
   tune_coredump: true
@@ -646,7 +655,7 @@ func TestSetMode(t *testing.T) {
 		conf := Default()
 		val := mode == ModeProd
 		conf.Redpanda.DeveloperMode = !val
-		conf.Rpk = &RpkConfig{
+		conf.Rpk = RpkConfig{
 			TuneNetwork:       val,
 			TuneDiskScheduler: val,
 			TuneNomerges:      val,
@@ -857,7 +866,7 @@ func TestReadAsJSON(t *testing.T) {
 				return WriteConfig(fs, &conf, conf.ConfigFile)
 			},
 			path:     Default().ConfigFile,
-			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","redpanda":{"admin":{"address":"0.0.0.0","port":9644},"data_directory":"/var/lib/redpanda/data","developer_mode":false,"kafka_api":{"address":"0.0.0.0","port":9092},"kafka_api_tls":{"cert_file":"","enabled":false,"key_file":"","truststore_file":""},"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145}},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tls":{"cert_file":"","key_file":"","truststore_file":""},"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
+			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","redpanda":{"admin":{"address":"0.0.0.0","port":9644},"data_directory":"/var/lib/redpanda/data","developer_mode":false,"kafka_api":{"address":"0.0.0.0","port":9092},"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
 		},
 		{
 			name:           "it should fail if the the config isn't found",
@@ -884,37 +893,30 @@ func TestReadAsJSON(t *testing.T) {
 
 func TestReadFlat(t *testing.T) {
 	expected := map[string]string{
-		"config_file":                            "/etc/redpanda/redpanda.yaml",
-		"redpanda.admin":                         "0.0.0.0:9644",
-		"redpanda.data_directory":                "/var/lib/redpanda/data",
-		"redpanda.developer_mode":                "false",
-		"redpanda.kafka_api":                     "0.0.0.0:9092",
-		"redpanda.kafka_api_tls.cert_file":       "",
-		"redpanda.kafka_api_tls.enabled":         "false",
-		"redpanda.kafka_api_tls.key_file":        "",
-		"redpanda.kafka_api_tls.truststore_file": "",
-		"redpanda.node_id":                       "0",
-		"redpanda.rpc_server":                    "0.0.0.0:33145",
-		"redpanda.seed_servers.1000":             "192.168.167.0:1337",
-		"redpanda.seed_servers.1001":             "192.168.167.1:1337",
-		"rpk.coredump_dir":                       "/var/lib/redpanda/coredump",
-		"rpk.enable_memory_locking":              "false",
-		"rpk.enable_usage_stats":                 "false",
-		"rpk.overprovisioned":                    "false",
-		"rpk.tls.cert_file":                      "",
-		"rpk.tls.key_file":                       "",
-		"rpk.tls.truststore_file":                "",
-		"rpk.tune_aio_events":                    "false",
-		"rpk.tune_clocksource":                   "false",
-		"rpk.tune_coredump":                      "false",
-		"rpk.tune_cpu":                           "false",
-		"rpk.tune_disk_irq":                      "false",
-		"rpk.tune_disk_nomerges":                 "false",
-		"rpk.tune_disk_scheduler":                "false",
-		"rpk.tune_fstrim":                        "false",
-		"rpk.tune_network":                       "false",
-		"rpk.tune_swappiness":                    "false",
-		"rpk.tune_transparent_hugepages":         "false",
+		"config_file":                    "/etc/redpanda/redpanda.yaml",
+		"redpanda.admin":                 "0.0.0.0:9644",
+		"redpanda.data_directory":        "/var/lib/redpanda/data",
+		"redpanda.developer_mode":        "false",
+		"redpanda.kafka_api":             "0.0.0.0:9092",
+		"redpanda.node_id":               "0",
+		"redpanda.rpc_server":            "0.0.0.0:33145",
+		"redpanda.seed_servers.1000":     "192.168.167.0:1337",
+		"redpanda.seed_servers.1001":     "192.168.167.1:1337",
+		"rpk.coredump_dir":               "/var/lib/redpanda/coredump",
+		"rpk.enable_memory_locking":      "false",
+		"rpk.enable_usage_stats":         "false",
+		"rpk.overprovisioned":            "false",
+		"rpk.tune_aio_events":            "false",
+		"rpk.tune_clocksource":           "false",
+		"rpk.tune_coredump":              "false",
+		"rpk.tune_cpu":                   "false",
+		"rpk.tune_disk_irq":              "false",
+		"rpk.tune_disk_nomerges":         "false",
+		"rpk.tune_disk_scheduler":        "false",
+		"rpk.tune_fstrim":                "false",
+		"rpk.tune_network":               "false",
+		"rpk.tune_swappiness":            "false",
+		"rpk.tune_transparent_hugepages": "false",
 	}
 	fs := afero.NewMemMapFs()
 	conf := Default()

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -203,12 +203,11 @@ func TestDefault(t *testing.T) {
 	expected := Config{
 		ConfigFile: "/etc/redpanda/redpanda.yaml",
 		Redpanda: &RedpandaConfig{
-			Directory:   "/var/lib/redpanda/data",
-			RPCServer:   SocketAddress{"0.0.0.0", 33145},
-			KafkaApi:    SocketAddress{"0.0.0.0", 9092},
-			AdminApi:    SocketAddress{"0.0.0.0", 9644},
-			Id:          0,
-			SeedServers: []*SeedServer{},
+			Directory: "/var/lib/redpanda/data",
+			RPCServer: SocketAddress{"0.0.0.0", 33145},
+			KafkaApi:  SocketAddress{"0.0.0.0", 9092},
+			AdminApi:  SocketAddress{"0.0.0.0", 9644},
+			Id:        0,
 		},
 		Rpk: &RpkConfig{
 			CoredumpDir: "/var/lib/redpanda/coredump",
@@ -858,7 +857,7 @@ func TestReadAsJSON(t *testing.T) {
 				return WriteConfig(fs, &conf, conf.ConfigFile)
 			},
 			path:     Default().ConfigFile,
-			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","redpanda":{"admin":{"address":"0.0.0.0","port":9644},"data_directory":"/var/lib/redpanda/data","developer_mode":false,"kafka_api":{"address":"0.0.0.0","port":9092},"kafka_api_tls":{"cert_file":"","enabled":false,"key_file":"","truststore_file":""},"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tls":{"cert_file":"","key_file":"","truststore_file":""},"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
+			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","redpanda":{"admin":{"address":"0.0.0.0","port":9644},"data_directory":"/var/lib/redpanda/data","developer_mode":false,"kafka_api":{"address":"0.0.0.0","port":9092},"kafka_api_tls":{"cert_file":"","enabled":false,"key_file":"","truststore_file":""},"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145}},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tls":{"cert_file":"","key_file":"","truststore_file":""},"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
 		},
 		{
 			name:           "it should fail if the the config isn't found",

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func getValidConfig() *Config {
-	conf := DefaultConfig()
+	conf := Default()
 	conf.Redpanda.SeedServers = []*SeedServer{
 		&SeedServer{
 			SocketAddress{"127.0.0.1", 33145},
@@ -177,7 +177,7 @@ func TestSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			conf := DefaultConfig()
+			conf := Default()
 			err := WriteConfig(fs, &conf, conf.ConfigFile)
 			require.NoError(t, err)
 			err = Set(fs, tt.key, tt.value, tt.format, conf.ConfigFile)
@@ -198,8 +198,8 @@ func TestSet(t *testing.T) {
 	}
 }
 
-func TestDefaultConfig(t *testing.T) {
-	defaultConfig := DefaultConfig()
+func TestDefault(t *testing.T) {
+	defaultConfig := Default()
 	expected := Config{
 		ConfigFile: "/etc/redpanda/redpanda.yaml",
 		Redpanda: &RedpandaConfig{
@@ -601,24 +601,24 @@ func TestInitConfig(t *testing.T) {
 	}{
 		{
 			name:       "it should generate a config file at the given location",
-			configFile: DefaultConfig().ConfigFile,
+			configFile: Default().ConfigFile,
 		},
 		{
 			name: "it shouldn't fail if there's a config file already",
 			setup: func(fs afero.Fs) error {
-				conf := DefaultConfig()
+				conf := Default()
 				return WriteConfig(fs, &conf, conf.ConfigFile)
 			},
-			configFile: DefaultConfig().ConfigFile,
+			configFile: Default().ConfigFile,
 		},
 		{
 			name: "it should fail if the existing config file's content isn't valid yaml",
 			setup: func(fs afero.Fs) error {
 				bs := []byte(`redpanda:
 - something`)
-				return vyaml.Persist(fs, bs, DefaultConfig().ConfigFile)
+				return vyaml.Persist(fs, bs, Default().ConfigFile)
 			},
-			configFile:  DefaultConfig().ConfigFile,
+			configFile:  Default().ConfigFile,
 			expectError: true,
 		},
 	}
@@ -644,7 +644,7 @@ func TestInitConfig(t *testing.T) {
 
 func TestSetMode(t *testing.T) {
 	fillRpkConfig := func(mode string) Config {
-		conf := DefaultConfig()
+		conf := Default()
 		val := mode == ModeProd
 		conf.Redpanda.DeveloperMode = !val
 		conf.Rpk = &RpkConfig{
@@ -703,7 +703,7 @@ func TestSetMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(st *testing.T) {
-			defaultConf := DefaultConfig()
+			defaultConf := Default()
 			conf, err := SetMode(tt.mode, &defaultConf)
 			if tt.expectedErrMsg != "" {
 				require.EqualError(t, err, tt.expectedErrMsg)
@@ -854,15 +854,15 @@ func TestReadAsJSON(t *testing.T) {
 		{
 			name: "it should load the config as JSON",
 			before: func(fs afero.Fs) error {
-				conf := DefaultConfig()
+				conf := Default()
 				return WriteConfig(fs, &conf, conf.ConfigFile)
 			},
-			path:     DefaultConfig().ConfigFile,
+			path:     Default().ConfigFile,
 			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","redpanda":{"admin":{"address":"0.0.0.0","port":9644},"data_directory":"/var/lib/redpanda/data","developer_mode":false,"kafka_api":{"address":"0.0.0.0","port":9092},"kafka_api_tls":{"cert_file":"","enabled":false,"key_file":"","truststore_file":""},"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tls":{"cert_file":"","key_file":"","truststore_file":""},"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
 		},
 		{
 			name:           "it should fail if the the config isn't found",
-			path:           DefaultConfig().ConfigFile,
+			path:           Default().ConfigFile,
 			expectedErrMsg: "open /etc/redpanda/redpanda.yaml: file does not exist",
 		},
 	}
@@ -918,7 +918,7 @@ func TestReadFlat(t *testing.T) {
 		"rpk.tune_transparent_hugepages":         "false",
 	}
 	fs := afero.NewMemMapFs()
-	conf := DefaultConfig()
+	conf := Default()
 	conf.Redpanda.SeedServers = []*SeedServer{
 		&SeedServer{
 			SocketAddress{"192.168.167.0", 1337},

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -23,12 +23,12 @@ import (
 
 func getValidConfig() *Config {
 	conf := Default()
-	conf.Redpanda.SeedServers = []*SeedServer{
-		&SeedServer{
+	conf.Redpanda.SeedServers = []SeedServer{
+		SeedServer{
 			SocketAddress{"127.0.0.1", 33145},
 			1,
 		},
-		&SeedServer{
+		SeedServer{
 			SocketAddress{"127.0.0.1", 33146},
 			2,
 		},
@@ -918,11 +918,11 @@ func TestReadFlat(t *testing.T) {
 	}
 	fs := afero.NewMemMapFs()
 	conf := Default()
-	conf.Redpanda.SeedServers = []*SeedServer{
-		&SeedServer{
+	conf.Redpanda.SeedServers = []SeedServer{
+		SeedServer{
 			SocketAddress{"192.168.167.0", 1337},
 			1000,
-		}, &SeedServer{
+		}, SeedServer{
 			SocketAddress{"192.168.167.1", 1337},
 			1001,
 		},

--- a/src/go/rpk/pkg/config/definition.go
+++ b/src/go/rpk/pkg/config/definition.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import "path"
+
+type Config struct {
+	NodeUuid     string         `yaml:"node_uuid,omitempty" mapstructure:"node_uuid,omitempty" json:"nodeUuid"`
+	Organization string         `yaml:"organization,omitempty" mapstructure:"organization,omitempty" json:"organization"`
+	LicenseKey   string         `yaml:"license_key,omitempty" mapstructure:"license_key,omitempty" json:"licenseKey"`
+	ClusterId    string         `yaml:"cluster_id,omitempty" mapstructure:"cluster_id,omitempty" json:"clusterId"`
+	ConfigFile   string         `yaml:"config_file" mapstructure:"config_file" json:"configFile"`
+	Redpanda     RedpandaConfig `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
+	Rpk          RpkConfig      `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
+}
+
+type RedpandaConfig struct {
+	Directory          string         `yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
+	RPCServer          SocketAddress  `yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
+	AdvertisedRPCAPI   *SocketAddress `yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
+	KafkaApi           SocketAddress  `yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
+	AdvertisedKafkaApi *SocketAddress `yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
+	KafkaApiTLS        ServerTLS      `yaml:"kafka_api_tls,omitempty" mapstructure:"kafka_api_tls,omitempty" json:"kafkaApiTls"`
+	AdminApi           SocketAddress  `yaml:"admin" mapstructure:"admin" json:"admin"`
+	Id                 int            `yaml:"node_id" mapstructure:"node_id" json:"id"`
+	SeedServers        []SeedServer   `yaml:"seed_servers" mapstructure:"seed_servers" json:"seedServers"`
+	DeveloperMode      bool           `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
+}
+
+type SeedServer struct {
+	Host SocketAddress `yaml:"host" mapstructure:"host" json:"host"`
+	Id   int           `yaml:"node_id" mapstructure:"node_id" json:"id"`
+}
+
+type SocketAddress struct {
+	Address string `yaml:"address" mapstructure:"address" json:"address"`
+	Port    int    `yaml:"port" mapstructure:"port" json:"port"`
+}
+
+type TLS struct {
+	KeyFile        string `yaml:"key_file,omitempty" mapstructure:"key_file,omitempty" json:"keyFile"`
+	CertFile       string `yaml:"cert_file,omitempty" mapstructure:"cert_file,omitempty" json:"certFile"`
+	TruststoreFile string `yaml:"truststore_file,omitempty" mapstructure:"truststore_file,omitempty" json:"truststoreFile"`
+}
+
+type ServerTLS struct {
+	KeyFile        string `yaml:"key_file,omitempty" mapstructure:"key_file,omitempty" json:"keyFile"`
+	CertFile       string `yaml:"cert_file,omitempty" mapstructure:"cert_file,omitempty" json:"certFile"`
+	TruststoreFile string `yaml:"truststore_file,omitempty" mapstructure:"truststore_file,omitempty" json:"truststoreFile"`
+	Enabled        bool   `yaml:"enabled,omitempty" mapstructure:"enabled,omitempty" json:"enabled"`
+}
+
+type RpkConfig struct {
+	TLS                      TLS      `yaml:"tls,omitempty" mapstructure:"tls,omitempty" json:"tls"`
+	AdditionalStartFlags     []string `yaml:"additional_start_flags,omitempty" mapstructure:"additional_start_flags,omitempty" json:"additionalStartFlags"`
+	EnableUsageStats         bool     `yaml:"enable_usage_stats" mapstructure:"enable_usage_stats" json:"enableUsageStats"`
+	TuneNetwork              bool     `yaml:"tune_network" mapstructure:"tune_network" json:"tuneNetwork"`
+	TuneDiskScheduler        bool     `yaml:"tune_disk_scheduler" mapstructure:"tune_disk_scheduler" json:"tuneDiskScheduler"`
+	TuneNomerges             bool     `yaml:"tune_disk_nomerges" mapstructure:"tune_disk_nomerges" json:"tuneNomerges"`
+	TuneDiskIrq              bool     `yaml:"tune_disk_irq" mapstructure:"tune_disk_irq" json:"tuneDiskIrq"`
+	TuneFstrim               bool     `yaml:"tune_fstrim" mapstructure:"tune_fstrim" json:"tuneFstrim"`
+	TuneCpu                  bool     `yaml:"tune_cpu" mapstructure:"tune_cpu" json:"tuneCpu"`
+	TuneAioEvents            bool     `yaml:"tune_aio_events" mapstructure:"tune_aio_events" json:"tuneAioEvents"`
+	TuneClocksource          bool     `yaml:"tune_clocksource" mapstructure:"tune_clocksource" json:"tuneClocksource"`
+	TuneSwappiness           bool     `yaml:"tune_swappiness" mapstructure:"tune_swappiness" json:"tuneSwappiness"`
+	TuneTransparentHugePages bool     `yaml:"tune_transparent_hugepages" mapstructure:"tune_transparent_hugepages" json:"tuneTransparentHugePages"`
+	EnableMemoryLocking      bool     `yaml:"enable_memory_locking" mapstructure:"enable_memory_locking" json:"enableMemoryLocking"`
+	TuneCoredump             bool     `yaml:"tune_coredump" mapstructure:"tune_coredump" json:"tuneCoredump"`
+	CoredumpDir              string   `yaml:"coredump_dir,omitempty" mapstructure:"coredump_dir,omitempty" json:"coredumpDir"`
+	WellKnownIo              string   `yaml:"well_known_io,omitempty" mapstructure:"well_known_io,omitempty" json:"wellKnownIo"`
+	Overprovisioned          bool     `yaml:"overprovisioned" mapstructure:"overprovisioned" json:"overprovisioned"`
+	SMP                      *int     `yaml:"smp,omitempty" mapstructure:"smp,omitempty" json:"smp,omitempty"`
+}
+
+func (conf *Config) PIDFile() string {
+	return path.Join(conf.Redpanda.Directory, "pid.lock")
+}

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -1,0 +1,371 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	fp "path/filepath"
+	"strings"
+	"vectorized/pkg/utils"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+)
+
+type Manager interface {
+	// Reads the config from the given path
+	Read(path string) (*Config, error)
+	// Writes the config to Config.ConfigFile
+	Write(conf *Config) error
+	// Reads the config from path, sets key to the given value (parsing it
+	// according to the format), and writes the config back
+	Set(key, value, format, path string) error
+	// If path is empty, tries to find the file in the default locations.
+	// Otherwise, it tries to read the file and load it. If the file doesn't
+	// exist, it tries to create it with the default configuration.
+	FindOrGenerate(path string) (*Config, error)
+	// Tries reading a config file at the given path, or generates a default config
+	// and writes it to the path.
+	ReadOrGenerate(path string) (*Config, error)
+	// Tries reading a config file at the given path, or tries to find it in
+	// the default locations if it doesn't exist.
+	ReadOrFind(path string) (*Config, error)
+	// Reads the config and returns a map where the keys are the flattened
+	// paths.
+	// e.g. "redpanda.tls.key_file" => "value"
+	ReadFlat(path string) (map[string]string, error)
+	// Reads the configuration as JSON
+	ReadAsJSON(path string) (string, error)
+	// Generates and writes the node's UUID
+	WriteNodeUUID(conf *Config) error
+	// Binds a flag's value to a configuration key.
+	BindFlag(key string, flag *pflag.Flag) error
+}
+
+type manager struct {
+	fs afero.Fs
+	v  *viper.Viper
+}
+
+func NewManager(fs afero.Fs) Manager {
+	return &manager{fs, InitViper(fs)}
+}
+
+func (m *manager) FindOrGenerate(path string) (*Config, error) {
+	if path == "" {
+		addConfigPaths(m.v)
+		err := m.v.ReadInConfig()
+		if err != nil {
+			_, notFound := err.(viper.ConfigFileNotFoundError)
+			if !notFound {
+				return nil, err
+			}
+			path = Default().ConfigFile
+		} else {
+			conf, err := unmarshal(m.v)
+			if err != nil {
+				return nil, err
+			}
+			conf.ConfigFile = m.v.ConfigFileUsed()
+			return conf, nil
+		}
+
+	}
+	return m.ReadOrGenerate(path)
+}
+
+func (m *manager) ReadOrGenerate(path string) (*Config, error) {
+	m.v.SetConfigFile(path)
+	err := m.v.ReadInConfig()
+	if err == nil {
+		// The config file's there, there's nothing to do.
+		return unmarshal(m.v)
+	}
+	_, notFound := err.(viper.ConfigFileNotFoundError)
+	notExist := os.IsNotExist(err)
+	if err != nil && !notFound && !notExist {
+		return nil, fmt.Errorf(
+			"An error happened while trying to read %s: %v",
+			path,
+			err,
+		)
+	}
+	log.Debug(err)
+	log.Infof(
+		"Couldn't find config file at %s. Generating it.",
+		path,
+	)
+	err = m.v.WriteConfigAs(path)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Couldn't write config to %s: %v",
+			path,
+			err,
+		)
+	}
+	return unmarshal(m.v)
+}
+
+func (m *manager) ReadOrFind(path string) (*Config, error) {
+	var err error
+	if path == "" {
+		path, err = FindConfigFile(m.fs)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return m.Read(path)
+}
+
+func (m *manager) ReadFlat(path string) (map[string]string, error) {
+	m.v.SetConfigFile(path)
+	err := m.v.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+	keys := m.v.AllKeys()
+	flatMap := map[string]string{}
+	compactAddrFields := []string{
+		"redpanda.kafka_api",
+		"redpanda.rpc_server",
+		"redpanda.admin",
+	}
+	unmarshalKey := func(key string, val interface{}) error {
+		return m.v.UnmarshalKey(
+			key,
+			val,
+			func(c *mapstructure.DecoderConfig) {
+				c.TagName = "yaml"
+			},
+		)
+	}
+	for _, k := range keys {
+		if k == "redpanda.seed_servers" {
+			seeds := &[]SeedServer{}
+			err := unmarshalKey(k, seeds)
+			if err != nil {
+				return nil, err
+			}
+			for _, s := range *seeds {
+				key := fmt.Sprintf("%s.%d", k, s.Id)
+				flatMap[key] = fmt.Sprintf("%s:%d", s.Host.Address, s.Host.Port)
+			}
+			continue
+		}
+		// These fields are added later on as <address>:<port>
+		// instead of
+		// field.address <address>
+		// field.port    <port>
+		if strings.HasSuffix(k, ".port") || strings.HasSuffix(k, ".address") {
+			continue
+		}
+
+		s := m.v.GetString(k)
+		flatMap[k] = s
+	}
+	for _, k := range compactAddrFields {
+		sa := &SocketAddress{}
+		err := unmarshalKey(k, sa)
+		if err != nil {
+			return nil, err
+		}
+		flatMap[k] = fmt.Sprintf("%s:%d", sa.Address, sa.Port)
+	}
+	return flatMap, nil
+}
+
+func (m *manager) ReadAsJSON(path string) (string, error) {
+	confMap, err := m.readMap(path)
+	if err != nil {
+		return "", err
+	}
+	confJSON, err := json.Marshal(confMap)
+	if err != nil {
+		return "", err
+	}
+	return string(confJSON), nil
+}
+
+func (m *manager) Read(path string) (*Config, error) {
+	// If the path was set, try reading only from there.
+	abs, err := fp.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	m.v.SetConfigFile(abs)
+	err = m.v.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+	conf, err := unmarshal(m.v)
+	if err != nil {
+		return nil, err
+	}
+	conf.ConfigFile = m.v.ConfigFileUsed()
+	return conf, nil
+}
+
+func (m *manager) readMap(path string) (map[string]interface{}, error) {
+	m.v.SetConfigFile(path)
+	err := m.v.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+	return m.v.AllSettings(), nil
+}
+
+func (m *manager) WriteNodeUUID(conf *Config) error {
+	id, err := uuid.NewUUID()
+	if err != nil {
+		return err
+	}
+	conf.NodeUuid = base58Encode(id.String())
+	return m.Write(conf)
+}
+
+// Checks config and writes it to the given path.
+func (m *manager) Write(conf *Config) error {
+	confMap, err := toMap(conf)
+	if err != nil {
+		return err
+	}
+	m.v.MergeConfigMap(confMap)
+	return m.checkAndWrite(conf.ConfigFile)
+}
+
+func (m *manager) write(path string) error {
+	err := m.v.WriteConfigAs(path)
+	if err != nil {
+		return err
+	}
+	log.Debugf(
+		"Configuration written to %s.",
+		path,
+	)
+	return nil
+}
+
+func (m *manager) Set(key, value, format, path string) error {
+	confMap, err := m.readMap(path)
+	if err != nil {
+		return err
+	}
+	m.v.MergeConfigMap(confMap)
+	var newConfValue interface{}
+	switch strings.ToLower(format) {
+	case "single":
+		m.v.Set(key, parse(value))
+		err = m.checkAndWrite(path)
+		if err == nil {
+			checkAndPrintRestartWarning(key)
+		}
+		return err
+	case "yaml":
+		err := yaml.Unmarshal([]byte(value), &newConfValue)
+		if err != nil {
+			return err
+		}
+	case "json":
+		err := json.Unmarshal([]byte(value), &newConfValue)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported format %s", format)
+	}
+	newV := viper.New()
+	newV.Set(key, newConfValue)
+	log.Infof("k %s, v: %v", key, newConfValue)
+	log.Infof("all: %v", newV.AllSettings())
+	m.v.MergeConfigMap(newV.AllSettings())
+	log.Infof("m.v: %v", m.v.AllSettings())
+	err = m.checkAndWrite(path)
+	if err == nil {
+		checkAndPrintRestartWarning(key)
+	}
+	return err
+}
+
+func (m *manager) checkAndWrite(path string) error {
+	ok, errs := checkViper(m.v)
+	if !ok {
+		reasons := []string{}
+		for _, err := range errs {
+			reasons = append(reasons, err.Error())
+		}
+		return errors.New(strings.Join(reasons, ", "))
+	}
+	lastBackupFile, err := findBackup(m.fs, fp.Dir(path))
+	if err != nil {
+		return err
+	}
+	exists, err := afero.Exists(m.fs, path)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		// If the config doesn't exist, just write it.
+		return m.write(path)
+	}
+	// Otherwise, backup the current config file, write the new one, and
+	// try to recover if there's an error.
+	log.Debug("Backing up the current config")
+	backup, err := utils.BackupFile(m.fs, path)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Backed up the current config to %s", backup)
+	if lastBackupFile != "" && lastBackupFile != backup {
+		log.Debug("Removing previous backup file")
+		err = m.fs.Remove(lastBackupFile)
+		if err != nil {
+			return err
+		}
+	}
+	log.Debugf("Writing the new redpanda config to '%s'", path)
+	err = m.write(path)
+	if err != nil {
+		return m.recover(backup, path, err)
+	}
+	return nil
+}
+
+func (m *manager) BindFlag(key string, flag *pflag.Flag) error {
+	return m.v.BindPFlag(key, flag)
+}
+
+func (m *manager) recover(backup, path string, err error) error {
+	log.Infof("Recovering the previous confing from %s", backup)
+	recErr := utils.CopyFile(m.fs, backup, path)
+	if recErr != nil {
+		msg := "couldn't persist the new config due to '%v'," +
+			" nor recover the backup due to '%v"
+		return fmt.Errorf(msg, err, recErr)
+	}
+	return fmt.Errorf("couldn't persist the new config due to '%v'", err)
+}
+
+func unmarshal(v *viper.Viper) (*Config, error) {
+	conf := &Config{}
+	err := v.Unmarshal(conf)
+	if err != nil {
+		return nil, err
+	}
+	conf.ConfigFile = v.ConfigFileUsed()
+	return conf, nil
+}

--- a/src/go/rpk/pkg/tuners/coredump/tuner.go
+++ b/src/go/rpk/pkg/tuners/coredump/tuner.go
@@ -52,7 +52,7 @@ func NewCoredumpTuner(
 }
 
 func (t *tuner) Tune() tuners.TuneResult {
-	script, err := renderTemplate(coredumpScriptTmpl, *t.conf.Rpk)
+	script, err := renderTemplate(coredumpScriptTmpl, t.conf.Rpk)
 	if err != nil {
 		return tuners.NewTuneError(err)
 	}

--- a/src/go/rpk/pkg/tuners/coredump/tuner_test.go
+++ b/src/go/rpk/pkg/tuners/coredump/tuner_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func validConfig() config.Config {
-	conf := config.DefaultConfig()
+	conf := config.Default()
 	conf.Rpk.TuneCoredump = true
 	conf.Rpk.CoredumpDir = "/var/lib/redpanda/coredumps"
 	return conf

--- a/src/go/rpk/pkg/tuners/coredump/tuner_test.go
+++ b/src/go/rpk/pkg/tuners/coredump/tuner_test.go
@@ -65,7 +65,7 @@ func TestTune(t *testing.T) {
 			// Check that the script is world-readable, writable and executable
 			expectedMode := os.FileMode(int(0777))
 			require.Equal(t, expectedMode, info.Mode())
-			expectedScript, err := renderTemplate(coredumpScriptTmpl, *conf.Rpk)
+			expectedScript, err := renderTemplate(coredumpScriptTmpl, conf.Rpk)
 			require.NoError(t, err)
 			buf := make([]byte, len(expectedScript))
 			_, err = script.Read(buf)

--- a/src/go/rpk/pkg/tuners/factory/factory.go
+++ b/src/go/rpk/pkg/tuners/factory/factory.go
@@ -126,7 +126,7 @@ func IsTunerAvailable(tuner string) bool {
 	return allTuners[tuner] != nil
 }
 
-func IsTunerEnabled(tuner string, rpkConfig *config.RpkConfig) bool {
+func IsTunerEnabled(tuner string, rpkConfig config.RpkConfig) bool {
 	switch tuner {
 	case "disk_irq":
 		return rpkConfig.TuneDiskIrq

--- a/src/go/rpk/pkg/tuners/factory/factory_test.go
+++ b/src/go/rpk/pkg/tuners/factory/factory_test.go
@@ -49,7 +49,7 @@ func TestMergeTunerParamsConfig(t *testing.T) {
 			expected: func() *factory.TunerParams {
 				params := getValidTunerParams()
 				params.Directories = []string{
-					config.DefaultConfig().Redpanda.Directory,
+					config.Default().Redpanda.Directory,
 				}
 				return params
 			},
@@ -58,7 +58,7 @@ func TestMergeTunerParamsConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conf := config.DefaultConfig()
+			conf := config.Default()
 			res, err := factory.MergeTunerParamsConfig(tt.tunerParams(), &conf)
 			require.NoError(t, err)
 			expected := tt.expected()

--- a/src/go/rpk/pkg/tuners/factory/factory_test.go
+++ b/src/go/rpk/pkg/tuners/factory/factory_test.go
@@ -59,7 +59,7 @@ func TestMergeTunerParamsConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := config.Default()
-			res, err := factory.MergeTunerParamsConfig(tt.tunerParams(), &conf)
+			res, err := factory.MergeTunerParamsConfig(tt.tunerParams(), conf)
 			require.NoError(t, err)
 			expected := tt.expected()
 			require.Exactly(t, expected, res)

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -64,7 +64,7 @@ func NewConfigChecker(conf *config.Config) Checker {
 		Fatal,
 		true,
 		func() (interface{}, error) {
-			ok, _ := config.CheckConfig(conf)
+			ok, _ := config.Check(conf)
 			return ok, nil
 		})
 }


### PR DESCRIPTION
Introduce a `Manager` interface, and its default implementation using afero & viper.

Viper allows binding command flags to specific config fields and easier configuration merging from env vars and flags.

Viper's docs suggest an approach where a single viper instance is available globally. That can work for simpler and flatter config definitions, but for rpk that would mean a lot of code similar to

```go
addr := viper.GetString("redpanda.advertised_kafka_api.address")
if addr == "" {
// handle missing field
}
```
Which is very verbose and is prone to typos. Therefore, `manager` maintains a viper instance through which we can get all of viper's benefits (config merging, binding to flags & env vars), but leveraging the existing `config.Config` struct to avoid runtime errs and redundant checks.

---

Make changes in the config packge to avoid bugs and keep consistency:
- Make `config.Config.{Rpk, Redpanda}` values and not pointers, given that they aren't optional.
- Make `config.Default` return a `*config.Config`, since all of the config pkg API uses pointers anyway.

---

Make `--seeds` & `--advertise-{kafka, rpc}-addr` available on `rpk start`, which allows for setting their corresponding config fields at startup, saving the extra step of editing the config prior. These fall back on the `REDPANDA_SEEDS`, `REDPANDA_ADVERTISE_KAFKA_ADDR` & `REDPANDA_ADVERTISE_RPC_ADDR` env vars.

Fix #125 
