### PR TITLE
redpanda/config: change default of target_quota_byte_rate to 2GB

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -175,9 +175,9 @@ configuration::configuration()
   , target_quota_byte_rate(
       *this,
       "target_quota_byte_rate",
-      "Target quota byte rate (bytes per second) - 1GB default",
+      "Target quota byte rate (bytes per second) - 2GB default",
       required::no,
-      1_GiB)
+      2_GiB)
   , rack(*this, "rack", "Rack identifier", required::no, std::nullopt)
   , dashboard_dir(
       *this,


### PR DESCRIPTION
Previously was set to 1GB but performance tools like
librdkafka_performance only use a single client on a single thread and
can hit the 1GB limit.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
