### PR TITLE
Adds a stub init_producer_id request handler

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -16,6 +16,7 @@ set(request_srcs
   requests/heartbeat_request.cc
   requests/leave_group_request.cc
   requests/sync_group_request.cc
+  requests/init_producer_id_request.cc
   requests/create_topics_request.cc
   requests/offset_commit_request.cc
   requests/delete_topics_request.cc

--- a/src/v/kafka/requests/api_versions_request.cc
+++ b/src/v/kafka/requests/api_versions_request.cc
@@ -17,6 +17,7 @@
 #include "kafka/requests/fetch_request.h"
 #include "kafka/requests/find_coordinator_request.h"
 #include "kafka/requests/heartbeat_request.h"
+#include "kafka/requests/init_producer_id_request.h"
 #include "kafka/requests/join_group_request.h"
 #include "kafka/requests/leave_group_request.h"
 #include "kafka/requests/list_groups_request.h"

--- a/src/v/kafka/requests/delete_topics_request.h
+++ b/src/v/kafka/requests/delete_topics_request.h
@@ -54,7 +54,7 @@ struct delete_topics_request final {
     }
 };
 
-static inline std::ostream&
+inline std::ostream&
 operator<<(std::ostream& os, const delete_topics_request& r) {
     return os << r.data;
 }
@@ -73,7 +73,7 @@ struct delete_topics_response final {
     }
 };
 
-static inline std::ostream&
+inline std::ostream&
 operator<<(std::ostream& os, const delete_topics_response& r) {
     return os << r.data;
 }

--- a/src/v/kafka/requests/init_producer_id_request.cc
+++ b/src/v/kafka/requests/init_producer_id_request.cc
@@ -1,0 +1,33 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/requests/init_producer_id_request.h"
+
+#include "kafka/groups/group_manager.h"
+#include "kafka/groups/group_router.h"
+#include "kafka/requests/request_context.h"
+#include "kafka/requests/response.h"
+#include "utils/remote.h"
+#include "utils/to_string.h"
+
+#include <seastar/core/print.hh>
+
+namespace kafka {
+
+ss::future<response_ptr> init_producer_id_api::process(
+  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+    return ss::do_with(std::move(ctx), [](request_context& ctx) {
+        init_producer_id_request request;
+        request.decode(ctx.reader(), ctx.header().version);
+        return ss::make_exception_future<response_ptr>(std::runtime_error(
+          fmt::format("Unsupported API {}", ctx.header().key)));
+    });
+}
+
+} // namespace kafka

--- a/src/v/kafka/requests/join_group_request.h
+++ b/src/v/kafka/requests/join_group_request.h
@@ -77,8 +77,7 @@ struct join_group_request final {
     void decode(request_context& ctx);
 };
 
-static inline std::ostream&
-operator<<(std::ostream& os, const join_group_request& r) {
+inline std::ostream& operator<<(std::ostream& os, const join_group_request& r) {
     return os << r.data;
 }
 
@@ -135,7 +134,7 @@ make_join_error(kafka::member_id member_id, error_code error) {
       _make_join_error(std::move(member_id), error));
 }
 
-static inline std::ostream&
+inline std::ostream&
 operator<<(std::ostream& os, const join_group_response& r) {
     return os << r.data;
 }

--- a/src/v/kafka/requests/leave_group_request.h
+++ b/src/v/kafka/requests/leave_group_request.h
@@ -48,7 +48,7 @@ struct leave_group_request final {
     }
 };
 
-static inline std::ostream&
+inline std::ostream&
 operator<<(std::ostream& os, const leave_group_request& r) {
     return os << r.data;
 }
@@ -75,7 +75,7 @@ make_leave_error(error_code error) {
     return ss::make_ready_future<leave_group_response>(error);
 }
 
-static inline std::ostream&
+inline std::ostream&
 operator<<(std::ostream& os, const leave_group_response& r) {
     return os << r.data;
 }

--- a/src/v/kafka/requests/requests.cc
+++ b/src/v/kafka/requests/requests.cc
@@ -18,6 +18,7 @@
 #include "kafka/requests/fetch_request.h"
 #include "kafka/requests/find_coordinator_request.h"
 #include "kafka/requests/heartbeat_request.h"
+#include "kafka/requests/init_producer_id_request.h"
 #include "kafka/requests/join_group_request.h"
 #include "kafka/requests/leave_group_request.h"
 #include "kafka/requests/list_groups_request.h"
@@ -132,6 +133,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<sasl_handshake_api>(std::move(ctx), g);
     case sasl_authenticate_api::key:
         return do_process<sasl_authenticate_api>(std::move(ctx), g);
