### PR TITLE
r/recovery_stm: fixed triggering read when there are no data

### DIFF
--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -125,7 +125,7 @@ bool recovery_stm::state_changed() {
         return true;
     }
     return _ptr->_log.offsets().dirty_offset
-           >= meta.value()->last_dirty_log_index;
+           > meta.value()->last_dirty_log_index;
 }
 
 ss::future<> recovery_stm::read_range_for_recovery(


### PR DESCRIPTION
Incorrect check was causing recovery to stop as there were no data to
read for the follower. Fixed this issue by only triggering read for
recovery when there are actual data to read for the follower.

Incorrect handling of recovery caused significant increase in ACKS=1
e2e latency.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
