### PR TITLE
kafka: support v4 of create topics request

### DIFF
--- a/src/v/kafka/requests/create_topics_request.cc
+++ b/src/v/kafka/requests/create_topics_request.cc
@@ -50,6 +50,18 @@ ss::future<response_ptr> create_topics_api::process(
             request.data.topics.end(),
             std::back_inserter(response.data.topics));
 
+          // fill in defaults if necessary
+          for (auto& r : boost::make_iterator_range(begin, valid_range_end)) {
+              if (r.num_partitions == -1) {
+                  r.num_partitions
+                    = config::shard_local_cfg().default_topic_partitions();
+              }
+              if (r.replication_factor == -1) {
+                  r.replication_factor
+                    = config::shard_local_cfg().default_topic_replication();
+              }
+          }
+
           // Validate with validators
           valid_range_end = validate_requests_range(
             begin,

--- a/src/v/kafka/requests/create_topics_request.h
+++ b/src/v/kafka/requests/create_topics_request.h
@@ -34,7 +34,7 @@ public:
     static constexpr const char* name = "create topics";
     static constexpr api_key key = api_key(19);
     static constexpr api_version min_supported = api_version(0);
-    static constexpr api_version max_supported = api_version(3);
+    static constexpr api_version max_supported = api_version(4);
 
     static ss::future<response_ptr>
     process(request_context&&, ss::smp_service_group);


### PR DESCRIPTION
This allows a new topic to receive default partition count and
replication factor in the same way as topic auto creation via metadata
request happens now. See kip-464.

fixes: #292