### PR TITLE
rpk/start: Check that the seeds list isn't empty

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -102,10 +102,13 @@ func NewStartCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 			if len(seeds) == 0 {
 				// If --seeds wasn't passed, fall back to the
 				// env var.
-				seeds = strings.Split(
+				envSeeds := strings.Split(
 					os.Getenv("REDPANDA_SEEDS"),
 					",",
 				)
+				if len(envSeeds) != 0 {
+					seeds = envSeeds
+				}
 			}
 			seedServers, err := parseSeeds(seeds)
 			if err != nil {


### PR DESCRIPTION
os.Getenv returns an empty string if nothing's found, which resulted in `Couldn't parse seed '': Format doesn't conform to <host>[:<port>]+<id>. Missing ID` when starting a node.