### PR TITLE
k/fetch_request: made fetch reads debouncing timeout configurable

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -209,6 +209,13 @@ configuration::configuration()
       "Interaval for metadata dissemination batching",
       required::no,
       3'000ms)
+  , fetch_reads_debounce_timeout(
+      *this,
+      "fetch_reads_debounce_timeout",
+      "Time to wait for next read in fetch request when requested min bytes "
+      "wasn't reached",
+      required::no,
+      1ms)
   , delete_retention_ms(
       *this,
       "delete_retention_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -69,6 +69,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> group_initial_rebalance_delay;
     property<std::chrono::milliseconds> group_new_member_join_timeout;
     property<std::chrono::milliseconds> metadata_dissemination_interval_ms;
+    property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
     // same as delete.retention.ms in kafka
     property<std::chrono::milliseconds> delete_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;


### PR DESCRIPTION
Made the fetch debouncing timeout configurable. We can leverage the
debouncing timeout setting to tune E2E latency.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
