### PR TITLE
k/create_topics: ignoring not supported configuration properties

### DIFF
--- a/src/v/kafka/requests/create_topics_request.h
+++ b/src/v/kafka/requests/create_topics_request.h
@@ -45,8 +45,7 @@ private:
       no_custom_partition_assignment,
       partition_count_must_be_positive,
       replication_factor_must_be_positive,
-      replication_factor_must_be_odd,
-      unsupported_configuration_entries>;
+      replication_factor_must_be_odd>;
 };
 
 struct create_topics_request final {


### PR DESCRIPTION
In order to maintain compatibility with existing applications we want to
ignore not supported configuration properties when creating topics.
Instead of returning an error we log a message informing users that some
of the options will be ignored.

Fixes #135

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
