### PR TITLE
Fixes a data race and time travel issue in kafkakv

### DIFF
--- a/src/consistency-testing/chaostest/control/kafkakv.py
+++ b/src/consistency-testing/chaostest/control/kafkakv.py
@@ -135,7 +135,7 @@ class KafkaKV:
         consumer = None
         tps = None
         cid = None
-        init_started = time.time()
+        init_started = time.clock_gettime(time.CLOCK_MONOTONIC)
 
         if len(self.consumers) > 0:
             consumer, tps, cid = self.consumers.pop(0)
@@ -162,8 +162,10 @@ class KafkaKV:
             self.n_consumers += 1
 
         try:
-            metrics["init_us"] = int((time.time() - init_started) * 1000000)
-            catchup_started = time.time()
+            metrics["init_us"] = int(
+                (time.clock_gettime(time.CLOCK_MONOTONIC) - init_started) *
+                1000000)
+            catchup_started = time.clock_gettime(time.CLOCK_MONOTONIC)
             if from_offset is None:
                 consumer.seek_to_beginning(tps[0])
             else:
@@ -215,7 +217,8 @@ class KafkaKV:
                   processed=processed,
                   cid=cid).with_time())
             metrics["catchup_us"] = int(
-                (time.time() - catchup_started) * 1000000)
+                (time.clock_gettime(time.CLOCK_MONOTONIC) - catchup_started) *
+                1000000)
             self.consumers.append((consumer, tps, cid))
             return state
         except:
@@ -226,7 +229,7 @@ class KafkaKV:
             raise
 
     def catchup_beginning(self, consumer_tps, state, to_offset, cmd, metrics):
-        init_started = time.time()
+        init_started = time.clock_gettime(time.CLOCK_MONOTONIC)
 
         if consumer_tps == None:
             try:
@@ -252,8 +255,10 @@ class KafkaKV:
         consumer, tps = consumer_tps
 
         try:
-            metrics["init_us"] = int((time.time() - init_started) * 1000000)
-            catchup_started = time.time()
+            metrics["init_us"] = int(
+                (time.clock_gettime(time.CLOCK_MONOTONIC) - init_started) *
+                1000000)
+            catchup_started = time.clock_gettime(time.CLOCK_MONOTONIC)
             consumer.seek_to_beginning(tps[0])
             processed = 0
 
@@ -295,7 +300,8 @@ class KafkaKV:
                   sent_offset=to_offset,
                   processed=processed).with_time())
             metrics["catchup_us"] = int(
-                (time.time() - catchup_started) * 1000000)
+                (time.clock_gettime(time.CLOCK_MONOTONIC) - catchup_started) *
+                1000000)
             return consumer_tps
         except:
             try:
@@ -320,7 +326,7 @@ class KafkaKV:
         kafkakv_log.info(
             m("executing", cmd=cmd, base_offset=offset).with_time())
 
-        send_started = time.time()
+        send_started = time.clock_gettime(time.CLOCK_MONOTONIC)
         written = None
         try:
             future = self.producer.send(self.topic, msg)
@@ -367,7 +373,9 @@ class KafkaKV:
                                 " on sending")
             raise
 
