### PR TITLE
s/segment_utils: marking segment as compacted after compaction

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -463,7 +463,6 @@ ss::future<> self_compact_segment(
             switch (state) {
             case compacted_index::recovery_state::recovered: {
                 vlog(stlog.info, "detected {} is already compacted", idx_path);
-                s->mark_as_finished_self_compaction();
                 return ss::now();
             }
             case compacted_index::recovery_state::nonrecovered:
@@ -495,6 +494,7 @@ ss::future<> self_compact_segment(
                 __builtin_unreachable();
             }
         })
+      .then([s] { s->mark_as_finished_self_compaction(); })
       .finally([&pb] { pb.segment_compacted(); });
 }
 


### PR DESCRIPTION
Before, we marked segment as compacted only after verifying compaction
index state. Modified the behavior so that we mark segment as self
compacted after successful compaction. This way we do not have to read
compaction index multiple times.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
