### PR TITLE
redpanda: serve http dashboard directory for `/` GET

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -161,6 +161,12 @@ configuration::configuration()
       required::no,
       64_MiB)
   , rack(*this, "rack", "Rack identifier", required::no, std::nullopt)
+  , dashboard_dir(
+      *this,
+      "dashboard_dir",
+      "serve http dashboard on / url",
+      required::no,
+      std::nullopt)
   , disable_metrics(
       *this,
       "disable_metrics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -62,6 +62,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> quota_manager_gc_sec;
     property<uint32_t> target_quota_byte_rate;
     property<std::optional<ss::sstring>> rack;
+    property<std::optional<ss::sstring>> dashboard_dir;
     property<bool> disable_metrics;
     property<std::chrono::milliseconds> group_min_session_timeout_ms;
     property<std::chrono::milliseconds> group_max_session_timeout_ms;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -206,6 +206,17 @@ void application::configure_admin_server() {
           })
           .get0();
     }
+    if (conf.dashboard_dir()) {
+        _admin
+          .invoke_on_all([](ss::http_server& server) {
+              server._routes.add(
+                ss::httpd::operation_type::GET,
+                ss::httpd::url("/"),
+                new ss::httpd::directory_handler(
+                  *config::shard_local_cfg().dashboard_dir()));
+          })
+          .get0();
+    }
     ss::prometheus::config metrics_conf;
     metrics_conf.metric_help = "redpanda metrics";
     metrics_conf.prefix = "vectorized";


### PR DESCRIPTION
This are necessary changes to serve the new dashboard
https://github.com/vectorizedio/redpanda/pull/230 for node local
metrics+admin API

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
