### PR TITLE
bytes: Adding new comparator to cmp iobuf against a string_view

### DIFF
--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -35,6 +35,7 @@
 #include <list>
 #include <ostream>
 #include <stdexcept>
+#include <string_view>
 #include <type_traits>
 
 /// our iobuf is a fragmented buffer. modeled after
@@ -159,6 +160,9 @@ public:
     bool operator==(const iobuf&) const;
     bool operator!=(const iobuf&) const;
 
+    bool operator==(std::string_view) const;
+    bool operator!=(std::string_view) const;
+
     iterator begin();
     iterator end();
     reverse_iterator rbegin();
@@ -199,6 +203,9 @@ inline iobuf::const_iterator iobuf::cbegin() const { return _frags.cbegin(); }
 inline iobuf::const_iterator iobuf::cend() const { return _frags.cend(); }
 
 inline bool iobuf::operator!=(const iobuf& o) const { return !(*this == o); }
+inline bool iobuf::operator!=(std::string_view o) const {
+    return !(*this == o);
+}
 inline bool iobuf::empty() const { return _frags.empty(); }
 inline size_t iobuf::size_bytes() const { return _size; }
 


### PR DESCRIPTION
- Useful for constant checks on a value within a buffer without having
to copy any data

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
