### PR TITLE
r/consensus: storing highest known configuration offset in background

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1568,13 +1568,19 @@ consensus::disk_append(model::record_batch_reader&& reader) {
               update_follower_stats(configurations.back().cfg);
               f = _configuration_manager.add(std::move(configurations));
           }
+
           return f.then([this, ret = ret] {
-              return _configuration_manager
-                .maybe_store_highest_known_offset(
-                  ret.last_offset, ret.byte_size)
-                .then([ret = ret]() mutable {
-                    return ss::make_ready_future<ret_t>(std::move(ret));
+              // if we are already shutting down, do nothing
+              if (_bg.is_closed()) {
+                  return ret;
+              }
+
+              (void)ss::with_gate(
+                _bg, [this, last_offset = ret.last_offset, sz = ret.byte_size] {
+                    return _configuration_manager
+                      .maybe_store_highest_known_offset(last_offset, sz);
                 });
+              return ret;
           });
       });
 }


### PR DESCRIPTION
Moved storing highest known configuration offset from write hot path to
background. Persisting highest know offset in configuration manager
caused latency spikes in write path.

In configuration manager we store highest known offset every 64MB of
data in log. The highest known offset is the last offset that for which
all previous configurations are safely stored in configuration manager.
In order to speed up raft bootstrap we store the highest known offset
every 64MB of data written to log. This allow us to read max 64MB per
log during recovery phase. The highest known offset is persisted in KV
store to be easily accessible. The KV store debounce flushing with 10ms
interval. This debouncing was responsible for latency spikes we observed
when system wasn't saturated.

Implemented fix move storing highest known offset into the background
future. This way we do not comprise safety, avoid latency and still
optimize recovery.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
