### PR TITLE
Safe dns resolver

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -84,7 +84,7 @@ ss::future<> maybe_create_tcp_client(
   model::node_id node,
   unresolved_address rpc_address,
   config::tls_config tls_config) {
-    return rpc_address.resolve().then([node,
+    return rpc::resolve_dns(std::move(rpc_address)).then([node,
                                        &cache,
                                        tls_config = std::move(tls_config)](
                                         ss::socket_address new_addr) mutable {

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -84,41 +84,41 @@ ss::future<> maybe_create_tcp_client(
   model::node_id node,
   unresolved_address rpc_address,
   config::tls_config tls_config) {
-    return rpc::resolve_dns(std::move(rpc_address)).then([node,
-                                       &cache,
-                                       tls_config = std::move(tls_config)](
-                                        ss::socket_address new_addr) mutable {
-        auto f = ss::now();
-        if (cache.contains(node)) {
-            // client is already there, check if configuration changed
-            if (cache.get(node)->server_address() == new_addr) {
-                // If configuration did not changed, do nothing
-                return f;
-            }
-            // configuration changed, first remove the client
-            f = cache.remove(node);
-        }
-        // there is no client in cache, create new
-        return f.then([&cache,
-                       node,
-                       new_addr,
-                       tls_config = std::move(tls_config)]() mutable {
-            return maybe_build_reloadable_certificate_credentials(
-                     std::move(tls_config))
-              .then([&cache, node, new_addr](
-                      ss::shared_ptr<ss::tls::certificate_credentials>&& cert) {
-                  return cache.emplace(
-                    node,
-                    rpc::transport_configuration{
-                      .server_addr = new_addr,
-                      .credentials = cert,
-                      .disable_metrics = rpc::metrics_disabled(
-                        config::shard_local_cfg().disable_metrics)},
-                    rpc::make_exponential_backoff_policy<rpc::clock_type>(
-                      std::chrono::seconds(1), std::chrono::seconds(60)));
-              });
-        });
-    });
+    return rpc::resolve_dns(std::move(rpc_address))
+      .then([node, &cache, tls_config = std::move(tls_config)](
+              ss::socket_address new_addr) mutable {
+          auto f = ss::now();
+          if (cache.contains(node)) {
+              // client is already there, check if configuration changed
+              if (cache.get(node)->server_address() == new_addr) {
+                  // If configuration did not changed, do nothing
+                  return f;
+              }
+              // configuration changed, first remove the client
+              f = cache.remove(node);
+          }
+          // there is no client in cache, create new
+          return f.then([&cache,
+                         node,
+                         new_addr,
+                         tls_config = std::move(tls_config)]() mutable {
+              return maybe_build_reloadable_certificate_credentials(
+                       std::move(tls_config))
+                .then(
+                  [&cache, node, new_addr](
+                    ss::shared_ptr<ss::tls::certificate_credentials>&& cert) {
+                      return cache.emplace(
+                        node,
+                        rpc::transport_configuration{
+                          .server_addr = new_addr,
+                          .credentials = cert,
+                          .disable_metrics = rpc::metrics_disabled(
+                            config::shard_local_cfg().disable_metrics)},
+                        rpc::make_exponential_backoff_policy<rpc::clock_type>(
+                          std::chrono::seconds(1), std::chrono::seconds(60)));
+                  });
+          });
+      });
 }
 
 ss::future<> add_one_tcp_client(

--- a/src/v/cluster/tests/controller_test_fixture.h
+++ b/src/v/cluster/tests/controller_test_fixture.h
@@ -27,6 +27,7 @@
 #include "raft/service.h"
 #include "random/generators.h"
 #include "resource_mgmt/memory_groups.h"
+#include "rpc/dns.h"
 #include "rpc/server.h"
 #include "rpc/simple_protocol.h"
 #include "seastarx.h"
@@ -174,7 +175,7 @@ public:
         _controller_started = true;
 
         rpc::server_configuration rpc_cfg("cluster_tests_rpc");
-        auto rpc_sa = _current_node.rpc_address().resolve().get0();
+        auto rpc_sa = rpc::resolve_dns(_current_node.rpc_address()).get();
         rpc_cfg.max_service_memory_per_core = memory_groups::rpc_total_memory();
         rpc_cfg.addrs.emplace_back(rpc_sa);
         rpc_cfg.disable_metrics = rpc::metrics_disabled::yes;

--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -10,12 +10,13 @@
 #include "kafka/client/broker.h"
 
 #include "kafka/client/logger.h"
+#include "rpc/dns.h"
 
 namespace kafka::client {
 
 ss::future<shared_broker_t>
 make_broker(model::node_id node_id, unresolved_address addr) {
-    return addr.resolve()
+    return rpc::resolve_dns(std::move(addr))
       .then([](ss::socket_address addr) {
           auto client = ss::make_lw_shared<transport>(
             rpc::base_transport::configuration{.server_addr = addr});

--- a/src/v/pandaproxy/application.cc
+++ b/src/v/pandaproxy/application.cc
@@ -12,6 +12,7 @@
 #include "kafka/client/configuration.h"
 #include "pandaproxy/configuration.h"
 #include "platform/stop_signal.h"
+#include "rpc/dns.h"
 #include "ssx/future-util.h"
 #include "syschecks/syschecks.h"
 #include "utils/file_io.h"
@@ -179,9 +180,7 @@ void application::configure_admin_server() {
           .get();
     }
 
-    shard_local_cfg()
-      .admin_api()
-      .resolve()
+    rpc::resolve_dns(shard_local_cfg().admin_api())
       .then([this](ss::socket_address addr) mutable {
           return _admin
             .invoke_on_all<ss::future<> (ss::http_server::*)(
@@ -205,7 +204,7 @@ void application::wire_up_services() {
 
     construct_service(
       _proxy,
-      shard_local_cfg().pandaproxy_api().resolve().get0(),
+      rpc::resolve_dns(shard_local_cfg().pandaproxy_api()).get(),
       kafka::client::shard_local_cfg().brokers())
       .get();
 }

--- a/src/v/pandaproxy/test/pandaproxy_fixture.h
+++ b/src/v/pandaproxy/test/pandaproxy_fixture.h
@@ -39,7 +39,8 @@ public:
     http::client make_client() {
         rpc::base_transport::configuration transport_cfg;
         transport_cfg.server_addr
-          = rpc::resolve_dns(pandaproxy::shard_local_cfg().pandaproxy_api()).get();
+          = rpc::resolve_dns(pandaproxy::shard_local_cfg().pandaproxy_api())
+              .get();
         return http::client(transport_cfg);
     }
 

--- a/src/v/pandaproxy/test/pandaproxy_fixture.h
+++ b/src/v/pandaproxy/test/pandaproxy_fixture.h
@@ -39,7 +39,7 @@ public:
     http::client make_client() {
         rpc::base_transport::configuration transport_cfg;
         transport_cfg.server_addr
-          = pandaproxy::shard_local_cfg().pandaproxy_api().resolve().get();
+          = rpc::resolve_dns(pandaproxy::shard_local_cfg().pandaproxy_api()).get();
         return http::client(transport_cfg);
     }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -350,7 +350,8 @@ void application::wire_up_services() {
 
     if (coproc_enabled()) {
         auto coproc_supervisor_server_addr
-          = rpc::resolve_dns(config::shard_local_cfg().coproc_supervisor_server())
+          = rpc::resolve_dns(
+              config::shard_local_cfg().coproc_supervisor_server())
               .get0();
         syschecks::systemd_message("Building coproc pacemaker").get();
         construct_service(
@@ -489,7 +490,8 @@ void application::wire_up_services() {
     rpc::server_configuration kafka_cfg("kafka_rpc");
     kafka_cfg.max_service_memory_per_core = memory_groups::kafka_total_memory();
     for (const auto& ep : config::shard_local_cfg().kafka_api()) {
-        kafka_cfg.addrs.emplace_back(ep.name, rpc::resolve_dns(ep.address).get0());
+        kafka_cfg.addrs.emplace_back(
+          ep.name, rpc::resolve_dns(ep.address).get0());
     }
     syschecks::systemd_message("Building TLS credentials for kafka").get();
     auto kafka_builder = config::shard_local_cfg()

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -93,7 +93,8 @@ public:
     }
 
     ss::future<kafka::client::transport> make_kafka_client() {
-        return rpc::resolve_dns(config::shard_local_cfg().kafka_api()[0].address)
+        return rpc::resolve_dns(
+                 config::shard_local_cfg().kafka_api()[0].address)
           .then([](ss::socket_address addr) {
               return kafka::client::transport(
                 rpc::base_transport::configuration{

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -17,6 +17,7 @@
 #include "model/namespace.h"
 #include "model/timeout_clock.h"
 #include "redpanda/application.h"
+#include "rpc/dns.h"
 #include "storage/directories.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "storage/tests/utils/random_batch.h"
@@ -92,8 +93,8 @@ public:
     }
 
     ss::future<kafka::client::transport> make_kafka_client() {
-        return config::shard_local_cfg().kafka_api()[0].address.resolve().then(
-          [](ss::socket_address addr) {
+        return rpc::resolve_dns(config::shard_local_cfg().kafka_api()[0].address)
+          .then([](ss::socket_address addr) {
               return kafka::client::transport(
                 rpc::base_transport::configuration{
                   .server_addr = addr,

--- a/src/v/rpc/CMakeLists.txt
+++ b/src/v/rpc/CMakeLists.txt
@@ -12,6 +12,7 @@ v_cc_library(
     reconnect_transport.cc
     connection_cache.cc
     simple_protocol.cc
+    dns.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/rpc/dns.cc
+++ b/src/v/rpc/dns.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "rpc/dns.h"
+
+#include "utils/mutex.h"
+#include "utils/unresolved_address.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/net/dns.hh>
+
+namespace rpc {
+ss::future<ss::socket_address> resolve_dns(unresolved_address address) {
+    static thread_local ss::net::dns_resolver resolver;
+    static thread_local mutex m;
+    // lock
+    auto units = co_await m.get_units();
+    // resolve
+    auto i_a = co_await resolver.resolve_name(address.host(), {});
+
+    co_return ss::socket_address(i_a, address.port());
+};
+} // namespace rpc

--- a/src/v/rpc/dns.h
+++ b/src/v/rpc/dns.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "utils/unresolved_address.h"
+namespace rpc {
+/**
+ * Resolves addresses using seastar DNS resolver. It uses mutex to workaround
+ * seastar bug causing segmentation fault when udp channel is being accessed by
+ * different fibers.
+ */
+ss::future<ss::socket_address> resolve_dns(unresolved_address);
+} // namespace rpc

--- a/src/v/utils/unresolved_address.h
+++ b/src/v/utils/unresolved_address.h
@@ -32,13 +32,6 @@ public:
     const ss::sstring& host() const { return _host; }
     uint16_t port() const { return _port; }
 
-    ss::future<ss::socket_address> resolve() const {
-        return ss::net::inet_address::find(_host).then(
-          [port = _port](ss::net::inet_address i_a) {
-              return ss::socket_address(i_a, port);
-          });
-    }
-
     bool operator==(const unresolved_address& other) const {
         return _host == other._host && _port == other._port;
     }


### PR DESCRIPTION
The dns resolver included in seastar caused redpanda to crash in K8S
installations. The issue is related with concurrent access to file
descriptors and incorrect error handling. In order to quickly fix the
issue, implemented simple class providing mutually exclusive DNS
lookups. This eliminates the concurrency problems and segmentation
fault.

Fixes: #523 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
