### PR TITLE
Lower environment sending error to debug level.

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -763,7 +763,7 @@ func sendEnv(
 	confJSON, err := mgr.ReadAsJSON(conf.ConfigFile)
 	if err != nil {
 		log.Warnf(
-			"Couldn't send latest config at '%s' due to: %s",
+			"Couldn't parse latest config at '%s' due to: %s",
 			conf.ConfigFile,
 			err,
 		)
@@ -778,7 +778,7 @@ func sendEnv(
 	}
 	err = api.SendEnvironment(fs, env, *conf, confJSON)
 	if err != nil {
-		log.Warnf("couldn't send environment data: %v", err)
+		log.Debugf("couldn't send environment data: %v", err)
 	}
 }
 


### PR DESCRIPTION
When rpk fails to connect to our metrics endpoint an error is produced
eg When host CAs are missing `couldn't send environment data: Post https://m.rp.vectorized.io/env: x509: certificate signed by unknown authority.`

Errors like that could alarm customers with no good reason.
Previous parsing and marshalling errors are left at want level, since
they could indicate configuration issues.