### PR TITLE
Rpk system info

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
 	github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8
-	github.com/shirou/gopsutil/v3 v3.20.12
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.7

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -41,9 +41,10 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.6.1
+	github.com/tklauser/go-sysconf v0.1.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20201029080932-201ba4db2418
+	golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc
 	google.golang.org/grpc v1.22.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools v2.2.0+incompatible // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -11,8 +11,6 @@ github.com/Shopify/sarama v1.26.1 h1:3jnfWKD7gVwbB1KSy/lE0szA9duPuSFLViK0o/d3DgA
 github.com/Shopify/sarama v1.26.1/go.mod h1:NbSGBSSndYaIhRcBtY9V0U7AyH+x71bG668AuWys/yU=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
-github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -88,8 +86,6 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
-github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -247,8 +243,6 @@ github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8 h1:2c1EFnZHIPCW8q
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/shirou/gopsutil/v3 v3.20.12 h1:abpcjSQRHdb3thCge/UyJty9CnvvmUHljTSrjtFU+Og=
-github.com/shirou/gopsutil/v3 v3.20.12/go.mod h1:igHnfak0qnw1biGeI2qKQvu0ZkwvEkUcCLlYhZzdr/4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -348,7 +342,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201029080932-201ba4db2418 h1:HlFl4V6pEMziuLXyRkm5BIYq1y1GAbb02pRlWvI54OM=
 golang.org/x/sys v0.0.0-20201029080932-201ba4db2418/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc h1:y0Og6AYdwus7SIAnKnDxjc4gJetRiYEWOx4AKbOeyEI=

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -282,6 +282,10 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/tklauser/go-sysconf v0.1.0 h1:f4fOH/B3HZYy2wz7o9Vr5i4dBhOKcedooHq7/4c0hxQ=
+github.com/tklauser/go-sysconf v0.1.0/go.mod h1:h54uFIrVIJBr8RXt3F5JJdxVkmFeallWuXajbMhn2O8=
+github.com/tklauser/numcpus v0.1.0 h1:BQeAuOQKZtytv8qblsFbi9mhTfXQdFFkyX0vaV6B4tc=
+github.com/tklauser/numcpus v0.1.0/go.mod h1:i3up9VjARpkV00NkBbexuDd0RAVQz4rV5Gl8miYgd5k=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
@@ -347,6 +351,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201029080932-201ba4db2418 h1:HlFl4V6pEMziuLXyRkm5BIYq1y1GAbb02pRlWvI54OM=
 golang.org/x/sys v0.0.0-20201029080932-201ba4db2418/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc h1:y0Og6AYdwus7SIAnKnDxjc4gJetRiYEWOx4AKbOeyEI=
+golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20191110171634-ad39bd3f0407 h1:5zh5atpUEdIc478E/ebrIaHLKcfVvG6dL/fGv7BcMoM=
 golang.org/x/term v0.0.0-20191110171634-ad39bd3f0407/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/go/rpk/pkg/api/api.go
