### PR TITLE
ducktape: tweaks to redpanda/pandaproxy services regarding config and bin paths

### DIFF
--- a/tests/rptest/services/pandaproxy.py
+++ b/tests/rptest/services/pandaproxy.py
@@ -44,10 +44,7 @@ class PandaProxyService(Service):
         node.account.mkdirs(PandaProxyService.PERSISTENT_ROOT)
         node.account.mkdirs(os.path.dirname(PandaProxyService.CONFIG_FILE))
 
-        platform = self._context.globals.get("platform", "docker-compose")
-
-        if platform == "docker-compose":
-            self.write_conf_file(node)
+        self.write_conf_file(node)
 
         cmd = "nohup {} ".format(self.find_binary("pandaproxy"))
         cmd += "--pandaproxy-cfg {} ".format(PandaProxyService.CONFIG_FILE)

--- a/tests/rptest/services/pandaproxy.py
+++ b/tests/rptest/services/pandaproxy.py
@@ -87,7 +87,7 @@ class PandaProxyService(Service):
         node.account.remove(f"{PandaProxyService.CONFIG_FILE}")
 
     def find_binary(self, name):
-        bin_path = f"{self._rp_install_path_root}/pandaproxy/bin/{name}"
+        bin_path = f"{self._rp_install_path_root}/bin/{name}"
         return bin_path
 
     def pids(self, node):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -84,10 +84,7 @@ class RedpandaService(Service):
         node.account.mkdirs(RedpandaService.DATA_DIR)
         node.account.mkdirs(os.path.dirname(RedpandaService.CONFIG_FILE))
 
-        platform = self._context.globals.get("platform", "docker-compose")
-
-        if platform == "docker-compose":
-            self.write_conf_file(node, override_cfg_params)
+        self.write_conf_file(node, override_cfg_params)
 
         cmd = (f"nohup {self.find_binary('redpanda')}"
                f" --redpanda-cfg {RedpandaService.CONFIG_FILE}"

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -113,8 +113,7 @@ class RedpandaService(Service):
     def find_binary(self, name):
         rp_install_path_root = self._context.globals.get(
             "rp_install_path_root", None)
-
-        return f"{rp_install_path_root}/redpanda/bin/{name}"
+        return f"{rp_install_path_root}/bin/{name}"
 
     def stop_node(self, node):
         pids = self.pids(node)


### PR DESCRIPTION
Removes the assumption of a globally defined ducktape option `platform` that instructs whether the configuration file should be created or not. These services now have full control of the way they create/manipulate their configuration. For extending or modifying the configuration of these services, one can make use of the `extra_rp_config` variable.

In addition, the path where binaries are expected to be available is now `{rp_install_root}/bin` as opposed to having this be `{rp_install_root}/{service}/bin`