### PR TITLE
operator/controller: Split reconcile loop per resource

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -13,45 +13,21 @@ package redpanda
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"reflect"
-	"strconv"
-	"strings"
 
 	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
-	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
-	"gopkg.in/yaml.v3"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
-	baseSuffix	= "-base"
-	dataDirectory	= "/var/lib/redpanda/data"
-	fsGroup		= 101
-
-	configDir		= "/etc/redpanda"
-	configuratorDir		= "/mnt/operator"
-	configuratorScript	= "configurator.sh"
-
-	debugLevel	= 2
-)
-
-var (
-	configPath		= filepath.Join(configDir, "redpanda.yaml")
-	configuratorPath	= filepath.Join(configuratorDir, configuratorScript)
+	debugLevel = 2
 )
 
 // ClusterReconciler reconciles a Cluster object
@@ -95,79 +71,26 @@ func (r *ClusterReconciler) Reconcile(
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	var svc corev1.Service
-
-	err := r.Get(ctx, types.NamespacedName{Name: redpandaCluster.Name, Namespace: redpandaCluster.Namespace}, &svc)
-	if err != nil && !errors.IsNotFound(err) {
-		log.V(debugLevel).Info("Unable to fetch Service resource")
-		return ctrl.Result{}, err
+	sts := resources.NewStatefulSet(r.Client, &redpandaCluster, r.Scheme)
+	toApply := []resources.OwnedResource{
+		resources.NewService(r.Client, &redpandaCluster, r.Scheme),
+		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme),
+		sts,
 	}
 
-	if errors.IsNotFound(err) {
-		log.V(debugLevel).Info("Creating headless service")
-
-		if err = r.createHeadlessService(ctx, &redpandaCluster, r.Scheme); err != nil {
-			log.Error(err, "Failed to create new service",
-				"Service.Namespace", redpandaCluster.Namespace,
-				"Service.Name", redpandaCluster.Name)
-
-			return ctrl.Result{}, err
-		}
-	}
-
-	var baseConfigMap corev1.ConfigMap
-
-	err = r.Get(ctx, types.NamespacedName{Name: redpandaCluster.Name + baseSuffix, Namespace: redpandaCluster.Namespace}, &baseConfigMap)
-	if err != nil && !errors.IsNotFound(err) {
-		log.V(debugLevel).Info("Unable to fetch base redpanda ConfigMap resource")
-
-		return ctrl.Result{}, err
-	}
-
-	if errors.IsNotFound(err) {
-		log.V(debugLevel).Info("Creating base redpanda ConfigMap")
-
-		if err = r.createBootstrapConfigMap(ctx, &redpandaCluster, r.Scheme); err != nil {
-			log.Error(err, "Failed to create new base redpanda ConfigMap",
-				"Configmap.Namespace", redpandaCluster.Namespace,
-				"Configmap.Name", redpandaCluster.Name+baseSuffix)
-
-			return ctrl.Result{}, err
-		}
-	}
-
-	var sts appsv1.StatefulSet
-
-	err = r.Get(ctx, types.NamespacedName{Name: redpandaCluster.Name, Namespace: redpandaCluster.Namespace}, &sts)
-	if err != nil && !errors.IsNotFound(err) {
-		log.V(debugLevel).Info("Unable to fetch StatefulSet resource")
-
-		return ctrl.Result{}, err
-	}
-
-	if errors.IsNotFound(err) {
-		log.V(debugLevel).Info("Creating bootstrap StatefulSet")
-
-		if err = r.createBootstrapStatefulSet(ctx, &redpandaCluster, r.Scheme, redpandaCluster.Name+baseSuffix); err != nil {
-			log.Error(err, "Failed to create new bootstrap StatefulSet",
-				"Configmap.Namespace", redpandaCluster.Namespace, "StatefulSet.Name", redpandaCluster.Name)
-
-			return ctrl.Result{}, err
-		}
-	}
-
-	// Ensure StatefulSet #replicas equals cluster requirement.
-	if sts.Spec.Replicas != redpandaCluster.Spec.Replicas {
-		sts.Spec.Replicas = redpandaCluster.Spec.Replicas
-		if err = r.Update(ctx, &sts); err != nil {
-			log.Error(err, "Failed to update StatefulSet", "StatefulSet.Namespace", redpandaCluster.Namespace, "StatefulSet.Name", redpandaCluster.Name)
-			return ctrl.Result{}, err
+	for _, res := range toApply {
+		err := res.Ensure(ctx)
+		if err != nil {
+			log.Error(err, "Failed to reconcile resource",
+				"Namespace", redpandaCluster.Namespace,
+				"Name", redpandaCluster.Name,
+				"Kind", res.Kind())
 		}
 	}
 
 	var observedPods corev1.PodList
 
-	err = r.List(ctx, &observedPods, &client.ListOptions{
+	err := r.List(ctx, &observedPods, &client.ListOptions{
 		LabelSelector:	labels.SelectorFromSet(redpandaCluster.Labels),
 		Namespace:	redpandaCluster.Namespace,
 	})
@@ -192,8 +115,12 @@ func (r *ClusterReconciler) Reconcile(
 		}
 	}
 
-	if !reflect.DeepEqual(sts.Status.ReadyReplicas, redpandaCluster.Status.Replicas) {
-		redpandaCluster.Status.Replicas = sts.Status.ReadyReplicas
+	if sts.LastObservedState != nil {
+		return ctrl.Result{}, fmt.Errorf("Expecting to have statefulset LastObservedState set but is null")
+	}
+
+	if sts.LastObservedState != nil && !reflect.DeepEqual(sts.LastObservedState.Status.ReadyReplicas, redpandaCluster.Status.Replicas) {
+		redpandaCluster.Status.Replicas = sts.LastObservedState.Status.ReadyReplicas
 		if err := r.Status().Update(ctx, &redpandaCluster); err != nil {
 			log.Error(err, "Failed to update RedpandaClusterStatus")
 
@@ -202,324 +129,6 @@ func (r *ClusterReconciler) Reconcile(
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (r *ClusterReconciler) createHeadlessService(
-	ctx context.Context,
-	clusterSpec *redpandav1alpha1.Cluster,
-	scheme *runtime.Scheme,
-) error {
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:	clusterSpec.Namespace,
-			Name:		clusterSpec.Name,
-			Labels:		clusterSpec.Labels,
-		},
-		Spec: corev1.ServiceSpec{
-			ClusterIP:	corev1.ClusterIPNone,
-			Ports: []corev1.ServicePort{
-				{
-					Name:		"kafka-tcp",
-					Protocol:	corev1.ProtocolTCP,
-					Port:		int32(clusterSpec.Spec.Configuration.KafkaAPI.Port),
-					TargetPort:	intstr.FromInt(clusterSpec.Spec.Configuration.KafkaAPI.Port),
-				},
-			},
-			Selector:	clusterSpec.Labels,
-		},
-	}
-
-	err := controllerutil.SetControllerReference(clusterSpec, svc, scheme)
-	if err != nil {
-		return err
-	}
-
-	return r.Create(ctx, svc)
-}
-
-func (r *ClusterReconciler) createBootstrapConfigMap(
-	ctx context.Context,
-	cluster *redpandav1alpha1.Cluster,
-	scheme *runtime.Scheme,
-) error {
-	serviceAddress := cluster.Name + "." + cluster.Namespace + ".svc.cluster.local"
-	cfg := config.Default()
-	cfg.Redpanda = copyConfig(&cluster.Spec.Configuration, &cfg.Redpanda)
-	cfg.Redpanda.Id = 0
-	cfg.Redpanda.AdvertisedKafkaApi.Port = cfg.Redpanda.KafkaApi.Port
-	cfg.Redpanda.AdvertisedRPCAPI.Port = cfg.Redpanda.RPCServer.Port
-	cfg.Redpanda.Directory = dataDirectory
-	cfg.Redpanda.SeedServers = []config.SeedServer{
-		{
-			Host: config.SocketAddress{
-				// Example address: cluster-sample-0.cluster-sample.default.svc.cluster.local
-				Address:	cluster.Name + "-0." + serviceAddress,
-				Port:		cfg.Redpanda.AdvertisedRPCAPI.Port,
-			},
-		},
-	}
-
-	cfgBytes, err := yaml.Marshal(cfg)
-	if err != nil {
-		return err
-	}
-
-	script :=
-		`set -xe;
-		CONFIG=` + configPath + `;
-		ORDINAL_INDEX=${HOSTNAME##*-};
-		SERVICE_NAME=${HOSTNAME}.` + serviceAddress + `
-		cp /mnt/operator/redpanda.yaml $CONFIG;
-		rpk --config $CONFIG config set redpanda.node_id $ORDINAL_INDEX;
-		if [ "$ORDINAL_INDEX" = "0" ]; then
-			rpk --config $CONFIG config set redpanda.seed_servers '[]' --format yaml;
-		fi;
-		rpk --config $CONFIG config set redpanda.advertised_rpc_api.address $SERVICE_NAME;
-		rpk --config $CONFIG config set redpanda.advertised_rpc_api.port ` + strconv.Itoa(cfg.Redpanda.AdvertisedRPCAPI.Port) + `;
-		rpk --config $CONFIG config set redpanda.advertised_kafka_api.address $SERVICE_NAME;
-		rpk --config $CONFIG config set redpanda.advertised_kafka_api.port ` + strconv.Itoa(cfg.Redpanda.AdvertisedKafkaApi.Port) + `;
-		cat $CONFIG`
-
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:	cluster.Namespace,
-			Name:		cluster.Name + baseSuffix,
-			Labels:		cluster.Labels,
-		},
-		Data: map[string]string{
-			"redpanda.yaml":	string(cfgBytes),
-			"configurator.sh":	script,
-		},
-	}
-
-	err = controllerutil.SetControllerReference(cluster, cm, scheme)
-	if err != nil {
-		return err
-	}
-
-	return r.Create(ctx, cm)
-}
-
-func copyConfig(
-	c *redpandav1alpha1.RedpandaConfig, cfgDefaults *config.RedpandaConfig,
-) config.RedpandaConfig {
-	rpcServerPort := c.RPCServer.Port
-	if c.RPCServer.Port == 0 {
-		rpcServerPort = cfgDefaults.RPCServer.Port
-	}
-
-	kafkaAPIPort := c.KafkaAPI.Port
-	if c.KafkaAPI.Port == 0 {
-		kafkaAPIPort = cfgDefaults.KafkaApi.Port
-	}
-
-	AdminAPIPort := c.AdminAPI.Port
-	if c.AdminAPI.Port == 0 {
-		AdminAPIPort = cfgDefaults.AdminApi.Port
-	}
-
-	return config.RedpandaConfig{
-		RPCServer: config.SocketAddress{
-			Address:	"0.0.0.0",
-			Port:		rpcServerPort,
-		},
-		AdvertisedRPCAPI:	&config.SocketAddress{},
-		KafkaApi: config.SocketAddress{
-			Address:	"0.0.0.0",
-			Port:		kafkaAPIPort,
-		},
-		AdvertisedKafkaApi:	&config.SocketAddress{},
-		AdminApi: config.SocketAddress{
-			Address:	"0.0.0.0",
-			Port:		AdminAPIPort,
-		},
-		DeveloperMode:	c.DeveloperMode,
-	}
-}
-
-// nolint:funlen // The definition needs further refinement
-func (r *ClusterReconciler) createBootstrapStatefulSet(
-	ctx context.Context,
-	cluster *redpandav1alpha1.Cluster,
-	scheme *runtime.Scheme,
-	configMapName string,
-) error {
-	// Default configMap mode is 0644. Adding og+x to execute configurator script.
-	var configMapDefaultMode int32 = 0754
-
-	memory, exist := cluster.Spec.Resources.Limits["memory"]
-	if !exist {
-		memory = resource.MustParse("2Gi")
-	}
-
-	ss := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:	cluster.Namespace,
-			Name:		cluster.Name,
-			Labels:		cluster.Labels,
-		},
-		Spec: appsv1.StatefulSetSpec{
-			Replicas:		pointer.Int32Ptr(1),
-			PodManagementPolicy:	appsv1.ParallelPodManagement,
-			Selector:		metav1.SetAsLabelSelector(cluster.Labels),
-			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-				Type: appsv1.RollingUpdateStatefulSetStrategyType,
-			},
-			ServiceName:	cluster.Name,
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:		cluster.Name,
-					Namespace:	cluster.Namespace,
-					Labels:		cluster.Labels,
-				},
-				Spec: corev1.PodSpec{
-					SecurityContext: &corev1.PodSecurityContext{
-						FSGroup: pointer.Int64Ptr(fsGroup),
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name:	"datadir",
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "datadir",
-								},
-							},
-						},
-						{
-							Name:	"configmap-dir",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: configMapName,
-									},
-									DefaultMode:	&configMapDefaultMode,
-								},
-							},
-						},
-						{
-							Name:	"config-dir",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-					},
-					InitContainers: []corev1.Container{
-						{
-							Name:		"redpanda-configurator",
-							Image:		cluster.Spec.Image + ":" + cluster.Spec.Version,
-							Command:	[]string{"/bin/sh", "-c"},
-							Args:		[]string{configuratorPath},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:		"config-dir",
-									MountPath:	configDir,
-								},
-								{
-									Name:		"configmap-dir",
-									MountPath:	configuratorDir,
-								},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name:	"redpanda",
-							Image:	cluster.Spec.Image + ":" + cluster.Spec.Version,
-							Args: []string{
-								"--check=false",
-								"--smp 1",
-								"--memory " + strings.ReplaceAll(memory.String(), "Gi", "G"),
-								"start",
-								"--",
-								"--default-log-level=debug",
-								"--reserve-memory 0M",
-							},
-							Ports: []corev1.ContainerPort{
-								{
-									Name:		"admin",
-									ContainerPort:	int32(cluster.Spec.Configuration.AdminAPI.Port),
-								},
-								{
-									Name:		"kafka",
-									ContainerPort:	int32(cluster.Spec.Configuration.KafkaAPI.Port),
-								},
-								{
-									Name:		"rpc",
-									ContainerPort:	int32(cluster.Spec.Configuration.RPCServer.Port),
-								},
-							},
-							Resources: corev1.ResourceRequirements{
-								Limits:		cluster.Spec.Resources.Limits,
-								Requests:	cluster.Spec.Resources.Requests,
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:		"datadir",
-									MountPath:	dataDirectory,
-								},
-								{
-									Name:		"config-dir",
-									MountPath:	configDir,
-								},
-							},
-						},
-					},
-					Affinity: &corev1.Affinity{
-						PodAntiAffinity: &corev1.PodAntiAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-								{
-									LabelSelector:	metav1.SetAsLabelSelector(cluster.Labels),
-									Namespaces:	[]string{cluster.Namespace},
-									TopologyKey:	corev1.LabelHostname},
-							},
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-								{
-									Weight:	100,
-									PodAffinityTerm: corev1.PodAffinityTerm{
-										LabelSelector:	metav1.SetAsLabelSelector(cluster.Labels),
-										Namespaces:	[]string{cluster.Namespace},
-										TopologyKey:	corev1.LabelHostname,
-									},
-								},
-							},
-						},
-					},
-					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
-						{
-							MaxSkew:		1,
-							TopologyKey:		corev1.LabelZoneFailureDomainStable,
-							WhenUnsatisfiable:	corev1.ScheduleAnyway,
-							LabelSelector:		metav1.SetAsLabelSelector(cluster.Labels),
-						},
-					},
-				},
-			},
-			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace:	cluster.Namespace,
-						Name:		"datadir",
-						Labels:		cluster.Labels,
-					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						AccessModes:	[]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								"storage": resource.MustParse("100Gi"),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	err := controllerutil.SetControllerReference(cluster, ss, scheme)
-	if err != nil {
-		return err
-	}
-
-	return r.Create(ctx, ss)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -162,7 +162,11 @@ func copyConfig(
 }
 
 func (r *ConfigMapResource) Key() types.NamespacedName {
-	return types.NamespacedName{Name: r.pandaCluster.Name + baseSuffix, Namespace: r.pandaCluster.Namespace}
+	return ConfigMapKey(r.pandaCluster)
+}
+
+func ConfigMapKey(pandaCluster *redpandav1alpha1.Cluster) types.NamespacedName {
+	return types.NamespacedName{Name: pandaCluster.Name + baseSuffix, Namespace: pandaCluster.Namespace}
 }
 
 func (r *ConfigMapResource) Kind() string {

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -1,0 +1,171 @@
+package resources
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+
+	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	baseSuffix	= "-base"
+	dataDirectory	= "/var/lib/redpanda/data"
+	fsGroup		= 101
+
+	configDir		= "/etc/redpanda"
+	configuratorDir		= "/mnt/operator"
+	configuratorScript	= "configurator.sh"
+)
+
+var (
+	configPath		= filepath.Join(configDir, "redpanda.yaml")
+	configuratorPath	= filepath.Join(configuratorDir, configuratorScript)
+)
+
+var _ Resource = &ConfigMapResource{}
+
+type ConfigMapResource struct {
+	client.Client
+	scheme		*runtime.Scheme
+	pandaCluster	*redpandav1alpha1.Cluster
+}
+
+func NewConfigMap(
+	client client.Client,
+	pandaCluster *redpandav1alpha1.Cluster,
+	scheme *runtime.Scheme,
+) *ConfigMapResource {
+	return &ConfigMapResource{
+		client, scheme, pandaCluster,
+	}
+}
+
+func (r *ConfigMapResource) Ensure(ctx context.Context) error {
+	var cfgm corev1.ConfigMap
+
+	err := r.Get(ctx, r.Key(), &cfgm)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if errors.IsNotFound(err) {
+		obj, err := r.Obj()
+		if err != nil {
+			return err
+		}
+		return r.Create(ctx, obj)
+	}
+	return nil
+}
+
+func (r *ConfigMapResource) Obj() (client.Object, error) {
+	serviceAddress := r.pandaCluster.Name + "." + r.pandaCluster.Namespace + ".svc.cluster.local"
+	cfg := config.Default()
+	cfg.Redpanda = copyConfig(&r.pandaCluster.Spec.Configuration, &cfg.Redpanda)
+	cfg.Redpanda.Id = 0
+	cfg.Redpanda.AdvertisedKafkaApi.Port = cfg.Redpanda.KafkaApi.Port
+	cfg.Redpanda.AdvertisedRPCAPI.Port = cfg.Redpanda.RPCServer.Port
+	cfg.Redpanda.Directory = dataDirectory
+	cfg.Redpanda.SeedServers = []config.SeedServer{
+		{
+			Host: config.SocketAddress{
+				// Example address: cluster-sample-0.cluster-sample.default.svc.cluster.local
+				Address:	r.pandaCluster.Name + "-0." + serviceAddress,
+				Port:		cfg.Redpanda.AdvertisedRPCAPI.Port,
+			},
+		},
+	}
+
+	cfgBytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	script :=
+		`set -xe;
+		CONFIG=` + configPath + `;
+		ORDINAL_INDEX=${HOSTNAME##*-};
+		SERVICE_NAME=${HOSTNAME}.` + serviceAddress + `
+		cp /mnt/operator/redpanda.yaml $CONFIG;
+		rpk --config $CONFIG config set redpanda.node_id $ORDINAL_INDEX;
+		if [ "$ORDINAL_INDEX" = "0" ]; then
+			rpk --config $CONFIG config set redpanda.seed_servers '[]' --format yaml;
+		fi;
+		rpk --config $CONFIG config set redpanda.advertised_rpc_api.address $SERVICE_NAME;
+		rpk --config $CONFIG config set redpanda.advertised_rpc_api.port ` + strconv.Itoa(cfg.Redpanda.AdvertisedRPCAPI.Port) + `;
+		rpk --config $CONFIG config set redpanda.advertised_kafka_api.address $SERVICE_NAME;
+		rpk --config $CONFIG config set redpanda.advertised_kafka_api.port ` + strconv.Itoa(cfg.Redpanda.AdvertisedKafkaApi.Port) + `;
+		cat $CONFIG`
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:	r.Key().Namespace,
+			Name:		r.Key().Name,
+			Labels:		r.pandaCluster.Labels,
+		},
+		Data: map[string]string{
+			"redpanda.yaml":	string(cfgBytes),
+			"configurator.sh":	script,
+		},
+	}
+	err = controllerutil.SetControllerReference(r.pandaCluster, cm, r.scheme)
+	if err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+func copyConfig(
+	c *redpandav1alpha1.RedpandaConfig, cfgDefaults *config.RedpandaConfig,
+) config.RedpandaConfig {
+	rpcServerPort := c.RPCServer.Port
+	if c.RPCServer.Port == 0 {
+		rpcServerPort = cfgDefaults.RPCServer.Port
+	}
+
+	kafkaAPIPort := c.KafkaAPI.Port
+	if c.KafkaAPI.Port == 0 {
+		kafkaAPIPort = cfgDefaults.KafkaApi.Port
+	}
+
+	AdminAPIPort := c.AdminAPI.Port
+	if c.AdminAPI.Port == 0 {
+		AdminAPIPort = cfgDefaults.AdminApi.Port
+	}
+
+	return config.RedpandaConfig{
+		RPCServer: config.SocketAddress{
+			Address:	"0.0.0.0",
+			Port:		rpcServerPort,
+		},
+		AdvertisedRPCAPI:	&config.SocketAddress{},
+		KafkaApi: config.SocketAddress{
+			Address:	"0.0.0.0",
+			Port:		kafkaAPIPort,
+		},
+		AdvertisedKafkaApi:	&config.SocketAddress{},
+		AdminApi: config.SocketAddress{
+			Address:	"0.0.0.0",
+			Port:		AdminAPIPort,
+		},
+		DeveloperMode:	c.DeveloperMode,
+	}
+}
+
+func (r *ConfigMapResource) Key() types.NamespacedName {
+	return types.NamespacedName{Name: r.pandaCluster.Name + baseSuffix, Namespace: r.pandaCluster.Namespace}
+}
+
+func (r *ConfigMapResource) Kind() string {
+	var cfg corev1.ConfigMap
+	return cfg.Kind
+}

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -1,0 +1,16 @@
+package resources
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Resource interface {
+	Obj() (client.Object, error)
+	Key() types.NamespacedName
+	Kind() string
+
+	Ensure(ctx context.Context) error
+}

