### PR TITLE
Recover empty raft group

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -24,6 +24,7 @@
 #include "raft/types.h"
 #include "raft/vote_stm.h"
 #include "reflection/adl.h"
+#include "storage/types.h"
 #include "utils/state_crc_file.h"
 #include "utils/state_crc_file_errc.h"
 #include "vlog.h"
@@ -720,19 +721,43 @@ ss::future<> consensus::start() {
                   _term = lstats.dirty_offset_term;
                   _voted_for = {};
               }
-              vlog(
-                _ctxlog.info,
-                "Recovered, log offsets: {}, term:{}",
-                lstats,
-                _term);
+              auto f = ss::now();
+              /**
+               * Snapshot and log was delted, try to recover by creating
+               * snapshot with initial data.
+               *
+               * MOST IMPORTANT:
+               * we can only do this when log is empty and there
+               * is no snapshot for given offset.
+               */
+              if (
+                _log.segment_count() == 0
+                // if log is empty and start offset is persisted in kvstore
+                // dirty offset is equal to (start_offset-1)
+                && lstats.start_offset > lstats.dirty_offset
+                // snapshot must be deleted (it is in the same folder as log
+                // segments)
+                && _last_snapshot_index != lstats.dirty_offset) {
+                  f = f.then([this, lstats] {
+                      return create_recovery_snapshot(lstats);
+                  });
+              }
               /**
                * The configuration manager state may be divereged from the log
                * state, as log is flushed lazily, we have to make sure that the
                * log and configuration manager has exactly the same offsets
                * range
                */
