### PR TITLE
r/vote_stm: fixed propagating backpressure of config replication

### DIFF
--- a/src/v/raft/vote_stm.h
+++ b/src/v/raft/vote_stm.h
@@ -84,9 +84,10 @@ private:
     ss::future<> self_vote();
     ss::future<> dispatch_one(model::node_id);
     ss::future<result<vote_reply>> do_dispatch_one(model::node_id);
-    void update_vote_state(ss::semaphore_units<>);
+    ss::future<> update_vote_state(ss::semaphore_units<>);
     ss::future<> process_replies();
-    void replicate_config_as_new_leader(ss::semaphore_units<>);
+    ss::future<std::error_code>
+      replicate_config_as_new_leader(ss::semaphore_units<>);
     // args
     consensus* _ptr;
     // make sure to always make a copy; never move() this struct


### PR DESCRIPTION
Previously after successful leader election we dispatched configuration
replication as a background fiber. This may have negative consequences
as backpressure isn't correctly propagated to the vote dispatching
timer. When one of the vote casting nodes is slow it may be quickly
overwhelmed by the requests from voters. Correctly propagating
backpressure i.e. waiting for configuration replication, prevents the
voting node prom being flooded with not necessary vote requests.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