-        metrics["send_us"] = int((time.time() - send_started) * 1000000)
+        metrics["send_us"] = int(
+            (time.clock_gettime(time.CLOCK_MONOTONIC) - send_started) *
+            1000000)
 
         kafkakv_log.info(
             m("sent", cmd=cmd, base_offset=offset,

--- a/src/consistency-testing/chaostest/control/kafkakv.py
+++ b/src/consistency-testing/chaostest/control/kafkakv.py
@@ -21,6 +21,7 @@ import sys
 from time import sleep
 import time
 import threading
+from threading import Lock
 import logging
 import logging.handlers
 import argparse
@@ -88,12 +89,14 @@ class KafkaKV:
         self.has_accessed = False
         self.has_data_loss = False
         self.data_loss_info = None
+        self.mutex = Lock()
 
     def start_history_check_thread(self):
         consumer_tps = None
         while not self.has_data_loss:
-            offset = self.offset
-            state = copy.deepcopy(self.state)
+            with self.mutex:
+                offset = self.offset
+                state = copy.deepcopy(self.state)
             try:
                 replay = dict()
                 consumer_tps = self.catchup_beginning(consumer_tps, replay,
@@ -120,12 +123,13 @@ class KafkaKV:
                             "reconstructed": replay[key]
                         })
                 if len(missing) > 0 or len(mismatch) > 0 or len(extra) > 0:
-                    self.data_loss_info = {
-                        "missing": missing,
-                        "mismatch": mismatch,
-                        "extra": extra
-                    }
-                    self.has_data_loss = True
+                    with self.mutex:
+                        self.data_loss_info = {
+                            "missing": missing,
+                            "mismatch": mismatch,
+                            "extra": extra
+                        }
+                        self.has_data_loss = True
             except:
                 consumer_tps = None
                 pass
@@ -158,8 +162,9 @@ class KafkaKV:
                 raise RequestTimedout()
             tps = [TopicPartition(self.topic, 0)]
             consumer.assign(tps)
-            cid = self.n_consumers
-            self.n_consumers += 1
+            with self.mutex:
+                cid = self.n_consumers
+                self.n_consumers += 1
 
         try:
             metrics["init_us"] = int(
@@ -311,17 +316,18 @@ class KafkaKV:
             raise
 
     def execute(self, payload, cmd, metrics):
-        if not self.has_accessed and self.offset is not None:
-            self.has_accessed = True
-            if self.check_history:
-                thread = threading.Thread(
-                    target=lambda: self.start_history_check_thread())
-                thread.start()
-
         msg = json.dumps(payload).encode("utf-8")
 
-        offset = self.offset
-        state = copy.deepcopy(self.state)
+        with self.mutex:
+            if not self.has_accessed and self.offset is not None:
+                self.has_accessed = True
+                if self.check_history:
+                    thread = threading.Thread(
+                        target=lambda: self.start_history_check_thread())
+                    thread.start()
+
+            offset = self.offset
+            state = copy.deepcopy(self.state)
 
         kafkakv_log.info(
             m("executing", cmd=cmd, base_offset=offset).with_time())
@@ -381,20 +387,21 @@ class KafkaKV:
             m("sent", cmd=cmd, base_offset=offset,
               sent_offset=written.offset).with_time())
 
-        if offset != None and written.offset <= offset:
-            error = f"Monotonicity violation: written offset ({written.offset}) is behind current offset ({offset})"
-            msg = m(error, stacktrace=stacktrace).with_time()
-            kafkakv_log.info(msg)
-            kafkakv_err.info(msg)
-            self.has_data_loss = True
-            self.data_loss_info = error
-        elif self.offset == written.offset:
-            error = f"Conflict write: written offset ({written.offset}) is same as the current offset ({self.offset})"
-            msg = m(error, stacktrace=stacktrace).with_time()
-            kafkakv_log.info(msg)
-            kafkakv_err.info(msg)
-            self.has_data_loss = True
-            self.data_loss_info = error
+        with self.mutex:
+            if offset != None and written.offset <= offset:
+                error = f"Monotonicity violation: written offset ({written.offset}) is behind current offset ({offset})"
+                msg = m(error, stacktrace=stacktrace).with_time()
+                kafkakv_log.info(msg)
+                kafkakv_err.info(msg)
+                self.has_data_loss = True
+                self.data_loss_info = error
+            elif self.offset == written.offset:
+                error = f"Conflict write: written offset ({written.offset}) is same as the current offset ({self.offset})"
+                msg = m(error, stacktrace=stacktrace).with_time()
+                kafkakv_log.info(msg)
+                kafkakv_err.info(msg)
+                self.has_data_loss = True
+                self.data_loss_info = error
 
         try:
             state = self.catchup(state, offset, written.offset, cmd, metrics)
@@ -418,16 +425,17 @@ class KafkaKV:
                                 " on catching up")
             raise RequestTimedout()
 
-        if self.offset is None or self.offset < written.offset:
-            base_offset = self.offset
-            self.state = state
-            self.offset = written.offset
-            kafkakv_log.info(
-                m("updated",
-                  cmd=cmd,
-                  base_offset=offset,
-                  root_offset=base_offset,
-                  sent_offset=written.offset).with_time())
+        with self.mutex:
+            if self.offset is None or self.offset < written.offset:
+                base_offset = self.offset
+                self.state = state
+                self.offset = written.offset
+                kafkakv_log.info(
+                    m("updated",
+                      cmd=cmd,
+                      base_offset=offset,
+                      root_offset=base_offset,
+                      sent_offset=written.offset).with_time())
 
         return state
 


### PR DESCRIPTION
Using time.time() to measure latency may lead to negative values when a strobe fault injection changes system time. Changing to monotonic time which is immune to this problem. Introduces mutex to avoid data race.