### PR TITLE
Raft config changes improvements

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -81,7 +81,7 @@ ss::future<> controller::start() {
       })
       .then([this] {
           return _tp_frontend.start(
-            _raft0->self(),
+            _raft0->self().id(),
             std::ref(_stm),
             std::ref(_connections),
             std::ref(_partition_allocator),

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -292,7 +292,11 @@ ss::future<std::error_code> controller_backend::update_partition_replica_set(
     // we are the leader, update configuration
     if (partition->is_leader()) {
         auto brokers = create_brokers_set(replicas, _members_table.local());
-        return partition->update_replica_set(std::move(brokers));
+        // TODO: replace with correct revision_id, this feature is not used yet.
+        //       The `update_partition_replica` set method is never called.
+        //       We have to fix this before enabling partition moving
+        return partition->update_replica_set(
+          std::move(brokers), model::revision_id(0));
     }
     // not the leader, wait for configuration update, only declare success
     // when configuration was actually updated

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -20,6 +20,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "outcome.h"
+#include "raft/configuration.h"
 #include "raft/types.h"
 #include "ssx/future-util.h"
 
@@ -261,9 +262,9 @@ bool is_configuration_up_to_date(
         return false;
     }
     cfg.for_each_voter(
-      [&all_ids](model::node_id nid) { all_ids.emplace(nid); });
+      [&all_ids](raft::vnode nid) { all_ids.emplace(nid.id()); });
     cfg.for_each_learner(
-      [&all_ids](model::node_id nid) { all_ids.emplace(nid); });
+      [&all_ids](raft::vnode nid) { all_ids.emplace(nid.id()); });
     // there is different number of brokers in group configuration
     if (all_ids.size() != bs.size()) {
         return false;

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -15,6 +15,7 @@
 #include "cluster/partition_allocator.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "model/metadata.h"
 #include "raft/errc.h"
 #include "raft/types.h"
 #include "random/generators.h"
@@ -310,7 +311,11 @@ members_manager::handle_join_request(model::broker broker) {
     // curent node is a leader
     if (_raft0->is_leader()) {
         // Just update raft0 configuration
-        return _raft0->add_group_members({std::move(broker)})
+        // we do not use revisions in raft0 configuration, it is always revision
+        // 0 which is perfectly fine. this will work like revision less raft
+        // protocol.
+        return _raft0
+          ->add_group_members({std::move(broker)}, model::revision_id(0))
           .then([](std::error_code ec) {
               if (!ec) {
                   return ret_t(join_reply{true});

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -289,7 +289,7 @@ auto members_manager::dispatch_rpc_to_leader(Func&& f) {
         return fut_t::convert(errc::no_leader_controller);
     }
 
-    auto leader = _raft0->config().find(*leader_id);
+    auto leader = _raft0->config().find_broker(*leader_id);
 
     if (!leader) {
         return fut_t::convert(errc::no_leader_controller);

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -13,6 +13,7 @@
 
 #include "cluster/partition_probe.h"
 #include "cluster/types.h"
+#include "model/metadata.h"
 #include "model/record_batch_reader.h"
 #include "raft/configuration.h"
 #include "raft/consensus.h"
@@ -101,9 +102,10 @@ public:
         return _raft->transfer_leadership(target);
     }
 
-    ss::future<std::error_code>
-    update_replica_set(std::vector<model::broker> brokers) {
-        return _raft->replace_configuration(std::move(brokers));
+    ss::future<std::error_code> update_replica_set(
+      std::vector<model::broker> brokers, model::revision_id new_revision_id) {
+        return _raft->replace_configuration(
+          std::move(brokers), new_revision_id);
     }
 
     raft::group_configuration group_configuration() const {

--- a/src/v/raft/configuration.cc
+++ b/src/v/raft/configuration.cc
@@ -45,10 +45,12 @@ group_configuration::group_configuration(std::vector<model::broker> brokers)
 group_configuration::group_configuration(
   std::vector<model::broker> brokers,
   group_nodes current,
+  model::revision_id revision,
   std::optional<group_nodes> old)
   : _brokers(std::move(brokers))
   , _current(std::move(current))
-  , _old(std::move(old)) {}
+  , _old(std::move(old))
+  , _revision(revision) {}
 
 std::optional<model::broker>
 group_configuration::find(model::node_id id) const {
@@ -282,9 +284,10 @@ void group_configuration::update(model::broker broker) {
 std::ostream& operator<<(std::ostream& o, const group_configuration& c) {
     fmt::print(
       o,
-      "{{current: {}, old:{}, brokers: {}}}",
+      "{{current: {}, old:{}, revision: {}, brokers: {}}}",
       c._current,
       c._old,
+      c._revision,
       c._brokers);
     return o;
 }
@@ -318,24 +321,42 @@ void adl<raft::group_configuration>::to(
       cfg.version(),
       cfg.brokers(),
       cfg.current_config(),
-      cfg.old_config());
+      cfg.old_config(),
+      cfg.revision_id());
 }
 
 raft::group_configuration
 adl<raft::group_configuration>::from(iobuf_parser& p) {
     auto version = adl<uint8_t>{}.from(p);
-    // currently we support only version 1
+    // currently we support only versions up to 1
     vassert(
-      version == raft::group_configuration::current_version,
-      "Version {} is not supported. We only support version {}",
+      version <= raft::group_configuration::current_version,
+      "Version {} is not supported. We only support versions up to {}",
       version,
       raft::group_configuration::current_version);
 
     auto brokers = adl<std::vector<model::broker>>{}.from(p);
     auto current = adl<raft::group_nodes>{}.from(p);
     auto old = adl<std::optional<raft::group_nodes>>{}.from(p);
+    /**
+     * we use versions field to maintain backward compatibility
+     * 
+     * version 0 - base
+     * version 1 - introduced revision id
+     */
+
+
+
+    if (version == 0) {
+        return raft::group_configuration(
+          std::move(brokers),
+          std::move(current),
+          model::revision_id(0),
+          std::move(old));
+    }
+    auto revision = adl<model::revision_id>{}.from(p);
     return raft::group_configuration(
-      std::move(brokers), std::move(current), std::move(old));
+      std::move(brokers), std::move(current), revision, std::move(old));
 }
 
 } // namespace reflection

--- a/src/v/raft/configuration.cc
+++ b/src/v/raft/configuration.cc
@@ -14,13 +14,15 @@
 
 #include <absl/container/flat_hash_set.h>
 #include <bits/stdint-uintn.h>
+#include <boost/range/join.hpp>
 
 #include <algorithm>
 #include <iterator>
 #include <optional>
+#include <utility>
 
 namespace raft {
-bool group_nodes::contains(model::node_id id) const {
+bool group_nodes::contains(vnode id) const {
     auto v_it = std::find(std::cbegin(voters), std::cend(voters), id);
     if (v_it != voters.cend()) {
         return true;
@@ -29,14 +31,33 @@ bool group_nodes::contains(model::node_id id) const {
     return l_it != learners.cend();
 }
 
-group_configuration::group_configuration(std::vector<model::broker> brokers)
-  : _brokers(std::move(brokers)) {
+std::optional<vnode> group_nodes::find(model::node_id id) const {
+    auto v_it = std::find_if(
+      std::cbegin(voters), std::cend(voters), [id](const vnode& rni) {
+          return rni.id() == id;
+      });
+
+    if (v_it != voters.cend()) {
+        return *v_it;
+    }
+    auto l_it = std::find_if(
+      std::cbegin(learners), std::cend(learners), [id](const vnode& rni) {
+          return rni.id() == id;
+      });
+
+    return l_it != learners.cend() ? std::make_optional(*l_it) : std::nullopt;
+}
+
+group_configuration::group_configuration(
+  std::vector<model::broker> brokers, model::revision_id revision)
+  : _brokers(std::move(brokers))
+  , _revision(revision) {
     _current.voters.resize(brokers.size());
     std::transform(
       std::cbegin(_brokers),
       std::cend(_brokers),
       std::back_inserter(_current.voters),
-      [](const model::broker& br) { return br.id(); });
+      [revision](const model::broker& br) { return vnode(br.id(), revision); });
 }
 
 /**
@@ -53,7 +74,7 @@ group_configuration::group_configuration(
   , _revision(revision) {}
 
 std::optional<model::broker>
-group_configuration::find(model::node_id id) const {
+group_configuration::find_broker(model::node_id id) const {
     auto it = std::find_if(
       std::cbegin(_brokers),
       std::cend(_brokers),
@@ -69,7 +90,7 @@ bool group_configuration::has_voters() {
     return !(_current.voters.empty() || (_old && _old->voters.empty()));
 }
 
-bool group_configuration::is_voter(model::node_id id) const {
+bool group_configuration::is_voter(vnode id) const {
     auto it = std::find(
       std::cbegin(_current.voters), std::cend(_current.voters), id);
 
@@ -101,10 +122,9 @@ configuration_type group_configuration::type() const {
     return configuration_type::simple;
 };
 
-std::vector<model::node_id> unique_ids(
-  const std::vector<model::node_id>& current,
-  const std::vector<model::node_id>& old) {
-    absl::flat_hash_set<model::node_id> unique_ids;
+std::vector<vnode>
+unique_ids(const std::vector<vnode>& current, const std::vector<vnode>& old) {
+    absl::flat_hash_set<vnode> unique_ids;
     unique_ids.reserve(current.size());
 
     for (auto& id : current) {
@@ -113,31 +133,39 @@ std::vector<model::node_id> unique_ids(
     for (auto& id : old) {
         unique_ids.insert(id);
     }
-    std::vector<model::node_id> ret;
+    std::vector<vnode> ret;
     ret.reserve(unique_ids.size());
     std::copy(unique_ids.begin(), unique_ids.end(), std::back_inserter(ret));
     return ret;
 }
 
-std::vector<model::node_id> group_configuration::unique_voter_ids() const {
-    auto old_voters = _old ? _old->voters : std::vector<model::node_id>();
+bool group_configuration::contains(vnode id) const {
+    return _current.contains(id) || (_old && _old->contains(id));
+}
+
+std::vector<vnode> group_configuration::unique_voter_ids() const {
+    auto old_voters = _old ? _old->voters : std::vector<vnode>();
     return unique_ids(_current.voters, old_voters);
 }
-std::vector<model::node_id> group_configuration::unique_learner_ids() const {
-    auto old_learners = _old ? _old->learners : std::vector<model::node_id>();
+std::vector<vnode> group_configuration::unique_learner_ids() const {
+    auto old_learners = _old ? _old->learners : std::vector<vnode>();
     return unique_ids(_current.learners, old_learners);
 }
 
-void erase_id(std::vector<model::node_id>& v, model::node_id id) {
-    auto it = std::find(std::cbegin(v), std::cend(v), id);
+void erase_id(std::vector<vnode>& v, model::node_id id) {
+    auto it = std::find_if(
+      std::cbegin(v), std::cend(v), [id](const vnode& rni) {
+          return id == rni.id();
+      });
     if (it != std::cend(v)) {
         v.erase(it);
     }
 }
 
-void group_configuration::add(std::vector<model::broker> brokers) {
+void group_configuration::add(
+  std::vector<model::broker> brokers, model::revision_id rev) {
     vassert(!_old, "can not add broker to joint configuration - {}", *this);
-
+    _revision = rev;
     for (auto& b : brokers) {
         auto it = std::find_if(
           std::cbegin(_brokers),
@@ -153,7 +181,7 @@ void group_configuration::add(std::vector<model::broker> brokers) {
 
     _old = _current;
     for (auto& b : brokers) {
-        _current.learners.push_back(b.id());
+        _current.learners.emplace_back(b.id(), rev);
         _brokers.push_back(std::move(b));
     }
 }
@@ -184,8 +212,10 @@ void group_configuration::remove(const std::vector<model::node_id>& ids) {
     _current = std::move(new_cfg);
 }
 
-void group_configuration::replace(std::vector<model::broker> brokers) {
+void group_configuration::replace(
+  std::vector<model::broker> brokers, model::revision_id rev) {
     vassert(!_old, "can not replace joint configuration - {}", *this);
+    _revision = rev;
 
     /**
      * If configurations are identical do nothing. For identical configuration
@@ -196,8 +226,8 @@ void group_configuration::replace(std::vector<model::broker> brokers) {
     if (brokers == _brokers) {
         // check if all brokers are assigned to current configuration (2)
         bool has_all = std::all_of(
-          brokers.begin(), brokers.end(), [this](model::broker& b) {
-              return _current.contains(b.id());
+          brokers.begin(), brokers.end(), [this, rev](model::broker& b) {
+              return _current.contains(vnode(b.id(), rev));
           });
         // configurations are identical, do nothing
         if (has_all) {
@@ -210,17 +240,29 @@ void group_configuration::replace(std::vector<model::broker> brokers) {
     _current.voters.clear();
 
     for (auto& br : brokers) {
-        auto was_voter = std::find(
-                           std::cbegin(_old->voters),
-                           std::cend(_old->voters),
-                           br.id())
-                         != std::cend(_old->voters);
+        // brokers was a voter
+        auto v_it = std::find_if(
+          std::cbegin(_old->voters),
+          std::cend(_old->voters),
+          [&br](const vnode& rni) { return rni.id() == br.id(); });
 
-        if (was_voter) {
-            _current.voters.push_back(br.id());
-        } else {
-            _current.learners.push_back(br.id());
+        if (v_it != std::cend(_old->voters)) {
+            _current.voters.push_back(*v_it);
+            continue;
         }
+        // brokers was a learner
+        auto l_it = std::find_if(
+          std::cbegin(_old->learners),
+          std::cend(_old->learners),
+          [&br](const vnode& rni) { return rni.id() == br.id(); });
+
+        if (l_it != std::cend(_old->learners)) {
+            _current.learners.push_back(*l_it);
+            continue;
+        }
+
+        // new broker, use provided revision
+        _current.learners.emplace_back(br.id(), rev);
     }
 
     for (auto& b : brokers) {
@@ -230,7 +272,7 @@ void group_configuration::replace(std::vector<model::broker> brokers) {
     }
 }
 
-void group_configuration::promote_to_voter(model::node_id id) {
+void group_configuration::promote_to_voter(vnode id) {
     auto it = std::find(
       std::cbegin(_current.learners), std::cend(_current.learners), id);
     // do nothing
@@ -248,19 +290,21 @@ void group_configuration::discard_old_config() {
       "can not discard old configuration as configuration is of simple type - "
       "{}",
       *this);
-    absl::flat_hash_set<model::node_id> ids;
+    absl::flat_hash_set<model::node_id> physical_node_ids;
 
     for (auto& id : _current.learners) {
-        ids.insert(id);
+        physical_node_ids.insert(id.id());
     }
 
     for (auto& id : _current.voters) {
-        ids.insert(id);
+        physical_node_ids.insert(id.id());
     }
     // remove unused brokers from brokers set
     auto it = std::stable_partition(
-      std::begin(_brokers), std::end(_brokers), [ids](const model::broker& b) {
-          return ids.contains(b.id());
+      std::begin(_brokers),
+      std::end(_brokers),
+      [physical_node_ids](const model::broker& b) {
+          return physical_node_ids.contains(b.id());
       });
     // we are only interested in current brokers
     _brokers.erase(it, std::end(_brokers));
@@ -325,6 +369,28 @@ void adl<raft::group_configuration>::to(
       cfg.revision_id());
 }
 
+std::vector<raft::vnode> make_vnodes(const std::vector<model::node_id> ids) {
+    std::vector<raft::vnode> ret;
+    ret.reserve(ids.size());
+    std::transform(
+      ids.begin(), ids.end(), std::back_inserter(ret), [](model::node_id id) {
+          return raft::vnode(id, model::revision_id(0));
+      });
+    return ret;
+}
+
+struct group_nodes_v0 {
+    std::vector<model::node_id> voters;
+    std::vector<model::node_id> learners;
+
+    raft::group_nodes to_v2() {
+        raft::group_nodes ret;
+        ret.voters = make_vnodes(voters);
+        ret.learners = make_vnodes(learners);
+        return ret;
+    }
+};
+
 raft::group_configuration
 adl<raft::group_configuration>::from(iobuf_parser& p) {
     auto version = adl<uint8_t>{}.from(p);
@@ -336,27 +402,47 @@ adl<raft::group_configuration>::from(iobuf_parser& p) {
       raft::group_configuration::current_version);
 
     auto brokers = adl<std::vector<model::broker>>{}.from(p);
-    auto current = adl<raft::group_nodes>{}.from(p);
-    auto old = adl<std::optional<raft::group_nodes>>{}.from(p);
+
     /**
      * we use versions field to maintain backward compatibility
-     * 
+     *
      * version 0 - base
      * version 1 - introduced revision id
+     * version 2 - introduced raft::vnode
      */
 
+    raft::group_nodes current;
+    std::optional<raft::group_nodes> old;
 
+    if (likely(version >= 2)) {
+        current = adl<raft::group_nodes>{}.from(p);
+        old = adl<std::optional<raft::group_nodes>>{}.from(p);
+    } else {
+        // no raft::vnodes
+        auto current_v0 = adl<group_nodes_v0>{}.from(p);
+        auto old_v0 = adl<std::optional<group_nodes_v0>>{}.from(p);
 
-    if (version == 0) {
-        return raft::group_configuration(
-          std::move(brokers),
-          std::move(current),
-          model::revision_id(0),
-          std::move(old));
+        current = current_v0.to_v2();
+        if (old_v0) {
+            old = old_v0->to_v2();
+        }
     }
-    auto revision = adl<model::revision_id>{}.from(p);
+    model::revision_id revision{0};
+    if (version > 0) {
+        revision = adl<model::revision_id>{}.from(p);
+    }
     return raft::group_configuration(
       std::move(brokers), std::move(current), revision, std::move(old));
+}
+
+void adl<raft::vnode>::to(iobuf& buf, raft::vnode id) {
+    serialize(buf, id.id(), id.revision());
+}
+
+raft::vnode adl<raft::vnode>::from(iobuf_parser& p) {
+    auto id = adl<model::node_id>{}.from(p);
+    auto rev = adl<model::revision_id>{}.from(p);
+    return raft::vnode(id, rev);
 }
 
 } // namespace reflection

--- a/src/v/raft/configuration.h
+++ b/src/v/raft/configuration.h
@@ -18,29 +18,58 @@
 
 #include <algorithm>
 #include <numeric>
+#include <optional>
 #include <type_traits>
 
 namespace raft {
 
+class vnode {
+public:
+    constexpr vnode() = default;
+
+    constexpr vnode(model::node_id nid, model::revision_id rev)
+      : _node_id(nid)
+      , _revision(rev) {}
+
+    bool operator==(const vnode& other) const = default;
+    bool operator!=(const vnode& other) const = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const vnode& node) {
+        return H::combine(std::move(h), node._node_id, node._revision);
+    }
+
+    constexpr model::node_id id() const { return _node_id; }
+    constexpr model::revision_id revision() const { return _revision; }
+
+private:
+    model::node_id _node_id;
+    model::revision_id _revision;
+};
+
 enum class configuration_type : uint8_t { simple, joint };
 
 struct group_nodes {
-    std::vector<model::node_id> voters;
-    std::vector<model::node_id> learners;
+    std::vector<vnode> voters;
+    std::vector<vnode> learners;
 
-    bool contains(model::node_id id) const;
+    bool contains(vnode id) const;
+
+    std::optional<vnode> find(model::node_id) const;
+
     friend std::ostream& operator<<(std::ostream&, const group_nodes&);
     friend bool operator==(const group_nodes&, const group_nodes&);
 };
 
 class group_configuration final {
 public:
-    static constexpr int8_t current_version = 1;
+    static constexpr int8_t current_version = 2;
     /**
      * creates a configuration where all provided brokers are current
      * configuration voters
      */
-    explicit group_configuration(std::vector<model::broker>);
+    explicit group_configuration(
+      std::vector<model::broker>, model::revision_id);
 
     /**
      * creates joint configuration
@@ -55,24 +84,27 @@ public:
     group_configuration(group_configuration&&) = default;
     group_configuration& operator=(const group_configuration&) = default;
     group_configuration& operator=(group_configuration&&) = default;
+    ~group_configuration() = default;
 
     bool has_voters();
 
-    std::optional<model::broker> find(model::node_id id) const;
+    std::optional<model::broker> find_broker(model::node_id id) const;
     bool contains_broker(model::node_id id) const;
+
+    bool contains(vnode) const;
 
     /**
      * Check if node with given id is allowed to request for votes
      */
-    bool is_voter(model::node_id) const;
+    bool is_voter(vnode) const;
 
     /**
      * Configuration manipulation API. Each operation cause the configuration to
      * become joint configuration.
      */
-    void add(std::vector<model::broker>);
+    void add(std::vector<model::broker>, model::revision_id);
     void remove(const std::vector<model::node_id>&);
-    void replace(std::vector<model::broker>);
+    void replace(std::vector<model::broker>, model::revision_id);
 
     /**
      * Updating broker configuration. This operation does not require entering
@@ -96,6 +128,9 @@ public:
 
     template<typename Func>
     void for_each_broker(Func&& f) const;
+
+    template<typename Func>
+    void for_each_broker_id(Func&& f) const;
 
     template<typename Func>
     void for_each_voter(Func&& f) const;
@@ -124,9 +159,9 @@ public:
     // clang-format off
     template<
       typename ValueProvider,
-      typename Ret = std::invoke_result_t<ValueProvider, model::node_id>>
+      typename Ret = std::invoke_result_t<ValueProvider, vnode>>
     CONCEPT(requires requires(
-        ValueProvider&& f, model::node_id nid, Ret ret_a, Ret ret_b) {
+        ValueProvider&& f, vnode nid, Ret ret_a, Ret ret_b) {
         f(nid);
         { ret_a < ret_b } -> std::same_as<bool>;
     })
@@ -137,12 +172,12 @@ public:
      * Returns true if for majority of group_nodes predicate returns true
      */
     template<typename Predicate>
-    CONCEPT(requires std::predicate<Predicate, model::node_id>)
+    CONCEPT(requires std::predicate<Predicate, vnode>)
     bool majority(Predicate&& f) const;
 
     int8_t version() const { return _version; }
 
-    void promote_to_voter(model::node_id id);
+    void promote_to_voter(vnode id);
     model::revision_id revision_id() const { return _revision; }
 
     friend bool
@@ -151,8 +186,8 @@ public:
     friend std::ostream& operator<<(std::ostream&, const group_configuration&);
 
 private:
-    std::vector<model::node_id> unique_voter_ids() const;
-    std::vector<model::node_id> unique_learner_ids() const;
+    std::vector<vnode> unique_voter_ids() const;
+    std::vector<vnode> unique_learner_ids() const;
 
     uint8_t _version = current_version;
     std::vector<model::broker> _brokers;
@@ -165,7 +200,7 @@ namespace details {
 
 template<typename ValueProvider, typename Range>
 auto quorum_match(ValueProvider&& f, Range&& range) {
-    using ret_t = std::invoke_result_t<ValueProvider, model::node_id>;
+    using ret_t = std::invoke_result_t<ValueProvider, vnode>;
     if (range.empty()) {
         return ret_t{};
     }
@@ -206,10 +241,19 @@ void group_configuration::for_each_broker(Func&& f) const {
       std::cbegin(_brokers), std::cend(_brokers), std::forward<Func>(f));
 }
 
+template<typename Func>
+void group_configuration::for_each_broker_id(Func&& f) const {
+    auto voters = unique_voter_ids();
+    auto learners = unique_learner_ids();
+    auto joined = boost::join(voters, learners);
+    std::for_each(
+      std::cbegin(joined), std::cend(joined), std::forward<Func>(f));
+}
+
 // clang-format off
 template<typename Func, typename Ret>
 CONCEPT(requires requires(
-    Func&& f, model::node_id nid, Ret ret_a, Ret ret_b) {
+    Func&& f, vnode nid, Ret ret_a, Ret ret_b) {
     f(nid);
     { ret_a < ret_b } -> std::same_as<bool>;
 })
@@ -224,7 +268,7 @@ auto group_configuration::quorum_match(Func&& f) const {
 }
 
 template<typename Predicate>
-CONCEPT(requires std::predicate<Predicate, model::node_id>)
+CONCEPT(requires std::predicate<Predicate, vnode>)
 bool group_configuration::majority(Predicate&& f) const {
     if (!_old) {
         return details::majority(std::forward<Predicate>(f), _current.voters);
@@ -257,6 +301,11 @@ struct offset_configuration {
 } // namespace raft
 
 namespace reflection {
+template<>
+struct adl<raft::vnode> {
+    void to(iobuf&, raft::vnode);
+    raft::vnode from(iobuf_parser&);
+};
 template<>
 struct adl<raft::group_configuration> {
     void to(iobuf&, raft::group_configuration);

--- a/src/v/raft/configuration.h
+++ b/src/v/raft/configuration.h
@@ -35,7 +35,7 @@ struct group_nodes {
 
 class group_configuration final {
 public:
-    static constexpr int8_t current_version = 0;
+    static constexpr int8_t current_version = 1;
     /**
      * creates a configuration where all provided brokers are current
      * configuration voters
@@ -48,6 +48,7 @@ public:
     group_configuration(
       std::vector<model::broker>,
       group_nodes,
+      model::revision_id,
       std::optional<group_nodes> = std::nullopt);
 
     group_configuration(const group_configuration&) = default;
@@ -102,6 +103,16 @@ public:
     template<typename Func>
     void for_each_learner(Func&& f) const;
 
+    void set_revision(model::revision_id new_revision) {
+        vassert(
+          new_revision >= _revision,
+          "can not set revision to value {} which is smaller than current one "
+          "{}",
+          new_revision,
+          _revision);
+
+        _revision = new_revision;
+    }
     /**
      * Return largest value for which every server in a quorum (majority) has a
      * value greater than or equal to.
@@ -132,6 +143,7 @@ public:
     int8_t version() const { return _version; }
 
     void promote_to_voter(model::node_id id);
+    model::revision_id revision_id() const { return _revision; }
 
     friend bool
     operator==(const group_configuration&, const group_configuration&);
@@ -146,6 +158,7 @@ private:
     std::vector<model::broker> _brokers;
     group_nodes _current;
     std::optional<group_nodes> _old;
+    model::revision_id _revision;
 };
 
 namespace details {

--- a/src/v/raft/configuration_manager.cc
+++ b/src/v/raft/configuration_manager.cc
@@ -326,6 +326,14 @@ ss::future<> configuration_manager::remove_persistent_state() {
       });
 }
 
+model::revision_id configuration_manager::get_latest_revision() const {
+    vassert(
+      !_configurations.empty(),
+      "Configuration manager should always have at least one "
+      "configuration");
+    return _configurations.rbegin()->second.revision_id();
+}
+
 std::ostream& operator<<(std::ostream& o, const configuration_manager& m) {
     o << "{configurations: ";
     for (const auto& p : m._configurations) {

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -123,6 +123,10 @@ public:
      */
     ss::future<offset_configuration>
     wait_for_change(model::offset, ss::abort_source&);
+    /**
+     * Return revision of last known configuration
+     */
+    model::revision_id get_latest_revision() const;
 
     /**
      * Removes state that configuration manager stores in key value store

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2116,10 +2116,10 @@ voter_priority consensus::get_node_priority(model::node_id id) const {
     if (it == brokers.cend()) {
         /**
          * If node is not present in current configuration i.e. was added to the
-         * cluster, return 1 which is lowest priority allowing to become a
-         * leader.
+         * cluster, return max, this way for joining node we will use
+         * priorityless, classic raft leader election
          */
-        return min_voter_priority;
+        return voter_priority::max();
     }
 
     auto idx = std::distance(brokers.cbegin(), it);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -15,6 +15,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/append_entries_buffer.h"
+#include "raft/configuration.h"
 #include "raft/configuration_manager.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/event_manager.h"
@@ -37,6 +38,8 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/util/bool_class.hh>
 
+#include <optional>
+
 namespace raft {
 class replicate_entries_stm;
 class vote_stm;
@@ -45,7 +48,9 @@ class recovery_stm;
 /// consensus for one raft group
 class consensus {
 public:
-    struct voted_for_configuration {
+    // we maintain this for backward compatibility, will be removed in future
+    // versions.
+    struct voted_for_configuration_old {
         model::node_id voted_for;
         // for term it doesn't make sense to use numeric_limits<>::min
         model::term_id term{0};
@@ -53,6 +58,19 @@ public:
         uint32_t crc() const {
             crc32 c;
             c.extend(voted_for());
+            c.extend(term());
+            return c.value();
+        }
+    };
+    struct voted_for_configuration {
+        vnode voted_for;
+        // for term it doesn't make sense to use numeric_limits<>::min
+        model::term_id term{0};
+
+        uint32_t crc() const {
+            crc32 c;
+            c.extend(voted_for.id()());
+            c.extend(voted_for.revision()());
             c.extend(term());
             return c.value();
         }
@@ -100,8 +118,11 @@ public:
 
     bool is_leader() const { return _vstate == vote_state::leader; }
     bool is_candidate() const { return _vstate == vote_state::candidate; }
-    std::optional<model::node_id> get_leader_id() const { return _leader_id; }
-    model::node_id self() const { return _self; }
+    std::optional<model::node_id> get_leader_id() const {
+        return _leader_id ? std::make_optional(_leader_id->id()) : std::nullopt;
+    }
+
+    vnode self() const { return _self; }
     protocol_metadata meta() const {
         auto lstats = _log.offsets();
         return protocol_metadata{
@@ -118,7 +139,7 @@ public:
     const model::ntp& ntp() const { return _log.config().ntp(); }
     clock_type::time_point last_heartbeat() const { return _hbeat; };
 
-    clock_type::time_point last_append_timestamp(model::node_id);
+    clock_type::time_point last_append_timestamp(vnode);
     /**
      * \brief Persist snapshot with given data and start offset
      *
@@ -130,7 +151,7 @@ public:
 
     /// Increment and returns next append_entries order tracking sequence for
     /// follower with given node id
-    follower_req_seq next_follower_sequence(model::node_id);
+    follower_req_seq next_follower_sequence(vnode);
 
     void process_append_entries_reply(
       model::node_id,
@@ -222,9 +243,9 @@ public:
 
     probe& get_probe() { return _probe; };
 
-    bool are_heartbeats_suppressed(model::node_id) const;
+    bool are_heartbeats_suppressed(vnode) const;
 
-    void suppress_heartbeats(model::node_id, follower_req_seq, bool);
+    void suppress_heartbeats(vnode, follower_req_seq, bool);
 
 private:
     friend replicate_entries_stm;
@@ -269,7 +290,7 @@ private:
 
     success_reply update_follower_index(
       model::node_id,
-      result<append_entries_reply>,
+      const result<append_entries_reply>&,
       follower_req_seq seq_id,
       model::offset);
 
@@ -300,8 +321,8 @@ private:
     ss::future<> maybe_update_follower_commit_idx(model::offset);
 
     void arm_vote_timeout();
-    void update_node_append_timestamp(model::node_id);
-    void update_node_hbeat_timestamp(model::node_id);
+    void update_node_append_timestamp(vnode);
+    void update_node_hbeat_timestamp(vnode);
 
     void update_follower_stats(const group_configuration&);
     void trigger_leadership_notification();
@@ -314,8 +335,7 @@ private:
 
     void maybe_step_down();
 
-    absl::flat_hash_map<model::node_id, follower_req_seq>
-    next_followers_request_seq();
+    absl::flat_hash_map<vnode, follower_req_seq> next_followers_request_seq();
 
     void setup_metrics();
 
@@ -328,7 +348,7 @@ private:
     ss::future<std::error_code> change_configuration(Func&&);
 
     ss::future<> maybe_commit_configuration(ss::semaphore_units<>);
-    void maybe_promote_to_voter(model::node_id);
+    void maybe_promote_to_voter(vnode);
 
     ss::future<model::record_batch_reader>
       do_make_reader(storage::log_reader_config);
@@ -341,7 +361,7 @@ private:
     void start_dispatching_disk_append_events();
 
     voter_priority next_target_priority();
-    voter_priority get_node_priority(model::node_id id) const;
+    voter_priority get_node_priority(vnode) const;
 
     /**
      * Return true if there is no state backing this consensus group i.e. there
@@ -357,7 +377,7 @@ private:
     }
 
     // args
-    model::node_id _self;
+    vnode _self;
     raft::group_id _group;
     timeout_jitter _jit;
     storage::log _log;
@@ -371,8 +391,8 @@ private:
     model::term_id _term;
 
     // read at `ss::future<> start()`
-    model::node_id _voted_for;
-    std::optional<model::node_id> _leader_id;
+    vnode _voted_for;
+    std::optional<vnode> _leader_id;
     bool _transferring_leadership{false};
 
     /// useful for when we are not the leader

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -87,14 +87,16 @@ public:
 
     /// This method adds multiple members to the group and performs
     /// configuration update
-    ss::future<std::error_code> add_group_members(std::vector<model::broker>);
+    ss::future<std::error_code>
+      add_group_members(std::vector<model::broker>, model::revision_id);
     /// Updates given member configuration
     ss::future<std::error_code> update_group_member(model::broker);
     // Removes members from group
-    ss::future<std::error_code> remove_members(std::vector<model::node_id>);
+    ss::future<std::error_code>
+      remove_members(std::vector<model::node_id>, model::revision_id);
     // Replace configuration of raft group with given set of nodes
     ss::future<std::error_code>
-      replace_configuration(std::vector<model::broker>);
+      replace_configuration(std::vector<model::broker>, model::revision_id);
 
     bool is_leader() const { return _vstate == vote_state::leader; }
     bool is_candidate() const { return _vstate == vote_state::candidate; }

--- a/src/v/raft/consensus_client_protocol.h
+++ b/src/v/raft/consensus_client_protocol.h
@@ -13,6 +13,7 @@
 #include "model/metadata.h"
 #include "model/timeout_clock.h"
 #include "outcome.h"
+#include "raft/errc.h"
 #include "raft/types.h"
 #include "rpc/types.h"
 
@@ -51,20 +52,23 @@ public:
     explicit consensus_client_protocol(ss::shared_ptr<impl> i)
       : _impl(std::move(i)) {}
     ss::future<result<vote_reply>>
-    vote(model::node_id targe_node, vote_request&& r, rpc::client_opts opts) {
-        return _impl->vote(targe_node, std::move(r), std::move(opts));
+    vote(model::node_id target_node, vote_request&& r, rpc::client_opts opts) {
+        return _impl->vote(target_node, std::move(r), std::move(opts));
     }
 
     ss::future<result<append_entries_reply>> append_entries(
-      model::node_id targe_node,
+      model::node_id target_node,
       append_entries_request&& r,
       rpc::client_opts opts) {
-        return _impl->append_entries(targe_node, std::move(r), std::move(opts));
+        return _impl->append_entries(
+          target_node, std::move(r), std::move(opts));
     }
 
     ss::future<result<heartbeat_reply>> heartbeat(
-      model::node_id targe_node, heartbeat_request&& r, rpc::client_opts opts) {
-        return _impl->heartbeat(targe_node, std::move(r), std::move(opts));
+      model::node_id target_node,
+      heartbeat_request&& r,
+      rpc::client_opts opts) {
+        return _impl->heartbeat(target_node, std::move(r), std::move(opts));
     }
 
     ss::future<result<install_snapshot_reply>> install_snapshot(

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -32,7 +32,8 @@ enum class errc {
     leadership_transfer_in_progress,
     node_already_exists,
     invalid_configuration_update,
-    not_voter
+    not_voter,
+    invalid_target_node,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "raft::errc"; }
@@ -73,6 +74,9 @@ struct errc_category final : public std::error_category {
             return "Configuration resulting from the update is invalid";
         case errc::not_voter:
             return "Requested node is not a voter";
+        case errc::invalid_target_node:
+            return "Node that received the request is not the one that the "
+                   "request was addressed to";
         default:
             return "raft::errc::unknown";
         }

--- a/src/v/raft/follower_stats.cc
+++ b/src/v/raft/follower_stats.cc
@@ -9,7 +9,21 @@
 
 #include "raft/follower_stats.h"
 
+#include <absl/container/node_hash_map.h>
+
 namespace raft {
+void follower_stats::update_with_configuration(const group_configuration& cfg) {
+    cfg.for_each_broker([this](const model::broker& n) {
+        if (n.id() == _self || _followers.contains(n.id())) {
+            return;
+        }
+        _followers.emplace(n.id(), follower_index_metadata(n.id()));
+    });
+
+    absl::erase_if(_followers, [&cfg](const container_t::value_type& p) {
+        return !cfg.contains_broker(p.first);
+    });
+}
 std::ostream& operator<<(std::ostream& o, const follower_stats& s) {
     o << "{followers:" << s._followers.size() << ", [";
     for (auto& f : s) {

--- a/src/v/raft/follower_stats.h
+++ b/src/v/raft/follower_stats.h
@@ -11,26 +11,23 @@
 
 #pragma once
 
+#include "model/metadata.h"
 #include "raft/types.h"
 #include "vassert.h"
 
-#include <absl/container/flat_hash_map.h>
-#include <boost/container/flat_map.hpp>
+#include <absl/container/node_hash_map.h>
 
 namespace raft {
 
 class follower_stats {
 public:
     using container_t
-      = boost::container::flat_map<model::node_id, follower_index_metadata>;
+      = absl::node_hash_map<model::node_id, follower_index_metadata>;
     using iterator = container_t::iterator;
     using const_iterator = container_t::const_iterator;
 
-    explicit follower_stats(std::vector<follower_index_metadata> meta) {
-        for (auto& i : meta) {
-            _followers.emplace(i.node_id, std::move(i));
-        }
-    }
+    explicit follower_stats(model::node_id self)
+      : _self(self) {}
 
     const follower_index_metadata& get(model::node_id n) const {
         auto it = _followers.find(n);
@@ -71,8 +68,11 @@ public:
 
     size_t size() const { return _followers.size(); }
 
+    void update_with_configuration(const group_configuration&);
+
 private:
     friend std::ostream& operator<<(std::ostream&, const follower_stats&);
+    model::node_id _self;
     container_t _followers;
 };
 

--- a/src/v/raft/follower_stats.h
+++ b/src/v/raft/follower_stats.h
@@ -21,15 +21,14 @@ namespace raft {
 
 class follower_stats {
 public:
-    using container_t
-      = absl::node_hash_map<model::node_id, follower_index_metadata>;
+    using container_t = absl::node_hash_map<vnode, follower_index_metadata>;
     using iterator = container_t::iterator;
     using const_iterator = container_t::const_iterator;
 
-    explicit follower_stats(model::node_id self)
+    explicit follower_stats(vnode self)
       : _self(self) {}
 
-    const follower_index_metadata& get(model::node_id n) const {
+    const follower_index_metadata& get(vnode n) const {
         auto it = _followers.find(n);
         vassert(
           it != _followers.end(),
@@ -38,7 +37,7 @@ public:
           n);
         return it->second;
     }
-    follower_index_metadata& get(model::node_id n) {
+    follower_index_metadata& get(vnode n) {
         auto it = _followers.find(n);
         vassert(
           it != _followers.end(),
@@ -48,18 +47,18 @@ public:
         return it->second;
     }
 
-    bool contains(model::node_id n) const {
+    bool contains(vnode n) const {
         return _followers.find(n) != _followers.end();
     }
 
-    iterator emplace(model::node_id n, follower_index_metadata m) {
+    iterator emplace(vnode n, follower_index_metadata m) {
         auto [it, success] = _followers.insert_or_assign(n, std::move(m));
         vassert(success, "could not insert node:{}", n);
         return it;
     }
 
-    iterator find(model::node_id n) { return _followers.find(n); }
-    const_iterator find(model::node_id n) const { return _followers.find(n); }
+    iterator find(vnode n) { return _followers.find(n); }
+    const_iterator find(vnode n) const { return _followers.find(n); }
 
     iterator begin() { return _followers.begin(); }
     iterator end() { return _followers.end(); }
@@ -72,7 +71,7 @@ public:
 
 private:
     friend std::ostream& operator<<(std::ostream&, const follower_stats&);
-    model::node_id _self;
+    vnode _self;
     container_t _followers;
 };
 

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "cluster/types.h"
+#include "model/metadata.h"
 #include "raft/consensus.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/heartbeat_manager.h"

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -81,7 +81,7 @@ static std::vector<heartbeat_manager::node_heartbeat> requests_for_range(
 
             auto seq_id = ptr->next_follower_sequence(rni);
             pending_beats[rni.id()].emplace_back(
-              heartbeat_metadata{ptr->meta(), ptr->self()}, seq_id);
+              heartbeat_metadata{ptr->meta(), ptr->self(), rni}, seq_id);
         };
 
         auto group = ptr->config();
@@ -163,7 +163,8 @@ ss::future<> heartbeat_manager::do_self_heartbeat(node_heartbeat&& r) {
       std::back_inserter(reply.meta),
       [](heartbeat_metadata& hb) {
           return append_entries_reply{
-            .node_id = hb.node_id,
+            .target_node_id = hb.target_node_id,
+            .node_id = hb.target_node_id,
             .group = hb.meta.group,
             .result = append_entries_reply::status::success};
       });

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -59,7 +59,10 @@ static std::vector<heartbeat_manager::node_heartbeat> requests_for_range(
                 pending_beats[n.id()].emplace_back(ptr->meta(), 0);
                 return;
             }
-
+            
+            if (ptr->are_heartbeats_suppressed(n.id())) {
+                return;
+            }
             auto last_append_timestamp = ptr->last_append_timestamp(n.id());
 
             if (last_append_timestamp > last_heartbeat) {
@@ -75,9 +78,6 @@ static std::vector<heartbeat_manager::node_heartbeat> requests_for_range(
                 return;
             }
 
-            if (ptr->are_heartbeats_suppressed(n.id())) {
-                return;
-            }
             auto seq_id = ptr->next_follower_sequence(n.id());
             pending_beats[n.id()].emplace_back(ptr->meta(), seq_id);
         };

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -13,6 +13,7 @@
 #include "model/metadata.h"
 #include "model/timeout_clock.h"
 #include "outcome_future_utils.h"
+#include "raft/configuration.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/errc.h"
 #include "raft/raftgen_service.h"
@@ -36,12 +37,11 @@ static std::vector<heartbeat_manager::node_heartbeat> requests_for_range(
   const consensus_set& c, clock_type::duration heartbeat_interval) {
     absl::flat_hash_map<
       model::node_id,
-      std::vector<std::pair<protocol_metadata, follower_req_seq>>>
+      std::vector<std::pair<heartbeat_metadata, follower_req_seq>>>
       pending_beats;
     if (c.empty()) {
         return {};
     }
-    auto self = (*c.begin())->self();
     auto last_heartbeat = clock_type::now() - heartbeat_interval;
     for (auto& ptr : c) {
         if (!ptr->is_leader()) {
@@ -51,26 +51,27 @@ static std::vector<heartbeat_manager::node_heartbeat> requests_for_range(
         auto maybe_create_follower_request = [ptr,
                                               last_heartbeat,
                                               &pending_beats](
-                                               const model::broker& n) mutable {
+                                               const vnode& rni) mutable {
             // special case self beat
             // self beat is used to make sure that the protocol will make
             // progress when there is only on node
-            if (n.id() == ptr->self()) {
-                pending_beats[n.id()].emplace_back(ptr->meta(), 0);
+            if (rni == ptr->self()) {
+                pending_beats[rni.id()].emplace_back(
+                  heartbeat_metadata{ptr->meta(), rni}, 0);
                 return;
             }
-            
-            if (ptr->are_heartbeats_suppressed(n.id())) {
+
+            if (ptr->are_heartbeats_suppressed(rni)) {
                 return;
             }
-            auto last_append_timestamp = ptr->last_append_timestamp(n.id());
+            auto last_append_timestamp = ptr->last_append_timestamp(rni);
 
             if (last_append_timestamp > last_heartbeat) {
                 vlog(
                   hbeatlog.trace,
                   "Skipping sending beat to {} gr: {} last hb {}, last append "
                   "{}",
-                  n.id(),
+                  rni,
                   ptr->group(),
                   last_heartbeat.time_since_epoch().count(),
                   last_append_timestamp.time_since_epoch().count());
@@ -78,36 +79,35 @@ static std::vector<heartbeat_manager::node_heartbeat> requests_for_range(
                 return;
             }
 
-            auto seq_id = ptr->next_follower_sequence(n.id());
-            pending_beats[n.id()].emplace_back(ptr->meta(), seq_id);
+            auto seq_id = ptr->next_follower_sequence(rni);
+            pending_beats[rni.id()].emplace_back(
+              heartbeat_metadata{ptr->meta(), ptr->self()}, seq_id);
         };
 
         auto group = ptr->config();
         // collect voters
-        group.for_each_broker(maybe_create_follower_request);
+        group.for_each_broker_id(maybe_create_follower_request);
     }
 
     std::vector<heartbeat_manager::node_heartbeat> reqs;
     reqs.reserve(pending_beats.size());
     for (auto& p : pending_beats) {
-        std::vector<protocol_metadata> requests;
+        std::vector<heartbeat_metadata> requests;
         absl::flat_hash_map<
           raft::group_id,
           heartbeat_manager::follower_request_meta>
           meta_map;
         requests.reserve(p.second.size());
         meta_map.reserve(p.second.size());
-        for (auto& [meta, seq] : p.second) {
+        for (auto& [hb, seq] : p.second) {
             meta_map.emplace(
-              meta.group,
+              hb.meta.group,
               heartbeat_manager::follower_request_meta{
-                seq, meta.prev_log_index});
-            requests.push_back(std::move(meta));
+                seq, hb.meta.prev_log_index});
+            requests.push_back(std::move(hb));
         }
         reqs.emplace_back(
-          p.first,
-          heartbeat_request{self, std::move(requests)},
-          std::move(meta_map));
+          p.first, heartbeat_request{std::move(requests)}, std::move(meta_map));
     }
 
     return reqs;
@@ -156,15 +156,15 @@ ss::future<> heartbeat_manager::do_dispatch_heartbeats() {
 ss::future<> heartbeat_manager::do_self_heartbeat(node_heartbeat&& r) {
     _dispatch_sem.signal();
     heartbeat_reply reply;
-    reply.meta.reserve(r.request.meta.size());
+    reply.meta.reserve(r.request.heartbeats.size());
     std::transform(
-      std::begin(r.request.meta),
-      std::end(r.request.meta),
+      std::begin(r.request.heartbeats),
+      std::end(r.request.heartbeats),
       std::back_inserter(reply.meta),
-      [nid = r.target](protocol_metadata& meta) {
+      [](heartbeat_metadata& hb) {
           return append_entries_reply{
-            .node_id = nid,
-            .group = meta.group,
+            .node_id = hb.node_id,
+            .group = hb.meta.group,
             .result = append_entries_reply::status::success};
       });
     process_reply(r.target, std::move(r.meta_map), std::move(reply));
@@ -204,12 +204,12 @@ void heartbeat_manager::process_reply(
                 continue;
             }
             // propagate error
-            (*it)->get_probe().heartbeat_request_error();
             (*it)->process_append_entries_reply(
               n,
               result<append_entries_reply>(r.error()),
               req_meta.seq,
               req_meta.dirty_offset);
+            (*it)->get_probe().heartbeat_request_error();
         }
         return;
     }

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -14,6 +14,7 @@
 #include "config/configuration.h"
 #include "model/metadata.h"
 #include "outcome.h"
+#include "raft/configuration.h"
 #include "raft/consensus.h"
 #include "raft/consensus_client_protocol.h"
 #include "raft/types.h"

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -242,7 +242,7 @@ group_cfg_from_args(const po::variables_map& opts) {
       model::broker_properties{
         .cores = ss::smp::count,
       }));
-    return raft::group_configuration(std::move(brokers));
+    return raft::group_configuration(std::move(brokers), model::revision_id(0));
 }
 
 int main(int args, char** argv, char** env) {

--- a/src/v/raft/prevote_stm.h
+++ b/src/v/raft/prevote_stm.h
@@ -48,10 +48,9 @@ private:
     };
 
     ss::future<bool> do_prevote();
-    ss::future<> dispatch_prevote(model::node_id);
-    ss::future<result<vote_reply>> do_dispatch_prevote(model::node_id);
-    ss::future<>
-    process_reply(model::node_id n, ss::future<result<vote_reply>> f);
+    ss::future<> dispatch_prevote(vnode);
+    ss::future<result<vote_reply>> do_dispatch_prevote(vnode);
+    ss::future<> process_reply(vnode n, ss::future<result<vote_reply>> f);
     ss::future<> process_replies();
     // args
     consensus* _ptr;
@@ -64,7 +63,7 @@ private:
     clock_type::time_point _prevote_timeout;
     // for safety to wait for all bg ops
     ss::gate _vote_bg;
-    absl::flat_hash_map<model::node_id, vmeta> _replies;
+    absl::flat_hash_map<vnode, vmeta> _replies;
     ctx_log _ctxlog;
 };
 

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -344,6 +344,12 @@ ss::future<> recovery_stm::replicate(
           }
           _ptr->process_append_entries_reply(
             _node_id, r.value(), seq, dirty_offset);
+          // If follower stats aren't present we have to stop recovery as
+          // follower was removed from configuration
+          if (!_ptr->_fstats.contains(_node_id)) {
+              _stop_requested = true;
+              return;
+          }
           // If request was reordered we have to stop recovery as follower state
           // is not known
           if (seq < _ptr->_fstats.get(_node_id).last_received_seq) {

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -19,7 +19,7 @@ namespace raft {
 
 class recovery_stm {
 public:
-    recovery_stm(consensus*, model::node_id, ss::io_priority_class);
+    recovery_stm(consensus*, vnode, ss::io_priority_class);
     ss::future<> apply();
 
 private:
@@ -41,7 +41,7 @@ private:
     bool is_recovery_finished();
 
     consensus* _ptr;
-    model::node_id _node_id;
+    vnode _node_id;
     model::offset _base_batch_offset;
     model::offset _last_batch_offset;
     model::offset _committed_offset;

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -173,7 +173,7 @@ ss::future<> replicate_batcher::do_flush(
   std::vector<replicate_batcher::item_ptr>&& notifications,
   append_entries_request&& req,
   ss::semaphore_units<> u,
-  absl::flat_hash_map<model::node_id, follower_req_seq> seqs) {
+  absl::flat_hash_map<vnode, follower_req_seq> seqs) {
     _ptr->_probe.replicate_batch_flushed();
     auto stm = ss::make_lw_shared<replicate_entries_stm>(
       _ptr, std::move(req), std::move(seqs));

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -55,7 +55,7 @@ public:
       std::vector<item_ptr>&&,
       append_entries_request&&,
       ss::semaphore_units<>,
-      absl::flat_hash_map<model::node_id, follower_req_seq>);
+      absl::flat_hash_map<vnode, follower_req_seq>);
 
 private:
     ss::future<item_ptr> do_cache(model::record_batch_reader&&);

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -146,7 +146,11 @@ replicate_entries_stm::append_to_self() {
 }
 
 inline bool replicate_entries_stm::is_follower_recovering(model::node_id id) {
-    return id != _ptr->self() && _ptr->_fstats.get(id).is_recovering;
+    if (auto it = _ptr->_fstats.find(id); it != _ptr->_fstats.end()) {
+        return it->second.is_recovering;
+    }
+
+    return false;
 }
 
 ss::future<result<replicate_result>>

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -13,6 +13,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "outcome_future_utils.h"
+#include "raft/configuration.h"
 #include "raft/consensus.h"
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
@@ -40,7 +41,7 @@ ss::future<append_entries_request> replicate_entries_stm::share_request() {
     });
 }
 ss::future<result<append_entries_reply>> replicate_entries_stm::do_dispatch_one(
-  model::node_id n,
+  vnode n,
   append_entries_request req,
   ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> units) {
     using ret_t = result<append_entries_reply>;
@@ -77,20 +78,19 @@ clock_type::time_point replicate_entries_stm::append_entries_timeout() {
 
 ss::future<result<append_entries_reply>>
 replicate_entries_stm::send_append_entries_request(
-  model::node_id n, append_entries_request req) {
+  vnode n, append_entries_request req) {
     _ptr->update_node_append_timestamp(n);
     vlog(_ctxlog.trace, "Sending append entries request {} to {}", req.meta, n);
 
     auto f = _ptr->_client_protocol.append_entries(
-      n, std::move(req), rpc::client_opts(append_entries_timeout()));
+      n.id(), std::move(req), rpc::client_opts(append_entries_timeout()));
     _dispatch_sem.signal();
     return f.finally(
       [this, n] { _ptr->suppress_heartbeats(n, _followers_seq[n], false); });
 }
 
 ss::future<> replicate_entries_stm::dispatch_one(
-  model::node_id id,
-  ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> units) {
+  vnode id, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> units) {
     return ss::with_gate(
              _req_bg,
              [this, id, units]() mutable {
@@ -104,7 +104,7 @@ ss::future<> replicate_entries_stm::dispatch_one(
                            _ptr->get_probe().replicate_request_error();
                        }
                        _ptr->process_append_entries_reply(
-                         id, reply, seq, _dirty_offset);
+                         id.id(), reply, seq, _dirty_offset);
                    });
              })
       .handle_exception_type([](const ss::gate_closed_exception&) {});
@@ -112,8 +112,7 @@ ss::future<> replicate_entries_stm::dispatch_one(
 
 ss::future<result<append_entries_reply>>
 replicate_entries_stm::dispatch_single_retry(
-  model::node_id id,
-  ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> units) {
+  vnode id, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> units) {
     return share_request()
       .then([this, id, units](append_entries_request r) mutable {
           return do_dispatch_one(id, std::move(r), units);
@@ -145,7 +144,7 @@ replicate_entries_stm::append_to_self() {
       });
 }
 
-inline bool replicate_entries_stm::is_follower_recovering(model::node_id id) {
+inline bool replicate_entries_stm::is_follower_recovering(vnode id) {
     if (auto it = _ptr->_fstats.find(id); it != _ptr->_fstats.end()) {
         return it->second.is_recovering;
     }
@@ -157,10 +156,10 @@ ss::future<result<replicate_result>>
 replicate_entries_stm::apply(ss::semaphore_units<> u) {
     // first append lo leader log, no flushing
     auto cfg = _ptr->config();
-    cfg.for_each_broker([this](const model::broker& n) {
+    cfg.for_each_broker_id([this](const vnode& rni) {
         // suppress follower heartbeat, before appending to self log
-        if (n.id() != _ptr->_self) {
-            _ptr->suppress_heartbeats(n.id(), _followers_seq[n.id()], true);
+        if (rni != _ptr->_self) {
+            _ptr->suppress_heartbeats(rni, _followers_seq[rni], true);
         }
     });
     return append_to_self()
@@ -177,21 +176,20 @@ replicate_entries_stm::apply(ss::semaphore_units<> u) {
           auto units = ss::make_lw_shared<std::vector<ss::semaphore_units<>>>(
             std::move(vec));
           uint16_t requests_count = 0;
-          cfg.for_each_broker(
-            [this, &requests_count, units](const model::broker& n) {
+          cfg.for_each_broker_id(
+            [this, &requests_count, units](const vnode& rni) {
                 // We are not dispatching request to followers that are
                 // recovering
-                if (is_follower_recovering(n.id())) {
+                if (is_follower_recovering(rni)) {
                     vlog(
                       _ctxlog.trace,
                       "Skipping sending append request to {}, recovering",
-                      n.id());
-                    _ptr->suppress_heartbeats(
-                      n.id(), _followers_seq[n.id()], false);
+                      rni);
+                    _ptr->suppress_heartbeats(rni, _followers_seq[rni], false);
                     return;
                 }
                 ++requests_count;
-                (void)dispatch_one(n.id(), units); // background
+                (void)dispatch_one(rni, units); // background
             });
           // Wait until all RPCs will be dispatched
           return _dispatch_sem.wait(requests_count)
@@ -257,7 +255,7 @@ ss::future<> replicate_entries_stm::wait() { return _req_bg.close(); }
 replicate_entries_stm::replicate_entries_stm(
   consensus* p,
   append_entries_request r,
-  absl::flat_hash_map<model::node_id, follower_req_seq> seqs)
+  absl::flat_hash_map<vnode, follower_req_seq> seqs)
   : _ptr(p)
   , _req(std::move(r))
   , _followers_seq(std::move(seqs))

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -80,7 +80,7 @@ public:
     replicate_entries_stm(
       consensus*,
       append_entries_request,
-      absl::flat_hash_map<model::node_id, follower_req_seq>);
+      absl::flat_hash_map<vnode, follower_req_seq>);
     ~replicate_entries_stm();
 
     /// caller have to pass _op_sem semaphore units, the apply call will do the
@@ -94,25 +94,25 @@ private:
     ss::future<append_entries_request> share_request();
 
     ss::future<> dispatch_one(
-      model::node_id, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>>);
+      vnode, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>>);
     ss::future<result<append_entries_reply>> dispatch_single_retry(
-      model::node_id, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>>);
+      vnode, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>>);
     ss::future<result<append_entries_reply>> do_dispatch_one(
-      model::node_id,
+      vnode,
       append_entries_request,
       ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>>);
 
     ss::future<result<append_entries_reply>>
-      send_append_entries_request(model::node_id, append_entries_request);
+      send_append_entries_request(vnode, append_entries_request);
     result<replicate_result> process_result(model::offset, model::term_id);
-    bool is_follower_recovering(model::node_id);
+    bool is_follower_recovering(vnode);
     clock_type::time_point append_entries_timeout();
     /// This append will happen under the lock
     ss::future<result<storage::append_result>> append_to_self();
     consensus* _ptr;
     /// we keep a copy around until we finish the retries
     append_entries_request _req;
-    absl::flat_hash_map<model::node_id, follower_req_seq> _followers_seq;
+    absl::flat_hash_map<vnode, follower_req_seq> _followers_seq;
     ss::semaphore _share_sem;
     ss::semaphore _dispatch_sem{0};
     ss::gate _req_bg;

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "likely.h"
 #include "raft/consensus.h"
 #include "raft/raftgen_service.h"
 #include "raft/types.h"
@@ -69,6 +70,7 @@ public:
         for (auto& m : r.heartbeats) {
             append_entries_request append_req(
               m.node_id,
+              m.target_node_id,
               m.meta,
               model::make_memory_record_batch_reader(
                 ss::circular_buffer<model::record_batch>{}),

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -65,15 +65,16 @@ public:
     heartbeat(heartbeat_request&& r, rpc::streaming_context&) final {
         using ret_t = std::vector<append_entries_reply>;
         std::vector<append_entries_request> reqs;
-        reqs.reserve(r.meta.size());
-        for (auto& m : r.meta) {
-            reqs.emplace_back(raft::append_entries_request(
-              r.node_id,
-              m,
+        reqs.reserve(r.heartbeats.size());
+        for (auto& m : r.heartbeats) {
+            append_entries_request append_req(
+              m.node_id,
+              m.meta,
               model::make_memory_record_batch_reader(
                 ss::circular_buffer<model::record_batch>{}),
-              append_entries_request::flush_after_append::no));
-        }
+              append_entries_request::flush_after_append::no);
+            reqs.push_back(std::move(append_req));
+        };
 
         auto req_size = reqs.size();
         auto groupped = group_hbeats_by_shard(std::move(reqs));

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -84,12 +84,13 @@ FIXTURE_TEST(write_configs, bootstrap_fixture) {
       cfg.data_batches_seen(),
       cfg.config_batches_seen());
 
-    cfg.config().for_each_voter([](model::node_id id) {
-        BOOST_REQUIRE(id >= 0 && id <= bootstrap_fixture::active_nodes);
+    cfg.config().for_each_voter([](raft::vnode rni) {
+        BOOST_REQUIRE(
+          rni.id() >= 0 && rni.id() <= bootstrap_fixture::active_nodes);
     });
 
-    cfg.config().for_each_learner([](model::node_id id) {
-        BOOST_REQUIRE(id > bootstrap_fixture::active_nodes);
+    cfg.config().for_each_learner([](raft::vnode rni) {
+        BOOST_REQUIRE(rni.id() > bootstrap_fixture::active_nodes);
     });
 
     BOOST_REQUIRE_EQUAL(cfg.data_batches_seen(), 10);

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -48,7 +48,10 @@ struct config_manager_fixture {
           raft::group_id(1),
           model::ntp(model::ns("t"), model::topic("t"), model::partition_id(0)))
       , _cfg_mgr(
-          raft::group_configuration({}), raft::group_id(1), _storage, _logger) {
+          raft::group_configuration({}, model::revision_id(0)),
+          raft::group_id(1),
+          _storage,
+          _logger) {
         _storage.start().get0();
     }
 
@@ -71,7 +74,8 @@ struct config_manager_fixture {
         for (auto i = 0; i < 2; ++i) {
             learners.push_back(tests::random_broker(i, i));
         }
-        return raft::group_configuration(std::move(nodes));
+        return raft::group_configuration(
+          std::move(nodes), model::revision_id(0));
     }
 
     raft::group_configuration add_random_cfg(model::offset offset) {
@@ -94,7 +98,10 @@ struct config_manager_fixture {
 
     void validate_recovery() {
         raft::configuration_manager recovered(
-          raft::group_configuration({}), raft::group_id(1), _storage, _logger);
+          raft::group_configuration({}, model::revision_id(0)),
+          raft::group_id(1),
+          _storage,
+          _logger);
 
         recovered.start(false).get0();
 
@@ -208,7 +215,10 @@ FIXTURE_TEST(test_start_write_concurrency, config_manager_fixture) {
     auto configurations = test_configurations();
 
     raft::configuration_manager new_cfg_manager(
-      raft::group_configuration({}), raft::group_id(1), _storage, _logger);
+      raft::group_configuration({}, model::revision_id(1)),
+      raft::group_id(1),
+      _storage,
+      _logger);
 
     auto start = new_cfg_manager.start(false);
     auto cfg = random_configuration();

--- a/src/v/raft/tests/configuration_serialization_test.cc
+++ b/src/v/raft/tests/configuration_serialization_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "model/metadata.h"
 #include "raft/configuration.h"
 #include "raft/consensus_utils.h"
 #include "random/generators.h"
@@ -44,10 +45,13 @@ raft::group_configuration random_configuration() {
             }
         }
         return raft::group_configuration(
-          std::move(brokers), std::move(current), std::move(old));
+          std::move(brokers),
+          std::move(current),
+          model::revision_id(0),
+          std::move(old));
     } else {
         return raft::group_configuration(
-          std::move(brokers), std::move(current));
+          std::move(brokers), std::move(current), model::revision_id(0));
     }
 }
 

--- a/src/v/raft/tests/group_configuration_tests.cc
+++ b/src/v/raft/tests/group_configuration_tests.cc
@@ -25,7 +25,7 @@ model::broker create_broker(int32_t id) {
 
 BOOST_AUTO_TEST_CASE(should_return_true_as_it_contains_learner) {
     raft::group_configuration test_grp = raft::group_configuration(
-      {create_broker(1)});
+      {create_broker(1)}, model::revision_id(0));
 
     auto contains = test_grp.contains_broker(model::node_id(1));
     BOOST_REQUIRE_EQUAL(contains, true);
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(should_return_true_as_it_contains_learner) {
 
 BOOST_AUTO_TEST_CASE(should_return_true_as_it_contains_voter) {
     raft::group_configuration test_grp = raft::group_configuration(
-      {create_broker(1)});
+      {create_broker(1)}, model::revision_id(0));
 
     auto contains = test_grp.contains_broker(model::node_id(1));
     BOOST_REQUIRE_EQUAL(contains, true);
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(should_return_true_as_it_contains_voter) {
 
 BOOST_AUTO_TEST_CASE(should_return_false_as_it_does_not_contain_machine) {
     raft::group_configuration test_grp = raft::group_configuration(
-      {create_broker(3)});
+      {create_broker(3)}, model::revision_id(0));
 
     auto contains = test_grp.contains_broker(model::node_id(1));
     BOOST_REQUIRE_EQUAL(contains, false);

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -345,7 +345,7 @@ struct raft_group {
           ntp,
           make_broker(node_id),
           _id,
-          raft::group_configuration(_initial_brokers),
+          raft::group_configuration(_initial_brokers, model::revision_id(0)),
           raft::timeout_jitter(heartbeat_interval * 2),
           fmt::format("{}/{}", _storage_dir, node_id()),
           _storage_type,
@@ -366,7 +366,7 @@ struct raft_group {
           ntp,
           broker,
           _id,
-          raft::group_configuration({}),
+          raft::group_configuration({}, model::revision_id(0)),
           raft::timeout_jitter(heartbeat_interval * 2),
           fmt::format("{}/{}", _storage_dir, node_id()),
           _storage_type,
@@ -416,14 +416,16 @@ struct raft_group {
     }
 
     void election_callback(model::node_id src, raft::leadership_status st) {
-        if (st.current_leader != src) {
+        if (
+          !st.current_leader
+          || st.current_leader && st.current_leader->id() != src) {
             // only accept election callbacks from current leader.
             return;
         }
         tstlog.info(
           "Group {} has new leader {}", st.group, st.current_leader.value());
 
-        _leader_id = st.current_leader;
+        _leader_id = st.current_leader->id();
         _election_cond.broadcast();
         _elections_count++;
     }

--- a/src/v/raft/tests/simple_record_fixture.h
+++ b/src/v/raft/tests/simple_record_fixture.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "model/metadata.h"
 #include "model/record.h"
 #include "storage/record_batch_builder.h"
 // testing
@@ -62,7 +63,8 @@ struct simple_record_fixture {
             learners.push_back(tests::random_broker(
               active_nodes + 1, active_nodes * active_nodes));
         }
-        return raft::group_configuration(std::move(nodes));
+        return raft::group_configuration(
+          std::move(nodes), model::revision_id{});
     }
     model::offset _base_offset{0};
     model::ntp _ntp{

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -8,9 +8,11 @@
 // by the Apache License, Version 2.0
 
 #include "compression/stream_zstd.h"
+#include "model/metadata.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
+#include "raft/configuration.h"
 #include "raft/consensus_utils.h"
 #include "raft/types.h"
 #include "random/generators.h"
@@ -73,12 +75,15 @@ SEASTAR_THREAD_TEST_CASE(append_entries_requests) {
       .last_visible_index = model::offset(200),
     };
     raft::append_entries_request req(
-      model::node_id(1), meta, std::move(readers.back()));
+      raft::vnode(model::node_id(1), model::revision_id(10)),
+      meta,
+      std::move(readers.back()));
 
     readers.pop_back();
     auto d = async_serialize_roundtrip_rpc(std::move(req)).get0();
 
-    BOOST_REQUIRE_EQUAL(d.node_id, model::node_id(1));
+    BOOST_REQUIRE_EQUAL(
+      d.node_id, raft::vnode(model::node_id(1), model::revision_id(10)));
     BOOST_REQUIRE_EQUAL(d.meta.group, meta.group);
     BOOST_REQUIRE_EQUAL(d.meta.commit_index, meta.commit_index);
     BOOST_REQUIRE_EQUAL(d.meta.term, meta.term);
@@ -111,15 +116,16 @@ model::broker create_test_broker() {
 SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip) {
     static constexpr int64_t one_k = 1'000;
     raft::heartbeat_request req;
-    req.node_id = model::node_id(one_k);
-    req.meta = std::vector<raft::protocol_metadata>(one_k);
+    req.heartbeats = std::vector<raft::heartbeat_metadata>(one_k);
     for (int64_t i = 0; i < one_k; ++i) {
-        req.meta[i].group = raft::group_id(i);
-        req.meta[i].commit_index = model::offset(i);
-        req.meta[i].term = model::term_id(i);
-        req.meta[i].prev_log_index = model::offset(i);
-        req.meta[i].prev_log_term = model::term_id(i);
-        req.meta[i].last_visible_index = model::offset(i);
+        req.heartbeats[i].node_id = raft::vnode(
+          model::node_id(one_k), model::revision_id(i));
+        req.heartbeats[i].meta.group = raft::group_id(i);
+        req.heartbeats[i].meta.commit_index = model::offset(i);
+        req.heartbeats[i].meta.term = model::term_id(i);
+        req.heartbeats[i].meta.prev_log_index = model::offset(i);
+        req.heartbeats[i].meta.prev_log_term = model::term_id(i);
+        req.heartbeats[i].meta.last_visible_index = model::offset(i);
     }
     iobuf buf;
     reflection::async_adl<raft::heartbeat_request>{}
@@ -133,26 +139,35 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip) {
     auto res
       = reflection::async_adl<raft::heartbeat_request>{}.from(parser).get0();
     for (int64_t i = 0; i < one_k; ++i) {
-        BOOST_REQUIRE_EQUAL(res.meta[i].group, raft::group_id(i));
-        BOOST_REQUIRE_EQUAL(res.meta[i].commit_index, model::offset(i));
-        BOOST_REQUIRE_EQUAL(res.meta[i].term, model::term_id(i));
-        BOOST_REQUIRE_EQUAL(res.meta[i].prev_log_index, model::offset(i));
-        BOOST_REQUIRE_EQUAL(res.meta[i].prev_log_term, model::term_id(i));
-        BOOST_REQUIRE_EQUAL(res.meta[i].last_visible_index, model::offset(i));
+        BOOST_REQUIRE_EQUAL(res.heartbeats[i].meta.group, raft::group_id(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].meta.commit_index, model::offset(i));
+        BOOST_REQUIRE_EQUAL(res.heartbeats[i].meta.term, model::term_id(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].meta.prev_log_index, model::offset(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].meta.prev_log_term, model::term_id(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].meta.last_visible_index, model::offset(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].node_id,
+          raft::vnode(model::node_id(one_k), model::revision_id(i)));
     }
 }
 SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip_with_negative) {
     static constexpr int64_t one_k = 10;
     raft::heartbeat_request req;
-    req.node_id = model::node_id(one_k);
-    req.meta = std::vector<raft::protocol_metadata>(one_k);
+
+    req.heartbeats = std::vector<raft::heartbeat_metadata>(one_k);
     for (int64_t i = 0; i < one_k; ++i) {
-        req.meta[i].group = raft::group_id(i);
-        req.meta[i].commit_index = model::offset(-i - 100);
-        req.meta[i].term = model::term_id(-i - 100);
-        req.meta[i].prev_log_index = model::offset(-i - 100);
-        req.meta[i].prev_log_term = model::term_id(-i - 100);
-        req.meta[i].last_visible_index = model::offset(-i - 100);
+        req.heartbeats[i].node_id = raft::vnode(
+          model::node_id(one_k), model::revision_id(-i - 100));
+        req.heartbeats[i].meta.group = raft::group_id(i);
+        req.heartbeats[i].meta.commit_index = model::offset(-i - 100);
+        req.heartbeats[i].meta.term = model::term_id(-i - 100);
+        req.heartbeats[i].meta.prev_log_index = model::offset(-i - 100);
+        req.heartbeats[i].meta.prev_log_term = model::term_id(-i - 100);
+        req.heartbeats[i].meta.last_visible_index = model::offset(-i - 100);
     }
     iobuf buf;
     reflection::async_adl<raft::heartbeat_request>{}
@@ -165,12 +180,12 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip_with_negative) {
     auto parser = iobuf_parser(codec.uncompress(std::move(buf)));
     auto res
       = reflection::async_adl<raft::heartbeat_request>{}.from(parser).get0();
-    for (auto& m : res.meta) {
-        BOOST_REQUIRE_EQUAL(m.commit_index, model::offset{});
-        BOOST_REQUIRE_EQUAL(m.term, model::term_id{-1});
-        BOOST_REQUIRE_EQUAL(m.prev_log_index, model::offset{});
-        BOOST_REQUIRE_EQUAL(m.prev_log_term, model::term_id{});
-        BOOST_REQUIRE_EQUAL(m.last_visible_index, model::offset{});
+    for (auto& hb : res.heartbeats) {
+        BOOST_REQUIRE_EQUAL(hb.meta.commit_index, model::offset{});
+        BOOST_REQUIRE_EQUAL(hb.meta.term, model::term_id{-1});
+        BOOST_REQUIRE_EQUAL(hb.meta.prev_log_index, model::offset{});
+        BOOST_REQUIRE_EQUAL(hb.meta.prev_log_term, model::term_id{});
+        BOOST_REQUIRE_EQUAL(hb.meta.last_visible_index, model::offset{});
     }
 }
 SEASTAR_THREAD_TEST_CASE(heartbeat_response_roundtrip) {
@@ -185,7 +200,7 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_response_roundtrip) {
                          + model::offset(random_generators::get_int(10000));
 
         reply.meta.push_back(raft::append_entries_reply{
-          .node_id = model::node_id(1),
+          .node_id = raft::vnode(model::node_id(1), model::revision_id(i)),
           .group = raft::group_id(i),
           .term = model::term_id(random_generators::get_int(-1, 1000)),
           .last_committed_log_index = commited_idx,
@@ -230,7 +245,9 @@ SEASTAR_THREAD_TEST_CASE(snapshot_metadata_roundtrip) {
     auto n3 = tests::random_broker(0, 100);
     std::vector<model::broker> nodes{n1, n2, n3};
     raft::group_nodes current{
-      .voters = {n1.id(), n3.id()}, .learners = {n2.id()}};
+      .voters
+      = {raft::vnode(n1.id(), model::revision_id(1)), raft::vnode(n3.id(), model::revision_id(3))},
+      .learners = {raft::vnode(n2.id(), model::revision_id(1))}};
 
     raft::group_configuration cfg(nodes, current, model::revision_id(0));
 

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -232,7 +232,7 @@ SEASTAR_THREAD_TEST_CASE(snapshot_metadata_roundtrip) {
     raft::group_nodes current{
       .voters = {n1.id(), n3.id()}, .learners = {n2.id()}};
 
-    raft::group_configuration cfg(nodes, current);
+    raft::group_configuration cfg(nodes, current, model::revision_id(0));
 
     auto ct = ss::lowres_clock::now();
     raft::snapshot_metadata metadata{

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -232,7 +232,7 @@ group_cfg_from_args(const po::variables_map& opts) {
       model::broker_properties{
         .cores = ss::smp::count,
       }));
-    return raft::group_configuration(std::move(brokers));
+    return raft::group_configuration(std::move(brokers), model::revision_id(0));
 }
 
 int main(int args, char** argv, char** env) {

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -22,6 +22,10 @@
 
 namespace raft {
 
+std::ostream& operator<<(std::ostream& o, const vnode& id) {
+    return o << "{id: " << id.id() << ", revision: " << id.revision() << "}";
+}
+
 std::ostream& operator<<(std::ostream& o, const append_entries_reply& r) {
     return o << "{node_id: " << r.node_id << ", group: " << r.group
              << ", term:" << r.term
@@ -48,9 +52,10 @@ std::ostream& operator<<(std::ostream& o, const follower_index_metadata& i) {
 }
 
 std::ostream& operator<<(std::ostream& o, const heartbeat_request& r) {
-    o << "{node: " << r.node_id << ", meta:(" << r.meta.size() << ") [";
-    for (auto& m : r.meta) {
-        o << m << ",";
+    o << "{meta:(" << r.heartbeats.size() << ") [";
+    for (auto& m : r.heartbeats) {
+        o << "meta: " << m.meta << ","
+          << "node_id: " << m.node_id << ",";
     }
     return o << "]}";
 }
@@ -179,7 +184,7 @@ async_adl<raft::append_entries_request>::from(iobuf_parser& in) {
     }
     auto reader = model::make_memory_record_batch_reader(std::move(batches));
     auto meta = reflection::adl<raft::protocol_metadata>{}.from(in);
-    auto n = reflection::adl<model::node_id>{}.from(in);
+    auto n = reflection::adl<raft::vnode>{}.from(in);
     auto flush
       = reflection::adl<raft::append_entries_request::flush_after_append>{}
           .from(in);
@@ -229,7 +234,9 @@ struct hbeat_soa {
       , terms(n)
       , prev_log_indices(n)
       , prev_log_terms(n)
-      , last_visible_indices(n) {}
+      , last_visible_indices(n)
+      , revisions(n) {}
+
     ~hbeat_soa() noexcept = default;
     hbeat_soa(const hbeat_soa&) = delete;
     hbeat_soa& operator=(const hbeat_soa&) = delete;
@@ -242,6 +249,7 @@ struct hbeat_soa {
     std::vector<model::offset> prev_log_indices;
     std::vector<model::term_id> prev_log_terms;
     std::vector<model::offset> last_visible_indices;
+    std::vector<model::revision_id> revisions;
 };
 
 struct hbeat_response_array {
@@ -250,13 +258,15 @@ struct hbeat_response_array {
       , terms(n)
       , last_committed_log_index(n)
       , last_dirty_log_index(n)
-      , last_term_base_offset(n) {}
+      , last_term_base_offset(n)
+      , revisions(n) {}
 
     std::vector<raft::group_id> groups;
     std::vector<model::term_id> terms;
     std::vector<model::offset> last_committed_log_index;
     std::vector<model::offset> last_dirty_log_index;
     std::vector<model::offset> last_term_base_offset;
+    std::vector<model::revision_id> revisions;
 };
 template<typename T>
 void encode_one_vint(iobuf& out, const T& t) {
@@ -295,18 +305,24 @@ ss::future<> async_adl<raft::heartbeat_request>::to(
   iobuf& out, raft::heartbeat_request&& request) {
     struct sorter_fn {
         constexpr bool operator()(
-          const raft::protocol_metadata& lhs,
-          const raft::protocol_metadata& rhs) const {
-            return lhs.commit_index < rhs.commit_index;
+          const raft::heartbeat_metadata& lhs,
+          const raft::heartbeat_metadata& rhs) const {
+            return lhs.meta.commit_index < rhs.meta.commit_index;
         }
     };
-    std::sort(request.meta.begin(), request.meta.end(), sorter_fn{});
+    std::sort(
+      request.heartbeats.begin(), request.heartbeats.end(), sorter_fn{});
     return ss::make_ready_future<>()
       .then([&out, request = std::move(request)] {
-          internal::hbeat_soa encodee(request.meta.size());
-          const size_t size = request.meta.size();
+          internal::hbeat_soa encodee(request.heartbeats.size());
+          // target physical node id is always the same it differs only by
+          // revision
+
+          const size_t size = request.heartbeats.size();
           for (size_t i = 0; i < size; ++i) {
-              const auto& m = request.meta[i];
+              const auto& m = request.heartbeats[i].meta;
+              const raft::vnode node = request.heartbeats[i].node_id;
+
               vassert(
                 m.group() >= 0, "Negative raft group detected. {}", m.group);
               encodee.groups[i] = m.group;
@@ -319,11 +335,17 @@ ss::future<> async_adl<raft::heartbeat_request>::to(
                 model::term_id(-1), m.prev_log_term);
               encodee.last_visible_indices[i] = std::max(
                 model::offset(-1), m.last_visible_index);
+              encodee.revisions[i] = std::max(
+                model::revision_id(-1), node.revision());
           }
           // important to release this memory after this function
           // request.meta = {}; // release memory
-          adl<model::node_id>{}.to(out, request.node_id);
+
+          // physical node ids are the same for all requests
+          adl<model::node_id>{}.to(
+            out, request.heartbeats.front().node_id.id());
           adl<uint32_t>{}.to(out, size);
+
           return encodee;
       })
       .then([&out](internal::hbeat_soa encodee) {
@@ -337,6 +359,8 @@ ss::future<> async_adl<raft::heartbeat_request>::to(
             out, encodee.prev_log_terms);
           internal::encode_one_delta_array<model::offset>(
             out, encodee.last_visible_indices);
+          internal::encode_one_delta_array<model::revision_id>(
+            out, encodee.revisions);
       });
 }
 
@@ -348,52 +372,67 @@ T decode_signed(T value) {
 ss::future<raft::heartbeat_request>
 async_adl<raft::heartbeat_request>::from(iobuf_parser& in) {
     raft::heartbeat_request req;
-    req.node_id = adl<model::node_id>{}.from(in);
-    req.meta = std::vector<raft::protocol_metadata>(adl<uint32_t>{}.from(in));
-    if (req.meta.empty()) {
+    auto node_id = adl<model::node_id>{}.from(in);
+    req.heartbeats = std::vector<raft::heartbeat_metadata>(
+      adl<uint32_t>{}.from(in));
+    if (req.heartbeats.empty()) {
         return ss::make_ready_future<raft::heartbeat_request>(std::move(req));
     }
-    const size_t max = req.meta.size();
-    req.meta[0].group = varlong_reader<raft::group_id>(in);
+    const size_t max = req.heartbeats.size();
+    req.heartbeats[0].meta.group = varlong_reader<raft::group_id>(in);
     for (size_t i = 1; i < max; ++i) {
-        req.meta[i].group = internal::read_one_varint_delta<raft::group_id>(
-          in, req.meta[i - 1].group);
+        req.heartbeats[i].meta.group
+          = internal::read_one_varint_delta<raft::group_id>(
+            in, req.heartbeats[i - 1].meta.group);
     }
-    req.meta[0].commit_index = varlong_reader<model::offset>(in);
+    req.heartbeats[0].meta.commit_index = varlong_reader<model::offset>(in);
     for (size_t i = 1; i < max; ++i) {
-        req.meta[i].commit_index
+        req.heartbeats[i].meta.commit_index
           = internal::read_one_varint_delta<model::offset>(
-            in, req.meta[i - 1].commit_index);
+            in, req.heartbeats[i - 1].meta.commit_index);
     }
-    req.meta[0].term = varlong_reader<model::term_id>(in);
+    req.heartbeats[0].meta.term = varlong_reader<model::term_id>(in);
     for (size_t i = 1; i < max; ++i) {
-        req.meta[i].term = internal::read_one_varint_delta<model::term_id>(
-          in, req.meta[i - 1].term);
-    }
-    req.meta[0].prev_log_index = varlong_reader<model::offset>(in);
-    for (size_t i = 1; i < max; ++i) {
-        req.meta[i].prev_log_index
-          = internal::read_one_varint_delta<model::offset>(
-            in, req.meta[i - 1].prev_log_index);
-    }
-    req.meta[0].prev_log_term = varlong_reader<model::term_id>(in);
-    for (size_t i = 1; i < max; ++i) {
-        req.meta[i].prev_log_term
+        req.heartbeats[i].meta.term
           = internal::read_one_varint_delta<model::term_id>(
-            in, req.meta[i - 1].prev_log_term);
+            in, req.heartbeats[i - 1].meta.term);
     }
-    req.meta[0].last_visible_index = varlong_reader<model::offset>(in);
+    req.heartbeats[0].meta.prev_log_index = varlong_reader<model::offset>(in);
     for (size_t i = 1; i < max; ++i) {
-        req.meta[i].last_visible_index
+        req.heartbeats[i].meta.prev_log_index
           = internal::read_one_varint_delta<model::offset>(
-            in, req.meta[i - 1].last_visible_index);
+            in, req.heartbeats[i - 1].meta.prev_log_index);
+    }
+    req.heartbeats[0].meta.prev_log_term = varlong_reader<model::term_id>(in);
+    for (size_t i = 1; i < max; ++i) {
+        req.heartbeats[i].meta.prev_log_term
+          = internal::read_one_varint_delta<model::term_id>(
+            in, req.heartbeats[i - 1].meta.prev_log_term);
+    }
+    req.heartbeats[0].meta.last_visible_index = varlong_reader<model::offset>(
+      in);
+    for (size_t i = 1; i < max; ++i) {
+        req.heartbeats[i].meta.last_visible_index
+          = internal::read_one_varint_delta<model::offset>(
+            in, req.heartbeats[i - 1].meta.last_visible_index);
     }
 
-    for (auto& m : req.meta) {
-        m.prev_log_index = decode_signed(m.prev_log_index);
-        m.commit_index = decode_signed(m.commit_index);
-        m.prev_log_term = decode_signed(m.prev_log_term);
-        m.last_visible_index = decode_signed(m.last_visible_index);
+    req.heartbeats[0].node_id = raft::vnode(
+      node_id, varlong_reader<model::revision_id>(in));
+    for (size_t i = 1; i < max; ++i) {
+        req.heartbeats[i].node_id = raft::vnode(
+          node_id,
+          internal::read_one_varint_delta<model::revision_id>(
+            in, req.heartbeats[i - 1].node_id.revision()));
+    }
+
+    for (auto& hb : req.heartbeats) {
+        hb.meta.prev_log_index = decode_signed(hb.meta.prev_log_index);
+        hb.meta.commit_index = decode_signed(hb.meta.commit_index);
+        hb.meta.prev_log_term = decode_signed(hb.meta.prev_log_term);
+        hb.meta.last_visible_index = decode_signed(hb.meta.last_visible_index);
+        hb.node_id = raft::vnode(
+          hb.node_id.id(), decode_signed(hb.node_id.revision()));
     }
     return ss::make_ready_future<raft::heartbeat_request>(std::move(req));
 }
@@ -413,8 +452,8 @@ ss::future<> async_adl<raft::heartbeat_reply>::to(
         return ss::make_ready_future<>();
     }
 
-    // replies are comming from the same node
-    adl<model::node_id>{}.to(out, reply.meta.front().node_id);
+    // replies are comming from the same physical node
+    adl<model::node_id>{}.to(out, reply.meta.front().node_id.id());
 
     std::sort(reply.meta.begin(), reply.meta.end(), sorter_fn{});
     internal::hbeat_response_array encodee(reply.meta.size());
@@ -429,6 +468,8 @@ ss::future<> async_adl<raft::heartbeat_reply>::to(
           model::offset(-1), reply.meta[i].last_dirty_log_index);
         encodee.last_term_base_offset[i] = std::max(
           model::offset(-1), reply.meta[i].last_term_base_offset);
+        encodee.revisions[i] = std::max(
+          model::revision_id(-1), reply.meta[i].node_id.revision());
     }
     internal::encode_one_delta_array<raft::group_id>(out, encodee.groups);
     internal::encode_one_delta_array<model::term_id>(out, encodee.terms);
@@ -439,6 +480,9 @@ ss::future<> async_adl<raft::heartbeat_reply>::to(
       out, encodee.last_dirty_log_index);
     internal::encode_one_delta_array<model::offset>(
       out, encodee.last_term_base_offset);
+    internal::encode_one_delta_array<model::revision_id>(
+      out, encodee.revisions);
+
     for (auto& m : reply.meta) {
         adl<raft::append_entries_reply::status>{}.to(out, m.result);
     }
@@ -459,10 +503,8 @@ async_adl<raft::heartbeat_reply>::from(iobuf_parser& in) {
     auto node_id = adl<model::node_id>{}.from(in);
 
     size_t size = reply.meta.size();
-    reply.meta[0].node_id = node_id;
     reply.meta[0].group = varlong_reader<raft::group_id>(in);
     for (size_t i = 1; i < size; ++i) {
-        reply.meta[i].node_id = node_id;
         reply.meta[i].group = internal::read_one_varint_delta<raft::group_id>(
           in, reply.meta[i - 1].group);
     }
@@ -493,6 +535,15 @@ async_adl<raft::heartbeat_reply>::from(iobuf_parser& in) {
             in, reply.meta[i - 1].last_term_base_offset);
     }
 
+    reply.meta[0].node_id = raft::vnode(
+      node_id, varlong_reader<model::revision_id>(in));
+    for (size_t i = 1; i < size; ++i) {
+        reply.meta[i].node_id = raft::vnode(
+          node_id,
+          internal::read_one_varint_delta<model::revision_id>(
+            in, reply.meta[i - 1].node_id.revision()));
+    }
+
     for (size_t i = 0; i < size; ++i) {
         reply.meta[i].result = adl<raft::append_entries_reply::status>{}.from(
           in);
@@ -502,6 +553,8 @@ async_adl<raft::heartbeat_reply>::from(iobuf_parser& in) {
         m.last_committed_log_index = decode_signed(m.last_committed_log_index);
         m.last_dirty_log_index = decode_signed(m.last_dirty_log_index);
         m.last_term_base_offset = decode_signed(m.last_term_base_offset);
+        m.node_id = raft::vnode(
+          m.node_id.id(), decode_signed(m.node_id.revision()));
     }
 
     return ss::make_ready_future<raft::heartbeat_reply>(std::move(reply));

--- a/src/v/raft/vote_stm.h
+++ b/src/v/raft/vote_stm.h
@@ -82,8 +82,8 @@ private:
 
     ss::future<> do_vote();
     ss::future<> self_vote();
-    ss::future<> dispatch_one(model::node_id);
-    ss::future<result<vote_reply>> do_dispatch_one(model::node_id);
+    ss::future<> dispatch_one(vnode);
+    ss::future<result<vote_reply>> do_dispatch_one(vnode);
     ss::future<> update_vote_state(ss::semaphore_units<>);
     ss::future<> process_replies();
     ss::future<std::error_code>
@@ -98,7 +98,7 @@ private:
     std::optional<raft::group_configuration> _config;
     // for safety to wait for all bg ops
     ss::gate _vote_bg;
-    absl::flat_hash_map<model::node_id, vmeta> _replies;
+    absl::flat_hash_map<vnode, vmeta> _replies;
     ctx_log _ctxlog;
 };
 


### PR DESCRIPTION
This PR introduces the two major changes

- adding `model::revision_id` to `raft::group_configuration`
- replacing `model::node_id` with `raft::vnode` being a tuple containing both revision and physical node id.

## Revision in configuration

Controller backed has to be able to know if raft group configuration change was already applied by backend residing on the other node. Additionally we will use `model::revision_id` to assign unique virtual id to the node that is being added to raft group.

## Virtual node id

In order to be able to distinguish node when it is being added to raft group configuration more than once we introduce `raft::vnode`. The `raft::vnode` is a tuple containing `model::node_id` and `model::revision_id`. The node id is assigned every time the node is added to current configuration using configuration revision. This way every time the node is added to the raft group its identity is unique. 

## Virtual vs physical nodes

The `raft::vnode` is an abstraction layer on top of the node physical identity. For each raft group, the same physical node identity can be different.

## `raft::vnode` and connections

Raft uses `rpc::connection_cache` to lookup the connection to connect to other cluster members. Different raft groups may perceive the same physical node as a different `raft::vnode` but even though they use the same connection addressed with physical `model::node_id` so that all requests coming from different raft groups are multiplexed through one TCP connection.

## `raft::vnode` heartbeat

In redpanda heartbeats coming from different raft groups are coalesced into single heartbeat_request per each core. This makes the heartbeat request to be addressed to the same physical node but each raft group may address different `raft::vnode`. The heartbeat request must therefore include the `raft::vnode` specific for each raft group.   

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
