### PR TITLE
kafka: adds a service to generate producer ids

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -29,6 +29,7 @@ v_cc_library(
     partition_allocator.cc
     logger.cc
     cluster_utils.cc
+    id_allocator.cc
     id_allocator_frontend.cc
     service.cc
     metadata_dissemination_handler.cc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -14,6 +14,13 @@ rpcgen(
   INCLUDES ${CMAKE_BINARY_DIR}/src/v
 )
 
+rpcgen(
+  TARGET id_allocator_rpc
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/id_allocator.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/id_allocator_service.h
+  INCLUDES ${CMAKE_BINARY_DIR}/src/v
+)
+
 v_cc_library(
   NAME cluster
   SRCS
@@ -42,6 +49,7 @@ v_cc_library(
     Seastar::seastar
     controller_rpc
     metadata_rpc
+    id_allocator_rpc
     v::raft
     Roaring::roaring
     absl::flat_hash_map

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -29,6 +29,7 @@ v_cc_library(
     partition_allocator.cc
     logger.cc
     cluster_utils.cc
+    id_allocator_frontend.cc
     service.cc
     metadata_dissemination_handler.cc
     metadata_dissemination_service.cc

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -40,6 +40,7 @@ public:
       ss::sharded<shard_table>& st,
       ss::sharded<storage::api>& storage);
 
+    model::node_id self() { return _raft0->self(); }
     ss::sharded<topics_frontend>& get_topics_frontend() { return _tp_frontend; }
     ss::sharded<members_manager>& get_members_manager() {
         return _members_manager;

--- a/src/v/cluster/id_allocator.cc
+++ b/src/v/cluster/id_allocator.cc
@@ -1,0 +1,33 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/id_allocator.h"
+
+#include "cluster/logger.h"
+#include "cluster/types.h"
+#include "model/namespace.h"
+#include "model/record_batch_reader.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace cluster {
+
+id_allocator::id_allocator(
+  ss::scheduling_group sg,
+  ss::smp_service_group ssg,
+  ss::sharded<cluster::id_allocator_frontend>& id_allocator_frontend)
+  : id_allocator_service(sg, ssg)
+  , _id_allocator_frontend(id_allocator_frontend) {}
+
+ss::future<allocate_id_reply>
+id_allocator::allocate_id(allocate_id_request&& req, rpc::streaming_context&) {
+    return _id_allocator_frontend.local().do_allocate_id(req.timeout);
+}
+
+} // namespace cluster

--- a/src/v/cluster/id_allocator.h
+++ b/src/v/cluster/id_allocator.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/id_allocator_frontend.h"
+#include "cluster/id_allocator_service.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/partition_manager.h"
+#include "cluster/topics_frontend.h"
+#include "cluster/types.h"
+
+#include <seastar/core/sharded.hh>
+
+#include <vector>
+
+namespace cluster {
+
+class id_allocator final : public id_allocator_service {
+public:
+    id_allocator(
+      ss::scheduling_group,
+      ss::smp_service_group,
+      ss::sharded<cluster::id_allocator_frontend>&);
+
+    virtual ss::future<allocate_id_reply>
+    allocate_id(allocate_id_request&&, rpc::streaming_context&) final;
+
+private:
+    ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
+};
+} // namespace cluster

--- a/src/v/cluster/id_allocator.json
+++ b/src/v/cluster/id_allocator.json
@@ -1,0 +1,14 @@
+{
+    "namespace": "cluster",
+    "service_name": "id_allocator",
+    "includes": [
+        "cluster/types.h"
+    ],
+    "methods": [
+        {
+            "name": "allocate_id",
+            "input_type": "allocate_id_request",
+            "output_type": "allocate_id_reply"
+        }
+    ]
+}

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -1,0 +1,186 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/id_allocator_frontend.h"
+
+#include "cluster/logger.h"
+#include "cluster/types.h"
+#include "model/namespace.h"
+#include "model/record_batch_reader.h"
+
+#include <seastar/core/do_with.hh>
+#include <seastar/core/sharded.hh>
+
+namespace cluster {
+
+cluster::errc map_errc_fixme(std::error_code ec);
+
+id_allocator_frontend::id_allocator_frontend(
+  ss::smp_service_group ssg,
+  ss::sharded<cluster::partition_manager>& partition_manager,
+  ss::sharded<cluster::shard_table>& shard_table,
+  ss::sharded<cluster::metadata_cache>& metadata_cache,
+  ss::sharded<rpc::connection_cache>& connection_cache,
+  ss::sharded<partition_leaders_table>& leaders,
+  std::unique_ptr<cluster::controller>& controller)
+  : _ssg(ssg)
+  , _partition_manager(partition_manager)
+  , _shard_table(shard_table)
+  , _metadata_cache(metadata_cache)
+  , _connection_cache(connection_cache)
+  , _leaders(leaders)
+  , _controller(controller) {}
+
+ss::future<allocate_id_reply>
+id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
+    auto nt = model::topic_namespace(
+      model::kafka_internal_namespace, model::id_allocator_topic);
+
+    auto has_topic = ss::make_ready_future<bool>(true);
+
+    if (!_metadata_cache.local().contains(nt, model::partition_id(0))) {
+        has_topic = try_create_id_allocator_topic();
+    }
+
+    return has_topic.then([this, timeout](bool does_topic_exist) {
+        if (!does_topic_exist) {
+            return ss::make_ready_future<allocate_id_reply>(
+              allocate_id_reply{0, errc::topic_not_exists});
+        }
+
+        auto leader = _leaders.local().get_leader(model::id_allocator_ntp);
+
+        if (!leader) {
+            vlog(
+              clusterlog.warn,
+              "can't find a leader for {}",
+              model::id_allocator_ntp);
+            return ss::make_ready_future<allocate_id_reply>(
+              allocate_id_reply{0, errc::no_leader_controller});
+        }
+
+        auto _self = _controller->self();
+
+        if (leader == _self) {
+            return do_allocate_id(timeout);
+        }
+
+        vlog(
+          clusterlog.trace,
+          "dispatching allocate id to {} from {}",
+          leader,
+          _self);
+
+        return dispatch_allocate_id_to_leader(leader.value(), timeout);
+    });
+}
+
+ss::future<allocate_id_reply>
+id_allocator_frontend::dispatch_allocate_id_to_leader(
+  model::node_id leader, model::timeout_clock::duration timeout) {
+    return _connection_cache.local()
+      .with_node_client<cluster::id_allocator_client_protocol>(
+        _controller->self(),
+        ss::this_shard_id(),
+        leader,
+        [timeout](id_allocator_client_protocol cp) {
+            return cp.allocate_id(
+              allocate_id_request{timeout},
+              rpc::client_opts(model::timeout_clock::now() + timeout));
+        })
+      .then(&rpc::get_ctx_data<allocate_id_reply>)
+      .then([](result<allocate_id_reply> r) {
+          if (r.has_error()) {
+              vlog(
+                clusterlog.warn,
+                "got error {} on remote allocate id",
+                r.error());
+              return allocate_id_reply{0, errc::timeout};
+          }
+
+          return r.value();
+      });
+}
+
+ss::future<allocate_id_reply>
+id_allocator_frontend::do_allocate_id(model::timeout_clock::duration timeout) {
+    auto shard = _shard_table.local().shard_for(model::id_allocator_ntp);
+
+    if (shard == std::nullopt) {
+        vlog(
+          clusterlog.warn,
+          "can't find a shard for {}",
+          model::id_allocator_ntp);
+        return ss::make_ready_future<allocate_id_reply>(
+          allocate_id_reply{0, errc::no_leader_controller});
+    }
+
+    return _partition_manager.invoke_on(
+      *shard, _ssg, [timeout](cluster::partition_manager& mgr) mutable {
+          auto partition = mgr.get(model::id_allocator_ntp);
+          if (!partition) {
+              vlog(
+                clusterlog.warn,
+                "can't get partition by {} ntp",
+                model::id_allocator_ntp);
+              return ss::make_ready_future<allocate_id_reply>(
+                allocate_id_reply{0, errc::topic_not_exists});
+          }
+          auto& stm = partition->id_allocator_stm();
+          if (!stm) {
+              vlog(
+                clusterlog.warn,
+                "can't get id allocator stm of the {}' partition",
+                model::id_allocator_ntp);
+              return ss::make_ready_future<allocate_id_reply>(
+                allocate_id_reply{0, errc::topic_not_exists});
+          }
+          return stm
+            ->allocate_id_and_wait(model::timeout_clock::now() + timeout)
+            .then([](raft::id_allocator_stm::stm_allocation_result r) {
+                if (r.raft_status == raft::errc::success) {
+                    return allocate_id_reply{r.id, errc::success};
+                } else {
+                    vlog(
+                      clusterlog.trace,
+                      "allocate id stm call failed with {}",
+                      r.raft_status);
+                    return allocate_id_reply{r.id, errc::replication_error};
+                }
+            });
+      });
+}
+
+ss::future<bool> id_allocator_frontend::try_create_id_allocator_topic() {
+    cluster::topic_configuration topic{
+      model::kafka_internal_namespace,
+      model::id_allocator_topic,
+      1,
+      config::shard_local_cfg().default_topic_replication()};
+
+    topic.cleanup_policy_bitflags = model::cleanup_policy_bitflags::none;
+
+    return _controller->get_topics_frontend()
+      .local()
+      .autocreate_topics(
+        {std::move(topic)}, config::shard_local_cfg().create_topic_timeout_ms())
+      .then([](std::vector<cluster::topic_result> res) {
+          vassert(res.size() == 1, "expected exactly one result");
+          if (res[0].ec != cluster::errc::success) {
+              return false;
+          }
+          return true;
+      })
+      .handle_exception([](std::exception_ptr e) {
+          vlog(clusterlog.warn, "cant create allocate id stm topic {}", e);
+          return false;
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/id_allocator_frontend.h
+++ b/src/v/cluster/id_allocator_frontend.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/controller.h"
+#include "cluster/id_allocator_service.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/partition_manager.h"
+#include "cluster/topics_frontend.h"
+#include "cluster/types.h"
+
+#include <seastar/core/sharded.hh>
+
+#include <vector>
+
+namespace cluster {
+
+class id_allocator;
+
+// id_allocator_frontend is an frontend of the id_allocator_stm,
+// an engine behind the id_allocator service.
+//
+// when a client invokes id_allocator_frontend::allocate_id on a
+// remote node the frontend redirects the request to the service
+// located on the leading broker of the id_allocator's partition.
+//
+// when a client is located on the same node as the leader then the
+// frontend bypasses the network and directly engages with the state
+// machine (id_allocator_stm.cc)
+//
+// when the service recieves a call it triggers id_allocator_frontend
+// which in its own turn pass the request to the id_allocator_stm
+class id_allocator_frontend {
+public:
+    id_allocator_frontend(
+      ss::smp_service_group,
+      ss::sharded<cluster::partition_manager>&,
+      ss::sharded<cluster::shard_table>&,
+      ss::sharded<cluster::metadata_cache>&,
+      ss::sharded<rpc::connection_cache>&,
+      ss::sharded<partition_leaders_table>&,
+      std::unique_ptr<cluster::controller>&);
+
+    ss::future<allocate_id_reply>
+    allocate_id(model::timeout_clock::duration timeout);
+
+private:
+    ss::smp_service_group _ssg;
+    ss::sharded<cluster::partition_manager>& _partition_manager;
+    ss::sharded<cluster::shard_table>& _shard_table;
+    ss::sharded<cluster::metadata_cache>& _metadata_cache;
+    ss::sharded<rpc::connection_cache>& _connection_cache;
+    ss::sharded<partition_leaders_table>& _leaders;
+    std::unique_ptr<cluster::controller>& _controller;
+
+    ss::future<allocate_id_reply> dispatch_allocate_id_to_leader(
+      model::node_id, model::timeout_clock::duration);
+
+    ss::future<allocate_id_reply>
+    do_allocate_id(model::timeout_clock::duration timeout);
+
+    ss::future<bool> try_create_id_allocator_topic();
+
+    friend id_allocator;
+};
+} // namespace cluster

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -17,6 +17,7 @@
 #include "model/record_batch_reader.h"
 #include "raft/configuration.h"
 #include "raft/consensus.h"
+#include "raft/id_allocator_stm.h"
 #include "raft/log_eviction_stm.h"
 #include "raft/types.h"
 #include "storage/types.h"
@@ -118,6 +119,10 @@ public:
         return _raft->log_config().get_revision();
     }
 
+    std::unique_ptr<raft::id_allocator_stm>& id_allocator_stm() {
+        return _id_allocator_stm;
+    }
+
 private:
     friend partition_manager;
 
@@ -126,6 +131,7 @@ private:
 private:
     consensus_ptr _raft;
     std::unique_ptr<raft::log_eviction_stm> _nop_stm;
+    std::unique_ptr<raft::id_allocator_stm> _id_allocator_stm;
     ss::abort_source _as;
     partition_probe _probe;
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -31,6 +31,7 @@ class consensus;
 namespace cluster {
 
 static constexpr model::record_batch_type controller_record_batch_type{3};
+static constexpr model::record_batch_type id_allocator_stm_batch_type{8};
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
 using broker_ptr = ss::lw_shared_ptr<model::broker>;
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -35,6 +35,15 @@ static constexpr model::record_batch_type id_allocator_stm_batch_type{8};
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
 using broker_ptr = ss::lw_shared_ptr<model::broker>;
 
+struct allocate_id_request {
+    model::timeout_clock::duration timeout;
+};
+
+struct allocate_id_reply {
+    int64_t id;
+    errc ec;
+};
+
 /// Join request sent by node to join raft-0
 struct join_request {
     explicit join_request(model::broker b)

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -420,6 +420,21 @@ configuration::configuration()
       "Max compacted segment size after consolidation",
       required::no,
       5_GiB)
+  , id_allocator_log_capacity(
+      *this,
+      "id_allocator_log_capacity",
+      "Capacity of the id_allocator log in number of messages. "
+      "Once it reached id_allocator_stm should compact the log.",
+      required::no,
+      100)
+  , id_allocator_batch_size(
+      *this,
+      "id_allocator_batch_size",
+      "Id allocator allocates messages in batches (each batch is a "
+      "one log record) and then serves requests from memory without "
+      "touching the log until the batch is exhausted.",
+      required::no,
+      1000)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -109,6 +109,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> segment_appender_flush_timeout_ms;
     property<std::chrono::milliseconds> fetch_session_eviction_timeout_ms;
     property<size_t> max_compacted_log_segment_size;
+    property<int16_t> id_allocator_log_capacity;
+    property<int16_t> id_allocator_batch_size;
 
     configuration();
 

--- a/src/v/kafka/protocol.cc
+++ b/src/v/kafka/protocol.cc
@@ -39,7 +39,8 @@ protocol::protocol(
   ss::sharded<cluster::shard_table>& tbl,
   ss::sharded<cluster::partition_manager>& pm,
   ss::sharded<coordinator_ntp_mapper>& coordinator_mapper,
-  ss::sharded<fetch_session_cache>& session_cache) noexcept
+  ss::sharded<fetch_session_cache>& session_cache,
+  ss::sharded<cluster::id_allocator_frontend>& id_allocator_frontend) noexcept
   : _smp_group(smp)
   , _topics_frontend(tf)
   , _metadata_cache(meta)
@@ -48,7 +49,8 @@ protocol::protocol(
   , _shard_table(tbl)
   , _partition_manager(pm)
   , _coordinator_mapper(coordinator_mapper)
-  , _fetch_session_cache(session_cache) {}
+  , _fetch_session_cache(session_cache)
+  , _id_allocator_frontend(id_allocator_frontend) {}
 
 ss::future<> protocol::apply(rpc::server::resources rs) {
     auto ctx = ss::make_lw_shared<connection_context>(*this, std::move(rs));

--- a/src/v/kafka/protocol.h
+++ b/src/v/kafka/protocol.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/id_allocator_frontend.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
@@ -38,7 +39,8 @@ public:
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::partition_manager>&,
       ss::sharded<coordinator_ntp_mapper>& coordinator_mapper,
-      ss::sharded<fetch_session_cache>&) noexcept;
+      ss::sharded<fetch_session_cache>&,
+      ss::sharded<cluster::id_allocator_frontend>&) noexcept;
 
     ~protocol() noexcept override = default;
     protocol(const protocol&) = delete;
@@ -57,6 +59,9 @@ public:
     }
     cluster::metadata_cache& metadata_cache() {
         return _metadata_cache.local();
+    }
+    cluster::id_allocator_frontend& id_allocator_frontend() {
+        return _id_allocator_frontend.local();
     }
     kafka::group_router& group_router() { return _group_router.local(); }
     cluster::shard_table& shard_table() { return _shard_table.local(); }
@@ -81,6 +86,7 @@ private:
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<kafka::coordinator_ntp_mapper>& _coordinator_mapper;
     ss::sharded<kafka::fetch_session_cache>& _fetch_session_cache;
+    ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
 };
 
 } // namespace kafka

--- a/src/v/kafka/requests/init_producer_id_request.cc
+++ b/src/v/kafka/requests/init_producer_id_request.cc
@@ -9,8 +9,10 @@
 
 #include "kafka/requests/init_producer_id_request.h"
 
+#include "cluster/topics_frontend.h"
 #include "kafka/groups/group_manager.h"
 #include "kafka/groups/group_router.h"
+#include "kafka/logger.h"
 #include "kafka/requests/request_context.h"
 #include "kafka/requests/response.h"
 #include "utils/remote.h"
@@ -23,10 +25,31 @@ namespace kafka {
 ss::future<response_ptr> init_producer_id_api::process(
   request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
     return ss::do_with(std::move(ctx), [](request_context& ctx) {
+        vlog(klog.trace, "processing init_producer_id");
+
         init_producer_id_request request;
         request.decode(ctx.reader(), ctx.header().version);
-        return ss::make_exception_future<response_ptr>(std::runtime_error(
-          fmt::format("Unsupported API {}", ctx.header().key)));
+
+        return ctx.id_allocator_frontend()
+          .allocate_id(config::shard_local_cfg().create_topic_timeout_ms())
+          .then([&ctx](cluster::allocate_id_reply r) {
+              init_producer_id_response reply;
+
+              if (r.ec == cluster::errc::success) {
+                  reply.data.producer_id = kafka::producer_id(r.id);
+                  reply.data.producer_epoch = 0;
+                  vlog(
+                    klog.trace,
+                    "allocated pid {} with epoch {}",
+                    reply.data.producer_id,
+                    reply.data.producer_epoch);
+              } else {
+                  vlog(klog.warn, "failed to allocate pid");
+                  reply.data.error_code = error_code::broker_not_available;
+              }
+
+              return ctx.respond(std::move(reply));
+          });
     });
 }
 

--- a/src/v/kafka/requests/request_context.h
+++ b/src/v/kafka/requests/request_context.h
@@ -101,6 +101,10 @@ public:
         return _conn->server().topics_frontend();
     }
 
+    cluster::id_allocator_frontend& id_allocator_frontend() const {
+        return _conn->server().id_allocator_frontend();
+    }
+
     int32_t throttle_delay_ms() const {
         return std::chrono::duration_cast<std::chrono::milliseconds>(
                  _throttle_delay)

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -74,6 +74,8 @@ std::istream& operator>>(std::istream&, compaction_strategy&);
 
 using term_id = named_type<int64_t, struct model_raft_term_id_type>;
 
+using run_id = named_type<int64_t, struct model_raft_run_id_type>;
+
 using partition_id = named_type<int32_t, struct model_partition_id_type>;
 
 using topic_view = named_type<std::string_view, struct model_topic_view_type>;

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -34,5 +34,11 @@ inline const model::ns kafka_namespace("kafka");
 
 inline const model::ns kafka_internal_namespace("kafka_internal");
 inline const model::topic kafka_group_topic("group");
+inline const model::topic id_allocator_topic("id_allocator");
+
+inline const model::ntp id_allocator_ntp(
+  model::kafka_internal_namespace,
+  model::id_allocator_topic,
+  model::partition_id(0));
 
 } // namespace model

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -17,7 +17,7 @@ namespace model {
 
 using record_batch_type = named_type<int8_t, struct model_record_batch_type>;
 
-constexpr std::array<record_batch_type, 8> well_known_record_batch_types{
+constexpr std::array<record_batch_type, 9> well_known_record_batch_types{
   record_batch_type(),  // unknown - used for debugging
   record_batch_type(1), // raft::data
   record_batch_type(2), // raft::configuration
@@ -26,5 +26,6 @@ constexpr std::array<record_batch_type, 8> well_known_record_batch_types{
   record_batch_type(5), // checkpoint - used to achieve linearizable reads
   record_batch_type(6), // controller topic command batch type
   record_batch_type(7), // ghost - used to fill gaps in raft recovery
+  record_batch_type(8), // id_allocator_stm::*
 };
 } // namespace model

--- a/src/v/raft/CMakeLists.txt
+++ b/src/v/raft/CMakeLists.txt
@@ -28,6 +28,7 @@ v_cc_library(
     event_manager.cc
     state_machine.cc
     log_eviction_stm.cc
+    id_allocator_stm.cc
     configuration_manager.cc
     configuration.cc
     append_entries_buffer.cc

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -880,6 +880,27 @@ model::offset consensus::read_last_applied() const {
     return model::offset{};
 }
 
+ss::future<model::run_id> consensus::get_run_id() {
+    iobuf buf;
+    reflection::serialize(buf, metadata_key::unique_local_id, _group);
+    const auto key = iobuf_to_bytes(buf);
+
+    auto value = _storage.kvs().get(
+      storage::kvstore::key_space::consensus, key);
+
+    int64_t last_id = 0;
+    if (value) {
+        last_id = reflection::adl<int64_t>{}.from(std::move(*value));
+    }
+    last_id++;
+
+    iobuf val = reflection::to_iobuf(last_id);
+    return _storage.kvs()
+      .put(
+        storage::kvstore::key_space::consensus, std::move(key), std::move(val))
+      .then([last_id] { return model::run_id(last_id); });
+}
+
 void consensus::read_voted_for() {
     /*
      * Initial values

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -241,6 +241,9 @@ public:
 
     model::offset read_last_applied() const;
 
+    // yields a node scoped unique number on each invocation
+    ss::future<model::run_id> get_run_id();
+
     probe& get_probe() { return _probe; };
 
     bool are_heartbeats_suppressed(vnode) const;

--- a/src/v/raft/id_allocator_stm.cc
+++ b/src/v/raft/id_allocator_stm.cc
@@ -1,0 +1,261 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "raft/id_allocator_stm.h"
+
+#include "raft/errc.h"
+#include "raft/logger.h"
+#include "raft/types.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/future.hh>
+
+namespace raft {
+
+template<typename T>
+model::record_batch serialize_cmd(T t, model::record_batch_type type) {
+    storage::record_batch_builder b(type, model::offset(0));
+    iobuf key_buf;
+    reflection::adl<uint8_t>{}.to(key_buf, T::record_key);
+    iobuf v_buf;
+    reflection::adl<T>{}.to(v_buf, std::move(t));
+    b.add_raw_kv(std::move(key_buf), std::move(v_buf));
+    return std::move(b).build();
+}
+
+id_allocator_stm::id_allocator_stm(
+  ss::logger& logger, raft::consensus* c, config::configuration& config)
+  : raft::state_machine(c, logger, ss::default_priority_class())
+  , _config(config)
+  , _last_seq_tick(0)
+  , _c(c) {}
+
+ss::future<id_allocator_stm::stm_allocation_result>
+id_allocator_stm::allocate_id_and_wait(
+  model::timeout_clock::time_point timeout) {
+    auto prelude = ss::now();
+    auto range = _config.id_allocator_batch_size.value();
+
+    if (_last_allocated_range > 0) {
+        auto allocated_id = _last_allocated_base;
+        _last_allocated_range -= 1;
+        _last_allocated_base += 1;
+
+        return ss::make_ready_future<stm_allocation_result>(
+          stm_allocation_result{allocated_id, raft::errc::success});
+    }
+
+    if (_processed > _config.id_allocator_log_capacity.value()) {
+        sequence_id seq = sequence_id{
+          _run_id.value(), _c->self(), ++_last_seq_tick};
+        prelude = replicate_and_wait(prepare_truncation_cmd{seq}, timeout, seq)
+                    .then([this](bool replicated) {
+                        if (replicated) {
+                            try {
+                                (void)ss::with_gate(_gate, [this] {
+                                    return replicate(serialize_cmd(
+                                      execute_truncation_cmd{
+                                        _prepare_offset, _prepare_state},
+                                      cluster::id_allocator_stm_batch_type));
+                                });
+                            } catch (const ss::gate_closed_exception&) {
+                                // it's ok to ignore the expection because
+                                // it doesn't lead to any violation and
+                                // we can't do anything
+                            }
+                        }
+                    });
+    } else if (_should_cache) {
+        try {
+            (void)ss::with_gate(_gate, [this] {
+                return replicate(serialize_cmd(
+                  execute_truncation_cmd{_prepare_offset, _prepare_state},
+                  cluster::id_allocator_stm_batch_type));
+            });
+        } catch (const ss::gate_closed_exception&) {
+            // it's ok to ignore the expection because
+            // it doesn't lead to any violation and
+            // we can't do anything
+        }
+    }
+
+    return prelude.then([this, timeout, range] {
+        sequence_id seq = sequence_id{
+          _run_id.value(), _c->self(), ++_last_seq_tick};
+
+        return replicate_and_wait(allocation_cmd{seq, range}, timeout, seq)
+          .then([this](log_allocation_result r) {
+              _last_allocated_base = r.base + 1;
+              _last_allocated_range = r.range - 1;
+              return stm_allocation_result{r.base, r.raft_status};
+          });
+    });
+}
+
+ss::future<> id_allocator_stm::apply(model::record_batch b) {
+    if (b.header().type == cluster::id_allocator_stm_batch_type) {
+        return process(std::move(b));
+    }
+
+    return ss::now();
+}
+
+ss::future<> id_allocator_stm::start() {
+    auto last = _c->read_last_applied();
+    if (last != model::offset{}) {
+        set_next(last);
+    }
+
+    return state_machine::start().then([this] {
+        return _c->get_run_id().then(
+          [this](model::run_id id) { _run_id.emplace(id); });
+    });
+}
+
+ss::future<> id_allocator_stm::process(model::record_batch&& b) {
+    vassert(b.record_count() == 1, "We expect single command in single batch");
+    auto r = b.copy_records();
+    auto& record = *r.begin();
+    auto rk = reflection::adl<uint8_t>{}.from(record.release_key());
+
+    if (rk == allocation_cmd::record_key) {
+        allocation_cmd cmd = reflection::adl<allocation_cmd>{}.from(
+          record.release_value());
+        if (_should_cache) {
+            _cache.emplace_back(cached_allocation_cmd{b.last_offset(), cmd});
+        } else {
+            execute(b.last_offset(), cmd);
+        }
+    } else if (rk == prepare_truncation_cmd::record_key) {
+        prepare_truncation_cmd cmd = reflection::adl<prepare_truncation_cmd>{}
+                                       .from(record.release_value());
+        if (!_should_cache) {
+            _processed = 0;
+            _should_cache = true;
+            _prepare_state = _state;
+            _prepare_offset = b.last_offset();
+        }
+        if (auto it = _prepare_promises.find(cmd.seq);
+            it != _prepare_promises.end()) {
+            it->second.set_value(true);
+        }
+    } else if (rk == execute_truncation_cmd::record_key) {
+        execute_truncation_cmd cmd = reflection::adl<execute_truncation_cmd>{}
+                                       .from(record.release_value());
+        if (_should_cache && _prepare_offset == cmd.prepare_offset) {
+            _state = cmd.state;
+            for (auto& it : _cache) {
+                execute(it.offset, it.cmd);
+            }
+            _cache.clear();
+            _should_cache = false;
+            return _c->write_last_applied(_prepare_offset).then([this] {
+                return _c->write_snapshot(raft::write_snapshot_cfg(
+                  model::offset(_prepare_offset - 1),
+                  iobuf(),
+                  raft::write_snapshot_cfg::should_prefix_truncate::yes));
+            });
+        }
+    }
+    return ss::now();
+}
+
+void id_allocator_stm::execute(model::offset offset, allocation_cmd c) {
+    auto base = _state;
+    _state += c.range;
+    _processed += 1;
+
+    id_allocator_stm::log_allocation_result result{
+      c.seq, base, c.range, raft::errc::success, offset};
+
+    if (auto it = _promises.find(result.seq); it != _promises.end()) {
+        it->second.set_value(result);
+    }
+}
+
+ss::future<id_allocator_stm::log_allocation_result>
+id_allocator_stm::replicate_and_wait(
+  allocation_cmd cmd,
+  model::timeout_clock::time_point timeout,
+  sequence_id seq) {
+    using ret_t = id_allocator_stm::log_allocation_result;
+
+    auto b = serialize_cmd(cmd, cluster::id_allocator_stm_batch_type);
+    _promises.emplace(seq, expiring_promise<ret_t>{});
+
+    return replicate(std::move(b))
+      .then([this, seq, timeout](result<raft::replicate_result> r) {
+          if (!r) {
+              _promises.erase(seq);
+              auto result = id_allocator_stm::log_allocation_result{
+                seq, 0, 0, raft::errc::timeout, model::offset(0)};
+              return ss::make_ready_future<ret_t>(result);
+          }
+
+          auto last_offset = r.value().last_offset;
+
+          auto it = _promises.find(seq);
+
+          vassert(
+            it != _promises.end(), "seq isn't in _promises after insertion");
+
+          return it->second
+            .get_future_with_timeout(
+              timeout,
+              [seq, last_offset] {
+                  return id_allocator_stm::log_allocation_result{
+                    seq, 0, 0, raft::errc::timeout, last_offset};
+              })
+            .then([this, seq, last_offset](ret_t r) {
+                _promises.erase(seq);
+                vassert(
+                  r.offset == last_offset,
+                  "seq uniqueness violation, got offset: {} expected offset: "
+                  "{}",
+                  r.offset,
+                  last_offset);
+                return ss::make_ready_future<ret_t>(r);
+            });
+      });
+}
+
+ss::future<bool> id_allocator_stm::replicate_and_wait(
+  prepare_truncation_cmd cmd,
+  model::timeout_clock::time_point timeout,
+  sequence_id seq) {
+    auto b = serialize_cmd(cmd, cluster::id_allocator_stm_batch_type);
+    _prepare_promises.emplace(seq, expiring_promise<bool>{});
+
+    return replicate(std::move(b))
+      .then([this, seq, timeout](result<raft::replicate_result> r) {
+          if (!r) {
+              _prepare_promises.erase(seq);
+              return ss::make_ready_future<bool>(false);
+          }
+
+          auto it = _prepare_promises.find(seq);
+
+          vassert(
+            it != _prepare_promises.end(),
+            "seq isn't in _prepare_promises after insertion");
+
+          return it->second
+            .get_future_with_timeout(timeout, [] { return false; })
+            .finally([this, seq] { _prepare_promises.erase(seq); });
+      });
+}
+
+ss::future<result<raft::replicate_result>>
+id_allocator_stm::replicate(model::record_batch&& batch) {
+    return _c->replicate(
+      model::make_memory_record_batch_reader(std::move(batch)),
+      raft::replicate_options{raft::consistency_level::quorum_ack});
+}
+
+} // namespace raft

--- a/src/v/raft/id_allocator_stm.h
+++ b/src/v/raft/id_allocator_stm.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "raft/consensus.h"
+#include "raft/errc.h"
+#include "raft/logger.h"
+#include "raft/state_machine.h"
+#include "utils/expiring_promise.h"
+#include "utils/mutex.h"
+
+#include <absl/container/flat_hash_map.h>
+
+namespace raft {
+
+// id_allocator is a service to generate cluster-wide unique id (int64)
+// It is based on a state machine running on top of a raft log. For each
+// request (*) it adds "+1" command to the log, reads the log up
+// to this command (identified by a sequence_id), sums all the read
+// commands and returns a result.
+//
+// (*) When we do this procedure for each request it becomes costly
+// in terms of latency so the id_allocator_stm allocates the ids in
+// batches using "+1000" commands (the actual value comes from the
+// configuration see id_allocator_batch_size) and then serves the
+// requests without touching the log until the batch is exhausted.
+//
+// sequence_id is 3-tuple, first component is a node-unique id generated
+// on the app start (we use kvstore to persist the value and guarantee
+// monotonicity / uniqueness), second component is a node id and the
+// last component is persisted in RAM. All the 3 components guarantees
+// uniqueness even if the node is restarted (last component is reset but
+// the first is incremented).
+//
+// Log garbage collection. If we do nothing all the "+1000" commands will
+// eventually consume all the disk. To prevent this from happening
+// we use the following snapshotting scheme:
+//
+//   1. once the log size passes a threshold a leader writes
+//      "prepare_truncation" message to mark a place in the log
+//      where we want to cut off the history
+//
+//   2. when the leader catches up with the "prepare_truncation"
+//      it knows the current state (sum of all the messages before
+//      the mark) and the prepare_truncation's  so it writes
+//      "execute_truncation(state, offset)"
+//
+//   3. after the leader catches up with the execute_truncation
+//      command it truncates the local log before the mark by
+//      calling raft::write_snapshot
+//
+//   4. after a follower catches up with the execute_truncation
+//      it truncates its log
+//
+// There may be regular "+1000" commands between the "prepare" and the
+// "execute" commands. When this happen the state_machine postpone the
+// execution of the "+1000" commands until it meets the execute_truncation
+// and use its state as a base for the increments.
+// A leader starts acting before it reads up to the current moment
+// so there may be a situation when a leader issues several
+// "prepare_truncation" before it issues "execute_truncation" in this
+// case the first "prepare_truncation" in the log order wins. The same
+// works with "execute_truncation" the first wins.
+
+class id_allocator_stm final : public raft::state_machine {
+public:
+    struct stm_allocation_result {
+        int64_t id;
+        raft::errc raft_status{raft::errc::success};
+    };
+
+    explicit id_allocator_stm(
+      ss::logger&, raft::consensus*, config::configuration&);
+
+    ss::future<> start() final;
+
+    ss::future<stm_allocation_result>
+    allocate_id_and_wait(model::timeout_clock::time_point timeout);
+
+private:
+    struct sequence_id {
+        model::run_id run_id;
+        model::node_id node_id;
+        int64_t tick;
+
+        bool operator==(const sequence_id& other) const {
+            return run_id == other.run_id && node_id == other.node_id
+                   && tick == other.tick;
+        }
+
+        bool operator!=(const sequence_id& other) const {
+            return !(*this == other);
+        }
+
+        template<typename H>
+        friend H AbslHashValue(H h, const sequence_id& seq) {
+            return H::combine(std::move(h), seq.run_id, seq.node_id, seq.tick);
+        }
+    };
+
+    struct log_allocation_result {
+        sequence_id seq;
+        int64_t base;
+        int64_t range;
+        raft::errc raft_status{raft::errc::success};
+        model::offset offset;
+    };
+
+    struct allocation_cmd {
+        static constexpr uint8_t record_key = 0;
+        sequence_id seq;
+        int64_t range;
+    };
+
+    struct prepare_truncation_cmd {
+        static constexpr uint8_t record_key = 1;
+        sequence_id seq;
+    };
+
+    struct execute_truncation_cmd {
+        static constexpr uint8_t record_key = 2;
+        model::offset prepare_offset;
+        int64_t state;
+    };
+
+    struct cached_allocation_cmd {
+        model::offset offset;
+        allocation_cmd cmd;
+    };
+
+    ss::future<> process(model::record_batch&& b);
+    void execute(model::offset offset, allocation_cmd c);
+
+    ss::future<> apply(model::record_batch b) override;
+    ss::future<result<raft::replicate_result>> replicate(model::record_batch&&);
+    ss::future<log_allocation_result> replicate_and_wait(
+      allocation_cmd, model::timeout_clock::time_point, sequence_id);
+    ss::future<bool> replicate_and_wait(
+      prepare_truncation_cmd, model::timeout_clock::time_point, sequence_id);
+
+    config::configuration& _config;
+    int64_t _last_seq_tick;
+    std::optional<model::run_id> _run_id;
+
+    raft::consensus* _c;
+    absl::flat_hash_map<sequence_id, expiring_promise<log_allocation_result>>
+      _promises;
+    absl::flat_hash_map<sequence_id, expiring_promise<bool>> _prepare_promises;
+
+    int64_t _state{0};
+    int64_t _processed{0};
+    int64_t _last_allocated_base{0};
+    int64_t _last_allocated_range{0};
+    bool _should_cache{false};
+    model::offset _prepare_offset{0};
+    int64_t _prepare_state{0};
+    std::vector<cached_allocation_cmd> _cache;
+};
+
+} // namespace raft

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -34,6 +34,8 @@ ss::future<> state_machine::start() {
     return ss::now();
 }
 
+void state_machine::set_next(model::offset offset) { _next = offset; }
+
 ss::future<> state_machine::stop() {
     _waiters.stop();
     _as.request_abort();

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -60,7 +60,7 @@ public:
     state_machine(consensus*, ss::logger& log, ss::io_priority_class io_prio);
 
     // start after ready to receive batches through apply upcall.
-    ss::future<> start();
+    virtual ss::future<> start();
 
     ss::future<> stop();
 
@@ -88,6 +88,12 @@ public:
     ss::future<result<replicate_result>>
       quorum_write_empty_batch(model::timeout_clock::time_point);
 
+    virtual ~state_machine() {}
+
+protected:
+    void set_next(model::offset offset);
+    ss::gate _gate;
+
 private:
     class batch_applicator {
     public:
@@ -111,7 +117,6 @@ private:
     offset_monitor _waiters;
     model::offset _next;
     ss::abort_source _as;
-    ss::gate _gate;
     model::offset _bootstrap_last_applied;
 };
 

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(srcs
     mux_state_machine_test.cc
     mutex_buffer_test.cc
     manual_log_deletion_test.cc
+    id_allocator_stm_test.cc
     configuration_manager_test.cc)
 
 rp_test(

--- a/src/v/raft/tests/id_allocator_stm_test.cc
+++ b/src/v/raft/tests/id_allocator_stm_test.cc
@@ -1,0 +1,103 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/timeout_clock.h"
+#include "outcome.h"
+#include "raft/id_allocator_stm.h"
+#include "raft/tests/mux_state_machine_fixture.h"
+#include "raft/types.h"
+#include "random/generators.h"
+#include "reflection/adl.h"
+#include "storage/record_batch_builder.h"
+#include "storage/tests/utils/disk_log_builder.h"
+#include "storage/tests/utils/random_batch.h"
+#include "test_utils/async.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/log.hh>
+
+#include <boost/range/irange.hpp>
+#include <boost/test/tools/old/interface.hpp>
+
+#include <thread>
+
+using namespace std::chrono_literals;
+
+ss::logger idstmlog{"idstm-test"};
+
+FIXTURE_TEST(stm_monotonicity_test, mux_state_machine_fixture) {
+    start_raft();
+
+    config::configuration cfg;
+    cfg.id_allocator_batch_size.set_value(int16_t(1));
+    cfg.id_allocator_log_capacity.set_value(int16_t(2));
+
+    raft::id_allocator_stm stm(idstmlog, _raft.get(), cfg);
+
+    stm.start().get0();
+    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+
+    wait_for_leader();
+
+    int64_t last_id = -1;
+
+    for (int i = 0; i < 5; i++) {
+        auto result
+          = stm.allocate_id_and_wait(model::timeout_clock::now() + 1s).get0();
+
+        BOOST_REQUIRE_EQUAL(raft::errc::success, result.raft_status);
+        BOOST_REQUIRE_LT(last_id, result.id);
+
+        last_id = result.id;
+    }
+}
+
+FIXTURE_TEST(stm_restart_test, mux_state_machine_fixture) {
+    start_raft();
+
+    config::configuration cfg;
+    cfg.id_allocator_batch_size.set_value(int16_t(1));
+    cfg.id_allocator_log_capacity.set_value(int16_t(2));
+
+    raft::id_allocator_stm stm1(idstmlog, _raft.get(), cfg);
+    stm1.start().get0();
+    wait_for_leader();
+
+    int64_t last_id = -1;
+
+    for (int i = 0; i < 5; i++) {
+        auto result
+          = stm1.allocate_id_and_wait(model::timeout_clock::now() + 1s).get0();
+
+        BOOST_REQUIRE_EQUAL(raft::errc::success, result.raft_status);
+        BOOST_REQUIRE_LT(last_id, result.id);
+
+        last_id = result.id;
+    }
+    stm1.stop().get0();
+
+    raft::id_allocator_stm stm2(idstmlog, _raft.get(), cfg);
+    stm2.start().get0();
+    for (int i = 0; i < 5; i++) {
+        auto result
+          = stm2.allocate_id_and_wait(model::timeout_clock::now() + 1s).get0();
+
+        BOOST_REQUIRE_EQUAL(raft::errc::success, result.raft_status);
+        BOOST_REQUIRE_LT(last_id, result.id);
+
+        last_id = result.id;
+    }
+    stm2.stop().get0();
+}

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
+#pragma once
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timeout_clock.h"

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -436,6 +436,7 @@ enum class metadata_key : int8_t {
     config_map = 1,
     config_latest_known_offset = 2,
     last_applied_offset = 3,
+    unique_local_id = 4,
 };
 
 // priority used to implement semi-deterministic leader election

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/controller.h"
+#include "cluster/id_allocator_frontend.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/metadata_dissemination_service.h"
 #include "cluster/partition_manager.h"
@@ -68,6 +69,7 @@ public:
     ss::sharded<kafka::fetch_session_cache> fetch_session_cache;
     smp_groups smp_service_groups;
     ss::sharded<kafka::quota_manager> quota_mgr;
+    ss::sharded<cluster::id_allocator_frontend> id_allocator_frontend;
 
 private:
     using deferred_actions

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -52,7 +52,8 @@ public:
           app.shard_table,
           app.partition_manager,
           app.coordinator_ntp_mapper,
-          app.fetch_session_cache);
+          app.fetch_session_cache,
+          app.id_allocator_frontend);
     }
 
     ~redpanda_thread_fixture() {


### PR DESCRIPTION
This series of the commits adds handling of the init_producer_id
request. This api is a part of the idempotent producer feature.
The series consist of the following major parts:

1. state machine (id_allocator_stm) running on top of a topic
   with a single partition and responsible for unique id generation

2. internal service (id_allocator.json) exposing the stm interface
   to the brokers

3. a client to the service (id_allocator_frontend). The client
   either sends a request to the service or acts on its behalf
   when the service's leader lives on the node

 See the id_allocator_stm.h file for more information

https://github.com/vectorizedio/redpanda/issues/216