### PR TITLE
rpk: Fixed a nil pointer dereference when running in a container

### DIFF
--- a/src/go/rpk/pkg/tuners/disk/block_devices.go
+++ b/src/go/rpk/pkg/tuners/disk/block_devices.go
@@ -162,6 +162,9 @@ func (b *blockDevices) GetDeviceFromPath(path string) (BlockDevice, error) {
 func (b *blockDevices) GetDeviceSystemPath(path string) (string, error) {
 	device, err := b.getBlockDeviceFromPath(path,
 		getDevNumFromDeviceDirectory)
+	if err != nil {
+		return "", err
+	}
 	return device.Syspath(), err
 }
 


### PR DESCRIPTION
When redpanda was running in a container using an external volume for storage, you would get the following error: 

```
System check 'Dir '/var/lib/redpanda/data' nomerges tuned' failed with non-fatal error 'open : no such file or directory'
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xb0c04d]
goroutine 1 [running]:
vectorized/pkg/tuners/disk.(*blockDevices).GetDeviceSystemPath(0xc00048e0f0, 0xc00034a3d4, 0x9, 0xc00034a3d4, 0x9, 0x1, 0x1)
	/workspace/src/go/rpk/pkg/tuners/disk/block_devices.go:165 +0x6d
```
You would then have to pass `check=false` to continue. This fix addresses this and drops the requirement to have `check=false` as an argument. 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
