### PR TITLE
rpk start: add tests

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/root_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/root_linux.go
@@ -11,6 +11,7 @@ package cmd
 
 import (
 	"vectorized/pkg/config"
+	"vectorized/pkg/redpanda"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -22,6 +23,6 @@ func addPlatformDependentCmds(
 	cmd.AddCommand(NewTuneCommand(fs, mgr))
 	cmd.AddCommand(NewCheckCommand(fs, mgr))
 	cmd.AddCommand(NewIoTuneCmd(fs, mgr))
-	cmd.AddCommand(NewStartCommand(fs, mgr))
+	cmd.AddCommand(NewStartCommand(fs, mgr, redpanda.NewLauncher()))
 	cmd.AddCommand(NewStopCommand(fs, mgr))
 }

--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -209,10 +209,10 @@ func NewStartCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 
 			sendEnv(mgr, env, conf, nil)
 			rpArgs.ExtraArgs = args
-			launcher := redpanda.NewLauncher(installDirectory, rpArgs)
+			launcher := redpanda.NewLauncher()
 			log.Info(feedbackMsg)
 			log.Info("Starting redpanda...")
-			return launcher.Start()
+			return launcher.Start(installDirectory, rpArgs)
 		},
 	}
 	command.Flags().StringVar(

--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -76,7 +76,9 @@ const (
 	seedFormat = "<host>[:<port>]+<id>"
 )
 
-func NewStartCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
+func NewStartCommand(
+	fs afero.Fs, mgr config.Manager, launcher redpanda.Launcher,
+) *cobra.Command {
 	prestartCfg := prestartConfig{}
 	var (
 		configFile      string
@@ -209,7 +211,6 @@ func NewStartCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 
 			sendEnv(mgr, env, conf, nil)
 			rpArgs.ExtraArgs = args
-			launcher := redpanda.NewLauncher()
 			log.Info(feedbackMsg)
 			log.Info("Starting redpanda...")
 			return launcher.Start(installDirectory, rpArgs)

--- a/src/go/rpk/pkg/cli/cmd/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/start_test.go
@@ -10,11 +10,22 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
 	"testing"
 	"vectorized/pkg/config"
+	"vectorized/pkg/redpanda"
 
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
+
+type noopLauncher struct{}
+
+func (*noopLauncher) Start(_ string, _ *redpanda.RedpandaArgs) error {
+	return nil
+}
 
 func TestMergeFlags(t *testing.T) {
 	tests := []struct {
@@ -145,6 +156,581 @@ func TestParseSeeds(t *testing.T) {
 				return
 			}
 			require.Exactly(st, tt.expected, addrs)
+		})
+	}
+}
+
+func TestStartCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		launcher       redpanda.Launcher
+		args           []string
+		before         func(afero.Fs) error
+		after          func()
+		postCheck      func(afero.Fs, *testing.T)
+		expectedErrMsg string
+	}{{
+		name: "should fail if the config at the given path is corrupt",
+		args: []string{"--config", config.Default().ConfigFile},
+		before: func(fs afero.Fs) error {
+			return afero.WriteFile(
+				fs,
+				config.Default().ConfigFile,
+				[]byte("^&notyaml"),
+				0755,
+			)
+		},
+		expectedErrMsg: "An error happened while trying to read /etc/redpanda/redpanda.yaml: While parsing config: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `^&notyaml` into map[string]interface {}",
+	}, {
+		name: "should generate the config at the given path if it doesn't exist",
+		args: []string{
+			"--config", config.Default().ConfigFile,
+			"--install-dir", "/var/lib/redpanda",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			path := config.Default().ConfigFile
+			exists, err := afero.Exists(
+				fs,
+				path,
+			)
+			require.NoError(st, err)
+			require.True(
+				st,
+				exists,
+				"The config should have been created at '%s'",
+				path,
+			)
+			defaultConf := config.Default()
+			// The default value for --overprovisioned is true in
+			// rpk start
+			defaultConf.Rpk.Overprovisioned = true
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(path)
+			require.NoError(st, err)
+			// Check that the generated config is as expected.
+			require.Exactly(st, defaultConf, conf)
+		},
+	}, {
+		name: "it should parse the --seeds and persist them",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--seeds", "192.168.34.32:33145+1,somehost:54321+3",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedSeeds := []config.SeedServer{{
+				Host: config.SocketAddress{
+					Address: "192.168.34.32",
+					Port:    33145,
+				},
+				Id: 1,
+			}, {
+				Host: config.SocketAddress{
+					Address: "somehost",
+					Port:    54321,
+				},
+				Id: 3,
+			}}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedSeeds,
+				conf.Redpanda.SeedServers,
+			)
+		},
+	}, {
+		name: "it should parse the --seeds and persist them (shorthand)",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"-s", "192.168.3.32:33145+1",
+			"-s", "192.168.123.32:33146+5,host+34",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedSeeds := []config.SeedServer{{
+				Host: config.SocketAddress{
+					Address: "192.168.3.32",
+					Port:    33145,
+				},
+				Id: 1,
+			}, {
+				Host: config.SocketAddress{
+					Address: "192.168.123.32",
+					Port:    33146,
+				},
+				Id: 5,
+			}, {
+				Host: config.SocketAddress{
+					Address: "host",
+					Port:    33145,
+				},
+				Id: 34,
+			}}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedSeeds,
+				conf.Redpanda.SeedServers,
+			)
+		},
+	}, {
+		name: "if --seeds wasn't passed, it should fall back to REDPANDA_SEEDS and persist it",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(_ afero.Fs) error {
+			os.Setenv("REDPANDA_SEEDS", "10.23.12.5:33146+5,host+34")
+			return nil
+		},
+		after: func() {
+			os.Unsetenv("REDPANDA_SEEDS")
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedSeeds := []config.SeedServer{{
+				Host: config.SocketAddress{
+					Address: "10.23.12.5",
+					Port:    33146,
+				},
+				Id: 5,
+			}, {
+				Host: config.SocketAddress{
+					Address: "host",
+					Port:    33145,
+				},
+				Id: 34,
+			}}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedSeeds,
+				conf.Redpanda.SeedServers,
+			)
+		},
+	}, {
+		name: "it should leave existing seeds untouched if --seeds or REDPANDA_SEEDS aren't set",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(fs afero.Fs) error {
+			mgr := config.NewManager(fs)
+			conf := config.Default()
+			conf.Redpanda.SeedServers = []config.SeedServer{{
+				Host: config.SocketAddress{
+					Address: "10.23.12.5",
+					Port:    33146,
+				},
+				Id: 5,
+			}}
+			return mgr.Write(conf)
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedSeeds := []config.SeedServer{{
+				Host: config.SocketAddress{
+					Address: "10.23.12.5",
+					Port:    33146,
+				},
+				Id: 5,
+			}}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedSeeds,
+				conf.Redpanda.SeedServers,
+			)
+		},
+	}, {
+		name: "it should fail if the host is missing in the given seed",
+		args: []string{
+			"-s", "goodhost.com:54897+2,:33145+1",
+		},
+		expectedErrMsg: "Couldn't parse seed ':33145+1': Empty host in address ':33145'",
+	}, {
+		name: "it should fail if the ID is missing in the given seed",
+		args: []string{
+			"-s", "host:33145",
+		},
+		expectedErrMsg: "Couldn't parse seed 'host:33145': Format doesn't conform to <host>[:<port>]+<id>. Missing ID.",
+	}, {
+		name: "it should fail if the port isn't an int",
+		args: []string{
+			"-s", "host:port+2",
+		},
+		expectedErrMsg: "Couldn't parse seed 'host:port+2': Port must be an int",
+	}, {
+		name: "it should parse the --rpc-addr and persist it",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--rpc-addr", "192.168.34.32:33145",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := config.SocketAddress{
+				Address: "192.168.34.32",
+				Port:    33145,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.RPCServer,
+			)
+		},
+	}, {
+		name: "it should fail if --rpc-addr is invalid",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--rpc-addr", "host:nonnumericport",
+		},
+		expectedErrMsg: "Port must be an int",
+	}, {
+		name: "if --rpc-addr wasn't passed, it should fall back to REDPANDA_RPC_ADDRESS and persist it",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(_ afero.Fs) error {
+			os.Setenv("REDPANDA_RPC_ADDRESS", "host:3123")
+			return nil
+		},
+		after: func() {
+			os.Unsetenv("REDPANDA_RPC_ADDRESS")
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := config.SocketAddress{
+				Address: "host",
+				Port:    3123,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.RPCServer,
+			)
+		},
+	}, {
+		name: "it should leave the RPC addr untouched if the env var & flag weren't set",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(fs afero.Fs) error {
+			mgr := config.NewManager(fs)
+			conf := config.Default()
+			conf.Redpanda.RPCServer = config.SocketAddress{
+				Address: "192.168.33.33",
+				Port:    9892,
+			}
+			return mgr.Write(conf)
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := config.SocketAddress{
+				Address: "192.168.33.33",
+				Port:    9892,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.RPCServer,
+			)
+		},
+	}, {
+		name: "it should parse the --kafka-addr and persist it",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--kafka-addr", "192.168.34.32:33145",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := config.SocketAddress{
+				Address: "192.168.34.32",
+				Port:    33145,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.KafkaApi,
+			)
+		},
+	}, {
+		name: "it should fail if --kafka-addr is invalid",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--kafka-addr", "host:nonnumericport",
+		},
+		expectedErrMsg: "Port must be an int",
+	}, {
+		name: "if --kafka-addr wasn't passed, it should fall back to REDPANDA_KAFKA_ADDRESS and persist it",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(_ afero.Fs) error {
+			os.Setenv("REDPANDA_KAFKA_ADDRESS", "host:3123")
+			return nil
+		},
+		after: func() {
+			os.Unsetenv("REDPANDA_KAFKA_ADDRESS")
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := config.SocketAddress{
+				Address: "host",
+				Port:    3123,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.KafkaApi,
+			)
+		},
+	}, {
+		name: "it should leave the Kafka addr untouched if the env var & flag weren't set",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(fs afero.Fs) error {
+			mgr := config.NewManager(fs)
+			conf := config.Default()
+			conf.Redpanda.KafkaApi = config.SocketAddress{
+				Address: "192.168.33.33",
+				Port:    9892,
+			}
+			return mgr.Write(conf)
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := config.SocketAddress{
+				Address: "192.168.33.33",
+				Port:    9892,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.KafkaApi,
+			)
+		},
+	}, {
+		name: "it should parse the --advertise-kafka-addr and persist it",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--advertise-kafka-addr", "192.168.34.32:33145",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := &config.SocketAddress{
+				Address: "192.168.34.32",
+				Port:    33145,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.AdvertisedKafkaApi,
+			)
+		},
+	}, {
+		name: "it should fail if --advertise-kafka-addr is invalid",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--advertise-kafka-addr", "host:nonnumericport",
+		},
+		expectedErrMsg: "Port must be an int",
+	}, {
+		name: "if --advertise-kafka-addr, it should fall back to REDPANDA_ADVERTISE_KAFKA_ADDRESS and persist it",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(_ afero.Fs) error {
+			os.Setenv("REDPANDA_ADVERTISE_KAFKA_ADDRESS", "host:3123")
+			return nil
+		},
+		after: func() {
+			os.Unsetenv("REDPANDA_ADVERTISE_KAFKA_ADDRESS")
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := &config.SocketAddress{
+				Address: "host",
+				Port:    3123,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.AdvertisedKafkaApi,
+			)
+		},
+	}, {
+		name: "it should leave the adv. Kafka addr untouched if the env var & flag weren't set",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(fs afero.Fs) error {
+			mgr := config.NewManager(fs)
+			conf := config.Default()
+			conf.Redpanda.AdvertisedKafkaApi = &config.SocketAddress{
+				Address: "192.168.33.33",
+				Port:    9892,
+			}
+			return mgr.Write(conf)
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := &config.SocketAddress{
+				Address: "192.168.33.33",
+				Port:    9892,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.AdvertisedKafkaApi,
+			)
+		},
+	}, {
+		name: "it should parse the --advertise-rpc-addr and persist it",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--advertise-rpc-addr", "192.168.34.32:33145",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := &config.SocketAddress{
+				Address: "192.168.34.32",
+				Port:    33145,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.AdvertisedRPCAPI,
+			)
+		},
+	}, {
+		name: "it should fail if --advertise-rpc-addr is invalid",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--advertise-rpc-addr", "host:nonnumericport",
+		},
+		expectedErrMsg: "Port must be an int",
+	}, {
+		name: "if --advertise-rpc-addr wasn't passed, it should fall back to REDPANDA_ADVERTISE_RPC_ADDRESS and persist it",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(_ afero.Fs) error {
+			os.Setenv("REDPANDA_ADVERTISE_RPC_ADDRESS", "host:3123")
+			return nil
+		},
+		after: func() {
+			os.Unsetenv("REDPANDA_ADVERTISE_RPC_ADDRESS")
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := &config.SocketAddress{
+				Address: "host",
+				Port:    3123,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.AdvertisedRPCAPI,
+			)
+		},
+	}, {
+		name: "it should leave the adv. RPC addr untouched if the env var & flag weren't set",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(fs afero.Fs) error {
+			mgr := config.NewManager(fs)
+			conf := config.Default()
+			conf.Redpanda.AdvertisedRPCAPI = &config.SocketAddress{
+				Address: "192.168.33.33",
+				Port:    9892,
+			}
+			return mgr.Write(conf)
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := &config.SocketAddress{
+				Address: "192.168.33.33",
+				Port:    9892,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.AdvertisedRPCAPI,
+			)
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			if tt.after != nil {
+				defer tt.after()
+			}
+			fs := afero.NewMemMapFs()
+			mgr := config.NewManager(fs)
+			var launcher redpanda.Launcher = &noopLauncher{}
+			if tt.launcher != nil {
+				launcher = tt.launcher
+			}
+			if tt.before != nil {
+				require.NoError(st, tt.before(fs))
+			}
+			var out bytes.Buffer
+			logrus.SetOutput(&out)
+			c := NewStartCommand(fs, mgr, launcher)
+			c.SetArgs(tt.args)
+			err := c.Execute()
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.NoError(st, err)
+			if tt.postCheck != nil {
+				tt.postCheck(fs, st)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Make `rpk start` testable by injecting the `redpanda.Launcher` instance instead of creating it when the command runs, allowing for mocking it and recreating various scenarios.

Fix #213 