### PR TITLE
r/consensus: suppressing heartbeats while in replicate stm

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1995,4 +1995,22 @@ void consensus::maybe_update_majority_replicated_index() {
       _majority_replicated_index, majority_match);
     _consumable_offset_monitor.notify(last_visible_index());
 }
+
+bool consensus::are_heartbeats_suppressed(model::node_id id) const {
+    if (!_fstats.contains(id)) {
+        return true;
+    }
+
+    return _fstats.get(id).suppress_heartbeats;
+}
+
+void consensus::suppress_heartbeats(
+  model::node_id id, follower_req_seq last_seq, bool is_suppressed) {
+    if (auto it = _fstats.find(id); it != _fstats.end()) {
+        if (last_seq <= it->second.last_sent_seq) {
+            it->second.suppress_heartbeats = is_suppressed;
+        }
+    }
+}
+
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -217,6 +217,10 @@ public:
 
     probe& get_probe() { return _probe; };
 
+    bool are_heartbeats_suppressed(model::node_id) const;
+
+    void suppress_heartbeats(model::node_id, follower_req_seq, bool);
+
 private:
     friend replicate_entries_stm;
     friend vote_stm;

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -74,6 +74,10 @@ static std::vector<heartbeat_manager::node_heartbeat> requests_for_range(
                 // we already sent heartbeat, skip it
                 return;
             }
+
+            if (ptr->are_heartbeats_suppressed(n.id())) {
+                return;
+            }
             auto seq_id = ptr->next_follower_sequence(n.id());
             pending_beats[n.id()].emplace_back(ptr->meta(), seq_id);
         };

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -329,7 +329,9 @@ ss::future<> recovery_stm::replicate(
     _ptr->update_node_append_timestamp(_node_id);
 
     auto seq = _ptr->next_follower_sequence(_node_id);
+    _ptr->suppress_heartbeats(_node_id, seq, true);
     return dispatch_append_entries(std::move(r))
+      .finally([this, seq] { _ptr->suppress_heartbeats(_node_id, seq, false); })
       .then([this, seq, dirty_offset = lstats.dirty_offset](auto r) {
           if (!r) {
               vlog(

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -147,6 +147,11 @@ struct follower_index_metadata {
      * - follower is going to be removed
      */
     ss::condition_variable follower_state_change;
+    /**
+     * We prevent race conditions accessing suppress_heartbeats flag using the
+     * `last_sent_seq` value for version control.
+     */
+    bool suppress_heartbeats = false;
 };
 
 struct append_entries_request {


### PR DESCRIPTION
When we are replicating data with acks=-1 we have to skip sending
heartbeats to the followers. The heartbeat might be send before an RPC
containing data already appended to this.

Example:

Initial state:
  -> leader dirty log offset = 10
  -> follower is up to date with the leader

1. leader replicate is called with batch containing 5 records
2. leader appends batch to local log (last log offset = 15)
3. heartbeat is created with last log offset = 15
4. heartbeat is sent to the follower
5. append_entries RPC is sent to the follower

follower receives first request with offset=15 which cause it to return
error in append entries reply what it turn triggers recovery on the
leader node.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
