### PR TITLE
rpk/coproc: add compression to coproc_topic

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/common.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/common.go
@@ -24,7 +24,9 @@ func CreateCoprocessorTopic(admin sarama.ClusterAdmin) error {
 	}
 	configEntry := make(map[string]*string)
 	compact := "compact"
+	compressionType := "zstd"
 	configEntry["cleanup.policy"] = &compact
+	configEntry["compression.type"] = &compressionType
 	detail := sarama.TopicDetail{
 		NumPartitions:		1,
 		ReplicationFactor:	replicationFactor,


### PR DESCRIPTION
add compression_type=zstd to coprocessor_internal_topic, in order
to compress rpk wasm message.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