+++ b/src/go/rpk/pkg/api/api.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/version"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cloud"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
@@ -92,7 +93,7 @@ func SendMetrics(p MetricsPayload, conf config.Config) error {
 }
 
 func SendEnvironment(
-	env EnvironmentPayload, conf config.Config, confJSON string,
+	fs afero.Fs, env EnvironmentPayload, conf config.Config, confJSON string,
 ) error {
 	confMap := map[string]interface{}{}
 	err := json.Unmarshal([]byte(confJSON), &confMap)
@@ -123,7 +124,7 @@ func SendEnvironment(
 	}
 	cpuModel := "N/A"
 	cpuCores := 0
-	cpuInfo, err := system.CpuInfo()
+	cpuInfo, err := system.CpuInfo(fs)
 	if err != nil {
 		log.Debug("Error querying CPU info: ", err)
 	} else if len(cpuInfo) > 0 {

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -196,9 +196,8 @@ func getMetrics(
 	fs afero.Fs, mgr config.Manager, timeout time.Duration, conf config.Config,
 ) (*metricsResult, error) {
 	res := &metricsResult{[][]string{}, nil}
-	m, errs := system.GatherMetrics(fs, timeout, conf)
-	if len(errs) != 0 {
-		err := multierror.Append(nil, errs...)
+	m, err := system.GatherMetrics(fs, timeout, conf)
+	if err != nil {
 		return res, errors.Wrap(err, "Error gathering metrics")
 	}
 	res.metrics = m

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -141,7 +141,7 @@ func executeInfo(
 		return getOSInfo(timeout, osInfoRowsCh)
 	})
 	grp.Go(func() error {
-		return getCPUInfo(cpuInfoRowsCh)
+		return getCPUInfo(fs, cpuInfoRowsCh)
 	})
 	grp.Go(func() error {
 		return getConf(mgr, conf.ConfigFile, confRowsCh)
@@ -222,9 +222,9 @@ func getOSInfo(timeout time.Duration, out chan<- [][]string) error {
 	return err
 }
 
-func getCPUInfo(out chan<- [][]string) error {
+func getCPUInfo(fs afero.Fs, out chan<- [][]string) error {
 	rows := [][]string{}
-	cpuInfo, err := system.CpuInfo()
+	cpuInfo, err := system.CpuInfo(fs)
 	if err != nil {
 		err = errors.Wrap(err, "Error querying CPU info")
 	}

--- a/src/go/rpk/pkg/cli/cmd/debug/info_test.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info_test.go
@@ -39,6 +39,43 @@ func writeConfig(fs afero.Fs, conf *config.Config) error {
 
 func TestInfo(t *testing.T) {
 	defaultSetup := func(fs afero.Fs) error {
+		contents := `processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 158
+model name	: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
+stepping	: 13
+microcode	: 0xca
+cpu MHz		: 953.249
+cache size	: 16384 KB
+physical id	: 0
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 15
+initial apicid	: 15
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit
+bogomips	: 4599.93
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+`
+		err := afero.WriteFile(
+			fs,
+			"/proc/cpuinfo",
+			[]byte(contents),
+			0755,
+		)
+		if err != nil {
+			return err
+		}
 		return writeConfig(fs, getConfig())
 	}
 	tests := []struct {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -117,7 +117,7 @@ func NewStartCommand(
 			}
 			seedServers, err := parseSeeds(seeds)
 			if err != nil {
-				sendEnv(mgr, env, conf, err)
+				sendEnv(fs, mgr, env, conf, err)
 				return err
 			}
 			if len(seedServers) != 0 {
@@ -133,7 +133,7 @@ func NewStartCommand(
 				config.Default().Redpanda.KafkaApi.Port,
 			)
 			if err != nil {
-				sendEnv(mgr, env, conf, err)
+				sendEnv(fs, mgr, env, conf, err)
 				return err
 			}
 			if kafkaApi != nil {
@@ -149,7 +149,7 @@ func NewStartCommand(
 				config.Default().Redpanda.RPCServer.Port,
 			)
 			if err != nil {
-				sendEnv(mgr, env, conf, err)
+				sendEnv(fs, mgr, env, conf, err)
 				return err
 			}
 			if rpcServer != nil {
@@ -165,7 +165,7 @@ func NewStartCommand(
 				config.Default().Redpanda.KafkaApi.Port,
 			)
 			if err != nil {
-				sendEnv(mgr, env, conf, err)
+				sendEnv(fs, mgr, env, conf, err)
 				return err
 			}
 			if advKafkaApi != nil {
@@ -180,7 +180,7 @@ func NewStartCommand(
 				config.Default().Redpanda.RPCServer.Port,
 			)
 			if err != nil {
-				sendEnv(mgr, env, conf, err)
+				sendEnv(fs, mgr, env, conf, err)
 				return err
 			}
 			if advRPCApi != nil {
@@ -188,7 +188,7 @@ func NewStartCommand(
 			}
 			installDirectory, err := cli.GetOrFindInstallDir(fs, installDirFlag)
 			if err != nil {
-				sendEnv(mgr, env, conf, err)
+				sendEnv(fs, mgr, env, conf, err)
 				return err
 			}
 			rpArgs, err := buildRedpandaFlags(
@@ -198,7 +198,7 @@ func NewStartCommand(
 				ccmd.Flags(),
 			)
 			if err != nil {
-				sendEnv(mgr, env, conf, err)
+				sendEnv(fs, mgr, env, conf, err)
 				return err
 			}
 			checkPayloads, tunerPayloads, err := prestart(
@@ -211,17 +211,17 @@ func NewStartCommand(
 			env.Checks = checkPayloads
 			env.Tuners = tunerPayloads
 			if err != nil {
-				sendEnv(mgr, env, conf, err)
+				sendEnv(fs, mgr, env, conf, err)
 				return err
 			}
 
 			err = mgr.Write(conf)
 			if err != nil {
-				sendEnv(mgr, env, conf, err)
+				sendEnv(fs, mgr, env, conf, err)
 				return err
 			}
 
-			sendEnv(mgr, env, conf, nil)
+			sendEnv(fs, mgr, env, conf, nil)
 			rpArgs.ExtraArgs = args
 			log.Info(common.FeedbackMsg)
 			log.Info("Starting redpanda...")
@@ -748,6 +748,7 @@ func parseAddress(addr string, defaultPort int) (*config.SocketAddress, error) {
 }
 
 func sendEnv(
+	fs afero.Fs,
 	mgr config.Manager,
 	env api.EnvironmentPayload,
 	conf *config.Config,
@@ -775,7 +776,7 @@ func sendEnv(
 		}
 		confJSON = string(confBytes)
 	}
-	err = api.SendEnvironment(env, *conf, confJSON)
+	err = api.SendEnvironment(fs, env, *conf, confJSON)
 	if err != nil {
 		log.Warnf("couldn't send environment data: %v", err)
 	}

--- a/src/go/rpk/pkg/system/cpu_test.go
+++ b/src/go/rpk/pkg/system/cpu_test.go
@@ -1,0 +1,122 @@
+package system_test
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/system"
+)
+
+func TestCpuInfo(t *testing.T) {
+	defaultSetup := func(fs afero.Fs) error {
+		contents := `processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 158
+model name	: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
+stepping	: 13
+microcode	: 0xca
+cpu MHz		: 953.249
+cache size	: 16384 KB
+physical id	: 0
+siblings	: 16
+core id		: 7
+cpu cores	: 8
+apicid		: 15
+initial apicid	: 15
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit
+bogomips	: 4599.93
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 158
+model name	: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
+stepping	: 13
+microcode	: 0xca
+cpu MHz		: 1311.446
+cache size	: 16384 KB
+physical id	: 0
+siblings	: 16
+core id		: 6
+cpu cores	: 8
+apicid		: 13
+initial apicid	: 13
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 22
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp md_clear flush_l1d arch_capabilities
+bugs		: spectre_v1 spectre_v2 spec_store_bypass swapgs taa itlb_multihit
+bogomips	: 4599.93
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+`
+		return afero.WriteFile(
+			fs,
+			"/proc/cpuinfo",
+			[]byte(contents),
+			0755,
+		)
+	}
+	tests := []struct {
+		name		string
+		before		func(fs afero.Fs) error
+		expectedErrMsg	string
+		expected	[]*system.CPUInfo
+	}{{
+		name:		"it should fail if /proc/cpuinfo is missing",
+		expectedErrMsg:	"/proc/cpuinfo",
+	}, {
+		name:		"it should fail if /proc/cpuinfo is empty",
+		expectedErrMsg:	"/proc/cpuinfo is empty",
+		before: func(fs afero.Fs) error {
+			return afero.WriteFile(
+				fs,
+				"/proc/cpuinfo",
+				[]byte(""),
+				0755,
+			)
+		},
+	}, {
+		name:	"it should parse the CPU model & # of cores",
+		expected: []*system.CPUInfo{{
+			ModelName:	"Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz",
+			Cores:		8,
+		}, {
+			ModelName:	"Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz",
+			Cores:		8,
+		}},
+		before:	defaultSetup,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			fs := afero.NewMemMapFs()
+			if tt.before != nil {
+				require.NoError(st, tt.before(fs))
+			}
+			cpus, err := system.CpuInfo(fs)
+			if tt.expectedErrMsg != "" {
+				require.Error(st, err)
+				require.Contains(st, err.Error(), tt.expectedErrMsg)
+				return
+			}
+			require.NoError(st, err)
+			require.Exactly(st, tt.expected, cpus)
+		})
+	}
+}

--- a/src/go/rpk/pkg/system/metrics_test.go
+++ b/src/go/rpk/pkg/system/metrics_test.go
@@ -1,0 +1,107 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package system_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/system"
+)
+
+func TestGatherMetrics(t *testing.T) {
+	tests := []struct {
+		name		string
+		before		func(fs afero.Fs) error
+		conf		func() *config.Config
+		expectedErrMsg	string
+	}{{
+		name:	"it should fail if the process's stat file doesn't exist",
+		before: func(fs afero.Fs) error {
+			return afero.WriteFile(
+				fs,
+				config.Default().PIDFile(),
+				// Usual /proc/sys/kernel/pid_max value
+				[]byte("4194304"),
+				0755,
+			)
+		},
+		expectedErrMsg:	"/proc/4194304/stat",
+	}, {
+		name:		"it should fail if the PID file doesn't exist",
+		expectedErrMsg:	"/var/lib/redpanda/data/pid.lock",
+	}, {
+		name:	"it should fail if the CPU utime can't be parsed",
+		before: func(fs afero.Fs) error {
+			err := afero.WriteFile(
+				fs,
+				config.Default().PIDFile(),
+				// Usual /proc/sys/kernel/pid_max value
+				[]byte("4194304"),
+				0755,
+			)
+			if err != nil {
+				return err
+			}
+			content := "4194304 (redpanda) S 1 2680757 2680757 0 -1 4194304 18612 8456 1 0 invalid-utime 422288 10 11 20 0 32 0 88937938 17593454493696 811178 18446744073709551615 1 1 0 0 0 0 2143394384 0 17442 0 0 0 17 1 0 0 0 0 0 0 0 0 0 0 0 0 0"
+			return afero.WriteFile(
+				fs,
+				"/proc/4194304/stat",
+				[]byte(content),
+				0755,
+			)
+		},
+		expectedErrMsg:	`parsing "invalid-utime": invalid syntax`,
+	}, {
+		name:	"it should fail if the CPU stime can't be parsed",
+		before: func(fs afero.Fs) error {
+			err := afero.WriteFile(
+				fs,
+				config.Default().PIDFile(),
+				// Usual /proc/sys/kernel/pid_max value
+				[]byte("4194304"),
+				0755,
+			)
+			if err != nil {
+				return err
+			}
+			content := "4194304 (redpanda) S 1 2680757 2680757 0 -1 4194304 18612 8456 1 0 398600 invalid-stime 10 11 20 0 32 0 88937938 17593454493696 811178 18446744073709551615 1 1 0 0 0 0 2143394384 0 17442 0 0 0 17 1 0 0 0 0 0 0 0 0 0 0 0 0 0"
+			return afero.WriteFile(
+				fs,
+				"/proc/4194304/stat",
+				[]byte(content),
+				0755,
+			)
+		},
+		expectedErrMsg:	`parsing "invalid-stime": invalid syntax`,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			fs := afero.NewMemMapFs()
+			conf := config.Default()
+			if tt.conf != nil {
+				conf = tt.conf()
+			}
+			if tt.before != nil {
+				require.NoError(st, tt.before(fs))
+			}
+			_, err := system.GatherMetrics(fs, 50*time.Millisecond, *conf)
+			if tt.expectedErrMsg != "" {
+				require.Error(st, err)
+				require.Contains(st, err.Error(), tt.expectedErrMsg)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
gopsutil depended on `getconf`, which it exec'd to get some of the system metrics, causing segfaults on some systems (at least Ubuntu).

Remove gopsutil and gather the metrics:

  * disk space & available memory: syscalls
  * CPU usage percentage: sampling syscalls

Fix #402