### PR TITLE
ci: use gcc-10 for open source build

### DIFF
--- a/.github/workflows/redpanda-build.yml
+++ b/.github/workflows/redpanda-build.yml
@@ -27,12 +27,7 @@ jobs:
             apt-get install -y git sudo pkg-config
 
         - name: install dependencies
-          run: |
-            ./install-dependencies.sh
-            apt-get install -y clang-11
+          run: ./install-dependencies.sh
 
         - name: build & test
-          env:
-            CC: clang-11
-            CXX: clang++-11
           run: ./build.sh -DCMAKE_UNITY_BUILD=ON


### PR DESCRIPTION
The memory issue compiling with ctre/cpp20/gcc was addressed in
261f78ada. This patch switches the oss build back to using gcc instead
of the clang+libstdc++ workaround.