### PR TITLE
rpk/config: Remove IDs from seed server entries

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -98,7 +98,7 @@ func bootstrap(mgr config.Manager) *cobra.Command {
 			defaultRpcPort := config.Default().Redpanda.RPCServer.Port
 			conf, err := mgr.FindOrGenerate(configPath)
 			if err != nil {
-				return errors.New("YAML")
+				return err
 			}
 			ips, err := parseIPs(ips)
 			if err != nil {
@@ -122,9 +122,8 @@ func bootstrap(mgr config.Manager) *cobra.Command {
 			conf.Redpanda.AdminApi.Address = ownIp.String()
 			conf.Redpanda.SeedServers = []config.SeedServer{}
 			seeds := []config.SeedServer{}
-			for i, ip := range ips {
+			for _, ip := range ips {
 				seed := config.SeedServer{
-					Id:	i,
 					Host: config.SocketAddress{
 						ip.String(),
 						defaultRpcPort,

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -26,11 +26,9 @@ func getValidConfig() *Config {
 	conf.Redpanda.SeedServers = []SeedServer{
 		{
 			SocketAddress{"127.0.0.1", 33145},
-			1,
 		},
 		{
 			SocketAddress{"127.0.0.1", 33146},
-			2,
 		},
 	}
 	conf.Redpanda.DeveloperMode = false
@@ -305,11 +303,9 @@ redpanda:
   - host:
       address: 127.0.0.1
       port: 33145
-    node_id: 1
   - host:
       address: 127.0.0.1
       port: 33146
-    node_id: 2
 rpk:
   coredump_dir: /var/lib/redpanda/coredumps
   enable_memory_locking: true
@@ -362,11 +358,9 @@ redpanda:
   - host:
       address: 127.0.0.1
       port: 33145
-    node_id: 1
   - host:
       address: 127.0.0.1
       port: 33146
-    node_id: 2
 rpk:
   coredump_dir: /var/lib/redpanda/coredumps
   enable_memory_locking: true
@@ -413,11 +407,9 @@ redpanda:
   - host:
       address: 127.0.0.1
       port: 33145
-    node_id: 1
   - host:
       address: 127.0.0.1
       port: 33146
-    node_id: 2
 rpk:
   coredump_dir: /var/lib/redpanda/coredump
   enable_memory_locking: false
@@ -468,11 +460,9 @@ redpanda:
   - host:
       address: 127.0.0.1
       port: 33145
-    node_id: 1
   - host:
       address: 127.0.0.1
       port: 33146
-    node_id: 2
 rpk:
   coredump_dir: /var/lib/redpanda/coredumps
   enable_memory_locking: true
@@ -545,11 +535,9 @@ redpanda:
   - host:
       address: 127.0.0.1
       port: 33145
-    node_id: 1
   - host:
       address: 127.0.0.1
       port: 33146
-    node_id: 2
   target_quota_byte_rate: 1000000
 rpk:
   coredump_dir: /var/lib/redpanda/coredumps
@@ -979,8 +967,8 @@ func TestReadFlat(t *testing.T) {
 		"redpanda.kafka_api":			"0.0.0.0:9092",
 		"redpanda.node_id":			"0",
 		"redpanda.rpc_server":			"0.0.0.0:33145",
-		"redpanda.seed_servers.1000":		"192.168.167.0:1337",
-		"redpanda.seed_servers.1001":		"192.168.167.1:1337",
+		"redpanda.seed_servers.0":		"192.168.167.0:1337",
+		"redpanda.seed_servers.1":		"192.168.167.1:1337",
 		"redpanda.developer_mode":		"true",
 		"rpk.coredump_dir":			"/var/lib/redpanda/coredump",
 		"rpk.enable_memory_locking":		"false",
@@ -1005,10 +993,8 @@ func TestReadFlat(t *testing.T) {
 	conf.Redpanda.SeedServers = []SeedServer{
 		{
 			SocketAddress{"192.168.167.0", 1337},
-			1000,
 		}, {
 			SocketAddress{"192.168.167.1", 1337},
-			1001,
 		},
 	}
 	err := mgr.Write(conf)

--- a/src/go/rpk/pkg/config/definition.go
+++ b/src/go/rpk/pkg/config/definition.go
@@ -35,8 +35,7 @@ type RedpandaConfig struct {
 }
 
 type SeedServer struct {
-	Host	SocketAddress	`yaml:"host" mapstructure:"host" json:"host"`
-	Id	int		`yaml:"node_id" mapstructure:"node_id" json:"id"`
+	Host SocketAddress `yaml:"host" mapstructure:"host" json:"host"`
 }
 
 type SocketAddress struct {

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -163,9 +163,13 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			for _, s := range *seeds {
-				key := fmt.Sprintf("%s.%d", k, s.Id)
-				flatMap[key] = fmt.Sprintf("%s:%d", s.Host.Address, s.Host.Port)
+			for i, s := range *seeds {
+				key := fmt.Sprintf("%s.%d", k, i)
+				flatMap[key] = fmt.Sprintf(
+					"%s:%d",
+					s.Host.Address,
+					s.Host.Port,
+				)
 			}
 			continue
 		}


### PR DESCRIPTION
This is the rpk counterpart to #479, deprecating seed server IDs.
