### PR TITLE
Raft recovery race condition fix

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -260,7 +260,12 @@ consensus::success_reply consensus::update_follower_index(
     }
 
     if (idx.is_recovering) {
-        // we are already recovering, do nothing
+        // we are already recovering, if follower dirty log index moved back
+        // from some reason (i.e. truncation, data loss, trigger recovery)
+        if (idx.last_dirty_log_index > reply.last_dirty_log_index) {
+            idx.next_index = details::next_offset(idx.last_dirty_log_index);
+            idx.follower_state_change.broadcast();
+        }
         return success_reply::no;
     }
 
@@ -316,8 +321,10 @@ void consensus::maybe_promote_to_voter(model::node_id id) {
 void consensus::process_append_entries_reply(
   model::node_id node,
   result<append_entries_reply> r,
-  follower_req_seq seq_id) {
-    auto is_success = update_follower_index(node, std::move(r), seq_id);
+  follower_req_seq seq_id,
+  model::offset dirty_offset) {
+    auto is_success = update_follower_index(
+      node, std::move(r), seq_id, dirty_offset);
     if (is_success) {
         maybe_promote_to_voter(node);
         maybe_update_majority_replicated_index();
@@ -340,10 +347,11 @@ void consensus::successfull_append_entries_reply(
       idx.next_index);
 }
 
-bool consensus::needs_recovery(const follower_index_metadata& idx) {
+bool consensus::needs_recovery(
+  const follower_index_metadata& idx, model::offset dirty_offset) {
     // follower match_index is behind, we have to recover it
-    auto lstats = _log.offsets();
-    return idx.match_index < lstats.dirty_offset
+
+    return idx.match_index < dirty_offset
            || idx.match_index > idx.last_dirty_log_index;
 }
 
@@ -750,7 +758,33 @@ ss::future<> consensus::start() {
                     _ctxlog.trace, "Recovered commit_index: {}", _commit_index);
               }
           })
-          .then([this] { return _event_manager.start(); });
+          .then([this] {
+              start_dispatching_disk_append_events();
+              return _event_manager.start();
+          });
+    });
+}
+
+void consensus::start_dispatching_disk_append_events() {
+    // forward disk appends to follower state changed condition
+    // variables
+    (void)ss::with_gate(_bg, [this] {
+        return ss::do_until(
+          [this] { return _as.abort_requested(); },
+          [this] {
+              return _disk_append.wait()
+                .then([this] {
+                    for (auto& idx : _fstats) {
+                        idx.second.follower_state_change.broadcast();
+                    }
+                })
+                .handle_exception_type(
+                  [this](const ss::broken_condition_variable&) {
+                      for (auto& idx : _fstats) {
+                          idx.second.follower_state_change.broken();
+                      }
+                  });
+          });
     });
 }
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -128,7 +128,10 @@ public:
     follower_req_seq next_follower_sequence(model::node_id);
 
     void process_append_entries_reply(
-      model::node_id, result<append_entries_reply>, follower_req_seq);
+      model::node_id,
+      result<append_entries_reply>,
+      follower_req_seq,
+      model::offset);
 
     ss::future<result<replicate_result>>
     replicate(model::record_batch_reader&&, replicate_options);
@@ -255,11 +258,15 @@ private:
     using success_reply = ss::bool_class<struct successfull_reply_tag>;
 
     success_reply update_follower_index(
-      model::node_id, result<append_entries_reply>, follower_req_seq seq_id);
+      model::node_id,
+      result<append_entries_reply>,
+      follower_req_seq seq_id,
+      model::offset);
+
     void successfull_append_entries_reply(
       follower_index_metadata&, append_entries_reply);
 
-    bool needs_recovery(const follower_index_metadata&);
+    bool needs_recovery(const follower_index_metadata&, model::offset);
     void dispatch_recovery(follower_index_metadata&);
     void maybe_update_leader_commit_idx();
     ss::future<> do_maybe_update_leader_commit_idx(ss::semaphore_units<>);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -327,6 +327,8 @@ private:
 
     void maybe_update_last_visible_index(model::offset);
     void maybe_update_majority_replicated_index();
+
+    void start_dispatching_disk_append_events();
     // args
     model::node_id _self;
     raft::group_id _group;

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -89,22 +89,27 @@ public:
     using consensus_set = boost::container::
       flat_set<consensus_ptr, details::consensus_ptr_by_group_id>;
 
+    struct follower_request_meta {
+        follower_req_seq seq;
+        model::offset dirty_offset;
+    };
     // Heartbeats from all groups for single node
     struct node_heartbeat {
         node_heartbeat(
           model::node_id t,
           heartbeat_request req,
-          absl::flat_hash_map<raft::group_id, follower_req_seq> seqs)
+          absl::flat_hash_map<raft::group_id, follower_request_meta> seqs)
           : target(t)
           , request(std::move(req))
-          , sequence_map(std::move(seqs)) {}
+          , meta_map(std::move(seqs)) {}
 
         model::node_id target;
         heartbeat_request request;
         // each raft group has its own follower metadata hence we need map to
         // track a sequence per group
-        absl::flat_hash_map<raft::group_id, follower_req_seq> sequence_map;
+        absl::flat_hash_map<raft::group_id, follower_request_meta> meta_map;
     };
+
     heartbeat_manager(
       duration_type interval, consensus_client_protocol, model::node_id);
 
