### PR TITLE
coproc: Fix for crash when wasm engine sends two successive deregisters

### DIFF
--- a/src/v/coproc/pacemaker.cc
+++ b/src/v/coproc/pacemaker.cc
@@ -133,7 +133,8 @@ void pacemaker::do_add_source(
             }
             vassert(
               ntp_ctx->offsets.emplace(id, ntp_context::offset_pair()).second,
-              "Script id expected to not exist: {}, id");
+              "Script id expected to not exist: {}",
+              id);
             ctxs.emplace(ntp, ntp_ctx);
         }
         acks.push_back(errc::success);

--- a/src/v/coproc/pacemaker.cc
+++ b/src/v/coproc/pacemaker.cc
@@ -163,7 +163,7 @@ bool pacemaker::local_script_id_exists(script_id id) {
     return _scripts.find(id) != _scripts.end();
 }
 
-bool pacemaker::ntp_is_registered(model::ntp ntp) {
+bool pacemaker::ntp_is_registered(const model::ntp& ntp) {
     auto found = _ntps.find(ntp);
     return found != _ntps.end() && found->second;
 }

--- a/src/v/coproc/pacemaker.cc
+++ b/src/v/coproc/pacemaker.cc
@@ -18,6 +18,8 @@
 #include "rpc/types.h"
 #include "ssx/future-util.h"
 
+#include <seastar/core/coroutine.hh>
+
 #include <absl/container/flat_hash_set.h>
 
 #include <algorithm>
@@ -84,12 +86,11 @@ std::vector<errc> pacemaker::add_source(
         /// Reasons are returned in the 'acks' structure
         return acks;
     }
-    const auto& [itr, success] = _scripts.emplace(
-      std::piecewise_construct,
-      std::forward_as_tuple(id),
-      std::forward_as_tuple(id, _shared_res, std::move(ctxs)));
+    auto script_ctx = std::make_unique<script_context>(
+      id, _shared_res, std::move(ctxs));
+    const auto& [itr, success] = _scripts.emplace(id, std::move(script_ctx));
     vassert(success, "Double coproc insert detected");
-    (void)itr->second.start();
+    (void)itr->second->start();
     return acks;
 }
 
@@ -142,26 +143,20 @@ void pacemaker::do_add_source(
 }
 
 ss::future<errc> pacemaker::remove_source(script_id id) {
-    auto found = _scripts.find(id);
-    if (found == _scripts.end()) {
-        return ss::make_ready_future<errc>(errc::script_id_does_not_exist);
+    auto handle = _scripts.extract(id);
+    if (handle.empty()) {
+        co_return errc::script_id_does_not_exist;
     }
-    script_context& ctx = found->second;
-    return ctx.shutdown()
-      .then([this] {
-          /// shutdown explicity clears out strong references to ntp
-          /// contexts. It is known to remove them from the pacemakers cache
-          /// when the use_count() == 1, as there are then known to be no
-          /// more subscribing scripts for the ntp
-          absl::erase_if(_ntps, [](const ntp_context_cache::value_type& p) {
-              return p.second.use_count() == 1;
-          });
-      })
-      .then([this, found] {
-          /// Finally, remove the script_context itself
-          _scripts.erase(found);
-          return errc::success;
-      });
+    std::unique_ptr<script_context> ctx = std::move(handle.mapped());
+    co_await ctx->shutdown();
+    /// shutdown explicity clears out strong references to ntp
+    /// contexts. It is known to remove them from the pacemakers cache
+    /// when the use_count() == 1, as there are then known to be no
+    /// more subscribing scripts for the ntp
+    absl::erase_if(_ntps, [](const ntp_context_cache::value_type& p) {
+        return p.second.use_count() == 1;
+    });
+    co_return errc::success;
 }
 
 bool pacemaker::local_script_id_exists(script_id id) {

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -87,7 +87,7 @@ private:
     shared_script_resources _shared_res;
 
     /// Main datastructure containing all active script_contexts
-    std::map<script_id, script_context> _scripts;
+    std::map<script_id, std::unique_ptr<script_context>> _scripts;
 
     /// Referencable cache of active ntps
     ntp_context_cache _ntps;

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -73,7 +73,7 @@ public:
     /**
      * @returns true if a matching ntp exists on 'this' shard
      */
-    bool ntp_is_registered(model::ntp);
+    bool ntp_is_registered(const model::ntp&);
 
 private:
     void do_add_source(

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -21,7 +21,7 @@
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/socket_defs.hh>
 
-#include <map>
+#include <absl/container/node_hash_map.h>
 
 namespace coproc {
 /**
@@ -87,7 +87,7 @@ private:
     shared_script_resources _shared_res;
 
     /// Main datastructure containing all active script_contexts
-    std::map<script_id, std::unique_ptr<script_context>> _scripts;
+    absl::node_hash_map<script_id, std::unique_ptr<script_context>> _scripts;
 
     /// Referencable cache of active ntps
     ntp_context_cache _ntps;


### PR DESCRIPTION
- The root cause of this error is that the coproc::service erranously believes
that v/rpc servers are not concurrent with respect to 1 TCP connection. This is
not true, as the rpc server issues the next request after the body of the
preceeding request has been parsed.

- Because of this its possible for two calls of remove_source to interleave so
that shutdown() is called twice on a script_context, causing the actual crash.

- The solution is to remove the script context from the _scripts collection as
the first item of business in the remove_source method. Since this does not
occur in a future this action cannot be reordered and subsequent calls to
remove_source correctly report that the item does not exist in the cache

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
