### PR TITLE
r/consensus: fixed race condition causing follower not to flush its log

### DIFF
--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -508,6 +508,7 @@ private:
      * majority.
      */
     model::offset _last_quorum_replicated_index;
+    consistency_level _last_write_consistency_level;
     offset_monitor _consumable_offset_monitor;
     ss::condition_variable _disk_append;
     append_entries_buffer _append_requests_buffer;

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -40,7 +40,8 @@ private:
     ss::future<> close_snapshot_reader();
     bool state_changed();
     bool is_recovery_finished();
-
+    append_entries_request::flush_after_append
+      should_flush(model::offset) const;
     consensus* _ptr;
     vnode _node_id;
     model::offset _base_batch_offset;

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -138,6 +138,7 @@ replicate_entries_stm::append_to_self() {
     return share_request()
       .then([this](append_entries_request req) mutable {
           vlog(_ctxlog.trace, "Self append entries - {}", req.meta);
+          _ptr->_last_write_consistency_level = consistency_level::quorum_ack;
           return _ptr->disk_append(
             std::move(req.batches), consensus::update_last_quorum_index::yes);
       })


### PR DESCRIPTION
Always flushing follower log when recovery finishes and previous
replicate call was executed with `consistency_level::quorum`.

In order to commit entries on the leader they have to be safely stored
on the followers i.e. follower log has to be flushed. We minimize number
of flushes to optimize recovery throughput and latency. Race condition
between dispatching recovery append entries request and updating last
quorum replicated index caused recovery STM to skip flush of last batch
send to the follower. This lead to the situation when raft group
committed index wasn't updated until next replicate call.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
