### PR TITLE
Pandaproxy consumer groups part2

### DIFF
--- a/src/v/pandaproxy/client/client.cc
+++ b/src/v/pandaproxy/client/client.cc
@@ -259,4 +259,14 @@ ss::future<kafka::offset_fetch_response> client::consumer_offset_fetch(
       });
 }
 
+ss::future<kafka::offset_commit_response> client::consumer_offset_commit(
+  const kafka::group_id& g_id,
+  const kafka::member_id& m_id,
+  std::vector<kafka::offset_commit_request_topic> topics) {
+    return get_consumer(g_id, m_id)
+      .then([topics{std::move(topics)}](shared_consumer_t c) mutable {
+          return c->offset_commit(std::move(topics));
+      });
+}
+
 } // namespace pandaproxy::client

--- a/src/v/pandaproxy/client/client.cc
+++ b/src/v/pandaproxy/client/client.cc
@@ -249,4 +249,14 @@ ss::future<assignment> client::consumer_assignment(
     });
 }
 
+ss::future<kafka::offset_fetch_response> client::consumer_offset_fetch(
+  const kafka::group_id& g_id,
+  const kafka::member_id& m_id,
+  std::vector<kafka::offset_fetch_request_topic> topics) {
+    return get_consumer(g_id, m_id)
+      .then([topics{std::move(topics)}](shared_consumer_t c) mutable {
+          return c->offset_fetch(std::move(topics));
+      });
+}
+
 } // namespace pandaproxy::client

--- a/src/v/pandaproxy/client/client.cc
+++ b/src/v/pandaproxy/client/client.cc
@@ -235,4 +235,11 @@ ss::future<> client::subscribe_consumer(
       });
 }
 
+ss::future<std::vector<model::topic>> client::consumer_topics(
+  const kafka::group_id& g_id, const kafka::member_id& m_id) {
+    return get_consumer(g_id, m_id).then([](shared_consumer_t c) {
+        return ss::make_ready_future<std::vector<model::topic>>(c->topics());
+    });
+}
+
 } // namespace pandaproxy::client

--- a/src/v/pandaproxy/client/client.cc
+++ b/src/v/pandaproxy/client/client.cc
@@ -242,4 +242,11 @@ ss::future<std::vector<model::topic>> client::consumer_topics(
     });
 }
 
+ss::future<assignment> client::consumer_assignment(
+  const kafka::group_id& g_id, const kafka::member_id& m_id) {
+    return get_consumer(g_id, m_id).then([](shared_consumer_t c) {
+        return ss::make_ready_future<assignment>(c->assignment());
+    });
+}
+
 } // namespace pandaproxy::client

--- a/src/v/pandaproxy/client/client.h
+++ b/src/v/pandaproxy/client/client.h
@@ -115,6 +115,9 @@ public:
       const kafka::member_id& member_id,
       std::vector<model::topic> topics);
 
+    ss::future<std::vector<model::topic>>
+    consumer_topics(const kafka::group_id& g_id, const kafka::member_id& m_id);
+
 private:
     /// \brief Connect and update metdata.
     ss::future<> do_connect(unresolved_address addr);

--- a/src/v/pandaproxy/client/client.h
+++ b/src/v/pandaproxy/client/client.h
@@ -118,6 +118,9 @@ public:
     ss::future<std::vector<model::topic>>
     consumer_topics(const kafka::group_id& g_id, const kafka::member_id& m_id);
 
+    ss::future<assignment> consumer_assignment(
+      const kafka::group_id& g_id, const kafka::member_id& m_id);
+
 private:
     /// \brief Connect and update metdata.
     ss::future<> do_connect(unresolved_address addr);

--- a/src/v/pandaproxy/client/client.h
+++ b/src/v/pandaproxy/client/client.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "kafka/client.h"
-#include "kafka/requests/join_group_request.h"
 #include "kafka/types.h"
 #include "pandaproxy/client/broker.h"
 #include "pandaproxy/client/brokers.h"

--- a/src/v/pandaproxy/client/client.h
+++ b/src/v/pandaproxy/client/client.h
@@ -13,6 +13,7 @@
 
 #include "kafka/client.h"
 #include "kafka/types.h"
+#include "pandaproxy/client/assignment_plans.h"
 #include "pandaproxy/client/broker.h"
 #include "pandaproxy/client/brokers.h"
 #include "pandaproxy/client/configuration.h"
