### PR TITLE
rpk/api: Return back friendly errors

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/api/consume.go
+++ b/src/go/rpk/pkg/cli/cmd/api/consume.go
@@ -68,7 +68,9 @@ func NewConsumeCommand(client func() (sarama.Client, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "consume <topic>",
 		Short: "Consume records from a topic",
-		Args:  cobra.ExactArgs(1),
+		Args:  exactArgs(1, "topic's name is missing."),
+		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, err := client()
 			if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/api/produce.go
+++ b/src/go/rpk/pkg/cli/cmd/api/produce.go
@@ -35,7 +35,9 @@ func NewProduceCommand(
 	cmd := &cobra.Command{
 		Use:   "produce <topic>",
 		Short: "Produce a record. Reads data from stdin.",
-		Args:  cobra.ExactArgs(1),
+		Args:  exactArgs(1, "topic's name is missing."),
+		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prod, err := producer(jvmPartitioner, partition)
 			if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/api/produce_test.go
+++ b/src/go/rpk/pkg/cli/cmd/api/produce_test.go
@@ -104,7 +104,7 @@ func TestProduceCmd(t *testing.T) {
 			name:        "it should fail if no topic is passed",
 			args:        []string{"-k", "key"},
 			data:        `{"very":"important", "data": true}`,
-			expectedErr: "accepts 1 arg(s), received 0",
+			expectedErr: "topic's name is missing.",
 		},
 		{
 			name: "it should fail if the producer creation fails",
@@ -148,7 +148,7 @@ func TestProduceCmd(t *testing.T) {
 			logrus.SetLevel(logrus.DebugLevel)
 			err := cmd.Execute()
 			if tt.expectedErr != "" {
-				require.EqualError(t, err, tt.expectedErr)
+				require.Contains(t, err.Error(), tt.expectedErr)
 				return
 			}
 			require.NoError(t, err)

--- a/src/go/rpk/pkg/cli/cmd/api/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/api/topic.go
@@ -53,7 +53,9 @@ func createTopic(admin func() (sarama.ClusterAdmin, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <topic name>",
 		Short: "Create a topic",
-		Args:  cobra.ExactArgs(1),
+		Args:  exactArgs(1, "topic's name is missing."),
+		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configEntries, err := parseKVs(config)
 			if err != nil {
@@ -144,7 +146,9 @@ func deleteTopic(admin func() (sarama.ClusterAdmin, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <topic name>",
 		Short: "Delete a topic",
-		Args:  cobra.ExactArgs(1),
+		Args:  exactArgs(1, "topic's name is missing."),
+		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			adm, err := admin()
 			if err != nil {
@@ -167,9 +171,11 @@ func deleteTopic(admin func() (sarama.ClusterAdmin, error)) *cobra.Command {
 
 func setTopicConfig(admin func() (sarama.ClusterAdmin, error)) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set-config <topic> <key> [<value>]",
+		Use:   "set-config <topic> <key> <value>",
 		Short: "Set the topic's config key/value pairs",
-		Args:  cobra.ExactArgs(3),
+		Args:  exactArgs(3, "topic's name, config key or value are missing."),
+		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			adm, err := admin()
 			if err != nil {
@@ -216,7 +222,9 @@ func describeTopic(
 		Use:   "describe <topic>",
 		Short: "Describe topic",
 		Long:  "Describe a topic. Default values of the configuration are omitted.",
-		Args:  cobra.ExactArgs(1),
+		Args:  exactArgs(1, "topic's name is missing."),
+		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cl, err := client()
 			if err != nil {
@@ -387,9 +395,10 @@ func topicStatus(admin func() (sarama.ClusterAdmin, error)) *cobra.Command {
 		Use:     "status <topic name>",
 		Aliases: []string{"health"},
 		Short:   "Show a topic's status - leader, replication, etc.",
-		Args:    cobra.ExactArgs(1),
+		Args:    exactArgs(1, "topic's name is missing."),
+		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			containsID := func(ids []int32, id int32) bool {
 				for _, i := range ids {
 					if i == id {
@@ -489,6 +498,8 @@ func listTopics(admin func() (sarama.ClusterAdmin, error)) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List topics",
 		Args:    cobra.ExactArgs(0),
+		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			adm, err := admin()
 			if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/api/topic_test.go
+++ b/src/go/rpk/pkg/cli/cmd/api/topic_test.go
@@ -163,7 +163,7 @@ func TestTopicCmd(t *testing.T) {
 			name:        "create should fail if no topic is passed",
 			cmd:         createTopic,
 			args:        []string{},
-			expectedErr: "accepts 1 arg(s), received 0",
+			expectedErr: "topic's name is missing.",
 		},
 		{
 			name: "create should fail if the topic creation req fails",
@@ -197,7 +197,7 @@ func TestTopicCmd(t *testing.T) {
 			name:        "delete should fail if no topic is passed",
 			cmd:         deleteTopic,
 			args:        []string{},
-			expectedErr: "accepts 1 arg(s), received 0",
+			expectedErr: "topic's name is missing.",
 		},
 		{
 			name:           "set-config should output the given config key-value pair",
@@ -225,19 +225,19 @@ func TestTopicCmd(t *testing.T) {
 			name:        "set-config should fail if no topic is passed",
 			cmd:         setTopicConfig,
 			args:        []string{},
-			expectedErr: "accepts 3 arg(s), received 0",
+			expectedErr: "topic's name, config key or value are missing.",
 		},
 		{
 			name:        "set-config should fail if no key is passed",
 			cmd:         setTopicConfig,
 			args:        []string{"Chepo"},
-			expectedErr: "accepts 3 arg(s), received 1",
+			expectedErr: "topic's name, config key or value are missing.",
 		},
 		{
 			name:        "set-config should fail if no value is passed",
 			cmd:         setTopicConfig,
 			args:        []string{"Chepo", "key"},
-			expectedErr: "accepts 3 arg(s), received 2",
+			expectedErr: "topic's name, config key or value are missing.",
 		},
 		{
 			name: "list should output the list of topics",
@@ -304,7 +304,7 @@ func TestTopicCmd(t *testing.T) {
 			logrus.SetOutput(&out)
 			err := cmd.Execute()
 			if tt.expectedErr != "" {
-				require.EqualError(t, err, tt.expectedErr)
+				require.Contains(t, err.Error(), tt.expectedErr)
 				return
 			}
 			require.NoError(t, err)
@@ -561,7 +561,7 @@ func TestDescribeTopic(t *testing.T) {
 			logrus.SetOutput(&out)
 			err := cmd.Execute()
 			if tt.expectedErr != "" {
-				require.EqualError(t, err, tt.expectedErr)
+				require.Contains(t, err.Error(), tt.expectedErr)
 				return
 			}
 			require.NoError(t, err)

--- a/src/go/rpk/pkg/cli/cmd/api/utils.go
+++ b/src/go/rpk/pkg/cli/cmd/api/utils.go
@@ -12,6 +12,8 @@ package api
 import (
 	"fmt"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 func parseKVs(kvs []string) (map[string]*string, error) {
@@ -30,4 +32,16 @@ func parseKVs(kvs []string) (map[string]*string, error) {
 		m[key] = &value
 	}
 	return m, nil
+}
+
+// exactArgs makes sure exactly n arguments are passed, if not, a custom error
+// err is returned back. This is so we can return more contextually friendly errors back
+// to users.
+func exactArgs(n int, err string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != n {
+			return fmt.Errorf(err + "\n\n" + cmd.UsageString())
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
when positional arguments are missing in all subcommands of `rpk api`. Instead of
Cobra's generic errors. Fixes half of #300.

#### Before
```
rpk api topic create
Error: accepts 1 arg(s), received 0
```

#### After
```
rpk api topic create
Error: topic's name is missing.

Usage:
  rpk api topic create <topic name> [flags]

Flags:
      --compact            Enable topic compaction
  -h, --help               help for create
  -p, --partitions int32   Number of partitions (default 1)
  -r, --replicas int16     Replication factor. If it's negative or is left unspecified, it will use the cluster's default topic replication factor. (default -1)

Global Flags:
      --brokers strings   Comma-separated list of broker ip:port pairs
      --config string     Redpanda config file, if not set the file will be searched for in the default locations
  -v, --verbose           enable verbose logging (default false)
```