### PR TITLE
coproc/js: change apply coprocessor function return type to Promise

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/template/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/template/wasm.go
@@ -42,7 +42,8 @@ transform.processRecord((recordBatch) => {
     };
   });
   result.set("result", transformedRecord);
-  return result;
+  // processRecord function returns a Promise
+  return Promise.resolve(result);
 });
 exports["default"] = transform;
 `

--- a/src/js/modules/public/Coprocessor.ts
+++ b/src/js/modules/public/Coprocessor.ts
@@ -73,7 +73,7 @@ interface Coprocessor {
   inputTopics: string[];
   policyError: PolicyError;
   globalId: bigint;
-  apply: (record: RecordBatch) => Map<Topic, RecordBatch>;
+  apply: (record: RecordBatch) => Promise<Map<Topic, RecordBatch>>;
 }
 
 export { RecordBatchHeader, RecordHeader, Record, RecordBatch, Coprocessor };

--- a/src/js/modules/public/SimpleTransform.ts
+++ b/src/js/modules/public/SimpleTransform.ts
@@ -38,7 +38,7 @@ export class SimpleTransform implements Coprocessor {
   inputTopics: string[];
   policyError: PolicyError;
 
-  apply = (record: RecordBatch): Map<string, RecordBatch> => {
+  apply = (record: RecordBatch): Promise<Map<string, RecordBatch>> => {
     throw Error("processRecord isn't implemented yet");
   };
 }

--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -87,18 +87,21 @@ export class ProcessBatchServer extends SupervisorServer {
    * @param coprocessor
    * @param processBatchRequest
    * @param error
+   * @param policyError, optional, by default this function takes value from
+   * coprocessor.
    */
   public handleErrorByPolicy(
     coprocessor: Coprocessor,
     processBatchRequest: ProcessBatchRequestItem,
-    error: Error
+    error: Error,
+    policyError = coprocessor.policyError
   ): Promise<never> {
     const errorMessage = this.createMessageError(
       coprocessor,
       processBatchRequest,
       error
     );
-    switch (coprocessor.policyError) {
+    switch (policyError) {
       case PolicyError.Deregister:
         return this.fileManager
           .deregisterCoprocessor(coprocessor)

--- a/src/js/test/rpc/server.test.ts
+++ b/src/js/test/rpc/server.test.ts
@@ -181,15 +181,17 @@ describe("Server", function () {
       spyGetHandles.returns([
         createHandle({
           apply: () =>
-            new Map([
-              [
-                "newTopic",
-                createRecordBatch({
-                  header: { recordCount: 1 },
-                  records: [{ value: Buffer.from("new VALUE") }],
-                }),
-              ],
-            ]),
+            Promise.resolve(
+              new Map([
+                [
+                  "newTopic",
+                  createRecordBatch({
+                    header: { recordCount: 1 },
+                    records: [{ value: Buffer.from("new VALUE") }],
+                  }),
+                ],
+              ])
+            ),
         }),
       ]);
       client
@@ -301,7 +303,7 @@ describe("Server", function () {
                 records: records.map(uppercase),
               }));
             result.set("result", transformedRecord);
-            return result;
+            return Promise.resolve(result);
           },
         })
       );
@@ -390,7 +392,7 @@ describe("Server", function () {
                 records: records.map(uppercase),
               }));
             result.set("result", transformedRecord);
-            return result;
+            return Promise.resolve(result);
           },
         })
       );

--- a/src/js/test/supervisors/FileManager.test.ts
+++ b/src/js/test/supervisors/FileManager.test.ts
@@ -95,8 +95,8 @@ describe("FileManager", () => {
   );
 
   it("should add listen for new file event", (done) => {
-    const repo = new Repository();
     const { readFolderStub, watchMock } = createStubs(sinonInstance);
+    const repo = new Repository();
     new FileManager(repo, "submit", "active", "inactive");
     // wait for promise readFolderCoprocessor resolves
     setTimeout(() => {
@@ -112,9 +112,9 @@ describe("FileManager", () => {
       "it should disable coprocessor topics and enable after adding" +
       "coprocessor",
     (done) => {
+      const { moveCoprocessor, getCoprocessor } = createStubs(sinonInstance);
       const handle = createHandle();
       const repo = new Repository();
-      const { moveCoprocessor, getCoprocessor } = createStubs(sinonInstance);
       moveCoprocessor.returns(Promise.resolve(handle));
       getCoprocessor.returns(Promise.resolve(handle));
 
@@ -150,13 +150,13 @@ describe("FileManager", () => {
       const handle = createHandle();
       const handle2 = createHandle({ inputTopics: ["anotherTopics"] });
       handle2.checksum = "different";
-      const repo = new Repository();
       const {
         moveCoprocessor,
         getCoprocessor,
         enableCoprocessor,
         disableCoprocessor,
       } = createStubs(sinonInstance);
+      const repo = new Repository();
       moveCoprocessor.returns(Promise.resolve(handle));
       getCoprocessor.returns(Promise.resolve(handle));
       getCoprocessor.returns(Promise.resolve(handle2));
@@ -180,10 +180,10 @@ describe("FileManager", () => {
 
   it("should remove a coprocessor from file path", (done) => {
     const handle = createHandle();
-    const repo = new Repository();
     const { moveCoprocessor, getCoprocessor, disableCoprocessor } = createStubs(
       sinonInstance
     );
+    const repo = new Repository();
 
     // add coprocessor
     repo.add(handle);
@@ -209,13 +209,13 @@ describe("FileManager", () => {
       "on enable request",
     function (done) {
       const handle = createHandle();
-      const repo = new Repository();
-      const removeSpy = sinonInstance.spy(repo, "remove");
       const {
         moveCoprocessor,
         getCoprocessor,
         enableCoprocessor,
       } = createStubs(sinonInstance);
+      const repo = new Repository();
+      const removeSpy = sinonInstance.spy(repo, "remove");
       moveCoprocessor.returns(Promise.resolve(handle));
       getCoprocessor.returns(Promise.resolve(handle));
       enableCoprocessor.returns(Promise.reject(Error("internal error")));

--- a/src/js/test/supervisors/Repository.test.ts
+++ b/src/js/test/supervisors/Repository.test.ts
@@ -128,18 +128,20 @@ describe("Repository", function () {
       ],
     };
     handleA.coprocessor.apply = (record: RecordBatch) =>
-      new Map([
-        [
-          "result",
-          createRecordBatch({
-            records: record.records.map((r) => ({
-              ...r,
-              value: Buffer.from("TEST"),
-              valueLen: 4,
-            })),
-          }),
-        ],
-      ]);
+      Promise.resolve(
+        new Map([
+          [
+            "result",
+            createRecordBatch({
+              records: record.records.map((r) => ({
+                ...r,
+                value: Buffer.from("TEST"),
+                valueLen: 4,
+              })),
+            }),
+          ],
+        ])
+      );
     const sinonInstance = sinon.createSandbox();
     const stubFire = sinonInstance.stub(
       ProcessBatchServer.prototype,

--- a/src/js/test/testUtilities.ts
+++ b/src/js/test/testUtilities.ts
@@ -16,7 +16,8 @@ export const createMockCoprocessor = (
   globalId: Coprocessor["globalId"] = BigInt(1),
   inputTopics: Coprocessor["inputTopics"] = ["topicA"],
   policyError: Coprocessor["policyError"] = PolicyError.SkipOnFailure,
-  apply: Coprocessor["apply"] = () => new Map([["result", createRecordBatch()]])
+  apply: Coprocessor["apply"] = () =>
+    Promise.resolve(new Map([["result", createRecordBatch()]]))
 ): Coprocessor => ({
   globalId,
   inputTopics,

--- a/src/js/test/utilities/Checksum.test.ts
+++ b/src/js/test/utilities/Checksum.test.ts
@@ -15,7 +15,7 @@ import { join } from "path";
 describe("Checksum utilities", () => {
   describe("When we call getChecksumFromFile", () => {
     const expectChecksum =
-      "0374d40e1d2b885e0cb2f23f181d50443b6473ef819c10f3dc3e73e9b8b9f800";
+      "948451abc0b5b04e542fa38ac6a5e1838b8755a48de78d69cd0000cce6affce1";
     describe("Given a existing file", () => {
       it("Should get file content's checksum", (done) => {
         const checksumPromise = getChecksumFromFile(

--- a/src/js/test/utilities/CoprocessorTest.ts
+++ b/src/js/test/utilities/CoprocessorTest.ts
@@ -19,8 +19,8 @@ class CoprocessorTest implements Coprocessor {
   inputTopics = ["topicA"];
   policyError = PolicyError.Deregister;
 
-  apply(record: RecordBatch): Map<string, RecordBatch> {
-    return new Map([["test", record]]);
+  apply(record: RecordBatch): Promise<Map<string, RecordBatch>> {
+    return Promise.resolve(new Map([["test", record]]));
   }
 }
 


### PR DESCRIPTION
when someone need to make a request or async code into coprocessor
the current approach allow it, but doesn't wait for promise result
like this:
```
apply(record) {
   const map = new Map()
   /*async code*/
   publishRecord(record)
   return map
}
```

with these changes, the apply method returns a Promise, with this
new approach wasm engine can wait for Promise result.

```
apply(record) {
   const map = new Map()
   /*async code*/
   return publishRecord(record)
    .then(() => map)
}
```