### PR TITLE
operator/controller: Redpanda multi-node cluster creation

### DIFF
--- a/src/go/k8s/config/samples/redpanda_v1alpha1_cluster.yaml
+++ b/src/go/k8s/config/samples/redpanda_v1alpha1_cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-sample
   labels:
     app.kubernetes.io/name: "redpanda"
-    app.kubernetes.io/instance: "redpandacluster-sample"
+    app.kubernetes.io/instance: "redpanda-cluster-sample"
 spec:
   image: "vectorized/redpanda"
   version: "latest"

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -204,9 +204,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *ClusterReconciler) createHeadlessService(
-	ctx context.Context,
-	clusterSpec *redpandav1alpha1.Cluster,
-	scheme *runtime.Scheme,
+	ctx context.Context, clusterSpec *redpandav1alpha1.Cluster, scheme *runtime.Scheme,
 ) error {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -235,23 +233,13 @@ func (r *ClusterReconciler) createHeadlessService(
 }
 
 func (r *ClusterReconciler) createBootstrapConfigMap(
-	ctx context.Context,
-	cluster *redpandav1alpha1.Cluster,
-	scheme *runtime.Scheme,
+	ctx context.Context, cluster *redpandav1alpha1.Cluster, scheme *runtime.Scheme,
 ) error {
 	serviceAddress := cluster.Name + "." + cluster.Namespace + ".svc.cluster.local"
 	cfg := config.Default()
 	cfg.Redpanda = copyConfig(&cluster.Spec.Configuration, &cfg.Redpanda)
 	cfg.Redpanda.Id = 0
-	cfg.Redpanda.AdvertisedKafkaApi.Address = cluster.Name + "-0" + "." +
-		cluster.Name + "." +
-		cluster.Namespace +
-		".svc.cluster.local"
 	cfg.Redpanda.AdvertisedKafkaApi.Port = cfg.Redpanda.KafkaApi.Port
-	cfg.Redpanda.AdvertisedRPCAPI.Address = cluster.Name + "-0" + "." +
-		cluster.Name + "." +
-		cluster.Namespace +
-		".svc.cluster.local"
 	cfg.Redpanda.AdvertisedRPCAPI.Port = cfg.Redpanda.RPCServer.Port
 	cfg.Redpanda.Directory = dataDirectory
 	cfg.Redpanda.SeedServers = []config.SeedServer{

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -154,7 +154,6 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	log.V(debugLevel).Info("Replicas comparison", "StatefulSet replicas", sts.Spec.Replicas, "Redpanda cluster replicas", redpandaCluster.Spec.Replicas)
 	// Ensure StatefulSet #replicas equals cluster requirement.
 	if sts.Spec.Replicas != redpandaCluster.Spec.Replicas {
 		sts.Spec.Replicas = redpandaCluster.Spec.Replicas

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -78,7 +78,9 @@ type ClusterReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
 // nolint:funlen // The complexity of Reconcile function will be address in the next version
-func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *ClusterReconciler) Reconcile(
+	ctx context.Context, req ctrl.Request,
+) (ctrl.Result, error) {
 	log := r.Log.WithValues("redpandacluster", req.NamespacedName)
 
 	log.Info(fmt.Sprintf("Starting reconcile loop for %v", req.NamespacedName))
@@ -203,7 +205,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *ClusterReconciler) createHeadlessService(
-	ctx context.Context, clusterSpec *redpandav1alpha1.Cluster, scheme *runtime.Scheme,
+	ctx context.Context,
+	clusterSpec *redpandav1alpha1.Cluster,
+	scheme *runtime.Scheme,
 ) error {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -224,15 +228,19 @@ func (r *ClusterReconciler) createHeadlessService(
 			Selector:	clusterSpec.Labels,
 		},
 	}
+
 	err := controllerutil.SetControllerReference(clusterSpec, svc, scheme)
 	if err != nil {
 		return err
 	}
+
 	return r.Create(ctx, svc)
 }
 
 func (r *ClusterReconciler) createBootstrapConfigMap(
-	ctx context.Context, cluster *redpandav1alpha1.Cluster, scheme *runtime.Scheme,
+	ctx context.Context,
+	cluster *redpandav1alpha1.Cluster,
+	scheme *runtime.Scheme,
 ) error {
 	serviceAddress := cluster.Name + "." + cluster.Namespace + ".svc.cluster.local"
 	cfg := config.Default()
@@ -280,9 +288,10 @@ func (r *ClusterReconciler) createBootstrapConfigMap(
 		},
 		Data: map[string]string{
 			"redpanda.yaml":	string(cfgBytes),
-			"configurator.sh":	scriptBytes,
+			"configurator.sh":	script,
 		},
 	}
+
 	err = controllerutil.SetControllerReference(cluster, cm, scheme)
 	if err != nil {
 		return err

--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -117,10 +117,14 @@ var _ = Describe("RedPandaCluster controller", func() {
 	})
 })
 
-func validOwner(cluster *v1alpha1.Cluster, owners []metav1.OwnerReference) bool {
+func validOwner(
+	cluster *v1alpha1.Cluster, owners []metav1.OwnerReference,
+) bool {
 	if len(owners) != 1 {
 		return false
 	}
+
 	owner := owners[0]
+
 	return owner.Name == cluster.Name && owner.Controller != nil && *owner.Controller
 }

--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -48,9 +48,9 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Name:		"redpanda-test",
 				Namespace:	"default",
 			}
-			seedKey := types.NamespacedName{
+			baseKey := types.NamespacedName{
+				Name:		key.Name + "-base",
 				Namespace:	"default",
-				Name:		"redpanda-test-seed",
 			}
 			redpandaCluster := &v1alpha1.Cluster{
 				TypeMeta: metav1.TypeMeta{
@@ -92,7 +92,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			By("Creating Configmap with the redpanda configuration")
 			var cm corev1.ConfigMap
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), seedKey, &cm)
+				err := k8sClient.Get(context.Background(), baseKey, &cm)
 				if err != nil {
 					return false
 				}
@@ -104,7 +104,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 			By("Creating StatefulSet")
 			var sts appsv1.StatefulSet
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), seedKey, &sts)
+				err := k8sClient.Get(context.Background(), key, &sts)
 				return err == nil &&
 					*sts.Spec.Replicas == replicas &&
 					sts.Spec.Template.Spec.Containers[0].Image == "vectorized/redpanda:"+redpandaContainerTag &&

