### PR TITLE
rpc/connection_cache: increased number of connections per shard

### DIFF
--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -102,11 +102,22 @@ inline ss::shard_id connection_cache::shard_for(
   ss::shard_id src_shard,
   model::node_id n,
   ss::shard_id total_shards) {
-    static const constexpr size_t vnodes = 3;
+    if (ss::smp::count <= 8) {
+        return src_shard;
+    }
+    static const constexpr size_t vnodes = 8;
     /// make deterministic - choose 1 prime to mix node_id with
     /// https://planetmath.org/goodhashtableprimes
     static const constexpr std::array<size_t, vnodes> universe{
-      {402653189, 805306457, 1610612741}};
+      {12582917,
+       25165843,
+       50331653,
+       100663319,
+       201326611,
+       402653189,
+       805306457,
+       1610612741}};
+
     // NOLINTNEXTLINE
     size_t h = universe[jump_consistent_hash(src_shard, vnodes)];
     boost::hash_combine(h, std::hash<model::node_id>{}(n));


### PR DESCRIPTION
Increased total number of inter node connections. On machines with
higher number of cores not sufficient connections count cause
performance issues.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
