### PR TITLE
rpc/transport: handing connection timeout

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -19,6 +19,7 @@
 #include "outcome_future_utils.h"
 #include "rpc/connection_cache.h"
 #include "rpc/dns.h"
+#include "rpc/types.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -76,12 +77,21 @@ auto with_client(
   model::node_id id,
   unresolved_address addr,
   config::tls_config tls_config,
+  rpc::clock_type::duration connection_timeout,
   Func&& f) {
     return update_broker_client(
              self, cache, id, std::move(addr), std::move(tls_config))
-      .then([id, self, &cache, f = std::forward<Func>(f)]() mutable {
+      .then([id,
+             self,
+             &cache,
+             f = std::forward<Func>(f),
+             connection_timeout]() mutable {
           return cache.local().with_node_client<Proto, Func>(
-            self, ss::this_shard_id(), id, std::forward<Func>(f));
+            self,
+            ss::this_shard_id(),
+            id,
+            connection_timeout,
+            std::forward<Func>(f));
       });
 }
 
@@ -124,7 +134,10 @@ maybe_build_reloadable_certificate_credentials(config::tls_config tls_config) {
 template<typename Proto, typename Func>
 CONCEPT(requires requires(Func&& f, Proto c) { f(c); })
 auto do_with_client_one_shot(
-  unresolved_address addr, config::tls_config tls_config, Func&& f) {
+  unresolved_address addr,
+  config::tls_config tls_config,
+  rpc::clock_type::duration connection_timeout,
+  Func&& f) {
     using transport_ptr = ss::lw_shared_ptr<rpc::transport>;
     return maybe_build_reloadable_certificate_credentials(std::move(tls_config))
       .then([addr = std::move(addr)](
@@ -138,8 +151,9 @@ auto do_with_client_one_shot(
                     .disable_metrics = rpc::metrics_disabled(true)});
             });
       })
