### PR TITLE
Build & package redpanda dashboard

### DIFF
--- a/tests/ci/build-pkg.yml
+++ b/tests/ci/build-pkg.yml
@@ -76,6 +76,7 @@ steps:
   - -c
   - |
     ./build/venv/v/bin/vtools build go --targets=rpk --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
+    ./build/venv/v/bin/vtools build redpanda-dashboard --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
     ./build/venv/v/bin/vtools build pkg --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml --format=rpm --format=deb --format=tar
   env:
   - SHORT_SHA=$SHORT_SHA

--- a/tests/ci/build-release.yaml
+++ b/tests/ci/build-release.yaml
@@ -77,6 +77,7 @@ steps:
   - -c
   - |
     ./build/venv/v/bin/vtools build go --targets=rpk --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
+    ./build/venv/v/bin/vtools build redpanda-dashboard --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
     ./build/venv/v/bin/vtools build pkg --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml --format=rpm --format=deb --format=tar
     ./build/venv/v/bin/vtools publish --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
   env:


### PR DESCRIPTION
Build the node dashboard so it can be included in the published packages.
The dashboard is available under `/usr/share/redpanda/dashboard`

Requires #344 to work as expected.