### PR TITLE
ci: add missing test-redpanda step in new yaml

### DIFF
--- a/tests/ci/build-pkg.yml
+++ b/tests/ci/build-pkg.yml
@@ -66,6 +66,10 @@ steps:
   name: 'gcr.io/redpandaci/builder'
   args: ['./build/venv/v/bin/vtools', 'build', 'cpp', '--conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml', '--skip-external']
 
+- id: 'test redpanda'
+  name: 'gcr.io/redpandaci/builder'
+  args: ['./build/venv/v/bin/vtools', 'test', 'cpp', '--conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml']
+
 - id: 'create and archive distro packages'
   name: 'gcr.io/redpandaci/builder'
   entrypoint: bash


### PR DESCRIPTION
The step was probably omitted for quicker testing & never got into the PR :disappointed:
