### PR TITLE
Fixed updating partition high watermark when relaxed consistency replicate is used on single node

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -469,6 +469,7 @@ ss::future<result<replicate_result>> consensus::do_replicate(
                     // bound with last offset appended to the log
                     _visibility_upper_bound_index = std::max(
                       _visibility_upper_bound_index, res.last_offset);
+                    maybe_update_majority_replicated_index();
                 }
                 return result<replicate_result>(
                   replicate_result{.last_offset = res.last_offset});


### PR DESCRIPTION
@BenPope  reported weird behavior in one of the kafka tests. Fetch requests weren't able to read batches even tough they were produced. The problem is related with lack of high watermark update when relaxed consistency appends were used on single node. 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
