### PR TITLE
Fix/rpk wasm deploy filename

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/Shopify/sarama"
 	"github.com/spf13/afero"
@@ -31,7 +30,6 @@ func NewDeployCommand(
 			if fileExt != ".js" {
 				return fmt.Errorf("can't deploy '%s': only .js files are supported.", path)
 			}
-			fileName := strings.Replace(fullFileName, fileExt, "", 1)
 			fileContent, err := afero.ReadFile(fs, path)
 			if err != nil {
 				return err
@@ -48,7 +46,7 @@ func NewDeployCommand(
 			}
 
 			return deploy(
-				fileName,
+				fullFileName,
 				fileContent,
 				description,
 				producer,

--- a/src/js/modules/supervisors/FileManager.ts
+++ b/src/js/modules/supervisors/FileManager.ts
@@ -392,13 +392,17 @@ class FileManager {
    * @param repository
    */
   private startWatchers(repository: Repository): void {
-    this.submitDirWatcher = watch(this.submitDir).on("add", (filePath) => {
+    this.submitDirWatcher = watch(this.submitDir, {
+      awaitWriteFinish: true,
+    }).on("add", (filePath) => {
       this.logger.info(`Detected new file in submit dir: ${filePath}`);
       this.addCoprocessor(filePath, repository).catch((e) => {
         this.logger.error(`addCoprocessor failed with exception: ${e.message}`);
       });
     });
-    this.activeDirWatcher = watch(this.activeDir).on("unlink", (filePath) => {
+    this.activeDirWatcher = watch(this.activeDir, {
+      awaitWriteFinish: true,
+    }).on("unlink", (filePath) => {
       this.logger.info(`Detected removed file from active dir: ${filePath}`);
       this.removeHandleFromFilePath(filePath, repository);
     });


### PR DESCRIPTION
Redpanda use DMA for writing file, when it starts to write file content, node js coprocessor start to read, therefore nodeJs fails because the file doesn't complete yet, for this reason, we enable `awaitWriteFinish: true`  on chokidar js, also add ".js" to rpk wasm messages 
