### PR TITLE
Fixes gobekli memory leak

### DIFF
--- a/src/consistency-testing/gobekli/gobekli/workloads/symmetrical_comrmw.py
+++ b/src/consistency-testing/gobekli/gobekli/workloads/symmetrical_comrmw.py
@@ -81,11 +81,10 @@ class MWClient:
                                     data.value)
 
             read_version = int(data.value.split(":")[1])
-            read_write_id = data.write_id
+            self.last_write_id = data.write_id
 
             if self.last_version < read_version:
                 self.last_version = read_version
-                self.last_write_id = read_write_id
 
             self.stat.inc(self.node.name + ":ok")
             self.stat.inc("all:ok")


### PR DESCRIPTION
Fixes a leak caused by a timeout happening before the gc, in that case we used to keep gc tombstones for ever.