+    case init_producer_id_api::key:
+        return do_process<init_producer_id_api>(std::move(ctx), g);
     };
     return ss::make_exception_future<response_ptr>(
       std::runtime_error(fmt::format("Unsupported API {}", ctx.header().key)));

--- a/src/v/kafka/requests/schemata/CMakeLists.txt
+++ b/src/v/kafka/requests/schemata/CMakeLists.txt
@@ -34,7 +34,9 @@ set(schemata
   sasl_handshake_request.json
   sasl_handshake_response.json
   sasl_authenticate_request.json
-  sasl_authenticate_response.json)
+  sasl_authenticate_response.json
+  init_producer_id_request.json
+  init_producer_id_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/requests/schemata/generator.py
+++ b/src/v/kafka/requests/schemata/generator.py
@@ -182,8 +182,10 @@ path_type_map = {
 # a few kafka field types specify an entity type
 entity_type_map = dict(
     groupId=("kafka::group_id", "string"),
+    transactionalId=("kafka::transactional_id", "string"),
     topicName=("model::topic", "string"),
     brokerId=("model::node_id", "int32"),
+    producerId=("kafka::producer_id", "int64"),
 )
 
 # mapping specified as a combination of native type and field name
@@ -715,7 +717,7 @@ void {{ struct.name }}::decode(request_reader& reader, [[maybe_unused]] api_vers
 {{- struct_serde(struct, field_decoder) | indent }}
 }
 {%- else %}
-void {{ struct.name }}::decode(iobuf buf, api_version version) {
+void {{ struct.name }}::decode(iobuf buf, [[maybe_unused]] api_version version) {
     request_reader reader(std::move(buf));
 
 {{- struct_serde(struct, field_decoder) | indent }}

--- a/src/v/kafka/requests/schemata/init_producer_id_request.json
+++ b/src/v/kafka/requests/schemata/init_producer_id_request.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 22,
+  "type": "request",
+  "name": "InitProducerIdRequest",
+  // Version 1 is the same as version 0.
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
+  "fields": [
+    { "name": "TransactionalId", "type": "string", "versions": "0+", "nullableVersions": "0+", "entityType": "transactionalId",
+      "about": "The transactional id, or null if the producer is not transactional." },
+    { "name": "TransactionTimeoutMs", "type": "int32", "versions": "0+",
+      "about": "The time in ms to wait for before aborting idle transactions sent by this producer. This is only relevant if a TransactionalId has been defined." }
+  ]
+}

--- a/src/v/kafka/requests/schemata/init_producer_id_response.json
+++ b/src/v/kafka/requests/schemata/init_producer_id_response.json
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 22,
+  "type": "response",
+  "name": "InitProducerIdResponse",
+  // Starting in version 1, on quota violation, brokers send out responses before throttling.
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+", "ignorable": true,
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ProducerId", "type": "int64", "versions": "0+", "entityType": "producerId",
+      "default": -1, "about": "The current producer id." },
+    { "name": "ProducerEpoch", "type": "int16", "versions": "0+",
+      "about": "The current epoch associated with the producer id." }
+  ]
+}

--- a/src/v/kafka/requests/sync_group_request.h
+++ b/src/v/kafka/requests/sync_group_request.h
@@ -62,8 +62,7 @@ struct sync_group_request final {
     }
 };
 
-static inline std::ostream&
-operator<<(std::ostream& os, const sync_group_request& r) {
+inline std::ostream& operator<<(std::ostream& os, const sync_group_request& r) {
     return os << r.data;
 }
 
@@ -95,7 +94,7 @@ make_sync_error(error_code error) {
     return ss::make_ready_future<sync_group_response>(error);
 }
 
-static inline std::ostream&
+inline std::ostream&
 operator<<(std::ostream& os, const sync_group_response& r) {
     return os << r.data;
 }

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -33,6 +33,12 @@ using api_version = named_type<int16_t, struct kafka_requests_api_version>;
 /// Kafka group identifier.
 using group_id = named_type<ss::sstring, struct kafka_group_id>;
 
+/// Kafka transactional id identifier.
+using transactional_id = named_type<ss::sstring, struct kafka_transactional_id>;
+
+/// Kafka producer id identifier.
+using producer_id = named_type<int64_t, struct kafka_producer_id>;
+
 /// Kafka group member identifier.
 using member_id = named_type<ss::sstring, struct kafka_member_id>;
 


### PR DESCRIPTION
The handler is a first step towards transactions and idempotent producers. So far it does nothing (throws an exception) but it's behind a feature flag so the behaviour is intact.

## Checklist
- [x] Reference related [Support idempotent producers](https://github.com/vectorizedio/redpanda/issues/216)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant