### PR TITLE
github-action: Automatically update the homebew forumla

### DIFF
--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -1,0 +1,32 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+name: Homebrew
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-homebrew:
+    name: Update Homebrew
+    runs-on: ubuntu-latest
+    steps: 
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+    - name: Update the homebrew tap
+      uses: mislav/bump-homebrew-formula-action@v1.8
+      with:
+        formula-name: redpanda
+        homebrew-tap: vectorizedio/homebrew-tap
+        base-branch: master
+        download-url: https://github.com/vectorizedio/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-amd64.zip
+      env:
+        COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}


### PR DESCRIPTION
Every time a new release is published, this will automatically update the
homebrew formula.

For this to run successfully, a new secret, `HOMEBREW_TOKEN`, will have to be entered into the redpanda repo. I will pass this information onto @senior7515. 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
