### PR TITLE
Feature/archival ntp service

### DIFF
--- a/src/v/archival/CMakeLists.txt
+++ b/src/v/archival/CMakeLists.txt
@@ -2,6 +2,8 @@
 v_cc_library(
   NAME archival
   SRCS
+    archival_policy.cc
+    ntp_archiver_service.cc
     manifest.cc
   DEPS
     Seastar::seastar

--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/archival_policy.h"
+
+#include "storage/disk_log_impl.h"
+#include "storage/segment.h"
+#include "storage/segment_set.h"
+
+namespace archival {
+
+class arch_policy_non_compacted_impl {
+public:
+    arch_policy_non_compacted_impl(
+      model::ntp ntp, const model::revision_id& rev)
+      : _ntp(std::move(ntp))
+      , _rev(rev) {}
+
+    std::optional<manifest> make_local_manifest(storage::log_manager& lm) {
+        manifest tmp(_ntp, _rev);
+        std::optional<storage::log> log = lm.get(_ntp);
+        if (!log) {
+            return std::nullopt;
+        }
+        auto plog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+        if (plog == nullptr) {
+            return std::nullopt;
+        }
+        for (const auto& segment : plog->segments()) {
+            bool closed = !segment->has_appender();
+            bool compacted = segment->is_compacted_segment();
+            if (!closed || compacted) {
+                continue;
+            }
+            manifest::segment_meta meta{
+              .is_compacted = segment->is_compacted_segment(),
+              .size_bytes = segment->size_bytes(),
+              .base_offset = segment->offsets().base_offset,
+              .committed_offset = segment->offsets().committed_offset,
+              .is_deleted_locally = false,
+            };
+            auto path = std::filesystem::path(segment->reader().filename());
+            auto seg_name = path.filename().string();
+            // generate segment path
+            tmp.add(segment_name(seg_name), meta);
+        }
+        return tmp;
+    }
+
+private:
+    model::ntp _ntp;
+    model::revision_id _rev;
+};
+
+template<class PolicyImpl>
+class manifest_based_policy final
+  : public PolicyImpl
+  , public archival_policy_base {
+public:
+    manifest_based_policy(const model::ntp& ntp, const model::revision_id& rev)
+      : PolicyImpl(ntp, rev) {}
+
+    std::optional<manifest> generate_upload_set(
+      const manifest& remote, storage::log_manager& lm) final {
+        auto local = PolicyImpl::make_local_manifest(lm);
+        if (!local) {
+            return local;
+        }
+        return local->difference(remote);
+    }
+
+    std::optional<manifest> generate_delete_set(
+      const manifest& remote, storage::log_manager& lm) final {
+        auto local = PolicyImpl::make_local_manifest(lm);
+        if (!local) {
+            return local;
+        }
+        return remote.difference(*local);
+    }
+};
+
+using manifest_based_policy_non_compacted
+  = manifest_based_policy<arch_policy_non_compacted_impl>;
+
+std::unique_ptr<archival_policy_base> make_archival_policy(
+  [[maybe_unused]] upload_policy_selector e,
+  [[maybe_unused]] delete_policy_selector d,
+  model::ntp ntp,
+  model::revision_id rev) {
+    return std::make_unique<manifest_based_policy_non_compacted>(ntp, rev);
+}
+} // namespace archival

--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "archival/manifest.h"
+#include "model/fundamental.h"
+#include "storage/log_manager.h"
+
+namespace archival {
+
+/// Policy that controls how archiver picks upload candidates
+enum class upload_policy_selector {
+    /// Archive only original, non-compacted segments
+    archive_non_compacted,
+};
+
+/// Policy that controls how archiver picks delete candidates
+enum class delete_policy_selector {
+    /// Don't keep segments in S3 if they're deleted localy
+    do_not_keep,
+};
+
+class upload_policy_base {
+public:
+    /// \brief Generate list of segments that should be uploaded to S3
+    ///
+    /// \param remote is a remote manifest (cached or downloade)
+    /// \param lm is log manager
+    virtual std::optional<manifest>
+    generate_upload_set(const manifest& remote, storage::log_manager& lm) = 0;
+};
+
+class delete_policy_base {
+public:
+    /// \brief Generate list of segments that should be remove from S3
+    ///
+    /// \param remote is a remote manifest (cached or downloade)
+    /// \param lm is log manager
+    virtual std::optional<manifest>
+    generate_delete_set(const manifest& remote, storage::log_manager& lm) = 0;
+};
+
+/// Archiving policy implementation interface
+class archival_policy_base
+  : public upload_policy_base
+  , public delete_policy_base {
+public:
+    archival_policy_base() = default;
+    virtual ~archival_policy_base() = default;
+    archival_policy_base(const archival_policy_base&) = delete;
+    archival_policy_base(archival_policy_base&&) = delete;
+    archival_policy_base& operator=(const archival_policy_base&) = delete;
+    archival_policy_base& operator=(archival_policy_base&&) = delete;
+};
+
+std::unique_ptr<archival_policy_base> make_archival_policy(
+  upload_policy_selector e,
+  delete_policy_selector d,
+  model::ntp ntp,
+  model::revision_id rev);
+} // namespace archival

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/ntp_archiver_service.h"
+
+#include "archival/logger.h"
+#include "model/metadata.h"
+#include "s3/client.h"
+#include "s3/error.h"
+#include "storage/disk_log_impl.h"
+#include "storage/fs_utils.h"
+#include "utils/gate_guard.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <fmt/format.h>
+
+#include <stdexcept>
+
+namespace archival {
+
+ntp_archiver::ntp_archiver(
+  const storage::ntp_config& ntp, const configuration& conf)
+  : _ntp(ntp.ntp())
+  , _rev(ntp.get_revision())
+  , _client_conf(conf.client_config)
+  , _policy(
+      make_archival_policy(conf.upload_policy, conf.delete_policy, _ntp, _rev))
+  , _bucket(conf.bucket_name)
+  , _remote(_ntp, _rev)
+  , _gate() {
+    vlog(archival_log.trace, "Create ntp_archiver {}", _ntp.path());
+}
+
+ss::future<> ntp_archiver::stop() { return _gate.close(); }
+
+const model::ntp& ntp_archiver::get_ntp() const { return _ntp; }
+
+const ss::lowres_clock::time_point ntp_archiver::get_last_upload_time() const {
+    return _last_upload_time;
+}
+
+const ss::lowres_clock::time_point ntp_archiver::get_last_delete_time() const {
+    return _last_delete_time;
+}
+
+ss::future<bool> ntp_archiver::download_manifest() {
+    gate_guard guard{_gate};
+    auto key = _remote.get_manifest_path();
+    vlog(archival_log.trace, "Download manifest {}", key());
+    auto path = s3::object_key(key());
+    s3::client client(_client_conf);
+    try {
+        auto resp = co_await client.get_object(_bucket, path);
+        co_await _remote.update(resp->as_input_stream());
+    } catch (const s3::rest_error_response& err) {
+        if (err.code() == "NoSuchKey") {
+            // This can happen when we're dealing with new partition for which
+            // manifest wasn't uploaded. But also, this can appen if we uploaded
+            // the first segment and crashed before we were able to upload the
+            // manifest. This shouldn't be the problem though. We will just
+            // re-upload this segment for once.
+            co_return false;
+        }
+        throw;
+    }
+    co_await client.shutdown();
+    co_return true;
+}
+
+ss::future<> ntp_archiver::upload_manifest() {
+    gate_guard guard{_gate};
+    auto key = _remote.get_manifest_path();
+    vlog(archival_log.trace, "Upload manifest {}", key());
+    auto path = s3::object_key(key());
+    auto [is, size] = _remote.serialize();
+    s3::client client(_client_conf);
+    co_await client.put_object(_bucket, path, size, std::move(is));
+    co_await client.shutdown();
+    co_return;
+}
+
+const manifest& ntp_archiver::get_remote_manifest() const { return _remote; }
+
+/// Returns true if segment matches the metadata
+static bool validate_metadata(
+  const ss::lw_shared_ptr<storage::segment>& segment,
+  const manifest::segment_meta& meta) {
+    // If the metadata don't match the segment then the
+    // local manifest needs to be updated. This can happen when
+    // segment was compacted after updated_local_manifest was
+    // called.
+    //
+    // We shouldn't upload this segment right away because it
+    // might not match the policy.
+    return meta.is_compacted == segment->is_compacted_segment()
+           && meta.size_bytes == segment->size_bytes()
+           && meta.base_offset == segment->offsets().base_offset
+           && meta.committed_offset == segment->offsets().committed_offset;
+}
+
+ss::future<bool> ntp_archiver::upload_segment(
+  manifest::segment_map::value_type target, storage::log_manager& lm) {
+    vlog(archival_log.trace, "Upload {} segments", target.first);
+    s3::client client(_client_conf);
+    const auto& [sname, meta] = target;
+    auto segment = get_segment(sname, lm);
+    if (segment) {
+        // match segment with metadata
+        if (!validate_metadata(segment, meta)) {
+            co_return false;
+        }
+        auto stream = segment->offset_data_stream(
+          meta.base_offset, ss::default_priority_class());
+        auto s3path = _remote.get_remote_segment_path(sname);
+        vlog(archival_log.trace, "Uploading segment \"{}\" to S3", s3path());
+        try {
+            co_await client.put_object(
+              _bucket,
+              s3::object_key(s3path()),
+              segment->size_bytes(),
+              std::move(stream));
+            vlog(
+              archival_log.trace, "Completed segment \"{}\" to S3", s3path());
+            _remote.add(sname, meta);
+        } catch (...) {
+            vlog(
+              archival_log.error,
+              "Failed to upload {} to S3. Reason: {}",
+              sname,
+              std::current_exception());
+            co_return false;
+        }
+    } else {
+        vlog(archival_log.error, "Can't find segment {}", sname());
+    }
+    co_return true;
+}
+
+ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidate(
+  ss::semaphore& req_limit, storage::log_manager& lm) {
+    vlog(archival_log.trace, "Uploading next candidate called");
+    gate_guard guard{_gate};
+    // calculate candidate set
+    auto candidates = _policy->generate_upload_set(_remote, lm);
+    if (!candidates) {
+        vlog(archival_log.error, "Failed to generate upload candidates");
+        co_return batch_result{};
+    }
+    auto num_candidates = std::min(
+      static_cast<ssize_t>(candidates->size()), req_limit.available_units());
+    if (num_candidates == 0) {
+        co_return batch_result{};
+    }
+    // NOTE: here consume API is used because we don't want the number of
+    // available semaphore units to change.
+    auto sem_units = ss::consume_units(req_limit, num_candidates);
+    std::vector<manifest::segment_map::value_type> upload_set;
+    std::copy_n(
+      candidates->begin(), num_candidates, std::back_inserter(upload_set));
+    vlog(archival_log.trace, "Upload {} elements", upload_set.size());
+    s3::client client(_client_conf);
+    batch_result result{};
+    auto fut = ss::parallel_for_each(
+      upload_set,
+      [this, &lm, &result](manifest::segment_map::value_type target) {
+          return upload_segment(std::move(target), lm).then([&result](bool ok) {
+              if (ok) {
+                  result.succeded++;
+              } else {
+                  result.failed++;
+              }
+          });
+      });
+    co_await std::move(fut);
+    if (num_candidates) {
+        vlog(archival_log.trace, "Completed S3 upload");
+        co_await client.shutdown();
+        co_await upload_manifest();
+        _last_upload_time = ss::lowres_clock::now();
+    }
+    co_return result;
+}
+
+ss::future<bool> ntp_archiver::delete_segment(
+  manifest::segment_map::value_type target, storage::log_manager& lm) {
+    const auto& [sname, meta] = target;
+    auto segment = get_segment(sname, lm);
+    if (!segment) {
+        s3::client client(_client_conf);
+        auto s3path = _remote.get_remote_segment_path(sname);
+        vlog(archival_log.trace, "Delete segment \"{}\" from S3", s3path());
+        try {
+            co_await client.delete_object(_bucket, s3::object_key(s3path()));
+            _remote.delete_permanently(sname);
+        } catch (...) {
+            vlog(
+              archival_log.error,
+              "Failed to delete {} from S3. Reason: {}",
+              sname,
+              std::current_exception());
+            co_return false;
+        }
+    }
+    co_return true;
+}
+
+ss::future<ntp_archiver::batch_result> ntp_archiver::delete_next_candidate(
+  ss::semaphore& req_limit, storage::log_manager& lm) {
+    vlog(archival_log.trace, "Delete next candidate called");
+    gate_guard guard{_gate};
+    // calculate candidate set
+    auto candidates = _policy->generate_delete_set(_remote, lm);
+    if (!candidates) {
+        vlog(archival_log.error, "Failed to generate candidates for deletion");
+        co_return batch_result{};
+    }
+    auto num_candidates = std::min(
+      static_cast<ssize_t>(candidates->size()), req_limit.available_units());
+    if (num_candidates == 0) {
+        co_return batch_result{};
+    }
+    std::vector<manifest::segment_map::value_type> delete_set;
+    std::copy_n(
+      candidates->begin(), num_candidates, std::back_inserter(delete_set));
+    vlog(archival_log.trace, "Delete {} elements", delete_set.size());
+    // upload segments in parallel
+    batch_result result{};
+    s3::client client(_client_conf);
+    auto fut = ss::parallel_for_each(
+      delete_set,
+      [this, &lm, &result](manifest::segment_map::value_type target) {
+          return delete_segment(std::move(target), lm).then([&result](bool ok) {
+              if (ok) {
+                  result.succeded++;
+              } else {
+                  result.failed++;
+              }
+          });
+      });
+    co_await std::move(fut);
+    if (num_candidates) {
+        vlog(archival_log.trace, "Completed S3 upload");
+        co_await client.shutdown();
+        co_await upload_manifest();
+        _last_upload_time = ss::lowres_clock::now();
+    }
+    co_return result;
+}
+
+ss::lw_shared_ptr<storage::segment>
+ntp_archiver::get_segment(segment_name path, storage::log_manager& lm) {
+    std::optional<storage::log> log = lm.get(_ntp);
+    if (!log) {
+        vlog(archival_log.trace, "log for {} not found", _ntp);
+        return nullptr;
+    }
+    auto plog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+    if (plog == nullptr) {
+        return nullptr;
+    }
+    std::filesystem::path target_path(path());
+    for (auto& segment : plog->segments()) {
+        auto segment_path = std::filesystem::path(segment->reader().filename())
+                              .filename()
+                              .string();
+        vlog(
+          archival_log.trace,
+          "comparing segment names {} and {}",
+          segment_path,
+          target_path);
+        if (segment_path == target_path) {
+            return segment;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace archival

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+#include "archival/archival_policy.h"
+#include "archival/manifest.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "s3/client.h"
+#include "storage/api.h"
+#include "storage/log_manager.h"
+#include "storage/ntp_config.h"
+#include "storage/segment.h"
+#include "storage/segment_set.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/lowres_clock.hh>
+
+namespace archival {
+
+/// Number of simultaneous connections to S3
+using s3_connection_limit
+  = named_type<size_t, struct archival_s3_connection_limit_t>;
+
+/// Archiver service configuration
+struct configuration {
+    /// S3 configuration
+    s3::configuration client_config;
+    /// Bucket used to store all archived data
+    s3::bucket_name bucket_name;
+    /// Policy for choosing candidates for archiving
+    upload_policy_selector upload_policy;
+    /// Policy for choosing candidates for removing from S3
+    delete_policy_selector delete_policy;
+    /// Time interval to run uploads & deletes
+    ss::lowres_clock::duration interval;
+    /// Time interval to run GC
+    ss::lowres_clock::duration gc_interval;
+    /// Number of simultaneous S3 uploads
+    s3_connection_limit connection_limit;
+};
+
+/// This class performs per-ntp arhcival workload. Every ntp can be
+/// processed independently, without the knowledge about others. All
+/// 'ntp_archiver' instances that the shard posesses are supposed to be
+/// aggregated on a higher level in the 'archiver_service'.
+///
+/// The 'ntp_archiver' is responsible for manifest manitpulations and
+/// generation of per-ntp candidate set. The actual file uploads are
+/// handled by 'archiver_service'.
+class ntp_archiver {
+public:
+    /// Iterator type used to retrieve candidates for upload
+    using back_insert_iterator
+      = std::back_insert_iterator<std::vector<segment_name>>;
+
+    /// Create new instance
+    ///
+    /// \param ntp is an ntp that archiver is responsible for
+    /// \param conf is an S3 client configuration
+    /// \param bucket is an S3 bucket that should be used to store the data
+    ntp_archiver(const storage::ntp_config& ntp, const configuration& conf);
+
+    /// Stop archiver.
+    ///
+    /// \return future that will become ready when all async operation will be
+    /// completed
+    ss::future<> stop();
+
+    /// Get NTP
+    const model::ntp& get_ntp() const;
+
+    /// Get timestamp
+    const ss::lowres_clock::time_point get_last_upload_time() const;
+    const ss::lowres_clock::time_point get_last_delete_time() const;
+
+    /// Download manifest from pre-defined S3 locatnewion
+    ///
+    /// \return future that returns true if the manifest was found in S3
+    ss::future<bool> download_manifest();
+
+    /// Upload manifest to the pre-defined S3 location
+    ss::future<> upload_manifest();
+
+    const manifest& get_remote_manifest() const;
+
+    struct batch_result {
+        size_t succeded;
+        size_t failed;
+    };
+
+    /// \brief Upload next segment to S3 (if any)
+    /// The semaphore is used to track number of parallel uploads. The method
+    /// will pick not more than 'req_limit.available_units()' candidates for
+    /// upload and consme one unit for every candidate (non-blocking).
+    ///
+    /// \param req_limit is used to limit number of parallel uploads
+    /// \param lm is a log manager instance
+    /// \return future that returns number of uploaded/failed segments
+    ss::future<batch_result>
+    upload_next_candidate(ss::semaphore& req_limit, storage::log_manager& lm);
+
+    /// \brief Delete next segment from S3
+    ///
+    /// \param req_limit is used to limit number of parallel operations
+    /// \param lm is a log manager instance
+    /// \return future that returns number of deleted/failed segments
+    ss::future<batch_result>
+    delete_next_candidate(ss::semaphore& req_limit, storage::log_manager& lm);
+
+private:
+    /// Get segment from log_manager instance by path
+    ///
+    /// \param path is a segment path (from the manifest)
+    /// \param lm is a log manager instance
+    /// \return pointer to segment instance or null
+    ss::lw_shared_ptr<storage::segment>
+    get_segment(segment_name path, storage::log_manager& lm);
+
+    /// Upload individual segment to S3. Locate the segment in 'lm' and adjust
+    /// 'req_limit' accordingly.
+    ///
+    /// \return true on success and false otherwise
+    ss::future<bool> upload_segment(
+      manifest::segment_map::value_type target, storage::log_manager& lm);
+
+    /// Delete segment from S3. Locate the segment in 'lm' and adjust
+    /// 'req_limit' accordingly.
+    ///
+    /// \return true on success and false otherwise
+    ss::future<bool> delete_segment(
+      manifest::segment_map::value_type target, storage::log_manager& lm);
+
+    model::ntp _ntp;
+    model::revision_id _rev;
+    s3::configuration _client_conf;
+
+    std::unique_ptr<archival_policy_base> _policy;
+    s3::bucket_name _bucket;
+    /// Remote manifest contains representation of the data stored in S3 (it
+    /// gets uploaded to the remote location)
+    manifest _remote;
+    ss::gate _gate;
+    ss::lowres_clock::time_point _last_upload_time;
+    ss::lowres_clock::time_point _last_delete_time;
+};
+
+} // namespace archival

--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -1,11 +1,21 @@
 
 rp_test(
   UNIT_TEST
-  BINARY_NAME test_arch_service
+  BINARY_NAME test_archival_manifest
   SOURCES manifest_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils
   ARGS "-- -c 1"
 )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME test_archival_service
+  SOURCES service_fixture.cc ntp_archiver_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils
+  ARGS "-- -c 1"
+)
+
 
 

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/archival_policy.h"
+#include "archival/ntp_archiver_service.h"
+#include "archival/tests/service_fixture.h"
+#include "cluster/tests/controller_test_fixture.h"
+#include "cluster/tests/utils.h"
+#include "cluster/types.h"
+#include "model/metadata.h"
+#include "test_utils/fixture.h"
+#include "utils/unresolved_address.h"
+
+#include <seastar/core/future-util.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/sstring.hh>
+
+#include <boost/algorithm/string.hpp>
+
+using namespace std::chrono_literals;
+using namespace archival;
+
+inline ss::logger test_log("test"); // NOLINT
+
+static constexpr std::string_view manifest_payload = R"json({
+    "namespace": "test-ns",
+    "topic": "test-topic",
+    "partition": 42,
+    "revision": 0,
+    "segments": {
+        "1-2-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 100,
+            "committed_offset": 2,
+            "base_offset": 1,
+            "deleted": false
+        },
+        "3-4-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 200,
+            "committed_offset": 4,
+            "base_offset": 3,
+            "deleted": false
+        }
+    }
+})json";
+static constexpr std::string_view manifest_with_deleted_segment = R"json({
+    "namespace": "test-ns",
+    "topic": "test-topic",
+    "partition": 42,
+    "revision": 0,
+    "segments": {
+        "3-4-v1.log": {
+            "is_compacted": false,
+            "size_bytes": 200,
+            "committed_offset": 4,
+            "base_offset": 3,
+            "deleted": false
+        }
+    }
+})json";
+
+static const auto manifest_namespace = model::ns("test-ns");    // NOLINT
+static const auto manifest_topic = model::topic("test-topic");  // NOLINT
+static const auto manifest_partition = model::partition_id(42); // NOLINT
+static const auto manifest_ntp = model::ntp(                    // NOLINT
+  manifest_namespace,
+  manifest_topic,
+  manifest_partition);
+static const auto manifest_revision = model::revision_id(0); // NOLINT
+static const ss::sstring manifest_url = fmt::format(         // NOLINT
+  "/a0000000/meta/{}_{}/manifest.json",
+  manifest_ntp.path(),
+  manifest_revision());
+
+// NOLINTNEXTLINE
+static const ss::sstring segment1_url
+  = "/3931f368/test-ns/test-topic/42_0/1-2-v1.log";
+// NOLINTNEXTLINE
+static const ss::sstring segment2_url
+  = "/47bef4d3/test-ns/test-topic/42_0/3-4-v1.log";
+
+static const std::vector<s3_imposter_fixture::expectation>
+  default_expectations({
+    s3_imposter_fixture::expectation{
+      .url = manifest_url, .body = ss::sstring(manifest_payload)},
+    s3_imposter_fixture::expectation{.url = segment1_url, .body = "segment1"},
+    s3_imposter_fixture::expectation{.url = segment2_url, .body = "segment2"},
+  });
+
+static storage::ntp_config get_ntp_conf() {
+    return storage::ntp_config(manifest_ntp, "base-dir");
+}
+
+static manifest load_manifest(std::string_view v) {
+    manifest m;
+    iobuf i;
+    i.append(v.data(), v.size());
+    auto s = make_iobuf_input_stream(std::move(i));
+    m.update(std::move(s)).get();
+    return std::move(m);
+}
+
+/// Compare two json objects logically by parsing them first and then going
+/// through fields
+static bool
+compare_json_objects(const std::string_view& lhs, const std::string_view& rhs) {
+    using namespace rapidjson;
+    Document lhsd, rhsd;
+    lhsd.Parse({lhs.data(), lhs.size()});
+    rhsd.Parse({rhs.data(), rhs.size()});
+    if (lhsd != rhsd) {
+        vlog(
+          test_log.trace, "Json objects are not equal:\n{}and\n{}", lhs, rhs);
+    }
+    return lhsd == rhsd;
+}
+
+FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
+    set_expectations_and_listen(default_expectations);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto action = ss::defer([&archiver] { archiver.stop().get(); });
+    archiver.download_manifest().get();
+    auto expected = load_manifest(manifest_payload);
+    BOOST_REQUIRE(expected == archiver.get_remote_manifest()); // NOLINT
+}
+
+FIXTURE_TEST(test_upload_manifest, s3_imposter_fixture) { // NOLINT
+    set_expectations_and_listen(default_expectations);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto action = ss::defer([&archiver] { archiver.stop().get(); });
+    auto pm = const_cast<manifest*>( // NOLINT
+      &archiver.get_remote_manifest());
+    pm->add(
+      segment_name("1-2-v1.log"),
+      {.is_compacted = false,
+       .size_bytes = 100, // NOLINT
+       .base_offset = model::offset(1),
+       .committed_offset = model::offset(2),
+       .is_deleted_locally = false
+
+      });
+    pm->add(
+      segment_name("3-4-v1.log"),
+      {.is_compacted = false,
+       .size_bytes = 200, // NOLINT
+       .base_offset = model::offset(3),
+       .committed_offset = model::offset(4),
+       .is_deleted_locally = false
+
+      });
+    archiver.upload_manifest().get();
+    auto req = get_requests().front();
+    // NOLINTNEXTLINE
+    BOOST_REQUIRE(compare_json_objects(req.content, manifest_payload));
+}
+
+// NOLINTNEXTLINE
+FIXTURE_TEST(test_archival_non_compacted_selection_policy, archiver_fixture) {
+    std::vector<segment_desc> segments = {
+      {manifest_ntp, model::offset(1), model::term_id(2)},
+      {manifest_ntp, model::offset(3), model::term_id(4)},
+    };
+    init_storage_api_local(segments);
+    auto policy = archival::make_archival_policy(
+      archival::upload_policy_selector::archive_non_compacted,
+      archival::delete_policy_selector::do_not_keep,
+      manifest_ntp,
+      manifest_revision);
+    vlog(test_log.trace, "update local manifest");
+    archival::manifest empty(manifest_ntp, manifest_revision);
+    auto m = policy->generate_upload_set(
+      empty, get_local_storage_api().log_mgr());
+    BOOST_REQUIRE(m.has_value());
+    std::stringstream json;
+    m->serialize(json);
+    vlog(test_log.trace, "local manifest: {}", json.str());
+    verify_manifest(*m);
+}
+
+// NOLINTNEXTLINE
+FIXTURE_TEST(test_upload_segments, archiver_fixture) {
+    set_expectations_and_listen(default_expectations);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto action = ss::defer([&archiver] { archiver.stop().get(); });
+
+    std::vector<segment_desc> segments = {
+      {manifest_ntp, model::offset(1), model::term_id(2)},
+      {manifest_ntp, model::offset(3), model::term_id(4)},
+    };
+    init_storage_api_local(segments);
+
+    ss::semaphore limit(2);
+    auto res
+      = archiver.upload_next_candidate(limit, get_local_storage_api().log_mgr())
+          .get0();
+    BOOST_REQUIRE_EQUAL(res.succeded, 2);
+    BOOST_REQUIRE_EQUAL(res.failed, 0);
+
+    for (auto [url, req] : get_targets()) {
+        vlog(test_log.error, "{}", url);
+    }
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
+    BOOST_REQUIRE(get_targets().count(manifest_url)); // NOLINT
+    {
+        auto it = get_targets().find(manifest_url);
+        const auto& [url, req] = *it;
+        verify_manifest_content(req.content);
+        BOOST_REQUIRE(req._method == "PUT"); // NOLINT
+    }
+    BOOST_REQUIRE(get_targets().count(segment1_url)); // NOLINT
+    {
+        auto it = get_targets().find(segment1_url);
+        const auto& [url, req] = *it;
+        auto name = url.substr(url.size() - std::strlen("#-#-v#.log"));
+        verify_segment(manifest_ntp, archival::segment_name(name), req.content);
+        BOOST_REQUIRE(req._method == "PUT"); // NOLINT
+    }
+    BOOST_REQUIRE(get_targets().count(segment2_url)); // NOLINT
+    {
+        auto it = get_targets().find(segment2_url);
+        const auto& [url, req] = *it;
+        auto name = url.substr(url.size() - std::strlen("#-#-v#.log"));
+        verify_segment(manifest_ntp, archival::segment_name(name), req.content);
+        BOOST_REQUIRE(req._method == "PUT"); // NOLINT
+    }
+}
+
+// NOLINTNEXTLINE
+FIXTURE_TEST(test_delete_segments, archiver_fixture) {
+    set_expectations_and_listen(default_expectations);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto action = ss::defer([&archiver] { archiver.stop().get(); });
+
+    std::vector<segment_desc> segments = {
+      {manifest_ntp, model::offset(3), model::term_id(4)},
+    };
+    init_storage_api_local(segments);
+
+    ss::semaphore limit(2);
+    archiver.download_manifest().get();
+    auto res
+      = archiver.delete_next_candidate(limit, get_local_storage_api().log_mgr())
+          .get0();
+    BOOST_REQUIRE_EQUAL(res.succeded, 2);
+    BOOST_REQUIRE_EQUAL(res.failed, 0);
+
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
+    BOOST_REQUIRE(get_targets().count(manifest_url)); // NOLINT
+    auto erange = get_targets().equal_range(manifest_url);
+    for (auto it = erange.first; it != erange.second; it++) {
+        const auto& [url, req] = *it;
+        if (req._method == "PUT") {
+            // NOLINTNEXTLINE
+            BOOST_REQUIRE(
+              compare_json_objects(req.content, manifest_with_deleted_segment));
+        } else {
+            BOOST_REQUIRE(req._method == "GET"); // NOLINT
+        }
+    }
+    BOOST_REQUIRE(get_targets().count(segment1_url)); // NOLINT
+    {
+        auto it = get_targets().find(segment1_url);
+        const auto& [url, req] = *it;
+        BOOST_REQUIRE(req._method == "DELETE"); // NOLINT
+    }
+}

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/tests/service_fixture.h"
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "random/generators.h"
+#include "s3/client.h"
+#include "seastarx.h"
+#include "storage/directories.h"
+#include "storage/disk_log_impl.h"
+#include "storage/tests/utils/random_batch.h"
+#include "test_utils/async.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/http/function_handlers.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/tmp_file.hh>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/core/noncopyable.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace std::chrono_literals;
+
+inline ss::logger fixt_log("fixture"); // NOLINT
+
+static constexpr uint16_t httpd_port_number = 4430;
+static constexpr const char* httpd_host_name = "127.0.0.1";
+
+static archival::manifest load_manifest_from_str(std::string_view v) {
+    archival::manifest m;
+    iobuf i;
+    i.append(v.data(), v.size());
+    auto s = make_iobuf_input_stream(std::move(i));
+    m.update(std::move(s)).get();
+    return std::move(m);
+}
+
+static void write_batches(
+  ss::lw_shared_ptr<storage::segment> seg,
+  ss::circular_buffer<model::record_batch> batches) { // NOLINT
+    vlog(fixt_log.trace, "num batches {}", batches.size());
+    for (auto& b : batches) {
+        b.header().header_crc = model::internal_header_only_crc(b.header());
+        auto res = seg->append(std::move(b)).get0();
+        vlog(fixt_log.trace, "last-offset {}", res.last_offset);
+    }
+    seg->flush().get();
+}
+
+static void
+write_random_batches(ss::lw_shared_ptr<storage::segment> seg) { // NOLINT
+    auto batches = storage::test::make_random_batches(
+      seg->offsets().base_offset + model::offset(1), 1);
+    write_batches(seg, std::move(batches));
+}
+
+archival::configuration get_configuration() {
+    ss::ipv4_addr ip_addr = {httpd_host_name, httpd_port_number};
+    ss::socket_address server_addr(ip_addr);
+    s3::configuration s3conf{
+      .uri = s3::access_point_uri(httpd_host_name),
+      .access_key = s3::public_key_str("acess-key"),
+      .secret_key = s3::private_key_str("secret-key"),
+      .region = s3::aws_region_name("us-east-1"),
+    };
+    s3conf.server_addr = server_addr;
+    archival::configuration conf;
+    conf.client_config = s3conf;
+    conf.bucket_name = s3::bucket_name("test-bucket");
+    conf.connection_limit = archival::s3_connection_limit(10);
+    return conf;
+}
+
+s3_imposter_fixture::s3_imposter_fixture() {
+    _server = ss::make_shared<ss::httpd::http_server_control>();
+    _server->start().get();
+    ss::ipv4_addr ip_addr = {httpd_host_name, httpd_port_number};
+    _server_addr = ss::socket_address(ip_addr);
+}
+
+s3_imposter_fixture::~s3_imposter_fixture() { _server->stop().get(); }
+
+const std::vector<ss::httpd::request>&
+s3_imposter_fixture::get_requests() const {
+    return _requests;
+}
+
+const std::multimap<ss::sstring, ss::httpd::request>&
+s3_imposter_fixture::get_targets() const {
+    return _targets;
+}
+
+void s3_imposter_fixture::set_expectations_and_listen(
+  const std::vector<s3_imposter_fixture::expectation>& expectations) {
+    _server
+      ->set_routes([this, &expectations](ss::httpd::routes& r) {
+          set_routes(r, expectations);
+      })
+      .get();
+    _server->listen(_server_addr).get();
+}
+
+void s3_imposter_fixture::set_routes(
+  ss::httpd::routes& r,
+  const std::vector<s3_imposter_fixture::expectation>& expectations) {
+    using namespace ss::httpd;
+    struct content_handler {
+        content_handler(
+          const std::vector<expectation>& exp, s3_imposter_fixture& imp)
+          : fixture(imp) {
+            for (const auto& e : exp) {
+                expectations[e.url] = e;
+            }
+        }
+        ss::sstring handle(const_req request, reply& repl) {
+            static const ss::sstring error_payload
+              = R"xml(<?xml version="1.0" encoding="UTF-8"?>
+                        <Error>
+                            <Code>NoSuchKey</Code>
+                            <Message>Object not found</Message>
+                            <Resource>resource</Resource>
+                            <RequestId>requestid</RequestId>
+                        </Error>)xml";
+            fixture._requests.push_back(request);
+            fixture._targets.insert(std::make_pair(request._url, request));
+            vlog(
+              fixt_log.trace,
+              "S3 imposter request {} - {} - {}",
+              request._url,
+              request.content_length,
+              request._method);
+            if (request._method == "GET") {
+                auto it = expectations.find(request._url);
+                if (it == expectations.end() || !it->second.body.has_value()) {
+                    vlog(fixt_log.trace, "Reply GET request with error");
+                    repl.set_status(reply::status_type::not_found);
+                    return error_payload;
+                }
+                return *it->second.body;
+            } else if (request._method == "PUT") {
+                expectations[request._url] = {
+                  .url = request._url, .body = request.content};
+                return "";
+            } else if (request._method == "DELETE") {
+                auto it = expectations.find(request._url);
+                if (it == expectations.end() || !it->second.body.has_value()) {
+                    vlog(fixt_log.trace, "Reply DELETE request with error");
+                    repl.set_status(reply::status_type::not_found);
+                    return error_payload;
+                }
+                repl.set_status(reply::status_type::no_content);
+                it->second.body = std::nullopt;
+                return "";
+            }
+            BOOST_FAIL("Unexpected request");
+            return "";
+        }
+        std::map<ss::sstring, expectation> expectations;
+        s3_imposter_fixture& fixture;
+    };
+    auto hd = ss::make_shared<content_handler>(expectations, *this);
+    for (const auto& [path, _] : expectations) {
+        auto get_handler = new function_handler(
+          [hd](const_req req, reply& repl) { return hd->handle(req, repl); },
+          "txt");
+        auto put_handler = new function_handler(
+          [hd](const_req req, reply& repl) { return hd->handle(req, repl); },
+          "txt");
+        auto del_handler = new function_handler(
+          [hd](const_req req, reply& repl) { return hd->handle(req, repl); },
+          "txt");
+        r.add(operation_type::GET, url(path), get_handler);
+        r.add(operation_type::PUT, url(path), put_handler);
+        r.add(operation_type::DELETE, url(path), del_handler);
+    }
+}
+
+// archiver service fixture
+
+std::unique_ptr<storage::disk_log_builder>
+archiver_fixture::get_started_log_builder(
+  model::ntp ntp, model::revision_id rev) {
+    storage::ntp_config ntp_cfg(
+      std::move(ntp), lconf().data_directory().as_sstring(), nullptr, rev);
+
+    auto conf = storage::log_config(
+      storage::log_config::storage_type::disk,
+      lconf().data_directory().as_sstring(),
+      1_MiB,
+      storage::debug_sanitize_files::yes);
+    auto builder = std::make_unique<storage::disk_log_builder>(std::move(conf));
+    builder->start(std::move(ntp_cfg)).get();
+    return builder;
+}
+/// Wait unill all information will be replicated and the local node
+/// will become a leader for 'ntp'.
+void archiver_fixture::wait_for_partition_leadership(const model::ntp& ntp) {
+    vlog(fixt_log.trace, "waiting for partition {}", ntp);
+    tests::cooperative_spin_wait_with_timeout(10s, [this, ntp] {
+        auto& table = app.controller->get_partition_leaders().local();
+        model::node_id node(0);
+        int cnt = 0;
+        auto self = app.controller->self();
+        ss::lowres_clock::time_point deadline = ss::lowres_clock::now() + 100ms;
+        return table.wait_for_leader(ntp, deadline, {}).get0() == self
+               && app.partition_manager.local().get(ntp)->is_leader();
+    }).get();
+}
+void archiver_fixture::delete_topic(model::ns ns, model::topic topic) {
+    vlog(fixt_log.trace, "delete topic {}/{}", ns(), topic());
+    app.controller->get_topics_frontend()
+      .local()
+      .delete_topics(
+        {model::topic_namespace(std::move(ns), std::move(topic))},
+        model::timeout_clock::now() + 100ms)
+      .get();
+}
+void archiver_fixture::wait_for_topic_deletion(const model::ntp& ntp) {
+    tests::cooperative_spin_wait_with_timeout(10s, [this, ntp] {
+        return !app.partition_manager.local().get(ntp);
+    }).get();
+}
+void archiver_fixture::add_topic_with_random_data(
+  const model::ntp& ntp, int num_batches) {
+    // In order to be picked up by archival service the topic should
+    // exist in partition manager and on disk
+    auto builder = get_started_log_builder(ntp);
+    builder->add_segment(model::offset(0)).get();
+    builder
+      ->add_random_batches(
+        model::offset(0), num_batches, storage::maybe_compress_batches::yes)
+      .get();
+    builder->stop().get();
+    builder.reset();
+    add_topic(model::topic_namespace_view(ntp)).get();
+}
+storage::api& archiver_fixture::get_local_storage_api() {
+    return app.storage.local();
+}
+
+void archiver_fixture::init_storage_api_local(std::vector<segment_desc>& segm) {
+    initialize_shard(get_local_storage_api(), segm);
+}
+
+void archiver_fixture::initialize_shard(
+  storage::api& api, const std::vector<segment_desc>& segm) {
+    absl::flat_hash_map<model::ntp, size_t> all_ntp;
+    for (const auto& d : segm) {
+        storage::ntp_config ntpc(d.ntp, data_dir.string());
+        storage::directories::initialize(ntpc.work_directory()).get();
+        vlog(fixt_log.trace, "make_log_segment {}", d.ntp.path());
+        auto seg = api.log_mgr()
+                     .make_log_segment(
+                       storage::ntp_config(d.ntp, data_dir.string()),
+                       d.base_offset,
+                       d.term,
+                       ss::default_priority_class())
+                     .get0();
+        vlog(fixt_log.trace, "write random batches to segment");
+        write_random_batches(seg);
+        vlog(fixt_log.trace, "segment close");
+        seg->close().get();
+        all_ntp[d.ntp] += 1;
+    }
+    for (const auto& ntp : all_ntp) {
+        vlog(fixt_log.trace, "manage {}", ntp.first);
+        api.log_mgr()
+          .manage(storage::ntp_config(ntp.first, data_dir.string()))
+          .get();
+        BOOST_CHECK_EQUAL(
+          api.log_mgr().get(ntp.first)->segment_count(), ntp.second);
+    }
+    BOOST_CHECK(all_ntp.size() <= api.log_mgr().size()); // NOLINT
+}
+
+// segment matcher
+
+template<class Fixture>
+std::vector<ss::lw_shared_ptr<storage::segment>>
+segment_matcher<Fixture>::list_segments(const model::ntp& ntp) {
+    std::vector<ss::lw_shared_ptr<storage::segment>> result;
+    auto log
+      = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+        dlog) {
+        std::copy_if(
+          dlog->segments().begin(),
+          dlog->segments().end(),
+          std::back_inserter(result),
+          [](ss::lw_shared_ptr<storage::segment> seg) {
+              return !seg->has_appender();
+          });
+    }
+    return result;
+}
+
+template<class Fixture>
+ss::lw_shared_ptr<storage::segment> segment_matcher<Fixture>::get_segment(
+  const model::ntp& ntp, const archival::segment_name& name) {
+    auto log
+      = static_cast<Fixture*>(this)->get_local_storage_api().log_mgr().get(ntp);
+    if (auto dlog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+        dlog) {
+        for (const auto& s : dlog->segments()) {
+            if (
+              !s->has_appender()
+              && boost::ends_with(s->reader().filename(), name())) {
+                return s;
+            }
+        }
+    }
+    return nullptr;
+}
+
+template<class Fixture>
+void segment_matcher<Fixture>::verify_segment(
+  const model::ntp& ntp,
+  const archival::segment_name& name,
+  const ss::sstring& expected) {
+    auto segment = get_segment(ntp, name);
+    auto pos = segment->offsets().base_offset;
+    auto size = segment->size_bytes();
+    auto stream = segment->offset_data_stream(
+      pos, ss::default_priority_class());
+    auto tmp = stream.read_exactly(size).get0();
+    ss::sstring actual = {tmp.get(), tmp.size()};
+    vlog(
+      fixt_log.error,
+      "expected {} bytes, got {}",
+      expected.size(),
+      actual.size());
+    BOOST_REQUIRE(actual == expected); // NOLINT
+}
+
+template<class Fixture>
+void segment_matcher<Fixture>::verify_manifest(const archival::manifest& man) {
+    auto all_segments = list_segments(man.get_ntp());
+    BOOST_REQUIRE_EQUAL(all_segments.size(), man.size());
+    for (const auto& s : all_segments) {
+        auto sname = archival::segment_name(
+          std::filesystem::path(s->reader().filename()).filename().string());
+        auto base = s->offsets().base_offset;
+        auto comm = s->offsets().committed_offset;
+        auto size = s->size_bytes();
+        auto comp = s->is_compacted_segment();
+        auto m = man.get(sname);
+        BOOST_REQUIRE(m != nullptr); // NOLINT
+        BOOST_REQUIRE_EQUAL(base, m->base_offset);
+        BOOST_REQUIRE_EQUAL(comm, m->committed_offset);
+        BOOST_REQUIRE_EQUAL(size, m->size_bytes);
+        BOOST_REQUIRE_EQUAL(comp, m->is_compacted);
+        BOOST_REQUIRE_EQUAL(false, m->is_deleted_locally);
+    }
+}
+
+template<class Fixture>
+void segment_matcher<Fixture>::verify_manifest_content(
+  const ss::sstring& manifest_content) {
+    archival::manifest m = load_manifest_from_str(manifest_content);
+    verify_manifest(m);
+}
+
+template class segment_matcher<archiver_fixture>;

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "archival/manifest.h"
+#include "archival/ntp_archiver_service.h"
+#include "cluster/partition_leaders_table.h"
+#include "cluster/tests/utils.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "redpanda/tests/fixture.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/http/httpd.hh>
+#include <seastar/util/tmp_file.hh>
+
+#include <chrono>
+#include <exception>
+#include <map>
+#include <vector>
+
+/// Emulates S3 REST API for testing purposes.
+/// The imposter is a simple KV-store that contains a set of expectations.
+/// Expectations are accessible by url via GET, PUT, and DELETE http calls.
+/// Expectations are provided before impster starts to listen. They have
+/// two field - url and optional body. If body is set to nullopt, attemtp
+/// to read it using GET or delete it using DELETE requests will trigger an
+/// http response with error code 404 and xml formatted error message.
+/// If the body of the expectation is set by the user or PUT request it can
+/// be retrieved using the GET request or deleted using the DELETE request.
+class s3_imposter_fixture {
+public:
+    s3_imposter_fixture();
+    ~s3_imposter_fixture();
+
+    s3_imposter_fixture(const s3_imposter_fixture&) = delete;
+    s3_imposter_fixture& operator=(const s3_imposter_fixture&) = delete;
+    s3_imposter_fixture(s3_imposter_fixture&&) = delete;
+    s3_imposter_fixture& operator=(s3_imposter_fixture&&) = delete;
+
+    struct expectation {
+        ss::sstring url;
+        std::optional<ss::sstring> body;
+    };
+
+    /// Set expectaitions on REST API calls that supposed to be made
+    /// Only the requests that described in this call will be possible
+    /// to make. This method can only be called once per test run.
+    ///
+    /// \param expectations is a collection of access points that allow GET,
+    /// PUT, and DELETE requests, each expectation has url and body. The body
+    /// will be returned by GET call if it's set or trigger error if its null.
+    /// The expectations are statefull. If the body of the expectation was set
+    /// to null but there was PUT call that sent some data, subsequent GET call
+    /// will retrieve this data.
+    void
+    set_expectations_and_listen(const std::vector<expectation>& expectations);
+
+    /// Access all http requests ordered by time
+    const std::vector<ss::httpd::request>& get_requests() const;
+
+    /// Access all http requests ordered by target url
+    const std::multimap<ss::sstring, ss::httpd::request>& get_targets() const;
+
+private:
+    void set_routes(
+      ss::httpd::routes& r, const std::vector<expectation>& expectations);
+
+    ss::socket_address _server_addr;
+    ss::shared_ptr<ss::httpd::http_server_control> _server;
+    /// Contains saved requests
+    std::vector<ss::httpd::request> _requests;
+    /// Contains all accessed target urls
+    std::multimap<ss::sstring, ss::httpd::request> _targets;
+};
+
+struct segment_desc {
+    model::ntp ntp;
+    model::offset base_offset;
+    model::term_id term;
+};
+
+/// This utility can be used to match content of the log
+/// with manifest and request content. It's also can be
+/// used to retrieve individual segments or iterate over
+/// them.
+///
+/// The 'Fixture' is supposed to implement the following
+/// method
+/// - storage::api& get_local_storage_api();
+/// - ss::sharded<storage::api>& get_storage_api();
+template<class Fixture>
+class segment_matcher {
+public:
+    /// \brief Get full list of segments that log contains
+    ///
+    /// \param ntp is an ntp of the log
+    /// \return vector of pointers to log segments
+    std::vector<ss::lw_shared_ptr<storage::segment>>
+    list_segments(const model::ntp& ntp);
+
+    /// \brief Get single segment by ntp and name
+    ///
+    /// \param ntp is an ntp of the log
+    /// \param name is a segment file name "<base-offset>-<term>-<version>.log"
+    /// \return pointer to segment or null if segment not found
+    ss::lw_shared_ptr<storage::segment>
+    get_segment(const model::ntp& ntp, const archival::segment_name& name);
+
+    /// Verify 'expected' segment content using the actual segment from
+    /// log_manager
+    void verify_segment(
+      const model::ntp& ntp,
+      const archival::segment_name& name,
+      const ss::sstring& expected);
+
+    /// Verify manifest using log_manager's state,
+    /// find matching segments and check the fields.
+    void verify_manifest(const archival::manifest& man);
+
+    /// Verify manifest content using log_manager's state,
+    /// find matching segments and check the fields.
+    void verify_manifest_content(const ss::sstring& manifest_content);
+};
+/// Archiver fixture that contains S3 mock and full redpanda stack.
+class archiver_fixture
+  : public s3_imposter_fixture
+  , public redpanda_thread_fixture
+  , public segment_matcher<archiver_fixture> {
+public:
+    std::unique_ptr<storage::disk_log_builder> get_started_log_builder(
+      model::ntp ntp, model::revision_id rev = model::revision_id(0));
+    /// Wait unill all information will be replicated and the local node
+    /// will become a leader for 'ntp'.
+    void wait_for_partition_leadership(const model::ntp& ntp);
+    void delete_topic(model::ns ns, model::topic topic);
+    void wait_for_topic_deletion(const model::ntp& ntp);
+    void add_topic_with_random_data(const model::ntp& ntp, int num_batches);
+    /// Provides access point for segment_matcher CRTP template
+    storage::api& get_local_storage_api();
+    /// \brief Init storage api for tests that require only storage
+    /// The method doesn't add topics, only creates segments in data_dir
+    void init_storage_api_local(std::vector<segment_desc>& segm);
+
+private:
+    void
+    initialize_shard(storage::api& api, const std::vector<segment_desc>& segm);
+};
+
+archival::configuration get_configuration();

