### PR TITLE
Pandaproxy consumer groups fetch

### DIFF
--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -37,6 +37,7 @@ public:
     brokers(brokers&&) = default;
     brokers& operator=(brokers const&) = delete;
     brokers& operator=(brokers&&) = delete;
+    ~brokers() = default;
 
     /// \brief stop and wait for all outstanding activity to finish.
     ss::future<> stop();
@@ -62,7 +63,7 @@ private:
     /// \brief Brokers map a model::node_id to a client.
     brokers_t _brokers;
     /// \brief Next broker to select with round-robin
-    size_t _next_broker;
+    size_t _next_broker{};
     /// \brief Leaders map a partition to a model::node_id.
     leaders_t _leaders;
 };

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -186,8 +186,9 @@ ss::future<member_id> client::create_consumer(const group_id& group_id) {
           return make_broker(
             res.data.node_id, unresolved_address(res.data.host, res.data.port));
       })
-      .then([group_id](shared_broker_t coordinator) mutable {
-          return make_consumer(std::move(coordinator), std::move(group_id));
+      .then([this, group_id](shared_broker_t coordinator) mutable {
+          return make_consumer(
+            _brokers, std::move(coordinator), std::move(group_id));
       })
       .then([this](shared_consumer_t c) {
           auto m_id = c->member_id();

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -264,4 +264,15 @@ ss::future<offset_commit_response> client::consumer_offset_commit(
       });
 }
 
+ss::future<kafka::fetch_response> client::consume(
+  const group_id& g_id,
+  const member_id& m_id,
+  std::chrono::milliseconds timeout,
+  int32_t max_bytes) {
+    return get_consumer(g_id, m_id)
+      .then([timeout, max_bytes](shared_consumer_t c) mutable {
+          return c->consume(timeout, max_bytes);
+      });
+}
+
 } // namespace kafka::client

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -20,6 +20,7 @@
 #include "kafka/client/producer.h"
 #include "kafka/client/retry_with_mitigation.h"
 #include "kafka/client/transport.h"
+#include "kafka/protocol/fetch.h"
 #include "kafka/types.h"
 #include "utils/retry.h"
 #include "utils/unresolved_address.h"
@@ -130,6 +131,12 @@ public:
       const group_id& g_id,
       const member_id& m_id,
       std::vector<offset_commit_request_topic> topics);
+
+    ss::future<fetch_response> consume(
+      const group_id& g_id,
+      const member_id& m_id,
+      std::chrono::milliseconds timeout,
+      int32_t max_bytes);
 
 private:
     /// \brief Connect and update metdata.

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -303,10 +303,10 @@ consumer::offset_commit(std::vector<offset_commit_request_topic> topics) {
     return req_res(std::move(req_builder));
 }
 
-ss::future<shared_consumer_t>
-make_consumer(shared_broker_t coordinator, group_id group_id) {
+ss::future<shared_consumer_t> make_consumer(
+  brokers& brokers, shared_broker_t coordinator, group_id group_id) {
     auto c = ss::make_lw_shared<consumer>(
-      std::move(coordinator), std::move(group_id));
+      brokers, std::move(coordinator), std::move(group_id));
     return c->join().then([c]() mutable { return std::move(c); });
 }
 

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "kafka/client/assignment_plans.h"
-#include "kafka/client/broker.h"
+#include "kafka/client/brokers.h"
 #include "kafka/client/logger.h"
 #include "kafka/types.h"
 
@@ -30,8 +30,9 @@ class consumer final : public ss::enable_lw_shared_from_this<consumer> {
     using assignment_t = client::assignment;
 
 public:
-    consumer(shared_broker_t coordinator, group_id group_id)
-      : _coordinator(std::move(coordinator))
+    consumer(brokers& brokers, shared_broker_t coordinator, group_id group_id)
+      : _brokers(brokers)
+      , _coordinator(std::move(coordinator))
       , _group_id(std::move(group_id))
       , _topics() {}
 
@@ -85,6 +86,7 @@ private:
         });
     }
 
+    brokers& _brokers;
     shared_broker_t _coordinator;
     ss::gate _gate{};
     ss::timer<> _timer;
@@ -112,7 +114,7 @@ private:
 using shared_consumer_t = ss::lw_shared_ptr<consumer>;
 
 ss::future<shared_consumer_t>
-make_consumer(shared_broker_t coordinator, group_id group_id);
+make_consumer(brokers& brokers, shared_broker_t coordinator, group_id group_id);
 
 namespace detail {
 

--- a/src/v/kafka/client/fetch_session.h
+++ b/src/v/kafka/client/fetch_session.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/types.h"
+#include "model/fundamental.h"
+
+#include <absl/container/flat_hash_map.h>
+
+namespace kafka::client {
+
+class fetch_session {
+public:
+    kafka::fetch_session_id id{kafka::invalid_fetch_session_id};
+    kafka::fetch_session_epoch epoch{kafka::initial_fetch_session_epoch};
+    absl::flat_hash_map<
+      model::topic,
+      absl::flat_hash_map<model::partition_id, model::offset>>
+      offsets;
+};
+
+} // namespace kafka::client

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -63,7 +63,7 @@ public:
             using namespace storage; // NOLINT
             builder | start(std::move(ntp_cfg)) | add_segment(model::offset(0))
               | add_random_batches(
-                model::offset(0), 20, maybe_compress_batches::yes)
+                model::offset(0), 20, maybe_compress_batches::no)
               | stop();
         }
         add_topic(tp_ns, partitions).get();


### PR DESCRIPTION
Change history:

* [force push](https://github.com/vectorizedio/redpanda/compare/0ffca187becbdfdcc13282044d5c17b9b1df1ecf..f73b11aae749f06a06b8727906f475e55d588025) Rebase - just the rebase - primarily due to:
   * #469 kafka: move kafka client from panda proxy to kafka folder 
   * #506 Split common and server files in the kafka tree
   * #515 Kafka Batch reader



## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
