### PR TITLE
Fix ppc fetch multibatch

### DIFF
--- a/src/v/kafka/requests/fetch_request.h
+++ b/src/v/kafka/requests/fetch_request.h
@@ -45,10 +45,10 @@ struct fetch_request final {
 
     struct partition {
         model::partition_id id;
-        int32_t current_leader_epoch; // >= v9
+        int32_t current_leader_epoch{-1}; // >= v9
         model::offset fetch_offset;
         // inter-broker data
-        model::offset log_start_offset; // >= v5
+        model::offset log_start_offset{-1}; // >= v5
         int32_t partition_max_bytes;
     };
 
@@ -66,10 +66,10 @@ struct fetch_request final {
     model::node_id replica_id;
     std::chrono::milliseconds max_wait_time;
     int32_t min_bytes;
-    int32_t max_bytes;                                 // >= v3
-    int8_t isolation_level;                            // >= v4
-    int32_t session_id = invalid_fetch_session_id;     // >= v7
-    int32_t session_epoch = final_fetch_session_epoch; // >= v7
+    int32_t max_bytes{std::numeric_limits<int32_t>::max()}; // >= v3
+    int8_t isolation_level{0};                              // >= v4
+    int32_t session_id = invalid_fetch_session_id;          // >= v7
+    int32_t session_epoch = final_fetch_session_epoch;      // >= v7
     std::vector<topic> topics;
     std::vector<forgotten_topic> forgotten_topics; // >= v7
 
@@ -241,13 +241,9 @@ struct fetch_response final {
           : name(std::move(name)) {}
     };
 
-    fetch_response()
-      : throttle_time(0) {}
-
-    std::chrono::milliseconds throttle_time = std::chrono::milliseconds(
-      0);               // >= v1
-    error_code error;   // >= v7
-    int32_t session_id; // >= v7
+    std::chrono::milliseconds throttle_time{0}; // >= v1
+    error_code error;                           // >= v7
+    int32_t session_id;                         // >= v7
     std::vector<partition> partitions;
 
     void encode(const request_context& ctx, response& resp);

--- a/src/v/kafka/requests/kafka_batch_adapter.h
+++ b/src/v/kafka/requests/kafka_batch_adapter.h
@@ -39,19 +39,25 @@ constexpr size_t kafka_header_size = sizeof(int64_t) + // base offset
 /**
  * Usage:
  *
- *   kafka_batch_adapter kba;
- *   kba.adapt(std::move(batch));
+ *   iobuf record_set; // May contain multiple batches, e.g., fetch_response
+ *   while(!record_set.empty()) {
+ *       kafka_batch_adapter kba;
+ *       record_set = kba.adapt(std::move(record_set));
+ *       do_something_with(kba.batch);
+ *   }
  *
  * 1. require that v2_format is true
  * 2. require that valid_crc is true
- * 3. if batch is empty then it signals that more data was on the wire than the
- *    expected single batch. otherwise, its good to go.
+ * 3. if kba.batch is empty then it signals that decoding failed. otherwise,
+ *    it's good to go.
+ * 4. if returned batch is not empty then it signals that more data was on the
+ *    wire than a single batch.
  *
  * Note that the default constructed batch adapter is in an undefined state.
  */
 class kafka_batch_adapter {
 public:
-    void adapt(iobuf&&);
+    iobuf adapt(iobuf&&);
 
     bool v2_format;
     bool valid_crc;

--- a/src/v/kafka/tests/CMakeLists.txt
+++ b/src/v/kafka/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ rp_test(
   SOURCES error_mapping_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
+  LABELS kafka
 )
 
 rp_test(
@@ -14,6 +15,7 @@ rp_test(
   SOURCES timeouts_conversion_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
+  LABELS kafka
 )
 
 rp_test(
@@ -22,6 +24,7 @@ rp_test(
   SOURCES types_conversion_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
+  LABELS kafka
 )
 
 rp_test(
@@ -30,6 +33,7 @@ rp_test(
   SOURCES topic_utils_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
+  LABELS kafka
 )
 
 set(srcs
@@ -55,6 +59,7 @@ rp_test(
   SOURCES ${srcs}
   LIBRARIES v::seastar_testing_main v::application v::raft v::kafka v::config v::storage_test_utils
   ARGS "-- -c 1"
+  LABELS kafka
 )
 
 find_program(KAFKA_PYTHON_ENV "kafka-python-env")
@@ -69,6 +74,7 @@ rp_test(
   # the same scratch directory so the generated output file writes to pwd.
   PREPARE_COMMAND "${KAFKA_PYTHON_ENV} ${PROJECT_SOURCE_DIR}/tools/kafka-python-api-serde.py 1000 > requests.bin"
   ARGS "-- -c 1"
+  LABELS kafka
 )
 
 rp_test(
@@ -76,4 +82,5 @@ rp_test(
   BINARY_NAME test_scram_algorithm
   SOURCES scram_algorithm_test.cc
   LIBRARIES v::seastar_testing_main v::kafka
+  LABELS kafka
 )

--- a/src/v/pandaproxy/client/client.h
+++ b/src/v/pandaproxy/client/client.h
@@ -100,7 +100,7 @@ public:
     ss::future<kafka::produce_response::partition> produce_record_batch(
       model::topic_partition tp, model::record_batch&& batch);
 
-    ss::future<kafka::fetch_response::partition> fetch_partition(
+    ss::future<kafka::fetch_response> fetch_partition(
       model::topic_partition tp,
       model::offset offset,
       int32_t max_bytes,

--- a/src/v/pandaproxy/client/fetcher.cc
+++ b/src/v/pandaproxy/client/fetcher.cc
@@ -40,8 +40,6 @@ kafka::fetch_request make_fetch_request(
       .min_bytes = 0,
       .max_bytes = max_bytes,
       .isolation_level = 0,
-      .session_id = 0,
-      .session_epoch = 0,
       .topics{std::move(topics)}};
 }
 

--- a/src/v/pandaproxy/client/fetcher.cc
+++ b/src/v/pandaproxy/client/fetcher.cc
@@ -43,7 +43,7 @@ kafka::fetch_request make_fetch_request(
       .topics{std::move(topics)}};
 }
 
-kafka::fetch_response::partition
+kafka::fetch_response
 make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
     kafka::error_code error;
     try {
@@ -77,7 +77,12 @@ make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
     responses.push_back(std::move(pr));
     auto response = kafka::fetch_response::partition(tp.topic);
     response.responses = std::move(responses);
-    return response;
+    std::vector<kafka::fetch_response::partition> parts;
+    parts.push_back(std::move(response));
+    return kafka::fetch_response{
+      .error = error,
+      .partitions = std::move(parts),
+    };
 }
 
 } // namespace pandaproxy::client

--- a/src/v/pandaproxy/client/fetcher.h
+++ b/src/v/pandaproxy/client/fetcher.h
@@ -21,7 +21,7 @@ kafka::fetch_request make_fetch_request(
   int32_t max_bytes,
   std::chrono::milliseconds timeout);
 
-kafka::fetch_response::partition
+kafka::fetch_response
 make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex);
 
 } // namespace pandaproxy::client

--- a/src/v/pandaproxy/client/test/fetch.cc
+++ b/src/v/pandaproxy/client/test/fetch.cc
@@ -44,8 +44,9 @@ FIXTURE_TEST(pandaproxy_fetch, ppc_test_fixture) {
         info("Fetching from unknown topic");
         auto ntp = make_default_ntp(
           model::topic("unknown"), model::partition_id(0));
-        auto p{
+        auto res{
           client.fetch_partition(ntp.tp, model::offset(0), 1024, 1000ms).get()};
+        const auto& p = res.partitions[0];
         BOOST_REQUIRE_EQUAL(p.name, ntp.tp.topic);
         BOOST_REQUIRE_EQUAL(p.responses.size(), 1);
         BOOST_REQUIRE_EQUAL(p.responses[0].id, ntp.tp.partition);
@@ -63,8 +64,9 @@ FIXTURE_TEST(pandaproxy_fetch, ppc_test_fixture) {
     {
         info("Fetching from nonempty known topic");
         ppc::shard_local_cfg().retries.set_value(size_t(3));
-        auto p{
+        auto res{
           client.fetch_partition(ntp.tp, model::offset(0), 1024, 1000ms).get()};
+        const auto& p = res.partitions[0];
         BOOST_REQUIRE_EQUAL(p.name, ntp.tp.topic);
         BOOST_REQUIRE_EQUAL(p.responses.size(), 1);
         auto const& r = p.responses[0];

--- a/src/v/pandaproxy/client/test/utils.h
+++ b/src/v/pandaproxy/client/test/utils.h
@@ -15,8 +15,7 @@
 #include "storage/record_batch_builder.h"
 
 inline model::record_batch make_batch(model::offset offset, size_t count) {
-    storage::record_batch_builder builder(
-      raft::data_batch_type, model::offset(0));
+    storage::record_batch_builder builder(raft::data_batch_type, offset);
     for (size_t i = 0; i < count; ++i) {
         builder.add_raw_kv(reflection::to_iobuf(i + offset), iobuf());
     }

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -108,12 +108,11 @@ get_topics_records(server::request_t rq, server::reply_t rp) {
     rq.req.reset();
     return rq.ctx.client
       .fetch_partition(std::move(tp), offset, max_bytes, timeout)
-      .then([fmt,
-             rp = std::move(rp)](kafka::fetch_response::partition res) mutable {
+      .then([fmt, rp = std::move(rp)](kafka::fetch_response res) mutable {
           rapidjson::StringBuffer str_buf;
           rapidjson::Writer<rapidjson::StringBuffer> w(str_buf);
 
-          ppj::rjson_serialize_fmt(fmt)(w, std::move(res));
+          ppj::rjson_serialize_fmt(fmt)(w, std::move(res.partitions[0]));
 
           // TODO Ben: Prevent this linearization
           ss::sstring json_rslt = str_buf.GetString();

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -112,7 +112,7 @@ get_topics_records(server::request_t rq, server::reply_t rp) {
           rapidjson::StringBuffer str_buf;
           rapidjson::Writer<rapidjson::StringBuffer> w(str_buf);
 
-          ppj::rjson_serialize_fmt(fmt)(w, std::move(res.partitions[0]));
+          ppj::rjson_serialize_fmt(fmt)(w, std::move(res));
 
           // TODO Ben: Prevent this linearization
           ss::sstring json_rslt = str_buf.GetString();


### PR DESCRIPTION
The record_set in a fetch response may contain multiple batches - consume them all.

There are also some drive-by fixes:
 * Label the kafka tests - `ctest -L kafka` will run them
 * Default member initialisation for fetch - they correspond with kafka defaults.
 * Remove a dead struct
 * A typo
 * Don't create fetch session on the server for fetch_partition one-offs.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
