### PR TITLE
r/configuration: assigning initial revisions to nodes without revisions

### DIFF
--- a/src/v/raft/configuration.h
+++ b/src/v/raft/configuration.h
@@ -23,6 +23,7 @@
 
 namespace raft {
 
+static constexpr model::revision_id no_revision{};
 class vnode {
 public:
     constexpr vnode() = default;
@@ -179,6 +180,14 @@ public:
 
     void promote_to_voter(vnode id);
     model::revision_id revision_id() const { return _revision; }
+
+    /**
+     * Used to set initial revision for old configuration vnodes to maintain
+     * backward compatibility.
+     *
+     * IMPORTANT: may be removed in future versions
+     */
+    void maybe_set_initial_revision(model::revision_id r);
 
     friend bool
     operator==(const group_configuration&, const group_configuration&);

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "model/record_batch_reader.h"
 #include "raft/logger.h"
 #include "raft/types.h"
@@ -51,7 +52,7 @@ public:
     configuration_manager(
       group_configuration, raft::group_id, storage::api&, ctx_log&);
 
-    ss::future<> start(bool reset);
+    ss::future<> start(bool reset, model::revision_id);
 
     ss::future<> stop();
     /**

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -750,7 +750,8 @@ ss::future<> consensus::start() {
     return _op_lock.with([this] {
         read_voted_for();
 
-        return _configuration_manager.start(is_initial_state())
+        return _configuration_manager
+          .start(is_initial_state(), _self.revision())
           .then([this] { return hydrate_snapshot(); })
           .then([this] {
               vlog(

--- a/src/v/raft/tests/configuration_serialization_test.cc
+++ b/src/v/raft/tests/configuration_serialization_test.cc
@@ -327,7 +327,7 @@ SEASTAR_THREAD_TEST_CASE(configuration_backward_compatibility_test) {
       cfg_v2.current_config().voters[0].id(),
       cfg_v3.current_config().voters[0].id());
 
-    BOOST_REQUIRE_EQUAL(cfg_v0.revision_id(), model::revision_id(0));
+    BOOST_REQUIRE_EQUAL(cfg_v0.revision_id(), raft::no_revision);
     BOOST_REQUIRE_EQUAL(cfg_v1.revision_id(), model::revision_id(15));
     BOOST_REQUIRE_EQUAL(cfg_v2.revision_id(), model::revision_id(15));
     BOOST_REQUIRE_EQUAL(cfg_v3.revision_id(), model::revision_id(15));


### PR DESCRIPTION
Implemented assigning initial revision id when old configuration format
is used by raft group.

Older raft::configuration didn't hold `raft::vnode` tuple. It was using
plain `model::node_id` instead. In current version we keep `raft::vnode`
in raft configuration.

When controller backend creates a topic it assign identity of a current
node recognized by this raft group. The `raft::vnode` is equal to
an offset of command that caused partition creation. The problem that we
experienced after updating from old raft configuration format to the new
one was caused by keeping nodes without revision in configuration but
assigning node revision when creating raft group. This made the nodes
hosting raft group not being part of its configured quorum.

Since redpanda now does not support raft configuration changes we can
safely modify configuration content to assign initial revisions to
nodes being part of raft group configuration.

Fixes: #501

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
