### PR TITLE
fixed assertion triggered when fetching multiple topics in one request

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -184,7 +184,7 @@ configuration::configuration()
       "heartbeats at the cost of a longer time to detect failures. "
       "Default quota tracking window size in milliseconds",
       required::no,
-      30'000ms)
+      300s)
   , group_initial_rebalance_delay(
       *this,
       "group_initial_rebalance_delay",

--- a/src/v/kafka/requests/fetch_request.cc
+++ b/src/v/kafka/requests/fetch_request.cc
@@ -523,7 +523,6 @@ static ss::future<> fetch_topic_partitions(op_context& octx) {
 
     octx.for_each_fetch_partition(
       [&resp_it, &octx, &fetches](fetch_partition p) {
-          // we use gate as we may not wait for all the fetch results
           return fetches.push_back(fetch_topic_partition(octx, p, resp_it++));
       });
 
@@ -540,7 +539,7 @@ static ss::future<> fetch_topic_partitions(op_context& octx) {
                   fetch_reads_debounce_timeout, octx.request.max_wait_time));
             });
       });
-} // namespace kafka
+}
 
 ss::future<response_ptr>
 fetch_api::process(request_context&& rctx, ss::smp_service_group ssg) {
@@ -710,7 +709,6 @@ op_context::response_iterator::response_iterator(
 
 void op_context::response_iterator::set(
   fetch_response::partition_response&& response) {
-    // we are already done, for now ignore what we read
     vassert(
       response.id == _it->partition_response->id,
       "Response and current partition ids have to be the same. Current "

--- a/src/v/kafka/requests/fetch_request.cc
+++ b/src/v/kafka/requests/fetch_request.cc
@@ -750,7 +750,7 @@ void op_context::response_iterator::set(
 }
 
 op_context::response_iterator& op_context::response_iterator::operator++() {
-    _it->partition_response++;
+    _it++;
     return *this;
 }
 


### PR DESCRIPTION
The response iterator that is used to correlate request/response partition entries was incorrectly handled which lead to assertion triggering. Fixed incrementing response iterator and added test for fetching multiple topics in one request.

Fixes #180 

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