-              auto f = _configuration_manager.truncate(
-                details::next_offset(lstats.dirty_offset));
+              f = f.then([this, dirty = lstats.dirty_offset] {
+                  return _configuration_manager.truncate(
+                    details::next_offset(dirty));
+              });
+
+              vlog(
+                _ctxlog.info,
+                "Recovered, log offsets: {}, term:{}",
+                lstats,
+                _term);
 
               /**
                * We read some batches from the log and have to update the
@@ -792,6 +817,42 @@ ss::future<> consensus::start() {
                 });
           });
     });
+}
+ss::future<> consensus::create_recovery_snapshot(
+  const storage::offset_stats& initial_offsets) {
+    auto snapshot_offset = details::prev_offset(initial_offsets.start_offset);
+    static constexpr model::term_id poisson_value{-2};
+    /**
+     * IMPORTANT NOTICE
+     *
+     * We can leverage the fact that log start offset is only updated up to the
+     * committed offset. We can safely update committed index with offset that
+     * is previous to log start offset (last prefix truncation offset).
+     */
+    _commit_index = snapshot_offset;
+    snapshot_metadata md{
+      .last_included_index = snapshot_offset,
+      .last_included_term = poisson_value,
+      .latest_configuration = _configuration_manager.get_latest(),
+      .cluster_time = clock_type::time_point::min(),
+    };
+
+    return details::persist_snapshot(_snapshot_mgr, std::move(md), iobuf())
+      .then([this,
+             snapshot_offset,
+             cfg = _configuration_manager.get_latest()]() mutable {
+          // update consensus state
+          _last_snapshot_index = snapshot_offset;
+          _last_snapshot_term = poisson_value;
+          // update configuration manager
+          return _configuration_manager
+            .add(_last_snapshot_index, std::move(cfg))
+            .then([this] {
+                return _configuration_manager.prefix_truncate(
+                  _last_snapshot_index);
+            });
+      });
+    ;
 }
 
 void consensus::start_dispatching_disk_append_events() {
@@ -1117,12 +1178,17 @@ consensus::do_append_entries(append_entries_request&& r) {
           ? lstats.dirty_offset_term // use term from lstats
           : get_term(model::offset(
             r.meta.prev_log_index)); // lookup for request term in log
-    // We can only check prev_log_term for entries that are present in the
-    // log. When leader installed snapshot on the follower we may require to
-    // skip the term check as term of prev_log_idx may not be available.
-    if (
-      r.meta.prev_log_index >= lstats.start_offset
-      && r.meta.prev_log_term != last_log_term) {
+
+    // if request prev log index is equal to snapshot index use snapshot as a
+    // source of term information
+    if (r.meta.prev_log_index == _last_snapshot_index) {
+        last_log_term = _last_snapshot_term;
+    }
+    /**
+     * Skip checking term if follower log is empty, we just accept any term from
+     * the leader. This is the case when follower log was deleted.
+     */
+    if (_log.segment_count() > 0 && r.meta.prev_log_term != last_log_term) {
         vlog(
           _ctxlog.debug,
           "Rejecting append entries. missmatching entry term at offset: "

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -335,6 +335,8 @@ private:
 
     void start_dispatching_disk_append_events();
 
+    ss::future<> create_recovery_snapshot(const storage::offset_stats&);
+
     voter_priority next_target_priority();
     voter_priority get_node_priority(model::node_id id) const;
 

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(srcs
     offset_monitor_test.cc
     mux_state_machine_test.cc
     mutex_buffer_test.cc
+    manual_log_deletion_test.cc
     configuration_manager_test.cc)
 
 rp_test(

--- a/src/v/raft/tests/manual_log_deletion_test.cc
+++ b/src/v/raft/tests/manual_log_deletion_test.cc
@@ -1,0 +1,147 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "finjector/hbadger.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/record.h"
+#include "model/timestamp.h"
+#include "raft/consensus_utils.h"
+#include "raft/tests/raft_group_fixture.h"
+#include "raft/types.h"
+#include "random/generators.h"
+#include "storage/record_batch_builder.h"
+#include "storage/tests/utils/disk_log_builder.h"
+#include "storage/tests/utils/random_batch.h"
+#include "test_utils/async.h"
+
+#include <seastar/core/abort_source.hh>
+
+#include <filesystem>
+#include <system_error>
+#include <vector>
+
+struct manual_deletion_fixture : public raft_test_fixture {
+    manual_deletion_fixture()
+      : gr(
+        raft::group_id(0),
+        3,
+        storage::log_config::storage_type::disk,
+        model::cleanup_policy_bitflags::deletion,
+        1_KiB) {
+        gr.enable_all();
+    }
+
+    void prepare_raft_group() {
+        auto leader_id = wait_for_group_leader(gr);
+        ss::abort_source as;
+
+        auto first_ts = model::timestamp::now();
+        // append some entries
+        bool res = replicate_compactible_batches(gr, first_ts).get0();
+        auto second_ts = model::timestamp(first_ts() + 200000);
+        // append some more entries
+        res = replicate_compactible_batches(gr, second_ts).get0();
+        retention_timestamp = first_ts;
+        validate_logs_replication(gr);
+    }
+
+    void apply_retention_policy() {
+        wait_for(
+          2s,
+          [this] {
+              for (auto& [_, n] : gr.get_members()) {
+                  n.log
+                    ->compact(storage::compaction_config(
+                      retention_timestamp,
+                      100_MiB,
+                      ss::default_priority_class(),
+                      as,
+                      storage::debug_sanitize_files::yes))
+                    .get0();
+                  if (n.log->offsets().start_offset <= model::offset(0)) {
+                      return false;
+                  }
+              }
+              return true;
+          },
+          "logs has prefix truncated");
+    }
+
+    void remove_data(std::vector<model::node_id> nodes) {
+        std::vector<std::filesystem::path> to_delete;
+        to_delete.reserve(nodes.size());
+
+        // disable and remove data
+        for (auto id : nodes) {
+            to_delete.push_back(std::filesystem::path(
+              gr.get_member(id).log->config().topic_directory()));
+            gr.disable_node(id);
+        }
+        for (auto& path : to_delete) {
+            std::filesystem::remove_all(path);
+        }
+        // enable back
+        for (auto id : nodes) {
+            gr.enable_node(id);
+        }
+    }
+
+    void remove_all_data() {
+        std::vector<model::node_id> nodes;
+        for (auto& [id, _] : gr.get_members()) {
+            nodes.push_back(id);
+        }
+        remove_data(nodes);
+    }
+
+    raft_group gr;
+    model::timestamp retention_timestamp;
+    ss::abort_source as;
+};
+
+FIXTURE_TEST(
+  test_collected_log_recovery_admin_deletion_all, manual_deletion_fixture) {
+    prepare_raft_group();
+    // compact logs
+    apply_retention_policy();
+
+    // simulate admin deleting log folders. For more details look here:
+    //
+    // https://github.com/vectorizedio/redpanda/issues/321
+
+    remove_all_data();
+
+    validate_logs_replication(gr);
+
+    wait_for(
+      10s,
+      [this] { return are_all_commit_indexes_the_same(gr); },
+      "After recovery state is consistent");
+};
+
+FIXTURE_TEST(
+  test_collected_log_recovery_admin_deletion_one, manual_deletion_fixture) {
+    prepare_raft_group();
+    // compact logs
+    apply_retention_policy();
+
+    // simulate admin deleting log folders. For more details look here:
+    //
+    // https://github.com/vectorizedio/redpanda/issues/321
+
+    remove_data({model::node_id(1)});
+
+    validate_logs_replication(gr);
+
+    wait_for(
+      10s,
+      [this] { return are_all_commit_indexes_the_same(gr); },
+      "After recovery state is consistent");
+};

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -719,7 +719,7 @@ static ss::future<bool> replicate_compactible_batches(
   model::timestamp ts,
   model::timeout_clock::duration tout = 1s) {
     return retry_with_leader(gr, 5, tout, [ts](raft_node& leader_node) {
-        auto rdr = make_compactible_batches(5, 30, ts);
+        auto rdr = make_compactible_batches(5, 80, ts);
         raft::replicate_options opts(raft::consistency_level::quorum_ack);
 
         return leader_node.consensus->replicate(std::move(rdr), opts)


### PR DESCRIPTION
   Added ability to recover raft group after complete data deletion. In
    redpanda we keep log start offset outside of log itself and outside of
    raft. We can leverage the fact that log start offset is persistent and
    available and recover initial raft group state. It is possible as start
    offset is only updated up to the committed offset boundary, so all the
    nodes can assume that previously removed data were already committed.

    IMPORTANT NOTE:
    This approach doesn't allow full state recovery, the only property that
    is guaranteed after recovery is that the log start offset will be
    preserved.

Fixes #321 
## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
