### PR TITLE
operator/controller: Add common labels to owned objects

### DIFF
--- a/src/go/k8s/pkg/labels/labels.go
+++ b/src/go/k8s/pkg/labels/labels.go
@@ -1,0 +1,52 @@
+package labels
+
+import redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+// TODO support "app.kubernetes.io/version"
+const (
+	// The name of a higher level application this one is part of
+	NameKey	= "app.kubernetes.io/name"
+	// A unique name identifying the instance of an application
+	InstanceKey	= "app.kubernetes.io/instance"
+	// The component within the architecture
+	ComponentKey	= "app.kubernetes.io/component"
+	// The name of a higher level application this one is part of
+	PartOfKey	= "app.kubernetes.io/part-of"
+	// The tool being used to manage the operation of an application
+	ManagedByKey	= "app.kubernetes.io/managed-by"
+)
+
+// ForCluster returns a set of labels that is a union of cluster labels as well as recommended default labels
+// recommended by the kubernetes documentation https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+func ForCluster(cluster *redpandav1alpha1.Cluster) map[string]string {
+	dl := defaultLabels(cluster)
+	labels := merge(cluster.Labels, dl)
+	return labels
+}
+
+// merge merges two sets of labels
+// if label is set in mainLabels, it won't be overwritten by newLabels
+func merge(
+	mainLabels map[string]string, newLabels map[string]string,
+) map[string]string {
+	if mainLabels == nil {
+		mainLabels = make(map[string]string)
+	}
+	for k, v := range newLabels {
+		if _, ok := mainLabels[k]; !ok {
+			mainLabels[k] = v
+		}
+	}
+	return mainLabels
+}
+
+func defaultLabels(cluster *redpandav1alpha1.Cluster) map[string]string {
+	labels := make(map[string]string)
+	labels[NameKey] = "redpanda"
+	labels[InstanceKey] = cluster.Name
+	labels[ComponentKey] = "database"
+	labels[PartOfKey] = "redpanda"
+	labels[ManagedByKey] = "redpanda-operator"
+	return labels
+}

--- a/src/go/k8s/pkg/labels/labels_test.go
+++ b/src/go/k8s/pkg/labels/labels_test.go
@@ -1,0 +1,56 @@
+package labels
+
+import (
+	"reflect"
+	"testing"
+
+	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLabels(t *testing.T) {
+	testCluster := &redpandav1alpha1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:		"RedpandaCluster",
+			APIVersion:	"core.vectorized.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:		"testcluster",
+			Namespace:	"default",
+		},
+		Spec:	redpandav1alpha1.ClusterSpec{},
+	}
+	withPartOfDefined := testCluster.DeepCopy()
+	withPartOfDefined.Labels = make(map[string]string)
+	withPartOfDefined.Labels[PartOfKey] = "part-of-something-else"
+
+	tests := []struct {
+		name		string
+		pandaCluster	*redpandav1alpha1.Cluster
+		expected	map[string]string
+	}{
+		{"empty inherited labels", testCluster, map[string]string{
+			"app.kubernetes.io/name":	"redpanda",
+			"app.kubernetes.io/instance":	"testcluster",
+			"app.kubernetes.io/component":	"database",
+			"app.kubernetes.io/part-of":	"redpanda",
+			"app.kubernetes.io/managed-by":	"redpanda-operator",
+		},
+		},
+		{"some inherited labels", withPartOfDefined, map[string]string{
+			"app.kubernetes.io/name":	"redpanda",
+			"app.kubernetes.io/instance":	"testcluster",
+			"app.kubernetes.io/component":	"database",
+			"app.kubernetes.io/part-of":	"part-of-something-else",
+			"app.kubernetes.io/managed-by":	"redpanda-operator",
+		},
+		},
+	}
+
+	for _, tt := range tests {
+		actual := ForCluster(tt.pandaCluster)
+		if !reflect.DeepEqual(actual, tt.expected) {
+			t.Errorf("%s: Expecting labels to be %v but got %v", tt.name, tt.expected, actual)
+		}
+	}
+}

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -110,7 +111,7 @@ func (r *ConfigMapResource) Obj() (client.Object, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:	r.Key().Namespace,
 			Name:		r.Key().Name,
-			Labels:		r.pandaCluster.Labels,
+			Labels:		labels.ForCluster(r.pandaCluster),
 		},
 		Data: map[string]string{
 			"redpanda.yaml":	string(cfgBytes),

--- a/src/go/k8s/pkg/resources/service.go
+++ b/src/go/k8s/pkg/resources/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +55,7 @@ func (r *ServiceResource) Obj() (client.Object, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:	r.Key().Namespace,
 			Name:		r.Key().Name,
-			Labels:		r.pandaCluster.Labels,
+			Labels:		labels.ForCluster(r.pandaCluster),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP:	corev1.ClusterIPNone,

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -78,7 +79,7 @@ func (r *StatefulSetResource) Obj() (client.Object, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:	r.Key().Namespace,
 			Name:		r.Key().Name,
-			Labels:		r.pandaCluster.Labels,
+			Labels:		labels.ForCluster(r.pandaCluster),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:		pointer.Int32Ptr(1),


### PR DESCRIPTION
As recommended per https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
