### PR TITLE
rpk/start: Fix default ports for rpc & kafka addrs

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -127,7 +127,10 @@ func NewStartCommand(
 				kafkaAddr,
 				os.Getenv("REDPANDA_KAFKA_ADDRESS"),
 			)
-			kafkaApi, err := parseAddress(kafkaAddr)
+			kafkaApi, err := parseAddress(
+				kafkaAddr,
+				config.Default().Redpanda.KafkaApi.Port,
+			)
 			if err != nil {
 				sendEnv(mgr, env, conf, err)
 				return err
@@ -140,7 +143,10 @@ func NewStartCommand(
 				rpcAddr,
 				os.Getenv("REDPANDA_RPC_ADDRESS"),
 			)
-			rpcServer, err := parseAddress(rpcAddr)
+			rpcServer, err := parseAddress(
+				rpcAddr,
+				config.Default().Redpanda.RPCServer.Port,
+			)
 			if err != nil {
 				sendEnv(mgr, env, conf, err)
 				return err
@@ -153,7 +159,10 @@ func NewStartCommand(
 				advertisedKafka,
 				os.Getenv("REDPANDA_ADVERTISE_KAFKA_ADDRESS"),
 			)
-			advKafkaApi, err := parseAddress(advertisedKafka)
+			advKafkaApi, err := parseAddress(
+				advertisedKafka,
+				config.Default().Redpanda.KafkaApi.Port,
+			)
 			if err != nil {
 				sendEnv(mgr, env, conf, err)
 				return err
@@ -165,7 +174,10 @@ func NewStartCommand(
 				advertisedRPC,
 				os.Getenv("REDPANDA_ADVERTISE_RPC_ADDRESS"),
 			)
-			advRPCApi, err := parseAddress(advertisedRPC)
+			advRPCApi, err := parseAddress(
+				advertisedRPC,
+				config.Default().Redpanda.RPCServer.Port,
+			)
 			if err != nil {
 				sendEnv(mgr, env, conf, err)
 				return err
@@ -669,7 +681,10 @@ func parseSeeds(seeds []string) ([]config.SeedServer, error) {
 				s,
 			)
 		}
-		addr, err := parseAddress(addressID[0])
+		addr, err := parseAddress(
+			addressID[0],
+			config.Default().Redpanda.RPCServer.Port,
+		)
 		if err != nil {
 			return seedServers, fmt.Errorf(
 				"Couldn't parse seed '%s': %v",
@@ -691,7 +706,7 @@ func parseSeeds(seeds []string) ([]config.SeedServer, error) {
 	return seedServers, nil
 }
 
-func parseAddress(addr string) (*config.SocketAddress, error) {
+func parseAddress(addr string, defaultPort int) (*config.SocketAddress, error) {
 	if addr == "" {
 		return nil, nil
 	}
@@ -701,10 +716,10 @@ func parseAddress(addr string) (*config.SocketAddress, error) {
 		return nil, fmt.Errorf("Empty host in address '%s'", addr)
 	}
 	if len(hostPort) != 2 {
-		// It's just a hostname with no port. Assume 9092.
+		// It's just a hostname with no port. Use the default port.
 		return &config.SocketAddress{
 			Address: strings.Trim(hostPort[0], " "),
-			Port:    config.Default().Redpanda.RPCServer.Port,
+			Port:    defaultPort,
 		}, nil
 	}
 	// It's a host:port combo.

--- a/src/go/rpk/pkg/cli/cmd/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/start_test.go
@@ -214,7 +214,7 @@ func TestStartCommand(t *testing.T) {
 		name: "it should parse the --seeds and persist them",
 		args: []string{
 			"--install-dir", "/var/lib/redpanda",
-			"--seeds", "192.168.34.32:33145+1,somehost:54321+3",
+			"--seeds", "192.168.34.32:33145+1,somehost:54321+3,justahostnoport+5",
 		},
 		postCheck: func(fs afero.Fs, st *testing.T) {
 			mgr := config.NewManager(fs)
@@ -232,6 +232,12 @@ func TestStartCommand(t *testing.T) {
 					Port:    54321,
 				},
 				Id: 3,
+			}, {
+				Host: config.SocketAddress{
+					Address: "justahostnoport",
+					Port:    33145,
+				},
+				Id: 5,
 			}}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -388,6 +394,27 @@ func TestStartCommand(t *testing.T) {
 			)
 		},
 	}, {
+		name: "it should parse the --rpc-addr and persist it (no port)",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--rpc-addr", "192.168.34.32",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := config.SocketAddress{
+				Address: "192.168.34.32",
+				Port:    33145,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.RPCServer,
+			)
+		},
+	}, {
 		name: "it should fail if --rpc-addr is invalid",
 		args: []string{
 			"--install-dir", "/var/lib/redpanda",
@@ -463,6 +490,27 @@ func TestStartCommand(t *testing.T) {
 			expectedAddr := config.SocketAddress{
 				Address: "192.168.34.32",
 				Port:    33145,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.KafkaApi,
+			)
+		},
+	}, {
+		name: "it should parse the --kafka-addr and persist it (no port)",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--kafka-addr", "192.168.34.32",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := config.SocketAddress{
+				Address: "192.168.34.32",
+				Port:    9092,
 			}
 			// Check that the generated config is as expected.
 			require.Exactly(
@@ -556,6 +604,27 @@ func TestStartCommand(t *testing.T) {
 			)
 		},
 	}, {
+		name: "it should parse the --advertise-kafka-addr and persist it (no port)",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--advertise-kafka-addr", "192.168.34.32",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := &config.SocketAddress{
+				Address: "192.168.34.32",
+				Port:    9092,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.AdvertisedKafkaApi,
+			)
+		},
+	}, {
 		name: "it should fail if --advertise-kafka-addr is invalid",
 		args: []string{
 			"--install-dir", "/var/lib/redpanda",
@@ -623,6 +692,27 @@ func TestStartCommand(t *testing.T) {
 		args: []string{
 			"--install-dir", "/var/lib/redpanda",
 			"--advertise-rpc-addr", "192.168.34.32:33145",
+		},
+		postCheck: func(fs afero.Fs, st *testing.T) {
+			mgr := config.NewManager(fs)
+			conf, err := mgr.Read(config.Default().ConfigFile)
+			require.NoError(st, err)
+			expectedAddr := &config.SocketAddress{
+				Address: "192.168.34.32",
+				Port:    33145,
+			}
+			// Check that the generated config is as expected.
+			require.Exactly(
+				st,
+				expectedAddr,
+				conf.Redpanda.AdvertisedRPCAPI,
+			)
+		},
+	}, {
+		name: "it should parse the --advertise-rpc-addr and persist it (no port)",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+			"--advertise-rpc-addr", "192.168.34.32",
 		},
 		postCheck: func(fs afero.Fs, st *testing.T) {
 			mgr := config.NewManager(fs)


### PR DESCRIPTION
Whenever an address given through the --advertise*, --*addr or --seeds flags didn't have a port, the default rpc port (33145) was assumed, which was wrong for --advertise-kafka-api and --kakfka-addr.

Specify a default port that parseAddress can use if the given address doesn't have one.