### PR TITLE
Initial support for multi-networking

### DIFF
--- a/src/v/cluster/tests/configuration_change_test.cc
+++ b/src/v/cluster/tests/configuration_change_test.cc
@@ -92,7 +92,7 @@ FIXTURE_TEST(test_single_node_update, cluster_test_fixture) {
             return false;
         }
 
-        return updated_broker.value()->kafka_api_address()
+        return updated_broker.value()->kafka_advertised_listeners()[0].address
                == unresolved_address("127.0.0.1", 15000);
     }).get0();
 }

--- a/src/v/cluster/tests/controller_test_fixture.h
+++ b/src/v/cluster/tests/controller_test_fixture.h
@@ -119,8 +119,7 @@ public:
         set_configuration("data_directory", data_dir_path);
         set_configuration("node_id", _current_node.id()());
         set_configuration(
-          "kafka_api",
-          _current_node.kafka_advertised_listeners().front().address);
+          "kafka_api", _current_node.kafka_advertised_listeners());
         set_configuration("rpc_server", _current_node.rpc_address());
         set_configuration("seed_servers", _seeds);
         set_configuration("disable_metrics", true);

--- a/src/v/cluster/tests/controller_test_fixture.h
+++ b/src/v/cluster/tests/controller_test_fixture.h
@@ -118,7 +118,9 @@ public:
           .path = std::filesystem::path(_base_dir)};
         set_configuration("data_directory", data_dir_path);
         set_configuration("node_id", _current_node.id()());
-        set_configuration("kafka_api", _current_node.kafka_api_address());
+        set_configuration(
+          "kafka_api",
+          _current_node.kafka_advertised_listeners().front().address);
         set_configuration("rpc_server", _current_node.rpc_address());
         set_configuration("seed_servers", _seeds);
         set_configuration("disable_metrics", true);

--- a/src/v/cluster/tests/controller_test_fixture.h
+++ b/src/v/cluster/tests/controller_test_fixture.h
@@ -175,7 +175,7 @@ public:
         rpc::server_configuration rpc_cfg("cluster_tests_rpc");
         auto rpc_sa = _current_node.rpc_address().resolve().get0();
         rpc_cfg.max_service_memory_per_core = memory_groups::rpc_total_memory();
-        rpc_cfg.addrs.push_back(rpc_sa);
+        rpc_cfg.addrs.emplace_back(rpc_sa);
         rpc_cfg.disable_metrics = rpc::metrics_disabled::yes;
 
         _rpc.start(rpc_cfg).get0();

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -65,8 +65,9 @@ SEASTAR_THREAD_TEST_CASE(broker_metadata_rt_test) {
     auto d = serialize_roundtrip_rpc(std::move(b));
 
     BOOST_REQUIRE_EQUAL(d.id(), model::node_id(0));
-    BOOST_REQUIRE_EQUAL(d.kafka_api_address().host(), "127.0.0.1");
-    BOOST_REQUIRE_EQUAL(d.kafka_api_address().port(), 9092);
+    BOOST_REQUIRE_EQUAL(
+      d.kafka_advertised_listeners()[0].address.host(), "127.0.0.1");
+    BOOST_REQUIRE_EQUAL(d.kafka_advertised_listeners()[0].address.port(), 9092);
     BOOST_REQUIRE_EQUAL(d.rpc_address().host(), "172.0.1.2");
     BOOST_REQUIRE_EQUAL(d.properties().cores, 8);
     BOOST_REQUIRE_EQUAL(d.properties().available_memory, 1024);

--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     rjson_serialization.cc
   DEPS
     v::json
+    v::model
    boost_filesystem
 )
 add_subdirectory(tests)

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -119,7 +119,7 @@ configuration::configuration()
       "kafka_api",
       "Address and port of an interface to listen for Kafka API requests",
       required::no,
-      unresolved_address("127.0.0.1", 9092))
+      {model::broker_endpoint(unresolved_address("127.0.0.1", 9092))})
   , kafka_api_tls(
       *this,
       "kafka_api_tls",
@@ -425,7 +425,7 @@ configuration::configuration()
       "advertised_kafka_api",
       "Address of Kafka API published to the clients",
       required::no,
-      std::nullopt)
+      {})
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -15,6 +15,7 @@
 #include "config/seed_server.h"
 #include "config/tls_config.h"
 #include "model/metadata.h"