--- a/src/go/k8s/pkg/resources/service.go
+++ b/src/go/k8s/pkg/resources/service.go
@@ -1,0 +1,88 @@
+package resources
+
+import (
+	"context"
+
+	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ Resource = &ServiceResource{}
+
+type ServiceResource struct {
+	client.Client
+	scheme		*runtime.Scheme
+	pandaCluster	*redpandav1alpha1.Cluster
+}
+
+func NewService(
+	client client.Client,
+	pandaCluster *redpandav1alpha1.Cluster,
+	scheme *runtime.Scheme,
+) *ServiceResource {
+	return &ServiceResource{
+		client, scheme, pandaCluster,
+	}
+}
+
+func (r *ServiceResource) Ensure(ctx context.Context) error {
+	var svc corev1.Service
+
+	err := r.Get(ctx, r.Key(), &svc)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if errors.IsNotFound(err) {
+		obj, err := r.Obj()
+		if err != nil {
+			return err
+		}
+		return r.Create(ctx, obj)
+	}
+	return nil
+}
+
+func (r *ServiceResource) Obj() (client.Object, error) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:	r.Key().Namespace,
+			Name:		r.Key().Name,
+			Labels:		r.pandaCluster.Labels,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP:	corev1.ClusterIPNone,
+			Ports: []corev1.ServicePort{
+				{
+					Name:		"kafka-tcp",
+					Protocol:	corev1.ProtocolTCP,
+					Port:		int32(r.pandaCluster.Spec.Configuration.KafkaAPI.Port),
+					TargetPort:	intstr.FromInt(r.pandaCluster.Spec.Configuration.KafkaAPI.Port),
+				},
+			},
+			Selector:	r.pandaCluster.Labels,
+		},
+	}
+
+	err := controllerutil.SetControllerReference(r.pandaCluster, svc, r.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return svc, nil
+}
+
+func (r *ServiceResource) Key() types.NamespacedName {
+	return types.NamespacedName{Name: r.pandaCluster.Name, Namespace: r.pandaCluster.Namespace}
+}
+
+func (r *ServiceResource) Kind() string {
+	var svc corev1.Service
+	return svc.Kind
+}

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -112,7 +112,7 @@ func (r *StatefulSetResource) Obj() (client.Object, error) {
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: r.pandaCluster.Name + baseSuffix,	// TODO extract this
+										Name: ConfigMapKey(r.pandaCluster).Name,
 									},
 									DefaultMode:	&configMapDefaultMode,
 								},

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -1,0 +1,254 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ Resource = &StatefulSetResource{}
+
+type StatefulSetResource struct {
+	client.Client
+	scheme		*runtime.Scheme
+	pandaCluster	*redpandav1alpha1.Cluster
+
+	LastObservedState	*appsv1.StatefulSet
+}
+
+func NewStatefulSet(
+	client client.Client,
+	pandaCluster *redpandav1alpha1.Cluster,
+	scheme *runtime.Scheme,
+) *StatefulSetResource {
+	return &StatefulSetResource{
+		client, scheme, pandaCluster, nil,
+	}
+}
+
+func (r *StatefulSetResource) Ensure(ctx context.Context) error {
+	var sts appsv1.StatefulSet
+
+	err := r.Get(ctx, r.Key(), &sts)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if errors.IsNotFound(err) {
+		obj, err := r.Obj()
+		if err != nil {
+			return err
+		}
+		err = r.Create(ctx, obj)
+		r.LastObservedState = obj.(*appsv1.StatefulSet)
+		return err
+	}
+	r.LastObservedState = &sts
+
+	// Ensure StatefulSet #replicas equals cluster requirement.
+	if sts.Spec.Replicas != r.pandaCluster.Spec.Replicas {
+		sts.Spec.Replicas = r.pandaCluster.Spec.Replicas
+		if err = r.Update(ctx, &sts); err != nil {
+			return fmt.Errorf("Failed to update StatefulSet: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *StatefulSetResource) Obj() (client.Object, error) {
+	var configMapDefaultMode int32 = 0754
+	memory, exist := r.pandaCluster.Spec.Resources.Limits["memory"]
+	if !exist {
+		memory = resource.MustParse("2Gi")
+	}
+
+	ss := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:	r.Key().Namespace,
+			Name:		r.Key().Name,
+			Labels:		r.pandaCluster.Labels,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:		pointer.Int32Ptr(1),
+			PodManagementPolicy:	appsv1.ParallelPodManagement,
+			Selector:		metav1.SetAsLabelSelector(r.pandaCluster.Labels),
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+			ServiceName:	r.pandaCluster.Name,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:		r.pandaCluster.Name,
+					Namespace:	r.pandaCluster.Namespace,
+					Labels:		r.pandaCluster.Labels,
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: pointer.Int64Ptr(fsGroup),
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name:	"datadir",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "datadir",
+								},
+							},
+						},
+						{
+							Name:	"configmap-dir",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: r.pandaCluster.Name + baseSuffix,	// TODO extract this
+									},
+									DefaultMode:	&configMapDefaultMode,
+								},
+							},
+						},
+						{
+							Name:	"config-dir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:		"redpanda-configurator",
+							Image:		r.pandaCluster.Spec.Image + ":" + r.pandaCluster.Spec.Version,
+							Command:	[]string{"/bin/sh", "-c"},
+							Args:		[]string{configuratorPath},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:		"config-dir",
+									MountPath:	configDir,
+								},
+								{
+									Name:		"configmap-dir",
+									MountPath:	configuratorDir,
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:	"redpanda",
+							Image:	r.pandaCluster.Spec.Image + ":" + r.pandaCluster.Spec.Version,
+							Args: []string{
+								"--check=false",
+								"--smp 1",
+								"--memory " + strings.ReplaceAll(memory.String(), "Gi", "G"),
+								"start",
+								"--",
+								"--default-log-level=debug",
+								"--reserve-memory 0M",
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:		"admin",
+									ContainerPort:	int32(r.pandaCluster.Spec.Configuration.AdminAPI.Port),
+								},
+								{
+									Name:		"kafka",
+									ContainerPort:	int32(r.pandaCluster.Spec.Configuration.KafkaAPI.Port),
+								},
+								{
+									Name:		"rpc",
+									ContainerPort:	int32(r.pandaCluster.Spec.Configuration.RPCServer.Port),
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits:		r.pandaCluster.Spec.Resources.Limits,
+								Requests:	r.pandaCluster.Spec.Resources.Requests,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:		"datadir",
+									MountPath:	dataDirectory,
+								},
+								{
+									Name:		"config-dir",
+									MountPath:	configDir,
+								},
+							},
+						},
+					},
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector:	metav1.SetAsLabelSelector(r.pandaCluster.Labels),
+									Namespaces:	[]string{r.pandaCluster.Namespace},
+									TopologyKey:	corev1.LabelHostname},
+							},
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight:	100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector:	metav1.SetAsLabelSelector(r.pandaCluster.Labels),
+										Namespaces:	[]string{r.pandaCluster.Namespace},
+										TopologyKey:	corev1.LabelHostname,
+									},
+								},
+							},
+						},
+					},
+					TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+						{
+							MaxSkew:		1,
+							TopologyKey:		corev1.LabelZoneFailureDomainStable,
+							WhenUnsatisfiable:	corev1.ScheduleAnyway,
+							LabelSelector:		metav1.SetAsLabelSelector(r.pandaCluster.Labels),
+						},
+					},
+				},
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:	r.pandaCluster.Namespace,
+						Name:		"datadir",
+						Labels:		r.pandaCluster.Labels,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes:	[]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"storage": resource.MustParse("100Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := controllerutil.SetControllerReference(r.pandaCluster, ss, r.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return ss, nil
+}
+
+func (r *StatefulSetResource) Key() types.NamespacedName {
+	return types.NamespacedName{Name: r.pandaCluster.Name, Namespace: r.pandaCluster.Namespace}
+}
+
+func (r *StatefulSetResource) Kind() string {
+	var statefulSet appsv1.StatefulSet
+	return statefulSet.Kind
+}


### PR DESCRIPTION
This is a proposal to split main reconcile loop into smaller chunks per resource type. That `Ensure()` function should then encapsulate create/update logic.

The goal is not to create future-proof abstraction rather something lightweight that we can build upon.

For reference, I've seen similar pattern in many operators e.g. https://github.com/cockroachdb/cockroach-operator or https://github.com/banzaicloud/kafka-operator

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
