### PR TITLE
Adds incremental alter configs parsing

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -24,6 +24,7 @@ set(request_srcs
   requests/describe_groups_request.cc
   requests/sasl_handshake_request.cc
   requests/sasl_authenticate_request.cc
+  requests/incremental_alter_configs_request.cc
   requests/topics/types.cc
   requests/topics/topic_utils.cc)
 

--- a/src/v/kafka/requests/api_versions_request.cc
+++ b/src/v/kafka/requests/api_versions_request.cc
@@ -17,6 +17,7 @@
 #include "kafka/requests/fetch_request.h"
 #include "kafka/requests/find_coordinator_request.h"
 #include "kafka/requests/heartbeat_request.h"
+#include "kafka/requests/incremental_alter_configs_request.h"
 #include "kafka/requests/init_producer_id_request.h"
 #include "kafka/requests/join_group_request.h"
 #include "kafka/requests/leave_group_request.h"
@@ -68,7 +69,8 @@ using request_types = make_request_types<
   delete_topics_api,
   describe_groups_api,
   sasl_handshake_api,
-  sasl_authenticate_api>;
+  sasl_authenticate_api,
+  incremental_alter_configs_api>;
 
 template<typename RequestType>
 static auto make_api() {

--- a/src/v/kafka/requests/incremental_alter_configs_request.cc
+++ b/src/v/kafka/requests/incremental_alter_configs_request.cc
@@ -1,0 +1,50 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "kafka/requests/incremental_alter_configs_request.h"
+
+#include "kafka/errors.h"
+#include "kafka/requests/request_context.h"
+#include "kafka/requests/response.h"
+#include "model/metadata.h"
+
+#include <seastar/core/do_with.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/util/log.hh>
+
+#include <fmt/ostream.h>
+
+#include <string_view>
+
+namespace kafka {
+
+ss::future<response_ptr> incremental_alter_configs_api::process(
+  request_context&& ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+    incremental_alter_configs_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    klog.trace("Handling request {}", request);
+
+    return ss::do_with(
+      std::move(ctx),
+      std::move(request),
+      [](request_context& ctx, incremental_alter_configs_request& request) {
+          incremental_alter_configs_response response;
+          for (auto& resource : request.data.resources) {
+              response.data.responses.push_back(
+                incremental_alter_configs_resource_response{
+                  .error_code = error_code::invalid_request,
+                  .error_message = "Cannot alter config resource",
+                  .resource_type = resource.resource_type,
+                  .resource_name = std::move(resource.resource_name),
+                });
+          }
+          return ctx.respond(std::move(response));
+      });
+}
+
+} // namespace kafka

--- a/src/v/kafka/requests/incremental_alter_configs_request.h
+++ b/src/v/kafka/requests/incremental_alter_configs_request.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "bytes/iobuf.h"
+#include "kafka/errors.h"
+#include "kafka/requests/request_context.h"
+#include "kafka/requests/response.h"
+#include "kafka/requests/schemata/incremental_alter_configs_request.h"
+#include "kafka/requests/schemata/incremental_alter_configs_response.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/future.hh>
+
+namespace kafka {
+
+struct incremental_alter_configs_response;
+
+class incremental_alter_configs_api final {
+public:
+    using response_type = incremental_alter_configs_response;
+
+    static constexpr const char* name = "incremental_alter_configs";
+    static constexpr api_key key = api_key(44);
+    static constexpr api_version min_supported = api_version(0);
+    static constexpr api_version max_supported = api_version(0);
+
+    static ss::future<response_ptr>
+    process(request_context&&, ss::smp_service_group);
+};
+
+struct incremental_alter_configs_request final {
+    using api_type = incremental_alter_configs_api;
+
+    incremental_alter_configs_request_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const incremental_alter_configs_request& r) {
+    return os << r.data;
+}
+
+struct incremental_alter_configs_response final {
+    using api_type = incremental_alter_configs_api;
+
+    incremental_alter_configs_response_data data;
+
+    void encode(const request_context& ctx, response& resp) {
+        data.encode(resp.writer(), ctx.header().version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const incremental_alter_configs_response& r) {
+    return os << r.data;
+}
+
+} // namespace kafka

--- a/src/v/kafka/requests/requests.cc
+++ b/src/v/kafka/requests/requests.cc
@@ -18,6 +18,7 @@
 #include "kafka/requests/fetch_request.h"
 #include "kafka/requests/find_coordinator_request.h"
 #include "kafka/requests/heartbeat_request.h"
+#include "kafka/requests/incremental_alter_configs_request.h"
 #include "kafka/requests/init_producer_id_request.h"
 #include "kafka/requests/join_group_request.h"
 #include "kafka/requests/leave_group_request.h"
@@ -135,6 +136,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<sasl_authenticate_api>(std::move(ctx), g);
     case init_producer_id_api::key:
         return do_process<init_producer_id_api>(std::move(ctx), g);
+    case incremental_alter_configs_api::key:
+        return do_process<incremental_alter_configs_api>(std::move(ctx), g);
     };
     return ss::make_exception_future<response_ptr>(
       std::runtime_error(fmt::format("Unsupported API {}", ctx.header().key)));

--- a/src/v/kafka/requests/schemata/CMakeLists.txt
+++ b/src/v/kafka/requests/schemata/CMakeLists.txt
@@ -36,7 +36,9 @@ set(schemata
   sasl_authenticate_request.json
   sasl_authenticate_response.json
   init_producer_id_request.json
-  init_producer_id_response.json)
+  init_producer_id_response.json
+  incremental_alter_configs_request.json
+  incremental_alter_configs_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/requests/schemata/generator.py
+++ b/src/v/kafka/requests/schemata/generator.py
@@ -207,6 +207,14 @@ basic_type_map = dict(
     int64=("int64_t", "read_int64()"),
 )
 
+# apply a rename to a struct. this is useful when there is a type name conflict
+# between two request types. since we generate types in a flat namespace this
+# feature is important for resolving naming conflicts.
+#
+# the format here is the field name path terminating with the expected type name
+# mapping to the new type name.
+struct_renames = {}
+
 # a listing of expected struct types
 STRUCT_TYPES = [
     "ApiVersionsRequestKey",
@@ -247,6 +255,14 @@ STRUCT_TYPES = [
 
 SCALAR_TYPES = list(basic_type_map.keys())
 ENTITY_TYPES = list(entity_type_map.keys())
+
+
+def apply_struct_renames(path, type_name):
+    rename = struct_renames.get(path, None)
+    if rename is None:
+        return type_name
+    assert rename[0] == type_name
+    return rename[1]
 
 
 class VersionRange:
@@ -332,6 +348,7 @@ class FieldType:
         else:
             assert is_array
             path = path + (field["name"], )
+            type_name = apply_struct_renames(path, type_name)
             t = StructType(type_name, field["fields"], path)
 
         if is_array:

--- a/src/v/kafka/requests/schemata/generator.py
+++ b/src/v/kafka/requests/schemata/generator.py
@@ -213,7 +213,18 @@ basic_type_map = dict(
 #
 # the format here is the field name path terminating with the expected type name
 # mapping to the new type name.
-struct_renames = {}
+# yapf: disable
+struct_renames = {
+    ("IncrementalAlterConfigsRequestData", "Resources"):
+        ("AlterConfigsResource", "IncrementalAlterConfigsResource"),
+
+    ("IncrementalAlterConfigsRequestData", "Resources", "Configs"):
+        ("AlterableConfig", "IncrementalAlterableConfig"),
+
+    ("IncrementalAlterConfigsResponseData", "Responses"):
+        ("AlterConfigsResourceResponse", "IncrementalAlterConfigsResourceResponse"),
+}
+# yapf: enable
 
 # a listing of expected struct types
 STRUCT_TYPES = [

--- a/src/v/kafka/requests/schemata/incremental_alter_configs_request.json
+++ b/src/v/kafka/requests/schemata/incremental_alter_configs_request.json
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 44,
+  "type": "request",
+  "name": "IncrementalAlterConfigsRequest",
+  // Version 1 is the first flexible version.
+  "validVersions": "0-1",
+  "flexibleVersions": "1+",
+  "fields": [
+    { "name": "Resources", "type": "[]AlterConfigsResource", "versions": "0+",
+      "about": "The incremental updates for each resource.", "fields": [
+      { "name": "ResourceType", "type": "int8", "versions": "0+", "mapKey": true,
+        "about": "The resource type." },
+      { "name": "ResourceName", "type": "string", "versions": "0+", "mapKey": true,
+        "about": "The resource name." },
+      { "name": "Configs", "type": "[]AlterableConfig", "versions": "0+",
+        "about": "The configurations.",  "fields": [
+        { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+          "about": "The configuration key name." },
+        { "name": "ConfigOperation", "type": "int8", "versions": "0+", "mapKey": true,
+          "about": "The type (Set, Delete, Append, Subtract) of operation." },
+        { "name": "Value", "type": "string", "versions": "0+", "nullableVersions": "0+",
+          "about": "The value to set for the configuration key."}
+      ]}
+    ]},
+    { "name": "ValidateOnly", "type": "bool", "versions": "0+",
+      "about": "True if we should validate the request, but not change the configurations."}
+  ]
+}

--- a/src/v/kafka/requests/schemata/incremental_alter_configs_response.json
+++ b/src/v/kafka/requests/schemata/incremental_alter_configs_response.json
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 44,
+  "type": "response",
+  "name": "IncrementalAlterConfigsResponse",
+  // Version 1 is the first flexible version.
+  "validVersions": "0-1",
+  "flexibleVersions": "1+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "Duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "Responses", "type": "[]AlterConfigsResourceResponse", "versions": "0+",
+      "about": "The responses for each resource.", "fields": [
+      { "name": "ErrorCode", "type": "int16", "versions": "0+",
+        "about": "The resource error code." },
+      { "name": "ErrorMessage", "type": "string", "nullableVersions": "0+", "versions": "0+",
+        "about": "The resource error message, or null if there was no error." },
+      { "name": "ResourceType", "type": "int8", "versions": "0+",
+        "about": "The resource type." },
+      { "name": "ResourceName", "type": "string", "versions": "0+",
+        "about": "The resource name." }
+    ]}
+  ]
+}


### PR DESCRIPTION
Adds parsing for incremental alter configs so that clients observe the API to be implemented. However, we do not support altering configurations at runtime (yet), so the API returns an error message for each configuration change requested.

Fixes: #282 