--- a/src/v/cluster/tests/controller_test_fixture.h
+++ b/src/v/cluster/tests/controller_test_fixture.h
@@ -90,6 +90,10 @@ public:
         return _pm;
     }
 
+    storage::api& get_local_storage_api() { return _storage.local(); }
+
+    ss::sharded<storage::api>& get_storage_api() { return _storage; }
+
     cluster::shard_table& get_shard_table() { return st.local(); }
 
     ~controller_tests_fixture() {

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -106,8 +106,9 @@ void set_routes(ss::httpd::routes& r) {
       },
       "txt");
     auto empty_delete_response = new function_handler(
-      [](const_req req) {
+      [](const_req req, reply& reply) {
           BOOST_REQUIRE(!req.get_header("x-amz-content-sha256").empty());
+          reply.set_status(reply::status_type::no_content);
           return "";
       },
       "txt");
@@ -271,8 +272,6 @@ SEASTAR_TEST_CASE(test_delete_object_success) {
     return ss::async([] {
         auto conf = transport_configuration();
         auto [server, client] = started_client_and_server(conf);
-        iobuf payload;
-        auto payload_stream = make_iobuf_ref_output_stream(payload);
         client
           ->delete_object(
             s3::bucket_name("test-bucket"), s3::object_key("test"))

--- a/src/v/utils/gate_guard.h
+++ b/src/v/utils/gate_guard.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/gate.hh>
+
+/// \brief RAII wrapper that holds the door^W gate open
+///        until the end of scope
+///
+/// The guard is moveable. The lifetime will be transferred
+/// to the new gate_guard instance.
+///
+/// \example ss::gate gate;
+///          {
+///             gate_guard g{gate};
+///             assert(gate.get_count() == 1);
+///          }
+///          assert(gate.get_count() == 0);
+struct gate_guard {
+    explicit gate_guard(ss::gate& g)
+      : _g(&g) {
+        _g->enter();
+    }
+    gate_guard(gate_guard&& o) noexcept
+      : _g(o._g) {
+        o._g = nullptr;
+    }
+    gate_guard& operator=(gate_guard&& o) noexcept {
+        if (this == &o) {
+            return *this;
+        }
+        _g = o._g;
+        o._g = nullptr;
+        return *this;
+    }
+    gate_guard(const gate_guard&) = delete;
+    gate_guard& operator=(const gate_guard&) = delete;
+    ~gate_guard() {
+        if (_g) {
+            _g->leave();
+        }
+    }
+
+private:
+    ss::gate* _g;
+};


### PR DESCRIPTION
This PR adds:
- fixes to s3 client
- test-suite for archival service
- ntp-archiver that manages s3 uploads and manifests for single ntp 

The `ntp_archiver` class is supposed to be used by the top-level component that runs per-shard. The `ntp_archiver` is created per-ntp on a leader node. It tracks changes in the log of that particular ntp and uploads sealed segments and manifest. The manifest contains a full listing of uploaded segments and the metadata.

The behaviour of the `ntp_archiver` is controlled by the policy. Right now only one policy is implemented. It uploads only non-compacted segments and it deletes segments from S3 as soon as they deleted locally. It's supposed to be extended in the future PR's.

The test suite has an S3 imposter that acts as a kvstore accessible via http REST interface (similar to S3). It also has a fixture that creates `storage:;api` with pre-defined set of segments. This fixture can integrate with controller_test_fixture to run more elaborate tests (not in this PR). 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
