### PR TITLE
ci/gcb: update references to fedora image

### DIFF
--- a/tests/ci/build-pkg.yml
+++ b/tests/ci/build-pkg.yml
@@ -31,7 +31,7 @@ steps:
     git clone --depth 1 -b dev https://$_GITHUB_API_TOKEN@github.com/vectorizedio/vtools vtools
 
 - id: 'install vtools'
-  name: 'gcr.io/redpandaci/fedora:31-python37-docker1903'
+  name: 'gcr.io/redpandaci/fedora:33-python39-docker2010'
   entrypoint: bash
   args:
   - -ec
@@ -44,7 +44,7 @@ steps:
     vtools install infra-deps --conf=vtools/vtools/artifacts/ci/vtools-gcc-release.yml
 
 - id: 'build builder image'
-  name: 'gcr.io/redpandaci/fedora:31-python37-docker1903'
+  name: 'gcr.io/redpandaci/fedora:33-python39-docker2010'
   args: ['./build/venv/v/bin/vtools', 'dbuild', 'toolchain', '--conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml']
 
 - id: 'check source code formatting'

--- a/tests/ci/build-release.yaml
+++ b/tests/ci/build-release.yaml
@@ -31,7 +31,7 @@ steps:
     git clone --depth 1 -b dev https://$_GITHUB_API_TOKEN@github.com/vectorizedio/vtools vtools
 
 - id: 'install vtools'
-  name: 'gcr.io/redpandaci/fedora:31-python37-docker1903'
+  name: 'gcr.io/redpandaci/fedora:33-python39-docker2010'
   entrypoint: bash
   args:
   - -ec
@@ -44,7 +44,7 @@ steps:
     vtools install infra-deps --conf=vtools/vtools/artifacts/ci/vtools-gcc-release.yml
 
 - id: 'build builder image'
-  name: 'gcr.io/redpandaci/fedora:31-python37-docker1903'
+  name: 'gcr.io/redpandaci/fedora:33-python39-docker2010'
   args: ['./build/venv/v/bin/vtools', 'dbuild', 'toolchain', '--conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml']
 
 - id: 'check source code formatting'

--- a/tests/ci/build.yaml
+++ b/tests/ci/build.yaml
@@ -31,7 +31,7 @@ steps:
     git clone --depth 1 -b dev https://$_GITHUB_API_TOKEN@github.com/vectorizedio/vtools vtools
 
 - id: 'install vtools'
-  name: 'gcr.io/redpandaci/fedora:31-python37-docker1903'
+  name: 'gcr.io/redpandaci/fedora:33-python39-docker2010'
   entrypoint: bash
   args:
   - -ec
@@ -44,7 +44,7 @@ steps:
     vtools install infra-deps --conf=vtools/vtools/artifacts/ci/vtools-gcc-release.yml
 
 - id: 'build builder image'
-  name: 'gcr.io/redpandaci/fedora:31-python37-docker1903'
+  name: 'gcr.io/redpandaci/fedora:33-python39-docker2010'
   args: ['./build/venv/v/bin/vtools', 'dbuild', 'toolchain', '--conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml']
 
 - id: 'check source code formatting'


### PR DESCRIPTION
point to newer fedora version on gcb.