### PR TITLE
rpk/topic: Don't use containers that aren't running

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/api.go
+++ b/src/go/rpk/pkg/cli/cmd/api.go
@@ -57,7 +57,12 @@ func NewApiCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	// path, the list of brokers passed through --brokers) to deduce the
 	// actual brokers list to be used.
 	configClosure := common.FindConfigFile(mgr, &configFile)
-	brokersClosure := common.DeduceBrokers(fs, configClosure, &brokers)
+	brokersClosure := common.DeduceBrokers(
+		fs,
+		common.CreateDockerClient,
+		configClosure,
+		&brokers,
+	)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure)
 	clientClosure := common.CreateClient(fs, brokersClosure, configClosure)
 	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure)

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -214,10 +214,7 @@ func ContainerBrokers() []string {
 			defer mu.Unlock()
 			addrs = append(
 				addrs,
-				fmt.Sprintf(
-					"127.0.0.1:%d",
-					s.HostKafkaPort,
-				),
+				common.HostAddr(s.HostKafkaPort),
 			)
 			return nil
 		})

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -1,0 +1,131 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package common_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	ccommon "github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/container/common"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+)
+
+func TestDeduceBrokers(t *testing.T) {
+	tests := []struct {
+		name		string
+		client		func() (ccommon.Client, error)
+		config		func() (*config.Config, error)
+		brokers		[]string
+		expected	[]string
+	}{{
+		name:	"it should prioritize the flag over the config & containers",
+		client: func() (ccommon.Client, error) {
+			return &ccommon.MockClient{
+				MockContainerInspect:	ccommon.MockContainerInspect,
+				MockContainerList: func(
+					_ context.Context,
+					_ types.ContainerListOptions,
+				) ([]types.Container, error) {
+					return []types.Container{{
+						ID:	"a",
+						Labels: map[string]string{
+							"node-id": "0",
+						},
+					}}, nil
+				},
+			}, nil
+		},
+		brokers:	[]string{"192.168.34.12:9093"},
+		expected:	[]string{"192.168.34.12:9093"},
+	}, {
+		name:	"it should prioritize the local containers over the config",
+		client: func() (ccommon.Client, error) {
+			return &ccommon.MockClient{
+				MockContainerInspect:	ccommon.MockContainerInspect,
+				MockContainerList: func(
+					_ context.Context,
+					_ types.ContainerListOptions,
+				) ([]types.Container, error) {
+					return []types.Container{{
+						ID:	"a",
+						Labels: map[string]string{
+							"node-id": "0",
+						},
+					}}, nil
+				},
+			}, nil
+		},
+		expected:	[]string{"127.0.0.1:89080"},
+	}, {
+		name: "it should fall back to the config if the docker client" +
+			" can't be init'd",
+		client: func() (ccommon.Client, error) {
+			return nil, errors.New("The docker client can't be initialized")
+		},
+		config: func() (*config.Config, error) {
+			conf := config.Default()
+			conf.Redpanda.KafkaApi = config.SocketAddress{
+				Address:	"192.168.25.88",
+				Port:		1235,
+			}
+			return conf, nil
+		},
+		expected:	[]string{"192.168.25.88:1235"},
+	}, {
+		name: "it should fall back to the default addr if there's an" +
+			" error reading the config",
+		config: func() (*config.Config, error) {
+			return nil, errors.New("The config file couldn't be read")
+		},
+		expected:	[]string{"127.0.0.1:9092"},
+	}, {
+		name:	"it should prioritize the config over the default broker addr",
+		config: func() (*config.Config, error) {
+			conf := config.Default()
+			conf.Redpanda.KafkaApi = config.SocketAddress{
+				Address:	"192.168.25.87",
+				Port:		1234,
+			}
+			return conf, nil
+		},
+		expected:	[]string{"192.168.25.87:1234"},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			fs := afero.NewMemMapFs()
+			client := func() (ccommon.Client, error) {
+				return &ccommon.MockClient{}, nil
+			}
+			config := func() (*config.Config, error) {
+				return config.Default(), nil
+			}
+			brokersList := []string{}
+			brokers := &brokersList
+
+			if tt.client != nil {
+				client = tt.client
+			}
+			if tt.config != nil {
+				config = tt.config
+			}
+			if tt.brokers != nil {
+				brokers = &tt.brokers
+			}
+			bs := common.DeduceBrokers(fs, client, config, brokers)()
+			require.Exactly(st, tt.expected, bs)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -52,6 +52,10 @@ type NodeState struct {
 	ContainerID	string
 }
 
+func HostAddr(port uint) string {
+	return fmt.Sprintf("127.0.0.1:%d", port)
+}
+
 // Returns the container name for the given node ID.
 func Name(nodeID uint) string {
 	return fmt.Sprintf("rp-node-%d", nodeID)
@@ -234,7 +238,7 @@ func CreateNode(
 		"--rpc-addr",
 		fmt.Sprintf("%s:%d", ip, config.Default().Redpanda.RPCServer.Port),
 		"--advertise-kafka-addr",
-		fmt.Sprintf("127.0.0.1:%d", kafkaPort),
+		HostAddr(kafkaPort),
 		"--advertise-rpc-addr",
 		fmt.Sprintf("%s:%d", ip, config.Default().Redpanda.RPCServer.Port),
 		"--smp 1 --memory 1G --reserve-memory 0M",

--- a/src/go/rpk/pkg/cli/cmd/container/common/test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/test.go
@@ -239,8 +239,8 @@ func (c *MockClient) IsErrConnectionFailed(err error) bool {
 func MockContainerInspect(
 	_ context.Context, _ string,
 ) (types.ContainerJSON, error) {
-	kafkaNatPort := nat.Port("tcp/9092")
-	rpcNatPort := nat.Port("tcp/33145")
+	kafkaNatPort := nat.Port("9092/tcp")
+	rpcNatPort := nat.Port("33145/tcp")
 	return types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{
 			State: &types.ContainerState{

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -57,7 +57,12 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	// closure with references to the required values (the config file
 	// path, the list of brokers passed through --brokers).
 	configClosure := common.FindConfigFile(mgr, &configFile)
-	brokersClosure := common.DeduceBrokers(fs, configClosure, &brokers)
+	brokersClosure := common.DeduceBrokers(
+		fs,
+		common.CreateDockerClient,
+		configClosure,
+		&brokers,
+	)
 	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure)
 	clientClosure := common.CreateClient(fs, brokersClosure, configClosure)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure)

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -31,7 +31,12 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 
 	// configure kafka producer
 	configClosure := common.FindConfigFile(mgr, &configFile)
-	brokersClosure := common.DeduceBrokers(fs, configClosure, &brokers)
+	brokersClosure := common.DeduceBrokers(
+		fs,
+		common.CreateDockerClient,
+		configClosure,
+		&brokers,
+	)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure)
 	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure)
 


### PR DESCRIPTION
Prevent `rpk api status` from attempting to connect to a local broker created with `rpk container start` if the container is stopped.

Fix #461.