@@ -120,6 +121,11 @@ public:
 
     ss::future<assignment> consumer_assignment(
       const kafka::group_id& g_id, const kafka::member_id& m_id);
+
+    ss::future<kafka::offset_fetch_response> consumer_offset_fetch(
+      const kafka::group_id& g_id,
+      const kafka::member_id& m_id,
+      std::vector<kafka::offset_fetch_request_topic> topics);
 
 private:
     /// \brief Connect and update metdata.

--- a/src/v/pandaproxy/client/client.h
+++ b/src/v/pandaproxy/client/client.h
@@ -127,6 +127,11 @@ public:
       const kafka::member_id& m_id,
       std::vector<kafka::offset_fetch_request_topic> topics);
 
+    ss::future<kafka::offset_commit_response> consumer_offset_commit(
+      const kafka::group_id& g_id,
+      const kafka::member_id& m_id,
+      std::vector<kafka::offset_commit_request_topic> topics);
+
 private:
     /// \brief Connect and update metdata.
     ss::future<> do_connect(unresolved_address addr);

--- a/src/v/pandaproxy/client/consumer.cc
+++ b/src/v/pandaproxy/client/consumer.cc
@@ -294,6 +294,19 @@ consumer::offset_fetch(std::vector<kafka::offset_fetch_request_topic> topics) {
       });
 }
 
+ss::future<kafka::offset_commit_response> consumer::offset_commit(
+  std::vector<kafka::offset_commit_request_topic> topics) {
+    auto req_builder = [me{shared_from_this()}, topics{std::move(topics)}]() {
+        return kafka::offset_commit_request{.data{
+          .group_id = me->_group_id,
+          .generation_id = me->_generation_id,
+          .member_id = me->_member_id,
+          .topics = topics}};
+    };
+
+    return req_res(std::move(req_builder));
+}
+
 ss::future<shared_consumer_t>
 make_consumer(shared_broker_t coordinator, kafka::group_id group_id) {
     auto c = ss::make_lw_shared<consumer>(

--- a/src/v/pandaproxy/client/consumer.cc
+++ b/src/v/pandaproxy/client/consumer.cc
@@ -20,9 +20,11 @@
 #include "kafka/types.h"
 #include "pandaproxy/client/assignment_plans.h"
 #include "pandaproxy/client/configuration.h"
+#include "pandaproxy/client/error.h"
 #include "pandaproxy/client/logger.h"
 
 #include <chrono>
+#include <exception>
 
 namespace pandaproxy::client {
 
@@ -65,7 +67,9 @@ void consumer::start() {
     ppclog.info("Consumer: {}: start", *this);
     _timer.set_callback([this]() {
         ppclog.info("Consumer: {}: timer cb", *this);
-        (void)heartbeat();
+        (void)heartbeat().handle_exception_type([this](consumer_error e) {
+            ppclog.error("Consumer: {}: heartbeat failed: {}", *this, e.error);
+        });
     });
     _timer.arm_periodic(std::chrono::duration_cast<ss::timer<>::duration>(
       shard_local_cfg().consumer_heartbeat_interval()));
@@ -122,8 +126,8 @@ ss::future<> consumer::join() {
               start();
               return sync();
           default:
-              vassert(false, "Consumer: join: unhandled error_code");
-              break;
+              return ss::make_exception_future<>(
+                consumer_error(_group_id, _member_id, res.data.error_code));
           }
       });
 }
@@ -230,12 +234,11 @@ ss::future<> consumer::sync() {
                     return join().then([this]() { return sync(); });
                 case kafka::error_code::none:
                     _assignment = _plan->decode(res.data.assignment);
-                    break;
+                    return ss::now();
                 default:
-                    vassert(false, "Consumer sync: unhandled error_code");
-                    break;
+                    return ss::make_exception_future<>(consumer_error(
+                      _group_id, _member_id, res.data.error_code));
                 }
-                return ss::now();
             });
       });
 }
@@ -259,12 +262,11 @@ ss::future<> consumer::heartbeat() {
           case kafka::error_code::rebalance_in_progress:
               return join();
           case kafka::error_code::none:
-              break;
+              return ss::now();
           default:
-              vassert(false, "Consumer heartbeat: unhandled error_code");
-              break;
+              return ss::make_exception_future<>(
+                consumer_error(_group_id, _member_id, res.data.error_code));
           }
-          return ss::now();
       });
 }
 
