### PR TITLE
k/requests: Introduce consumer_records

### DIFF
--- a/src/v/coproc/tests/read_materialized_topic_test.cc
+++ b/src/v/coproc/tests/read_materialized_topic_test.cc
@@ -180,6 +180,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(
       resp.partitions[0].responses[0].error, kafka::error_code::none);
     BOOST_REQUIRE_EQUAL(resp.partitions[0].responses[0].id, pid);
-    BOOST_REQUIRE(resp.partitions[0].responses[0].record_set);
-    BOOST_REQUIRE_EQUAL(resp.partitions[0].responses[0].record_set, data);
+    auto record_set = std::move(resp.partitions[0].responses[0].record_set);
+    BOOST_REQUIRE(record_set);
+    BOOST_REQUIRE_EQUAL(std::move(record_set).release(), data);
 }

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -9,6 +9,7 @@ set(request_srcs
   requests/describe_configs_request.cc
   requests/offset_fetch_request.cc
   requests/kafka_batch_adapter.cc
+  requests/consumer_records.cc
   requests/produce_request.cc
   requests/list_offsets_request.cc
   requests/fetch_request.cc

--- a/src/v/kafka/requests/consumer_records.cc
+++ b/src/v/kafka/requests/consumer_records.cc
@@ -1,0 +1,104 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/requests/consumer_records.h"
+
+#include "kafka/requests/kafka_batch_adapter.h"
+#include "model/record.h"
+
+namespace kafka {
+
+namespace {
+
+/// \brief A subset of the model::record_batch_header
+///
+/// Just enough to delineate record_batch within consumer_records.
+struct record_batch_info {
+    model::offset base_offset{};
+    int32_t record_count{};
+    int32_t size_bytes{};
+
+    int32_t record_bytes() {
+        return size_bytes - model::packed_record_batch_header_size;
+    }
+    model::offset last_offset() {
+        return base_offset + model::offset{record_count - 1};
+    }
+};
+
+record_batch_info read_record_batch_info(iobuf_const_parser& in) {
+    const size_t initial_bytes_consumed = in.bytes_consumed();
+    const auto base_offset = model::offset(in.consume_be_type<int64_t>());
+    const auto batch_length = in.consume_be_type<int32_t>();
+    constexpr size_t skip_len_1 = sizeof(int32_t) + // partition_leader_epoch
+                                  sizeof(int8_t) +  // magic
+                                  sizeof(int32_t) + // crc
+                                  sizeof(int16_t);  // attrs
+
+    in.skip(skip_len_1);
+    const auto last_offset_delta = in.consume_be_type<int32_t>();
+    constexpr size_t skip_len_2 = sizeof(int64_t) + // first_timestamp
+                                  sizeof(int64_t) + // max_timestamp
+                                  sizeof(int64_t) + // producer_id
+                                  sizeof(int16_t) + // producer_epoch
+                                  sizeof(int32_t);  // base_sequence
+    in.skip(skip_len_2);
+    const auto record_count = in.consume_be_type<int32_t>();
+
+    // size_bytes are  the normal kafka batch length minus the `IGNORED`
+    const int32_t size_bytes
+      = batch_length - internal::kafka_header_size
+        + model::packed_record_batch_header_size
+        // Kafka *does not* include the first 2 fields in the size calculation
+        // they build the types bottoms up, not top down
+        + sizeof(base_offset) + sizeof(batch_length);
+
+    if (unlikely(record_count - 1 != last_offset_delta)) {
+        throw std::runtime_error(fmt::format(
+          "Invalid kafka header parsing. "
+          "record count:{}, but"
+          "base_offset: {} and last_offset_delta: {}",
+          record_count,
+          base_offset,
+          last_offset_delta));
+    }
+
+    const size_t total_bytes_consumed = in.bytes_consumed()
+                                        - initial_bytes_consumed;
+    if (unlikely(total_bytes_consumed != kafka::internal::kafka_header_size)) {
+        throw std::runtime_error(fmt::format(
+          "Invalid kafka header parsing. Must consume exactly:{}, but "
+          "consumed:{}",
+          kafka::internal::kafka_header_size,
+          total_bytes_consumed));
+    }
+    return record_batch_info{
+      .base_offset = base_offset,
+      .record_count = record_count,
+      .size_bytes = size_bytes};
+}
+
+} // namespace
+
+model::offset consumer_records::last_offset() const {
+    if (empty()) {
+        return model::offset{-1};
+    }
+    iobuf_const_parser p{*_record_set};
+    record_batch_info rbi{};
+    // This is expected to be fast, but if there are stalls, it'll have to be
+    // futurized.
+    while (p.bytes_left()) {
+        rbi = read_record_batch_info(p);
+        p.skip(rbi.record_bytes());
+    }
+    return rbi.last_offset();
+}
+
+} // namespace kafka

--- a/src/v/kafka/requests/consumer_records.cc
+++ b/src/v/kafka/requests/consumer_records.cc
@@ -101,4 +101,14 @@ model::offset consumer_records::last_offset() const {
     return rbi.last_offset();
 }
 
+kafka_batch_adapter consumer_records::consume_record_batch() {
+    iobuf_const_parser p{*_record_set};
+    const auto hdr = read_record_batch_info(p);
+    const auto size_bytes = hdr.size_bytes;
+    kafka_batch_adapter kba;
+    kba.adapt(_record_set->share(0, size_bytes));
+    _record_set->trim_front(size_bytes);
+    return kba;
+}
+
 } // namespace kafka

