### PR TITLE
Fix issue with absolute path

### DIFF
--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -6,5 +6,6 @@ v_cc_library(
     rjson_serialization.cc
   DEPS
     v::json
+   boost_filesystem
 )
 add_subdirectory(tests)

--- a/src/v/config/tests/tls_config_convert_test.cc
+++ b/src/v/config/tests/tls_config_convert_test.cc
@@ -15,27 +15,28 @@
 
 #include <yaml-cpp/yaml.h>
 
-auto empty = "tls_config:\n";
-auto with_values = "tls_config:\n"
-                   "  enabled: true\n"
-                   "  cert_file: /fake/cret_file.crt\n"
-                   "  key_file: /fake/key_file.key\n"
-                   "  truststore_file: /fake/truststore\n"
-                   "  require_client_auth: true\n";
-
 config::tls_config read_from_yaml(ss::sstring yaml_string) {
     auto node = YAML::Load(yaml_string);
     return node["tls_config"].as<config::tls_config>();
 }
 
-SEASTAR_THREAD_TEST_CASE(test_decode) {
+SEASTAR_THREAD_TEST_CASE(test_decode_empty) {
+    auto empty = "tls_config:\n";
     auto empty_cfg = read_from_yaml(empty);
 
     BOOST_TEST(!empty_cfg.is_enabled());
     BOOST_TEST(!empty_cfg.get_key_cert_files());
     BOOST_TEST(!empty_cfg.get_truststore_file());
     BOOST_TEST(!empty_cfg.get_require_client_auth());
+}
 
+SEASTAR_THREAD_TEST_CASE(test_decode_full_abs_path) {
+    auto with_values = "tls_config:\n"
+                       "  enabled: true\n"
+                       "  cert_file: /fake/cret_file.crt\n"
+                       "  key_file: /fake/key_file.key\n"
+                       "  truststore_file: /fake/truststore\n"
+                       "  require_client_auth: true\n";
     auto full_cfg = read_from_yaml(with_values);
     BOOST_TEST(full_cfg.is_enabled());
     BOOST_TEST(
@@ -44,4 +45,48 @@ SEASTAR_THREAD_TEST_CASE(test_decode) {
       (*full_cfg.get_key_cert_files()).cert_file == "/fake/cret_file.crt");
     BOOST_TEST(*full_cfg.get_truststore_file() == "/fake/truststore");
     BOOST_TEST(full_cfg.get_require_client_auth());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_decode_full_rel_path) {
+    auto with_values = "tls_config:\n"
+                       "  enabled: true\n"
+                       "  cert_file: ./cret_file.crt\n"
+                       "  key_file: ./key_file.key\n"
+                       "  truststore_file: ./truststore\n"
+                       "  require_client_auth: true\n";
+    auto full_cfg = read_from_yaml(with_values);
+    BOOST_TEST(full_cfg.is_enabled());
+    BOOST_TEST((*full_cfg.get_key_cert_files()).key_file != "./key_file.key");
+    BOOST_TEST((*full_cfg.get_key_cert_files()).cert_file != "./cret_file.crt");
+    BOOST_TEST(*full_cfg.get_truststore_file() != "./truststore");
+    BOOST_TEST(full_cfg.get_require_client_auth());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_decode_default_config) {
+    auto with_values = "tls_config:\n"
+                       "  enabled: false\n"
+                       "  cert_file: \"\"\n"
+                       "  key_file: \"\"\n"
+                       "  truststore_file: \"\"\n"
+                       "  require_client_auth: false\n";
+    auto empty_cfg = read_from_yaml(with_values);
+    BOOST_TEST(!empty_cfg.is_enabled());
+    BOOST_TEST(!empty_cfg.get_key_cert_files());
+    BOOST_TEST(!empty_cfg.get_truststore_file());
+    BOOST_TEST(!empty_cfg.get_require_client_auth());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_decode_enabled_but_contains_empty_path) {
+    auto with_values = "tls_config:\n"
+                       "  enabled: true\n"
+                       "  cert_file: \"\"\n"
+                       "  key_file: \"\"\n"
+                       "  truststore_file: \"\"\n"
+                       "  require_client_auth: false\n";
+    auto full_cfg = read_from_yaml(with_values);
+    BOOST_TEST(full_cfg.is_enabled());
+    BOOST_TEST((*full_cfg.get_key_cert_files()).key_file == "");
+    BOOST_TEST((*full_cfg.get_key_cert_files()).cert_file == "");
+    BOOST_TEST(*full_cfg.get_truststore_file() == "");
+    BOOST_TEST(!full_cfg.get_require_client_auth());
 }


### PR DESCRIPTION
The default tls config for kafka api contains empty paths. The gcc
and clang filesystem::absolute implementations behave differently
in case of empty path.

This commit fixes the issue and adds test cases for configs with
absolute paths, relative paths, and default tls config. The last one
fails with gcc without changes in configuration.h but works OK
with clang.

This PR doesn't change the behaviour. It just fixes the conversion.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