--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -117,9 +117,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 	})
 })
 
-func validOwner(
-	cluster *v1alpha1.Cluster, owners []metav1.OwnerReference,
-) bool {
+func validOwner(cluster *v1alpha1.Cluster, owners []metav1.OwnerReference) bool {
 	if len(owners) != 1 {
 		return false
 	}

--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/vectorizedio/redpanda/src/go/rpk v0.0.0-00010101000000-000000000000
-	golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 // indirect
 	golang.org/x/tools v0.0.0-20210107193943-4ed967dd8eff // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -43,7 +43,6 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/sarama v1.26.1/go.mod h1:NbSGBSSndYaIhRcBtY9V0U7AyH+x71bG668AuWys/yU=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -138,7 +137,6 @@ github.com/go-logr/logr v0.3.0 h1:q4c+kbcR0d5rSurhBR8dIgieOaYpXtsdTYfx22Cu6rs=
 github.com/go-logr/logr v0.3.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/zapr v0.2.0 h1:v6Ji8yBW77pva6NkJKQdHLAJKrIJKRHz0RXwPqCHSR4=
 github.com/go-logr/zapr v0.2.0/go.mod h1:qhKdvif7YF5GI9NWEpyxTSSBdGmzkNguibrdCNVPunU=
-github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -393,7 +391,6 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/shirou/gopsutil/v3 v3.20.12/go.mod h1:igHnfak0qnw1biGeI2qKQvu0ZkwvEkUcCLlYhZzdr/4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -433,6 +430,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tklauser/go-sysconf v0.1.0/go.mod h1:h54uFIrVIJBr8RXt3F5JJdxVkmFeallWuXajbMhn2O8=
+github.com/tklauser/numcpus v0.1.0/go.mod h1:i3up9VjARpkV00NkBbexuDd0RAVQz4rV5Gl8miYgd5k=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -580,10 +579,9 @@ golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 h1:5/PjkGUjvEU5Gl6BxmvKRPpqo
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201029080932-201ba4db2418/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 h1:/dSxr6gT0FNI1MO5WLJo8mTmItROeOKTkDn+7OwWBos=
-golang.org/x/sys v0.0.0-20210105210732-16f7687f5001/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc h1:y0Og6AYdwus7SIAnKnDxjc4gJetRiYEWOx4AKbOeyEI=
+golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20191110171634-ad39bd3f0407/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This PR introduces the creation and formation of a multi-node/pod Redpanda cluster.

1. Adds update call to match number of replicas in StatefulSet with desired Redpanda nodes
2. Generates per-node `redpanda.yaml` configuration based on a common ConfigMap and node-specific attributes provided during each container's creation (such as advertised address).
3. Remove node-specific network fields from basis configuration.
4. Adjust RedpandaCluster such that Pods in SS can be addressed as a service from Pods in same namespace, such as other Redpanda nodes in same cluster.
5. Adjust test to reflect some naming changes.