### PR TITLE
Introduce chaos testing pipeline

### DIFF
--- a/.github/workflows/consistency-test.yml
+++ b/.github/workflows/consistency-test.yml
@@ -1,0 +1,95 @@
+name: consistency_testing
+on:
+  repository_dispatch:
+    types: [chaos-test-command]
+
+jobs:
+  run_consistency_tests:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CI: 1
+      CI_INSTALL_INFRA: 1
+      AWS_EC2_METADATA_DISABLED: true
+
+    steps:
+      - name: Setup gcloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          project_id: 'redpandaci'
+          service_account_key: ${{ secrets.GCR_JSON}}
+          export_default_credentials: true
+
+      - name: setup env slash command
+        run: |
+          echo "Populating env from PR context"
+          commit=${{ github.event.client_payload.pull_request.head.sha }}
+          short=${commit:0:7}
+
+          # Make env available to next steps
+          echo "deb_pkg_url=gs://vectorizedio/rp_dev/release/clang/$short/redpanda_*.deb" >> $GITHUB_ENV
+          echo "upload_dir=redpanda/pr-${{ github.event.client_payload.pull_request.number }}" >> $GITHUB_ENV
+        if: ${{ github.event.action == 'chaos-test-command' }}
+
+      - name: fetch release from gcb
+        run: |
+          # check if the file exists
+          check=$(gsutil -q stat $deb_pkg_url || echo "NotFound")
+          if [[ $check == "NotFound" ]]; then
+            echo "Provided file $deb_pkg_url was not found"; exit 1
+          fi
+
+          gsutil cp $deb_pkg_url redpanda.deb
+
+      - name: Setup vtools
+        run: |
+          sudo apt-get install python3-pip unzip python3-setuptools python3-venv
+          python3 -m venv .chaosenv && source .chaosenv/bin/activate
+          pip install git+https://${{ secrets.GH_API_TOKEN }}@github.com/vectorizedio/vtools > vtools_out.log 2>&1
+
+          cat <<EOF >> .vtools.yml
+          ---
+          build:
+            root: ./vbuild
+            src: ./
+            gopath: ./vbuild
+            node_build_dir: ./vbuild
+            default_type: release
+          EOF
+
+          vtools install infra-deps >> vtools_out.log 2>&1
+
+      - name: Run chaos tests
+        id: run-tests
+        run: |
+          .chaosenv/bin/vtools test chaos \
+          --binary-path ${{ github.workspace }}/redpanda.deb \
+          --result-path ${{ github.workspace }}/ > vtools_out.log 2>&1
+
+      - name: Upload results
+        run: |
+          tar -xvf chaos_results.tar.gz
+          vbuild/infra/v2/current/bin/aws s3 cp results/ \
+          s3://${{ secrets.S3_BUCKET }}/$upload_dir \
+          --recursive >> vtools_out.log 2>&1
+
+      - name: Destroy Test Resources
+        run: |
+          .chaosenv/bin/vtools deploy cluster --provider aws \
+          --destroy true || true >> vtools_out.log 2>&1
+
+          vbuild/infra/v2/current/bin/aws s3 cp vtools_out.log \
+          s3://${{ secrets.S3_BUCKET }}/$upload_dir/
+        if: ${{ always() }}
+
+      - name: Notify PR
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GH_API_TOKEN }}
+          issue-number: ${{ github.event.client_payload.pull_request.number }}
+          body: |
+            Chaos test status: ${{ steps.run-tests.conclusion }}
+            Run: https://github.com/vectorizedio/redpanda/actions/runs/${{ github.run_id }}
+        if: always() && github.event.action == 'chaos-test-command'

--- a/.github/workflows/packages-created.yml
+++ b/.github/workflows/packages-created.yml
@@ -1,0 +1,20 @@
+name: package_creation_handler
+on:
+  repository_dispatch:
+    types: [packages-created]
+
+jobs:
+  package_creation_handler:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Notify PR
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GH_API_TOKEN }}
+          issue-number: ${{ github.event.client_payload.pr_number }}
+          body: |
+            Packages created for ${{ github.event.client_payload.ref }}
+            Tests requiring them can now be run. Try:
+            `/chaos-test` or `/ducktape`
+        if: ${{ github.event.client_payload.pr_number }}

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -1,0 +1,15 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@dc2f82020dc2c4e9bfed7e87eb4a09506afd431b
+        with:
+          token: ${{ secrets.GH_API_TOKEN }}
+          issue-type: pull-request
+          commands: |
+            chaos-test

--- a/tests/ci/build-pkg.yml
+++ b/tests/ci/build-pkg.yml
@@ -78,8 +78,10 @@ steps:
     ./build/venv/v/bin/vtools build go --targets=rpk --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
     ./build/venv/v/bin/vtools build redpanda-dashboard --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
     ./build/venv/v/bin/vtools build pkg --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml --format=rpm --format=deb --format=tar
+    ./build/venv/v/bin/vtools ci github-event --event-type packages-created
   env:
   - SHORT_SHA=$SHORT_SHA
+  - GH_TOKEN=$_GITHUB_API_TOKEN
 
 timeout: 3600s
 

--- a/tests/ci/build-release.yaml
+++ b/tests/ci/build-release.yaml
@@ -80,6 +80,7 @@ steps:
     ./build/venv/v/bin/vtools build redpanda-dashboard --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
     ./build/venv/v/bin/vtools build pkg --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml --format=rpm --format=deb --format=tar
     ./build/venv/v/bin/vtools publish --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
+    ./build/venv/v/bin/vtools ci github-event --event-type packages-created || true # let's not mess with the release pipeline yet
   env:
   - SHORT_SHA=$SHORT_SHA
   - TAG_NAME=$TAG_NAME
@@ -87,6 +88,7 @@ steps:
   - DOCKER_USERNAME=$_DOCKER_USERNAME
   - DOCKER_PASSWORD=$_DOCKER_PASSWORD
   - CLOUDSMITH_TOKEN=$_CLOUDSMITH_TOKEN
+  - GH_TOKEN=$_GITHUB_API_TOKEN
 
 timeout: 3600s
 


### PR DESCRIPTION
Adds ability to run chaos tests on demand in PRs through `/chaos-test`.
A bunch of infra code has been put in place to accommodate feedback loops between GCB and Github Actions.
Also slash command triggers can now be introduced in any workflow by adding them to the slash command handler.

The new workflows include:
* Building package artifacts for PRs (and notifying GitHub on when the packages are available).
* PR notifications on package availability
* Running chaos tests through `/chaos-test` and posting result status & URLs back to PR.
* Infra for future slash-command/custom-event  triggered actions