### PR TITLE
add remove and move behaviour when register coprocessor fail.

### DIFF
--- a/src/js/modules/domain/generatedRpc/enableDisableCoproc.json
+++ b/src/js/modules/domain/generatedRpc/enableDisableCoproc.json
@@ -95,7 +95,7 @@
       "fields": [
         {
           "name": "inputs",
-          "type": "Array<uint32>"
+          "type": "Array<int8>"
         }
       ]
     },

--- a/src/js/test/supervisors/HandleError.test.ts
+++ b/src/js/test/supervisors/HandleError.test.ts
@@ -57,14 +57,17 @@ describe("handle error enable and disable coprocessor", () => {
         `${errorNumber} errors, when it receives ${codes} enable ` +
         `response code`,
       function () {
-        const [errors] = validateEnableResponseCode({
-          inputs: [
-            {
-              id: BigInt(1),
-              response: codes,
-            },
-          ],
-        });
+        const [errors] = validateEnableResponseCode(
+          {
+            inputs: [
+              {
+                id: BigInt(1),
+                response: codes,
+              },
+            ],
+          },
+          [createMockCoprocessor()]
+        );
         assert.ok(errors.length === errorNumber);
       }
     );
@@ -89,20 +92,36 @@ describe("handle error enable and disable coprocessor", () => {
         DisableResponseCode.scriptDoesNotExist,
       ],
       errorNumber: 2,
+      coprocessors: [
+        createMockCoprocessor(BigInt(1)),
+        createMockCoprocessor(BigInt(2)),
+      ],
     },
-  ].forEach(({ codes, errorNumber }) => {
+    {
+      codes: [
+        DisableResponseCode.internalError,
+        DisableResponseCode.scriptDoesNotExist,
+      ],
+      errorNumber: 2,
+      fail: true,
+    },
+  ].forEach(({ codes, errorNumber, coprocessors, fail = false }) => {
     it(
       `should validateDisableCodeResponse returns an array with ` +
         `${errorNumber} errors, when it receives ${codes} disable ` +
         `response code`,
       function () {
-        const errors = validateDisableResponseCode(
-          {
-            inputs: codes,
-          },
-          [createMockCoprocessor(BigInt(1)), createMockCoprocessor(BigInt(2))]
-        );
-        assert.ok(errors.length === errorNumber);
+        try {
+          const errors = validateDisableResponseCode(
+            {
+              inputs: codes,
+            },
+            coprocessors || [createMockCoprocessor(BigInt(1))]
+          );
+          assert.ok(errors.length === errorNumber);
+        } catch (e) {
+          assert.ok(fail, "it should be fail");
+        }
       }
     );
   });


### PR DESCRIPTION
add remove and move behavior on next situations:

when enableCoprocessor fail:
  - move the wrong coprocessor definition from active to inactive folder
  - remove handle from the repository
  - print error on the new format

when disable fail:
  - print error on the new format