-      .then([addr, f = std::forward<Func>(f)](transport_ptr transport) mutable {
-          return transport->connect()
+      .then([addr, f = std::forward<Func>(f), connection_timeout](
+              transport_ptr transport) mutable {
+          return transport->connect(connection_timeout)
             .then([transport, f = std::forward<Func>(f)]() mutable {
                 return ss::futurize_invoke(
                   std::forward<Func>(f), Proto(*transport));

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -89,6 +89,7 @@ id_allocator_frontend::dispatch_allocate_id_to_leader(
         _controller->self(),
         ss::this_shard_id(),
         leader,
+        timeout,
         [timeout](id_allocator_client_protocol cp) {
             return cp.allocate_id(
               allocate_id_request{timeout},

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -69,7 +69,7 @@ private:
 
     ss::future<join_reply> dispatch_join_request();
     template<typename Func>
-    auto dispatch_rpc_to_leader(Func&& f);
+    auto dispatch_rpc_to_leader(rpc::clock_type::duration, Func&& f);
 
     // Raft 0 config updates
     ss::future<> handle_raft0_cfg_update(raft::group_configuration);

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -246,6 +246,7 @@ metadata_dissemination_service::dispatch_get_metadata_update(
     return do_with_client_one_shot<metadata_dissemination_rpc_client_protocol>(
       address,
       _rpc_tls_config,
+      _dissemination_interval,
       [this](metadata_dissemination_rpc_client_protocol c) {
           return c
             .get_leadership(
@@ -309,6 +310,7 @@ ss::future<> metadata_dissemination_service::dispatch_one_update(
         _self.id(),
         ss::this_shard_id(),
         target_id,
+        _dissemination_interval,
         [this, &meta, target_id](
           metadata_dissemination_rpc_client_protocol proto) mutable {
             vlog(

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -287,6 +287,7 @@ topics_frontend::dispatch_create_to_leader(
         _self,
         ss::this_shard_id(),
         leader,
+        timeout,
         [topics, timeout](controller_client_protocol cp) mutable {
             return cp.create_topics(
               create_topics_request{std::move(topics), timeout},

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -98,8 +98,8 @@ ss::future<> script_context::do_execute() {
             return ss::make_ready_future<ss::stop_iteration>(
               ss::stop_iteration::yes);
         }
-        return _resources.transport.get_connected().then(
-          [this](result<rpc::transport*> transport) {
+        return _resources.transport.get_connected(model::no_timeout)
+          .then([this](result<rpc::transport*> transport) {
               if (!transport) {
                   /// Failed to connected to the wasm engine for whatever
                   /// reason, exit to yield

--- a/src/v/coproc/tests/read_materialized_topic_test.cc
+++ b/src/v/coproc/tests/read_materialized_topic_test.cc
@@ -50,7 +50,7 @@ public:
             .server_addr = ss::socket_address(
               ss::net::inet_address("127.0.0.1"), 43118),
             .credentials = nullptr});
-        client.connect().get();
+        client.connect(model::no_timeout).get();
         const auto resp = client
                             .enable_copros(
                               coproc::enable_copros_request{

--- a/src/v/coproc/tests/utils/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/utils/coproc_test_fixture.cc
@@ -43,7 +43,7 @@ ss::future<> coproc_test_fixture::startup(log_layout_map llm) {
     _llm = llm;
     return ss::do_with(std::move(llm), [this](log_layout_map& llm) {
         return wait_for_controller_leadership()
-          .then([this] { return _client.connect(); })
+          .then([this] { return _client.connect(model::no_timeout); })
           .then([this, &llm] {
               return ss::parallel_for_each(
                 llm, [this](auto& p) { return add_topic(p.first, p.second); });

--- a/src/v/raft/rpc_client_protocol.cc
+++ b/src/v/raft/rpc_client_protocol.cc
@@ -24,6 +24,7 @@ ss::future<result<vote_reply>> rpc_client_protocol::vote(
       _self,
       ss::this_shard_id(),
       n,
+      opts.timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.vote(std::move(r), std::move(opts))
@@ -37,6 +38,7 @@ ss::future<result<append_entries_reply>> rpc_client_protocol::append_entries(
       _self,
       ss::this_shard_id(),
       n,
+      opts.timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.append_entries(std::move(r), std::move(opts))
@@ -50,6 +52,7 @@ ss::future<result<heartbeat_reply>> rpc_client_protocol::heartbeat(
       _self,
       ss::this_shard_id(),
       n,
+      opts.timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.heartbeat(std::move(r), std::move(opts))
@@ -64,6 +67,7 @@ rpc_client_protocol::install_snapshot(
       _self,
       ss::this_shard_id(),
       n,
+      opts.timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.install_snapshot(std::move(r), std::move(opts))
@@ -77,6 +81,7 @@ ss::future<result<timeout_now_reply>> rpc_client_protocol::timeout_now(
       _self,
       ss::this_shard_id(),
       n,
+      opts.timeout,
       [r = std::move(r),
        opts = std::move(opts)](raftgen_client_protocol client) mutable {
           return client.timeout_now(std::move(r), std::move(opts))

--- a/src/v/raft/tron/client.cc
+++ b/src/v/raft/tron/client.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "model/record_batch_reader.h"
+#include "model/timeout_clock.h"
 #include "raft/tron/logger.h"
 #include "raft/tron/service.h"
 #include "random/generators.h"
@@ -91,7 +92,7 @@ public:
     ss::future<> connect() {
         return ss::parallel_for_each(
           _clients.begin(), _clients.end(), [](auto& c) {
-              return c->connect();
+              return c->connect(model::no_timeout);
           });
     }
     ss::future<> stop() {

--- a/src/v/rpc/demo/client.cc
+++ b/src/v/rpc/demo/client.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "model/timeout_clock.h"
 #include "rpc/demo/demo_utils.h"
 #include "rpc/demo/simple_service.h"
 #include "rpc/types.h"
@@ -118,7 +119,7 @@ public:
     ss::future<> connect() {
         return ss::parallel_for_each(
           _clients.begin(), _clients.end(), [](auto& c) {
-              return c->connect();
+              return c->connect(model::no_timeout);
           });
     }
     ss::future<> stop() {

--- a/src/v/rpc/reconnect_transport.cc
+++ b/src/v/rpc/reconnect_transport.cc
@@ -9,10 +9,12 @@
 
 #include "rpc/reconnect_transport.h"
 
+#include "model/timeout_clock.h"
 #include "raft/logger.h"
 #include "rpc/errc.h"
 #include "rpc/logger.h"
 #include "rpc/transport.h"
+#include "rpc/types.h"
 
 #include <seastar/net/inet_address.hh>
 
@@ -34,41 +36,54 @@ static inline bool has_backoff_expired(
 ss::future<> reconnect_transport::stop() {
     return _dispatch_gate.close().then([this] { return _transport.stop(); });
 }
+ss::future<result<transport*>>
+reconnect_transport::get_connected(clock_type::duration connection_timeout) {
+    return get_connected(clock_type::now() + connection_timeout);
+}
 
-ss::future<result<transport*>> reconnect_transport::get_connected() {
+ss::future<result<transport*>>
+reconnect_transport::get_connected(clock_type::time_point connection_timeout) {
     if (is_valid()) {
         return ss::make_ready_future<result<transport*>>(&_transport);
     }
-    return reconnect();
+    return reconnect(connection_timeout);
 }
 
-ss::future<result<transport*>> reconnect_transport::reconnect() {
+ss::future<result<rpc::transport*>>
+reconnect_transport::reconnect(clock_type::duration connection_timeout) {
+    return reconnect(clock_type::now() + connection_timeout);
+}
+
+ss::future<result<transport*>>
+reconnect_transport::reconnect(clock_type::time_point connection_timeout) {
     using ret_t = result<transport*>;
     if (!has_backoff_expired(
           _stamp, _backoff_policy.current_backoff_duration())) {
         return ss::make_ready_future<ret_t>(errc::exponential_backoff);
     }
     _stamp = rpc::clock_type::now();
-    return with_gate(_dispatch_gate, [this] {
-        return with_semaphore(_connected_sem, 1, [this] {
+    return with_gate(_dispatch_gate, [this, connection_timeout] {
+        return with_semaphore(_connected_sem, 1, [this, connection_timeout] {
             if (is_valid()) {
                 return ss::make_ready_future<ret_t>(&_transport);
             }
-            return _transport.connect().then_wrapped([this](ss::future<> f) {
-                try {
-                    f.get();
-                    rpclog.debug(
-                      "connected to {}", _transport.server_address());
-                    _backoff_policy.reset();
-                    return ss::make_ready_future<ret_t>(&_transport);
-                } catch (...) {
-                    _backoff_policy.next_backoff();
-                    rpclog.trace(
-                      "error reconnecting {}", std::current_exception());
-                    return ss::make_ready_future<ret_t>(
-                      errc::disconnected_endpoint);
-                }
-            });
+            vlog(rpclog.trace, "connecting to {}", _transport.server_address());
+            return _transport.connect(connection_timeout)
+              .then_wrapped([this](ss::future<> f) {
+                  try {
+                      f.get();
+                      rpclog.debug(
+                        "connected to {}", _transport.server_address());
+                      _backoff_policy.reset();
+                      return ss::make_ready_future<ret_t>(&_transport);
+                  } catch (...) {
+                      _backoff_policy.next_backoff();
+                      rpclog.trace(
+                        "error reconnecting {}", std::current_exception());
+                      return ss::make_ready_future<ret_t>(
+                        errc::disconnected_endpoint);
+                  }
+              });
         });
     });
 }

--- a/src/v/rpc/reconnect_transport.h
+++ b/src/v/rpc/reconnect_transport.h
@@ -31,12 +31,14 @@ public:
 
     bool is_valid() const { return _transport.is_valid(); }
 
-    ss::future<result<rpc::transport*>> reconnect();
+    ss::future<result<rpc::transport*>> reconnect(clock_type::time_point);
+    ss::future<result<rpc::transport*>> reconnect(clock_type::duration);
 
     rpc::transport& get() { return _transport; }
 
     /// safe client connect - attempts to reconnect if not connected
-    ss::future<result<transport*>> get_connected();
+    ss::future<result<transport*>> get_connected(clock_type::time_point);
+    ss::future<result<transport*>> get_connected(clock_type::duration);
 
     const ss::socket_address& server_address() const {
         return _transport.server_address();

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -39,7 +39,7 @@ FIXTURE_TEST(rpcgen_integration, rpc_integration_fixture) {
     auto cli = rpc::client<cycling::team_movistar_client_protocol>(
       client_config());
     info("client connecting");
-    cli.connect().get();
+    cli.connect(model::no_timeout).get();
     auto dcli = ss::defer([&cli] { cli.stop().get(); });
     info("client calling method");
     auto ret = cli
@@ -67,7 +67,7 @@ FIXTURE_TEST(rpcgen_tls_integration, rpc_integration_fixture) {
     auto cli = rpc::client<cycling::team_movistar_client_protocol>(
       client_config(creds_builder));
     info("client connecting");
-    cli.connect().get();
+    cli.connect(model::no_timeout).get();
     auto dcli = ss::defer([&cli] { cli.stop().get(); });
     info("client calling method");
     auto ret = cli
@@ -191,7 +191,7 @@ FIXTURE_TEST(rpcgen_reload_credentials_integration, rpc_integration_fixture) {
     info("client connection attempt");
     auto cli = rpc::client<cycling::team_movistar_client_protocol>(
       client_config(client_creds_builder));
-    cli.connect().get();
+    cli.connect(model::no_timeout).get();
     auto okret = cli
                    .ibis_hakka(
                      cycling::san_francisco{66},
@@ -210,7 +210,7 @@ FIXTURE_TEST(client_muxing, rpc_integration_fixture) {
     rpc::
       client<cycling::team_movistar_client_protocol, echo::echo_client_protocol>
         client(client_config());
-    client.connect().get();
+    client.connect(model::no_timeout).get();
     info("Calling movistar method");
     auto ret = client
                  .ibis_hakka(
@@ -234,7 +234,7 @@ FIXTURE_TEST(timeout_test, rpc_integration_fixture) {
     start_server();
 
     rpc::client<echo::echo_client_protocol> client(client_config());
-    client.connect().get();
+    client.connect(model::no_timeout).get();
     info("Calling echo method");
     auto echo_resp = client.sleep_1s(
       echo::echo_req{.str = "testing..."},
@@ -253,7 +253,7 @@ FIXTURE_TEST(rpc_mixed_compression, rpc_integration_fixture) {
 
     using client_t = rpc::client<echo::echo_client_protocol>;
     client_t client(client_config());
-    client.connect().get();
+    client.connect(model::no_timeout).get();
     BOOST_TEST_MESSAGE("Calling echo method no compression");
     auto echo_resp
       = client
@@ -280,7 +280,7 @@ FIXTURE_TEST(ordering_test, rpc_integration_fixture) {
     register_services();
     start_server();
     rpc::client<echo::echo_client_protocol> client(client_config());
-    client.connect().get();
+    client.connect(model::no_timeout).get();
     std::vector<ss::future<>> futures;
     futures.reserve(10);
     for (uint64_t i = 0; i < 10; ++i) {
@@ -301,7 +301,7 @@ FIXTURE_TEST(server_exception_test, rpc_integration_fixture) {
     register_services();
     start_server();
     rpc::client<echo::echo_client_protocol> client(client_config());
-    client.connect().get();
+    client.connect(model::no_timeout).get();
     auto ret = client
                  .throw_exception(
                    echo::failure_type::exceptional_future,
@@ -318,7 +318,7 @@ FIXTURE_TEST(missing_method_test, rpc_integration_fixture) {
     register_services();
     start_server();
     rpc::transport t(client_config());
-    t.connect().get();
+    t.connect(model::no_timeout).get();
     auto ret = t.send_typed<echo::failure_type, echo::throw_resp>(
                   echo::failure_type::exceptional_future,
                   1234,
@@ -334,7 +334,7 @@ FIXTURE_TEST(corrupted_header_at_client_test, rpc_integration_fixture) {
     register_services();
     start_server();
     rpc::transport t(client_config());
-    t.connect().get();
+    t.connect(model::no_timeout).get();
     auto client = echo::echo_client_protocol(t);
     auto stop_action = ss::defer([&t] { t.stop().get(); });
     BOOST_TEST_MESSAGE("Request with valid payload");
@@ -361,7 +361,7 @@ FIXTURE_TEST(corrupted_header_at_client_test, rpc_integration_fixture) {
 
     // reconnect
     BOOST_TEST_MESSAGE("Another request with valid payload");
-    t.connect().get0();
+    t.connect(model::no_timeout).get0();
     for (int i = 0; i < 10; ++i) {
         auto echo_resp_new = client
                                .echo(
@@ -378,7 +378,7 @@ FIXTURE_TEST(corrupted_data_at_server, rpc_integration_fixture) {
     register_services();
     start_server();
     rpc::transport t(client_config());
-    t.connect().get();
+    t.connect(model::no_timeout).get();
     auto client = echo::echo_client_protocol(t);
     auto stop_action = ss::defer([&t] { t.stop().get(); });
     BOOST_TEST_MESSAGE("Request with valid payload");
@@ -403,7 +403,7 @@ FIXTURE_TEST(corrupted_data_at_server, rpc_integration_fixture) {
                  .get0();
     // reconnect
     BOOST_TEST_MESSAGE("Another request with valid payload");
-    t.connect().get0();
+    t.connect(model::no_timeout).get0();
     for (int i = 0; i < 10; ++i) {
         auto echo_resp_new = client
                                .echo(

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -59,7 +59,8 @@ public:
     base_transport(const base_transport&) = delete;
     base_transport& operator=(const base_transport&) = delete;
 
-    virtual ss::future<> connect();
+    virtual ss::future<>
+      connect(clock_type::time_point = clock_type::time_point::max());
     ss::future<> stop();
     void shutdown() noexcept;
 
@@ -76,7 +77,7 @@ protected:
     client_probe _probe;
 
 private:
-    ss::future<> do_connect();
+    ss::future<> do_connect(clock_type::time_point);
 
     std::unique_ptr<ss::connected_socket> _fd;
     ss::socket_address _server_addr;
@@ -96,7 +97,8 @@ public:
     transport(const transport&) = delete;
     transport& operator=(const transport&) = delete;
 
-    ss::future<> connect() final;
+    ss::future<> connect(clock_type::time_point) final;
+    ss::future<> connect(clock_type::duration);
     ss::future<result<std::unique_ptr<streaming_context>>>
       send(netbuf, rpc::client_opts);
 
@@ -214,7 +216,9 @@ public:
       : Protocol(_transport)...
       , _transport(std::move(cfg)) {}
 
-    ss::future<> connect() { return _transport.connect(); }
+    ss::future<> connect(rpc::clock_type::time_point connection_timeout) {
+        return _transport.connect(connection_timeout);
+    }
     ss::future<> stop() { return _transport.stop(); };
     void shutdown() { _transport.shutdown(); }
 


### PR DESCRIPTION
Implemented handling for connection timeout. When it is impossible to
open a connection in given time period caller will be returned with an
exceptional future and socket will be closed.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
