### PR TITLE
r/recovery_stm: we have to stop recovery stm when node is not a leader

### DIFF
--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -380,7 +380,8 @@ bool recovery_stm::is_recovery_finished() {
      */
     return (is_up_to_date && quorum_writes) // fully caught up
            || _stop_requested               // stop requested
-           || _term != _ptr->term();        // leadership changed
+           || _term != _ptr->term()         // term changed
+           || !_ptr->is_leader();           // no longer a leader
 }
 
 ss::future<> recovery_stm::apply() {


### PR DESCRIPTION
Fixed recovery stopping recovery stm when a node is not a leader.

It may happen that the recovery state machine will start when the node
is not longer a leader. It may lead to the situation when non leader
node will be trying to send append entry requests. This is incorrect and
may lead to protocol not being able to make progress.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
