### PR TITLE
rpk/topic/create: Send negative repl factor if none specified

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/api/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/api/topic.go
@@ -73,13 +73,16 @@ func createTopic(admin func() (sarama.ClusterAdmin, error)) *cobra.Command {
 			}
 			defer adm.Close()
 			topicName := args[0]
+			topicDetail := &sarama.TopicDetail{
+				NumPartitions: partitions,
+				ConfigEntries: configEntries,
+			}
+			if replicas > 0 {
+				topicDetail.ReplicationFactor = replicas
+			}
 			err = adm.CreateTopic(
 				topicName,
-				&sarama.TopicDetail{
-					NumPartitions:     partitions,
-					ReplicationFactor: replicas,
-					ConfigEntries:     configEntries,
-				},
+				topicDetail,
 				false,
 			)
 			if err != nil {
@@ -123,8 +126,10 @@ func createTopic(admin func() (sarama.ClusterAdmin, error)) *cobra.Command {
 		&replicas,
 		"replicas",
 		"r",
-		int16(1),
-		"Number of replicas",
+		int16(-1),
+		"Replication factor. If it's negative or is left unspecified,"+
+			" it will use the cluster's default topic replication"+
+			" factor.",
 	)
 	cmd.Flags().BoolVar(
 		&compact,

--- a/src/go/rpk/pkg/cli/cmd/api/topic_test.go
+++ b/src/go/rpk/pkg/cli/cmd/api/topic_test.go
@@ -139,7 +139,7 @@ func TestTopicCmd(t *testing.T) {
 			name:           "create should output info about the created topic (default values)",
 			cmd:            createTopic,
 			args:           []string{"San Francisco"},
-			expectedOutput: `Created topic 'San Francisco'. Partitions: 1, replicas: 1, configuration:\n'cleanup.policy':'delete'`,
+			expectedOutput: `Created topic 'San Francisco'. Partitions: 1, replicas: -1, configuration:\n'cleanup.policy':'delete'`,
 		},
 		{
 			name:           "create should output info about the created topic (custom values)",
@@ -151,13 +151,13 @@ func TestTopicCmd(t *testing.T) {
 			name:           "create should allow passing arbitrary topic config",
 			cmd:            createTopic,
 			args:           []string{"San Francisco", "-c", "custom.config:value", "--config", "another.config:anothervalue"},
-			expectedOutput: `Created topic 'San Francisco'. Partitions: 1, replicas: 1, configuration:\n'another.config':'anothervalue'\n'cleanup.policy':'delete'\n'custom.config':'value'`,
+			expectedOutput: `Created topic 'San Francisco'. Partitions: 1, replicas: -1, configuration:\n'another.config':'anothervalue'\n'cleanup.policy':'delete'\n'custom.config':'value'`,
 		},
 		{
 			name:           "create should allow passing comma-separated config values",
 			cmd:            createTopic,
 			args:           []string{"San Francisco", "-c", "custom.config:value", "--config", "cleanup.policy:cleanup,compact"},
-			expectedOutput: `Created topic 'San Francisco'. Partitions: 1, replicas: 1, configuration:\n'cleanup.policy':'cleanup,compact'\n'custom.config':'value'`,
+			expectedOutput: `Created topic 'San Francisco'. Partitions: 1, replicas: -1, configuration:\n'cleanup.policy':'cleanup,compact'\n'custom.config':'value'`,
 		},
 		{
 			name:        "create should fail if no topic is passed",


### PR DESCRIPTION
The `redpanda.default_topic_replication` config field should be
the default if --replicas/ -r isn't passed. Sending -1 in that
case causes the server to use that configured value.

Fix #302.