+#include "utils/unresolved_address.h"
 
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/ip.hh>
@@ -54,7 +55,7 @@ struct configuration final : public config_store {
     property<int16_t> min_version;
     property<int16_t> max_version;
     // Kafka
-    property<unresolved_address> kafka_api;
+    one_or_many_property<model::broker_endpoint> kafka_api;
     property<tls_config> kafka_api_tls;
     property<bool> use_scheduling_groups;
     property<unresolved_address> admin;
@@ -114,8 +115,11 @@ struct configuration final : public config_store {
 
     void read_yaml(const YAML::Node& root_node) override;
 
-    unresolved_address advertised_kafka_api() const {
-        return _advertised_kafka_api().value_or(kafka_api());
+    const std::vector<model::broker_endpoint>& advertised_kafka_api() const {
+        if (_advertised_kafka_api().empty()) {
+            return kafka_api();
+        }
+        return _advertised_kafka_api();
     }
 
     unresolved_address advertised_rpc_api() const {
@@ -128,7 +132,7 @@ struct configuration final : public config_store {
     }
 
 private:
-    property<std::optional<unresolved_address>> _advertised_kafka_api;
+    one_or_many_property<model::broker_endpoint> _advertised_kafka_api;
     property<std::optional<unresolved_address>> _advertised_rpc_api;
 };
 
@@ -359,6 +363,36 @@ struct convert<named_type<T, Tag>> {
             return false;
         }
         rhs = type{node.as<T>()};
+        return true;
+    }
+};
+
+template<>
+struct convert<model::broker_endpoint> {
+    using type = model::broker_endpoint;
+
+    static Node encode(const type& rhs) {
+        Node node;
+        node["name"] = rhs.name;
+        node["address"] = rhs.address.host();
+        node["port"] = rhs.address.port();
+        return node;
+    }
+
+    static bool decode(const Node& node, type& rhs) {
+        for (auto s : {"address", "port"}) {
+            if (!node[s]) {
+                return false;
+            }
+        }
+        ss::sstring name;
+        if (node["name"]) {
+            name = node["name"].as<ss::sstring>();
+        }
+        auto address = node["address"].as<ss::sstring>();
+        auto port = node["port"].as<uint16_t>();
+        auto addr = unresolved_address(std::move(address), port);
+        rhs = model::broker_endpoint(std::move(name), std::move(addr));
         return true;
     }
 };

--- a/src/v/config/tests/advertised_kafka_api_test.cc
+++ b/src/v/config/tests/advertised_kafka_api_test.cc
@@ -48,14 +48,16 @@ SEASTAR_THREAD_TEST_CASE(shall_return_kafka_api_as_advertised_api_was_not_set) {
     config::configuration cfg;
     cfg.read_yaml(no_advertised_kafka_api());
     auto adv_list = cfg.advertised_kafka_api();
-    BOOST_REQUIRE_EQUAL(adv_list.host(), cfg.kafka_api().host());
-    BOOST_REQUIRE_EQUAL(adv_list.port(), cfg.kafka_api().port());
+    BOOST_REQUIRE_EQUAL(
+      adv_list[0].address.host(), cfg.kafka_api()[0].address.host());
+    BOOST_REQUIRE_EQUAL(
+      adv_list[0].address.port(), cfg.kafka_api()[0].address.port());
 };
 
 SEASTAR_THREAD_TEST_CASE(shall_return_advertised_kafka_api) {
     config::configuration cfg;
     cfg.read_yaml(with_advertised_kafka_api());
     auto adv_list = cfg.advertised_kafka_api();
-    BOOST_REQUIRE_EQUAL(adv_list.host(), "10.48.0.2");
-    BOOST_REQUIRE_EQUAL(adv_list.port(), 1234);
+    BOOST_REQUIRE_EQUAL(adv_list[0].address.host(), "10.48.0.2");
+    BOOST_REQUIRE_EQUAL(adv_list[0].address.port(), 1234);
 };

--- a/src/v/config/tests/advertised_kafka_api_test.cc
+++ b/src/v/config/tests/advertised_kafka_api_test.cc
@@ -34,6 +34,34 @@ static auto const advertised_kafka_api_conf = "  advertised_kafka_api:\n"
                                               "    address: 10.48.0.2\n"
                                               "    port: 1234\n";
 
+static auto const kafka_endpoints_conf_v2
+  = "redpanda:\n"
+    "  data_directory: /var/lib/redpanda/data\n"
+    "  node_id: 1\n"
+    "  rpc_server:\n"
+    "    address: 127.0.0.1\n"
+    "    port: 33145\n"
+    "  kafka_api:\n"
+    "    - address: 192.168.1.1\n"
+    "      port: 9999\n"
+    "    - address: 2.2.2.2\n"
+    "      name: lala\n"
+    "      port: 8888\n"
+    "  seed_servers:\n"
+    "    - host: \n"
+    "        address: 127.0.0.1\n"
+    "        port: 33145\n"
+    "      node_id: 1\n"
+    "  admin:\n"
+    "    address: 127.0.0.1\n"
+    "    port: 9644\n"
+    "  advertised_kafka_api:\n"
+    "    - address: 10.48.0.2\n"
+    "      port: 1234\n"
+    "    - address: 1.1.1.1\n"
+    "      name: foobar\n"
+    "      port: 9999\n";
+
 YAML::Node no_advertised_kafka_api() {
     return YAML::Load(no_advertised_kafka_api_conf);
 }
@@ -61,3 +89,33 @@ SEASTAR_THREAD_TEST_CASE(shall_return_advertised_kafka_api) {
     BOOST_REQUIRE_EQUAL(adv_list[0].address.host(), "10.48.0.2");
     BOOST_REQUIRE_EQUAL(adv_list[0].address.port(), 1234);
 };
+
+SEASTAR_THREAD_TEST_CASE(handles_v2) {
+    config::configuration cfg_v1;
+    cfg_v1.read_yaml(with_advertised_kafka_api());
+
+    config::configuration cfg_v2;
+    auto node = YAML::Load(kafka_endpoints_conf_v2);
+    cfg_v2.read_yaml(node);
+
+    BOOST_REQUIRE_EQUAL(cfg_v2.kafka_api().size(), 2);
+    BOOST_REQUIRE_EQUAL(cfg_v2.advertised_kafka_api().size(), 2);
+
+    // v1 parses to match first in v2 list
+    BOOST_REQUIRE_EQUAL(cfg_v1.kafka_api()[0], cfg_v2.kafka_api()[0]);
+    BOOST_REQUIRE_EQUAL(
+      cfg_v1.advertised_kafka_api()[0], cfg_v2.advertised_kafka_api()[0]);
+    BOOST_REQUIRE(cfg_v1.kafka_api()[0].name.empty());
+    BOOST_REQUIRE(cfg_v1.advertised_kafka_api()[0].name.empty());
+    BOOST_REQUIRE(cfg_v2.kafka_api()[0].name.empty());
+    BOOST_REQUIRE(cfg_v2.advertised_kafka_api()[0].name.empty());
+
+    // v2 parses out more than one item
+    BOOST_REQUIRE_EQUAL(cfg_v2.kafka_api()[1].name, "lala");
+    BOOST_REQUIRE_EQUAL(cfg_v2.kafka_api()[1].address.host(), "2.2.2.2");
+    BOOST_REQUIRE_EQUAL(cfg_v2.kafka_api()[1].address.port(), 8888);
+    BOOST_REQUIRE_EQUAL(cfg_v2.advertised_kafka_api()[1].name, "foobar");
+    BOOST_REQUIRE_EQUAL(
+      cfg_v2.advertised_kafka_api()[1].address.host(), "1.1.1.1");
+    BOOST_REQUIRE_EQUAL(cfg_v2.advertised_kafka_api()[1].address.port(), 9999);
+}

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -92,4 +92,17 @@ void rjson_serialize(
     rjson_serialize(w, _tmp);
 }
 
+void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const model::broker_endpoint& ep) {
+    w.StartObject();
+    w.Key("name");
+    w.String(ep.name);
+    w.Key("host");
+    w.String(ep.address.host());
+    w.Key("port");
+    w.Uint(ep.address.port());
+    w.EndObject();
+}
+
 } // namespace json

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "likely.h"
+#include "model/metadata.h"
 #include "utils/named_type.h"
 #include "utils/unresolved_address.h"
 
