### PR TITLE
Feature/handle error load coproc

### DIFF
--- a/src/js/modules/supervisors/FileManager.ts
+++ b/src/js/modules/supervisors/FileManager.ts
@@ -151,10 +151,11 @@ class FileManager {
     const id = hash64(Buffer.from(name), 0).readBigUInt64LE();
     const [handle] = repository.getHandlesByCoprocessorIds([id]);
     if (!handle) {
-      this.logger.error(
-        `Trying to disable a removed coprocessor from 'active' folder but it` +
-          `wasn't loaded in memory, file name: ${name}.js`
-      );
+      /**
+       * this case is possible when a coprocessor is disabled either by
+       * 'rpk wasm disable' or by the error policy, so the file is moved
+       * from the active folder to the inactive folder.
+       */
       return Promise.resolve();
     } else {
       this.repository.remove(handle);


### PR DESCRIPTION
When the wasm engine tries to load the file into memory and it fails by js syntax or incompatible Coprocessor class, this file should move to the inactive folder.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
