### PR TITLE
Disable status and config when not running on linux

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -65,8 +65,6 @@ func Execute() {
 		"v", false, "enable verbose logging (default false)")
 
 	rootCmd.AddCommand(NewModeCommand(mgr))
-	rootCmd.AddCommand(NewConfigCommand(fs, mgr))
-	rootCmd.AddCommand(NewStatusCommand(fs, mgr))
 	rootCmd.AddCommand(NewGenerateCommand(mgr))
 	rootCmd.AddCommand(NewVersionCommand())
 	rootCmd.AddCommand(NewApiCommand(fs, mgr))

--- a/src/go/rpk/pkg/cli/cmd/root_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/root_linux.go
@@ -24,4 +24,6 @@ func addPlatformDependentCmds(
 	cmd.AddCommand(NewIoTuneCmd(fs, mgr))
 	cmd.AddCommand(NewStartCommand(fs, mgr, redpanda.NewLauncher()))
 	cmd.AddCommand(NewStopCommand(fs, mgr))
+	cmd.AddCommand(NewConfigCommand(fs, mgr))
+	cmd.AddCommand(NewStatusCommand(fs, mgr))
 }


### PR DESCRIPTION
One way of solving this is to remove those commands completely. An alternative route would be to let them in but print out an error message.

## Checklist
- [x] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

fixes #170
