### PR TITLE
Add istreambuf implementation that uses iobuf as a source

### DIFF
--- a/src/v/bytes/iobuf_istreambuf.h
+++ b/src/v/bytes/iobuf_istreambuf.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+
+#include <streambuf>
+
+/// A simple istream buffer reader.
+///
+/// iobuf underlying;
+/// std::string out;
+/// iobuf_istreambuf ibuf(underlying);
+/// std::istream is(&ibuf);
+///
+/// is >> out;
+///
+class iobuf_istreambuf final : public std::streambuf {
+public:
+    explicit iobuf_istreambuf(iobuf& buf) noexcept
+      : _curr(buf.begin())
+      , _end(buf.end()) {}
+    iobuf_istreambuf(iobuf_istreambuf&&) noexcept = default;
+    iobuf_istreambuf& operator=(iobuf_istreambuf&&) noexcept = default;
+    iobuf_istreambuf(const iobuf_istreambuf&) = delete;
+    iobuf_istreambuf& operator=(const iobuf_istreambuf&) = delete;
+    ~iobuf_istreambuf() noexcept override = default;
+
+    int_type underflow() override {
+        if (gptr() == egptr()) {
+            while (_curr != _end) {
+                if (_curr->is_empty()) {
+                    _curr++;
+                    continue;
+                }
+                setg(
+                  _curr->get_write(), _curr->get_write(), _curr->get_current());
+                _curr++;
+                return traits_type::to_int_type(*gptr());
+            }
+        }
+        return traits_type::eof();
+    }
+
+private:
+    iobuf::iterator _curr;
+    iobuf::iterator _end;
+};


### PR DESCRIPTION
The iobuf_istreambuf mirrors iobuf_ostreambuf and allows iobuf to
be used as a data source for any code that expects std::istream.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
