### PR TITLE
s/consensus: add initial revision to config coming from snapshot & log

### DIFF
--- a/src/v/raft/configuration_manager.cc
+++ b/src/v/raft/configuration_manager.cc
@@ -89,6 +89,8 @@ configuration_manager::add(std::vector<offset_configuration> configurations) {
     return _lock.with([this,
                        configurations = std::move(configurations)]() mutable {
         for (auto& co : configurations) {
+            // handling backward compatibility i.e. revisionless configurations
+            co.cfg.maybe_set_initial_revision(_initial_revision);
             vlog(
               _ctxlog.trace,
               "Adding configuration: {}, offset: {}",
@@ -105,6 +107,9 @@ configuration_manager::add(std::vector<offset_configuration> configurations) {
 
 ss::future<>
 configuration_manager::add(model::offset offset, group_configuration cfg) {
+    // handling backward compatibility i.e. revisionless configurations
+    cfg.maybe_set_initial_revision(_initial_revision);
+
     vlog(_ctxlog.trace, "Adding configuration: {}, offset: {}", cfg, offset);
     return _lock.with([this, cfg = std::move(cfg), offset]() mutable {
         auto it = _configurations.find(offset);
@@ -231,6 +236,7 @@ ss::future<> configuration_manager::stop() {
 
 ss::future<>
 configuration_manager::start(bool reset, model::revision_id initial_revision) {
+    _initial_revision = initial_revision;
     if (reset) {
         return _storage.kvs()
           .remove(
@@ -244,9 +250,7 @@ configuration_manager::start(bool reset, model::revision_id initial_revision) {
 
     auto map_buf = _storage.kvs().get(
       storage::kvstore::key_space::consensus, configurations_map_key());
-    return _lock.with([this,
-                       map_buf = std::move(map_buf),
-                       initial_revision]() mutable {
+    return _lock.with([this, map_buf = std::move(map_buf)]() mutable {
         auto f = ss::now();
 
         if (map_buf) {
@@ -271,9 +275,9 @@ configuration_manager::start(bool reset, model::revision_id initial_revision) {
             });
         }
 
-        return f.then([this, initial_revision] {
+        return f.then([this] {
             for (auto& [o, cfg] : _configurations) {
-                cfg.maybe_set_initial_revision(initial_revision);
+                cfg.maybe_set_initial_revision(_initial_revision);
             }
         });
     });

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -166,6 +166,8 @@ private:
      * bootstrap redpanda will have to read up to 64MB per raft group.
      */
     size_t _bytes_since_last_offset_update = 0;
+
+    model::revision_id _initial_revision{};
     ctx_log& _ctxlog;
 };
 } // namespace raft


### PR DESCRIPTION
Adding revision to revision less configuration that were stored in raft
snapshot by previous version of redpanda.

Similarly to #504 the configuration stored in snapshot metadata may be
in old format. We have to assign initial revision to the configuration
stored in snapshot metadata before adding it to configuration manager as
it may already exists at the same offset. If configuration stored in
snapshot has the same offset as the one in `raft::configuration_manager`
it means the configuration have to be identical. The same rule apply to
the configuration stored in raft log. Whenever it configuration is
revision less we have it must be assigned with initial revision.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