@@ -71,6 +72,9 @@ void rjson_serialize(
 void rjson_serialize(
   rapidjson::Writer<rapidjson::StringBuffer>& w,
   const std::chrono::milliseconds& v);
+
+void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>&, const model::broker_endpoint&);
 
 template<typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
 void rjson_serialize(rapidjson::Writer<rapidjson::StringBuffer>& w, T v) {

--- a/src/v/kafka/connection_context.h
+++ b/src/v/kafka/connection_context.h
@@ -43,6 +43,7 @@ public:
     connection_context& operator=(connection_context&&) = delete;
 
     protocol& server() { return _proto; }
+    const ss::sstring& listener() const { return _rs.conn->name(); }
 
     ss::future<> process_one_request();
     bool is_finished_parsing() const;

--- a/src/v/kafka/requests/request_context.h
+++ b/src/v/kafka/requests/request_context.h
@@ -142,6 +142,8 @@ public:
         return _conn->server().coordinator_mapper();
     }
 
+    const ss::sstring& listener() const { return _conn->listener(); }
+
 private:
     ss::lw_shared_ptr<connection_context> _conn;
     request_header _header;

--- a/src/v/model/adl_serde.h
+++ b/src/v/model/adl_serde.h
@@ -61,9 +61,21 @@ struct adl<model::broker_properties> {
 };
 
 template<>
