### PR TITLE
archival: Add manifest implementation

### DIFF
--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -24,6 +24,7 @@ add_subdirectory(reflection)
 add_subdirectory(pandaproxy)
 add_subdirectory(http)
 add_subdirectory(s3)
+add_subdirectory(archival)
 
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)

--- a/src/v/archival/CMakeLists.txt
+++ b/src/v/archival/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+v_cc_library(
+  NAME archival
+  SRCS
+    manifest.cc
+  DEPS
+    Seastar::seastar
+    v::bytes
+    v::http
+    v::s3
+)
+add_subdirectory(tests)

--- a/src/v/archival/logger.h
+++ b/src/v/archival/logger.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace archival {
+inline ss::logger archival_log("archival");
+} // namespace archival

--- a/src/v/archival/manifest.cc
+++ b/src/v/archival/manifest.cc
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/manifest.h"
+
+#include "archival/logger.h"
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_istreambuf.h"
+#include "bytes/iobuf_ostreambuf.h"
+#include "hashing/murmur.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "storage/ntp_config.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <boost/algorithm/string.hpp>
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/writer.h>
+
+#include <algorithm>
+#include <array>
+
+namespace archival {
+
+manifest::manifest()
+  : _ntp()
+  , _rev() {}
+
+manifest::manifest(model::ntp ntp, model::revision_id rev)
+  : _ntp(std::move(ntp))
+  , _rev(rev) {}
+
+remote_manifest_path manifest::get_manifest_path() const {
+    // NOTE: the idea here is to split all possible hash values into
+    // 16 bins. Every bin should have lowest 28-bits set to 0.
+    // As result, for segment names all prefixes are possible, but
+    // for manifests, only 0x00000000, 0x10000000, ... 0xf0000000
+    // are used. This will allow us to quickly find all manifests
+    // that S3 bucket contains.
+    constexpr uint32_t bitmask = 0xF0000000;
+    auto path = fmt::format("{}_{}", _ntp.path(), _rev());
+    uint32_t hash = bitmask & murmurhash3_x86_32(path.data(), path.size());
+    return remote_manifest_path(fmt::format(
+      "{:08x}/meta/{}_{}/manifest.json", hash, _ntp.path(), _rev()));
+}
+
+remote_segment_path
+manifest::get_remote_segment_path(const segment_name& name) const {
+    auto path = fmt::format("{}_{}/{}", _ntp.path(), _rev(), name());
+    uint32_t hash = murmurhash3_x86_32(path.data(), path.size());
+    return remote_segment_path(fmt::format("{:08x}/{}", hash, path));
+}
+
+const model::ntp& manifest::get_ntp() const { return _ntp; }
+
+model::revision_id manifest::get_revision_id() const { return _rev; }
+
+manifest::const_iterator manifest::begin() const { return _segments.begin(); }
+
+manifest::const_iterator manifest::end() const { return _segments.end(); }
+
+size_t manifest::size() const { return _segments.size(); }
+
+bool manifest::contains(const segment_name& obj) const {
+    return _segments.count(obj) != 0;
+}
+
+bool manifest::add(const segment_name& key, const segment_meta& meta) {
+    auto [it, ok] = _segments.insert(std::make_pair(key, meta));
+    return ok;
+}
+
+const manifest::segment_meta* manifest::get(const segment_name& key) const {
+    auto it = _segments.find(key);
+    if (it == _segments.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+std::insert_iterator<manifest::segment_map> manifest::get_insert_iterator() {
+    return std::inserter(_segments, _segments.begin());
+}
+
+manifest manifest::difference(const manifest& remote_set) const {
+    if (_ntp != remote_set._ntp && _rev != remote_set._rev) {
+        throw std::logic_error(fmt_with_ctx(
+          fmt::format,
+          "{}-{} do not match {}-{}",
+          _ntp,
+          _rev,
+          remote_set._ntp,
+          remote_set._rev));
+    }
+    manifest result(_ntp, _rev);
+    std::set_difference(
+      begin(),
+      end(),
+      remote_set.begin(),
+      remote_set.end(),
+      result.get_insert_iterator());
+    return result;
+}
+
+ss::future<> manifest::update(ss::input_stream<char>&& is) {
+    using namespace rapidjson;
+    iobuf result;
+    auto os = make_iobuf_ref_output_stream(result);
+    co_await ss::copy(is, os);
+    iobuf_istreambuf ibuf(result);
+    std::istream stream(&ibuf);
+    Document m;
+    IStreamWrapper wrapper(stream);
+    m.ParseStream(wrapper);
+    update(m);
+    co_return;
+}
+
+void manifest::update(const rapidjson::Document& m) {
+    using namespace rapidjson;
+    auto ns = model::ns(m["namespace"].GetString());
+    auto tp = model::topic(m["topic"].GetString());
+    auto pt = model::partition_id(m["partition"].GetInt());
+    _rev = model::revision_id(m["revision"].GetInt());
+    _ntp = model::ntp(ns, tp, pt);
+    segment_map tmp;
+    if (m.HasMember("segments")) {
+        const auto& s = m["segments"].GetObject();
+        for (auto it = s.MemberBegin(); it != s.MemberEnd(); it++) {
+            auto name = segment_name(it->name.GetString());
+            auto coffs = it->value["committed_offset"].GetInt64();
+            auto boffs = it->value["base_offset"].GetInt64();
+            auto size_bytes = it->value["size_bytes"].GetInt64();
+            segment_meta meta{
+              .is_compacted = it->value["is_compacted"].GetBool(),
+              .size_bytes = static_cast<size_t>(size_bytes),
+              .base_offset = model::offset(boffs),
+              .committed_offset = model::offset(coffs),
+              .is_deleted_locally = it->value["deleted"].GetBool(),
+            };
+            tmp.insert(std::make_pair(name, meta));
+        }
+    }
+    std::swap(tmp, _segments);
+}
+
+std::tuple<ss::input_stream<char>, size_t> manifest::serialize() const {
+    iobuf serialized;
+    iobuf_ostreambuf obuf(serialized);
+    std::ostream os(&obuf);
+    serialize(os);
+    size_t size_bytes = serialized.size_bytes();
+    return std::make_tuple(
+      make_iobuf_input_stream(std::move(serialized)), size_bytes);
+}
+
+void manifest::serialize(std::ostream& out) const {
+    using namespace rapidjson;
+    OStreamWrapper wrapper(out);
+    Writer<OStreamWrapper> w(wrapper);
+    w.StartObject();
+    w.Key("namespace");
+    w.String(_ntp.ns().c_str());
+    w.Key("topic");
+    w.String(_ntp.tp.topic().c_str());
+    w.Key("partition");
+    w.Int64(_ntp.tp.partition());
+    w.Key("revision");
+    w.Int64(_rev());
+    if (!_segments.empty()) {
+        w.Key("segments");
+        w.StartObject();
+        for (const auto& [sn, meta] : _segments) {
+            w.Key(sn().c_str());
+            w.StartObject();
+            w.Key("is_compacted");
+            w.Bool(meta.is_compacted);
+            w.Key("size_bytes");
+            w.Int64(meta.size_bytes);
+            w.Key("committed_offset");
+            w.Int64(meta.committed_offset());
+            w.Key("base_offset");
+            w.Int64(meta.base_offset());
+            w.Key("deleted");
+            w.Bool(meta.is_deleted_locally);
+            w.EndObject();
+        }
+        w.EndObject();
+    }
+    w.EndObject();
+}
+
+bool manifest::delete_permanently(const segment_name& name) {
+    auto it = _segments.find(name);
+    if (it != _segments.end()) {
+        _segments.erase(it);
+        return true;
+    }
+    return false;
+}
+
+bool manifest::mark_as_deleted(const segment_name& name) {
+    auto it = _segments.find(name);
+    if (it != _segments.end() && it->second.is_deleted_locally == false) {
+        it->second.is_deleted_locally = true;
+        return true;
+    }
+    return false;
+}
+
+} // namespace archival

--- a/src/v/archival/manifest.h
+++ b/src/v/archival/manifest.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "json/json.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+#include "storage/ntp_config.h"
+
+#include <seastar/util/bool_class.hh>
+
+#include <absl/container/btree_map.h>
+#include <rapidjson/fwd.h>
+
+#include <compare>
+#include <iterator>
+
+namespace archival {
+
+/// Segment file name without working directory,
+/// expected format: <base-offset>-<term-id>-<revision>.log
+using segment_name = named_type<ss::sstring, struct archival_segment_name_t>;
+/// Segment path in S3, expected format:
+/// <prefix>/<ns>/<topic>/<part-id>_<rev>/<base-offset>-<term-id>-<revision>.log
+using remote_segment_path
+  = named_type<ss::sstring, struct archival_remote_segment_path_t>;
+using remote_manifest_path
+  = named_type<ss::sstring, struct archival_remote_manifest_path_t>;
+/// Local segment path, expected format:
+/// <work-dir>/<ns>/<topic>/<part-id>_<rev>/<base-offset>-<term-id>-<revision>.log
+using local_segment_path
+  = named_type<ss::sstring, struct archival_local_segment_path_t>;
+
+/// Manifest file stored in S3
+class manifest final {
+public:
+    struct segment_meta {
+        bool is_compacted;
+        size_t size_bytes;
+        model::offset base_offset;
+        model::offset committed_offset;
+        /// Set to true if the file was deleted
+        bool is_deleted_locally;
+        // NOTE: because S3 doesn't delete files
+        // immediately we will still be able to read
+        // the deleted file for a while, to prevent
+        // confusion we mark such file as deleted in
+        // manifest in order for GC alg. to remove the
+        // record eventually
+
+        // bool operator==(const segment_meta& other) const = default;
+        // bool operator<(const segment_meta& other) const = default;
+        auto operator<=>(const segment_meta&) const = default;
+    };
+    using key = segment_name;
+    using value = segment_meta;
+    using segment_map = absl::btree_map<key, value>;
+    using const_iterator = segment_map::const_iterator;
+
+    /// Create empty manifest that supposed to be updated later
+    manifest();
+
+    /// Create manifest for specific ntp
+    explicit manifest(model::ntp ntp, model::revision_id rev);
+
+    /// Manifest object name in S3
+    remote_manifest_path get_manifest_path() const;
+
+    /// Segment file name in S3
+    remote_segment_path get_remote_segment_path(const segment_name& name) const;
+
+    /// Get NTP
+    const model::ntp& get_ntp() const;
+
+    /// Get revision
+    model::revision_id get_revision_id() const;
+
+    /// Return iterator to the begining(end) of the segments list
+    const_iterator begin() const;
+    const_iterator end() const;
+    size_t size() const;
+
+    /// Check if the manifest contains particular segment
+    bool contains(const segment_name& obj) const;
+
+    /// Add new segment to the manifest
+    bool add(const segment_name& key, const segment_meta& meta);
+
+    /// Get segment if available or nullopt
+    const segment_meta* get(const segment_name& key) const;
+
+    /// Get insert iterator for segments set
+    std::insert_iterator<segment_map> get_insert_iterator();
+
+    /// Return new manifest that contains only those segments that present
+    /// in local manifest and not found in 'remote_set'.
+    ///
+    /// \param remote_set the manifest to compare to
+    /// \return manifest with segments that doesn't present in 'remote_set'
+    manifest difference(const manifest& remote_set) const;
+
+    /// Update manifest file from input_stream (remote set)
+    ss::future<> update(ss::input_stream<char>&& is);
+
+    /// Serialize manifest object
+    ///
+    /// \return asynchronous input_stream with the serialized json
+    std::tuple<ss::input_stream<char>, size_t> serialize() const;
+
+    /// Serialize manifest object
+    ///
+    /// \param out output stream that should be used to output the json
+    void serialize(std::ostream& out) const;
+
+    /// Compare two manifests for equality
+    bool operator==(const manifest& other) const = default;
+
+    /// Remove segment record from manifest
+    ///
+    /// \param name is a segment name
+    /// \return true on success, false on failure (no such segment)
+    bool delete_permanently(const segment_name& name);
+
+    /// Remove segment as deleted in manifest
+    ///
+    /// \param name is a segment name
+    /// \return true on success, false on failure (no such segment or already
+    /// marked)
+    bool mark_as_deleted(const segment_name& name);
+
+private:
+    /// Update manifest content from json document that supposed to be generated
+    /// from manifest.json file
+    void update(const rapidjson::Document& m);
+
+    model::ntp _ntp;
+    model::revision_id _rev;
+    segment_map _segments;
+};
+
+} // namespace archival

--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME test_arch_service
+  SOURCES manifest_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils
+  ARGS "-- -c 1"
+)
+
+

--- a/src/v/archival/tests/manifest_test.cc
+++ b/src/v/archival/tests/manifest_test.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/manifest.h"
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <exception>
+
+using namespace archival;
+
+static std::string_view empty_manifest_json = R"json({
+    "namespace": "test-ns",
+    "topic": "test-topic",
+    "partition": 42,
+    "revision": 0
+})json";
+static std::string_view complete_manifest_json = R"json({
+    "namespace": "test-ns",
+    "topic": "test-topic",
+    "partition": 42,
+    "revision": 1,
+    "segments": {
+        "10-1-v1.log": { 
+            "is_compacted": false,
+            "size_bytes": 1024,
+            "base_offset": 10,
+            "committed_offset": 19,
+            "deleted": false
+        },
+        "20-1-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 2048,
+            "base_offset": 20,
+            "committed_offset": 29,
+            "deleted": false
+        }
+    }
+})json";
+static const model::ntp manifest_ntp(
+  model::ns("test-ns"), model::topic("test-topic"), model::partition_id(42));
+
+inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
+    iobuf i;
+    i.append(json.data(), json.size());
+    return make_iobuf_input_stream(std::move(i));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_manifest_path) {
+    manifest m(manifest_ntp, model::revision_id(0));
+    auto path = m.get_manifest_path();
+    BOOST_REQUIRE_EQUAL(
+      path, "a0000000/meta/test-ns/test-topic/42_0/manifest.json");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_segment_path) {
+    manifest m(manifest_ntp, model::revision_id(0));
+    auto path = m.get_remote_segment_path(segment_name("22-11-v1.log"));
+    // use pre-calculated murmur hash value from full ntp path + file name
+    BOOST_REQUIRE_EQUAL(path, "7da10588/test-ns/test-topic/42_0/22-11-v1.log");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_empty_manifest_update) {
+    manifest m;
+    m.update(make_manifest_stream(empty_manifest_json)).get0();
+    auto path = m.get_manifest_path();
+    BOOST_REQUIRE_EQUAL(
+      path, "a0000000/meta/test-ns/test-topic/42_0/manifest.json");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
+    manifest m;
+    m.update(make_manifest_stream(complete_manifest_json)).get0();
+    auto path = m.get_manifest_path();
+    BOOST_REQUIRE_EQUAL(
+      path, "50000000/meta/test-ns/test-topic/42_1/manifest.json");
+    BOOST_REQUIRE_EQUAL(m.size(), 2);
+    std::map<ss::sstring, manifest::segment_meta> expected = {
+      {"10-1-v1.log",
+       manifest::segment_meta{
+         false, 1024, model::offset(10), model::offset(19), false}},
+      {"20-1-v1.log",
+       manifest::segment_meta{
+         false, 2048, model::offset(20), model::offset(29), false}}};
+    for (const auto& actual : m) {
+        auto it = expected.find(actual.first);
+        BOOST_REQUIRE(it != expected.end());
+        BOOST_REQUIRE_EQUAL(it->second.base_offset, actual.second.base_offset);
+        BOOST_REQUIRE_EQUAL(
+          it->second.committed_offset, actual.second.committed_offset);
+        BOOST_REQUIRE_EQUAL(
+          it->second.is_compacted, actual.second.is_compacted);
+        BOOST_REQUIRE_EQUAL(it->second.size_bytes, actual.second.size_bytes);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
+    manifest m(manifest_ntp, model::revision_id(0));
+    m.add(
+      segment_name("10-1-v1.log"),
+      {
+        .is_compacted = false,
+        .size_bytes = 1024,
+        .base_offset = model::offset(10),
+        .committed_offset = model::offset(19),
+        .is_deleted_locally = false,
+      });
+    m.add(
+      segment_name("20-1-v1.log"),
+      {
+        .is_compacted = false,
+        .size_bytes = 2048,
+        .base_offset = model::offset(20),
+        .committed_offset = model::offset(29),
+        .is_deleted_locally = false,
+      });
+    auto [is, size] = m.serialize();
+    iobuf buf;
+    auto os = make_iobuf_ref_output_stream(buf);
+    ss::copy(is, os).get();
+
+    auto rstr = make_iobuf_input_stream(std::move(buf));
+    manifest restored;
+    restored.update(std::move(rstr)).get0();
+
+    BOOST_REQUIRE(m == restored);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_manifest_difference) {
+    manifest a(manifest_ntp, model::revision_id(0));
+    a.add(segment_name("0-0-1.log"), {});
+    a.add(segment_name("0-0-2.log"), {});
+    a.add(segment_name("0-0-3.log"), {});
+    manifest b(manifest_ntp, model::revision_id(0));
+    b.add(segment_name("0-0-1.log"), {});
+    b.add(segment_name("0-0-2.log"), {});
+    {
+        auto c = a.difference(b);
+        BOOST_REQUIRE(c.size() == 1);
+        auto res = *c.begin();
+        BOOST_REQUIRE(res.first() == "0-0-3.log");
+    }
+    // check that set difference is not symmetrical
+    b.add(segment_name("0-0-3.log"), {});
+    b.add(segment_name("0-0-4.log"), {});
+    {
+        auto c = a.difference(b);
+        BOOST_REQUIRE(c.size() == 0);
+    }
+}


### PR DESCRIPTION
Manifest is an object needed to track objects in S3 and map them
to and from local log segments. One manifest is created per ntp.
It also takes revision into account, so when partition gets deleted
and created it will have new manifest. Manifest contains information
about the partition and about every segment located in S3. It can be
used to map local log segments to S3 locations and back. It can also
be (de)serialized to json.

There is a diff fucntion implementaiton that is supposed to be used
to find candidates for upload or removal. The archival service
creates one manifest for local data and one for remote (stored in S3)
and uses this funciton to find the upload/remove candidates.
Manifest is supposed to be stored in S3 bucket.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
