### PR TITLE
Feature/change notify implementation

### DIFF
--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -908,18 +908,18 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "chokidar": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.2.0"
+        "readdirp": "~3.5.0"
       }
     },
     "chownr": {
@@ -2201,14 +2201,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "inotifywait": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/inotifywait/-/inotifywait-1.8.3.tgz",
-      "integrity": "sha1-Fu3/PxXnlV1fUci3aaImmNesqwU=",
-      "requires": {
-        "lazy": "~1.0.11"
-      }
-    },
     "inquirer": {
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
@@ -2518,11 +2510,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-    },
-    "lazy": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
-      "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA="
     },
     "levn": {
       "version": "0.4.1",
@@ -2853,6 +2840,21 @@
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
+        "chokidar": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+          "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.2.0"
+          }
+        },
         "js-yaml": {
           "version": "3.13.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -2860,6 +2862,14 @@
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
+          }
+        },
+        "readdirp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+          "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+          "requires": {
+            "picomatch": "^2.0.4"
           }
         }
       }
@@ -3397,11 +3407,11 @@
       }
     },
     "readdirp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "requires": {
-        "picomatch": "^2.0.4"
+        "picomatch": "^2.2.1"
       }
     },
     "regex-not": {

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -24,7 +24,7 @@
     "@types/mocha": "7.0.2",
     "@types/node": "14.0.23",
     "fast-crc32c": "2.0.0",
-    "inotifywait": "1.8.3",
+    "chokidar": "^3.4.3",
     "mocha": "7.1.1",
     "prettier": "2.0.5",
     "rewire": "5.0.0",

--- a/src/js/test/rpc/server.test.ts
+++ b/src/js/test/rpc/server.test.ts
@@ -19,8 +19,7 @@ import { ProcessBatchRequest } from "../../modules/domain/generatedRpc/generated
 import { createHandle } from "../testUtilities";
 import { PolicyError, RecordBatch } from "../../modules/public/Coprocessor";
 import assert = require("assert");
-
-const INotifyWait = require("inotifywait");
+import * as chokidar from "chokidar";
 
 let sinonInstance: SinonSandbox;
 let server: ProcessBatchServer;
@@ -28,13 +27,13 @@ let client: SupervisorClient;
 let manageServer: ManagementServer;
 
 const createStubs = (sandbox: SinonSandbox) => {
+  const watchMock = sandbox.stub(chokidar, "watch");
+  watchMock.returns(({ on: sandbox.stub() } as unknown) as chokidar.FSWatcher);
   const readCoprocessorFolder = sandbox.stub(
     FileManager.prototype,
     "readCoprocessorFolder"
   );
   readCoprocessorFolder.returns(Promise.resolve());
-  sandbox.stub(FileManager.prototype, "updateRepositoryOnNewFile");
-  sandbox.stub(INotifyWait.prototype);
   const spyFireExceptionServer = sandbox.stub(
     ProcessBatchServer.prototype,
     "fireException"
@@ -61,6 +60,7 @@ const createStubs = (sandbox: SinonSandbox) => {
     spyFindByCoprocessor,
     spyMoveHandle,
     spyDeregister,
+    watchMock,
   };
 };
 


### PR DESCRIPTION
coproc: change Inotify dependency for chokidar
Reason for changing:
    1. Inotifywait needs to SO dependency (libnotify) for working, but chokidar
       works with native nodeJs packages (fs)
    2. chokidar has a bigger community than Inotifywait.
    3. chokidar needs a simples change in order to eliminate Inotify.