### PR TITLE
k/tests: fixed assertion in test_recreate_topic

### DIFF
--- a/src/v/kafka/tests/topic_recreate_test.cc
+++ b/src/v/kafka/tests/topic_recreate_test.cc
@@ -155,6 +155,10 @@ FIXTURE_TEST(test_topic_recreation, recreate_test_fixture) {
                 return false;
             }
             auto& partitions = md.topics.begin()->partitions;
+            if (partitions.size() != 6) {
+                return false;
+            }
+
             return std::all_of(
               partitions.begin(),
               partitions.end(),
@@ -163,14 +167,6 @@ FIXTURE_TEST(test_topic_recreation, recreate_test_fixture) {
               });
         });
     }).get0();
-
-    auto md = get_topic_metadata(test_tp).get0();
-    BOOST_REQUIRE_EQUAL(md.topics.size(), 1);
-    BOOST_REQUIRE_EQUAL(md.topics.begin()->partitions.size(), 6);
-
-    for (auto& p : md.topics.begin()->partitions) {
-        BOOST_REQUIRE_EQUAL(p.leader, model::node_id{1});
-    }
 }
 
 FIXTURE_TEST(test_topic_recreation_recovery, recreate_test_fixture) {


### PR DESCRIPTION
Fixed redundant assertion in topic recreation test.

In redpanda we optimize topic leadership querying. When topic is created
we assume that leader is elected immediately. There may be a short
period however during which the leader election happens and it updates
the cached leader id to (-1) which means that election is in progress.
Checking metadata twice sometimes caused us to query for leadership when
election was taking place which caused test to fail.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
