### PR TITLE
rpk: container command will now spawn containers with specific limits

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -228,6 +228,7 @@ func CreateNode(
 		fmt.Sprintf("127.0.0.1:%d", kafkaPort),
 		"--advertise-rpc-addr",
 		fmt.Sprintf("%s:%d", ip, config.Default().Redpanda.RPCServer.Port),
+		"--smp 1 --memory 1G --reserve-memory 0M",
 	}
 	containerConfig := container.Config{
 		Image:		redpandaImageBase,


### PR DESCRIPTION
A container is now created with limits of 1 core and 1GB of memory.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
