### PR TITLE
Add file_stm component

### DIFF
--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -29,6 +29,7 @@ v_cc_library(
     segment_utils.cc
     compaction_reducers.cc
     parser_utils.cc
+    file_stm.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/file_stm.cc
+++ b/src/v/storage/file_stm.cc
@@ -1,0 +1,343 @@
+#include "storage/file_stm.h"
+
+#include "storage/logger.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/weak_ptr.hh>
+
+#include <exception>
+#include <variant>
+
+namespace storage {
+
+open_file_cache::open_file_cache(uint32_t limit)
+  : _limit(limit) {}
+
+open_file_cache::~open_file_cache() {
+    vassert(_lru.empty(), "open_file_cache is not empty");
+}
+
+void open_file_cache::touch(entry_t& file) {
+    file._hook.unlink();
+    _lru.push_back(file);
+    if (is_full()) {
+        auto candidate = _lru.begin();
+        if (candidate->gate.get_count() == 0) {
+            _eviction.trigger(*candidate);
+        }
+    }
+}
+
+ss::future<> open_file_cache::put(entry_t& file) {
+    // if we have a room for a new element just add it
+    // to the cache, otherwise, use this fiber to evict
+    // the other element from the cache and add the new
+    // one
+    _lru.push_back(file);
+    auto fut = ss::now();
+    if (is_full()) {
+        auto candidate = _lru.begin();
+        if (candidate->gate.get_count() == 0) {
+            // eviction candidate is not used
+            fut = candidate->_on_evict();
+        } else {
+            fut = _eviction.wait().then(
+              [](entry_t& it) { return it._on_evict(); });
+        }
+    }
+    return fut;
+}
+
+void open_file_cache::evict(entry_t& entry) {
+    vlog(
+      stlog.debug,
+      "open_file_cache evict called, path: {}",
+      entry.open_args.path);
+    entry._hook.unlink();
+    vassert(entry.gate.get_count() == 0, "file is in use");
+    // This is OK since the eviction will be triggered by the futurized
+    // code path that will 'wait' on '_eviction' before calling 'evict'.
+    _eviction.trigger(entry);
+}
+
+bool open_file_cache::is_candidate(const entry_t& entry) const {
+    auto it = _lru.iterator_to(entry);
+    return it == _lru.begin();
+}
+
+bool open_file_cache::eviction_awaited() const { return _eviction.size() != 0; }
+
+uint32_t open_file_cache::max_allowed_count() const { return _limit; }
+
+/// file_stm implementation
+
+file_stm::impl::impl(
+  std::string_view name,
+  ss::open_flags flags,
+  ss::file_open_options options,
+  ss::lw_shared_ptr<open_file_cache> cache)
+  : _state(details::st_pre_open{
+    .path = std::string(name.begin(), name.end()),
+    .flags = flags,
+    .options = options})
+  , _cache(std::move(cache)) {}
+
+// Removes 'create' flag from 'flags', keeps remaining flags
+// intact.
+static ss::open_flags make_reopen_flags(ss::open_flags flags) {
+    auto tmp = flags & ss::open_flags::create;
+    return static_cast<ss::open_flags>((unsigned)tmp ^ (unsigned)flags);
+}
+
+// lock_guard implementation
+
+file_stm::lock_guard::lock_guard()
+  : _elem(std::nullopt)
+  , _cache() {}
+
+file_stm::lock_guard::lock_guard(
+  details::st_open& state, ss::lw_shared_ptr<open_file_cache> cache)
+  : _elem(std::ref(state))
+  , _cache(std::move(cache)) {
+    _elem->get().gate.enter();
+}
+
+file_stm::lock_guard::~lock_guard() {
+    try {
+        if (_cache) {
+            auto& element = _elem->get();
+            element.gate.leave();
+            if (
+              element._hook.is_linked() && element.gate.get_count() == 0
+              && _cache->eviction_awaited() && _cache->is_candidate(element)) {
+                // This will trigger actual cache eviction, the node will be
+                // unlinked and the file_stm::impl object that owns the element
+                // will be transitioned to st_evict state.
+                _cache->evict(element);
+            }
+        }
+    } catch (...) {
+        vlog(
+          stlog.error,
+          "delayed eviction failed, error: {}",
+          std::current_exception());
+    }
+}
+
+ss::file file_stm::lock_guard::get_file() {
+    vassert((bool)_elem, "lock_guard is empty");
+    return *_elem->get().file;
+}
+
+ss::future<file_stm::lock_guard>
+file_stm::impl::state_transition_to_open(details::st_open&& newstate) {
+    vlog(
+      stlog.debug,
+      "file_stm transition to st_open state, path: {}",
+      newstate.open_args.path);
+    _state = std::move(newstate);
+    auto fut = _cache->put(std::get<details::st_open>(_state));
+    return fut.then([this] {
+        const auto& st = std::get<details::st_open>(_state);
+        return ss::open_file_dma(
+                 st.open_args.path, st.open_args.flags, st.open_args.options)
+          .then_wrapped([this](ss::future<ss::file> fd) {
+              auto& current = std::get<details::st_open>(_state);
+              try {
+                  current.open_args.flags = make_reopen_flags(
+                    current.open_args.flags);
+                  current.file = fd.get();
+                  current._on_evict = [this] { return ev_evict(); };
+                  // notify other fibers that wait for this state to be
+                  // initialized
+                  current._wait_open.trigger_all();
+              } catch (...) {
+                  vlog(
+                    stlog.error,
+                    "can't open file: {} error: {}",
+                    current.open_args.path,
+                    std::current_exception());
+              }
+              return ss::make_ready_future<lock_guard>(
+                lock_guard(current, _cache));
+          });
+    });
+}
+
+ss::future<file_stm::lock_guard> file_stm::impl::ev_access() {
+    auto result = ss::make_ready_future<lock_guard>();
+    switch (_state.index()) {
+    case ix_pre_open: {
+        const auto& args = std::get<details::st_pre_open>(_state);
+        result = state_transition_to_open(details::st_open{
+          .open_args = args,
+          .file = std::nullopt,
+          .gate = {},
+        });
+    } break;
+    case ix_evict: {
+        const auto& args = std::get<details::st_evict>(_state);
+        result = state_transition_to_open(details::st_open{
+          .open_args = args.reopen_args,
+          .file = std::nullopt,
+          .gate = {},
+        });
+    } break;
+    case ix_open: {
+        // ..touch lru entry, state stays the same
+        auto& item = std::get<details::st_open>(_state);
+        if (item.file) {
+            _cache->touch(item);
+            result = ss::make_ready_future<lock_guard>(
+              lock_guard(item, _cache));
+        } else {
+            // This path handles concuurent access to file. In this case
+            // first future will change state to 'st_open' and start opening the
+            // file asynchronously. Before it's completed the 'file' filed of
+            // the state will be set to std::nullopt. Fibers that see that this
+            // is the case should wait until it'll be opened.
+            result = item._wait_open.wait().then_wrapped(
+              [this](ss::future<> fut) {
+                  if (fut.failed()) {
+                      // handle case when file was closed
+                      return ss::make_exception_future<lock_guard>(
+                        fut.get_exception());
+                  }
+                  if (auto p = std::get_if<details::st_open>(&_state);
+                      p != nullptr) {
+                      return ss::make_ready_future<lock_guard>(
+                        lock_guard(*p, _cache));
+                  }
+                  return ss::make_exception_future<lock_guard>(
+                    std::runtime_error("file is not opened"));
+              });
+        }
+    } break;
+    case ix_close:
+        result = ss::make_exception_future<lock_guard>(
+          std::runtime_error("file is not opened"));
+        break;
+    }
+    return result;
+}
+
+ss::future<> file_stm::impl::ev_close() {
+    auto fut = ss::now();
+    if (auto s = std::get_if<details::st_open>(&_state); s && s->file) {
+        auto open_state = std::move(*s);
+        vlog(
+          stlog.debug,
+          "file_stm transition to st_close state, path: {}",
+          open_state.open_args.path);
+        fut = open_state.gate.close().then(
+          [this, os = std::move(open_state)]() mutable {
+              if (_cache->is_full() && _cache->is_candidate(os)) {
+                  _cache->evict(os);
+              }
+              return os.file->flush().then([file = *os.file]() mutable {
+                  return file.close().finally([file] {});
+              });
+          });
+    }
+    _state = details::st_close{};
+    return fut;
+}
+
+ss::future<> file_stm::impl::ev_evict() {
+    if (auto s = std::get_if<details::st_open>(&_state); s && s->file) {
+        auto fut = ss::now();
+        auto open_state = std::move(*s);
+        vlog(
+          stlog.debug,
+          "file_stm evict wait for readers {}",
+          open_state.open_args.path);
+        fut = open_state.gate.close().then(
+          [file = std::move(*open_state.file),
+           path = open_state.open_args.path]() mutable {
+              vlog(stlog.debug, "file_stm evicting {}", path);
+              return file.flush().then(
+                [file]() mutable { return file.close().finally([file] {}); });
+          });
+        // This will be called from the open_file_cache::evict method. In this
+        // scenario the old state (st_open) will already be unlinked from the
+        // cache.
+        _state = details::st_evict{
+          .reopen_args = {
+            .path = open_state.open_args.path,
+            .flags = make_reopen_flags(open_state.open_args.flags),
+            .options = open_state.open_args.options}};
+        return fut;
+    }
+    return ss::make_exception_future<>(
+      std::runtime_error("can't evict file from cache, file not opened"));
+}
+
+bool file_stm::impl::is_pre_open() const {
+    return std::holds_alternative<details::st_pre_open>(_state);
+}
+
+bool file_stm::impl::is_opened() const {
+    return std::holds_alternative<details::st_open>(_state);
+}
+
+bool file_stm::impl::is_evicted() const {
+    return std::holds_alternative<details::st_evict>(_state);
+}
+
+bool file_stm::impl::is_closed() const {
+    return std::holds_alternative<details::st_close>(_state);
+}
+
+file_stm::impl::~impl() {
+    vassert(is_closed(), "file_stm is not closed properly");
+}
+
+file_stm::file_stm(ss::lw_shared_ptr<file_stm::impl> i)
+  : _impl(std::move(i)) {}
+
+ss::future<> file_stm::close() { return _impl->ev_close(); }
+
+bool file_stm::is_pre_open() const {
+    vassert(static_cast<bool>(_impl), "not initialized");
+    return _impl->is_pre_open();
+}
+bool file_stm::is_opened() const {
+    vassert(static_cast<bool>(_impl), "not initialized");
+    return _impl->is_opened();
+}
+bool file_stm::is_evicted() const {
+    vassert(static_cast<bool>(_impl), "not initialized");
+    return _impl->is_evicted();
+}
+bool file_stm::is_closed() const {
+    vassert(static_cast<bool>(_impl), "not initialized");
+    return _impl->is_closed();
+}
+
+ss::future<file_stm> open_file_dma(
+  std::string_view name,
+  ss::open_flags flags,
+  ss::file_open_options options,
+  ss::lw_shared_ptr<open_file_cache> cache,
+  open_file_stm_options stm_opt) {
+    auto file = file_stm::impl::create(name, flags, options, std::move(cache));
+    if (stm_opt == open_file_stm_options::lazy) {
+        return ss::make_ready_future<file_stm>(file_stm(file));
+    }
+    return file->ev_access().then(
+      [file]([[maybe_unused]] file_stm::lock_guard lg) mutable {
+          return ss::make_ready_future<file_stm>(file_stm(file));
+      });
+}
+
+ss::future<file_stm> open_file_dma(
+  std::string_view name,
+  ss::open_flags flags,
+  ss::lw_shared_ptr<open_file_cache> cache,
+  open_file_stm_options stm_opt) {
+    return open_file_dma(name, flags, {}, std::move(cache), stm_opt);
+}
+
+} // namespace storage

--- a/src/v/storage/file_stm.h
+++ b/src/v/storage/file_stm.h
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "storage/batch_cache.h"
+#include "storage/compacted_index_writer.h"
+#include "storage/segment_appender.h"
+#include "storage/segment_index.h"
+#include "storage/segment_reader.h"
+#include "storage/types.h"
+#include "storage/version.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/weak_ptr.hh>
+
+#include <optional>
+#include <variant>
+
+namespace storage {
+
+// FSM states:
+//
+// - st_pre_open - file is created but not yet accessed
+// - st_open     - actual file descriptor is opened
+// - st_close    - file closed (no further I/O operations are possible)
+// - st_evict    - file closed temporarily and prepared to be reopened
+//
+// FSM events:
+//
+// - ev_access   - triggered by any async file operation except close
+// - ev_close    - triggered by close
+// - ev_evict    - triggered by eviction process
+//
+// FSM transition table
+//
+// clang-format off
+// +--------------+-----------+--------------+------------------------------+------------------------------------+
+// | source state |   event   | target state |        event trigger         |         transition effect          |
+// +--------------+-----------+--------------+------------------------------+------------------------------------+
+// | st_pre_open  | ev_access | st_open      | any operation except close   | file is opened/created and         |
+// |              |           |              |                              | added to cache triggering eviction |
+// |              |           |              | and the cache is full        |                                    |
+// | st_pre_open  | ev_close  | st_close     | close method called          | no effect                          |
+// | ------------ | --------- | ------------ | ---------------------------- | ---------------------------------- |
+// | st_open      | ev_evict  | st_evict     | triggered by eviction policy | file is temporarily closed         |
+// |              |           |              |                              | and removed from cache             |
+// | st_open      | ev_access | st_open      | any operation except close   | touch LRU cache entry              |
+// | st_open      | ev_close  | st_close     | close method called          | file is closed, removed from cache |
+// | ------------ | --------- | ------------ | ---------------------------- | ---------------------------------- |
+// | st_evict     | ev_access | st_open      | any operation except close   | file is reopened and               |
+// |              |           |              |                              | added to cache                     |
+// | st_evict     | ev_close  | st_close     | close method called          | no effect                          |
+// | ------------ | --------- | ------------ | ---------------------------- | ---------------------------------- |
+// | st_closed    | any       | st_close     |                              |                                    |
+// +--------------+-----------+--------------+------------------------------+------------------------------------+
+// clang-format on
+
+/// Control the way file_stm is created
+enum class open_file_stm_options {
+    /// Open/create file on first access
+    lazy,
+    /// Force open/create file ASAP
+    eager,
+};
+
+namespace details {
+
+/// This object acts as a synchronization primitive for open_file_cache.
+/// It allows multiple file_stm objects to wait for eviction. It guarantees
+/// fairness so waiting fibers will be served in fifo order.
+template<class... T>
+class wait_list {
+public:
+    /// Wait for the trigger method to be called
+    ss::future<T...> wait() {
+        _fifo.push(ss::promise<T...>());
+        return _fifo.back().get_future();
+    }
+
+    /// Trigger oldest request in the list
+    void trigger(T&&... value) {
+        if (!_fifo.empty()) {
+            _fifo.front().set_value(std::forward<T>(value)...);
+            _fifo.pop();
+        }
+    }
+
+    /// Number of clients in the queue
+    size_t size() const { return _fifo.size(); }
+
+    /// Trigger all requests
+    void trigger_all(const T&... value) {
+        while (!_fifo.empty()) {
+            trigger(T(value)...);
+        }
+    }
+
+private:
+    using list_t = std::queue<ss::promise<T...>>;
+    list_t _fifo;
+};
+
+// FSM states
+
+using event_t = std::function<ss::future<>()>;
+
+struct st_pre_open {
+    std::string path;
+    ss::open_flags flags;
+    ss::file_open_options options;
+};
+struct st_open {
+    st_pre_open open_args;
+    std::optional<ss::file> file;
+    ss::gate gate;
+    /// Used by open_file_cache
+    intrusive_list_hook _hook;
+    /// Set by the file_stm::impl and invoked by cache on eviction. Switches the
+    /// file_stm state to st_evict.
+    event_t _on_evict;
+    /// Used by the file_stm in case when multiple fibers need to open the file
+    wait_list<> _wait_open;
+};
+struct st_evict {
+    st_pre_open reopen_args;
+    event_t _on_restore;
+};
+struct st_close {};
+} // namespace details
+
+/// \brief Cache that tracks opened files.
+///
+/// The max allowed cache size is an integer which
+/// allows the cache to hold more than 4-billion opened
+/// which is plentyfull. Zero value allows the cache
+/// to grow unconstrained.
+class open_file_cache final : ss::weakly_referencable<open_file_cache> {
+public:
+    using entry_t = details::st_open;
+    using entry_ref = std::reference_wrapper<entry_t>;
+
+    /// \brief Create file cache
+    ///
+    /// \param limit is a max allowed cache size
+    explicit open_file_cache(uint32_t limit);
+    ~open_file_cache();
+    open_file_cache(const open_file_cache&) = delete;
+    open_file_cache(open_file_cache&&) = delete;
+    open_file_cache& operator=(const open_file_cache&) = delete;
+    open_file_cache& operator=(open_file_cache&&) = delete;
+
+    /// Returns true if the cache is empty, and false otherwise.
+    bool empty() const { return _lru.empty(); }
+
+    /// Returns true if the cache is full
+    bool is_full() const { return _limit && _lru.size() >= _limit; }
+
+    /// \brief Add entry to the cache
+    ///
+    /// \param entry is a cache entry to put
+    ss::future<> put(entry_t& entry);
+
+    /// Evict file from cache
+    void evict(entry_t& entry);
+
+    /// Return true if the 'entry' is a first candidate for eviction
+    bool is_candidate(const entry_t& entry) const;
+
+    /// Bump file position in LRU cache
+    void touch(entry_t& entry);
+
+    /// Returns max allowed cache size
+    uint32_t max_allowed_count() const;
+
+    /// Returns true if some other fiber is waiting for eviction
+    bool eviction_awaited() const;
+
+private:
+    uint32_t _limit;
+    using list_t = intrusive_list<entry_t, &entry_t::_hook>;
+    using wait_list_t = details::wait_list<entry_ref>;
+    list_t _lru;
+    wait_list_t _eviction;
+};
+
+class file_stm final {
+    /// The object enters the gate of the st_open state
+    /// variable on creation and exits it when the object
+    /// is destroyed. Can be moved safely.
+    class lock_guard {
+        using gate_ref_t = std::reference_wrapper<ss::gate>;
+        using element_t = details::st_open;
+        using element_ref = std::reference_wrapper<element_t>;
+
+    public:
+        lock_guard();
+        lock_guard(
+          details::st_open& st, ss::lw_shared_ptr<open_file_cache> cache);
+        lock_guard(const lock_guard&) = delete;
+        lock_guard(lock_guard&&) = default;
+        lock_guard& operator=(const lock_guard&) = delete;
+        lock_guard& operator=(lock_guard&&) = default;
+        ~lock_guard();
+
+        /// Get transient file handle
+        /// The value returned by the method only works until the object
+        /// exist
+        ss::file get_file();
+
+    private:
+        std::optional<element_ref> _elem;
+        ss::lw_shared_ptr<open_file_cache> _cache;
+    };
+
+    class impl {
+        enum {
+            ix_pre_open,
+            ix_open,
+            ix_evict,
+            ix_close,
+        };
+        using file_state_t = std::variant<
+          details::st_pre_open,
+          details::st_open,
+          details::st_evict,
+          details::st_close>;
+
+    public:
+        impl(
+          std::string_view name,
+          ss::open_flags flags,
+          ss::file_open_options options,
+          ss::lw_shared_ptr<open_file_cache> cache);
+        ~impl();
+
+        // FSM events
+        ss::future<lock_guard> ev_access();
+        ss::future<> ev_close();
+        ss::future<> ev_evict();
+
+        bool is_pre_open() const;
+        bool is_opened() const;
+        bool is_evicted() const;
+        bool is_closed() const;
+
+        template<class... Arg>
+        static ss::lw_shared_ptr<impl> create(Arg... arg) {
+            return ss::make_lw_shared<impl>(arg...);
+        }
+
+    private:
+        ss::future<lock_guard>
+        state_transition_to_open(details::st_open&& newstate);
+
+        friend class open_file_cache;
+        file_state_t _state;
+        ss::lw_shared_ptr<open_file_cache> _cache;
+    };
+
+    explicit file_stm(ss::lw_shared_ptr<impl> impl);
+
+public:
+    file_stm() = default;
+    file_stm(const file_stm&) = default;
+    file_stm(file_stm&&) = default;
+    file_stm& operator=(const file_stm&) = default;
+    file_stm& operator=(file_stm&&) = default;
+
+    /// Call the function with ss::file as a parameter
+    ///
+    /// \param cb is a function to call with file
+    /// \param args is a list of optional arguments for 'cb'
+    /// \return future that returns result of the 'cb'
+    template<class Fn, class... OptArgs>
+    auto with_file(Fn&& cb, OptArgs... args) {
+        return _impl->ev_access().then([this,
+                                        func = std::forward<Fn>(cb),
+                                        args...](lock_guard guard) mutable {
+            return func(guard.get_file(), args...);
+        });
+    }
+
+    /// Check internal state
+    bool is_pre_open() const;
+    bool is_opened() const;
+    bool is_evicted() const;
+    bool is_closed() const;
+
+    /// Returns true if the object refers to the actual file
+    explicit operator bool() const noexcept { return static_cast<bool>(_impl); }
+
+    ss::future<> close();
+
+    /// Access the file object indirectly
+    ss::future<lock_guard> get_file();
+
+private:
+    friend class open_file_cache;
+    friend ss::future<file_stm> open_file_dma(
+      std::string_view name,
+      ss::open_flags flags,
+      ss::file_open_options options,
+      ss::lw_shared_ptr<open_file_cache> cache,
+      open_file_stm_options stm_opt);
+
+    ss::lw_shared_ptr<impl> _impl;
+};
+
+/// Opens or creates a file_stm object. Similar to
+/// seastar function with the same name.
+///
+/// \param name  the name of the file
+/// \param flags open flags
+/// \param options file opening options
+/// \param cache is a file cache
+/// \param stm_opt controls how the file is opened (immediately or on-demand)
+/// \return a \ref file_stm as a future
+ss::future<file_stm> open_file_dma(
+  std::string_view name,
+  ss::open_flags flags,
+  ss::file_open_options options,
+  ss::lw_shared_ptr<open_file_cache> cache,
+  open_file_stm_options stm_opt = open_file_stm_options::eager);
+ss::future<file_stm> open_file_dma(
+  std::string_view name,
+  ss::open_flags flags,
+  ss::lw_shared_ptr<open_file_cache> cache,
+  open_file_stm_options stm_opt = open_file_stm_options::eager);
+
+/// \brief Creates an input_stream to read a portion of a file.
+///
+/// Same as make_file_input_stream. Prevents eviction of the file until
+/// input_stream exists.
+ss::input_stream<char> make_file_input_stream(
+  file_stm file,
+  uint64_t offset,
+  uint64_t len,
+  ss::file_input_stream_options options = {});
+
+} // namespace storage

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -189,3 +189,12 @@ rp_test(
   LIBRARIES Seastar::seastar_perf_testing v::storage
   LABELS storage
 )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME file_stm_test
+  SOURCES file_stm_test.cc
+  LIBRARIES v::seastar_testing_main v::storage_test_utils
+  LABELS storage
+  ARGS "-- -c 1"
+)

