### PR TITLE
Fixed mixed consistency level replication

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -458,9 +458,11 @@ ss::future<result<replicate_result>> consensus::do_replicate(
                 errc::not_leader);
           }
 
-          return disk_append(model::make_record_batch_reader<
-                               details::term_assigning_reader>(
-                               std::move(rdr), model::term_id(_term)))
+          return disk_append(
+                   model::make_record_batch_reader<
+                     details::term_assigning_reader>(
+                     std::move(rdr), model::term_id(_term)),
+                   update_last_quorum_index::no)
             .then([this](storage::append_result res) {
                 // only update visibility upper bound if all quorum replicated
                 // entries are committed already
@@ -1316,7 +1318,7 @@ consensus::do_append_entries(append_entries_request&& r) {
 
     // success. copy entries for each subsystem
     using offsets_ret = storage::append_result;
-    return disk_append(std::move(r.batches))
+    return disk_append(std::move(r.batches), update_last_quorum_index::no)
       .then([this, m = r.meta, target = r.node_id](offsets_ret ofs) {
           auto f = ss::make_ready_future<>();
           auto last_visible = std::min(ofs.last_offset, m.last_visible_index);
@@ -1632,8 +1634,9 @@ ss::future<> consensus::flush_log() {
     return _log.flush().then([this] { _has_pending_flushes = false; });
 }
 
-ss::future<storage::append_result>
-consensus::disk_append(model::record_batch_reader&& reader) {
+ss::future<storage::append_result> consensus::disk_append(
+  model::record_batch_reader&& reader,
+  update_last_quorum_index should_update_last_quorum_idx) {
     using ret_t = storage::append_result;
     auto cfg = storage::log_append_config{
       // no fsync explicit on a per write, we verify at the end to
@@ -1646,9 +1649,19 @@ consensus::disk_append(model::record_batch_reader&& reader) {
              std::move(reader),
              _log.make_appender(cfg),
              cfg.timeout)
-      .then([this](std::tuple<ret_t, std::vector<offset_configuration>> t) {
-          _disk_append.broadcast();
+      .then([this, should_update_last_quorum_idx](
+              std::tuple<ret_t, std::vector<offset_configuration>> t) {
           auto& [ret, configurations] = t;
+          if (should_update_last_quorum_idx) {
+              /**
+               * We have to update last quorum replicated index before we
+               * trigger read for followers recovery as recovery_stm will have
+               * to deceide if follower flush is required basing on last quorum
+               * replicated index.
+               */
+              _last_quorum_replicated_index = ret.last_offset;
+          }
+          _disk_append.broadcast();
           _has_pending_flushes = true;
           // TODO
           // if we rolled a log segment. write current configuration

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -286,7 +286,8 @@ private:
     friend replicate_batcher;
     friend event_manager;
     friend append_entries_buffer;
-
+    using update_last_quorum_index
+      = ss::bool_class<struct update_last_quorum_index>;
     // all these private functions assume that we are under exclusive operations
     // via the _op_sem
     void do_step_down();
@@ -318,7 +319,7 @@ private:
       replicate_options);
 
     ss::future<storage::append_result>
-    disk_append(model::record_batch_reader&&);
+    disk_append(model::record_batch_reader&&, update_last_quorum_index);
 
     using success_reply = ss::bool_class<struct successfull_reply_tag>;
 

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -24,7 +24,8 @@ public:
 
 private:
     ss::future<> do_recover();
-    ss::future<> read_range_for_recovery(model::offset, model::offset);
+    ss::future<>
+      read_range_for_recovery(model::offset, model::offset, model::offset);
     ss::future<> replicate(
       model::record_batch_reader&&, append_entries_request::flush_after_append);
     ss::future<result<append_entries_reply>>

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -138,10 +138,10 @@ replicate_entries_stm::append_to_self() {
     return share_request()
       .then([this](append_entries_request req) mutable {
           vlog(_ctxlog.trace, "Self append entries - {}", req.meta);
-          return _ptr->disk_append(std::move(req.batches));
+          return _ptr->disk_append(
+            std::move(req.batches), consensus::update_last_quorum_index::yes);
       })
-      .then([this](storage::append_result res) {
-          _ptr->_last_quorum_replicated_index = res.last_offset;
+      .then([](storage::append_result res) {
           return result<storage::append_result>(std::move(res));
       })
       .handle_exception([this](const std::exception_ptr& e) {

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -660,9 +660,7 @@ FIXTURE_TEST(test_mixed_consisteny_levels, raft_test_fixture) {
         auto lvl = random_generators::get_int(0, 10) > 5
                      ? raft::consistency_level::leader_ack
                      : raft::consistency_level::quorum_ack;
-        success = replicate_random_batches(
-                    gr, 2, raft::consistency_level::leader_ack)
-                    .get0();
+        success = replicate_random_batches(gr, 2, lvl).get0();
         BOOST_REQUIRE(success);
     }
 

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -241,7 +241,7 @@ ss::future<> vote_stm::update_vote_state(ss::semaphore_units<> u) {
     // Set last heartbeat timestamp to max as we are the leader
     _ptr->_hbeat = clock_type::time_point::max();
     vlog(_ctxlog.info, "became the leader term:{}", _ptr->term());
-
+    _ptr->_last_quorum_replicated_index = _ptr->_log.offsets().committed_offset;
     _ptr->trigger_leadership_notification();
 
     return replicate_config_as_new_leader(std::move(u))


### PR DESCRIPTION
Fixed recovery of followers when we use mixed `raft::consistency_level` to replicate batches.

Fixes: #447 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
