### PR TITLE
Gcp local ssd cache tuner

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/config_test.go
@@ -64,6 +64,7 @@ func TestSet(t *testing.T) {
 				"overprovisioned":            false,
 				"tune_network":               false,
 				"tune_disk_scheduler":        false,
+				"tune_disk_write_cache":      false,
 				"tune_disk_nomerges":         false,
 				"tune_disk_irq":              true,
 				"tune_cpu":                   false,

--- a/src/go/rpk/pkg/cli/cmd/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/mode_test.go
@@ -29,17 +29,18 @@ func fillRpkConfig(path, mode string) *config.Config {
 	val := mode == config.ModeProd
 	conf.Redpanda.DeveloperMode = !val
 	conf.Rpk = config.RpkConfig{
-		TuneNetwork:       val,
-		TuneDiskScheduler: val,
-		TuneNomerges:      val,
-		TuneDiskIrq:       val,
-		TuneFstrim:        val,
-		TuneCpu:           val,
-		TuneAioEvents:     val,
-		TuneClocksource:   val,
-		TuneSwappiness:    val,
-		CoredumpDir:       path,
-		Overprovisioned:   !val,
+		TuneNetwork:        val,
+		TuneDiskScheduler:  val,
+		TuneDiskWriteCache: val,
+		TuneNomerges:       val,
+		TuneDiskIrq:        val,
+		TuneFstrim:         val,
+		TuneCpu:            val,
+		TuneAioEvents:      val,
+		TuneClocksource:    val,
+		TuneSwappiness:     val,
+		CoredumpDir:        path,
+		Overprovisioned:    !val,
 	}
 	return conf
 }

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -170,6 +170,7 @@ func setProduction(conf *Config) *Config {
 	conf.Rpk.TuneClocksource = true
 	conf.Rpk.TuneSwappiness = true
 	conf.Rpk.Overprovisioned = false
+	conf.Rpk.TuneDiskWriteCache = true
 	return conf
 }
 

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -38,6 +38,7 @@ func getValidConfig() *Config {
 		EnableUsageStats:         true,
 		TuneNetwork:              true,
 		TuneDiskScheduler:        true,
+		TuneDiskWriteCache:       true,
 		TuneNomerges:             true,
 		TuneDiskIrq:              true,
 		TuneFstrim:               true,
@@ -118,6 +119,7 @@ func TestSet(t *testing.T) {
 				"enable_memory_locking":      false,
 				"tune_fstrim":                false,
 				"tune_coredump":              false,
+				"tune_disk_write_cache":      false,
 				"coredump_dir":               "/var/lib/redpanda/coredump",
 			},
 		},
@@ -320,6 +322,7 @@ rpk:
   tune_disk_irq: true
   tune_disk_nomerges: true
   tune_disk_scheduler: true
+  tune_disk_write_cache: true
   tune_fstrim: true
   tune_network: true
   tune_swappiness: true
@@ -376,6 +379,7 @@ rpk:
   tune_disk_irq: true
   tune_disk_nomerges: true
   tune_disk_scheduler: true
+  tune_disk_write_cache: true
   tune_fstrim: true
   tune_network: true
   tune_swappiness: true
@@ -426,6 +430,7 @@ rpk:
   tune_disk_irq: false
   tune_disk_nomerges: false
   tune_disk_scheduler: false
+  tune_disk_write_cache: false
   tune_fstrim: false
   tune_network: false
   tune_swappiness: false
@@ -480,6 +485,7 @@ rpk:
   tune_disk_irq: true
   tune_disk_nomerges: true
   tune_disk_scheduler: true
+  tune_disk_write_cache: true
   tune_fstrim: true
   tune_network: true
   tune_swappiness: true
@@ -557,6 +563,7 @@ rpk:
   tune_disk_irq: true
   tune_disk_nomerges: true
   tune_disk_scheduler: true
+  tune_disk_write_cache: true
   tune_fstrim: true
   tune_network: true
   tune_swappiness: true
@@ -624,6 +631,7 @@ rpk:
   tune_disk_irq: true
   tune_disk_nomerges: true
   tune_disk_scheduler: true
+  tune_disk_write_cache: true
   tune_fstrim: true
   tune_network: true
   tune_swappiness: true
@@ -725,17 +733,18 @@ func TestSetMode(t *testing.T) {
 		val := mode == ModeProd
 		conf.Redpanda.DeveloperMode = !val
 		conf.Rpk = RpkConfig{
-			TuneNetwork:       val,
-			TuneDiskScheduler: val,
-			TuneNomerges:      val,
-			TuneDiskIrq:       val,
-			TuneFstrim:        val,
-			TuneCpu:           val,
-			TuneAioEvents:     val,
-			TuneClocksource:   val,
-			TuneSwappiness:    val,
-			CoredumpDir:       conf.Rpk.CoredumpDir,
-			Overprovisioned:   !val,
+			TuneNetwork:        val,
+			TuneDiskScheduler:  val,
+			TuneNomerges:       val,
+			TuneDiskWriteCache: val,
+			TuneDiskIrq:        val,
+			TuneFstrim:         val,
+			TuneCpu:            val,
+			TuneAioEvents:      val,
+			TuneClocksource:    val,
+			TuneSwappiness:     val,
+			CoredumpDir:        conf.Rpk.CoredumpDir,
+			Overprovisioned:    !val,
 		}
 		return conf
 	}
@@ -936,7 +945,7 @@ func TestReadAsJSON(t *testing.T) {
 				return mgr.Write(conf)
 			},
 			path:     Default().ConfigFile,
-			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","redpanda":{"admin":{"address":"0.0.0.0","port":9644},"data_directory":"/var/lib/redpanda/data","developer_mode":true,"kafka_api":{"address":"0.0.0.0","port":9092},"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
+			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","redpanda":{"admin":{"address":"0.0.0.0","port":9644},"data_directory":"/var/lib/redpanda/data","developer_mode":true,"kafka_api":{"address":"0.0.0.0","port":9092},"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_disk_write_cache":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
 		},
 		{
 			name:           "it should fail if the the config isn't found",
@@ -984,6 +993,7 @@ func TestReadFlat(t *testing.T) {
 		"rpk.tune_disk_irq":              "false",
 		"rpk.tune_disk_nomerges":         "false",
 		"rpk.tune_disk_scheduler":        "false",
+		"rpk.tune_disk_write_cache":      "false",
 		"rpk.tune_fstrim":                "false",
 		"rpk.tune_network":               "false",
 		"rpk.tune_swappiness":            "false",

--- a/src/go/rpk/pkg/config/definition.go
+++ b/src/go/rpk/pkg/config/definition.go
@@ -64,6 +64,7 @@ type RpkConfig struct {
 	TuneNetwork              bool     `yaml:"tune_network" mapstructure:"tune_network" json:"tuneNetwork"`
 	TuneDiskScheduler        bool     `yaml:"tune_disk_scheduler" mapstructure:"tune_disk_scheduler" json:"tuneDiskScheduler"`
 	TuneNomerges             bool     `yaml:"tune_disk_nomerges" mapstructure:"tune_disk_nomerges" json:"tuneNomerges"`
+	TuneDiskWriteCache       bool     `yaml:"tune_disk_write_cache" mapstructure:"tune_disk_write_cache" json:"tuneDiskWriteCache"`
 	TuneDiskIrq              bool     `yaml:"tune_disk_irq" mapstructure:"tune_disk_irq" json:"tuneDiskIrq"`
 	TuneFstrim               bool     `yaml:"tune_fstrim" mapstructure:"tune_fstrim" json:"tuneFstrim"`
 	TuneCpu                  bool     `yaml:"tune_cpu" mapstructure:"tune_cpu" json:"tuneCpu"`

--- a/src/go/rpk/pkg/tuners/disk/device_features_test.go
+++ b/src/go/rpk/pkg/tuners/disk/device_features_test.go
@@ -50,7 +50,7 @@ func (m *blockDevicesMock) GetDiskInfoByType(
 
 var noopSchedulerEnabled = "deadline cfq [noop]"
 
-func TestSchedulerInfo_GetScheduler(t *testing.T) {
+func TestDeviceFeatures_GetScheduler(t *testing.T) {
 	// given
 	blockDevices := &blockDevicesMock{
 		getBlockDeviceFromPath: func(path string) (BlockDevice, error) {
@@ -65,15 +65,15 @@ func TestSchedulerInfo_GetScheduler(t *testing.T) {
 	afero.WriteFile(fs,
 		"/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue/scheduler",
 		[]byte(noopSchedulerEnabled), 0644)
-	schedulerInfo := NewSchedulerInfo(fs, blockDevices)
+	deviceFeatures := NewDeviceFeatures(fs, blockDevices)
 	// when
-	scheduler, err := schedulerInfo.GetScheduler("fake")
+	scheduler, err := deviceFeatures.GetScheduler("fake")
 	// then
 	require.NoError(t, err)
 	require.Equal(t, "noop", scheduler)
 }
 
-func TestSchedulerInfo_GetSupportedScheduler(t *testing.T) {
+func TestDeviceFeatures_GetSupportedScheduler(t *testing.T) {
 	// given
 	blockDevices := &blockDevicesMock{
 		getBlockDeviceFromPath: func(path string) (BlockDevice, error) {
@@ -88,9 +88,9 @@ func TestSchedulerInfo_GetSupportedScheduler(t *testing.T) {
 	afero.WriteFile(fs,
 		"/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue/scheduler",
 		[]byte(noopSchedulerEnabled), 0644)
-	schedulerInfo := NewSchedulerInfo(fs, blockDevices)
+	deviceFeatures := NewDeviceFeatures(fs, blockDevices)
 	// when
-	schedulers, err := schedulerInfo.GetSupportedSchedulers("fake")
+	schedulers, err := deviceFeatures.GetSupportedSchedulers("fake")
 	// then
 	require.NoError(t, err)
 	require.Contains(t, schedulers, "noop")
@@ -99,7 +99,7 @@ func TestSchedulerInfo_GetSupportedScheduler(t *testing.T) {
 	require.Len(t, schedulers, 3)
 }
 
-func TestSchedulerInfo_GetNoMerges(t *testing.T) {
+func TestDeviceFeatures_GetNoMerges(t *testing.T) {
 	// given
 	blockDevices := &blockDevicesMock{
 		getBlockDeviceFromPath: func(path string) (BlockDevice, error) {
@@ -114,9 +114,9 @@ func TestSchedulerInfo_GetNoMerges(t *testing.T) {
 	afero.WriteFile(fs,
 		"/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue/nomerges",
 		[]byte("2"), 0644)
-	schedulerInfo := NewSchedulerInfo(fs, blockDevices)
+	deviceFeatures := NewDeviceFeatures(fs, blockDevices)
 	// when
-	nomerges, err := schedulerInfo.GetNomerges("fake")
+	nomerges, err := deviceFeatures.GetNomerges("fake")
 	// then
 	require.NoError(t, err)
 	require.Equal(t, nomerges, 2)

--- a/src/go/rpk/pkg/tuners/disk_checkers.go
+++ b/src/go/rpk/pkg/tuners/disk_checkers.go
@@ -35,7 +35,7 @@ func CreateDirectoryCheckers(
 }
 
 func NewDeviceNomergesChecker(
-	fs afero.Fs, device string, schedulerInfo disk.SchedulerInfo,
+	fs afero.Fs, device string, deviceFeatures disk.DeviceFeatures,
 ) Checker {
 	return NewEqualityChecker(
 		NomergesChecker,
@@ -43,7 +43,7 @@ func NewDeviceNomergesChecker(
 		Warning,
 		true,
 		func() (interface{}, error) {
-			return checkDeviceNomerges(schedulerInfo, device)
+			return checkDeviceNomerges(deviceFeatures, device)
 		},
 	)
 }
@@ -51,7 +51,7 @@ func NewDeviceNomergesChecker(
 func NewDirectoryNomergesChecker(
 	fs afero.Fs,
 	dir string,
-	schedulerInfo disk.SchedulerInfo,
+	deviceFeatures disk.DeviceFeatures,
 	blockDevices disk.BlockDevices,
 ) Checker {
 	return NewEqualityChecker(
@@ -66,7 +66,7 @@ func NewDirectoryNomergesChecker(
 			}
 			tuned := true
 			for _, device := range devices {
-				ok, err := checkDeviceNomerges(schedulerInfo, device)
+				ok, err := checkDeviceNomerges(deviceFeatures, device)
 				if err != nil {
 					return false, err
 				}
@@ -78,9 +78,9 @@ func NewDirectoryNomergesChecker(
 }
 
 func checkDeviceNomerges(
-	schedulerInfo disk.SchedulerInfo, device string,
+	deviceFeatures disk.DeviceFeatures, device string,
 ) (bool, error) {
-	nomerges, err := schedulerInfo.GetNomerges(device)
+	nomerges, err := deviceFeatures.GetNomerges(device)
 	if err != nil {
 		return false, err
 	}
@@ -88,7 +88,7 @@ func checkDeviceNomerges(
 }
 
 func NewDeviceSchedulerChecker(
-	fs afero.Fs, device string, schedulerInfo disk.SchedulerInfo,
+	fs afero.Fs, device string, deviceFeatures disk.DeviceFeatures,
 ) Checker {
 	return NewEqualityChecker(
 		SchedulerChecker,
@@ -96,7 +96,7 @@ func NewDeviceSchedulerChecker(
 		Warning,
 		true,
 		func() (interface{}, error) {
-			return checkScheduler(schedulerInfo, device)
+			return checkScheduler(deviceFeatures, device)
 		},
 	)
 }
@@ -104,7 +104,7 @@ func NewDeviceSchedulerChecker(
 func NewDirectorySchedulerChecker(
 	fs afero.Fs,
 	dir string,
-	schedulerInfo disk.SchedulerInfo,
+	deviceFeatures disk.DeviceFeatures,
 	blockDevices disk.BlockDevices,
 ) Checker {
 	return NewEqualityChecker(
@@ -119,7 +119,7 @@ func NewDirectorySchedulerChecker(
 			}
 			tuned := true
 			for _, device := range devices {
-				ok, err := checkScheduler(schedulerInfo, device)
+				ok, err := checkScheduler(deviceFeatures, device)
 				if err != nil {
 					return false, err
 				}
@@ -131,9 +131,9 @@ func NewDirectorySchedulerChecker(
 }
 
 func checkScheduler(
-	schedulerInfo disk.SchedulerInfo, device string,
+	deviceFeatures disk.DeviceFeatures, device string,
 ) (bool, error) {
-	scheduler, err := schedulerInfo.GetScheduler(device)
+	scheduler, err := deviceFeatures.GetScheduler(device)
 	if err != nil {
 		return false, err
 	}

--- a/src/go/rpk/pkg/tuners/disk_nomerges_tuner.go
+++ b/src/go/rpk/pkg/tuners/disk_nomerges_tuner.go
@@ -20,13 +20,13 @@ import (
 func NewDeviceNomergesTuner(
 	fs afero.Fs,
 	device string,
-	schedulerInfo disk.SchedulerInfo,
+	deviceFeatures disk.DeviceFeatures,
 	executor executors.Executor,
 ) Tunable {
 	return NewCheckedTunable(
-		NewDeviceNomergesChecker(fs, device, schedulerInfo),
+		NewDeviceNomergesChecker(fs, device, deviceFeatures),
 		func() TuneResult {
-			return tuneNomerges(fs, device, schedulerInfo, executor)
+			return tuneNomerges(fs, device, deviceFeatures, executor)
 		},
 		func() (bool, string) {
 			return true, ""
@@ -38,10 +38,10 @@ func NewDeviceNomergesTuner(
 func tuneNomerges(
 	fs afero.Fs,
 	device string,
-	schedulerInfo disk.SchedulerInfo,
+	deviceFeatures disk.DeviceFeatures,
 	executor executors.Executor,
 ) TuneResult {
-	featureFile, err := schedulerInfo.GetNomergesFeatureFile(device)
+	featureFile, err := deviceFeatures.GetNomergesFeatureFile(device)
 	if err != nil {
 		return NewTuneError(err)
 	}
@@ -60,14 +60,14 @@ func NewNomergesTuner(
 	blockDevices disk.BlockDevices,
 	executor executors.Executor,
 ) Tunable {
-	schedulerInfo := disk.NewSchedulerInfo(fs, blockDevices)
+	deviceFeatures := disk.NewDeviceFeatures(fs, blockDevices)
 	return NewDiskTuner(
 		fs,
 		directories,
 		devices,
 		blockDevices,
 		func(device string) Tunable {
-			return NewDeviceNomergesTuner(fs, device, schedulerInfo, executor)
+			return NewDeviceNomergesTuner(fs, device, deviceFeatures, executor)
 		},
 	)
 }

--- a/src/go/rpk/pkg/tuners/disk_nomerges_tuner_test.go
+++ b/src/go/rpk/pkg/tuners/disk_nomerges_tuner_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestDeviceNomergesTuner_Tune(t *testing.T) {
 	// given
-	schedulerInfo := &schedulerInfoMock{
+	deviceFeatures := &deviceFeaturesMock{
 		getNomergesFeatureFile: func(string) (string, error) {
 			return "/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue/nomerges", nil
 		},
@@ -29,7 +29,7 @@ func TestDeviceNomergesTuner_Tune(t *testing.T) {
 	}
 	fs := afero.NewMemMapFs()
 	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
-	tuner := NewDeviceNomergesTuner(fs, "fake", schedulerInfo, executors.NewDirectExecutor())
+	tuner := NewDeviceNomergesTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	tuner.Tune()
 	// then

--- a/src/go/rpk/pkg/tuners/disk_scheduler_tuner.go
+++ b/src/go/rpk/pkg/tuners/disk_scheduler_tuner.go
@@ -21,16 +21,16 @@ import (
 func NewDeviceSchedulerTuner(
 	fs afero.Fs,
 	device string,
-	schedulerInfo disk.SchedulerInfo,
+	deviceFeatures disk.DeviceFeatures,
 	executor executors.Executor,
 ) Tunable {
 	return NewCheckedTunable(
-		NewDeviceSchedulerChecker(fs, device, schedulerInfo),
+		NewDeviceSchedulerChecker(fs, device, deviceFeatures),
 		func() TuneResult {
-			return tuneScheduler(fs, device, schedulerInfo, executor)
+			return tuneScheduler(fs, device, deviceFeatures, executor)
 		},
 		func() (bool, string) {
-			_, err := getPreferredScheduler(device, schedulerInfo)
+			_, err := getPreferredScheduler(device, deviceFeatures)
 			if err != nil {
 				return false, err.Error()
 			}
@@ -43,14 +43,14 @@ func NewDeviceSchedulerTuner(
 func tuneScheduler(
 	fs afero.Fs,
 	device string,
-	schedulerInfo disk.SchedulerInfo,
+	deviceFeatures disk.DeviceFeatures,
 	executor executors.Executor,
 ) TuneResult {
-	preferredScheduler, err := getPreferredScheduler(device, schedulerInfo)
+	preferredScheduler, err := getPreferredScheduler(device, deviceFeatures)
 	if err != nil {
 		return NewTuneError(err)
 	}
-	featureFile, err := schedulerInfo.GetSchedulerFeatureFile(device)
+	featureFile, err := deviceFeatures.GetSchedulerFeatureFile(device)
 	if err != nil {
 		return NewTuneError(err)
 	}
@@ -64,9 +64,9 @@ func tuneScheduler(
 }
 
 func getPreferredScheduler(
-	device string, schedulerInfo disk.SchedulerInfo,
+	device string, deviceFeatures disk.DeviceFeatures,
 ) (string, error) {
-	supported, err := schedulerInfo.GetSupportedSchedulers(device)
+	supported, err := deviceFeatures.GetSupportedSchedulers(device)
 	if err != nil {
 		return "", err
 	}
@@ -93,14 +93,14 @@ func NewSchedulerTuner(
 	blockDevices disk.BlockDevices,
 	executor executors.Executor,
 ) Tunable {
-	schedulerInfo := disk.NewSchedulerInfo(fs, blockDevices)
+	deviceFeatures := disk.NewDeviceFeatures(fs, blockDevices)
 	return NewDiskTuner(
 		fs,
 		directories,
 		devices,
 		blockDevices,
 		func(device string) Tunable {
-			return NewDeviceSchedulerTuner(fs, device, schedulerInfo, executor)
+			return NewDeviceSchedulerTuner(fs, device, deviceFeatures, executor)
 		},
 	)
 }

--- a/src/go/rpk/pkg/tuners/disk_scheduler_tuner_test.go
+++ b/src/go/rpk/pkg/tuners/disk_scheduler_tuner_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type schedulerInfoMock struct {
-	disk.SchedulerInfo
+type deviceFeaturesMock struct {
+	disk.DeviceFeatures
 	getSupportedSchedulers  func(string) ([]string, error)
 	getNomerges             func(string) (int, error)
 	getNomergesFeatureFile  func(string) (string, error)
@@ -27,27 +27,27 @@ type schedulerInfoMock struct {
 	getScheduler            func(string) (string, error)
 }
 
-func (m *schedulerInfoMock) GetScheduler(device string) (string, error) {
+func (m *deviceFeaturesMock) GetScheduler(device string) (string, error) {
 	return m.getScheduler(device)
 }
 
-func (m *schedulerInfoMock) GetSupportedSchedulers(
+func (m *deviceFeaturesMock) GetSupportedSchedulers(
 	device string,
 ) ([]string, error) {
 	return m.getSupportedSchedulers(device)
 }
 
-func (m *schedulerInfoMock) GetNomerges(device string) (int, error) {
+func (m *deviceFeaturesMock) GetNomerges(device string) (int, error) {
 	return m.getNomerges(device)
 }
 
-func (m *schedulerInfoMock) GetNomergesFeatureFile(
+func (m *deviceFeaturesMock) GetNomergesFeatureFile(
 	device string,
 ) (string, error) {
 	return m.getNomergesFeatureFile(device)
 }
 
-func (m *schedulerInfoMock) GetSchedulerFeatureFile(
+func (m *deviceFeaturesMock) GetSchedulerFeatureFile(
 	device string,
 ) (string, error) {
 	return m.getSchedulerFeatureFile(device)
@@ -55,7 +55,7 @@ func (m *schedulerInfoMock) GetSchedulerFeatureFile(
 
 func TestDeviceSchedulerTuner_Tune(t *testing.T) {
 	// given
-	schedulerInfo := &schedulerInfoMock{
+	deviceFeatures := &deviceFeaturesMock{
 		getSchedulerFeatureFile: func(string) (string, error) {
 			return "/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue/scheduler", nil
 		},
@@ -68,7 +68,7 @@ func TestDeviceSchedulerTuner_Tune(t *testing.T) {
 	}
 	fs := afero.NewMemMapFs()
 	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
-	tuner := NewDeviceSchedulerTuner(fs, "fake", schedulerInfo, executors.NewDirectExecutor())
+	tuner := NewDeviceSchedulerTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	tuner.Tune()
 	// then
@@ -78,7 +78,7 @@ func TestDeviceSchedulerTuner_Tune(t *testing.T) {
 
 func TestDeviceSchedulerTuner_IsSupported_Should_return_true(t *testing.T) {
 	// given
-	schedulerInfo := &schedulerInfoMock{
+	deviceFeatures := &deviceFeaturesMock{
 		getSchedulerFeatureFile: func(string) (string, error) {
 			return "/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue/scheduler", nil
 		},
@@ -91,7 +91,7 @@ func TestDeviceSchedulerTuner_IsSupported_Should_return_true(t *testing.T) {
 	}
 	fs := afero.NewMemMapFs()
 	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
-	tuner := NewDeviceSchedulerTuner(fs, "fake", schedulerInfo, executors.NewDirectExecutor())
+	tuner := NewDeviceSchedulerTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	supported, _ := tuner.CheckIfSupported()
 	// then
@@ -100,7 +100,7 @@ func TestDeviceSchedulerTuner_IsSupported_Should_return_true(t *testing.T) {
 
 func TestDeviceSchedulerTuner_IsSupported_should_return_false(t *testing.T) {
 	// given
-	schedulerInfo := &schedulerInfoMock{
+	deviceFeatures := &deviceFeaturesMock{
 		getSchedulerFeatureFile: func(string) (string, error) {
 			return "/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue/scheduler", nil
 		},
@@ -113,7 +113,7 @@ func TestDeviceSchedulerTuner_IsSupported_should_return_false(t *testing.T) {
 	}
 	fs := afero.NewMemMapFs()
 	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
-	tuner := NewDeviceSchedulerTuner(fs, "fake", schedulerInfo, executors.NewDirectExecutor())
+	tuner := NewDeviceSchedulerTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	supported, _ := tuner.CheckIfSupported()
 	// then
@@ -122,7 +122,7 @@ func TestDeviceSchedulerTuner_IsSupported_should_return_false(t *testing.T) {
 
 func TestDeviceSchedulerTuner_Tune_should_prefer_none_over_noop(t *testing.T) {
 	// given
-	schedulerInfo := &schedulerInfoMock{
+	deviceFeatures := &deviceFeaturesMock{
 		getSchedulerFeatureFile: func(string) (string, error) {
 			return "/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue/scheduler", nil
 		},
@@ -135,7 +135,7 @@ func TestDeviceSchedulerTuner_Tune_should_prefer_none_over_noop(t *testing.T) {
 	}
 	fs := afero.NewMemMapFs()
 	fs.MkdirAll("/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake/queue", 0644)
-	tuner := NewDeviceSchedulerTuner(fs, "fake", schedulerInfo, executors.NewDirectExecutor())
+	tuner := NewDeviceSchedulerTuner(fs, "fake", deviceFeatures, executors.NewDirectExecutor())
 	// when
 	tuner.Tune()
 	// then

--- a/src/go/rpk/pkg/tuners/disk_scheduler_tuner_test.go
+++ b/src/go/rpk/pkg/tuners/disk_scheduler_tuner_test.go
@@ -20,11 +20,13 @@ import (
 
 type deviceFeaturesMock struct {
 	disk.DeviceFeatures
-	getSupportedSchedulers  func(string) ([]string, error)
-	getNomerges             func(string) (int, error)
-	getNomergesFeatureFile  func(string) (string, error)
-	getSchedulerFeatureFile func(string) (string, error)
-	getScheduler            func(string) (string, error)
+	getSupportedSchedulers   func(string) ([]string, error)
+	getNomerges              func(string) (int, error)
+	getNomergesFeatureFile   func(string) (string, error)
+	getSchedulerFeatureFile  func(string) (string, error)
+	getScheduler             func(string) (string, error)
+	getWriteCacheFeatureFile func(string) (string, error)
+	getWriteCache            func(string) (string, error)
 }
 
 func (m *deviceFeaturesMock) GetScheduler(device string) (string, error) {
@@ -51,6 +53,16 @@ func (m *deviceFeaturesMock) GetSchedulerFeatureFile(
 	device string,
 ) (string, error) {
 	return m.getSchedulerFeatureFile(device)
+}
+
+func (m *deviceFeaturesMock) GetWriteCacheFeatureFile(
+	device string,
+) (string, error) {
+	return m.getWriteCacheFeatureFile(device)
+}
+
+func (m *deviceFeaturesMock) GetWriteCache(device string) (string, error) {
+	return m.getWriteCache(device)
 }
 
 func TestDeviceSchedulerTuner_Tune(t *testing.T) {

--- a/src/go/rpk/pkg/tuners/factory/factory.go
+++ b/src/go/rpk/pkg/tuners/factory/factory.go
@@ -12,6 +12,7 @@ package factory
 import (
 	"runtime"
 	"time"
+	"vectorized/pkg/cloud/gcp"
 	"vectorized/pkg/config"
 	"vectorized/pkg/net"
 	"vectorized/pkg/os"
@@ -34,6 +35,7 @@ var (
 		"disk_irq":              (*tunersFactory).newDiskIRQTuner,
 		"disk_scheduler":        (*tunersFactory).newDiskSchedulerTuner,
 		"disk_nomerges":         (*tunersFactory).newDiskNomergesTuner,
+		"disk_write_cache":      (*tunersFactory).newGcpWriteCacheTuner,
 		"fstrim":                (*tunersFactory).newFstrimTuner,
 		"net":                   (*tunersFactory).newNetworkTuner,
 		"cpu":                   (*tunersFactory).newCpuTuner,
@@ -134,6 +136,8 @@ func IsTunerEnabled(tuner string, rpkConfig config.RpkConfig) bool {
 		return rpkConfig.TuneDiskScheduler
 	case "disk_nomerges":
 		return rpkConfig.TuneNomerges
+	case "disk_write_cache":
+		return rpkConfig.TuneDiskWriteCache
 	case "fstrim":
 		return rpkConfig.TuneFstrim
 	case "net":
@@ -200,6 +204,19 @@ func (factory *tunersFactory) newDiskNomergesTuner(
 		params.Directories,
 		params.Disks,
 		factory.blockDevices,
+		factory.executor,
+	)
+}
+
+func (factory *tunersFactory) newGcpWriteCacheTuner(
+	params *TunerParams,
+) tuners.Tunable {
+	return tuners.NewGcpWriteCacheTuner(
+		factory.fs,
+		params.Directories,
+		params.Disks,
+		factory.blockDevices,
+		&gcp.GcpVendor{},
 		factory.executor,
 	)
 }

--- a/src/go/rpk/pkg/tuners/gcp_disk_write_cache_tuner.go
+++ b/src/go/rpk/pkg/tuners/gcp_disk_write_cache_tuner.go
@@ -1,0 +1,86 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package tuners
+
+import (
+	"vectorized/pkg/cloud/gcp"
+	"vectorized/pkg/cloud/vendor"
+	"vectorized/pkg/tuners/disk"
+	"vectorized/pkg/tuners/executors"
+	"vectorized/pkg/tuners/executors/commands"
+
+	"github.com/spf13/afero"
+)
+
+func NewGcpWriteCacheTuner(
+	fs afero.Fs,
+	directories []string,
+	devices []string,
+	blockDevices disk.BlockDevices,
+	vendor vendor.Vendor,
+	executor executors.Executor,
+) Tunable {
+	deviceFeatures := disk.NewDeviceFeatures(fs, blockDevices)
+	return NewDiskTuner(
+		fs,
+		directories,
+		devices,
+		blockDevices,
+		func(device string) Tunable {
+			return NewDeviceGcpWriteCacheTuner(fs, device, deviceFeatures,
+				vendor, executor)
+		},
+	)
+}
+
+func NewDeviceGcpWriteCacheTuner(
+	fs afero.Fs,
+	device string,
+	deviceFeatures disk.DeviceFeatures,
+	vendor vendor.Vendor,
+	executor executors.Executor,
+) Tunable {
+	return NewCheckedTunable(
+		NewDeviceWriteCacheChecker(fs, device, deviceFeatures),
+		func() TuneResult {
+			return tuneWriteCache(fs, device, deviceFeatures, executor)
+		},
+		func() (bool, string) {
+			v, err := vendor.Init()
+			if err != nil {
+				return false, "Disk write cache tuner is only supported in GCP"
+			}
+			gcpVendor := gcp.GcpVendor{}
+			return v.Name() == gcpVendor.Name(), ""
+		},
+		executor.IsLazy(),
+	)
+}
+
+func tuneWriteCache(
+	fs afero.Fs,
+	device string,
+	deviceFeatures disk.DeviceFeatures,
+	executor executors.Executor,
+) TuneResult {
+
+	featureFile, err := deviceFeatures.GetWriteCacheFeatureFile(device)
+	if err != nil {
+		return NewTuneError(err)
+	}
+	err = executor.Execute(
+		commands.NewWriteFileCmd(fs, featureFile, disk.CachePolicyWriteThrough))
+
+	if err != nil {
+		return NewTuneError(err)
+	}
+
+	return NewTuneResult(false)
+}

--- a/src/go/rpk/pkg/tuners/gcp_disk_write_cache_tuner_test.go
+++ b/src/go/rpk/pkg/tuners/gcp_disk_write_cache_tuner_test.go
@@ -1,0 +1,131 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package tuners
+
+import (
+	"fmt"
+	"testing"
+	"vectorized/pkg/cloud/vendor"
+	"vectorized/pkg/tuners/executors"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+type vendorMock struct {
+	init func() (vendor.InitializedVendor, error)
+}
+
+type currentVendor struct {
+	name string
+}
+
+func (v *vendorMock) Init() (vendor.InitializedVendor, error) {
+	return v.init()
+}
+
+func (v *vendorMock) Name() string {
+	return "none"
+}
+
+func (v *currentVendor) Name() string {
+	return v.name
+}
+
+func (v *currentVendor) VmType() (string, error) {
+	return "", nil
+}
+
+const devicePath = "/sys/devices/pci0000:00/0000:00:1d.0/0000:71:00.0/nvme/fake"
+
+func TestDeviceWriteCacheTuner_Tune(t *testing.T) {
+	// given
+	v := &vendorMock{
+		init: func() (vendor.InitializedVendor, error) {
+			return &currentVendor{
+				name: "gcp",
+			}, nil
+		},
+	}
+	deviceFeatures := &deviceFeaturesMock{
+		getWriteCacheFeatureFile: func(string) (string, error) {
+			return devicePath + "/queue/write_cache", nil
+		},
+		getWriteCache: func(string) (string, error) {
+			return "write back", nil
+		},
+	}
+	fs := afero.NewMemMapFs()
+	fs.MkdirAll(devicePath+"/queue", 0644)
+	tuner := NewDeviceGcpWriteCacheTuner(fs, "fake", deviceFeatures, v, executors.NewDirectExecutor())
+	// when
+	tuner.Tune()
+	// then
+	setValue, _ := afero.ReadFile(fs, devicePath+"/queue/write_cache")
+	require.Equal(t, "write through", string(setValue))
+}
+
+func TestGCPCacheTunerSupported(t *testing.T) {
+	type args struct {
+		vendor vendor.Vendor
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should be supported on GCP",
+			args: args{
+				vendor: &vendorMock{
+					init: func() (vendor.InitializedVendor, error) {
+						return &currentVendor{
+							name: "gcp",
+						}, nil
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "should not be supported on AWS",
+			args: args{
+				vendor: &vendorMock{
+					init: func() (vendor.InitializedVendor, error) {
+						return &currentVendor{
+							name: "aws",
+						}, nil
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should not be supported on not cloud deployments",
+			args: args{
+				vendor: &vendorMock{
+					init: func() (vendor.InitializedVendor, error) {
+						return nil, fmt.Errorf("no vendor")
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tuner := NewDeviceGcpWriteCacheTuner(afero.NewMemMapFs(), "fake",
+				&deviceFeaturesMock{}, tt.args.vendor,
+				executors.NewDirectExecutor())
+			supported, _ := tuner.CheckIfSupported()
+			require.Equal(t, tt.want, supported)
+		})
+	}
+}

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -181,17 +181,17 @@ func RedpandaCheckers(
 	irqProcFile := irq.NewProcFile(fs)
 	irqDeviceInfo := irq.NewDeviceInfo(fs, irqProcFile)
 	blockDevices := disk.NewBlockDevices(fs, irqDeviceInfo, irqProcFile, proc, timeout)
-	schedulerInfo := disk.NewSchedulerInfo(fs, blockDevices)
+	deviceFeatures := disk.NewDeviceFeatures(fs, blockDevices)
 	schedulerChecker := NewDirectorySchedulerChecker(
 		fs,
 		config.Redpanda.Directory,
-		schedulerInfo,
+		deviceFeatures,
 		blockDevices,
 	)
 	nomergesChecker := NewDirectoryNomergesChecker(
 		fs,
 		config.Redpanda.Directory,
-		schedulerInfo,
+		deviceFeatures,
 		blockDevices,
 	)
 	balanceService := irq.NewBalanceService(fs, proc, executor, timeout)


### PR DESCRIPTION
Implemented `write_cache` feature tuner for local SSDs in GCP.

Fixes #254 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
