### PR TITLE
Pin used vtools to a specific version

### DIFF
--- a/tests/ci/build-release.yaml
+++ b/tests/ci/build-release.yaml
@@ -28,7 +28,8 @@ steps:
       echo "Expecting value for _GITHUB_API_TOKEN"
       exit 1
     fi
-    git clone --depth 1 -b dev https://$_GITHUB_API_TOKEN@github.com/vectorizedio/vtools vtools
+    git clone --depth 1 -b release https://$_GITHUB_API_TOKEN@github.com/vectorizedio/vtools vtools
+    echo "Building against vtools rev:$(git -C vtools/ rev-parse HEAD)"
 
 - id: 'install vtools'
   name: 'gcr.io/redpandaci/fedora:33-python39-docker2010'


### PR DESCRIPTION
To make our internal build more stable we pin the version of vtools used in release builds to a specific commit.
This makes the build more predictable, since new/unstable vtools changes will be explicitly allowed.
