### PR TITLE
Revert "r/tests: fixed incorrect election timeout"

### DIFF
--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -45,7 +45,7 @@ inline ss::logger tstlog("raft_test");
 
 using namespace std::chrono_literals; // NOLINT
 
-inline static auto heartbeat_interval = 80ms;
+inline static auto heartbeat_interval = 40ms;
 inline static const raft::replicate_options
   default_replicate_opts(raft::consistency_level::quorum_ack);
 
@@ -346,7 +346,7 @@ struct raft_group {
           make_broker(node_id),
           _id,
           raft::group_configuration(_initial_brokers),
-          raft::timeout_jitter(heartbeat_interval * 10),
+          raft::timeout_jitter(heartbeat_interval * 2),
           fmt::format("{}/{}", _storage_dir, node_id()),
           _storage_type,
           [this, node_id](raft::leadership_status st) {
@@ -367,7 +367,7 @@ struct raft_group {
           broker,
           _id,
           raft::group_configuration({}),
-          raft::timeout_jitter(heartbeat_interval * 10),
+          raft::timeout_jitter(heartbeat_interval * 2),
           fmt::format("{}/{}", _storage_dir, node_id()),
           _storage_type,
           [this, node_id](raft::leadership_status st) {


### PR DESCRIPTION
Reason behind the test failing was an actual bug related with stopping `raft::recovery_stm`. 
It was fixed in  vectorizedio/redpanda#231

Reverts vectorizedio/redpanda#229