### PR TITLE
rpk/start: Fix the default seed port

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -704,7 +704,7 @@ func parseAddress(addr string) (*config.SocketAddress, error) {
 		// It's just a hostname with no port. Assume 9092.
 		return &config.SocketAddress{
 			Address: strings.Trim(hostPort[0], " "),
-			Port:    9092,
+			Port:    config.Default().Redpanda.RPCServer.Port,
 		}, nil
 	}
 	// It's a host:port combo.

--- a/src/go/rpk/pkg/cli/cmd/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/start_test.go
@@ -91,11 +91,11 @@ func TestParseSeeds(t *testing.T) {
 					1,
 				},
 				{
-					config.SocketAddress{"lonely-host", 9092},
+					config.SocketAddress{"lonely-host", 33145},
 					30,
 				},
 				{
-					config.SocketAddress{"192.168.34.1", 9092},
+					config.SocketAddress{"192.168.34.1", 33145},
 					5,
 				},
 			},


### PR DESCRIPTION
The default port for a seed should be the default RPC port, not the Kafka one.

