### PR TITLE
k/requests: inline operator<<(ostream&, coordinator_type)

### DIFF
--- a/src/v/kafka/requests/requests.cc
+++ b/src/v/kafka/requests/requests.cc
@@ -154,17 +154,6 @@ std::ostream& operator<<(std::ostream& os, const request_header& header) {
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, coordinator_type t) {
-    switch (t) {
-    case coordinator_type::group:
-        return os << "{group}";
-    case coordinator_type::transaction:
-        return os << "{transaction}";
-    default:
-        return os << "{unknown type}";
-    };
-}
-
 std::ostream& operator<<(std::ostream& os, config_resource_type t) {
     switch (t) {
     case config_resource_type::topic:

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -80,7 +80,17 @@ enum class coordinator_type : int8_t {
     transaction = 1,
 };
 
-std::ostream& operator<<(std::ostream& os, coordinator_type t);
+// TODO Ben: Why is this an undefined reference for pandaproxy when defined in
+// kafka/requests.cc
+inline std::ostream& operator<<(std::ostream& os, coordinator_type t) {
+    switch (t) {
+    case coordinator_type::group:
+        return os << "{group}";
+    case coordinator_type::transaction:
+        return os << "{transaction}";
+    };
+    return os << "{unknown type}";
+}
 
 enum class config_resource_type : int8_t {
     topic = 2,


### PR DESCRIPTION
Work around this failure:

```
FAILED: bin/pandaproxy
: && ccache /usr/bin/g++ -fcoroutines -fuse-ld=gold -fPIC -march=westmere -fsanitize=undefined -fsanitize=address -O0 -gsplit-dwarf -Wl,--gdb-index -Wl,--build-id=sha1 -L/vectorized/lib -L/vectorized/lib64 -fsanitize=undefined -fsanitize=address -pie   -rdynamic src/v/pandaproxy/CMakeFiles/pandaproxy.dir/main.cc.o -o bin/pandaproxy  -Wl,-rpath,/vectorized/lib64:/vectorized/lib:  lib/libv_v_rest_application.a  lib/libv_v_pandaproxy_client.a  lib/libv_v_kafka.a  lib/libv_v_cluster.a  lib/libcontroller_rpc.a  lib/libmetadata_rpc.a  lib/libv_v_raft.a  lib/libv_v_storage.a  lib/libv_v_syschecks.a  -lsystemd  lib/libv_v_config.a  lib/libv_v_json.a  -lboost_filesystem  /vectorized/lib64/libabsl_random_seed_sequences.a  /vectorized/lib64/libabsl_random_internal_pool_urbg.a  /vectorized/lib64/libabsl_random_internal_randen.a  /vectorized/lib64/libabsl_random_internal_randen_hwaes.a  /vectorized/lib64/libabsl_random_internal_randen_hwaes_impl.a  /vectorized/lib64/libabsl_random_internal_randen_slow.a  /vectorized/lib64/libabsl_random_internal_platform.a  /vectorized/lib64/libabsl_random_internal_seed_material.a  /vectorized/lib64/libabsl_random_seed_gen_exception.a  /vectorized/lib/libroaring.a  lib/libraft_rpc.a  lib/libv_v_finjector.a  /vectorized/lib/libroaring.a  lib/libv_v_model.a  lib/libv_v_kafka_request_schemata.a  lib/libv_v_rpc.a  lib/libv_v_compression.a  /vectorized/lib64/libzstd.a  /vectorized/lib64/liblz4.so  /vectorized/lib64/libsnappy.a  /vectorized/lib/libz.so  /vectorized/lib64/libabsl_cord.a  /vectorized/lib64/libabsl_hash.a  /vectorized/lib64/libabsl_bad_variant_access.a  /vectorized/lib64/libabsl_city.a  /vectorized/lib64/libabsl_raw_hash_set.a  /vectorized/lib64/libabsl_bad_optional_access.a  /vectorized/lib64/libabsl_hashtablez_sampler.a  /vectorized/lib64/libabsl_exponential_biased.a  /vectorized/lib64/libabsl_synchronization.a  /vectorized/lib64/libabsl_graphcycles_internal.a  /vectorized/lib64/libabsl_stacktrace.a  /vectorized/lib64/libabsl_symbolize.a  /vectorized/lib64/libabsl_malloc_internal.a  /vectorized/lib64/libabsl_debugging_internal.a  /vectorized/lib64/libabsl_demangle_internal.a  /vectorized/lib64/libabsl_time.a  /vectorized/lib64/libabsl_strings.a  /vectorized/lib64/libabsl_throw_delegate.a  /vectorized/lib64/libabsl_strings_internal.a  /vectorized/lib64/libabsl_base.a  /vectorized/lib64/libabsl_spinlock_wait.a  /vectorized/lib64/libabsl_raw_logging_internal.a  /vectorized/lib64/libabsl_log_severity.a  /vectorized/lib64/libabsl_int128.a  /vectorized/lib64/libabsl_civil_time.a  /vectorized/lib64/libabsl_time_zone.a  lib/libv_v_utils.a  lib/libv_v_bytes.a  /vectorized/lib64/libseastar.a  /vectorized/lib/libboost_program_options.so  /vectorized/lib/libboost_thread.so  /vectorized/lib/libboost_chrono.so  /vectorized/lib/libboost_date_time.so  /vectorized/lib/libboost_atomic.so  /vectorized/lib/libcares.so  /vectorized/lib64/libcryptopp.so  /vectorized/lib64/libfmtd.a  /vectorized/lib64/liblz4.so  -ldl  /vectorized/lib/libgnutls.so  -latomic  /vectorized/lib/libsctp.so  /vectorized/lib64/libprotobufd.a  -lrt  /vectorized/lib/libyaml-cpp.a  -lpthread  -fsanitize=address  -fsanitize=undefined  -fno-sanitize=vptr  /vectorized/lib/libhwloc.so  -Wl,--build-id=sha1 -L/vectorized/lib -L/vectorized/lib64 -fsanitize=undefined -fsanitize=address -pthread  /vectorized/lib/libnuma.so  /vectorized/lib64/libhdr_histogram_static.a  lib/libv_v_rphashing.a  /vectorized/lib64/libxxhash.a  /vectorized/lib64/libcrc32c.a && :
/vectorized/include/fmt/ostream.h:104: error: undefined reference to 'kafka::operator<<(std::ostream&, kafka::coordinator_type)'
collect2: error: ld returned 1 exit status
```

Signed-off-by: Ben Pope <ben@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
