### PR TITLE
c/partition_leaders: support multiple notifications per ntp

### DIFF
--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -17,6 +17,7 @@
 #include "utils/expiring_promise.h"
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 namespace cluster {
 
@@ -134,9 +135,12 @@ private:
     // per-ntp notifications for leadership election. note that the
     // namespace is currently ignored pending an update to the metadata
     // cache that attaches a namespace to all topics partition references.
-    absl::
-      flat_hash_map<model::ntp, std::vector<expiring_promise<model::node_id>>>
-        _leader_promises;
+    int32_t _promise_id = 0;
+    using promises_t = absl::node_hash_map<
+      model::ntp,
+      absl::node_hash_map<int32_t, expiring_promise<model::node_id>>>;
+
+    promises_t _leader_promises;
 };
 
 } // namespace cluster


### PR DESCRIPTION
Implemented support for multiple independent waiters waiting
for the same ntp leadership notification.

Current implementation didn't allow to call `wait_for_leader(ntp)` from
multiple places as only one notification for given `ntp` might
exists in the notifications map. Added support for multiple independent
waiters waiting for the same NTP.

Related to: #487 

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
