### PR TITLE
Replicate batch size configuration

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -288,6 +288,12 @@ configuration::configuration()
       "Max duration before dispatching batched replicate requests",
       required::no,
       4ms)
+  , raft_replicate_batch_window_size(
+      *this,
+      "raft_replicate_batch_window_size",
+      "Max size of requests cached for replication",
+      required::no,
+      128_KiB)
   , reclaim_min_size(
       *this,
       "reclaim_min_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -84,6 +84,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> replicate_append_timeout_ms;
     property<std::chrono::milliseconds> recovery_append_timeout_ms;
     property<std::chrono::milliseconds> replicate_request_debounce_timeout_ms;
+    property<size_t> raft_replicate_batch_window_size;
 
     property<size_t> reclaim_min_size;
     property<size_t> reclaim_max_size;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -56,7 +56,9 @@ consensus::consensus(
   , _leader_notification(std::move(cb))
   , _fstats({})
   , _batcher(
-      this, config::shard_local_cfg().replicate_request_debounce_timeout_ms())
+      this,
+      config::shard_local_cfg().replicate_request_debounce_timeout_ms(),
+      config::shard_local_cfg().raft_replicate_batch_window_size())
   , _event_manager(this)
   , _ctxlog(group, _log.config().ntp())
   , _replicate_append_timeout(

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -29,13 +29,10 @@ public:
         size_t record_count;
     };
     using item_ptr = ss::lw_shared_ptr<item>;
-    // 1MB default size
-    static constexpr size_t default_batch_bytes = 1_MiB;
-
     explicit replicate_batcher(
       consensus* ptr,
       std::chrono::milliseconds debounce_duration,
-      size_t cache_size = default_batch_bytes);
+      size_t cache_size);
 
     replicate_batcher(replicate_batcher&&) noexcept = default;
     replicate_batcher& operator=(replicate_batcher&&) noexcept = delete;
@@ -62,7 +59,7 @@ private:
 
     consensus* _ptr;
     std::chrono::milliseconds _debounce_duration;
-    size_t _max_batch_size{default_batch_bytes};
+    size_t _max_batch_size;
     size_t _pending_bytes{0};
     timer_type _flush_timer;
 


### PR DESCRIPTION
Allowing user to configure max batch size in replicate batcher. 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