--- a/src/v/kafka/requests/consumer_records.h
+++ b/src/v/kafka/requests/consumer_records.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "kafka/types.h"
+
+#include <optional>
+
+namespace kafka {
+
+///\brief consumer_records are a concatenation of multiple model::record_batch
+/// on the wire; without a size header (c.f. a kafka array<thing>)
+class consumer_records {
+public:
+    consumer_records() = default;
+
+    explicit consumer_records(std::optional<iobuf> buf)
+      : _record_set(std::move(buf)) {}
+
+    // Returns true if the record_set is nullopt or empty
+    bool empty() const { return !_record_set || _record_set->empty(); }
+
+    // Returns the size of the buffer, or -1 if it's nullopt
+    size_t size_bytes() const {
+        return _record_set ? _record_set->size_bytes() : -1;
+    }
+
+    // Check that the iobuf isn't nullopt
+    constexpr explicit operator bool() const noexcept {
+        return _record_set.operator bool();
+    }
+
+    // Release any remaining iobuf that hasn't been consumed
+    std::optional<iobuf> release() && { return std::move(_record_set); }
+
+private:
+    std::optional<iobuf> _record_set;
+};
+
+} // namespace kafka

--- a/src/v/kafka/requests/consumer_records.h
+++ b/src/v/kafka/requests/consumer_records.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "bytes/iobuf.h"
+#include "kafka/requests/kafka_batch_adapter.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 
@@ -38,6 +39,9 @@ public:
 
     // Obtain the offset of the last record in the last batch
     model::offset last_offset() const;
