### PR TITLE
rpk/topic/create: Make 1 the default repl factor

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/create.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/create.go
@@ -107,10 +107,8 @@ func NewCreateCommand(
 		&replicas,
 		"replicas",
 		"r",
-		int16(-1),
-		"Replication factor. If it's negative or is left unspecified,"+
-			" it will use the cluster's default topic replication"+
-			" factor.",
+		int16(1),
+		"Replication factor",
 	)
 	cmd.Flags().BoolVar(
 		&compact,

--- a/src/go/rpk/pkg/cli/cmd/topic_test.go
+++ b/src/go/rpk/pkg/cli/cmd/topic_test.go
@@ -61,7 +61,7 @@ func TestTopicCmd(t *testing.T) {
 			name:		"create should output info about the created topic (default values)",
 			cmd:		topic.NewCreateCommand,
 			args:		[]string{"San Francisco"},
-			expectedOutput:	`Created topic 'San Francisco'. Partitions: 1, replicas: -1, configuration:\n'cleanup.policy':'delete'`,
+			expectedOutput:	`Created topic 'San Francisco'. Partitions: 1, replicas: 1, configuration:\n'cleanup.policy':'delete'`,
 		},
 		{
 			name:		"create should output info about the created topic (custom values)",
@@ -73,13 +73,13 @@ func TestTopicCmd(t *testing.T) {
 			name:		"create should allow passing arbitrary topic config",
 			cmd:		topic.NewCreateCommand,
 			args:		[]string{"San Francisco", "-c", "custom.config:value", "--config", "another.config:anothervalue"},
-			expectedOutput:	`Created topic 'San Francisco'. Partitions: 1, replicas: -1, configuration:\n'another.config':'anothervalue'\n'cleanup.policy':'delete'\n'custom.config':'value'`,
+			expectedOutput:	`Created topic 'San Francisco'. Partitions: 1, replicas: 1, configuration:\n'another.config':'anothervalue'\n'cleanup.policy':'delete'\n'custom.config':'value'`,
 		},
 		{
 			name:		"create should allow passing comma-separated config values",
 			cmd:		topic.NewCreateCommand,
 			args:		[]string{"San Francisco", "-c", "custom.config:value", "--config", "cleanup.policy:cleanup,compact"},
-			expectedOutput:	`Created topic 'San Francisco'. Partitions: 1, replicas: -1, configuration:\n'cleanup.policy':'cleanup,compact'\n'custom.config':'value'`,
+			expectedOutput:	`Created topic 'San Francisco'. Partitions: 1, replicas: 1, configuration:\n'cleanup.policy':'cleanup,compact'\n'custom.config':'value'`,
 		},
 		{
 			name:		"create should fail if no topic is passed",


### PR DESCRIPTION
Sending -1 as the replication factor used to signal the server to
use the default replication factor
(`redpanda.default_topic_replication`). However, it seems that's
not the case anymore, so default to 1 while it's fixed.