@@ -272,19 +274,7 @@ ss::future<kafka::describe_groups_response> consumer::describe_group() {
     auto req_builder = [this]() {
         return kafka::describe_groups_request{.data{.groups = {{_group_id}}}};
     };
-    return req_res(req_builder).then([](kafka::describe_groups_response res) {
-        vassert(res.data.groups.size() == 1, "Unexpected group response");
-        const auto& grp = res.data.groups[0];
-        switch (grp.error_code) {
-        case kafka::error_code::none:
-            break;
-        default:
-            vassert(false, "Consumer desc: unhandled error_code");
-            break;
-        }
-        return ss::make_ready_future<kafka::describe_groups_response>(
-          std::move(res));
-    });
+    return req_res(req_builder);
 }
 
 ss::future<shared_consumer_t>

--- a/src/v/pandaproxy/client/consumer.cc
+++ b/src/v/pandaproxy/client/consumer.cc
@@ -228,10 +228,10 @@ ss::future<> consumer::sync() {
                 case kafka::error_code::rebalance_in_progress:
                     return sync();
                 case kafka::error_code::illegal_generation:
-                    return join().then([this]() { return sync(); });
+                    return join();
                 case kafka::error_code::unknown_member_id:
                     _member_id = kafka::no_member;
-                    return join().then([this]() { return sync(); });
+                    return join();
                 case kafka::error_code::none:
                     _assignment = _plan->decode(res.data.assignment);
                     return ss::now();

--- a/src/v/pandaproxy/client/consumer.h
+++ b/src/v/pandaproxy/client/consumer.h
@@ -27,6 +27,8 @@ namespace pandaproxy::client {
 
 // consumer manages the lifetime of a consumer within a group.
 class consumer final : public ss::enable_lw_shared_from_this<consumer> {
+    using assignment_t = client::assignment;
+
 public:
     consumer(shared_broker_t coordinator, kafka::group_id group_id)
       : _coordinator(std::move(coordinator))
@@ -36,6 +38,7 @@ public:
     const kafka::group_id& group_id() const { return _group_id; }
     const kafka::member_id& member_id() const { return _member_id; }
     const std::vector<model::topic>& topics() const { return _topics; }
+    const assignment_t& assignment() const { return _assignment; }
 
     ss::future<> join();
     ss::future<kafka::leave_group_response> leave();
@@ -91,7 +94,7 @@ private:
     std::vector<kafka::member_id> _members{};
     std::vector<model::topic> _subscribed_topics{};
     std::unique_ptr<assignment_plan> _plan{};
-    assignment _assignment{};
+    assignment_t _assignment{};
 
     friend std::ostream& operator<<(std::ostream& os, const consumer& c) {
         fmt::print(

--- a/src/v/pandaproxy/client/consumer.h
+++ b/src/v/pandaproxy/client/consumer.h
@@ -43,7 +43,8 @@ public:
     ss::future<> join();
     ss::future<kafka::leave_group_response> leave();
     ss::future<> subscribe(std::vector<model::topic> topics);
-    ss::future<kafka::offset_fetch_response> offset_fetch();
+    ss::future<kafka::offset_fetch_response>
+    offset_fetch(std::vector<kafka::offset_fetch_request_topic> topics);
 
 private:
     bool is_leader() const {

--- a/src/v/pandaproxy/client/consumer.h
+++ b/src/v/pandaproxy/client/consumer.h
@@ -35,6 +35,7 @@ public:
 
     const kafka::group_id& group_id() const { return _group_id; }
     const kafka::member_id& member_id() const { return _member_id; }
+    const std::vector<model::topic>& topics() const { return _topics; }
 
     ss::future<> join();
     ss::future<kafka::leave_group_response> leave();

--- a/src/v/pandaproxy/client/consumer.h
+++ b/src/v/pandaproxy/client/consumer.h
@@ -45,6 +45,8 @@ public:
     ss::future<> subscribe(std::vector<model::topic> topics);
     ss::future<kafka::offset_fetch_response>
     offset_fetch(std::vector<kafka::offset_fetch_request_topic> topics);
+    ss::future<kafka::offset_commit_response>
+    offset_commit(std::vector<kafka::offset_commit_request_topic> topics);
 
 private:
     bool is_leader() const {

--- a/src/v/pandaproxy/client/test/consumer_group.cc
+++ b/src/v/pandaproxy/client/test/consumer_group.cc
@@ -219,6 +219,20 @@ FIXTURE_TEST(pandaproxy_consumer_group, ppc_test_fixture) {
         BOOST_REQUIRE_EQUAL(consumer_topics[0], topics[i]);
     }
 
+    // Check member assignment
+    // range_assignment is allocated according to sorted member ids
+    auto sorted_members = members;
+    std::sort(sorted_members.begin(), sorted_members.end());
+    for (int i = 0; i < sorted_members.size(); ++i) {
+        auto m_id = sorted_members[i];
+        auto assignment = client.consumer_assignment(group_id, m_id).get();
+        BOOST_REQUIRE_EQUAL(assignment.size(), 3);
+        for (auto const& [topic, partitions] : assignment) {
+            BOOST_REQUIRE_EQUAL(partitions.size(), 1);
+            BOOST_REQUIRE_EQUAL(partitions[0](), i);
+        }
+    }
+
     ss::when_all_succeed(
       client.remove_consumer(group_id, members[0]),
       client.remove_consumer(group_id, members[1]),

--- a/src/v/pandaproxy/client/test/consumer_group.cc
+++ b/src/v/pandaproxy/client/test/consumer_group.cc
@@ -268,6 +268,64 @@ FIXTURE_TEST(pandaproxy_consumer_group, ppc_test_fixture) {
         }
     }
 
+    // Commit offsets
+    // Each partition is commited with the offset of the index of the sorted
+    // member, and with metadata of the member id.
+    for (int i = 0; i < sorted_members.size(); ++i) {
+        auto m_id = sorted_members[i];
+        auto t = std::vector<kafka::offset_commit_request_topic>{};
+        t.reserve(3);
+        std::transform(
+          topics.begin(),
+          topics.end(),
+          std::back_inserter(t),
+          [i, m_id](auto& topic) {
+              return kafka::offset_commit_request_topic{
+                .name = topic,
+                .partitions = {
+                  {.partition_index = model::partition_id{i},
+                   .committed_offset = model::offset{i},
+                   .committed_metadata{m_id()}}}};
+          });
+        auto res
+          = client.consumer_offset_commit(group_id, m_id, std::move(t)).get();
+        BOOST_REQUIRE_EQUAL(res.data.topics.size(), 3);
+        for (const auto& t : res.data.topics) {
+            BOOST_REQUIRE_EQUAL(t.partitions.size(), 1);
+            auto& p = t.partitions[0];
+            BOOST_REQUIRE_EQUAL(p.error_code, kafka::error_code::none);
+            BOOST_REQUIRE_EQUAL(p.partition_index, i);
+        }
+    }
+
+    // Check member assignment and offsets
+    // range_assignment is allocated according to sorted member ids
+    for (int i = 0; i < sorted_members.size(); ++i) {
+        auto m_id = sorted_members[i];
+        auto assignment = client.consumer_assignment(group_id, m_id).get();
+        BOOST_REQUIRE_EQUAL(assignment.size(), 3);
+        for (auto const& [topic, partitions] : assignment) {
+            BOOST_REQUIRE_EQUAL(partitions.size(), 1);
+            BOOST_REQUIRE_EQUAL(partitions[0](), i);
+        }
+
+        auto topics = offset_request_from_assignment(std::move(assignment));
+        auto offsets
+          = client.consumer_offset_fetch(group_id, m_id, std::move(topics))
+              .get();
+        BOOST_REQUIRE_EQUAL(offsets.data.error_code, kafka::error_code::none);
+        BOOST_REQUIRE_EQUAL(offsets.data.topics.size(), 3);
+        for (auto const& t : offsets.data.topics) {
+            BOOST_REQUIRE_EQUAL(t.partitions.size(), 1);
+            for (auto const& p : t.partitions) {
+                BOOST_REQUIRE_EQUAL(p.error_code, kafka::error_code::none);
+                BOOST_REQUIRE_EQUAL(p.partition_index(), i);
+                BOOST_REQUIRE_EQUAL(p.committed_offset(), i);
+                BOOST_REQUIRE_EQUAL(p.metadata, m_id());
+            }
+        }
+    }
+
     ss::when_all_succeed(
       client.remove_consumer(group_id, members[0]),
       client.remove_consumer(group_id, members[1]),


### PR DESCRIPTION
### Some tidy up
* ppc/client: Remove unused header
* ppc/consumer: Improve error handling
* ppc/consumer: A successful join already calls sync

### New consumer endpoints
* consumer_topics
* consumer_assignments
* consumer_offset_fetch
* consumer_offset_commit

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
