### PR TITLE
rpk/debug/info: Fix unchecked deref

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -154,10 +154,8 @@ func executeInfo(
 		<-confRowsCh,
 		<-kafkaRowsCh,
 	}
-
-	errs := grp.Wait().Errors
-	if errs != nil {
-		for _, err := range errs {
+	if errs := grp.Wait(); errs != nil {
+		for _, err := range errs.Errors {
 			log.Info(err)
 		}
 	}


### PR DESCRIPTION
When there are no errors, grp.Wait() returns nil, so it has to be
checked before attempting to access the underlying []error.
