### PR TITLE
Fix iobuf trim_front

### DIFF
--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -14,6 +14,7 @@
 #include "bytes/details/out_of_range.h"
 #include "seastarx.h"
 #include "utils/intrusive_list_helpers.h"
+#include "vassert.h"
 
 #include <seastar/core/temporary_buffer.hh>
 
@@ -90,6 +91,12 @@ public:
     void trim(size_t len) { _used_bytes = std::min(len, _used_bytes); }
     void trim_front(size_t pos) {
         // required by input_stream<char> converter
+        vassert(
+          pos <= _used_bytes,
+          "trim_front requested {} bytes but io_fragment have only {}",
+          pos,
+          _used_bytes);
+        _used_bytes -= pos;
         _buf.trim_front(pos);
     }
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)


### PR DESCRIPTION
The problem: when `iobuf.trim_front` is used on non empty iobuf instance, the total size of all `io_fragment` values inside it doesn't always match the iobuf.size_bytes(). This PR adds test case that reproduces the issue and fixes it. 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