+
+    // Consume a model::record_batch
+    kafka_batch_adapter consume_record_batch();
 
     // Check that the iobuf isn't nullopt
     constexpr explicit operator bool() const noexcept {

--- a/src/v/kafka/requests/consumer_records.h
+++ b/src/v/kafka/requests/consumer_records.h
@@ -13,6 +13,7 @@
 
 #include "bytes/iobuf.h"
 #include "kafka/types.h"
+#include "model/fundamental.h"
 
 #include <optional>
 
@@ -34,6 +35,9 @@ public:
     size_t size_bytes() const {
         return _record_set ? _record_set->size_bytes() : -1;
     }
+
+    // Obtain the offset of the last record in the last batch
+    model::offset last_offset() const;
 
     // Check that the iobuf isn't nullopt
     constexpr explicit operator bool() const noexcept {

--- a/src/v/kafka/requests/fetch_request.h
+++ b/src/v/kafka/requests/fetch_request.h
@@ -13,6 +13,7 @@
 
 #include "cluster/partition.h"
 #include "kafka/fetch_session.h"
+#include "kafka/requests/consumer_records.h"
 #include "kafka/requests/request_context.h"
 #include "kafka/requests/response.h"
 #include "kafka/types.h"
@@ -221,7 +222,7 @@ struct fetch_response final {
         model::offset last_stable_offset;                      // >= v4
         model::offset log_start_offset;                        // >= v5
         std::vector<aborted_transaction> aborted_transactions; // >= v4
-        std::optional<iobuf> record_set;
+        consumer_records record_set;
         /*
          * _not part of kafka protocol
          * used to indicate wether we have to

--- a/src/v/kafka/tests/CMakeLists.txt
+++ b/src/v/kafka/tests/CMakeLists.txt
@@ -51,7 +51,8 @@ set(srcs
   offset_commit_test.cc
   topic_recreate_test.cc
   fetch_session_test.cc
-  produce_consume_test.cc)
+  produce_consume_test.cc
+  consumer_records_test.cc)
 
 rp_test(
   UNIT_TEST

--- a/src/v/kafka/tests/consumer_records_test.cc
+++ b/src/v/kafka/tests/consumer_records_test.cc
@@ -40,3 +40,32 @@ SEASTAR_THREAD_TEST_CASE(consumer_records_last_offset) {
     BOOST_REQUIRE(crs);
     BOOST_REQUIRE_EQUAL(crs.last_offset(), expected_last_offset);
 }
+
+SEASTAR_THREAD_TEST_CASE(consumer_records_consume_record_batch) {
+    constexpr model::offset init_offset{0};
+
+    // Create some batches
+    auto input = storage::test::make_random_batches(init_offset, 40);
+    BOOST_REQUIRE(!input.empty());
+    const auto expected_last_offset = input.back().last_offset();
+
+    // Serialise the batches
+    auto mem_res = model::make_memory_record_batch_reader(std::move(input))
+                     .consume(
+                       kafka::kafka_batch_serializer{}, model::no_timeout)
+                     .get();
+
+    // Functionality under test
+    auto crs = kafka::consumer_records(std::move(mem_res.data));
+
+    model::offset last_offset{};
+    while (!crs.empty()) {
+        auto kba = crs.consume_record_batch();
+        BOOST_REQUIRE(kba.v2_format);
+        BOOST_REQUIRE(kba.valid_crc);
+        BOOST_REQUIRE(kba.batch);
+        last_offset = kba.batch->last_offset();
+    }
+
+    BOOST_REQUIRE_EQUAL(last_offset, expected_last_offset);
+}

--- a/src/v/kafka/tests/consumer_records_test.cc
+++ b/src/v/kafka/tests/consumer_records_test.cc
@@ -1,0 +1,42 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/requests/batch_consumer.h"
+#include "kafka/requests/consumer_records.h"
+#include "model/timeout_clock.h"
+#include "redpanda/tests/fixture.h"
+#include "storage/tests/utils/random_batch.h"
+#include "test_utils/async.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/std-coroutine.hh>
+
+#include <chrono>
+#include <limits>
+
+SEASTAR_THREAD_TEST_CASE(consumer_records_last_offset) {
+    constexpr model::offset init_offset{0};
+
+    // Create some batches
+    auto input = storage::test::make_random_batches(init_offset, 40);
+    BOOST_REQUIRE(!input.empty());
+    const auto expected_last_offset = input.back().last_offset();
+
+    // Serialise the batches
+    auto mem_res = model::make_memory_record_batch_reader(std::move(input))
+                     .consume(
+                       kafka::kafka_batch_serializer{}, model::no_timeout)
+                     .get();
+
+    // Functionality under test
+    auto crs = kafka::consumer_records(std::move(mem_res.data));
+
+    BOOST_REQUIRE(crs);
+    BOOST_REQUIRE_EQUAL(crs.last_offset(), expected_last_offset);
+}

--- a/src/v/kafka/tests/consumer_records_test.cc
+++ b/src/v/kafka/tests/consumer_records_test.cc
@@ -69,3 +69,30 @@ SEASTAR_THREAD_TEST_CASE(consumer_records_consume_record_batch) {
 
     BOOST_REQUIRE_EQUAL(last_offset, expected_last_offset);
 }
+
+SEASTAR_THREAD_TEST_CASE(consumer_records_as_reader) {
+    constexpr model::offset init_offset{0};
+
+    // Create some batches
+    auto input = storage::test::make_random_batches(init_offset, 40);
+    BOOST_REQUIRE(!input.empty());
+    const auto expected_last_offset = input.back().last_offset();
+
+    // Serialise the batches
+    auto mem_res = model::make_memory_record_batch_reader(std::move(input))
+                     .consume(
+                       kafka::kafka_batch_serializer{}, model::no_timeout)
+                     .get();
+
+    // Functionality under test
+    auto rdr = model::make_record_batch_reader<kafka::consumer_records>(
+      std::move(mem_res.data));
+    auto output = model::consume_reader_to_memory(
+                    std::move(rdr), model::no_timeout)
+                    .get();
+
+    BOOST_REQUIRE(!output.empty());
+    BOOST_REQUIRE_EQUAL(output.back().last_offset(), expected_last_offset);
+    BOOST_REQUIRE_EQUAL(
+      output.back().last_offset()() + 1, init_offset() + mem_res.record_count);
+}

--- a/src/v/kafka/tests/fetch_test.cc
+++ b/src/v/kafka/tests/fetch_test.cc
@@ -262,9 +262,7 @@ FIXTURE_TEST(fetch_one, redpanda_thread_fixture) {
         BOOST_REQUIRE(
           resp.partitions[0].responses[0].error == kafka::error_code::none);
         BOOST_REQUIRE(resp.partitions[0].responses[0].id == pid);
-        BOOST_REQUIRE(resp.partitions[0].responses[0].record_set);
-        BOOST_REQUIRE(
-          resp.partitions[0].responses[0].record_set->size_bytes() > 0);
+        BOOST_REQUIRE(!resp.partitions[0].responses[0].record_set.empty());
     }
 }
 
@@ -430,7 +428,7 @@ FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
           resp.partitions[0].responses[i].id, model::partition_id(i));
         BOOST_REQUIRE(resp.partitions[0].responses[i].record_set);
 
-        total_size += resp.partitions[0].responses[i].record_set->size_bytes();
+        total_size += resp.partitions[0].responses[i].record_set.size_bytes();
     }
     BOOST_REQUIRE_GT(total_size, 0);
 }
@@ -488,8 +486,7 @@ FIXTURE_TEST(fetch_one_debounce, redpanda_thread_fixture) {
     BOOST_REQUIRE(
       resp.partitions[0].responses[0].error == kafka::error_code::none);
     BOOST_REQUIRE(resp.partitions[0].responses[0].id == pid);
-    BOOST_REQUIRE(resp.partitions[0].responses[0].record_set);
-    BOOST_REQUIRE(resp.partitions[0].responses[0].record_set->size_bytes() > 0);
+    BOOST_REQUIRE(!resp.partitions[0].responses[0].record_set.empty());
 }
 
 FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
@@ -576,7 +573,7 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
           resp.partitions[0].responses[i].id, model::partition_id(i));
         BOOST_REQUIRE(resp.partitions[0].responses[i].record_set);
 
-        total_size += resp.partitions[0].responses[i].record_set->size_bytes();
+        total_size += resp.partitions[0].responses[i].record_set.size_bytes();
     }
     BOOST_REQUIRE_GT(total_size, 0);
 }

--- a/src/v/kafka/tests/produce_consume_test.cc
+++ b/src/v/kafka/tests/produce_consume_test.cc
@@ -118,11 +118,11 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
               auto& part = *resp.partitions.begin();
 
               for (auto& r : part.responses) {
-                  std::optional<iobuf> data = std::move(
-                    part.responses.begin()->record_set);
-                  if (data && !data->empty()) {
+                  auto data = std::move(part.responses.begin()->record_set);
+                  if (!data.empty()) {
                       // update next fetch offset the same way as Kafka clients
-                      fetch_offset = read_last_batch_offset(std::move(*data))
+                      fetch_offset = read_last_batch_offset(
+                                       *std::move(data).release())
                                      + model::offset(1);
                   }
               }

--- a/src/v/kafka/tests/produce_consume_test.cc
+++ b/src/v/kafka/tests/produce_consume_test.cc
@@ -66,7 +66,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
     }
 
     template<typename T>
-    ss::future<> produce(T&& batch_factory) {
+    ss::future<size_t> produce(T&& batch_factory) {
         kafka::produce_request::topic tp;
         size_t count = random_generators::get_int(1, 20);
         tp.partitions = batch_factory(count);
@@ -78,20 +78,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         req.has_idempotent = false;
         req.has_transactional = false;
         return producer->dispatch(std::move(req))
-          .then([](kafka::produce_response) {});
-    }
-
-    model::offset read_last_batch_offset(iobuf&& record_set) {
-        kafka::request_reader rdr(std::move(record_set));
-        auto bo = rdr.read_int64();
-        auto len = rdr.read_int32();
-        auto ple = rdr.read_int32();
-        auto magic = rdr.read_int8();
-        auto crc = rdr.read_int32();
-        auto attr = rdr.read_int16();
-        auto lod = rdr.read_int32();
-
-        return model::offset(bo + lod);
+          .then([count](kafka::produce_response) { return count; });
     }
 
     ss::future<kafka::fetch_response> fetch_next() {
@@ -118,12 +105,10 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
               auto& part = *resp.partitions.begin();
 
               for (auto& r : part.responses) {
-                  auto data = std::move(part.responses.begin()->record_set);
+                  const auto& data = part.responses.begin()->record_set;
                   if (!data.empty()) {
                       // update next fetch offset the same way as Kafka clients
-                      fetch_offset = read_last_batch_offset(
-                                       *std::move(data).release())
-                                     + model::offset(1);
+                      fetch_offset = ++data.last_offset();
                   }
               }
               return resp;
@@ -142,11 +127,17 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
  * batches.
  */
 FIXTURE_TEST(test_produce_consume_small_batches, prod_consume_fixture) {
+    const int64_t initial_offset{0};
     wait_for_controller_leadership().get0();
     start();
-    produce([this](size_t cnt) { return small_batches(cnt); }).get0();
+    auto cnt_1 = produce([this](size_t cnt) {
+                     return small_batches(cnt);
+                 }).get0();
     auto resp_1 = fetch_next().get0();
-    produce([this](size_t cnt) { return small_batches(cnt); }).get0();
+
+    auto cnt_2 = produce([this](size_t cnt) {
+                     return small_batches(cnt);
+                 }).get0();
     auto resp_2 = fetch_next().get0();
 
     BOOST_REQUIRE_EQUAL(resp_1.partitions.empty(), false);
@@ -155,8 +146,15 @@ FIXTURE_TEST(test_produce_consume_small_batches, prod_consume_fixture) {
     BOOST_REQUIRE_EQUAL(
       resp_1.partitions.begin()->responses.begin()->error,
       kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(
+      resp_1.partitions.begin()->responses.begin()->record_set.last_offset()(),
+      initial_offset + cnt_1);
     BOOST_REQUIRE_EQUAL(resp_2.partitions.begin()->responses.empty(), false);
     BOOST_REQUIRE_EQUAL(
       resp_2.partitions.begin()->responses.begin()->error,
       kafka::error_code::none);
+    // This fails - the record set is empty
+    BOOST_REQUIRE_EQUAL(
+      resp_2.partitions.begin()->responses.begin()->record_set.last_offset()(),
+      initial_offset + cnt_1 + cnt_2);
 };

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -92,9 +92,10 @@ public:
         for (auto& v : res) {
             auto r = std::move(*v.partition_response);
             model::topic_partition_view tpv(v.partition->name, r.id);
-            while (r.record_set && !r.record_set->empty()) {
+            while (!r.record_set.empty()) {
                 kafka::kafka_batch_adapter adapter;
-                r.record_set = adapter.adapt(std::move(*r.record_set));
+                r.record_set = kafka::consumer_records(
+                  adapter.adapt(*std::move(r.record_set).release()));
                 auto rjs = rjson_serialize_impl<model::record>(
                   _fmt, tpv, adapter.batch->base_offset());
 

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -93,9 +93,7 @@ public:
             auto r = std::move(*v.partition_response);
             model::topic_partition_view tpv(v.partition->name, r.id);
             while (!r.record_set.empty()) {
-                kafka::kafka_batch_adapter adapter;
-                r.record_set = kafka::consumer_records(
-                  adapter.adapt(*std::move(r.record_set).release()));
+                auto adapter = r.record_set.consume_record_batch();
                 auto rjs = rjson_serialize_impl<model::record>(
                   _fmt, tpv, adapter.batch->base_offset());
 


### PR DESCRIPTION
kafka::fetch_response::partition_response::record_set contains multiple record_batch, which deserves a type.

This utility supports:

* `empty`
* `size_bytes`
* `last_offset` - last offset of last batch
* `consume_record_batch` - as a `record_batch_adaptor`
* `record_batch_reader::impl` implementation
* `operator bool` - check if the underlying `iobuf` is nullopt
* `release()` - release the underlying `iobuf`

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the external tracker. This is not relevant for most users.
