### PR TITLE
Kafka request client compatibility

### DIFF
--- a/src/v/kafka/requests/api_versions_request.h
+++ b/src/v/kafka/requests/api_versions_request.h
@@ -65,7 +65,7 @@ struct api_versions_response final {
 
 std::ostream& operator<<(std::ostream&, const api_versions_response&);
 
-static inline bool operator==(
+inline bool operator==(
   const api_versions_response_key& a, const api_versions_response_key& b) {
     return a.api_key == b.api_key && a.min_version == b.min_version
            && a.max_version == b.max_version;

--- a/src/v/kafka/requests/heartbeat_request.h
+++ b/src/v/kafka/requests/heartbeat_request.h
@@ -22,7 +22,11 @@
 
 namespace kafka {
 
+struct heartbeat_response;
+
 struct heartbeat_api final {
+    using response_type = heartbeat_response;
+
     static constexpr const char* name = "heartbeat";
     static constexpr api_key key = api_key(12);
     static constexpr api_version min_supported = api_version(0);
@@ -33,6 +37,8 @@ struct heartbeat_api final {
 };
 
 struct heartbeat_request final {
+    using api_type = heartbeat_api;
+
     heartbeat_request_data data;
 
     // set during request processing after mapping group to ntp
@@ -56,6 +62,8 @@ struct heartbeat_response final {
 
     heartbeat_response_data data;
 
+    heartbeat_response() = default;
+
     explicit heartbeat_response(error_code error)
       : data({
         .throttle_time_ms = std::chrono::milliseconds(0),
@@ -66,6 +74,10 @@ struct heartbeat_response final {
       : heartbeat_response(error) {}
 
     void encode(const request_context&, response&);
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
 };
 
 inline ss::future<heartbeat_response> make_heartbeat_error(error_code error) {

--- a/src/v/kafka/requests/join_group_request.h
+++ b/src/v/kafka/requests/join_group_request.h
@@ -131,7 +131,7 @@ struct join_group_response final {
     }
 };
 
-static inline join_group_response
+inline join_group_response
 _make_join_error(kafka::member_id member_id, error_code error) {
     return join_group_response(
       error, no_generation, no_protocol, no_leader, std::move(member_id));
@@ -150,7 +150,7 @@ operator<<(std::ostream& os, const join_group_response& r) {
 
 // group membership helper to compare a protocol set from the wire with our
 // internal type without doing a full type conversion.
-static inline bool operator==(
+inline bool operator==(
   const std::vector<join_group_request_protocol>& a,
   const std::vector<member_protocol>& b) {
     return std::equal(

--- a/src/v/kafka/requests/join_group_request.h
+++ b/src/v/kafka/requests/join_group_request.h
@@ -102,7 +102,7 @@ struct join_group_response final {
       : join_group_response(
         error, no_generation, no_protocol, no_leader, member_id) {}
 
-    join_group_response(kafka::error_code error)
+    explicit join_group_response(kafka::error_code error)
       : join_group_response(no_member, error) {}
 
     join_group_response(const join_group_request& r, kafka::error_code error)

--- a/src/v/kafka/requests/join_group_request.h
+++ b/src/v/kafka/requests/join_group_request.h
@@ -24,7 +24,11 @@
 
 namespace kafka {
 
+struct join_group_response;
+
 struct join_group_api final {
+    using response_type = join_group_response;
+
     static constexpr const char* name = "join group";
     static constexpr api_key key = api_key(11);
     static constexpr api_version min_supported = api_version(0);
@@ -35,6 +39,8 @@ struct join_group_api final {
 };
 
 struct join_group_request final {
+    using api_type = join_group_api;
+
     join_group_request_data data;
 
     join_group_request() = default;
@@ -90,6 +96,8 @@ struct join_group_response final {
 
     join_group_response_data data;
 
+    join_group_response() = default;
+
     join_group_response(kafka::member_id member_id, kafka::error_code error)
       : join_group_response(
         error, no_generation, no_protocol, no_leader, member_id) {}
@@ -117,6 +125,10 @@ struct join_group_response final {
     }
 
     void encode(const request_context&, response&);
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
 };
 
 static inline join_group_response

--- a/src/v/kafka/requests/leave_group_request.h
+++ b/src/v/kafka/requests/leave_group_request.h
@@ -22,7 +22,11 @@
 
 namespace kafka {
 
+struct leave_group_response;
+
 struct leave_group_api final {
+    using response_type = leave_group_response;
+
     static constexpr const char* name = "leave group";
     static constexpr api_key key = api_key(13);
     static constexpr api_version min_supported = api_version(0);
@@ -33,6 +37,8 @@ struct leave_group_api final {
 };
 
 struct leave_group_request final {
+    using api_type = leave_group_api;
+
     leave_group_request_data data;
 
     // set during request processing after mapping group to ntp
@@ -53,7 +59,11 @@ operator<<(std::ostream& os, const leave_group_request& r) {
 }
 
 struct leave_group_response final {
+    using api_type = leave_group_api;
+
     leave_group_response_data data;
+
+    leave_group_response() = default;
 
     explicit leave_group_response(error_code error)
       : data({
@@ -65,6 +75,10 @@ struct leave_group_response final {
       : leave_group_response(error) {}
 
     void encode(const request_context&, response&);
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
 };
 
 inline ss::future<leave_group_response> make_leave_error(error_code error) {

--- a/src/v/kafka/requests/sync_group_request.h
+++ b/src/v/kafka/requests/sync_group_request.h
@@ -24,7 +24,11 @@
 
 namespace kafka {
 
+struct sync_group_response;
+
 struct sync_group_api final {
+    using response_type = sync_group_response;
+
     static constexpr const char* name = "sync group";
     static constexpr api_key key = api_key(14);
     static constexpr api_version min_supported = api_version(0);
@@ -35,6 +39,8 @@ struct sync_group_api final {
 };
 
 struct sync_group_request final {
+    using api_type = sync_group_api;
+
     sync_group_request_data data;
 
     // set during request processing after mapping group to ntp
@@ -70,6 +76,8 @@ struct sync_group_response final {
 
     sync_group_response_data data;
 
+    sync_group_response() = default;
+
     sync_group_response(error_code error, bytes assignment)
       : data({
         .throttle_time_ms = std::chrono::milliseconds(0),
@@ -84,6 +92,10 @@ struct sync_group_response final {
       : sync_group_response(error) {}
 
     void encode(const request_context&, response&);
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
 };
 
 static inline ss::future<sync_group_response>

--- a/src/v/kafka/requests/sync_group_request.h
+++ b/src/v/kafka/requests/sync_group_request.h
@@ -98,8 +98,7 @@ struct sync_group_response final {
     }
 };
 
-static inline ss::future<sync_group_response>
-make_sync_error(error_code error) {
+inline ss::future<sync_group_response> make_sync_error(error_code error) {
     return ss::make_ready_future<sync_group_response>(error);
 }
 


### PR DESCRIPTION
Kafka/client requires:

* requests need an api_type
* api_type needs a response_type
* responses need a default constructor
* responses need decode

Fixes for:

* heartbeat
* join_group
* leave_group
* sync_group

Also some various tidy-up:

* Single arg constructor should be explicit
* remove static scope from header definitions

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
