### PR TITLE
Two phase controller shutdown

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -120,11 +120,11 @@ ss::future<> controller::stop() {
     }
 
     return f.then([this] {
-        return _stm.stop()
-          .then([this] { return _members_manager.stop(); })
+        return _backend.stop()
           .then([this] { return _tp_frontend.stop(); })
-          .then([this] { return _backend.stop(); })
+          .then([this] { return _stm.stop(); })
           .then([this] { return _tp_state.stop(); })
+          .then([this] { return _members_manager.stop(); })
           .then([this] { return _partition_allocator.stop(); })
           .then([this] { return _partition_leaders.stop(); })
           .then([this] { return _members_table.stop(); })

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -55,6 +55,8 @@ public:
     ss::future<> wire_up();
 
     ss::future<> start();
+    // prevents controller from accepting new requests
+    ss::future<> shutdown_input();
     ss::future<> stop();
 
 private:

--- a/src/v/cluster/tests/configuration_change_test.cc
+++ b/src/v/cluster/tests/configuration_change_test.cc
@@ -41,7 +41,6 @@ FIXTURE_TEST(test_updating_node_rpc_ip_address, cluster_test_fixture) {
       })
       .get0();
 
-    cntrl_2->stop().get0();
     remove_controller(node_2);
     // Change RPC port from 11000 to 13000
     info("Restarting node {} with changed configuration", node_2);
@@ -79,7 +78,6 @@ FIXTURE_TEST(test_single_node_update, cluster_test_fixture) {
     cntrl->start().get();
     wait_for_leadership(cntrl->get_partition_leaders().local());
 
-    cntrl->stop().get0();
     remove_controller(node_id);
     // Change kafka port from 9092 to 15000
     cntrl = create_controller(node_id, 15000, 13000);

--- a/src/v/cluster/tests/controller_test_fixture.h
+++ b/src/v/cluster/tests/controller_test_fixture.h
@@ -39,6 +39,8 @@
 
 #include <seastar/net/socket_defs.hh>
 
+#include <fmt/ostream.h>
+
 using namespace std::chrono_literals;
 
 template<typename T>
@@ -94,6 +96,9 @@ public:
     cluster::shard_table& get_shard_table() { return st.local(); }
 
     ~controller_tests_fixture() {
+        if (_controller_started) {
+            _controller->shutdown_input().get();
+        }
         _rpc.stop().get0();
         _metadata_dissemination_service.stop().get0();
         if (_controller_started) {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -96,6 +96,9 @@ public:
     /// Stop all communications.
     ss::future<> stop();
 
+    /// Stop consensus instance from accepting requests
+    void shutdown_input();
+
     ss::future<vote_reply> vote(vote_request&& r);
     ss::future<append_entries_reply> append_entries(append_entries_request&& r);
     ss::future<install_snapshot_reply>

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -34,6 +34,7 @@ enum class errc {
     invalid_configuration_update,
     not_voter,
     invalid_target_node,
+    shutting_down
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "raft::errc"; }
@@ -77,6 +78,8 @@ struct errc_category final : public std::error_category {
         case errc::invalid_target_node:
             return "Node that received the request is not the one that the "
                    "request was addressed to";
+        case errc::shutting_down:
+            return "raft protocol shutting down";
         default:
             return "raft::errc::unknown";
         }

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -101,6 +101,14 @@ public:
     // Lifecycle management
     ss::future<> start() { return raft::state_machine::start(); }
 
+    ss::future<> stop() {
+        _mutex.broken();
+        for (auto& p : _promises) {
+            p.second.set_value(std::error_code(errc::shutting_down));
+        }
+        return raft::state_machine::stop();
+    }
+
     /// Replicates record batch
     ss::future<result<raft::replicate_result>> replicate(model::record_batch&&);
 

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -27,7 +27,7 @@
 #include <seastar/util/bool_class.hh>
 #include <seastar/util/log.hh>
 
-#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 #include <optional>
 #include <system_error>
@@ -116,7 +116,7 @@ private:
     // promises used to wait for result of state applies, keyed by offser
     // returned in replication result (i.e. last batch end offset)
     using container_t
-      = absl::flat_hash_map<model::offset, expiring_promise<std::error_code>>;
+      = absl::node_hash_map<model::offset, expiring_promise<std::error_code>>;
 
     ss::future<> apply(model::record_batch b) final;
 

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -58,6 +58,8 @@ public:
 
     auto get_units() noexcept { return ss::get_units(_sem, 1); }
 
+    void broken() noexcept { _sem.broken(); }
+
 private:
     ss::semaphore _sem;
 };


### PR DESCRIPTION
Untangled the shutdown sequence. Shutting down the RPC server is waiting for all requests dispatches to finish. The RPS server is a first service that we stop on shutdown. This made the shutdown sequence deadlock as shutting down `_raft0` was waiting for RPC server shutdown. Untangled this dependency by introducing two phase shutdown of controller. We could potentially make RPC server to be stopped as a last component, but unregister all downstream services. This approach seams clean and more natural but it isn't perfect. We would still have to wait for all the request to finish before going further with shutdown sequence. When `ss::sharded<>::stop()` method is called we have to make sure that no other component will access the stopped one as it is immediately destoryed.


## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
