### PR TITLE
Tracing mutex

### DIFF
--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -28,24 +28,14 @@
  *    return m.with([] { ... });
  *    ```
  *
- * The `named_mutex` variant is analgous to `seastar::named_semaphore`. See
- * `seastar/core/semaphore.hh` for more information using an exception factory.
- *
  */
-template<
-  typename ExceptionFactory,
-  typename Clock = typename ss::timer<>::clock>
-class basic_mutex {
+class mutex {
 public:
-    using underlying_t = ss::basic_semaphore<ExceptionFactory, Clock>;
-    using duration = typename underlying_t::duration;
-    using time_point = typename underlying_t::time_point;
+    using duration = typename ss::semaphore::duration;
+    using time_point = typename ss::semaphore::time_point;
 
-    basic_mutex()
+    mutex()
       : _sem(1) {}
-
-    basic_mutex(ExceptionFactory&& factory)
-      : _sem(1, std::forward<ExceptionFactory>(factory)) {}
 
     template<typename Func>
     auto with(Func&& func) noexcept {
@@ -69,8 +59,5 @@ public:
     auto get_units() noexcept { return ss::get_units(_sem, 1); }
 
 private:
-    underlying_t _sem;
+    ss::semaphore _sem;
 };
-
-using mutex = basic_mutex<ss::semaphore_default_exception_factory>;
-using named_mutex = basic_mutex<ss::named_semaphore_exception_factory>;

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -77,3 +77,10 @@ rp_test(
   SOURCES base64_test.cc
   LIBRARIES v::seastar_testing_main v::utils
 )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME timed_mutex_test
+  SOURCES timed_mutex_test.cc
+  LIBRARIES v::seastar_testing_main v::utils
+)

--- a/src/v/utils/tests/timed_mutex_test.cc
+++ b/src/v/utils/tests/timed_mutex_test.cc
@@ -1,0 +1,59 @@
+#include "seastarx.h"
+#include "utils/timed_mutex.h"
+
+#include <seastar/core/loop.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+/*
+ * The test spawns several fibers incrementing a shared variable, the increment
+ * reads a value, sleep(1s) and writes value+1. The long pause between the &
+ * the write "guarantees" that the fibers interleave causing a lost update
+ * anomaly.
+ *
+ * Some of the interleaving fibers overwrite a result of another leading to
+ * the final value of the variable be less than expected:
+ *
+ *   v1 = read();
+ *   v2 = read(); <- interleaving
+ *   write(v1+1);
+ *   write(v2+1); <- overwrites the first fiber
+ */
+
+seastar::future<> slow(timed_mutex& mutex, int& counter) {
+    return mutex.lock("slow").then([&counter](locked_token t) {
+        int read = counter;
+        return seastar::sleep(std::chrono::seconds(1))
+          .then([&counter, read] { counter = read + 1; })
+          .then([t = std::move(t)] {});
+    });
+}
+
+seastar::future<>
+concurrent_increment(int num_fibers, int& variable, timed_mutex& mutex) {
+    return seastar::do_with(
+      seastar::semaphore(0), [&mutex, &variable, num_fibers](auto& sem) {
+          for (int i = 0; i < num_fibers; i++) {
+              (void)slow(mutex, variable).then([&sem] { sem.signal(1); });
+          }
+          return sem.wait(num_fibers);
+      });
+}
+
+SEASTAR_THREAD_TEST_CASE(test_timed_mutex_counts_locks) {
+    int num_fibers = 5;
+    int variable = 0;
+    timed_mutex mutex(true);
+    concurrent_increment(num_fibers, variable, mutex).get();
+    BOOST_REQUIRE_EQUAL(mutex.get_lock_counter(), num_fibers);
+    BOOST_REQUIRE_EQUAL(variable, num_fibers);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_timed_mutex_doesnt_count_locks) {
+    int num_fibers = 5;
+    int variable = 0;
+    timed_mutex mutex(false);
+    concurrent_increment(num_fibers, variable, mutex).get();
+    BOOST_REQUIRE_EQUAL(mutex.get_lock_counter(), 0);
+    BOOST_REQUIRE_EQUAL(variable, num_fibers);
+}

--- a/src/v/utils/timed_mutex.h
+++ b/src/v/utils/timed_mutex.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/semaphore.hh>
+
+#include <utility>
+
+/*
+ * This is a extension of mutex.h. The primary motivation for this class
+ * is to gather statistics on how ofter the mutex is taken (lock_counter)
+ * and the id of the top lock holder.
+ *
+ * Usage
+ * =====
+ *
+ *    ```
+ *    timed_mutex m;
+ *    return m.with("timed_mutex_example", [] { ... });
+ *    ```
+ * The first argument of `with` and `lock` is const char* lock_holder_id.
+ * timed_mutex doesn't make any copy of the string, just pass the pointer
+ * around and may store it indefinely long so it should have unlimited
+ * lifetime. From the caller perspective it means they can't really pass
+ * in a dynamic or stack-allocated string: it should really only be a string
+ * literal. This is important for performance to avoid allocating on every
+ * lock()
+ */
+
+class timed_mutex;
+
+class locked_token {
+    timed_mutex* _mutex;
+    ss::semaphore_units<> _unit;
+    bool _is_moved{false};
+    const char* _lock_holder_id;
+
+public:
+    locked_token(
+      timed_mutex* mutex,
+      const char* lock_holder_id,
+      ss::semaphore_units<>&& unit) noexcept
+      : _mutex(mutex)
+      , _lock_holder_id(lock_holder_id)
+      , _unit(std::move(unit)) {}
+    locked_token(locked_token&& token) noexcept
+      : _mutex(token._mutex)
+      , _lock_holder_id(token._lock_holder_id)
+      , _unit(std::move(token._unit)) {
+        token._is_moved = true;
+    }
+    locked_token(const locked_token&) = delete;
+    locked_token() = delete;
+
+    ~locked_token() noexcept;
+};
+
+struct lock_trace {
+    std::chrono::microseconds duration{0};
+    const char* lock_holder_id{nullptr};
+};
+
+class timed_mutex {
+public:
+    using duration = typename ss::semaphore::duration;
+    using time_point = typename ss::semaphore::time_point;
+
+    explicit timed_mutex(bool should_tracing)
+      : _sem(1)
+      , _is_tracing(should_tracing) {}
+
+    ss::future<> start_tracing() {
+        return this->lock("timed_mutex:start_tracing")
+          .then([this](locked_token t) {
+              if (!this->_is_tracing) {
+                  this->_is_tracing = true;
+                  _lock_counter += 1;
+                  _acquired_at = std::chrono::steady_clock::now();
+              }
+          });
+    }
+
+    ss::future<> stop_tracing() {
+        return this->lock("timed_mutex:stop_tracing")
+          .then([this](locked_token t) { this->_is_tracing = false; });
+    }
+
+    template<typename Func>
+    auto
+    with(const char* lock_holder_id, duration timeout, Func&& func) noexcept {
+        return ss::with_semaphore(
+          _sem,
+          1,
+          timeout,
+          [this, lock_holder_id, func = std::forward<Func>(func)]() mutable {
+              if (_is_tracing) {
+                  _lock_counter += 1;
+                  _acquired_at = std::chrono::steady_clock::now();
+              }
+              return ss::futurize_invoke(std::forward<Func>(func))
+                .finally(
+                  [this, lock_holder_id] { about_to_release(lock_holder_id); });
+          });
+    }
+
+    template<typename Func>
+    auto
+    with(const char* lock_holder_id, time_point timeout, Func&& func) noexcept {
+        return ss::get_units(_sem, 1, timeout)
+          .then([this, lock_holder_id, func = std::forward<Func>(func)](
+                  auto units) mutable {
+              if (_is_tracing) {
+                  _lock_counter += 1;
+                  _acquired_at = std::chrono::steady_clock::now();
+              }
+              return ss::futurize_invoke(std::forward<Func>(func))
+                .finally([this, lock_holder_id, units = std::move(units)] {
+                    about_to_release(lock_holder_id);
+                });
+          });
+    }
+
+    ss::future<locked_token> lock(const char* lock_holder_id) {
+        return ss::get_units(_sem, 1).then(
+          [this, lock_holder_id](ss::semaphore_units<> u) {
+              if (_is_tracing) {
+                  _lock_counter += 1;
+                  _acquired_at = std::chrono::steady_clock::now();
+              }
+              return locked_token(this, lock_holder_id, std::move(u));
+          });
+    }
+
+    lock_trace get_top_leasee() { return _top_leasee; }
+
+    int get_lock_counter() { return _lock_counter; }
+
+    void reset_statistics() {
+        _lock_counter = 0;
+        _top_leasee = lock_trace{std::chrono::microseconds{0}, nullptr};
+    }
+
+private:
+    bool _is_tracing{false};
+    ss::semaphore _sem;
+    int64_t _lock_counter{0};
+    std::chrono::steady_clock::time_point _acquired_at;
+    lock_trace _top_leasee;
+
+    void about_to_release(const char* lock_holder_id) {
+        auto duration_us
+          = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - _acquired_at);
+
+        if (duration_us > _top_leasee.duration) {
+            _top_leasee.duration = duration_us;
+            _top_leasee.lock_holder_id = lock_holder_id;
+        }
+    }
+
+    friend class locked_token;
+};
+
+inline locked_token::~locked_token() noexcept {
+    if (!_is_moved) {
+        _mutex->about_to_release(_lock_holder_id);
+    }
+}


### PR DESCRIPTION
Adds a tracing mutex, it tracks acquire rate and the longest lock holder (duration and id).

https://github.com/vectorizedio/redpanda/issues/285