### PR TITLE
systemd: implement sd_notify manually to remove systemd dependency

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -27,7 +27,6 @@ deb_deps=(
   curl
   libzstd-dev
   libsnappy-dev
-  libsystemd-dev
   rapidjson-dev
   libxxhash-dev
   python3-venv
@@ -38,7 +37,6 @@ fedora_deps=(
   libzstd-static
   libzstd-devel
   snappy-devel
-  systemd-devel
   rapidjson-devel
   xxhash-devel
   python3-virtualenv

--- a/src/v/syschecks/CMakeLists.txt
+++ b/src/v/syschecks/CMakeLists.txt
@@ -6,4 +6,4 @@ v_cc_library(
     pidfile.cc
   DEPS
     v::utils
-    systemd)
+    )

--- a/src/v/syschecks/syschecks.h
+++ b/src/v/syschecks/syschecks.h
@@ -49,15 +49,15 @@ ss::future<> disk(const ss::sstring& path);
 
 void memory(bool ignore);
 
-void systemd_raw_message(const ss::sstring& out);
+ss::future<> systemd_raw_message(ss::sstring out);
 
-void systemd_notify_ready();
+ss::future<> systemd_notify_ready();
 
 template<typename... Args>
-void systemd_message(const char* fmt, Args&&... args) {
+ss::future<> systemd_message(const char* fmt, Args&&... args) {
     ss::sstring s = fmt::format(
       "STATUS={}\n", fmt::format(fmt, std::forward<Args>(args)...));
-    systemd_raw_message(s);
+    return systemd_raw_message(std::move(s));
 }
 
 /*


### PR DESCRIPTION
The motivation here is to remove dependency on libsystemd-dev

https://www.freedesktop.org/software/systemd/man/sd_notify.html#Description

* Your daemon will receive an environment variable NOTIFY_SOCKET,
  which contains a path to an AF_UNIX socket.
  (If the first path byte is @, this means an "abstract" socket,
  and you should change the 1st byte to 0x00 before using.)

* The protocol consists of sending datagrams containing textual
  (UTF-8) status messages.

* Each message contains newline-separated KEY=value parameters.

* When the daemon is ready, it must send READY=1,
  and systemd will transition the service from "starting" to "running".

* At any point, you can send STATUS=Some text and the text will be shown in
  systemctl status.

* You can be combined ready with status like so: READY=1\nSTATUS=w00t-woot

