### PR TITLE
Ignore generated files also in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: lint go files
       run: |
-        find . -name *.go -type f | xargs -n1 crlfmt -wrap=80 -w
+        find . -name *.go -type f | xargs -n1 crlfmt -wrap=80 -ignore '_generated.deepcopy.go$$' -w
         git diff --exit-code
 
   js:


### PR DESCRIPTION
This is follow-up of https://github.com/vectorizedio/redpanda/pull/439

Turns out we have to change it here as well because crlfmt is not happy with the generated code right now.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
