### PR TITLE
r/replicate_batcher: removed debouncing timeout from replicate batcher

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -288,18 +288,12 @@ configuration::configuration()
       "follower",
       required::no,
       5s)
-  , replicate_request_debounce_timeout_ms(
-      *this,
-      "replicate_request_debounce_timeout_ms",
-      "Max duration before dispatching batched replicate requests",
-      required::no,
-      4ms)
   , raft_replicate_batch_window_size(
       *this,
       "raft_replicate_batch_window_size",
       "Max size of requests cached for replication",
       required::no,
-      128_KiB)
+      1_MiB)
   , reclaim_min_size(
       *this,
       "reclaim_min_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -84,7 +84,6 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> kafka_group_recovery_timeout_ms;
     property<std::chrono::milliseconds> replicate_append_timeout_ms;
     property<std::chrono::milliseconds> recovery_append_timeout_ms;
-    property<std::chrono::milliseconds> replicate_request_debounce_timeout_ms;
     property<size_t> raft_replicate_batch_window_size;
 
     property<size_t> reclaim_min_size;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -55,10 +55,7 @@ consensus::consensus(
   , _client_protocol(client)
   , _leader_notification(std::move(cb))
   , _fstats({})
-  , _batcher(
-      this,
-      config::shard_local_cfg().replicate_request_debounce_timeout_ms(),
-      config::shard_local_cfg().raft_replicate_batch_window_size())
+  , _batcher(this, config::shard_local_cfg().raft_replicate_batch_window_size())
   , _event_manager(this)
   , _ctxlog(group, _log.config().ntp())
   , _replicate_append_timeout(


### PR DESCRIPTION
Changed replicate batcher to use backpressure to debounce incoming
replicate requests.

In previous solutions the replicate batcher was waiting for either max
bytes threshold or debouncing timer tick. Changed the implementation to
use lock and semaphore to 'self regulate' the debouncing timeout.
Implemented solution where we dispatch replicate immediately when there
are no requests in progress. When replication is in progress we cache
all the incoming requests that will eventually be dispatched as a single
batch.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
