### PR TITLE
coproc: off-by-one error

### DIFF
--- a/src/v/coproc/ntp_context.h
+++ b/src/v/coproc/ntp_context.h
@@ -30,8 +30,8 @@ namespace coproc {
 /// subscribers to an input ntp
 struct ntp_context {
     struct offset_pair {
-        model::offset last_read{model::model_limits<model::offset>::min()};
-        model::offset last_acked{model::model_limits<model::offset>::min()};
+        model::offset last_read{};
+        model::offset last_acked{};
     };
 
     explicit ntp_context(storage::log lg)

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -201,7 +201,7 @@ script_context::get_reader(const ss::lw_shared_ptr<ntp_context>& ntp_ctx) {
     const storage::offset_stats os = ntp_ctx->log.offsets();
     return storage::log_reader_config(
       next_read,
-      os.committed_offset,
+      os.dirty_offset,
       1,
       max_batch_size(),
       ss::default_priority_class(),

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -18,6 +18,7 @@
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "raft/types.h"
+#include "storage/types.h"
 #include "vlog.h"
 
 #include <chrono>
@@ -177,7 +178,7 @@ ss::future<std::vector<process_batch_request::data>> script_context::read() {
       });
 }
 
-std::optional<storage::log_reader_config>
+storage::log_reader_config
 script_context::get_reader(const ss::lw_shared_ptr<ntp_context>& ntp_ctx) {
     auto found = ntp_ctx->offsets.find(_id);
     vassert(
@@ -185,26 +186,22 @@ script_context::get_reader(const ss::lw_shared_ptr<ntp_context>& ntp_ctx) {
       "script_id must exist: {} for ntp: {}",
       _id,
       ntp_ctx->ntp());
-    const auto& cp_offsets = found->second;
-    if (cp_offsets.last_read != cp_offsets.last_acked) {
+    const ntp_context::offset_pair& cp_offsets = found->second;
+    const model::offset next_read
+      = (unlikely(cp_offsets.last_acked == model::offset{}))
+          ? model::offset(0)
+          : cp_offsets.last_acked + model::offset(1);
+    if (next_read <= cp_offsets.last_acked) {
         vlog(
           coproclog.info,
           "Replaying read on ntp: {} at offset: {}",
           ntp_ctx->ntp(),
           cp_offsets.last_read);
     }
-    const storage::offset_stats stats = ntp_ctx->log.offsets();
-    const model::offset next_read
-      = (unlikely(
-          cp_offsets.last_acked == model::model_limits<model::offset>::min()))
-          ? model::offset(0)
-          : cp_offsets.last_acked + model::offset(1);
-    if (next_read >= stats.committed_offset()) {
-        return std::nullopt;
-    }
+    const storage::offset_stats os = ntp_ctx->log.offsets();
     return storage::log_reader_config(
       next_read,
-      model::model_limits<model::offset>::max(),
+      os.committed_offset,
       1,
       max_batch_size(),
       ss::default_priority_class(),
@@ -217,12 +214,8 @@ ss::future<std::optional<process_batch_request::data>>
 script_context::read_ntp(ss::lw_shared_ptr<ntp_context> ntp_ctx) {
     return ss::with_semaphore(
       _resources.read_sem, max_batch_size(), [this, ntp_ctx]() {
-          auto cfg = get_reader(ntp_ctx);
-          if (!cfg) {
-              return ss::make_ready_future<
-                std::optional<process_batch_request::data>>(std::nullopt);
-          }
-          return ntp_ctx->log.make_reader(*cfg)
+          storage::log_reader_config cfg = get_reader(ntp_ctx);
+          return ntp_ctx->log.make_reader(cfg)
             .then([](model::record_batch_reader rbr) {
                 return model::consume_reader_to_memory(
                   std::move(rbr), model::no_timeout);

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -75,7 +75,7 @@ private:
     ss::future<>
       send_request(supervisor_client_protocol, process_batch_request);
 
-    std::optional<storage::log_reader_config>
+    storage::log_reader_config
     get_reader(const ss::lw_shared_ptr<ntp_context>&);
 
     ss::future<std::vector<process_batch_request::data>> read();

--- a/src/v/coproc/tests/utils/helpers.cc
+++ b/src/v/coproc/tests/utils/helpers.cc
@@ -11,6 +11,8 @@
 
 #include "coproc/tests/utils/helpers.h"
 
+#include "storage/tests/utils/random_batch.h"
+
 #include <algorithm>
 
 coproc::enable_copros_request::data make_enable_req(
@@ -50,4 +52,17 @@ deregister_coprocessors(
     coproc::disable_copros_request req{.ids = std::move(script_ids)};
     return client.disable_copros(
       std::move(req), rpc::client_opts(rpc::no_timeout));
+}
+
+model::record_batch_reader single_record_record_batch_reader() {
+    return model::make_generating_record_batch_reader([total = 1]() mutable {
+        model::record_batch_reader::data_t batches;
+        if (total--) {
+            model::record_batch_reader::data_t reader;
+            batches.push_back(
+              storage::test::make_random_batch(model::offset(0), 1, false));
+        }
+        return ss::make_ready_future<model::record_batch_reader::data_t>(
+          std::move(batches));
+    });
 }

--- a/src/v/coproc/tests/utils/helpers.h
+++ b/src/v/coproc/tests/utils/helpers.h
@@ -46,3 +46,6 @@ ss::future<result<rpc::client_context<coproc::disable_copros_reply>>>
 deregister_coprocessors(
   rpc::client<coproc::script_manager_client_protocol>&,
   std::vector<uint32_t>&&);
+
+/// Produces a batch with 1 record_batch which has 1 single record within it
+model::record_batch_reader single_record_record_batch_reader();


### PR DESCRIPTION
The coprocessor engine will not send record batches when the difference between the committed offset and the offset of a tracked input topic is not greater then 1. The effect seen during testing of single record pushes to the input topic is no response at the wasm engine side, until a second record is pushed.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