--- a/src/v/storage/tests/file_stm_test.cc
+++ b/src/v/storage/tests/file_stm_test.cc
@@ -1,0 +1,386 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "storage/file_stm.h"
+
+#include <seastar/core/future-util.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/tmp_file.hh>
+
+#include <boost/scope_exit.hpp>
+#include <boost/test/tools/old/interface.hpp>
+
+#include <chrono>
+
+SEASTAR_THREAD_TEST_CASE(wait_list_void_trigger_all) {
+    using namespace storage::details;
+    wait_list<> list;
+    auto fut1 = list.wait();
+    auto fut2 = list.wait();
+    BOOST_REQUIRE(!fut1.available());
+    BOOST_REQUIRE(!fut2.available());
+    list.trigger_all();
+    BOOST_REQUIRE(fut1.available());
+    BOOST_REQUIRE(fut2.available());
+    fut1.get();
+    fut2.get();
+}
+
+SEASTAR_THREAD_TEST_CASE(wait_list_int_trigger_all) {
+    using namespace storage::details;
+    wait_list<int> list;
+    auto fut1 = list.wait();
+    auto fut2 = list.wait();
+    BOOST_REQUIRE(!fut1.available());
+    BOOST_REQUIRE(!fut2.available());
+    list.trigger_all(42);
+    BOOST_REQUIRE(fut1.available());
+    BOOST_REQUIRE(fut2.available());
+    BOOST_REQUIRE_EQUAL(fut1.get0(), 42);
+    BOOST_REQUIRE_EQUAL(fut2.get0(), 42);
+}
+
+SEASTAR_THREAD_TEST_CASE(wait_list_trigger_by_one) {
+    using namespace storage::details;
+    wait_list<int> list;
+    auto fut1 = list.wait();
+    auto fut2 = list.wait();
+    BOOST_REQUIRE(!fut1.available());
+    BOOST_REQUIRE(!fut2.available());
+    list.trigger(42);
+    BOOST_REQUIRE(fut1.available());
+    BOOST_REQUIRE(!fut2.available());
+    BOOST_REQUIRE_EQUAL(fut1.get0(), 42);
+    list.trigger(24);
+    BOOST_REQUIRE(fut2.available());
+    BOOST_REQUIRE_EQUAL(fut2.get0(), 24);
+}
+
+SEASTAR_THREAD_TEST_CASE(wait_list_destroyed) {
+    using namespace storage::details;
+    auto fut = ss::now();
+    {
+        wait_list<> list;
+        fut = list.wait();
+    }
+    BOOST_REQUIRE(fut.available());
+    BOOST_REQUIRE(fut.failed());
+    BOOST_REQUIRE_THROW(fut.get0(), ss::broken_promise);
+}
+
+SEASTAR_THREAD_TEST_CASE(wait_list_trigger_empty) {
+    using namespace storage::details;
+    wait_list<> list;
+    list.trigger();
+    BOOST_REQUIRE(list.size() == 0);
+}
+
+static ss::future<> no_op_event() { return ss::now(); }
+
+SEASTAR_THREAD_TEST_CASE(open_file_cache_entry_dtor) {
+    using namespace storage;
+    open_file_cache cache(1);
+    BOOST_REQUIRE(cache.empty());
+    {
+        open_file_cache::entry_t node{
+          ._on_evict = &no_op_event,
+        };
+        BOOST_REQUIRE(!node._hook.is_linked());
+        cache.put(node).get();
+        BOOST_REQUIRE(!cache.empty());
+        BOOST_REQUIRE(node._hook.is_linked());
+    }
+    BOOST_REQUIRE(cache.empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(open_file_cache_put_evict) {
+    using namespace storage;
+    open_file_cache cache(1);
+    BOOST_REQUIRE(cache.empty());
+    open_file_cache::entry_t node{
+      ._on_evict = &no_op_event,
+    };
+    BOOST_REQUIRE(!node._hook.is_linked());
+    cache.put(node).get();
+    BOOST_REQUIRE(node._hook.is_linked());
+    cache.evict(node);
+    BOOST_REQUIRE(!node._hook.is_linked());
+}
+
+SEASTAR_THREAD_TEST_CASE(open_file_cache_no_wait_evict) {
+    using namespace storage;
+    open_file_cache cache(1);
+    BOOST_REQUIRE(cache.empty());
+    bool node1_triggered = false;
+    open_file_cache::entry_t node1{
+      ._on_evict =
+        [&node1_triggered] {
+            node1_triggered = true;
+            return ss::now();
+        },
+    };
+    open_file_cache::entry_t node2{
+      ._on_evict = &no_op_event,
+    };
+    cache.put(node1).get();
+    BOOST_REQUIRE(cache.is_full());
+    auto fut = cache.put(node2); // this future should evict node1
+    BOOST_REQUIRE(fut.available());
+    fut.get();
+    BOOST_REQUIRE(node1_triggered);
+    BOOST_REQUIRE(cache.is_full());
+    cache.evict(node1);
+    BOOST_REQUIRE(!node1._hook.is_linked());
+    BOOST_REQUIRE(node2._hook.is_linked());
+}
+
+SEASTAR_THREAD_TEST_CASE(open_file_cache_wait_evict) {
+    using namespace storage;
+    open_file_cache cache(1);
+    BOOST_REQUIRE(cache.empty());
+    bool node1_triggered = false;
+    open_file_cache::entry_t node1{
+      ._on_evict =
+        [&node1_triggered] {
+            node1_triggered = true;
+            return ss::now();
+        },
+    };
+    open_file_cache::entry_t node2{
+      ._on_evict = &no_op_event,
+    };
+    cache.put(node1).get();
+    BOOST_REQUIRE(cache.is_full());
+    BOOST_REQUIRE(cache.is_candidate(node1));
+    node1.gate.enter(); // this should prevent subsequent put to evict node1
+    auto fut = cache.put(node2); // this future should evict node1
+    BOOST_REQUIRE(cache.is_candidate(node1));
+    BOOST_REQUIRE(
+      !fut.available()); // will only be available after node1 eviction
+    node1.gate.leave();
+    cache.evict(node1);
+    fut.get();
+    BOOST_REQUIRE(node1_triggered);
+    BOOST_REQUIRE(cache.is_full());
+    BOOST_REQUIRE(!node1._hook.is_linked());
+    BOOST_REQUIRE(node2._hook.is_linked());
+}
+
+SEASTAR_THREAD_TEST_CASE(file_stm_close) {
+    ss::tmp_dir dir = ss::make_tmp_dir("/tmp/file-stm-test-XXXX").get0();
+    BOOST_SCOPE_EXIT_ALL(&dir) { dir.remove().get(); };
+    using namespace storage;
+    auto cache = ss::make_lw_shared<open_file_cache>(3);
+    auto path1 = dir.get_path();
+    path1.append("file1");
+    auto path2 = dir.get_path();
+    path2.append("file2");
+    auto file1 = open_file_dma(
+                   path1.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    auto file2 = open_file_dma(
+                   path2.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    file1.close().get();
+    file2.close().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(file_stm_evict) {
+    ss::tmp_dir dir = ss::make_tmp_dir("/tmp/file-stm-test-XXXX").get0();
+    BOOST_SCOPE_EXIT_ALL(&dir) { dir.remove().get(); };
+    using namespace storage;
+    auto cache = ss::make_lw_shared<open_file_cache>(3);
+    auto path1 = dir.get_path();
+    path1.append("file1");
+    auto path2 = dir.get_path();
+    path2.append("file2");
+    auto path3 = dir.get_path();
+    path3.append("file3");
+    auto file1 = open_file_dma(
+                   path1.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    auto file2 = open_file_dma(
+                   path2.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    auto file3 = open_file_dma(
+                   path3.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    BOOST_REQUIRE(file1.is_evicted());
+    BOOST_REQUIRE(file2.is_opened());
+    BOOST_REQUIRE(file3.is_opened());
+    file1.close().get();
+    file2.close().get();
+    file3.close().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(file_stm_reopen_triggered_by_access) {
+    ss::tmp_dir dir = ss::make_tmp_dir("/tmp/file-stm-test-XXXX").get0();
+    BOOST_SCOPE_EXIT_ALL(&dir) { dir.remove().get(); };
+    using namespace storage;
+    auto cache = ss::make_lw_shared<open_file_cache>(3);
+    auto path1 = dir.get_path();
+    path1.append("file1");
+    auto path2 = dir.get_path();
+    path2.append("file2");
+    auto path3 = dir.get_path();
+    path3.append("file3");
+    auto file1 = open_file_dma(
+                   path1.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    auto file2 = open_file_dma(
+                   path2.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    auto file3 = open_file_dma(
+                   path3.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    BOOST_REQUIRE(file1.is_evicted());
+    BOOST_REQUIRE(file2.is_opened());
+    BOOST_REQUIRE(file3.is_opened());
+    file1
+      .with_file([file1, file2, file3](const ss::file& underlying) {
+          BOOST_REQUIRE(static_cast<bool>(underlying));
+          BOOST_REQUIRE(file1.is_opened());
+          BOOST_REQUIRE(file2.is_evicted());
+          BOOST_REQUIRE(file3.is_opened());
+          return ss::now();
+      })
+      .get();
+    file1.close().get();
+    file2.close().get();
+    file3.close().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(file_stm_blocked_eviction) {
+    /// File open operation can't evict another file immediately because it's in
+    /// use
+    ss::tmp_dir dir = ss::make_tmp_dir("/tmp/file-stm-test-XXXX").get0();
+    BOOST_SCOPE_EXIT_ALL(&dir) { dir.remove().get(); };
+    using namespace storage;
+    auto cache = ss::make_lw_shared<open_file_cache>(2);
+    auto path1 = dir.get_path();
+    path1.append("file1");
+    auto path2 = dir.get_path();
+    path2.append("file2");
+    auto file1 = open_file_dma(
+                   path1.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    auto file2 = open_file_dma(
+                   path2.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache,
+                   open_file_stm_options::lazy)
+                   .get0();
+    BOOST_REQUIRE(file1.is_opened());
+    BOOST_REQUIRE(
+      file2.is_pre_open()); // file is to be opened on first access attempt
+    file1
+      .with_file([file1, file2](const ss::file& underlying) mutable {
+          // file1 is an eviction candidate because it's LRU, it can't be
+          // evicted while this lambda is still running
+          BOOST_REQUIRE(static_cast<bool>(underlying));
+          BOOST_REQUIRE(file1.is_opened());
+          BOOST_REQUIRE(file2.is_pre_open());
+          return file2.with_file(
+            [file1, file2](const ss::file& underlying) mutable {
+                // here first lambda is not running anymore, file1 should be
+                // evicted
+                BOOST_REQUIRE(static_cast<bool>(underlying));
+                BOOST_REQUIRE(file1.is_evicted());
+                BOOST_REQUIRE(file2.is_opened());
+                return file1.with_file(
+                  [file1, file2](const ss::file& underlying) mutable {
+                      BOOST_REQUIRE(static_cast<bool>(underlying));
+                      BOOST_REQUIRE(file1.is_opened());
+                      BOOST_REQUIRE(file2.is_evicted());
+                      return ss::now();
+                  });
+            });
+      })
+      .get();
+    file1.close().get();
+    file2.close().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(file_stm_eviction_triggered_by_close) {
+    // Eviction is triggered by close of the file.
+    ss::tmp_dir dir = ss::make_tmp_dir("/tmp/file-stm-test-XXXX").get0();
+    BOOST_SCOPE_EXIT_ALL(&dir) { dir.remove().get(); };
+    using namespace storage;
+    auto cache = ss::make_lw_shared<open_file_cache>(3);
+    auto path1 = dir.get_path();
+    path1.append("file1");
+    auto path2 = dir.get_path();
+    path2.append("file2");
+    auto path3 = dir.get_path();
+    path3.append("file3");
+    auto file1 = open_file_dma(
+                   path1.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    auto file2 = open_file_dma(
+                   path2.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache)
+                   .get0();
+    auto file3 = open_file_dma(
+                   path3.native(),
+                   ss::open_flags::create | ss::open_flags::rw,
+                   cache,
+                   open_file_stm_options::lazy)
+                   .get0();
+    BOOST_REQUIRE(file1.is_opened());
+    BOOST_REQUIRE(file2.is_opened());
+    BOOST_REQUIRE(
+      file3.is_pre_open()); // file is to be opened on first access attempt
+    file1
+      .with_file([file1, file2, file3](const ss::file& underlying) mutable {
+          BOOST_REQUIRE(static_cast<bool>(underlying));
+          BOOST_REQUIRE(file1.is_opened());
+          BOOST_REQUIRE(file2.is_opened());
+          BOOST_REQUIRE(file3.is_pre_open());
+          auto fut = file3.with_file(
+            [file1, file2, file3](const ss::file& underlying) mutable {
+                // this will wait until file1 will be closed
+                BOOST_REQUIRE(static_cast<bool>(underlying));
+                BOOST_REQUIRE(file1.is_opened());
+                BOOST_REQUIRE(file2.is_closed());
+                BOOST_REQUIRE(file3.is_opened());
+                return ss::now();
+            });
+          // should become available when file1 will be closed
+          return ss::when_all_succeed(file2.close(), std::move(fut));
+      })
+      .get();
+    file1.close().get();
+    file3.close().get();
+}


### PR DESCRIPTION
## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.

The `file_stm` is a file object controlled by the shared LRU cache. The `open_file_cache` should be created per-shard. 
Every created 'file_stm' can be in one of the following states:
- st_pre_open
- st_open
- st_evict
- st_close

The 'st_pre_open' state contains information needed to open the file. The file transitions to the next 'st_open' state on first access. After transition it's added to the LRU cache which can eventually evict it. In this case the 'file_stm' object transitions to 'st_evict' state from which it can be brought back by any attempt to access the file (which will reopen the file and move it to st_open state).
File can be closed (and moved to st_close state) from any other sate. 

The reads are performed via `with_file` method which prevents file being closed or evicted.

You can find more details in [this RFC](https://docs.google.com/document/d/18V2JFOU-7bBrdO4vjFUax28cEEOaDGGpjVT5LZ0m2rQ/edit?usp=sharing).
