### PR TITLE
NamedSocketAddress

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -130,7 +130,7 @@ func DeduceBrokers(
 				addr := fmt.Sprintf(
 					"%s:%d",
 					b.Host.Address,
-					conf.Redpanda.KafkaApi.Port,
+					b.Host.Port,
 				)
 				bs = append(bs, addr)
 			}
@@ -138,8 +138,8 @@ func DeduceBrokers(
 		// Add the current node's Kafka addr.
 		selfAddr := fmt.Sprintf(
 			"%s:%d",
-			conf.Redpanda.KafkaApi.Address,
-			conf.Redpanda.KafkaApi.Port,
+			conf.Redpanda.KafkaApi[0].Address,
+			conf.Redpanda.KafkaApi[0].Port,
 		)
 		bs = append(bs, selfAddr)
 		log.Debugf(

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -76,10 +76,11 @@ func TestDeduceBrokers(t *testing.T) {
 		},
 		config: func() (*config.Config, error) {
 			conf := config.Default()
-			conf.Redpanda.KafkaApi = config.SocketAddress{
-				Address:	"192.168.25.88",
-				Port:		1235,
-			}
+			conf.Redpanda.KafkaApi = []config.NamedSocketAddress{{
+				SocketAddress: config.SocketAddress{
+					Address:	"192.168.25.88",
+					Port:		1235,
+				}}}
 			return conf, nil
 		},
 		expected:	[]string{"192.168.25.88:1235"},
@@ -94,10 +95,11 @@ func TestDeduceBrokers(t *testing.T) {
 		name:	"it should prioritize the config over the default broker addr",
 		config: func() (*config.Config, error) {
 			conf := config.Default()
-			conf.Redpanda.KafkaApi = config.SocketAddress{
-				Address:	"192.168.25.87",
-				Port:		1234,
-			}
+			conf.Redpanda.KafkaApi = []config.NamedSocketAddress{{
+				SocketAddress: config.SocketAddress{
+					Address:	"192.168.25.87",
+					Port:		1234,
+				}}}
 			return conf, nil
 		},
 		expected:	[]string{"192.168.25.87:1234"},

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -122,7 +122,7 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 		return nil, err
 	}
 	hostKafkaPort, err := getHostPort(
-		config.Default().Redpanda.KafkaApi.Port,
+		config.Default().Redpanda.KafkaApi[0].Port,
 		containerJSON,
 	)
 	if err != nil {
@@ -212,7 +212,7 @@ func CreateNode(
 	}
 	kPort, err := nat.NewPort(
 		"tcp",
-		strconv.Itoa(config.Default().Redpanda.KafkaApi.Port),
+		strconv.Itoa(config.Default().Redpanda.KafkaApi[0].Port),
 	)
 	if err != nil {
 		return nil, err
@@ -234,7 +234,7 @@ func CreateNode(
 		"--node-id",
 		fmt.Sprintf("%d", nodeID),
 		"--kafka-addr",
-		fmt.Sprintf("%s:%d", ip, config.Default().Redpanda.KafkaApi.Port),
+		fmt.Sprintf("%s:%d", ip, config.Default().Redpanda.KafkaApi[0].Port),
 		"--rpc-addr",
 		fmt.Sprintf("%s:%d", ip, config.Default().Redpanda.RPCServer.Port),
 		"--advertise-kafka-addr",

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -265,8 +265,8 @@ func getKafkaInfo(
 	kInfo := kafkaInfo{}
 	addr := fmt.Sprintf(
 		"%s:%d",
-		conf.Redpanda.KafkaApi.Address,
-		conf.Redpanda.KafkaApi.Port,
+		conf.Redpanda.KafkaApi[0].Address,
+		conf.Redpanda.KafkaApi[0].Port,
 	)
 	client, err := kafka.InitClientWithConf(&conf, addr)
 	if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
@@ -129,8 +129,8 @@ func executePrometheusConfig(
 		return []byte(""), err
 	}
 	hosts, err := discoverHosts(
-		conf.Redpanda.KafkaApi.Address,
-		conf.Redpanda.KafkaApi.Port,
+		conf.Redpanda.KafkaApi[0].Address,
+		conf.Redpanda.KafkaApi[0].Port,
 	)
 	if err != nil {
 		return []byte(""), err

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -118,7 +118,7 @@ func bootstrap(mgr config.Manager) *cobra.Command {
 			}
 			conf.Redpanda.Id = id
 			conf.Redpanda.RPCServer.Address = ownIp.String()
-			conf.Redpanda.KafkaApi.Address = ownIp.String()
+			conf.Redpanda.KafkaApi[0].Address = ownIp.String()
 			conf.Redpanda.AdminApi.Address = ownIp.String()
 			conf.Redpanda.SeedServers = []config.SeedServer{}
 			seeds := []config.SeedServer{}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -85,10 +85,10 @@ func TestSet(t *testing.T) {
   "address": "192.168.54.2"
 }`,
 			args:	[]string{"--format", "json"},
-			expected: map[string]interface{}{
+			expected: []map[string]interface{}{{
 				"address":	"192.168.54.2",
 				"port":		9092,
-			},
+			}},
 		},
 		{
 			name:		"it should fail if the new value is invalid",
@@ -243,7 +243,7 @@ func TestBootstrap(t *testing.T) {
 			conf, err := mgr.Read(configPath)
 			require.NoError(t, err)
 			require.Equal(t, conf.Redpanda.RPCServer.Address, tt.self)
-			require.Equal(t, conf.Redpanda.KafkaApi.Address, tt.self)
+			require.Equal(t, conf.Redpanda.KafkaApi[0].Address, tt.self)
 			require.Equal(t, conf.Redpanda.AdminApi.Address, tt.self)
 			if len(tt.ips) == 1 {
 				require.Equal(

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -170,7 +170,11 @@ func NewStartCommand(
 				return err
 			}
 			if advKafkaApi != nil {
-				conf.Redpanda.AdvertisedKafkaApi = advKafkaApi
+				aka := make([]config.NamedSocketAddress, 0, len(advKafkaApi))
+				for _, a := range advKafkaApi {
+					aka = append(aka, config.NamedSocketAddress{Name: "", SocketAddress: a})
+				}
+				conf.Redpanda.AdvertisedKafkaApi = aka
 			}
 			advertisedRPC = stringOr(
 				advertisedRPC,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -556,10 +556,11 @@ func TestStartCommand(t *testing.T) {
 			mgr := config.NewManager(fs)
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
-			expectedAddr := []config.SocketAddress{{
-				Address:	"192.168.34.32",
-				Port:		33145,
-			}}
+			expectedAddr := []config.NamedSocketAddress{{
+				SocketAddress: config.SocketAddress{
+					Address:	"192.168.34.32",
+					Port:		33145,
+				}}}
 			// Check that the generated config is as expected.
 			require.Exactly(
 				st,
@@ -577,10 +578,11 @@ func TestStartCommand(t *testing.T) {
 			mgr := config.NewManager(fs)
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
-			expectedAddr := []config.SocketAddress{{
-				Address:	"192.168.34.32",
-				Port:		9092,
-			}}
+			expectedAddr := []config.NamedSocketAddress{{
+				SocketAddress: config.SocketAddress{
+					Address:	"192.168.34.32",
+					Port:		9092,
+				}}}
 			// Check that the generated config is as expected.
 			require.Exactly(
 				st,
@@ -611,10 +613,11 @@ func TestStartCommand(t *testing.T) {
 			mgr := config.NewManager(fs)
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
-			expectedAddr := []config.SocketAddress{{
-				Address:	"host",
-				Port:		3123,
-			}}
+			expectedAddr := []config.NamedSocketAddress{{
+				SocketAddress: config.SocketAddress{
+					Address:	"host",
+					Port:		3123,
+				}}}
 			// Check that the generated config is as expected.
 			require.Exactly(
 				st,
@@ -630,9 +633,12 @@ func TestStartCommand(t *testing.T) {
 		before: func(fs afero.Fs) error {
 			mgr := config.NewManager(fs)
 			conf := config.Default()
-			conf.Redpanda.AdvertisedKafkaApi = []config.SocketAddress{{
-				Address:	"192.168.33.33",
-				Port:		9892,
+			conf.Redpanda.AdvertisedKafkaApi = []config.NamedSocketAddress{{
+				Name:	"",
+				SocketAddress: config.SocketAddress{
+					Address:	"192.168.33.33",
+					Port:		9892,
+				},
 			}}
 			return mgr.Write(conf)
 		},
@@ -640,10 +646,11 @@ func TestStartCommand(t *testing.T) {
 			mgr := config.NewManager(fs)
 			conf, err := mgr.Read(config.Default().ConfigFile)
 			require.NoError(st, err)
-			expectedAddr := []config.SocketAddress{{
-				Address:	"192.168.33.33",
-				Port:		9892,
-			}}
+			expectedAddr := []config.NamedSocketAddress{{
+				SocketAddress: config.SocketAddress{
+					Address:	"192.168.33.33",
+					Port:		9892,
+				}}}
 			// Check that the generated config is as expected.
 			require.Exactly(
 				st,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -525,10 +525,11 @@ func TestStartCommand(t *testing.T) {
 		before: func(fs afero.Fs) error {
 			mgr := config.NewManager(fs)
 			conf := config.Default()
-			conf.Redpanda.KafkaApi = config.SocketAddress{
-				Address:	"192.168.33.33",
-				Port:		9892,
-			}
+			conf.Redpanda.KafkaApi = []config.NamedSocketAddress{{
+				SocketAddress: config.SocketAddress{
+					Address:	"192.168.33.33",
+					Port:		9892,
+				}}}
 			return mgr.Write(conf)
 		},
 		postCheck: func(fs afero.Fs, _ *rp.RedpandaArgs, st *testing.T) {

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -86,10 +86,10 @@ func defaultMap() map[string]interface{} {
 				"address":	"0.0.0.0",
 				"port":		33145,
 			},
-			"kafka_api": map[string]interface{}{
+			"kafka_api": []interface{}{map[string]interface{}{
 				"address":	"0.0.0.0",
 				"port":		9092,
-			},
+			}},
 			"admin": map[string]interface{}{
 				"address":	"0.0.0.0",
 				"port":		9644,
@@ -245,7 +245,7 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 				fmt.Errorf("%s missing", key),
 			)
 		} else {
-			socket := &SocketAddress{}
+			socket := &NamedSocketAddress{}
 			err := v.UnmarshalKey(key, socket)
 			if err != nil {
 				errs = append(
@@ -255,7 +255,7 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 			} else {
 				errs = append(
 					errs,
-					checkSocketAddress(*socket, key)...,
+					checkSocketAddress(*&socket.SocketAddress, key)...,
 				)
 			}
 		}
@@ -312,11 +312,15 @@ func checkRpkConfig(v *viper.Viper) []error {
 }
 
 func toMap(conf *Config) (map[string]interface{}, error) {
+	fmt.Println(conf)
+
 	mapConf := make(map[string]interface{})
 	bs, err := yaml.Marshal(conf)
+	fmt.Println(string(bs))
 	if err != nil {
 		return mapConf, err
 	}
 	err = yaml.Unmarshal(bs, &mapConf)
+	fmt.Println(conf)
 	return mapConf, err
 }

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -330,10 +330,11 @@ rpk:
 			name:	"shall write a valid config file without advertised_rpc_api",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.Redpanda.AdvertisedKafkaApi = []SocketAddress{{
-					"174.32.64.2",
-					9092,
-				}}
+				c.Redpanda.AdvertisedKafkaApi = []NamedSocketAddress{{
+					Name:	"default", SocketAddress: SocketAddress{
+						"174.32.64.2",
+						9092,
+					}}}
 				return c
 			},
 			wantErr:	false,
@@ -344,6 +345,7 @@ redpanda:
     port: 9644
   advertised_kafka_api:
   - address: 174.32.64.2
+    name: default
     port: 9092
   data_directory: /var/lib/redpanda/data
   developer_mode: false

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -128,10 +128,10 @@ func TestSet(t *testing.T) {
 		  "address": "192.168.54.2"
 		}`,
 			format:	"json",
-			expected: map[string]interface{}{
+			expected: []map[string]interface{}{{
 				"address":	"192.168.54.2",
 				"port":		9092,
-			},
+			}},
 		},
 		{
 			name:		"it should fail if the new value is invalid",
@@ -201,7 +201,8 @@ func TestDefault(t *testing.T) {
 		Redpanda: RedpandaConfig{
 			Directory:	"/var/lib/redpanda/data",
 			RPCServer:	SocketAddress{"0.0.0.0", 33145},
-			KafkaApi:	SocketAddress{"0.0.0.0", 9092},
+			KafkaApi: []NamedSocketAddress{{
+				Name:	"", SocketAddress: SocketAddress{"0.0.0.0", 9092}}},
 			AdminApi:	SocketAddress{"0.0.0.0", 9644},
 			Id:		0,
 			DeveloperMode:	true,
@@ -293,8 +294,8 @@ redpanda:
   data_directory: /var/lib/redpanda/data
   developer_mode: false
   kafka_api:
-    address: 0.0.0.0
-    port: 9092
+    - address: 0.0.0.0
+      port: 9092
   node_id: 0
   rpc_server:
     address: 0.0.0.0
@@ -350,8 +351,8 @@ redpanda:
   data_directory: /var/lib/redpanda/data
   developer_mode: false
   kafka_api:
-    address: 0.0.0.0
-    port: 9092
+    - address: 0.0.0.0
+      port: 9092
   node_id: 0
   rpc_server:
     address: 0.0.0.0
@@ -399,8 +400,8 @@ redpanda:
   data_directory: /var/lib/redpanda/data
   developer_mode: false
   kafka_api:
-    address: 0.0.0.0
-    port: 9092
+    - address: 0.0.0.0
+      port: 9092
   node_id: 0
   rpc_server:
     address: 0.0.0.0
@@ -452,8 +453,8 @@ redpanda:
   data_directory: /var/lib/redpanda/data
   developer_mode: false
   kafka_api:
-    address: 0.0.0.0
-    port: 9092
+    - address: 0.0.0.0
+      port: 9092
   node_id: 0
   rpc_server:
     address: 0.0.0.0
@@ -842,7 +843,7 @@ func TestCheckConfig(t *testing.T) {
 			name:	"shall return an error when the Kafka API port is 0",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.Redpanda.KafkaApi.Port = 0
+				c.Redpanda.KafkaApi[0].Port = 0
 				return c
 			},
 			expected:	[]string{"redpanda.kafka_api.port can't be 0"},
@@ -851,7 +852,7 @@ func TestCheckConfig(t *testing.T) {
 			name:	"shall return an error when the Kafka API address is empty",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.Redpanda.KafkaApi.Address = ""
+				c.Redpanda.KafkaApi[0].Address = ""
 				return c
 			},
 			expected:	[]string{"redpanda.kafka_api.address can't be empty"},

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -147,7 +147,7 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 	keys := m.v.AllKeys()
 	flatMap := map[string]string{}
 	compactAddrFields := []string{
-		"redpanda.kafka_api",
+		"redpanda.kafka_api[0]",
 		"redpanda.rpc_server",
 		"redpanda.admin",
 	}

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -22,16 +22,16 @@ type Config struct {
 }
 
 type RedpandaConfig struct {
-	Directory		string		`yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
-	RPCServer		SocketAddress	`yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
-	AdvertisedRPCAPI	*SocketAddress	`yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
-	KafkaApi		SocketAddress	`yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
-	AdvertisedKafkaApi	[]SocketAddress	`yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
-	KafkaApiTLS		ServerTLS	`yaml:"kafka_api_tls,omitempty" mapstructure:"kafka_api_tls,omitempty" json:"kafkaApiTls"`
-	AdminApi		SocketAddress	`yaml:"admin" mapstructure:"admin" json:"admin"`
-	Id			int		`yaml:"node_id" mapstructure:"node_id" json:"id"`
-	SeedServers		[]SeedServer	`yaml:"seed_servers" mapstructure:"seed_servers" json:"seedServers"`
-	DeveloperMode		bool		`yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
+	Directory		string			`yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
+	RPCServer		SocketAddress		`yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
+	AdvertisedRPCAPI	*SocketAddress		`yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
+	KafkaApi		SocketAddress		`yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
+	AdvertisedKafkaApi	[]NamedSocketAddress	`yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
+	KafkaApiTLS		ServerTLS		`yaml:"kafka_api_tls,omitempty" mapstructure:"kafka_api_tls,omitempty" json:"kafkaApiTls"`
+	AdminApi		SocketAddress		`yaml:"admin" mapstructure:"admin" json:"admin"`
+	Id			int			`yaml:"node_id" mapstructure:"node_id" json:"id"`
+	SeedServers		[]SeedServer		`yaml:"seed_servers" mapstructure:"seed_servers" json:"seedServers"`
+	DeveloperMode		bool			`yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
 }
 
 type SeedServer struct {
@@ -41,6 +41,11 @@ type SeedServer struct {
 type SocketAddress struct {
 	Address	string	`yaml:"address" mapstructure:"address" json:"address"`
 	Port	int	`yaml:"port" mapstructure:"port" json:"port"`
+}
+
+type NamedSocketAddress struct {
+	Name		string	`yaml:"name,omitempty" mapstructure:"name,omitempty" json:"name,omitempty"`
+	SocketAddress	`yaml:",inline" mapstructure:",squash"`
 }
 
 type TLS struct {

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -25,7 +25,7 @@ type RedpandaConfig struct {
 	Directory		string			`yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
 	RPCServer		SocketAddress		`yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
 	AdvertisedRPCAPI	*SocketAddress		`yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
-	KafkaApi		SocketAddress		`yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
+	KafkaApi		[]NamedSocketAddress	`yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
 	AdvertisedKafkaApi	[]NamedSocketAddress	`yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
 	KafkaApiTLS		ServerTLS		`yaml:"kafka_api_tls,omitempty" mapstructure:"kafka_api_tls,omitempty" json:"kafkaApiTls"`
 	AdminApi		SocketAddress		`yaml:"admin" mapstructure:"admin" json:"admin"`

--- a/src/go/rpk/pkg/tuners/factory/factory.go
+++ b/src/go/rpk/pkg/tuners/factory/factory.go
@@ -289,7 +289,7 @@ func MergeTunerParamsConfig(
 ) (*TunerParams, error) {
 	if len(params.Nics) == 0 {
 		nics, err := net.GetInterfacesByIps(
-			conf.Redpanda.KafkaApi.Address,
+			conf.Redpanda.KafkaApi[0].Address,
 			conf.Redpanda.RPCServer.Address,
 		)
 		if err != nil {
@@ -307,7 +307,7 @@ func FillTunerParamsWithValuesFromConfig(
 	params *TunerParams, conf *config.Config,
 ) error {
 	nics, err := net.GetInterfacesByIps(
-		conf.Redpanda.KafkaApi.Address, conf.Redpanda.RPCServer.Address)
+		conf.Redpanda.KafkaApi[0].Address, conf.Redpanda.RPCServer.Address)
 	if err != nil {
 		return err
 	}

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -207,7 +207,7 @@ func RedpandaCheckers(
 		blockDevices,
 		balanceService,
 	)
-	interfaces, err := net.GetInterfacesByIps(config.Redpanda.KafkaApi.Address, config.Redpanda.RPCServer.Address)
+	interfaces, err := net.GetInterfacesByIps(config.Redpanda.KafkaApi[0].Address, config.Redpanda.RPCServer.Address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I can't figure out why, e.g.:
```
        config_test.go:920: 
                Error Trace:    config_test.go:920
                Error:          Not equal: 
                                expected: []string{}
                                actual  : []string{"redpanda.kafka_api missing"}
```

Pretty sure it's the same error prior to any of these changes if I just modify kafka_api from:
```yaml
kafka_api:
  address: "foo"
  port: 42
```
to
```yaml
kafka_api:
  - address: "foo"
    port: 42
```
Which I've essentially done in the defaults.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