+struct adl<model::broker_endpoint> {
+    void to(iobuf&, model::broker_endpoint&&);
+    model::broker_endpoint from(iobuf_parser&);
+};
+
+template<>
 struct adl<model::broker> {
     void to(iobuf& out, model::broker&& r);
     model::broker from(iobuf_parser& in);
+};
+
+template<>
+struct adl<model::internal::broker_v0> {
+    void to(iobuf& out, model::internal::broker_v0&& r);
+    model::internal::broker_v0 from(iobuf_parser& in);
 };
 
 // TODO: optimize this transmition with varints

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -77,17 +77,7 @@ public:
     const unresolved_address& rpc_address() const { return _rpc_address; }
     const std::optional<ss::sstring>& rack() const { return _rack; }
 
-    inline bool operator==(const model::broker& other) const {
-        return _id == other._id
-               && _kafka_api_address == other._kafka_api_address
-               && _rpc_address == other._rpc_address && _rack == other._rack
-               && _properties == other._properties;
-    }
-
-    inline bool operator!=(const model::broker& other) const {
-        return !(*this == other);
-    }
-
+    bool operator==(const model::broker& other) const = default;
     bool operator<(const model::broker& other) const { return _id < other._id; }
 
 private:

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -51,19 +51,49 @@ struct broker_properties {
     }
 };
 
