### PR TITLE
operator/controller: Fix node status

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -154,7 +154,7 @@ func (r *ClusterReconciler) Reconcile(
 		return ctrl.Result{}, err
 	}
 
-	observedNodes := make([]string, len(observedPods.Items))
+	observedNodes := make([]string, 0, len(observedPods.Items))
 	// nolint:gocritic // the copies are necessary for further redpandacluster updates
 	for _, item := range observedPods.Items {
 		observedNodes = append(observedNodes, item.Name)


### PR DESCRIPTION
Fixing an issue where empty node status entries are present due to a slice length vs. capacity mishup.

Example

Before
```
Status:
  Nodes:
    
    cluster-sample-seed-0
```

After
```
Status:
  Nodes:
    cluster-sample-seed-0
```