### PR TITLE
rpk/checkers: fixed creating gcp ssd tuner checker

### DIFF
--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -246,8 +246,7 @@ func RedpandaCheckers(
 	// NOTE: important workaround for very high flush latency in
 	//       GCP when using local SSD's
 	gcpVendor := gcp.GcpVendor{}
-	if err != nil && v.Name() == gcpVendor.Name() {
-
+	if err == nil && v.Name() == gcpVendor.Name() {
 		checkers[WriteCachePolicyChecker] = []Checker{NewDirectoryWriteCacheChecker(fs,
 			config.Redpanda.Directory,
 			deviceFeatures,


### PR DESCRIPTION
Incorrect error handling caused NIL pointer dereference and RPK crash.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
