### PR TITLE
Do not use seed server ids

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -268,8 +268,9 @@ members_manager::dispatch_join_to_seed_server(seed_iterator it) {
         }
         vlog(
           clusterlog.info,
-          "Error joining cluster using {} seed server",
-          it->id);
+          "Error joining cluster using {} seed server - {}",
+          it->id,
+          fut.get_exception());
 
         // Dispatch to next server
         return dispatch_join_to_seed_server(std::next(it));

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -211,10 +211,7 @@ ss::future<result<join_reply>> members_manager::dispatch_join_to_remote(
       target.id,
       target.addr);
 
-    return with_client<controller_client_protocol>(
-      _self.id(),
-      _connection_cache,
-      target.id,
+    return do_with_client_one_shot<controller_client_protocol>(
       target.addr,
       _rpc_tls_config,
       [joining_node = std::move(joining_node),

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -205,11 +205,7 @@ wait_for_next_join_retry(std::chrono::milliseconds tout, ss::abort_source& as) {
 
 ss::future<result<join_reply>> members_manager::dispatch_join_to_remote(
   const config::seed_server& target, model::broker joining_node) {
-    vlog(
-      clusterlog.info,
-      "Sending join request to {} @ {}",
-      target.id,
-      target.addr);
+    vlog(clusterlog.info, "Sending join request to {}", target.addr);
 
     return do_with_client_one_shot<controller_client_protocol>(
       target.addr,
@@ -252,7 +248,7 @@ members_manager::dispatch_join_to_seed_server(seed_iterator it) {
         return f;
     }
     // Current node is a seed server, just call the method
-    if (it->id == _self.id()) {
+    if (it->addr == _self.rpc_address()) {
         vlog(clusterlog.debug, "Using current node as a seed server");
         f = handle_join_request(_self);
     } else {
@@ -269,7 +265,7 @@ members_manager::dispatch_join_to_seed_server(seed_iterator it) {
         vlog(
           clusterlog.info,
           "Error joining cluster using {} seed server - {}",
-          it->id,
+          it->addr,
           fut.get_exception());
 
         // Dispatch to next server

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -76,9 +76,7 @@ public:
       model::node_id node_id, int kafka_port = 9092, int rpc_port = 11000) {
         std::vector<config::seed_server> seeds = {};
         if (node_id != 0) {
-            seeds.push_back(
-              {.id = model::node_id{0},
-               .addr = unresolved_address("127.0.0.1", 11000)});
+            seeds.push_back({.addr = unresolved_address("127.0.0.1", 11000)});
         }
         add_controller(
           node_id,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -178,19 +178,43 @@ struct convert<config::seed_server> {
     using type = config::seed_server;
     static Node encode(const type& rhs) {
         Node node;
-        node["node_id"] = rhs.id();
-        node["host"] = rhs.addr;
+        node = rhs.addr;
         return node;
     }
+
+    /**
+     * We support two seed server YAML representations:
+     *
+     *  1) Old one
+     *      seed_servers:
+     *      - host:
+     *          address: ...
+     *          port: ...
+     *        node_id : ...
+     *
+     *  2) New one
+     *      seed_servers:
+     *      - address: ...
+     *        port: ...
+     *      - address:
+     *        port: ...
+     *
+     * Node id field is not used
+     *
+     */
     static bool decode(const Node& node, type& rhs) {
         // Required fields
-        for (auto s : {"node_id", "host"}) {
-            if (!node[s]) {
-                return false;
-            }
+        if (!node["host"] && !node["address"]) {
+            return false;
         }
-        rhs.id = model::node_id(node["node_id"].as<int32_t>());
-        rhs.addr = node["host"].as<unresolved_address>();
+
+        if (node["host"]) {
+            rhs.addr = node["host"].as<unresolved_address>();
+            return true;
+        } else {
+            rhs.addr = node.as<unresolved_address>();
+        }
+
         return true;
     }
 };

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -25,9 +25,6 @@ void rjson_serialize(
 void rjson_serialize(
   rapidjson::Writer<rapidjson::StringBuffer>& w, const config::seed_server& v) {
     w.StartObject();
-    w.Key("node_id");
-    rjson_serialize(w, v.id());
-
     w.Key("host");
     rjson_serialize(w, v.addr);
     w.EndObject();

--- a/src/v/config/seed_server.h
+++ b/src/v/config/seed_server.h
@@ -20,14 +20,13 @@
 
 namespace config {
 struct seed_server {
-    model::node_id id;
     unresolved_address addr;
 };
 } // namespace config
 
 namespace std {
 static inline ostream& operator<<(ostream& o, const config::seed_server& s) {
-    fmt::print(o, "node_id: {}, addr: {}", s.id, s.addr);
+    fmt::print(o, "addr: {}", s.addr);
     return o;
 }
 } // namespace std

--- a/src/v/config/seed_server.h
+++ b/src/v/config/seed_server.h
@@ -21,6 +21,8 @@
 namespace config {
 struct seed_server {
     unresolved_address addr;
+
+    bool operator==(const seed_server&) const = default;
 };
 } // namespace config
 

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -30,3 +30,9 @@ rp_test(
   LIBRARIES v::seastar_testing_main v::config
 
 )
+rp_test(
+  UNIT_TEST
+  BINARY_NAME seed_server_property_test
+  SOURCES seed_server_property_test.cc
+  LIBRARIES v::seastar_testing_main v::config
+)

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -1,38 +1,12 @@
+set(srcs
+    config_store_test.cc
+    socket_address_convert_test.cc
+    tls_config_convert_test.cc
+    advertised_kafka_api_test.cc
+    seed_server_property_test.cc)
 
 rp_test(
   UNIT_TEST
-  BINARY_NAME config_store_test
-  SOURCES config_store_test.cc
-  LIBRARIES v::seastar_testing_main v::config
-
-)
-
-rp_test(
-  UNIT_TEST
-  BINARY_NAME socket_address_yaml_convert_test
-  SOURCES socket_address_convert_test.cc
-  LIBRARIES v::seastar_testing_main v::config
-
-)
-
-rp_test(
-  UNIT_TEST
-  BINARY_NAME tls_config_convert_test
-  SOURCES tls_config_convert_test.cc
-  LIBRARIES v::seastar_testing_main v::config
-
-)
-
-rp_test(
-  UNIT_TEST
-  BINARY_NAME advertised_kafka_api_test
-  SOURCES advertised_kafka_api_test.cc
-  LIBRARIES v::seastar_testing_main v::config
-
-)
-rp_test(
-  UNIT_TEST
-  BINARY_NAME seed_server_property_test
-  SOURCES seed_server_property_test.cc
-  LIBRARIES v::seastar_testing_main v::config
-)
+  BINARY_NAME test_configuration
+  SOURCES ${srcs}
+  LIBRARIES v::seastar_testing_main v::config)

--- a/src/v/config/tests/seed_server_property_test.cc
+++ b/src/v/config/tests/seed_server_property_test.cc
@@ -1,0 +1,108 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/configuration.h"
+#include "config/seed_server.h"
+#include "utils/unresolved_address.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+static auto const old_seed_server_format = R"(
+redpanda:
+  data_directory: /var/lib/redpanda/data
+  node_id: 1
+  rpc_server:
+    address: 127.0.0.1
+    port: 33145
+  kafka_api:
+    address: 192.168.1.1
+    port: 9999
+  seed_servers:
+    - host: 
+        address: 1.2.3.4
+        port: 1234
+      node_id: 1
+    - host: 
+        address: 4.3.2.1
+        port: 4321
+      node_id: 2
+  admin:
+    address: 127.0.0.1
+    port: 9644)";
+
+static auto const old_seed_server_format_no_id = R"(
+redpanda:
+  data_directory: /var/lib/redpanda/data
+  node_id: 1
+  rpc_server:
+    address: 127.0.0.1
+    port: 33145
+  kafka_api:
+    address: 192.168.1.1
+    port: 9999
+  seed_servers:
+     - host: 
+        address: 1.2.3.4
+        port: 1234
+     - host: 
+        address: 4.3.2.1
+        port: 4321
+  admin:
+    address: 127.0.0.1
+    port: 9644)";
+
+static auto const new_seed_server_format = R"(
+redpanda:
+  data_directory: /var/lib/redpanda/data"
+  node_id: 1
+  rpc_server:
+    address: 127.0.0.1
+    port: 33145
+  kafka_api:
+    address: 192.168.1.1
+    port: 9999
+  seed_servers:
+     - address: 1.2.3.4
+       port: 1234
+     - address: 4.3.2.1
+       port: 4321
+  admin:
+    address: 127.0.0.1
+    port: 9644)";
+
+YAML::Node read_old_seed_server_format() {
+    return YAML::Load(old_seed_server_format);
+}
+
+YAML::Node read_old_seed_server_format_no_id() {
+    return YAML::Load(old_seed_server_format_no_id);
+}
+
+YAML::Node read_new_seed_server_format() {
+    return YAML::Load(new_seed_server_format);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_seed_servers_yaml_parsing) {
+    config::configuration old_seed;
+    config::configuration old_seed_no_id;
+    config::configuration new_seed;
+
+    old_seed.read_yaml(read_old_seed_server_format());
+    old_seed_no_id.read_yaml(read_old_seed_server_format_no_id());
+    new_seed.read_yaml(read_new_seed_server_format());
+
+    BOOST_REQUIRE_EQUAL(
+      new_seed.seed_servers()[0],
+      config::seed_server{unresolved_address("1.2.3.4", 1234)});
+    BOOST_REQUIRE_EQUAL(
+      new_seed.seed_servers()[1],
+      config::seed_server{unresolved_address("4.3.2.1", 4321)});
+    BOOST_REQUIRE_EQUAL(old_seed.seed_servers(), new_seed.seed_servers());
+    BOOST_REQUIRE_EQUAL(old_seed_no_id.seed_servers(), new_seed.seed_servers());
+};

--- a/src/v/config/tests/socket_address_convert_test.cc
+++ b/src/v/config/tests/socket_address_convert_test.cc
@@ -33,7 +33,7 @@ auto hostname_address_str = "test_addr:\n"
 ss::socket_address ip4_addr = ss::socket_address(
   ss::ipv4_addr("192.168.0.1", 6547));
 
-ss::socket_address read_from_yaml(ss::sstring yaml_string) {
+ss::socket_address read_socket_from_yaml(ss::sstring yaml_string) {
     auto node = YAML::Load(yaml_string);
     return node["test_addr"].as<ss::socket_address>();
 }
@@ -41,13 +41,13 @@ ss::socket_address read_from_yaml(ss::sstring yaml_string) {
 SEASTAR_THREAD_TEST_CASE(write_as_yaml) {}
 
 SEASTAR_THREAD_TEST_CASE(test_decode_ipv4) {
-    auto ip4 = read_from_yaml(ipv4_address_str);
+    auto ip4 = read_socket_from_yaml(ipv4_address_str);
 
     BOOST_TEST(ip4.port() == 6547);
     BOOST_TEST(ip4.addr().is_ipv4());
     BOOST_TEST(ip4.addr().as_ipv4_address().ip == 0xC0A80001);
 
-    auto ip6 = read_from_yaml(ipv6_address_str);
+    auto ip6 = read_socket_from_yaml(ipv6_address_str);
 
     BOOST_TEST(ip6.port() == 7777);
     BOOST_TEST(ip6.addr().is_ipv6());
@@ -70,13 +70,13 @@ SEASTAR_THREAD_TEST_CASE(test_decode_ipv4) {
       0x34};
     BOOST_TEST(ip6.addr().as_ipv6_address().ip == expected_ip6);
 
-    auto all_interfaces = read_from_yaml(all_interfaces_address_str);
+    auto all_interfaces = read_socket_from_yaml(all_interfaces_address_str);
 
     BOOST_TEST(all_interfaces.port() == 3214);
     BOOST_TEST(all_interfaces.addr().is_ipv4());
     BOOST_TEST(all_interfaces.addr().as_ipv4_address().ip == 0x00000000);
 
-    auto host_name = read_from_yaml(hostname_address_str);
+    auto host_name = read_socket_from_yaml(hostname_address_str);
 
     BOOST_TEST(host_name.port() == 1234);
     BOOST_TEST(host_name.addr().is_ipv4());


### PR DESCRIPTION
Made `id` an optional field in seed_server configuration. Even if node id is present it will not be used.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
