### PR TITLE
Buffering append entries on follower

### DIFF
--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -18,6 +18,7 @@
 #include "raft/event_manager.h"
 #include "raft/follower_stats.h"
 #include "raft/logger.h"
+#include "raft/mutex_buffer.h"
 #include "raft/prevote_stm.h"
 #include "raft/probe.h"
 #include "raft/replicate_batcher.h"
@@ -395,7 +396,8 @@ private:
     model::offset _last_quorum_replicated_index;
     offset_monitor _consumable_offset_monitor;
     ss::condition_variable _disk_append;
-
+    details::mutex_buffer<append_entries_request, append_entries_reply>
+      _append_requests_buffer;
     friend std::ostream& operator<<(std::ostream&, const consensus&);
 };
 

--- a/src/v/raft/mutex_buffer.h
+++ b/src/v/raft/mutex_buffer.h
@@ -1,0 +1,144 @@
+#pragma once
+#include "raft/types.h"
+#include "ssx/future-util.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/do_with.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/shared_ptr.hh>
+
+namespace raft::details {
+
+/**
+ * This class allow to buffer arguments of a callers waiting for mutex and
+ * when mutex is eventually available execute all buffered calls without
+ * releasing mutex in beetween single calls.
+ */
+template<typename Request, typename Response>
+class mutex_buffer {
+public:
+    explicit mutex_buffer(mutex& m, size_t max_buffered_elements)
+      : _mutex(m)
+      , _max_buffered(max_buffered_elements) {}
+
+    ss::future<Response> enqueue(Request&& r) {
+        return ss::with_gate(
+          _gate, [this, r = std::forward<Request>(r)]() mutable {
+              // we do not use a semaphore as we do not want to wait, waiting
+              // may cause requests reordering
+              if (_requests.size() >= _max_buffered) {
+                  return ss::make_exception_future<Response>(
+                    std::overflow_error("max buffered entries count reached."));
+              }
+              ss::promise<Response> p;
+              auto f = p.get_future();
+              _requests.push_back(std::move(r));
+              _responsens.push_back(std::move(p));
+              _enequeued.signal();
+              return f;
+          });
+    }
+
+    /**
+     * Start method accepts a function that is executed for each element. This
+     * function is executed for each buffered request. This method is always
+     * executed while holding mutex lock. This method starts background dispatch
+     * loop that waits for the mutex to be acquired.
+     */
+    // clang-format off
+    template<typename Func>
+    CONCEPT(requires requires(Func f, Request req) {
+        { f(std::move(req)) } -> ss::future<Response>;
+    })
+    // clang-format on
+    void start(Func&& f);
+
+    ss::future<> stop() {
+        _enequeued.broken();
+        return _gate.close();
+    }
+
+private:
+    using request_t = std::vector<Request>;
+    using response_t = std::vector<ss::promise<Response>>;
+    template<typename Func>
+    ss::future<> flush(Func&& f);
+    template<typename Func>
+    ss::future<> do_flush(request_t, response_t, Func&& f);
+
+    request_t _requests;
+    response_t _responsens;
+    ss::condition_variable _enequeued;
+    ss::gate _gate;
+    mutex& _mutex;
+    const size_t _max_buffered;
+};
+
+template<typename Request, typename Response>
+template<typename Func>
+void mutex_buffer<Request, Response>::start(Func&& f) {
+    (void)ss::with_gate(_gate, [this, f = std::forward<Func>(f)]() mutable {
+        return ss::do_until(
+          [this] { return _gate.is_closed(); },
+          [this, f = std::forward<Func>(f)]() mutable {
+              return _enequeued.wait([this] { return !_requests.empty(); })
+                .then([this, f = std::forward<Func>(f)]() mutable {
+                    return flush(std::forward<Func>(f));
+                })
+                .handle_exception_type(
+                  [](const ss::broken_condition_variable&) {
+                      // ignore exception, we are about to stop
+                  });
+          });
+    });
+}
+template<typename Request, typename Response>
+template<typename Func>
+ss::future<> mutex_buffer<Request, Response>::flush(Func&& f) {
+    auto requests = std::exchange(_requests, {});
+    auto response_promises = std::exchange(_responsens, {});
+
+    return _mutex.with(
+      [this,
+       f = std::forward<Func>(f),
+       requests = std::move(requests),
+       response_promises = std::move(response_promises)]() mutable {
+          return do_flush(
+            std::move(requests),
+            std::move(response_promises),
+            std::forward<Func>(f));
+      });
+}
+
+template<typename Request, typename Response>
+template<typename Func>
+ss::future<> mutex_buffer<Request, Response>::do_flush(
+  request_t requests, response_t response_promises, Func&& f) {
+    auto resp = ss::make_lw_shared(std::move(response_promises));
+    return ss::do_with(
+             std::move(requests),
+             resp->begin(),
+             [f = std::forward<Func>(f)](
+               request_t& requests, typename response_t::iterator& it) mutable {
+                 return ss::do_for_each(
+                   requests,
+                   [&it, f = std::forward<Func>(f)](Request& req) mutable {
+                       auto current = it;
+                       ++it;
+                       return f(std::move(req))
+                         .then([current](Response r) {
+                             current->set_value(std::move(r));
+                         })
+                         .handle_exception(
+                           [current](const std::exception_ptr& e) {
+                               current->set_exception(e);
+                           });
+                   });
+             })
+      .finally([resp] {});
+}
+} // namespace raft::details

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(srcs
     append_entries_test.cc
     offset_monitor_test.cc
     mux_state_machine_test.cc
+    mutex_buffer_test.cc
     configuration_manager_test.cc)
 
 rp_test(

--- a/src/v/raft/tests/mutex_buffer_test.cc
+++ b/src/v/raft/tests/mutex_buffer_test.cc
@@ -1,0 +1,103 @@
+#include "raft/mutex_buffer.h"
+#include "test_utils/fixture.h"
+#include "utils/mutex.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <fmt/core.h>
+
+struct request {
+    ss::sstring content;
+};
+
+struct response {
+    ss::sstring content;
+};
+
+struct fixture {
+    fixture()
+      : buf(lock, 20) {}
+
+    static ss::future<response> add_postfix(request r) {
+        return ss::make_ready_future<response>(
+          response{r.content + "-response"});
+    }
+
+    mutex lock;
+    raft::details::mutex_buffer<request, response> buf;
+};
+
+FIXTURE_TEST(test_single_request_dispatch, fixture) {
+    buf.start(&fixture::add_postfix);
+
+    auto f = buf.enqueue(request{"test"});
+    BOOST_REQUIRE_EQUAL(f.get0().content, "test-response");
+    buf.stop().get0();
+}
+
+FIXTURE_TEST(test_requests_buffering, fixture) {
+    buf.start(&fixture::add_postfix);
+
+    std::vector<ss::future<response>> enqueued;
+    enqueued.reserve(5);
+    {
+        auto u = lock.get_units().get0();
+        for (auto i = 0; i < 5; ++i) {
+            enqueued.push_back(buf.enqueue(request{fmt::format("test-{}", i)}));
+        }
+        BOOST_REQUIRE(enqueued[0].available() == false);
+    }
+
+    auto i = 0;
+    for (auto& f : enqueued) {
+        BOOST_REQUIRE_EQUAL(
+          f.get0().content, fmt::format("test-{}-response", i));
+        i++;
+    }
+
+    buf.stop().get0();
+}
+
+FIXTURE_TEST(after_close_buffer_should_stop_accepting_requests, fixture) {
+    // stop buffer first
+    buf.stop().get0();
+
+    BOOST_REQUIRE_THROW(
+      buf.enqueue(request{"should-fail"}).get0(), ss::gate_closed_exception);
+}
+
+FIXTURE_TEST(should_propagate_exception, fixture) {
+    int cnt = 0;
+    buf.start([&cnt](request r) {
+        cnt++;
+        if (cnt % 2 != 0) {
+            return ss::make_exception_future<response>(
+              std::runtime_error("error"));
+        }
+
+        return add_postfix(std::move(r));
+    });
+
+    std::vector<ss::future<response>> enqueued;
+    enqueued.reserve(5);
+    {
+        auto u = lock.get_units().get0();
+
+        for (auto i = 0; i < 5; ++i) {
+            enqueued.push_back(buf.enqueue(request{fmt::format("test-{}", i)}));
+        }
+    }
+    auto i = 0;
+
+    for (auto& f : enqueued) {
+        i++;
+        if (i % 2 != 0) {
+            BOOST_REQUIRE_THROW(f.get(), std::runtime_error);
+        } else {
+            BOOST_REQUIRE_EQUAL(
+              f.get().content, fmt::format("test-{}-response", i - 1));
+        }
+    }
+
+    buf.stop().get0();
+}


### PR DESCRIPTION
Implemented buffering append entries requests waiting for the `raft::consensus` semaphore. If there are more than one request waiting for being processed by the semaphore all of the waiters will be processed without releasing semaphore in between requests. 

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
