### PR TITLE
rpk/start: Fix flags

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -169,6 +169,12 @@ func NewStartCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 				return err
 			}
 
+			err = mgr.Write(conf)
+			if err != nil {
+				sendEnv(mgr, env, conf, err)
+				return err
+			}
+
 			sendEnv(mgr, env, conf, nil)
 			rpArgs.ExtraArgs = args
 			launcher := redpanda.NewLauncher(installDirectory, rpArgs)
@@ -200,7 +206,7 @@ func NewStartCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		"The Kafka address to advertise (<host>:<port>)",
 	)
 	command.Flags().StringVar(
-		&advertisedKafka,
+		&advertisedRPC,
 		"advertise-rpc-addr",
 		"",
 		"The advertised RPC address (<host>:<port>)",


### PR DESCRIPTION
- Map `--advertise-rpc-addr` to the right var.
- Write the conf before starting redpanda. This is needed to persist any changes in the config, so that redpanda can pick them up at startup.
