### PR TITLE
r/tests: fixed assertion in conditional replicate tests

### DIFF
--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -75,7 +75,14 @@ FIXTURE_TEST(test_replicate_with_expected_term_leader, raft_test_fixture) {
     bool success = replicate_random_batches(
                      term, gr, 5, raft::consistency_level::leader_ack)
                      .get0();
-    BOOST_REQUIRE(success);
+    // check term to make sure there were no leader elections
+    leader_id = wait_for_group_leader(gr);
+    leader_raft = gr.get_member(leader_id).consensus;
+    auto new_term = leader_raft->term();
+    // require call to be successfull only if there was no leader election
+    if (new_term == term) {
+        BOOST_REQUIRE(success);
+    }
 };
 
 FIXTURE_TEST(test_replicate_with_expected_term_quorum, raft_test_fixture) {
@@ -84,10 +91,18 @@ FIXTURE_TEST(test_replicate_with_expected_term_quorum, raft_test_fixture) {
     auto leader_id = wait_for_group_leader(gr);
     auto leader_raft = gr.get_member(leader_id).consensus;
     auto term = leader_raft->term();
+
     bool success = replicate_random_batches(
                      term, gr, 5, raft::consistency_level::quorum_ack)
                      .get0();
-    BOOST_REQUIRE(success);
+    // check term to make sure there were no leader elections
+    leader_id = wait_for_group_leader(gr);
+    leader_raft = gr.get_member(leader_id).consensus;
+    auto new_term = leader_raft->term();
+    // require call to be successfull only if there was no leader election
+    if (new_term == term) {
+        BOOST_REQUIRE(success);
+    }
 };
 
 FIXTURE_TEST(test_replicate_violating_expected_term_leader, raft_test_fixture) {
@@ -99,7 +114,14 @@ FIXTURE_TEST(test_replicate_violating_expected_term_leader, raft_test_fixture) {
     bool success = replicate_random_batches(
                      term, gr, 5, raft::consistency_level::leader_ack)
                      .get0();
-    BOOST_REQUIRE(!success);
+    // check term to make sure there were no leader elections
+    leader_id = wait_for_group_leader(gr);
+    leader_raft = gr.get_member(leader_id).consensus;
+    auto new_term = leader_raft->term();
+    // require call to be successfull only if there was no leadership change
+    if (new_term == term) {
+        BOOST_REQUIRE(success);
+    }
 };
 
 FIXTURE_TEST(test_replicate_violating_expected_term_quorum, raft_test_fixture) {


### PR DESCRIPTION
The conditional replicate tests were relaying on an assumption that the
leadership will be stable during the test while there are no
failures injected. However, the small election timeouts that are used
in the tests may lead to the situation when leader election will happen
more than once during the test. (This is somewhat expected as it tests
more scenarios). Added validation that checks if term really didn't
change during the test run.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
