### PR TITLE
r/consensus: updating follower heartbeat even when response is reordered

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -188,6 +188,9 @@ consensus::success_reply consensus::update_follower_index(
           "Append entries response send to wrong group: {}, current group: {}",
           reply.group));
     }
+
+    update_node_hbeat_timestamp(node);
+
     if (
       seq < idx.last_received_seq
       && reply.last_dirty_log_index < _log.offsets().dirty_offset) {
@@ -235,8 +238,6 @@ consensus::success_reply consensus::update_follower_index(
         });
         return success_reply::no;
     }
-
-    update_node_hbeat_timestamp(node);
 
     // If recovery is in progress the recovery STM will handle follower index
     // updates


### PR DESCRIPTION
Even if follower response is reordered it is still sign of the follower
node being up and running. Consensus shouldn't ignore that information
when deciding whether it is required to demote itself to follower.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
