### PR TITLE
rpk: Remove all license key checks

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/api.go
+++ b/src/go/rpk/pkg/cli/cmd/api.go
@@ -98,9 +98,7 @@ func findConfigFile(
 			return conf, nil
 		}
 		conf, err = mgr.ReadOrFind(*configFile)
-		if err == nil {
-			config.CheckAndPrintNotice(conf.LicenseKey)
-		} else {
+		if err != nil {
 			log.Debug(err)
 			if os.IsNotExist(err) && *configFile == "" {
 				log.Debug(

--- a/src/go/rpk/pkg/cli/cmd/check.go
+++ b/src/go/rpk/pkg/cli/cmd/check.go
@@ -73,7 +73,6 @@ func executeCheck(
 	if err != nil {
 		return err
 	}
-	config.CheckAndPrintNotice(conf.LicenseKey)
 	results, err := tuners.Check(fs, conf, timeout)
 	if err != nil {
 		return err

--- a/src/go/rpk/pkg/cli/cmd/config.go
+++ b/src/go/rpk/pkg/cli/cmd/config.go
@@ -100,7 +100,6 @@ func bootstrap(mgr config.Manager) *cobra.Command {
 			if err != nil {
 				return errors.New("YAML")
 			}
-			config.CheckAndPrintNotice(conf.LicenseKey)
 			ips, err := parseIPs(ips)
 			if err != nil {
 				return err

--- a/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
@@ -128,7 +128,6 @@ func executePrometheusConfig(
 	if err != nil {
 		return []byte(""), err
 	}
-	config.CheckAndPrintNotice(conf.LicenseKey)
 	hosts, err := discoverHosts(
 		conf.Redpanda.KafkaApi.Address,
 		conf.Redpanda.KafkaApi.Port,

--- a/src/go/rpk/pkg/cli/cmd/iotune.go
+++ b/src/go/rpk/pkg/cli/cmd/iotune.go
@@ -37,7 +37,6 @@ func NewIoTuneCmd(fs afero.Fs, mgr config.Manager) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			config.CheckAndPrintNotice(conf.LicenseKey)
 			var evalDirectories []string
 			if directories != nil && len(directories) != 0 {
 				log.Infof("Overriding evaluation directories with '%v'",

--- a/src/go/rpk/pkg/cli/cmd/mode.go
+++ b/src/go/rpk/pkg/cli/cmd/mode.go
@@ -50,7 +50,6 @@ func executeMode(mgr config.Manager, configFile string, mode string) error {
 	if err != nil {
 		return err
 	}
-	config.CheckAndPrintNotice(conf.LicenseKey)
 	conf, err = config.SetMode(mode, conf)
 	if err != nil {
 		return err

--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -100,7 +100,6 @@ func NewStartCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			config.CheckAndPrintNotice(conf.LicenseKey)
 			env := api.EnvironmentPayload{}
 			if len(seeds) == 0 {
 				// If --seeds wasn't passed, fall back to the

--- a/src/go/rpk/pkg/cli/cmd/status.go
+++ b/src/go/rpk/pkg/cli/cmd/status.go
@@ -85,7 +85,6 @@ func executeStatus(
 	if err != nil {
 		return err
 	}
-	config.CheckAndPrintNotice(conf.LicenseKey)
 	if !conf.Rpk.EnableUsageStats && send {
 		log.Warn("Usage stats reporting is disabled, so nothing will" +
 			" be sent. To enable it, run" +

--- a/src/go/rpk/pkg/cli/cmd/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/stop.go
@@ -68,7 +68,6 @@ func executeStop(
 	if err != nil {
 		return err
 	}
-	config.CheckAndPrintNotice(conf.LicenseKey)
 	pidFile := conf.PIDFile()
 	isLocked, err := os.CheckLocked(pidFile)
 	if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/tune.go
@@ -107,7 +107,6 @@ Would you like to continue with the default configuration?`,
 				}
 				conf = config.Default()
 			}
-			config.CheckAndPrintNotice(conf.LicenseKey)
 			var tunerFactory factory.TunersFactory
 			if outTuneScriptFile != "" {
 				tunerFactory = factory.NewScriptRenderingTunersFactory(


### PR DESCRIPTION
Currently there are no enterprise-only features that require
checking the license key in every command. However, that could
change in the future, so the functions in config/license.go are
preserved.

Fix #335.