### PR TITLE
Rename the default operator namespace

### DIFF
--- a/src/go/k8s/config/default/kustomization.yaml
+++ b/src/go/k8s/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: redpanda-operator-system
+namespace: redpanda-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named


### PR DESCRIPTION
Naming convention used among different opensource project is that
operator should be deployed in NAME-system namespace. The `operator`
could be dropped from the namespace to have only `redpanda-system`.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