@@ -135,7 +140,7 @@ private:
     /// \param result if the node return successful heartbeats
     void process_reply(
       model::node_id n,
-      absl::flat_hash_map<raft::group_id, follower_req_seq> groups,
+      absl::flat_hash_map<raft::group_id, follower_request_meta> groups,
       result<heartbeat_reply> result);
 
     // private members

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -316,46 +316,47 @@ ss::future<> recovery_stm::replicate(
     _ptr->update_node_append_timestamp(_node_id);
 
     auto seq = _ptr->next_follower_sequence(_node_id);
-    return dispatch_append_entries(std::move(r)).then([this, seq, dirty_offset = lstats.dirty_offset](auto r) {
-        if (!r) {
-            vlog(
-              _ctxlog.error,
-              "recovery_stm: not replicate entry: {} - {}",
-              r,
-              r.error().message());
-            _stop_requested = true;
-            _ptr->get_probe().recovery_request_error();
-        }
-        _ptr->process_append_entries_reply(
-          _node_id, r.value(), seq, dirty_offset);
-        // If request was reordered we have to stop recovery as follower state
-        // is not known
-        if (seq < _ptr->_fstats.get(_node_id).last_received_seq) {
-            _stop_requested = true;
-            return;
-        }
-        // move the follower next index backward if recovery were not
-        // successfull
-        //
-        // Raft paper:
-        // If AppendEntries fails because of log inconsistency: decrement
-        // nextIndex and retry(§5.3)
+    return dispatch_append_entries(std::move(r))
+      .then([this, seq, dirty_offset = lstats.dirty_offset](auto r) {
+          if (!r) {
+              vlog(
+                _ctxlog.error,
+                "recovery_stm: not replicate entry: {} - {}",
+                r,
+                r.error().message());
+              _stop_requested = true;
+              _ptr->get_probe().recovery_request_error();
+          }
+          _ptr->process_append_entries_reply(
+            _node_id, r.value(), seq, dirty_offset);
+          // If request was reordered we have to stop recovery as follower state
+          // is not known
+          if (seq < _ptr->_fstats.get(_node_id).last_received_seq) {
+              _stop_requested = true;
+              return;
+          }
+          // move the follower next index backward if recovery were not
+          // successfull
+          //
+          // Raft paper:
+          // If AppendEntries fails because of log inconsistency: decrement
+          // nextIndex and retry(§5.3)
 
-        if (r.value().result == append_entries_reply::status::failure) {
-            auto meta = get_follower_meta();
-            if (!meta) {
-                _stop_requested = true;
-                return;
-            }
-            meta.value()->next_index = std::max(
-              model::offset(0), details::prev_offset(_base_batch_offset));
-            vlog(
-              _ctxlog.trace,
-              "Move node {} next index {} backward",
-              _node_id,
-              meta.value()->next_index);
-        }
-    });
+          if (r.value().result == append_entries_reply::status::failure) {
+              auto meta = get_follower_meta();
+              if (!meta) {
+                  _stop_requested = true;
+                  return;
+              }
+              meta.value()->next_index = std::max(
+                model::offset(0), details::prev_offset(_base_batch_offset));
+              vlog(
+                _ctxlog.trace,
+                "Move node {} next index {} backward",
+                _node_id,
+                meta.value()->next_index);
+          }
+      });
 }
 
 clock_type::time_point recovery_stm::append_entries_timeout() {

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -37,7 +37,7 @@ private:
     ss::future<> handle_install_snapshot_reply(result<install_snapshot_reply>);
     ss::future<> open_snapshot_reader();
     ss::future<> close_snapshot_reader();
-
+    bool state_changed();
     bool is_recovery_finished();
 
     consensus* _ptr;

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -102,7 +102,8 @@ ss::future<> replicate_entries_stm::dispatch_one(
                        if (!reply) {
                            _ptr->get_probe().replicate_request_error();
                        }
-                       _ptr->process_append_entries_reply(id, reply, seq);
+                       _ptr->process_append_entries_reply(
+                         id, reply, seq, _dirty_offset);
                    });
              })
       .handle_exception_type([](const ss::gate_closed_exception&) {});
@@ -157,6 +158,7 @@ replicate_entries_stm::apply(ss::semaphore_units<> u) {
               return ss::make_ready_future<result<storage::append_result>>(
                 append_result);
           }
+          _dirty_offset = append_result.value().last_offset;
           // dispatch requests to followers & leader flush
           std::vector<ss::semaphore_units<>> vec;
           vec.push_back(std::move(u));

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/consensus.h"
 #include "seastarx.h"
@@ -116,6 +117,7 @@ private:
     ss::semaphore _dispatch_sem{0};
     ss::gate _req_bg;
     ctx_log _ctxlog;
+    model::offset _dirty_offset;
 };
 
 } // namespace raft

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -137,6 +137,16 @@ struct follower_index_metadata {
      * on the recovery_finished condition variable.
      */
     ss::condition_variable recovery_finished;
+    /**
+     * When recovering, the recovery state machine will wait on this condition
+     * variable to wait for any changes that may require triggering recovery.
+     *
+     * This is:
+     * - follower log indices moved backward
+     * - disk append happened on the leader
+     * - follower is going to be removed
+     */
+    ss::condition_variable follower_state_change;
 };
 
 struct append_entries_request {


### PR DESCRIPTION
Fixed race condition causing unnecessary recovery requests to be sent to the followers. 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
