### PR TITLE
r/consensus: fixed updating follower state when its data were deleted

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -266,6 +266,10 @@ consensus::success_reply consensus::update_follower_index(
         // we are already recovering, if follower dirty log index moved back
         // from some reason (i.e. truncation, data loss, trigger recovery)
         if (idx.last_dirty_log_index > reply.last_dirty_log_index) {
+            // update follower state to allow recovery of follower with
+            // missing entries
+            idx.last_dirty_log_index = reply.last_dirty_log_index;
+            idx.last_committed_log_index = reply.last_committed_log_index;
             idx.next_index = details::next_offset(idx.last_dirty_log_index);
             idx.follower_state_change.broadcast();
         }


### PR DESCRIPTION
When follower was up to date with the leader and its data were deleted
it may happen that recovery STM will never be trigger as the follower
state is not updated. Added updating follower state (its dirty and
committed offset) when its dirty index moved backward.

NOTE: this problem caused `test_raft_rpunit` to fail sometimes.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
