### PR TITLE
rpk: fix running tests on macos

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/status_test.go
+++ b/src/go/rpk/pkg/cli/cmd/status_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package cmd
 
 import (

--- a/src/go/rpk/pkg/tuners/redpanda_checkers_test.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package tuners_test
 
 import (


### PR DESCRIPTION
by excluding linux specific files using build tags. 