### PR TITLE
Disable cache for internal topics

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -36,7 +36,7 @@ storage::ntp_config topic_configuration::make_ntp_config(
                          || segment_size || retention_bytes.has_value()
                          || retention_bytes.is_disabled()
                          || retention_duration.has_value()
-                         || retention_duration.is_disabled();
+                         || retention_duration.is_disabled() || is_internal();
     std::unique_ptr<storage::ntp_config::default_overrides> overrides = nullptr;
 
     if (has_overrides) {
@@ -46,7 +46,10 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .compaction_strategy = compaction_strategy,
             .segment_size = segment_size,
             .retention_bytes = retention_bytes,
-            .retention_time = retention_duration});
+            .retention_time = retention_duration,
+            // we disable cache for internal topics as they are read only once
+            // during bootstrap.
+            .cache_enabled = storage::with_cache(!is_internal())});
     }
     return storage::ntp_config(
       model::ntp(tp_ns.ns, tp_ns.tp, p_id),

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/errc.h"
+#include "cluster/namespace.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -83,6 +84,8 @@ struct topic_configuration {
 
     storage::ntp_config make_ntp_config(
       const ss::sstring&, model::partition_id, model::revision_id) const;
+
+    bool is_internal() const { return tp_ns.ns == kafka_internal_namespace; }
 
     model::topic_namespace tp_ns;
     // using signed integer because Kafka protocol defines it as signed int

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -39,7 +39,7 @@ struct bootstrap_fixture : raft::simple_record_fixture {
           "test.dir",
           1_GiB,
           storage::debug_sanitize_files::yes,
-          storage::log_config::with_cache::no)) {
+          storage::with_cache::no)) {
         _storage.start().get();
         // ignore the get_log()
         (void)_storage.log_mgr()

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -89,7 +89,7 @@ struct mux_state_machine_fixture {
           _data_dir,
           100_MiB,
           storage::debug_sanitize_files::yes,
-          storage::log_config::with_cache::yes);
+          storage::with_cache::yes);
     }
 
     model::broker self_broker() {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -316,8 +316,7 @@ static storage::log_config manager_config_from_global_config() {
       config::shard_local_cfg().retention_bytes(),
       config::shard_local_cfg().log_compaction_interval_ms(),
       config::shard_local_cfg().delete_retention_ms(),
-      storage::log_config::with_cache(
-        !config::shard_local_cfg().disable_batch_cache()),
+      storage::with_cache(!config::shard_local_cfg().disable_batch_cache()),
       storage::batch_cache::reclaim_options{
         .growth_window = config::shard_local_cfg().reclaim_growth_window(),
         .stable_window = config::shard_local_cfg().reclaim_stable_window(),

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -158,7 +158,7 @@ ss::future<ss::lw_shared_ptr<segment>> log_manager::make_log_segment(
 }
 
 std::optional<batch_cache_index> log_manager::create_cache() {
-    if (unlikely(_config.cache == log_config::with_cache::no)) {
+    if (unlikely(_config.cache == with_cache::no)) {
         return std::nullopt;
     }
 

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -41,7 +41,6 @@ namespace storage {
 
 struct log_config {
     enum class storage_type { memory, disk };
-    using with_cache = ss::bool_class<struct log_cache_tag>;
     log_config(
       storage_type type,
       ss::sstring directory,
@@ -105,7 +104,7 @@ struct log_config {
     std::chrono::milliseconds compaction_interval = std::chrono::minutes(10);
     // same as delete.retention.ms in kafka - default 1 week
     std::chrono::milliseconds delete_retention = std::chrono::minutes(10080);
-    with_cache cache = log_config::with_cache::yes;
+    with_cache cache = with_cache::yes;
     batch_cache::reclaim_options reclaim_opts{
       .growth_window = std::chrono::seconds(3),
       .stable_window = std::chrono::seconds(10),

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -204,7 +204,7 @@ private:
     void arm_housekeeping();
     ss::future<> housekeeping();
 
-    std::optional<batch_cache_index> create_cache();
+    std::optional<batch_cache_index> create_cache(with_cache);
 
     ss::future<> dispatch_topic_dir_deletion(ss::sstring dir);
     ss::future<> recover_log_state(const ntp_config&);

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -19,6 +19,8 @@
 #include <optional>
 
 namespace storage {
+using with_cache = ss::bool_class<struct log_cache_tag>;
+
 class ntp_config {
 public:
     struct default_overrides {

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -35,6 +35,9 @@ public:
         // will be disabled if there is no value set the default will be used
         tristate<size_t> retention_bytes{std::nullopt};
         tristate<std::chrono::milliseconds> retention_time{std::nullopt};
+        // if set, log will not use batch cache
+        with_cache cache_enabled = with_cache::yes;
+
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
     };
@@ -102,6 +105,10 @@ public:
 
     std::filesystem::path topic_directory() const {
         return std::filesystem::path(_base_dir) / _ntp.topic_path();
+    }
+
+    with_cache cache_enabled() const {
+        return with_cache(!has_overrides() || _overrides->cache_enabled);
     }
 
 private:

--- a/src/v/storage/opfuzz/opfuzz_test.cc
+++ b/src/v/storage/opfuzz/opfuzz_test.cc
@@ -39,7 +39,7 @@ FIXTURE_TEST(test_random_workload, storage_test_fixture) {
       std::move(test_dir),
       200_MiB,
       storage::debug_sanitize_files::no,
-      storage::log_config::with_cache::yes));
+      storage::with_cache::yes));
     auto deferred = ss::defer([&mngr]() mutable { mngr.stop().get0(); });
 
     // Test parameters
@@ -87,7 +87,7 @@ FIXTURE_TEST(test_random_remove, storage_test_fixture) {
       std::move(test_dir),
       200_MiB,
       storage::debug_sanitize_files::no,
-      storage::log_config::with_cache::yes));
+      storage::with_cache::yes));
     auto deferred = ss::defer([&mngr]() mutable { mngr.stop().get0(); });
 
     // Test parameters

--- a/src/v/storage/tests/half_page_concurrent_dispatch.cc
+++ b/src/v/storage/tests/half_page_concurrent_dispatch.cc
@@ -20,7 +20,7 @@ struct fixture {
       storage::random_dir(),
       1_GiB,
       storage::debug_sanitize_files::yes,
-      storage::log_config::with_cache::no)};
+      storage::with_cache::no)};
     ~fixture() { b.stop().get(); }
 };
 

--- a/src/v/storage/tests/produce_consume_test.cc
+++ b/src/v/storage/tests/produce_consume_test.cc
@@ -17,7 +17,7 @@ using namespace storage; // NOLINT
 
 SEASTAR_THREAD_TEST_CASE(produce_consume_concurrency) {
     auto cfg = log_builder_config();
-    cfg.cache = storage::log_config::with_cache::no;
+    cfg.cache = storage::with_cache::no;
     storage::disk_log_builder builder(std::move(cfg));
     builder | storage::start();
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -792,7 +792,7 @@ void append_single_record_batch(
 FIXTURE_TEST(truncate_and_roll_segment, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.stype = storage::log_config::storage_type::disk;
-    cfg.cache = storage::log_config::with_cache::yes;
+    cfg.cache = storage::with_cache::yes;
 
     {
         storage::log_manager mgr = make_log_manager(cfg);
@@ -838,7 +838,7 @@ FIXTURE_TEST(truncate_and_roll_segment, storage_test_fixture) {
 FIXTURE_TEST(compacted_log_truncation, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.stype = storage::log_config::storage_type::disk;
-    cfg.cache = storage::log_config::with_cache::yes;
+    cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::compaction;
@@ -903,7 +903,7 @@ FIXTURE_TEST(
   check_segment_roll_after_compacted_log_truncate, storage_test_fixture) {
     auto cfg = default_log_config(test_dir);
     cfg.stype = storage::log_config::storage_type::disk;
-    cfg.cache = storage::log_config::with_cache::yes;
+    cfg.cache = storage::with_cache::yes;
     storage::ntp_config::default_overrides overrides;
     overrides.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::compaction;
@@ -985,7 +985,7 @@ FIXTURE_TEST(partition_size_while_cleanup, storage_test_fixture) {
     cfg.max_compacted_segment_size = 10_KiB;
     cfg.stype = storage::log_config::storage_type::disk;
     // we want force reading most recent compacted batches, disable the cache
-    cfg.cache = storage::log_config::with_cache::no;
+    cfg.cache = storage::with_cache::no;
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
 

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -76,8 +76,8 @@ public:
         auto stype = i > 50 ? storage::log_config::storage_type::disk
                             : storage::log_config::storage_type::memory;
 
-        auto cache = i > 50 ? storage::log_config::with_cache::yes
-                            : storage::log_config::with_cache::no;
+        auto cache = i > 50 ? storage::with_cache::yes
+                            : storage::with_cache::no;
         return storage::log_config(
           stype,
           std::move(test_dir),


### PR DESCRIPTION
Some of the topics with high message rate (i.e. consumer groups topics)
may waste a lot of space in batch cache causing latency degradation.
Internal topics are read only during bootstrap phase to rebuild an in
memory state, therefore we can safely disable cache for those topics
without performance degradation.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
