### PR TITLE
Optimized `acks=-1` produce tail latency  

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -282,6 +282,12 @@ configuration::configuration()
       "follower",
       required::no,
       5s)
+  , replicate_request_debounce_timeout_ms(
+      *this,
+      "replicate_request_debounce_timeout_ms",
+      "Max duration before dispatching batched replicate requests",
+      required::no,
+      4ms)
   , reclaim_min_size(
       *this,
       "reclaim_min_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -81,6 +81,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> kafka_group_recovery_timeout_ms;
     property<std::chrono::milliseconds> replicate_append_timeout_ms;
     property<std::chrono::milliseconds> recovery_append_timeout_ms;
+    property<std::chrono::milliseconds> replicate_request_debounce_timeout_ms;
 
     property<size_t> reclaim_min_size;
     property<size_t> reclaim_max_size;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -55,7 +55,8 @@ consensus::consensus(
   , _client_protocol(client)
   , _leader_notification(std::move(cb))
   , _fstats({})
-  , _batcher(this)
+  , _batcher(
+      this, config::shard_local_cfg().replicate_request_debounce_timeout_ms())
   , _event_manager(this)
   , _ctxlog(group, _log.config().ntp())
   , _replicate_append_timeout(

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -32,15 +32,16 @@ replicate_batcher::replicate_batcher(
   : _ptr(ptr)
   , _debounce_duration(debounce_duration)
   , _max_batch_size(cache_size) {
-    _flush_timer.set_callback([this] {
-        (void)ss::with_gate(_ptr->_bg, [this] {
-            // background block further caching too
-            return _lock.with([this] { return flush(); });
-        }).handle_exception_type([this](const ss::gate_closed_exception&) {
-            vlog(
-              _ptr->_ctxlog.debug,
-              "Gate closed while flushing replicate requests");
-        });
+    _flush_timer.set_callback([this] { dispatch_background_flush(); });
+}
+
+void replicate_batcher::dispatch_background_flush() {
+    (void)ss::with_gate(_ptr->_bg, [this] {
+        // background block further caching too
+        return _lock.with([this] { return flush(); });
+    }).handle_exception_type([this](const ss::gate_closed_exception&) {
+        vlog(
+          _ptr->_ctxlog.debug, "Gate closed while flushing replicate requests");
     });
 }
 
@@ -50,7 +51,13 @@ replicate_batcher::replicate(model::record_batch_reader&& r) {
       .with(
         [this, r = std::move(r)]() mutable { return do_cache(std::move(r)); })
       .then([this](item_ptr i) {
-          if (_pending_bytes < _max_batch_size || !_flush_timer.armed()) {
+          if (_pending_bytes >= _max_batch_size) {
+              _flush_timer.cancel();
+              dispatch_background_flush();
+              return i->_promise.get_future();
+          }
+
+          if (!_flush_timer.armed()) {
               _flush_timer.rearm(clock_type::now() + _debounce_duration);
           }
           return i->_promise.get_future();

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -14,6 +14,7 @@
 #include "model/record_batch_reader.h"
 #include "outcome.h"
 #include "raft/types.h"
+#include "units.h"
 #include "utils/mutex.h"
 
 #include <absl/container/flat_hash_map.h>
@@ -29,7 +30,7 @@ public:
     };
     using item_ptr = ss::lw_shared_ptr<item>;
     // 1MB default size
-    static constexpr size_t default_batch_bytes = 1024 * 1024;
+    static constexpr size_t default_batch_bytes = 1_MiB;
 
     explicit replicate_batcher(
       consensus* ptr, size_t cache_size = default_batch_bytes);

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -33,7 +33,9 @@ public:
     static constexpr size_t default_batch_bytes = 1_MiB;
 
     explicit replicate_batcher(
-      consensus* ptr, size_t cache_size = default_batch_bytes);
+      consensus* ptr,
+      std::chrono::milliseconds debounce_duration,
+      size_t cache_size = default_batch_bytes);
 
     replicate_batcher(replicate_batcher&&) noexcept = default;
     replicate_batcher& operator=(replicate_batcher&&) noexcept = delete;
@@ -58,6 +60,7 @@ private:
     ss::future<item_ptr> do_cache(model::record_batch_reader&&);
 
     consensus* _ptr;
+    std::chrono::milliseconds _debounce_duration;
     size_t _max_batch_size{default_batch_bytes};
     size_t _pending_bytes{0};
     timer_type _flush_timer;

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -58,6 +58,7 @@ public:
 
 private:
     ss::future<item_ptr> do_cache(model::record_batch_reader&&);
+    void dispatch_background_flush();
 
     consensus* _ptr;
     std::chrono::milliseconds _debounce_duration;


### PR DESCRIPTION
Made filtering reordered append entries reply less strict. i.e. if
the response dirty offset is greater or equal to the leader offset we
can safely accept the response as it will not trigger the recovery.

Additionally fixed dispatching flushes in replicate batcher. 

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