+struct broker_endpoint final {
+    ss::sstring name;
+    unresolved_address address;
+
+    broker_endpoint(ss::sstring name, unresolved_address address) noexcept
+      : name(std::move(name))
+      , address(std::move(address)) {}
+
+    explicit broker_endpoint(unresolved_address address) noexcept
+      : address(std::move(address)) {}
+
+    bool operator==(const broker_endpoint&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const broker_endpoint&);
+};
+
+std::ostream& operator<<(std::ostream&, const broker_endpoint&);
+
 class broker {
 public:
     broker(
       node_id id,
-      unresolved_address kafka_api_address,
+      std::vector<broker_endpoint> kafka_advertised_listeners,
       unresolved_address rpc_address,
       std::optional<ss::sstring> rack,
       broker_properties props) noexcept
       : _id(id)
-      , _kafka_api_address(std::move(kafka_api_address))
+      , _kafka_advertised_listeners(std::move(kafka_advertised_listeners))
       , _rpc_address(std::move(rpc_address))
       , _rack(std::move(rack))
       , _properties(std::move(props)) {}
+
+    broker(
+      node_id id,
+      unresolved_address kafka_advertised_listener,
+      unresolved_address rpc_address,
+      std::optional<ss::sstring> rack,
+      broker_properties props) noexcept
+      : broker(
+        id,
+        {broker_endpoint(std::move(kafka_advertised_listener))},
+        std::move(rpc_address),
+        std::move(rack),
+        std::move(props)) {}
 
     broker(broker&&) noexcept = default;
     broker& operator=(broker&&) noexcept = default;
@@ -71,8 +101,8 @@ public:
     const node_id& id() const { return _id; }
 
     const broker_properties& properties() const { return _properties; }
-    const unresolved_address& kafka_api_address() const {
-        return _kafka_api_address;
+    const std::vector<broker_endpoint>& kafka_advertised_listeners() const {
+        return _kafka_advertised_listeners;
     }
     const unresolved_address& rpc_address() const { return _rpc_address; }
     const std::optional<ss::sstring>& rack() const { return _rack; }
@@ -82,7 +112,7 @@ public:
 
 private:
     node_id _id;
-    unresolved_address _kafka_api_address;
+    std::vector<broker_endpoint> _kafka_advertised_listeners;
     unresolved_address _rpc_address;
     std::optional<ss::sstring> _rack;
     broker_properties _properties;
@@ -209,9 +239,39 @@ struct topic_metadata {
 
     friend std::ostream& operator<<(std::ostream&, const topic_metadata&);
 };
+
+namespace internal {
+/*
+ * Old version for use in backwards compatibility serialization /
+ * deserialization helpers.
+ */
+struct broker_v0 {
+    model::node_id id;
+    unresolved_address kafka_address;
+    unresolved_address rpc_address;
+    std::optional<ss::sstring> rack;
+    model::broker_properties properties;
+
+    model::broker to_v3() const {
+        return model::broker(id, kafka_address, rpc_address, rack, properties);
+    }
+};
+
+} // namespace internal
 } // namespace model
 
 namespace std {
+
+template<>
+struct hash<model::broker_endpoint> {
+    size_t operator()(const model::broker_endpoint& ep) const {
+        size_t h = 0;
+        boost::hash_combine(h, std::hash<ss::sstring>()(ep.name));
+        boost::hash_combine(h, std::hash<unresolved_address>()(ep.address));
+        return h;
+    }
+};
+
 template<>
 struct hash<model::broker_properties> {
     size_t operator()(const model::broker_properties& b) const {
@@ -229,13 +289,15 @@ struct hash<model::broker_properties> {
         return h;
     }
 };
+
 template<>
 struct hash<model::broker> {
     size_t operator()(const model::broker& b) const {
         size_t h = 0;
         boost::hash_combine(h, std::hash<model::node_id>()(b.id()));
-        boost::hash_combine(
-          h, std::hash<unresolved_address>()(b.kafka_api_address()));
+        for (const auto& ep : b.kafka_advertised_listeners()) {
+            boost::hash_combine(h, std::hash<model::broker_endpoint>()(ep));
+        }
         boost::hash_combine(
           h, std::hash<unresolved_address>()(b.rpc_address()));
         boost::hash_combine(

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -55,6 +55,9 @@ struct broker_endpoint final {
     ss::sstring name;
     unresolved_address address;
 
+    // required for yaml serde
+    broker_endpoint() = default;
+
     broker_endpoint(ss::sstring name, unresolved_address address) noexcept
       : name(std::move(name))
       , address(std::move(address)) {}

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -267,10 +267,10 @@ std::ostream& operator<<(std::ostream& o, const model::broker_properties& b) {
 std::ostream& operator<<(std::ostream& o, const model::broker& b) {
     return ss::fmt_print(
       o,
-      "{{id: {}, kafka_api_address: {}, rpc_address: {}, rack: {}, "
+      "{{id: {}, kafka_advertised_listeners: {}, rpc_address: {}, rack: {}, "
       "properties: {}}}",
       b.id(),
-      b.kafka_api_address(),
+      b.kafka_advertised_listeners(),
       b.rpc_address(),
       b.rack(),
       b.properties());
@@ -359,6 +359,11 @@ std::istream& operator>>(std::istream& i, cleanup_policy_bitflags& cp) {
              cleanup_policy_bitflags::deletion
                | cleanup_policy_bitflags::compaction);
     return i;
+}
+
+std::ostream& operator<<(std::ostream& os, const model::broker_endpoint& ep) {
+    fmt::print(os, "{{{}:{}}}", ep.name, ep.address);
+    return os;
 }
 
 } // namespace model

--- a/src/v/pandaproxy/client/test/pandaproxy_client_fixture.h
+++ b/src/v/pandaproxy/client/test/pandaproxy_client_fixture.h
@@ -34,7 +34,7 @@ public:
 
     ppc::client make_client() {
         return ppc::client(std::vector<unresolved_address>{
-          config::shard_local_cfg().kafka_api()});
+          config::shard_local_cfg().kafka_api()[0].address});
     }
     ppc::client make_connected_client() {
         auto client = make_client();

--- a/src/v/pandaproxy/test/pandaproxy_fixture.h
+++ b/src/v/pandaproxy/test/pandaproxy_fixture.h
@@ -48,7 +48,7 @@ private:
         pandaproxy::shard_local_cfg().developer_mode.set_value(true);
         pandaproxy::client::shard_local_cfg().brokers.set_value(
           std::vector<unresolved_address>{
-            config::shard_local_cfg().advertised_kafka_api()});
+            config::shard_local_cfg().advertised_kafka_api()[0].address});
     }
 
     void start_proxy() {

--- a/src/v/raft/configuration.h
+++ b/src/v/raft/configuration.h
@@ -63,7 +63,7 @@ struct group_nodes {
 
 class group_configuration final {
 public:
-    static constexpr int8_t current_version = 2;
+    static constexpr int8_t current_version = 3;
     /**
      * creates a configuration where all provided brokers are current
      * configuration voters

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -266,7 +266,7 @@ int main(int args, char** argv, char** env) {
             auto ccd = ss::defer(
               [&connection_cache] { connection_cache.stop().get(); });
             rpc::server_configuration scfg("kvelldb_rpc");
-            scfg.addrs.push_back(ss::socket_address(
+            scfg.addrs.emplace_back(ss::socket_address(
               ss::net::inet_address(cfg["ip"].as<ss::sstring>()),
               cfg["port"].as<uint16_t>()));
             scfg.max_service_memory_per_core

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -145,7 +145,7 @@ struct raft_node {
         tstlog.info("Starting node {} stack ", id());
         // start rpc
         rpc::server_configuration scfg("raft_test_rpc");
-        scfg.addrs = {broker.rpc_address().resolve().get0()};
+        scfg.addrs.emplace_back(broker.rpc_address().resolve().get0());
         scfg.max_service_memory_per_core = 1024 * 1024 * 1024;
         scfg.credentials = nullptr;
         scfg.disable_metrics = rpc::metrics_disabled::yes;

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -256,7 +256,7 @@ int main(int args, char** argv, char** env) {
             auto ccd = ss::defer(
               [&connection_cache] { connection_cache.stop().get(); });
             rpc::server_configuration scfg("tron_rpc");
-            scfg.addrs.push_back(ss::socket_address(
+            scfg.addrs.emplace_back(ss::socket_address(
               ss::net::inet_address(cfg["ip"].as<ss::sstring>()),
               cfg["port"].as<uint16_t>()));
             scfg.max_service_memory_per_core

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -437,7 +437,7 @@ void application::wire_up_services() {
     rpc_cfg.max_service_memory_per_core = memory_groups::rpc_total_memory();
     auto rpc_server_addr
       = config::shard_local_cfg().rpc_server().resolve().get0();
-    rpc_cfg.addrs.push_back(rpc_server_addr);
+    rpc_cfg.addrs.emplace_back(rpc_server_addr);
     auto rpc_builder = config::shard_local_cfg()
                          .rpc_server_tls()
                          .get_credentials_builder()
@@ -466,7 +466,7 @@ void application::wire_up_services() {
         rpc::server_configuration cp_rpc_cfg("coproc_rpc");
         cp_rpc_cfg.max_service_memory_per_core
           = memory_groups::rpc_total_memory();
-        cp_rpc_cfg.addrs.push_back(coproc_script_manager_server_addr);
+        cp_rpc_cfg.addrs.emplace_back(coproc_script_manager_server_addr);
         syschecks::systemd_message(
           "Starting coprocessor internal RPC {}", cp_rpc_cfg);
         construct_service(_coproc_rpc, cp_rpc_cfg).get();
@@ -475,7 +475,7 @@ void application::wire_up_services() {
     rpc::server_configuration kafka_cfg("kafka_rpc");
     kafka_cfg.max_service_memory_per_core = memory_groups::kafka_total_memory();
     auto kafka_addr = config::shard_local_cfg().kafka_api().resolve().get0();
-    kafka_cfg.addrs.push_back(kafka_addr);
+    kafka_cfg.addrs.emplace_back(kafka_addr);
     syschecks::systemd_message("Building TLS credentials for kafka");
     auto kafka_builder = config::shard_local_cfg()
                            .kafka_api_tls()

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -474,8 +474,9 @@ void application::wire_up_services() {
 
     rpc::server_configuration kafka_cfg("kafka_rpc");
     kafka_cfg.max_service_memory_per_core = memory_groups::kafka_total_memory();
-    auto kafka_addr = config::shard_local_cfg().kafka_api().resolve().get0();
-    kafka_cfg.addrs.emplace_back(kafka_addr);
+    for (const auto& ep : config::shard_local_cfg().kafka_api()) {
+        kafka_cfg.addrs.emplace_back(ep.name, ep.address.resolve().get0());
+    }
     syschecks::systemd_message("Building TLS credentials for kafka");
     auto kafka_builder = config::shard_local_cfg()
                            .kafka_api_tls()

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -91,7 +91,7 @@ public:
     }
 
     ss::future<kafka::client> make_kafka_client() {
-        return config::shard_local_cfg().kafka_api().resolve().then(
+        return config::shard_local_cfg().kafka_api()[0].address.resolve().then(
           [](ss::socket_address addr) {
               return kafka::client(rpc::base_transport::configuration{
                 .server_addr = addr,

--- a/src/v/rpc/connection.cc
+++ b/src/v/rpc/connection.cc
@@ -14,11 +14,13 @@
 namespace rpc {
 connection::connection(
   boost::intrusive::list<connection>& hook,
+  ss::sstring name,
   ss::connected_socket f,
   ss::socket_address a,
   server_probe& p)
   : addr(std::move(a))
   , _hook(hook)
+  , _name(std::move(name))
   , _fd(std::move(f))
   , _in(_fd.input())
   , _out(_fd.output())

--- a/src/v/rpc/connection.h
+++ b/src/v/rpc/connection.h
@@ -27,6 +27,7 @@ class connection : public boost::intrusive::list_base_hook<> {
 public:
     connection(
       boost::intrusive::list<connection>& hook,
+      ss::sstring name,
       ss::connected_socket f,
       ss::socket_address a,
       server_probe& p);
@@ -36,6 +37,7 @@ public:
     connection(connection&&) noexcept = default;
     connection& operator=(connection&&) noexcept = delete;
 
+    const ss::sstring& name() const { return _name; }
     ss::input_stream<char>& input() { return _in; }
     ss::future<> write(ss::scattered_message<char> msg);
     ss::future<> shutdown();
@@ -46,6 +48,7 @@ public:
 
 private:
     boost::intrusive::list<connection>& _hook;
+    ss::sstring _name;
     ss::connected_socket _fd;
     ss::input_stream<char> _in;
     batched_output_stream _out;

--- a/src/v/rpc/demo/server.cc
+++ b/src/v/rpc/demo/server.cc
@@ -79,7 +79,7 @@ int main(int args, char** argv, char** env) {
         auto& cfg = app.configuration();
         return ss::async([&] {
             rpc::server_configuration scfg("demo_rpc");
-            scfg.addrs.push_back(ss::socket_address(ss::ipv4_addr(
+            scfg.addrs.emplace_back(ss::socket_address(ss::ipv4_addr(
               cfg["ip"].as<std::string>(), cfg["port"].as<uint16_t>())));
             scfg.max_service_memory_per_core
               = ss::memory::stats().total_memory() * .9 /*90%*/;

--- a/src/v/rpc/server.h
+++ b/src/v/rpc/server.h
@@ -81,13 +81,22 @@ public:
     const hdr_hist& histogram() const { return _hist; }
 
 private:
+    struct listener {
+        ss::sstring name;
+        ss::server_socket socket;
+
+        listener(ss::sstring name, ss::server_socket socket)
+          : name(std::move(name))
+          , socket(std::move(socket)) {}
+    };
+
     friend resources;
-    ss::future<> accept(ss::server_socket&);
+    ss::future<> accept(listener&);
     void setup_metrics();
 
     std::unique_ptr<protocol> _proto;
     ss::semaphore _memory;
-    std::vector<std::unique_ptr<ss::server_socket>> _listeners;
+    std::vector<std::unique_ptr<listener>> _listeners;
     boost::intrusive::list<connection> _connections;
     ss::abort_source _as;
     ss::gate _conn_gate;

--- a/src/v/rpc/test/rpc_integration_fixture.h
+++ b/src/v/rpc/test/rpc_integration_fixture.h
@@ -155,7 +155,7 @@ public:
       std::optional<ss::tls::credentials_builder> credentials = std::nullopt,
       ss::tls::reload_callback&& cb = {}) override {
         rpc::server_configuration scfg("unit_test_rpc");
-        scfg.addrs = {_listen_address};
+        scfg.addrs.emplace_back(_listen_address);
         scfg.max_service_memory_per_core = static_cast<int64_t>(
           ss::memory::stats().total_memory() / 10);
         scfg.credentials
@@ -201,7 +201,7 @@ public:
       std::optional<ss::tls::credentials_builder> credentials = std::nullopt,
       ss::tls::reload_callback&& cb = {}) override {
         rpc::server_configuration scfg("unit_test_rpc_sharded");
-        scfg.addrs = {_listen_address};
+        scfg.addrs.emplace_back(_listen_address);
         scfg.max_service_memory_per_core = static_cast<int64_t>(
           ss::memory::stats().total_memory() / 10);
         scfg.credentials

--- a/src/v/rpc/types.cc
+++ b/src/v/rpc/types.cc
@@ -58,6 +58,11 @@ std::ostream& operator<<(std::ostream& o, const server_configuration& c) {
     return o << "}";
 }
 
+std::ostream& operator<<(std::ostream& os, const server_endpoint& ep) {
+    fmt::print(os, "{{{}:{}}}", ep.name, ep.addr);
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& o, const status& s) {
     switch (s) {
     case status::success:

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -177,8 +177,20 @@ inline result<T> get_ctx_data(result<client_context<T>>&& ctx) {
 
 using metrics_disabled = ss::bool_class<struct metrics_disabled_tag>;
 
+struct server_endpoint {
+    ss::sstring name;
+    ss::socket_address addr;
+
+    server_endpoint(ss::sstring name, ss::socket_address addr)
+      : name(std::move(name))
+      , addr(addr) {}
+
+    explicit server_endpoint(ss::socket_address addr)
+      : server_endpoint("", addr) {}
+};
+
 struct server_configuration {
-    std::vector<ss::socket_address> addrs;
+    std::vector<server_endpoint> addrs;
     int64_t max_service_memory_per_core;
     ss::shared_ptr<ss::tls::server_credentials> credentials;
     metrics_disabled disable_metrics = metrics_disabled::no;
@@ -203,6 +215,7 @@ struct transport_configuration {
 };
 
 std::ostream& operator<<(std::ostream&, const header&);
+std::ostream& operator<<(std::ostream&, const server_endpoint&);
 std::ostream& operator<<(std::ostream&, const server_configuration&);
 std::ostream& operator<<(std::ostream&, const status&);
 } // namespace rpc


### PR DESCRIPTION
This PR adds the plumbing for supporting multi-network configuration. The basic idea is that listeners and advertised apis are associated using common naming. Given the following configuration:

```
  kafka_api:
    - name: public
      address: "0.0.0.0"
      port: 9092
    - name: private
      address: "0.0.0.0"
      port: 9093

  advertised_kafka_api:
    - name: public
      address: public.asdf.com
      port: 9092
    - name: private
      address: internal.network
      port: 9093
```

kafka will report public.asdf.com as an advertised listener if the client is connected on the public listener connection, and similar behavior for the private network.