### PR TITLE
Priority based leader election

### DIFF
--- a/src/v/raft/configuration_manager.cc
+++ b/src/v/raft/configuration_manager.cc
@@ -122,7 +122,7 @@ configuration_manager::add(model::offset offset, group_configuration cfg) {
     });
 }
 
-group_configuration configuration_manager::get_latest() const {
+const group_configuration& configuration_manager::get_latest() const {
     vassert(
       !_configurations.empty(),
       "Configuration manager should always have at least one configuration");

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -92,7 +92,7 @@ public:
     /**
      * Get latest configuration.
      */
-    group_configuration get_latest() const;
+    const group_configuration& get_latest() const;
 
     /**
      * Get latest configuration offset.

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -333,6 +333,10 @@ private:
     void maybe_update_majority_replicated_index();
 
     void start_dispatching_disk_append_events();
+
+    voter_priority next_target_priority();
+    voter_priority get_node_priority(model::node_id id) const;
+
     // args
     model::node_id _self;
     raft::group_id _group;
@@ -390,6 +394,7 @@ private:
     configuration_manager _configuration_manager;
     model::offset _majority_replicated_index;
     model::offset _visibility_upper_bound_index;
+    voter_priority _target_priority = voter_priority::max();
     /**
      * We keep an idex of the most recent entry replicated with quorum
      * consistency level to make sure that all requests replicated with quorum

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -397,6 +397,14 @@ enum class metadata_key : int8_t {
     last_applied_offset = 3,
 };
 
+// priority used to implement semi-deterministic leader election
+using voter_priority = named_type<uint32_t, struct voter_priority_tag>;
+
+// zero priority doesn't allow node to become a leader
+static constexpr voter_priority zero_voter_priority = voter_priority{0};
+// 1 is smallest possible priority allowing node to become a leader
+static constexpr voter_priority min_voter_priority = voter_priority{1};
+
 std::ostream& operator<<(std::ostream& o, const consistency_level& l);
 std::ostream& operator<<(std::ostream& o, const protocol_metadata& m);
 std::ostream& operator<<(std::ostream& o, const vote_reply& r);

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -228,6 +228,8 @@ ss::future<> vote_stm::update_vote_state(ss::semaphore_units<> u) {
     // section vote:5.2.2
     _ptr->_vstate = consensus::vote_state::leader;
     _ptr->_leader_id = _ptr->self();
+    // reset target priority
+    _ptr->_target_priority = voter_priority::max();
     _ptr->_became_leader_at = clock_type::now();
     // Set last heartbeat timestamp to max as we are the leader
     _ptr->_hbeat = clock_type::time_point::max();

--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -100,6 +100,14 @@ public:
     // implicit conversion operator
     constexpr operator type() const { return _value; }
 
+    static constexpr base_named_type min() {
+        return base_named_type(std::numeric_limits<type>::min());
+    }
+
+    static constexpr base_named_type max() {
+        return base_named_type(std::numeric_limits<type>::max());
+    }
+
 protected:
     type _value = std::numeric_limits<T>::min();
 };


### PR DESCRIPTION
## Motivation

In genuine raft algorithm leader election mechanism randomize the leader election timeouts on different nodes with jitter value added to the base election timeout. In Redpanda we host multiple Raft protocol instances on each node ( 1 instance per partition replica). In order to read or write to the partition clients communicate with partition leader, therefore it is important to spread partition leaders evenly on all available cluster nodes. The priority based leader election mechanism allow us to prioritize and by that control which node is most likely be the next raft group leader.

## New definitions

We define a new type `raft::voter_priority` which describes node priority. The priority type is based on `uint32_t` and it range is equal to the range of 32-bit unsigned integer. 

We define two special priority values:
```c++
// zero priority doesn't allow node to become a leader
static constexpr voter_priority zero_voter_priority = voter_priority{0};
// 1 is smallest possible priority allowing node to become a leader
static constexpr voter_priority min_voter_priority = voter_priority{1};
```
## Node priority

Each node has a priority assigned, in order to assign the priorities to nodes we project range of node indices from configuration onto the possible range of priorities. In a way that first node from `raft::configuration` brokers vector has biggest priority.

Example for 5 nodes cluster
 ```
node index:      4     3     2     1     0
                  +-----+-----+-----+-----+
                  |     |     |     |     |
                  |     |     |     |     |
                  |     |     |     |     |
                  v     v     v     v     v
                  +-----+-----+-----+-----+
node priority:  min                     max

```

We can use node index to assign priorities as we assign nodes to replica set in a deterministic way and we shuffle each replica set order. This give us even distribution of partition leaders across the cluster.

## Node target priority

In order to determine if node with given priority can be elected as a leader in a certain voting round we introduce additional volatile (in memory) state in `raft::consensus` called `_target_priority`. The `_target_priority` is a lowest node priority which may be granted a vote. Target priority is multiplied by 0.8 each time the election is not successful. 

Target priority is reset to max of the nodes priorities if election was successful. 

## Election duration

This solution makes election process require more than one voting round to elect the leader when node with highest priority is not available. 


Fixes: #255 

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [x] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
