### PR TITLE
rptest: skip removal of config file when running VMs

### DIFF
--- a/tests/rptest/services/pandaproxy.py
+++ b/tests/rptest/services/pandaproxy.py
@@ -44,9 +44,8 @@ class PandaProxyService(Service):
         node.account.mkdirs(PandaProxyService.PERSISTENT_ROOT)
         node.account.mkdirs(os.path.dirname(PandaProxyService.CONFIG_FILE))
 
-        platform = self._context.globals.get("platform", "docker-compose")
-
-        if platform == "docker-compose":
+        if self._context.globals.get("platform",
+                                     "docker-compose") == "docker-compose":
             self.write_conf_file(node)
 
         cmd = "nohup {} ".format(self.find_binary("pandaproxy"))
@@ -84,7 +83,10 @@ class PandaProxyService(Service):
     def clean_node(self, node):
         node.account.kill_process("pandaproxy", clean_shutdown=False)
         node.account.remove(f"{PandaProxyService.PERSISTENT_ROOT}/*")
-        node.account.remove(f"{PandaProxyService.CONFIG_FILE}")
+
+        if self._context.globals.get("platform",
+                                     "docker-compose") == "docker-compose":
+            node.account.remove(f"{PandaProxyService.CONFIG_FILE}")
 
     def find_binary(self, name):
         bin_path = f"{self._rp_install_path_root}/pandaproxy/bin/{name}"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -84,9 +84,8 @@ class RedpandaService(Service):
         node.account.mkdirs(RedpandaService.DATA_DIR)
         node.account.mkdirs(os.path.dirname(RedpandaService.CONFIG_FILE))
 
-        platform = self._context.globals.get("platform", "docker-compose")
-
-        if platform == "docker-compose":
+        if self._context.globals.get("platform",
+                                     "docker-compose") == "docker-compose":
             self.write_conf_file(node, override_cfg_params)
 
         cmd = (f"nohup {self.find_binary('redpanda')}"
@@ -131,7 +130,10 @@ class RedpandaService(Service):
     def clean_node(self, node):
         node.account.kill_process("redpanda", clean_shutdown=False)
         node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/*")
-        node.account.remove(f"{RedpandaService.CONFIG_FILE}")
+
+        if self._context.globals.get("platform",
+                                     "docker-compose") == "docker-compose":
+            node.account.remove(f"{RedpandaService.CONFIG_FILE}")
 
     def pids(self, node):
         """Return process ids associated with running processes on the given node."""


### PR DESCRIPTION
The changes in #391 add logic for removing the config file after a test finishes. This is not correct in the case when the test runs against VMs, since this configuration is managed externally to the ducktape test.