### PR TITLE
Rpk container metrics

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -194,8 +194,10 @@ func RemoveNetwork(c Client) error {
 }
 
 func CreateNode(
-	c Client, nodeID,
-	kafkaPort, rpcPort uint, netID string, args ...string,
+	c Client,
+	nodeID, kafkaPort, rpcPort, metricsPort uint,
+	netID string,
+	args ...string,
 ) (*NodeState, error) {
 	rPort, err := nat.NewPort(
 		"tcp",
@@ -207,6 +209,13 @@ func CreateNode(
 	kPort, err := nat.NewPort(
 		"tcp",
 		strconv.Itoa(config.Default().Redpanda.KafkaApi.Port),
+	)
+	if err != nil {
+		return nil, err
+	}
+	metPort, err := nat.NewPort(
+		"tcp",
+		strconv.Itoa(config.Default().Redpanda.AdminApi.Port),
 	)
 	if err != nil {
 		return nil, err
@@ -250,6 +259,9 @@ func CreateNode(
 			}},
 			kPort: []nat.PortBinding{{
 				HostPort: fmt.Sprint(kafkaPort),
+			}},
+			metPort: []nat.PortBinding{{
+				HostPort: fmt.Sprint(metricsPort),
 			}},
 		},
 	}

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -141,11 +141,16 @@ func startCluster(
 	if err != nil {
 		return err
 	}
+	seedMetricsPort, err := net.GetFreePort()
+	if err != nil {
+		return err
+	}
 	seedState, err := common.CreateNode(
 		c,
 		seedID,
 		seedKafkaPort,
 		seedRPCPort,
+		seedMetricsPort,
 		netID,
 	)
 	if err != nil {
@@ -183,6 +188,10 @@ func startCluster(
 			if err != nil {
 				return err
 			}
+			metricsPort, err := net.GetFreePort()
+			if err != nil {
+				return err
+			}
 			args := []string{
 				"--seeds",
 				fmt.Sprintf(
@@ -197,6 +206,7 @@ func startCluster(
 				id,
 				kafkaPort,
 				rpcPort,
+				metricsPort,
 				netID,
 				args...,
 			)

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
-	"runtime"
 	"sync"
 	"time"
 
@@ -154,19 +152,10 @@ func startCluster(
 		return err
 	}
 
-	coreCount := int(math.Max(1, float64(runtime.NumCPU())/float64(n)))
-
 	log.Info("Starting cluster")
 	err = startNode(
 		c,
-		seedID,
-		seedKafkaPort,
-		seedRPCPort,
-		seedID,
 		seedState.ContainerID,
-		seedState.ContainerIP,
-		"",
-		coreCount,
 	)
 	if err != nil {
 		return err
@@ -222,14 +211,7 @@ func startCluster(
 			)
 			err = startNode(
 				c,
-				id,
-				kafkaPort,
-				rpcPort,
-				seedRPCPort,
 				state.ContainerID,
-				state.ContainerIP,
-				seedState.ContainerIP,
-				coreCount,
 			)
 			if err != nil {
 				return err
@@ -314,12 +296,7 @@ func restartCluster(
 	return nodes, nil
 }
 
-func startNode(
-	c common.Client,
-	nodeID, kafkaPort, rpcPort, seedRPCPort uint,
-	containerID, ip, seedIP string,
-	cores int,
-) error {
+func startNode(c common.Client, containerID string) error {
 	ctx, _ := common.DefaultCtx()
 	err := c.ContainerStart(ctx, containerID, types.ContainerStartOptions{})
 	return err


### PR DESCRIPTION
Export the metrics port so that prometheus metrics can be consumed from a local container cluster.
