### PR TITLE
ppc: fix lifetime issues during shutdown

### DIFF
--- a/src/v/pandaproxy/client/brokers.h
+++ b/src/v/pandaproxy/client/brokers.h
@@ -32,6 +32,12 @@ class brokers {
       = absl::flat_hash_map<model::topic_partition, model::node_id>;
 
 public:
+    brokers() = default;
+    brokers(const brokers&) = delete;
+    brokers(brokers&&) = default;
+    brokers& operator=(brokers const&) = delete;
+    brokers& operator=(brokers&&) = delete;
+
     /// \brief stop and wait for all outstanding activity to finish.
     ss::future<> stop();
 

--- a/src/v/pandaproxy/client/client.cc
+++ b/src/v/pandaproxy/client/client.cc
@@ -147,7 +147,6 @@ ss::future<kafka::fetch_response::partition> client::fetch_partition(
   model::offset offset,
   int32_t max_bytes,
   std::chrono::milliseconds timeout) {
-    using namespace std::chrono_literals;
     auto build_request =
       [offset, max_bytes, timeout](model::topic_partition& tp) {
           return make_fetch_request(tp, offset, max_bytes, timeout);
@@ -157,6 +156,7 @@ ss::future<kafka::fetch_response::partition> client::fetch_partition(
       std::move(build_request),
       std::move(tp),
       [this](auto& build_request, model::topic_partition& tp) {
+          vlog(ppclog.debug, "fetching: {}", tp);
           return gated_retry_with_mitigation([this, &tp, &build_request]() {
                      return _brokers.find(tp)
                        .then([&tp, &build_request](shared_broker_t&& b) {

--- a/src/v/pandaproxy/client/client.cc
+++ b/src/v/pandaproxy/client/client.cc
@@ -72,6 +72,7 @@ ss::future<> client::stop() {
 }
 
 ss::future<> client::update_metadata(wait_or_start::tag) {
+    return ss::with_gate(_gate, [this]() {
     vlog(ppclog.debug, "updating metadata");
     return _brokers.any().then([this](shared_broker_t broker) {
         return broker
@@ -88,6 +89,7 @@ ss::future<> client::update_metadata(wait_or_start::tag) {
               return _brokers.apply(std::move(res));
           })
           .finally([]() { vlog(ppclog.trace, "updated metadata"); });
+    });
     });
 }
 
@@ -129,12 +131,15 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
 
 ss::future<kafka::produce_response::partition> client::produce_record_batch(
   model::topic_partition tp, model::record_batch&& batch) {
+    return ss::with_gate(
+      _gate, [this, tp{std::move(tp)}, batch{std::move(batch)}]() mutable {
     vlog(
       ppclog.debug,
       "produce record_batch: {}, {{record_count: {}}}",
       tp,
       batch.record_count());
     return _producer.produce(std::move(tp), std::move(batch));
+    });
 }
 
 ss::future<kafka::fetch_response::partition> client::fetch_partition(
@@ -152,10 +157,7 @@ ss::future<kafka::fetch_response::partition> client::fetch_partition(
       std::move(build_request),
       std::move(tp),
       [this](auto& build_request, model::topic_partition& tp) {
-          return retry_with_mitigation(
-                   shard_local_cfg().retries(),
-                   shard_local_cfg().retry_base_backoff(),
-                   [this, &tp, &build_request]() {
+          return gated_retry_with_mitigation([this, &tp, &build_request]() {
                        return _brokers.find(tp)
                          .then([&tp, &build_request](shared_broker_t&& b) {
                              return b->dispatch(build_request(tp));
@@ -163,8 +165,7 @@ ss::future<kafka::fetch_response::partition> client::fetch_partition(
                          .then([](kafka::fetch_response res) {
                              return std::move(res.partitions[0]);
                          });
-                   },
-                   [this](std::exception_ptr ex) { return mitigate_error(ex); })
+                   })
             .handle_exception([&tp](std::exception_ptr ex) {
                 return make_fetch_response(tp, ex);
             });


### PR DESCRIPTION
Fixes #178

Lifetime fixes:
 * Requests weren't protected by a gate.

Drive-by fixes:
 * Add a log for `fetch_partition`
 * Removed unused `using namespace`
 * Delete special members for `brokers`

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
