### PR TITLE
Save logs on files

### DIFF
--- a/src/js/modules/rpc/service.ts
+++ b/src/js/modules/rpc/service.ts
@@ -13,14 +13,11 @@ import { safeLoadAll } from "js-yaml";
 import { join, resolve } from "path";
 import * as fs from "fs";
 import { promisify } from "util";
-import { newLogger } from "../utilities/Logging";
-
-const logger = newLogger("service");
+import LogService from "../utilities/Logging";
 
 // read yaml config file
 const readConfigFile = (confPath: string): Promise<Record<string, any>> => {
   try {
-    logger.info(`Reading from config file: ${confPath}`);
     return fs.promises.readFile(confPath).then((file) => safeLoadAll(file)[0]);
   } catch (e) {
     return Promise.reject(new Error(`Error reading config file: ${e.message}`));
@@ -37,6 +34,7 @@ const validateOrCreateScaffolding = (directoryPath: string): Promise<void> => {
     const path = join(directoryPath, folder);
     return exists(path).then((exist) => {
       if (!exist) {
+        const logger = LogService.createLogger("service");
         logger.info(`Creating part of scaffolding ${path}`);
         return fs.promises.mkdir(path, { recursive: true });
       }
@@ -47,17 +45,21 @@ const validateOrCreateScaffolding = (directoryPath: string): Promise<void> => {
 
 function main() {
   // read config file path argument
-  logger.info("Starting redpanda wasm service...");
   const configPathArg = process.argv.splice(2)[0];
-  const defaultConfigPath = "/var/lib/redpanda/conf/redpanda.yaml";
+  const defaultConfigPath = "/etc/redpanda/redpanda.yaml";
   const defaultCoprocessorPath = "/var/lib/redpanda/coprocessor";
+  const defaultLogFile = "/var/lib/redpanda/coprocessor/logs/wasm";
   // resolve config path or assign default value
   const configPath = configPathArg ? resolve(configPathArg) : defaultConfigPath;
-  logger.info(`Using redpanda configuration path: ${configPath}`);
 
   readConfigFile(configPath).then((config) => {
     const port = config?.redpanda?.coproc_supervisor_server || 43189;
     const path = config?.coproc_engine?.path || defaultCoprocessorPath;
+    const logFilePath = config?.coproc_engine?.logFilePath || defaultLogFile;
+    LogService.setPath(logFilePath);
+    const logger = LogService.createLogger("service");
+    logger.info("Starting redpanda wasm service...");
+    logger.info(`Reading from config file: ${configPath}`);
     logger.info(`Using root scaffolding path: ${path}`);
     validateOrCreateScaffolding(path).then(() => {
       const service = new ProcessBatchServer(

--- a/src/js/modules/supervisors/FileManager.ts
+++ b/src/js/modules/supervisors/FileManager.ts
@@ -24,6 +24,7 @@ import {
   validateDisableResponseCode,
   validateEnableResponseCode,
 } from "./HandleError";
+import { closeProcess } from "../rpc/service";
 
 /**
  * FileManager class is an inotify implementation, it receives a
@@ -46,7 +47,8 @@ class FileManager {
       .then(() => this.readCoprocessorFolder(repository, this.submitDir))
       .then(() => this.startWatchers(repository))
       .catch((e) => {
-        throw Error(`Failed startup the FileManager: ${e.message}`);
+        // fatal error close
+        closeProcess(e);
       });
   }
 

--- a/src/js/modules/utilities/Logging.ts
+++ b/src/js/modules/utilities/Logging.ts
@@ -9,40 +9,112 @@
  */
 
 import * as winston from "winston";
+import { Container, Logger, LoggerOptions } from "winston";
 
-export function newLogger(
-  module_name: string,
-  logLevel = "info",
-  simplify = false
-) {
-  const rpWasmFormatter = () => {
-    const logLineFormatter = winston.format.printf(
-      ({ level, message, label, timestamp }) => {
-        return `${timestamp} [${label}] ${level}: ${message}`;
+const maxLogFileSize = 5000000;
+
+const rpWasmFormatter = (moduleName: string, simplify: boolean) => {
+  const logLineFormatter = winston.format.printf(
+    ({ level, message, label, timestamp }) => {
+      return `${timestamp} [${label}] ${level}: ${message}`;
+    }
+  );
+  const simpleLogLineFormatter = winston.format.printf(
+    ({ level, message, label }) => {
+      return `[${label}] ${level}: ${message}`;
+    }
+  );
+
+  return (simplify ? [] : [winston.format.timestamp()]).concat([
+    winston.format.splat(),
+    winston.format.label({ label: moduleName }),
+    simplify ? simpleLogLineFormatter : logLineFormatter,
+  ]);
+};
+
+export class LogService {
+  private static instance: LogService;
+  private logFilePath: string;
+  private winstonContext: Container;
+  private isClosed = false;
+
+  constructor() {
+    this.winstonContext = new winston.Container();
+  }
+
+  static getInstance(): LogService {
+    if (this.instance == undefined) {
+      this.instance = new LogService();
+      return this.instance;
+    }
+    return this.instance;
+  }
+
+  setPath(path: string): void {
+    if (this.logFilePath == undefined) {
+      this.logFilePath = path;
+    }
+  }
+
+  getPath(): string {
+    return this.logFilePath;
+  }
+
+  createLogger(
+    moduleName: string,
+    option?: LoggerOptions,
+    simplify = false
+  ): Logger {
+    if (!this.isClosed) {
+      const prevModule = this.winstonContext.has(moduleName);
+      if (prevModule) {
+        return this.winstonContext.get(moduleName);
       }
-    );
-    const simpleLogLineFormatter = winston.format.printf(
-      ({ level, message, label }) => {
-        return `[${label}] ${level}: ${message}`;
-      }
-    );
 
-    return (simplify ? [] : [winston.format.timestamp()]).concat([
-      winston.format.splat(),
-      winston.format.label({ label: module_name }),
-      simplify ? simpleLogLineFormatter : logLineFormatter,
-    ]);
-  };
+      const loggerConfig = {
+        ...option,
+        level: option?.level,
+        format: winston.format.combine(
+          ...rpWasmFormatter(moduleName, simplify)
+        ),
+        defaultMeta: { service: moduleName },
+        transports: [
+          new winston.transports.Console({
+            level: option?.level,
+          }),
+          new winston.transports.File({
+            maxsize: maxLogFileSize,
+            filename: this.logFilePath,
+            level: option?.level,
+          }),
+        ],
+        exitOnError: false,
+      };
+      return this.winstonContext.add(moduleName, loggerConfig);
+    } else {
+      throw Error(
+        "Service Logger was closed, it's not possible create a new " + "logger"
+      );
+    }
+  }
 
-  const logger = winston.createLogger({
-    level: logLevel,
-    format: winston.format.combine(...rpWasmFormatter()),
-    defaultMeta: { service: module_name },
-    transports: [
-      new winston.transports.Console({
-        level: logLevel,
-      }),
-    ],
-  });
-  return logger;
+  getLogger(id: string): Logger {
+    return this.winstonContext.get(id);
+  }
+
+  close(): Promise<void> {
+    this.isClosed = true;
+    const closeLoggers = [...this.winstonContext.loggers.values()].map(
+      (logger) =>
+        new Promise((resolve) => {
+          logger.on("finish", resolve);
+          logger.end();
+        })
+    );
+    return Promise.all(closeLoggers).then(() =>
+      console.log("All outstanding logs have been flushed")
+    );
+  }
 }
+
+export default LogService.getInstance();

--- a/src/js/test/rpc/server.test.ts
+++ b/src/js/test/rpc/server.test.ts
@@ -21,6 +21,7 @@ import { PolicyError, RecordBatch } from "../../modules/public/Coprocessor";
 import assert = require("assert");
 import * as chokidar from "chokidar";
 import LogService from "../../modules/utilities/Logging";
+const fs = require("fs");
 
 let sinonInstance: SinonSandbox;
 let server: ProcessBatchServer;
@@ -340,6 +341,26 @@ describe("Server", function () {
           });
         });
       });
+    });
+
+    it("should close logger if there is a fatal exception", (done) => {
+      const fsStub = sinonInstance.stub(fs, "writeFile").returns(null);
+      sinonInstance.stub(LogService, "getPath").returns("a");
+      const close = sinonInstance.stub(LogService, "close");
+      close.returns(Promise.resolve());
+      new ProcessBatchServer("a", "a", "a");
+      // waiting for firing exception
+      setTimeout(() => {
+        assert(close.called);
+        assert(fsStub.called);
+        // validate FileManager exception, this exception happens when it tries
+        // to read unexciting folder
+        assert.strictEqual(
+          fsStub.firstCall.args[1],
+          "Error: ENOENT: no such file or directory, scandir 'a'"
+        );
+        done();
+      }, 10);
     });
   });
 });

--- a/src/js/test/rpc/server.test.ts
+++ b/src/js/test/rpc/server.test.ts
@@ -20,6 +20,7 @@ import { createHandle } from "../testUtilities";
 import { PolicyError, RecordBatch } from "../../modules/public/Coprocessor";
 import assert = require("assert");
 import * as chokidar from "chokidar";
+import LogService from "../../modules/utilities/Logging";
 
 let sinonInstance: SinonSandbox;
 let server: ProcessBatchServer;
@@ -82,8 +83,8 @@ const createProcessBatchRequest = (
 describe("Client", function () {
   it("create() should not return a client if fails to connect", () => {
     return SupervisorClient.create(40000)
-      .then((_c) => false)
-      .catch((_e) => true)
+      .then(() => false)
+      .catch(() => true)
       .then((value) => {
         assert(value, "A client should not have been created");
       });
@@ -94,6 +95,15 @@ describe("Server", function () {
   describe("Given a Request", function () {
     beforeEach(() => {
       sinonInstance = createSandbox();
+      //Mock LogService
+      sinonInstance.stub(LogService, "createLogger").returns({
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        info: sinonInstance.stub(),
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        error: sinonInstance.stub(),
+      });
       manageServer = new ManagementServer();
       manageServer.disable_copros = () => Promise.resolve({ inputs: [0] });
       manageServer.listen(43118);

--- a/src/js/test/supervisors/FileManager.test.ts
+++ b/src/js/test/supervisors/FileManager.test.ts
@@ -17,6 +17,7 @@ import * as fs from "fs";
 import { createHandle } from "../testUtilities";
 import { hash64 } from "xxhash";
 import * as chokidar from "chokidar";
+import LogService from "../../modules/utilities/Logging";
 
 let sinonInstance: SinonSandbox;
 let server: ManagementServer;
@@ -45,6 +46,15 @@ const createStubs = (sandbox: SinonSandbox) => {
   const disableCoprocessor = sandbox
     .stub(FileManager.prototype, "disableCoprocessors")
     .returns(Promise.resolve());
+
+  sandbox.stub(LogService, "createLogger").returns({
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    info: sandbox.stub(),
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    error: sandbox.stub(),
+  });
 
   return {
     moveCoprocessor,

--- a/src/js/test/utilities/Logging.test.ts
+++ b/src/js/test/utilities/Logging.test.ts
@@ -1,0 +1,58 @@
+import { LogService } from "../../modules/utilities/Logging";
+import assert = require("assert");
+import { readFile } from "fs";
+import * as fs from "fs";
+import * as path from "path";
+
+describe("Logging Wrap", () => {
+  const logPath = path.resolve("./test/utilities/logs.log");
+
+  before(() => {
+    try {
+      fs.unlink(logPath, () => {
+        console.log("remove file");
+      });
+    } catch (e) {
+      undefined;
+    }
+  });
+
+  it("shouldn't change log path after set the first time ", function () {
+    const LoggerWrapInstance = new LogService();
+    LoggerWrapInstance.setPath(logPath);
+    assert.strictEqual(LoggerWrapInstance.getPath(), logPath);
+    LoggerWrapInstance.setPath("another/path");
+    assert.strictEqual(LoggerWrapInstance.getPath(), logPath);
+  });
+
+  it("should wait for closing loggers", function (done) {
+    const LoggerWrapInstance = new LogService();
+    LoggerWrapInstance.setPath(logPath);
+    const logger1 = LoggerWrapInstance.createLogger("test");
+    const logger2 = LoggerWrapInstance.createLogger("test2");
+
+    logger1.info("test1.1");
+    logger1.info("test1.2");
+    logger2.info("test2.1");
+    logger2.info("test2.2");
+
+    LoggerWrapInstance.close().then(() => {
+      // add a timeout in order to wait for creating log file, when we put small
+      // logs on winston it doesn't create the log file immediately
+      setTimeout(() => {
+        readFile(logPath, (err, data) => {
+          if (err) {
+            done(err);
+          }
+          // it doesn't check all log format because the time changes for each
+          // test, just check the log message.
+          assert(data.toString().includes("[test] info: test1.1\n"));
+          assert(data.toString().includes("[test] info: test1.2\n"));
+          assert(data.toString().includes("[test2] info: test2.1\n"));
+          assert(data.toString().includes("[test2] info: test2.2\n"));
+          done();
+        });
+      }, 10);
+    });
+  });
+});


### PR DESCRIPTION
why? save logs on files, no more 5mb per file

changes:
- Logging.ts -> add a transform for files and add extra argument to
createLogger, in order to pass the logs file path.

- service.ts -> create service class for read and start server

- FileManager.ts ^ server.ts -> pass new function argument that
allows to crate a logger with same log files

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
