### PR TITLE
r/consensus: amortized flushing when executing append entries request

### DIFF
--- a/src/v/raft/CMakeLists.txt
+++ b/src/v/raft/CMakeLists.txt
@@ -30,6 +30,7 @@ v_cc_library(
     log_eviction_stm.cc
     configuration_manager.cc
     configuration.cc
+    append_entries_buffer.cc
   DEPS
     v::storage
     raft_rpc

--- a/src/v/raft/append_entries_buffer.cc
+++ b/src/v/raft/append_entries_buffer.cc
@@ -1,0 +1,121 @@
+#include "raft/append_entries_buffer.h"
+
+#include "raft/consensus.h"
+#include "raft/types.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/do_with.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/util/later.hh>
+#include <seastar/util/variant_utils.hh>
+
+#include <exception>
+#include <variant>
+#include <vector>
+namespace raft {
+
+append_entries_buffer::append_entries_buffer(
+  consensus& c, size_t max_buffered_elements)
+  : _consensus(c)
+  , _max_buffered(max_buffered_elements) {}
+
+ss::future<append_entries_reply>
+append_entries_buffer::enqueue(append_entries_request&& r) {
+    return ss::with_gate(_gate, [this, r = std::move(r)]() mutable {
+        // we normally do not want to wait as it would cause requests
+        // reordering. Reordering may only happend if we would wait on condition
+        // variable.
+
+        return _flushed
+          .wait([this] { return _requests.size() < _max_buffered; })
+          .then([this, r = std::move(r)]() mutable {
+              ss::promise<append_entries_reply> p;
+              auto f = p.get_future();
+              _requests.push_back(std::move(r));
+              _responses.push_back(std::move(p));
+              _enqueued.signal();
+              return f;
+          });
+    });
+}
+
+ss::future<> append_entries_buffer::stop() {
+    _enqueued.broken();
+    _flushed.broken();
+    return _gate.close();
+}
+
+void append_entries_buffer::start() {
+    (void)ss::with_gate(_gate, [this] {
+        return ss::do_until(
+          [this] { return _gate.is_closed(); },
+          [this] {
+              return _enqueued.wait([this] { return !_requests.empty(); })
+                .then([this] { return flush(); })
+                .handle_exception_type(
+                  [](const ss::broken_condition_variable&) {
+                      // ignore exception, we are about to stop
+                  });
+          });
+    });
+}
+
+ss::future<> append_entries_buffer::flush() {
+    auto requests = std::exchange(_requests, {});
+    auto response_promises = std::exchange(_responses, {});
+
+    return _consensus._op_lock.with(
+      [this,
+       requests = std::move(requests),
+       response_promises = std::move(response_promises)]() mutable {
+          return do_flush(std::move(requests), std::move(response_promises));
+      });
+}
+
+ss::future<> append_entries_buffer::do_flush(
+  request_t requests, response_t response_promises) {
+    bool needs_flush = false;
+    std::vector<reply_t> replies;
+    replies.reserve(requests.size());
+    for (auto& req : requests) {
+        if (req.flush) {
+            needs_flush = true;
+        }
+        try {
+            // NOTE: do_append_entries do not flush
+            auto reply = co_await _consensus.do_append_entries(std::move(req));
+            replies.emplace_back(reply);
+        } catch (...) {
+            replies.emplace_back(std::current_exception());
+        }
+    }
+    if (needs_flush) {
+        co_await _consensus.flush_log();
+    }
+
+    propagate_results(std::move(replies), std::move(response_promises));
+    _flushed.broadcast();
+    co_return;
+}
+
+void append_entries_buffer::propagate_results(
+  std::vector<reply_t> replies, response_t response_promises) {
+    auto resp_it = response_promises.begin();
+    for (auto& reply : replies) {
+        auto lstats = _consensus._log.offsets();
+        ss::visit(
+          reply,
+          [&resp_it, &lstats](append_entries_reply r) {
+              // this is important, we want to update response committed
+              // offset here as we flushed after the response structure was
+              // created
+              r.last_committed_log_index = lstats.committed_offset;
+              resp_it->set_value(r);
+          },
+          [&resp_it](std::exception_ptr& e) {
+              resp_it->set_exception(std::move(e));
+          });
+        resp_it++;
+    }
+}
+} // namespace raft

--- a/src/v/raft/append_entries_buffer.h
+++ b/src/v/raft/append_entries_buffer.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include "raft/types.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/gate.hh>
+
+namespace raft {
+
+class consensus;
+/**
+ * This class allows to buffer append entries request  waiting for consensus op
+ * mutex and when mutex is eventually available execute all buffered calls
+ * without releasing mutex in between single calls. Additionally the
+ * append_entries buffer leverages the fact that single flush after all log
+ * append is enough to synchronize data on disk and guarantee safety. This
+ * approach leverages the fact that our append are much faster (up to hundreds
+ * of microseconds) compared to flush.
+ *
+ * Standard append entries processing:
+ *
+ *  +---------------+              +-----------+   +-------+ +-----+
+ *  | raft_service  |              | consensus |   | mutex | | log |
+ *  +---------------+              +-----------+   +-------+ +-----+
+ *          |                            |             |        |
+ *          | append_entries             |             |        |
+ *          |--------------------------->|             |        |
+ *          |                            |             |        |
+ *          |                            | acquire     |        |
+ *          |                            |------------>|        |
+ *          |                            |             |        |
+ *          |                            |     granted |        |
+ *          |                            |<------------|        |
+ *          |                            |             |        |
+ *          |                            | append      |        |
+ *          |                            |--------------------->|
+ *          |                            |             |        |
+ *          |                            |        append_result |
+ *          |                            |<---------------------|
+ *          |                            |             |        |
+ *          |                            | flush       |        |
+ *          |                            |--------------------->|
+ *          |                            |             |        |
+ *          |                            |             |     ok |
+ *          |                            |<---------------------|
+ *          |                            |             |        |
+ *          |       append entries reply |             |        |
+ *          |<---------------------------|             |        |
+ *          |                            |             |        |
+ *          |                            | release     |        |
+ *          |                            |------------>|        |
+ *          |                            |             |        |
+ *          |                            |             |        |
+ *          | next append_entries        |             |        |
+ *          |--------------------------->|             |        |
+ *          |                            |             |        |
+ *
+ * With append_entries_buffer:
+ *
+ * +---------------+             +-----------+   +--------+    +-------+ +-----+
+ * | raft_service  |             | consensus |   | buffer |    | mutex | | log |
+ * +---------------+             +-----------+   +--------+    +-------+ +-----+
+ *         |                           |            |                 |        |
+ *         | append_entries            |            |                 |        |
+ *         |-------------------------->|            |                 |        |
+ *         |                           |            |                 |        |
+ *         |                           | enqueue    |                 |        |
+ *         |                           |----------->|                 |        |
+ *         |                           |            |                 |        |
+ *         | next append_entries       |            |                 |        |
+ *         |-------------------------->|            |                 |        |
+ *         |                           |            |                 |        |
+ *         |                           | enqueue    |                 |        |
+ *         |                           |----------->|                 |        |
+ *         |                           |            |                 |        |
+ *         |                           |            | acquire         |        |
+ *         |                           |            |---------------->|        |
+ *         |                           |            |                 |        |
+ *         |                           |            |         granted |        |
+ *         |                           |            |<----------------|        |
+ *         |                           |            |                 |        |
+ *         |                           |            | append          |        |
+ *         |                           |            |------------------------->|
+ *         |                           |            |                 |        |
+ *         |                           |            |            append_result |
+ *         |                           |<--------------------------------------|
+ *         |                           |            |                 |        |
+ *         |                           |            | next append     |        |
+ *         |                           |            |------------------------->|
+ *         |                           |            |                 |        |
+ *         |                           |            |            append_result |
+ *         |                           |<--------------------------------------|
+ *         |                           |            |                 |        |
+ *         |                           | flush      |                 |        |
+ *         |                           |-------------------------------------->|
+ *         |                           |            |                 |        |
+ *         |                           |            |                 |   ok   |
+ *         |                           |<--------------------------------------|
+ *         |                           |            |                 |        |
+ *         | append entries reply      |            |                 |        |
+ *         |<---------------------------------------|                 |        |
+ *         |                           |            |                 |        |
+ *         | next append entries reply |            |                 |        |
+ *         |<---------------------------------------|                 |        |
+ *         |                           |            |                 |        |
+ *         |                           | release    |                 |        |
+ *         |                           |----------------------------->|        |
+ *         |                           |            |                 |        |
+ *
+ * Described approach allows us to reduce number of expensive log::flush
+ * operations.
+ *
+ * The class is taking additional advantage by setting all replies committed
+ * offset to the latest value updated by log::flush. Since all the requests were
+ * already sent by the leader it means that leader already appendend all
+ * entries to its local log. It can therefore update commit_index as soon as it
+ * will receive the first response, still being correct and guaranteeing safety.
+ *
+ * Note on backpressure handling:
+ *
+ * The backpressure is handled using condition variable. When buffer has free
+ * space we notify waiters.
+ */
+class append_entries_buffer {
+public:
+    explicit append_entries_buffer(consensus&, size_t max_buffered_elements);
+
+    ss::future<append_entries_reply> enqueue(append_entries_request&& r);
+
+    void start();
+    ss::future<> stop();
+
+private:
+    using request_t = std::vector<append_entries_request>;
+    using response_t = std::vector<ss::promise<append_entries_reply>>;
+    using reply_t = std::variant<append_entries_reply, std::exception_ptr>;
+
+    ss::future<> flush();
+    ss::future<> do_flush(request_t, response_t);
+
+    void propagate_results(std::vector<reply_t>, response_t);
+
+    consensus& _consensus;
+    request_t _requests;
+    response_t _responses;
+    ss::condition_variable _enqueued;
+    ss::gate _gate;
+    ss::condition_variable _flushed;
+    const size_t _max_buffered;
+};
+
+} // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -14,6 +14,7 @@
 #include "hashing/crc32c.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "raft/append_entries_buffer.h"
 #include "raft/configuration_manager.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/event_manager.h"
@@ -230,6 +231,7 @@ private:
     friend recovery_stm;
     friend replicate_batcher;
     friend event_manager;
+    friend append_entries_buffer;
 
     // all these private functions assume that we are under exclusive operations
     // via the _op_sem
@@ -419,8 +421,7 @@ private:
     model::offset _last_quorum_replicated_index;
     offset_monitor _consumable_offset_monitor;
     ss::condition_variable _disk_append;
-    details::mutex_buffer<append_entries_request, append_entries_reply>
-      _append_requests_buffer;
+    append_entries_buffer _append_requests_buffer;
     friend std::ostream& operator<<(std::ostream&, const consensus&);
 };
 

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -71,7 +71,8 @@ public:
               r.node_id,
               m,
               model::make_memory_record_batch_reader(
-                ss::circular_buffer<model::record_batch>{})));
+                ss::circular_buffer<model::record_batch>{}),
+              append_entries_request::flush_after_append::no));
         }
 
         auto req_size = reqs.size();


### PR DESCRIPTION
Reduced number of disk log flushes by leveraging the fact that multiple
requests may wait for the raft mutex to be available. All waiting
requests are executed when raft mutex is acquired without releasing it.
We can leverage the fact that flush executed after the last append is
automatically committing all previous writes. This allows us to reduce
number of log flushes and call `storage::log::flush` only after last
request was processed.
```
Example:

Assumptions:
  - 3 requests pending to acquire raft mutex

    +----------+
Box |   ....   | represent log operation
    +----------+

Implementation change the following:

+----------+---------+----------+---------+----------+---------+
|  append  |  flush  |  append  |  flush  |  append  |  flush  |
+----------+---------+----------+---------+----------+---------+

To:

+----------+----------+----------+---------+
|  append  |  append  |  append  |  flush  |
+----------+----------+----------+---------+
```
Those two call sequences are equivalent.

Note: we return control to the client after final flush.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
