### PR TITLE
Wasm engine logging

### DIFF
--- a/src/js/build-package.json
+++ b/src/js/build-package.json
@@ -16,7 +16,8 @@
     "ts-node": "^9.0.0",
     "webpack": "^4.44.2",
     "xxhash": "0.3.0",
-    "js-yaml": "^3.14.0"
+    "js-yaml": "^3.14.0",
+    "winston": "3.3.3"
   },
   "devDependencies": {
     "sinon": "^9.0.2",

--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -27,6 +27,7 @@ export class ProcessBatchServer extends SupervisorServer {
 
   constructor(activeDir: string, inactiveDir: string, submitDir: string) {
     super();
+    // TODO Can lookup the port redpanda is listening for copros on in the redpanda.yaml file
     this.managementClient = new ManagementClient(43118);
     this.applyCoprocessor = this.applyCoprocessor.bind(this);
     this.repository = new Repository();

--- a/src/js/modules/rpc/service.ts
+++ b/src/js/modules/rpc/service.ts
@@ -13,13 +13,17 @@ import { safeLoadAll } from "js-yaml";
 import { join, resolve } from "path";
 import * as fs from "fs";
 import { promisify } from "util";
+import { newLogger } from "../utilities/Logging";
+
+const logger = newLogger("service");
 
 // read yaml config file
 const readConfigFile = (confPath: string): Promise<Record<string, any>> => {
   try {
+    logger.info(`Reading from config file: ${confPath}`);
     return fs.promises.readFile(confPath).then((file) => safeLoadAll(file)[0]);
   } catch (e) {
-    return Promise.reject(new Error(`Error reading config file: ${e}`));
+    return Promise.reject(new Error(`Error reading config file: ${e.message}`));
   }
 };
 
@@ -33,7 +37,7 @@ const validateOrCreateScaffolding = (directoryPath: string): Promise<void> => {
     const path = join(directoryPath, folder);
     return exists(path).then((exist) => {
       if (!exist) {
-        console.log(path);
+        logger.info(`Creating part of scaffolding ${path}`);
         return fs.promises.mkdir(path, { recursive: true });
       }
     });
@@ -41,22 +45,30 @@ const validateOrCreateScaffolding = (directoryPath: string): Promise<void> => {
   return Promise.all(validations).then(() => null);
 };
 
-// read config file path argument
-const configPathArg = process.argv.splice(2)[0];
-const defaultConfigPath = "/var/lib/redpanda/conf/redpanda.yaml";
-const defaultCoprocessorPath = "/var/lib/redpanda/coprocessor";
-// resolve config path or assign default value
-const configPath = configPathArg ? resolve(configPathArg) : defaultConfigPath;
+function main() {
+  // read config file path argument
+  logger.info("Starting redpanda wasm service...");
+  const configPathArg = process.argv.splice(2)[0];
+  const defaultConfigPath = "/var/lib/redpanda/conf/redpanda.yaml";
+  const defaultCoprocessorPath = "/var/lib/redpanda/coprocessor";
+  // resolve config path or assign default value
+  const configPath = configPathArg ? resolve(configPathArg) : defaultConfigPath;
+  logger.info(`Using redpanda configuration path: ${configPath}`);
 
-readConfigFile(configPath).then((config) => {
-  const port = config?.redpanda?.coproc_supervisor_server || 43189;
-  const path = config?.coproc_engine?.path || defaultCoprocessorPath;
-  validateOrCreateScaffolding(path).then(() => {
-    const service = new ProcessBatchServer(
-      join(path, "active"),
-      join(path, "inactive"),
-      join(path, "submit")
-    );
-    service.listen(port);
+  readConfigFile(configPath).then((config) => {
+    const port = config?.redpanda?.coproc_supervisor_server || 43189;
+    const path = config?.coproc_engine?.path || defaultCoprocessorPath;
+    logger.info(`Using root scaffolding path: ${path}`);
+    validateOrCreateScaffolding(path).then(() => {
+      const service = new ProcessBatchServer(
+        join(path, "active"),
+        join(path, "inactive"),
+        join(path, "submit")
+      );
+      logger.info(`Starting redpanda wasm service on port: ${port}`);
+      service.listen(port);
+    });
   });
-});
+}
+
+main();

--- a/src/js/modules/supervisors/HandleError.ts
+++ b/src/js/modules/supervisors/HandleError.ts
@@ -26,7 +26,7 @@ export const validateDisableResponseCode = (
 ): Error[] => {
   if (responses.inputs.length !== coprocessors.length) {
     throw new Error(
-      "error: inconsistent response for disable coprocessors, " +
+      "inconsistent response for disable coprocessors, " +
         `the disabled coprocessor response for ${coprocessors.join(", ")} ` +
         "doesn't have the same number item results, expected: " +
         `${coprocessors.length} result: ${responses.inputs.length}`
@@ -36,17 +36,14 @@ export const validateDisableResponseCode = (
     switch (code) {
       case DisableResponseCode.internalError: {
         errors.push(
-          new Error(
-            `internal error: wasm function ID: ${coprocessors[index].globalId}`
-          )
+          new Error(`wasm function ID: ${coprocessors[index].globalId}`)
         );
         break;
       }
       case DisableResponseCode.scriptDoesNotExist: {
         errors.push(
           new Error(
-            `error: script with ID ${coprocessors[index].globalId} ` +
-              "doesn't exist."
+            `script with ID ${coprocessors[index].globalId} ` + "doesn't exist."
           )
         );
       }
@@ -61,7 +58,7 @@ export const validateEnableResponseCode = (
 ): Error[][] => {
   if (responses.inputs.length !== coprocessors.length) {
     throw new Error(
-      "error: inconsistent response for enable coprocessors, " +
+      "inconsistent response for enable coprocessors, " +
         `the enable coprocessor response for ${coprocessors.join(", ")} ` +
         "doesn't have the same number item results, expected: " +
         `${coprocessors.length} result: ${responses.inputs.length}`
@@ -73,25 +70,23 @@ export const validateEnableResponseCode = (
       const coprocessor = coprocessors[index];
       switch (code) {
         case EnableResponseCode.internalError: {
-          errors.push(new Error(`internal error: wasm function ID: ${id}`));
+          errors.push(new Error(`wasm function ID: ${id}`));
           break;
         }
         case EnableResponseCode.invalidIngestionPolicy: {
-          errors.push(new Error(`error: invalid ingestion policy`));
+          errors.push(new Error(`invalid ingestion policy`));
           break;
         }
         case EnableResponseCode.invalidTopic: {
           errors.push(
-            new Error(
-              `error: invalid topic "${coprocessor.inputTopics[topicIndex]}"`
-            )
+            new Error(`invalid topic "${coprocessor.inputTopics[topicIndex]}"`)
           );
           break;
         }
         case EnableResponseCode.topicDoesNotExist: {
           errors.push(
             new Error(
-              `error: topic "${coprocessor.inputTopics[topicIndex]}" ` +
+              `topic "${coprocessor.inputTopics[topicIndex]}" ` +
                 `doesn't exist`
             )
           );
@@ -100,14 +95,13 @@ export const validateEnableResponseCode = (
         case EnableResponseCode.scriptIdAlreadyExist: {
           errors.push(
             new Error(
-              "error: wasm function already register, ID: " +
-                coprocessor.globalId
+              "wasm function already register, ID: " + coprocessor.globalId
             )
           );
           break;
         }
         case EnableResponseCode.materializedTopic: {
-          errors.push(new Error("error: materialized topic"));
+          errors.push(new Error("materialized topic"));
           break;
         }
         case EnableResponseCode.success: {

--- a/src/js/modules/utilities/Logging.ts
+++ b/src/js/modules/utilities/Logging.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+import * as winston from "winston";
+
+export function newLogger(
+  module_name: string,
+  logLevel = "info",
+  simplify = false
+) {
+  const rpWasmFormatter = () => {
+    const logLineFormatter = winston.format.printf(
+      ({ level, message, label, timestamp }) => {
+        return `${timestamp} [${label}] ${level}: ${message}`;
+      }
+    );
+    const simpleLogLineFormatter = winston.format.printf(
+      ({ level, message, label }) => {
+        return `[${label}] ${level}: ${message}`;
+      }
+    );
+
+    return (simplify ? [] : [winston.format.timestamp()]).concat([
+      winston.format.splat(),
+      winston.format.label({ label: module_name }),
+      simplify ? simpleLogLineFormatter : logLineFormatter,
+    ]);
+  };
+
+  const logger = winston.createLogger({
+    level: logLevel,
+    format: winston.format.combine(...rpWasmFormatter()),
+    defaultMeta: { service: module_name },
+    transports: [
+      new winston.transports.Console({
+        level: logLevel,
+      }),
+    ],
+  });
+  return logger;
+}

--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -27,6 +27,16 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -563,6 +573,11 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -1022,6 +1037,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1034,6 +1058,29 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "commander": {
       "version": "2.20.3",
@@ -1354,6 +1401,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -1825,6 +1877,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -1909,6 +1971,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -2323,6 +2390,11 @@
         }
       }
     },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2430,6 +2502,11 @@
         "has": "^1.0.3"
       }
     },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -2511,6 +2588,11 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2562,6 +2644,18 @@
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "requires": {
         "chalk": "^2.4.2"
+      }
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
       }
     },
     "lru-cache": {
@@ -3095,6 +3189,14 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -3803,6 +3905,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "sinon": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.0.tgz",
@@ -4040,6 +4150,11 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -4251,6 +4366,11 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4332,6 +4452,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-loader": {
       "version": "8.0.4",
@@ -4872,6 +4997,43 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
       }
     },
     "word-wrap": {

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -34,7 +34,8 @@
     "typescript-formatter": "7.2.2",
     "webpack": "^4.44.2",
     "xxhash": "0.3.0",
-    "js-yaml": "^3.14.0"
+    "js-yaml": "^3.14.0",
+    "winston": "3.3.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.7.0",


### PR DESCRIPTION
Introducing log framework for the wasm engine. Heres a sample of the output at startup:
```
> Depedencies@0.0.1 start /home/robert/workspace/redpanda/build/node/output
> sudo node ./modules/rpc/service.js

2020-12-04T22:00:05.847Z [service] info: Starting redpanda wasm service...
2020-12-04T22:00:05.849Z [service] info: Using redpanda configuration path: /var/lib/redpanda/conf/redpanda.yaml
2020-12-04T22:00:05.849Z [service] info: Reading from config file: /var/lib/redpanda/conf/redpanda.yaml
2020-12-04T22:00:05.855Z [service] info: Using root scaffolding path: /var/lib/redpanda/coprocessor
2020-12-04T22:00:05.858Z [service] info: Starting redpanda wasm service on port 43189
```