### PR TITLE
Kafka batch reader

### DIFF
--- a/src/v/coproc/tests/read_materialized_topic_test.cc
+++ b/src/v/coproc/tests/read_materialized_topic_test.cc
@@ -181,5 +181,6 @@ FIXTURE_TEST(
       resp.partitions[0].responses[0].error, kafka::error_code::none);
     BOOST_REQUIRE_EQUAL(resp.partitions[0].responses[0].id, pid);
     BOOST_REQUIRE(resp.partitions[0].responses[0].record_set);
-    BOOST_REQUIRE_EQUAL(resp.partitions[0].responses[0].record_set, data);
+    BOOST_REQUIRE_EQUAL(
+      std::move(*resp.partitions[0].responses[0].record_set).release(), data);
 }

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -33,6 +33,7 @@ set(handlers_srcs
 v_cc_library(
   NAME kafka
   SRCS
+    protocol/batch_reader.cc
     protocol/kafka_batch_adapter.cc
     ${security_srcs}
     ${handlers_srcs}

--- a/src/v/kafka/protocol/CMakeLists.txt
+++ b/src/v/kafka/protocol/CMakeLists.txt
@@ -6,3 +6,5 @@ v_cc_library(
     errors.cc
   DEPS
     v::kafka_request_schemata)
+
+add_subdirectory(tests)

--- a/src/v/kafka/protocol/batch_reader.cc
+++ b/src/v/kafka/protocol/batch_reader.cc
@@ -111,4 +111,14 @@ model::offset batch_reader::last_offset() const {
     return last_offset;
 }
 
+kafka_batch_adapter batch_reader::consume_batch() {
+    iobuf_const_parser p{_buf};
+    const auto hdr = read_record_batch_info(p);
+    const auto size_bytes = hdr.size_bytes();
+    kafka_batch_adapter kba;
+    kba.adapt(_buf.share(0, size_bytes));
+    _buf.trim_front(size_bytes);
+    return kba;
+}
+
 } // namespace kafka

--- a/src/v/kafka/protocol/batch_reader.cc
+++ b/src/v/kafka/protocol/batch_reader.cc
@@ -1,0 +1,114 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/protocol/batch_reader.h"
+
+#include "kafka/protocol/kafka_batch_adapter.h"
+#include "model/record.h"
+#include "model/timeout_clock.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/std-coroutine.hh>
+
+namespace kafka {
+
+namespace {
+
+/// \brief A subset of the model::record_batch_header
+///
+/// Just enough to delineate record_batch within consumer_records.
+class record_batch_info {
+public:
+    record_batch_info(model::offset bo, int32_t lod, int32_t sb)
+      : _base_offset{bo}
+      , _last_offset_delta{lod}
+      , _size_bytes{sb} {}
+
+    int32_t size_bytes() const { return _size_bytes; }
+    int32_t record_bytes() const {
+        return _size_bytes - model::packed_record_batch_header_size;
+    }
+    model::offset last_offset() const {
+        return _base_offset + model::offset{_last_offset_delta};
+    }
+
+private:
+    model::offset _base_offset;
+    int32_t _last_offset_delta;
+    int32_t _size_bytes;
+};
+
+record_batch_info read_record_batch_info(iobuf_const_parser& in) {
+    if (unlikely(in.bytes_left() < internal::kafka_header_size)) {
+        throw exception(
+          error_code::corrupt_message,
+          fmt_with_ctx(
+            fmt::format,
+            "Invalid kafka header parsing: Only {} bytes remain",
+            in.bytes_left()));
+    }
+    const size_t initial_bytes_consumed = in.bytes_consumed();
+    const auto base_offset = model::offset(in.consume_be_type<int64_t>());
+    const auto batch_length = in.consume_be_type<int32_t>();
+    constexpr size_t skip_len_1 = sizeof(int32_t) + // partition_leader_epoch
+                                  sizeof(int8_t) +  // magic
+                                  sizeof(int32_t) + // crc
+                                  sizeof(int16_t);  // attrs
+
+    in.skip(skip_len_1);
+    const auto last_offset_delta = in.consume_be_type<int32_t>();
+    constexpr size_t skip_len_2 = sizeof(int64_t) + // first_timestamp
+                                  sizeof(int64_t) + // max_timestamp
+                                  sizeof(int64_t) + // producer_id
+                                  sizeof(int16_t) + // producer_epoch
+                                  sizeof(int32_t) + // base_sequence
+                                  sizeof(int32_t);  // record_count
+    in.skip(skip_len_2);
+
+    // size_bytes are  the normal kafka batch length minus the `IGNORED`
+    const int32_t size_bytes
+      = batch_length - internal::kafka_header_size
+        + model::packed_record_batch_header_size
+        // Kafka *does not* include the first 2 fields in the size calculation
+        // they build the types bottoms up, not top down
+        + sizeof(base_offset) + sizeof(batch_length);
+
+    const size_t total_bytes_consumed = in.bytes_consumed()
+                                        - initial_bytes_consumed;
+    if (unlikely(total_bytes_consumed != internal::kafka_header_size)) {
+        throw exception(
+          error_code::corrupt_message,
+          fmt_with_ctx(
+            fmt::format,
+            "Invalid kafka header parsing. Must consume exactly: {} bytes, but "
+            "consumed: {} bytes",
+            internal::kafka_header_size,
+            total_bytes_consumed));
+    }
+    return record_batch_info{base_offset, last_offset_delta, size_bytes};
+}
+
+} // namespace
+
+model::offset batch_reader::last_offset() const {
+    iobuf_const_parser p{_buf};
+    model::offset last_offset{0};
+    // Complexity: O(n) record_batches
+    // This should be futurized if there are stalls.
+    while (p.bytes_left()) {
+        const auto rbi = read_record_batch_info(p);
+        last_offset = rbi.last_offset();
+        p.skip(rbi.record_bytes());
+    }
+    return last_offset;
+}
+
+} // namespace kafka

--- a/src/v/kafka/protocol/batch_reader.h
+++ b/src/v/kafka/protocol/batch_reader.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "bytes/iobuf.h"
+#include "kafka/protocol/kafka_batch_adapter.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 
@@ -38,6 +39,9 @@ public:
     //
     // Complexity: O(n) record_batches
     model::offset last_offset() const;
+
+    // Consume a model::record_batch as a kafka_batch_adaptor
+    kafka_batch_adapter consume_batch();
 
     // Release any remaining iobuf that hasn't been consumed
     iobuf release() && { return std::move(_buf); }

--- a/src/v/kafka/protocol/batch_reader.h
+++ b/src/v/kafka/protocol/batch_reader.h
@@ -13,6 +13,7 @@
 
 #include "bytes/iobuf.h"
 #include "kafka/types.h"
+#include "model/fundamental.h"
 
 #include <optional>
 
@@ -32,6 +33,11 @@ public:
     bool empty() const { return _buf.empty(); }
 
     size_t size_bytes() const { return _buf.size_bytes(); }
+
+    // Obtain the offset of the last record in the last batch
+    //
+    // Complexity: O(n) record_batches
+    model::offset last_offset() const;
 
     // Release any remaining iobuf that hasn't been consumed
     iobuf release() && { return std::move(_buf); }

--- a/src/v/kafka/protocol/batch_reader.h
+++ b/src/v/kafka/protocol/batch_reader.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "kafka/types.h"
+
+#include <optional>
+
+namespace kafka {
+
+///\brief batch_reader owns an iobuf that's a concatenation of
+/// model::record_batch on the wire
+///
+/// The array bound is not serialized, c.f. array<kafka::thing>
+class batch_reader {
+public:
+    batch_reader() = default;
+
+    explicit batch_reader(iobuf buf)
+      : _buf(std::move(buf)) {}
+
+    bool empty() const { return _buf.empty(); }
+
+    size_t size_bytes() const { return _buf.size_bytes(); }
+
+    // Release any remaining iobuf that hasn't been consumed
+    iobuf release() && { return std::move(_buf); }
+
+private:
+    iobuf _buf;
+};
+
+} // namespace kafka

--- a/src/v/kafka/protocol/exceptions.h
+++ b/src/v/kafka/protocol/exceptions.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "kafka/protocol/errors.h"
+
+#include <fmt/core.h>
+
+#include <exception>
+
+namespace kafka {
+
+struct exception_base : std::exception {
+    explicit exception_base(error_code err, std::string msg)
+      : std::exception{}
+      , error{err}
+      , msg{std::move(msg)} {}
+    const char* what() const noexcept final { return msg.c_str(); }
+    error_code error;
+    std::string msg;
+};
+
+struct exception final : exception_base {
+    explicit exception(error_code err, std::string msg)
+      : exception_base{err, std::move(msg)} {}
+};
+
+} // namespace kafka

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/partition.h"
+#include "kafka/protocol/batch_reader.h"
 #include "kafka/server/fetch_session.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
@@ -216,7 +217,7 @@ struct fetch_response final {
         model::offset last_stable_offset;                      // >= v4
         model::offset log_start_offset;                        // >= v5
         std::vector<aborted_transaction> aborted_transactions; // >= v4
-        std::optional<iobuf> record_set;
+        std::optional<batch_reader> record_set;
         /*
          * _not part of kafka protocol
          * used to indicate wether we have to

--- a/src/v/kafka/protocol/request_reader.h
+++ b/src/v/kafka/protocol/request_reader.h
@@ -13,6 +13,7 @@
 
 #include "bytes/bytes.h"
 #include "bytes/iobuf_parser.h"
+#include "kafka/protocol/batch_reader.h"
 #include "likely.h"
 #include "seastarx.h"
 #include "utils/concepts-enabled.h"
@@ -74,6 +75,14 @@ public:
         }
         auto ret = _parser.share(len);
         return {std::move(ret), len};
+    }
+
+    std::optional<batch_reader> read_nullable_batch_reader() {
+        auto io = read_fragmented_nullable_bytes();
+        if (!io) {
+            return std::nullopt;
+        }
+        return batch_reader(std::move(*io));
     }
 
     template<

--- a/src/v/kafka/protocol/response_writer.h
+++ b/src/v/kafka/protocol/response_writer.h
@@ -13,6 +13,7 @@
 
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
+#include "kafka/protocol/batch_reader.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
@@ -115,6 +116,13 @@ public:
                     + data->size_bytes();
         _out->append(std::move(*data));
         return size;
+    }
+
+    uint32_t write(std::optional<batch_reader>&& rdr) {
+        if (!rdr) {
+            return write(std::optional<iobuf>());
+        }
+        return write(std::move(*rdr).release());
     }
 
     // write bytes directly to output without a length prefix

--- a/src/v/kafka/protocol/tests/CMakeLists.txt
+++ b/src/v/kafka/protocol/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+find_package(CppKafka CONFIG REQUIRED)
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME
+    test_kafka_protocol
+  SOURCES
+    batch_reader_test.cc
+  DEFINITIONS
+    BOOST_TEST_DYN_LINK
+  LIBRARIES
+    v::seastar_testing_main
+    v::kafka
+    v::storage_test_utils
+  ARGS "-- -c 1"
+  LABELS
+    kafka
+    kafka_protocol
+)

--- a/src/v/kafka/protocol/tests/batch_reader_test.cc
+++ b/src/v/kafka/protocol/tests/batch_reader_test.cc
@@ -1,0 +1,105 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/details/io_iterator_consumer.h"
+#include "bytes/iobuf_parser.h"
+#include "kafka/protocol/batch_consumer.h"
+#include "kafka/protocol/batch_reader.h"
+#include "kafka/protocol/exceptions.h"
+#include "kafka/protocol/kafka_batch_adapter.h"
+#include "model/fundamental.h"
+#include "redpanda/tests/fixture.h"
+#include "storage/tests/utils/random_batch.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/sstring.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <iterator>
+#include <type_traits>
+
+struct context {
+    model::offset base_offset;
+    model::offset last_offset;
+    iobuf record_set;
+};
+
+context make_context(model::offset base_offset, size_t batch_count) {
+    auto input = storage::test::make_random_batches(base_offset, batch_count);
+    BOOST_REQUIRE(!input.empty());
+    const auto last_offset = input.back().last_offset();
+
+    // Serialise the batches
+    auto mem_res = model::make_memory_record_batch_reader(std::move(input))
+                     .consume(
+                       kafka::kafka_batch_serializer{}, model::no_timeout)
+                     .get();
+    BOOST_REQUIRE_EQUAL(
+      (last_offset - base_offset)() + 1, mem_res.record_count);
+    return context{
+      .base_offset{base_offset},
+      .last_offset{last_offset},
+      .record_set{std::move(mem_res.data)}};
+}
+
+void corrupt_with_short_header(iobuf& record_set) {
+    record_set.trim_back(
+      record_set.size_bytes() - kafka::internal::kafka_header_size + 3);
+}
+
+template<
+  typename T,
+  typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
+void corrupt_offset(iobuf& buf, size_t offset, void (*fun)(T& t)) {
+    ss::sstring linearised{ss::uninitialized_string(buf.size_bytes())};
+    auto consumer = details::io_iterator_consumer{buf.begin(), buf.end()};
+    consumer.consume_to(buf.size_bytes(), linearised.data());
+    buf.clear();
+
+    T t;
+    auto val_it = reinterpret_cast<char*>(&t);                         // NOLINT
+    auto buf_it = reinterpret_cast<char*>(linearised.data() + offset); // NOLINT
+    std::memcpy(val_it, buf_it, sizeof(T));
+    fun(t);
+    std::memcpy(buf_it, val_it, sizeof(T));
+
+    buf.append(linearised.data(), linearised.size());
+}
+
+static constexpr size_t mag_offset = sizeof(model::offset) + // base_offset
+                                     sizeof(int32_t) +       // batch_length
+                                     sizeof(int32_t);        // part_lead_epoch
+static constexpr size_t crc_offset = mag_offset +            //
+                                     sizeof(int8_t);         // magic
+static constexpr size_t lod_offset = crc_offset +            //
+                                     sizeof(int32_t) +       // crc
+                                     sizeof(int16_t);        // attr
+
+static constexpr model::offset base_offset(42);
+static constexpr size_t few_batches = 2;
+static constexpr size_t many_batches = 40;
+
+SEASTAR_THREAD_TEST_CASE(batch_reader_last_offset) {
+    auto ctx = make_context(base_offset, many_batches);
+
+    auto crs = kafka::batch_reader(std::move(ctx.record_set));
+    BOOST_REQUIRE_EQUAL(crs.last_offset(), ctx.last_offset);
+}
+
+SEASTAR_THREAD_TEST_CASE(batch_reader_last_offset_short_header) {
+    auto ctx = make_context(base_offset, few_batches);
+    corrupt_with_short_header(ctx.record_set);
+
+    auto crs = kafka::batch_reader(std::move(ctx.record_set));
+    BOOST_REQUIRE_EXCEPTION(
+      crs.last_offset(), kafka::exception, [](const kafka::exception& e) {
+          return e.error == kafka::error_code::corrupt_message;
+      });
+}

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -224,7 +224,7 @@ void fetch_response::decode(iobuf buf, api_version version) {
                       .first_offset = model::offset(reader.read_int64()),
                     };
                 }),
-              .record_set = reader.read_fragmented_nullable_bytes()};
+              .record_set = reader.read_nullable_batch_reader()};
         });
         return p;
     });
@@ -277,7 +277,7 @@ make_partition_response_error(model::partition_id p_id, error_code error) {
       .error = error,
       .high_watermark = model::offset(-1),
       .last_stable_offset = model::offset(-1),
-      .record_set = iobuf(),
+      .record_set = batch_reader(),
     };
 }
 
@@ -403,7 +403,7 @@ static ss::future<> do_fill_fetch_responses(
               fetch_response::partition_response resp{
                 .id = pid,
                 .error = error_code::none,
-                .record_set = std::move(res.data),
+                .record_set = batch_reader(std::move(res.data)),
               };
               resp_it.set(std::move(resp));
           })
@@ -658,7 +658,7 @@ void op_context::start_response_partition(const fetch_request::partition& p) {
         .error = error_code::none,
         .high_watermark = model::offset(-1),
         .last_stable_offset = model::offset(-1),
-        .record_set = iobuf()});
+        .record_set = batch_reader()});
 }
 
 void op_context::create_response_placeholders() {
@@ -687,7 +687,7 @@ void op_context::create_response_placeholders() {
                 .error = error_code::none,
                 .high_watermark = fp.high_watermark,
                 .last_stable_offset = fp.high_watermark,
-                .record_set = iobuf()};
+                .record_set = batch_reader()};
 
               response.partitions.back().responses.push_back(std::move(p));
           });

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -93,8 +93,7 @@ public:
             auto r = std::move(*v.partition_response);
             model::topic_partition_view tpv(v.partition->name, r.id);
             while (r.record_set && !r.record_set->empty()) {
-                kafka::kafka_batch_adapter adapter;
-                r.record_set = adapter.adapt(std::move(*r.record_set));
+                auto adapter = r.record_set->consume_batch();
                 auto rjs = rjson_serialize_impl<model::record>(
                   _fmt, tpv, adapter.batch->base_offset());
 


### PR DESCRIPTION
This PR replaces #464 

`kafka::fetch_response::partition_response::record_set` contains `optional<record_batch[]>`, which deserves a type.

This utility supports:
 * `empty`
 * `size_bytes`
 * `last_offset` - last offset of last batch
 * `consume_batch` - as a `record_batch_adaptor`
 * `record_batch_reader::impl` implementation
 * `release()` - release the underlying `iobuf`

Major differences since #464:
 * Renamed `consumer_records` to `batch_reader`
 * Renamed member `consume_record_batch` to `consume_batch`
 * Renamed member `_record_set` to `_buf`
 * Support in `request_reader` and `response_writer`
 * Maintain nullable semantics by inverting the optionality
 * Removed logging - `record_batch adaptor` already logs
 * Reordered the patchset as it's a much closer drop-in replacement

Major differences after force push:
 * Rebased
 * Introduce an exception hierarchy
 * Improved error handling with exceptions
 * Tests for failure modes

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
