### PR TITLE
r/consensus: triggering recovery when leader has to send snapshot

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -357,10 +357,12 @@ void consensus::successfull_append_entries_reply(
 
 bool consensus::needs_recovery(
   const follower_index_metadata& idx, model::offset dirty_offset) {
-    // follower match_index is behind, we have to recover it
-
+    // follower is behind
     return idx.match_index < dirty_offset
-           || idx.match_index > idx.last_dirty_log_index;
+           // follower is ahead of the leader
+           || idx.match_index > idx.last_dirty_log_index
+           // leader has to sent snapshot to the follower, follower is behind
+           || idx.last_dirty_log_index < _log.offsets().start_offset;
 }
 
 void consensus::dispatch_recovery(follower_index_metadata& idx) {


### PR DESCRIPTION
We have to trigger recovery not only if follower is either behind or
ahead of the leader but also in case when leader has to send the
snapshot to follower to reset its log start_offset.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
