### PR TITLE
Wasm engine retries on all RPC requests

### DIFF
--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -17,26 +17,22 @@ import {
   ProcessBatchRequest,
   ProcessBatchRequestItem,
 } from "../domain/generatedRpc/generatedClasses";
-import { Script_ManagerClient as ManagementClient } from "./serverAndClients/server";
 import { SupervisorServer } from "./serverAndClients/processBatch";
 
 export class ProcessBatchServer extends SupervisorServer {
   private readonly repository: Repository;
   private fileManager: FileManager;
-  managementClient: ManagementClient;
 
   constructor(activeDir: string, inactiveDir: string, submitDir: string) {
     super();
     // TODO Can lookup the port redpanda is listening for copros on in the redpanda.yaml file
-    this.managementClient = new ManagementClient(43118);
     this.applyCoprocessor = this.applyCoprocessor.bind(this);
     this.repository = new Repository();
     this.fileManager = new FileManager(
       this.repository,
       submitDir,
       activeDir,
-      inactiveDir,
-      this.managementClient
+      inactiveDir
     );
   }
 

--- a/src/js/modules/supervisors/FileManager.ts
+++ b/src/js/modules/supervisors/FileManager.ts
@@ -36,15 +36,16 @@ const logger = newLogger("FileManager");
 class FileManager {
   private submitDirWatcher: FSWatcher;
   private activeDirWatcher: FSWatcher;
+  private managementClient: ManagementClient;
 
   constructor(
     private repository: Repository,
     private submitDir: string,
     private activeDir: string,
-    private inactiveDir: string,
-    public managementClient: ManagementClient
+    private inactiveDir: string
   ) {
     try {
+      this.managementClient = new ManagementClient(43118);
       this.readCoprocessorFolder(repository, this.activeDir, false)
         .then(() => this.readCoprocessorFolder(repository, this.submitDir))
         .then(() => this.startWatchers(repository));

--- a/src/js/modules/supervisors/FileManager.ts
+++ b/src/js/modules/supervisors/FileManager.ts
@@ -44,15 +44,12 @@ class FileManager {
     private activeDir: string,
     private inactiveDir: string
   ) {
-    try {
-      this.managementClient = new ManagementClient(43118);
-      this.readCoprocessorFolder(repository, this.activeDir, false)
-        .then(() => this.readCoprocessorFolder(repository, this.submitDir))
-        .then(() => this.startWatchers(repository));
-    } catch (e) {
-      // TODO: This should be a FATAL error
-      logger.error(`Failed to register watch(es): ${e.message}`);
-    }
+    this.readCoprocessorFolder(repository, this.activeDir, false)
+      .then(() => this.readCoprocessorFolder(repository, this.submitDir))
+      .then(() => this.startWatchers(repository))
+      .catch((e) => {
+        throw Error(`Failed startup the FileManager: ${e.message}`);
+      });
   }
 
   /**
@@ -230,20 +227,29 @@ class FileManager {
       `Initiating RPC call to redpandas coprocessor service at endpoint - ` +
         `disable_coprocessors with data: ${coprocessors}`
     );
-    return this.managementClient
-      .disable_copros({ inputs: coprocessors.map((coproc) => coproc.globalId) })
-      .then((response) => {
-        const errors = validateDisableResponseCode(response, coprocessors);
-        if (errors.length > 0) {
-          const compactedErrors = this.compactErrors([errors]);
-          logger.error(
-            `disable_coprocessors RPC returned with errors: ${compactedErrors}`
-          );
-          return Promise.reject(compactedErrors);
-        } else {
+    return this.getClient().then((client) => {
+      return client
+        .disable_copros({
+          inputs: coprocessors.map((coproc) => coproc.globalId),
+        })
+        .then((response) => {
+          const errors = validateDisableResponseCode(response, coprocessors);
+          if (errors.length > 0) {
+            const compactedErrors = this.compactErrors([errors]);
+            logger.error(
+              `disable_coprocessors() RPC returned with ` +
+                `errors: ${compactedErrors}`
+            );
+            return Promise.reject(compactedErrors);
+          }
           return Promise.resolve();
-        }
-      });
+        })
+        .catch((e) => {
+          return Promise.reject(
+            `disable_coprocessors() RPC failed: ${e.message}`
+          );
+        });
+    });
   }
 
   /**
@@ -268,12 +274,13 @@ class FileManager {
   ): Promise<void> {
     if (coprocessors.length == 0) {
       return Promise.resolve();
-    } else {
-      logger.info(
-        `Initiating RPC call to redpandas coprocessor service at endpoint - ` +
-          `enable_coprocessors with data: ${coprocessors}`
-      );
-      return this.managementClient
+    }
+    logger.info(
+      `Initiating RPC call to redpandas coprocessor service at endpoint - ` +
+        `enable_coprocessors with data: ${coprocessors}`
+    );
+    return this.getClient().then((client) => {
+      return client
         .enable_copros({
           coprocessors: coprocessors.map((coproc) => ({
             id: coproc.globalId,
@@ -305,11 +312,10 @@ class FileManager {
                 `${compactedErrors}`
             );
             return Promise.reject(compactedErrors);
-          } else {
-            return Promise.resolve();
           }
+          return Promise.resolve();
         });
-    }
+    });
   }
 
   /**
@@ -394,6 +400,37 @@ class FileManager {
       logger.info(`Detected removed file from active dir: ${filePath}`);
       this.removeHandleFromFilePath(filePath, repository);
     });
+  }
+
+  /**
+   * Lazily load the ManagementClient
+   * Retires and sleeps 1s between configurable max number of attempts
+   *
+   * @param retries - Max number of connection attempts
+   * @return Promise with management client on success or error on failure
+   */
+  private getClient(): Promise<ManagementClient> {
+    if (!this.managementClient) {
+      return ManagementClient.create(43118)
+        .then((client) => {
+          logger.info("Succeeded in establishing a connection to redpanda");
+          this.managementClient = client;
+          return client;
+        })
+        .catch((err) => {
+          logger.warn(
+            `Failed to connect to redpanda, retrying again, reason: ${err.message}`
+          );
+          return new Promise((resolve, reject) => {
+            setTimeout(() => {
+              this.getClient()
+                .then((response) => resolve(response))
+                .catch((error) => reject(error));
+            }, 1000);
+          });
+        });
+    }
+    return Promise.resolve(this.managementClient);
   }
 }
 

--- a/src/js/test/rpc/server.test.ts
+++ b/src/js/test/rpc/server.test.ts
@@ -79,6 +79,17 @@ const createProcessBatchRequest = (
   };
 };
 
+describe("Client", function () {
+  it("create() should not return a client if fails to connect", () => {
+    return SupervisorClient.create(40000)
+      .then((_c) => false)
+      .catch((_e) => true)
+      .then((value) => {
+        assert(value, "A client should not have been created");
+      });
+  });
+});
+
 describe("Server", function () {
   describe("Given a Request", function () {
     beforeEach(() => {
@@ -87,8 +98,15 @@ describe("Server", function () {
       manageServer.disable_copros = () => Promise.resolve({ inputs: [0] });
       manageServer.listen(43118);
       server = new ProcessBatchServer("a", "i", "s");
-      server.listen(4300);
-      client = new SupervisorClient(4300);
+      server.listen(43000);
+      return new Promise<void>((resolve, reject) => {
+        return SupervisorClient.create(43000)
+          .then((c) => {
+            client = c;
+            resolve();
+          })
+          .catch((e) => reject(e));
+      });
     });
 
     afterEach(async () => {

--- a/src/js/test/supervisors/FileManager.test.ts
+++ b/src/js/test/supervisors/FileManager.test.ts
@@ -12,10 +12,7 @@ import * as assert from "assert";
 import { SinonSandbox, createSandbox } from "sinon";
 import FileManager from "../../modules/supervisors/FileManager";
 import Repository from "../../modules/supervisors/Repository";
-import {
-  Script_ManagerClient as ManagementClient,
-  Script_ManagerServer as ManagementServer,
-} from "../../modules/rpc/serverAndClients/server";
+import { Script_ManagerServer as ManagementServer } from "../../modules/rpc/serverAndClients/server";
 import * as fs from "fs";
 import { createHandle } from "../testUtilities";
 import { hash64 } from "xxhash";
@@ -23,7 +20,6 @@ import * as chokidar from "chokidar";
 
 let sinonInstance: SinonSandbox;
 let server: ManagementServer;
-let client: ManagementClient;
 
 const createStubs = (sandbox: SinonSandbox) => {
   const watchMock = sandbox.stub(chokidar, "watch");
@@ -65,13 +61,11 @@ describe("FileManager", () => {
   beforeEach(() => {
     sinonInstance = createSandbox();
     server = new ManagementServer();
-    server.listen(4300);
-    client = new ManagementClient(4300);
+    server.listen(43118);
   });
 
   afterEach(async () => {
     sinonInstance.restore();
-    client.close();
     await server.closeConnection();
   });
 
@@ -81,7 +75,7 @@ describe("FileManager", () => {
     () => {
       const { readFolderStub } = createStubs(sinonInstance);
       const repo = new Repository();
-      new FileManager(repo, "submit", "active", "inactive", client);
+      new FileManager(repo, "submit", "active", "inactive");
       // wait for promise readFolderCoprocessor resolves
       setTimeout(() => {
         assert(readFolderStub.firstCall.calledWith(repo, "active"));
@@ -93,7 +87,7 @@ describe("FileManager", () => {
   it("should add listen for new file event", (done) => {
     const repo = new Repository();
     const { readFolderStub, watchMock } = createStubs(sinonInstance);
-    new FileManager(repo, "submit", "active", "inactive", client);
+    new FileManager(repo, "submit", "active", "inactive");
     // wait for promise readFolderCoprocessor resolves
     setTimeout(() => {
       assert(readFolderStub.firstCall.calledWith(repo, "active"));
@@ -125,13 +119,7 @@ describe("FileManager", () => {
           ],
         });
 
-      const file = new FileManager(
-        repo,
-        "submit",
-        "active",
-        "inactive",
-        client
-      );
+      const file = new FileManager(repo, "submit", "active", "inactive");
       file.addCoprocessor("active/file", repo);
       setTimeout(() => {
         assert(getCoprocessor.called);
@@ -163,13 +151,7 @@ describe("FileManager", () => {
       getCoprocessor.returns(Promise.resolve(handle));
       getCoprocessor.returns(Promise.resolve(handle2));
 
-      const fileManager = new FileManager(
-        repo,
-        "submit",
-        "active",
-        "inactive",
-        client
-      );
+      const fileManager = new FileManager(repo, "submit", "active", "inactive");
 
       fileManager
         .addCoprocessor(handle.filename, repo)
@@ -202,7 +184,7 @@ describe("FileManager", () => {
     server.disable_copros = () => Promise.resolve({ inputs: [0] });
     // add spy to server
 
-    const file = new FileManager(repo, "submit", "active", "inactive", client);
+    const file = new FileManager(repo, "submit", "active", "inactive");
     file.deregisterCoprocessor(handle.coprocessor).then(() => {
       assert(moveCoprocessor.called);
       assert(moveCoprocessor.calledWith(handle, "inactive"));
@@ -238,13 +220,7 @@ describe("FileManager", () => {
           ],
         });
 
-      const file = new FileManager(
-        repo,
-        "submit",
-        "active",
-        "inactive",
-        client
-      );
+      const file = new FileManager(repo, "submit", "active", "inactive");
       file
         .addCoprocessor("active/file", repo)
         .catch(() => console.log("expected fail"));
@@ -288,7 +264,7 @@ describe("FileManager", () => {
 
     const repo = new Repository();
     const removeSpy = sinonInstance.spy(repo, "remove");
-    const file = new FileManager(repo, "submit", "active", "inactive", client);
+    const file = new FileManager(repo, "submit", "active", "inactive");
 
     repo.add(handle);
 


### PR DESCRIPTION
This patchset changes the startup behavior of the wasm engine, and the behavior of failed RPC requests. During startup it will throw if it cannot attempt to connect to redpanda. Also if an RPC fails retries will not be performed. This patchset introduces retries on connect and on failed requests

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
