### PR TITLE
lint action: update tag matching regex

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@
 name: Lint all codez
 on:
   push:
-    tags: 'release-*'
+    tags: 'v2**'
     branches:
       - dev
       - release


### PR DESCRIPTION
A while ago we changed our release naming scheme 4ed045653ddb3007a42699121fd1172be1f56bc5.

Looks like this actions was left out.