### PR TITLE
r/replicate_stm: skip sending requests to not responding follower

### DIFF
--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -153,10 +153,26 @@ replicate_entries_stm::append_to_self() {
           return result<storage::append_result>(errc::leader_append_failed);
       });
 }
-
-inline bool replicate_entries_stm::is_follower_recovering(vnode id) {
+/**
+ *  We skip sending follower requests it those two cases:
+ *   - follower is recovering - when follower is not fully caught up it will not
+ *     accept append entries request, missing data will be replicated to
+ *     follower during recovery process
+ *   - we haven't received any response from the follower for replicate append
+ *     timeout duration - follower is probably down, we will not be able to
+ *     send the request to the follower and it will require recovery. This
+ *     prevents pending follower request queue build up and relieve memory
+ *     pressure. Follower will still receive heartbeats, as we skip sending
+ *     append entries request, after recovery follower will start receiving
+ *     requests.
+ */
+inline bool replicate_entries_stm::should_skip_follower_request(vnode id) {
     if (auto it = _ptr->_fstats.find(id); it != _ptr->_fstats.end()) {
-        return it->second.is_recovering;
+        const auto timeout = clock_type::now()
+                             - _ptr->_replicate_append_timeout;
+
+        return it->second.last_hbeat_timestamp < timeout
+               || it->second.is_recovering;
     }
 
     return false;
@@ -190,10 +206,10 @@ replicate_entries_stm::apply(ss::semaphore_units<> u) {
             [this, &requests_count, units](const vnode& rni) {
                 // We are not dispatching request to followers that are
                 // recovering
-                if (is_follower_recovering(rni)) {
+                if (should_skip_follower_request(rni)) {
                     vlog(
                       _ctxlog.trace,
-                      "Skipping sending append request to {}, recovering",
+                      "Skipping sending append request to {}",
                       rni);
                     _ptr->suppress_heartbeats(rni, _followers_seq[rni], false);
                     return;

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -105,7 +105,7 @@ private:
     ss::future<result<append_entries_reply>>
       send_append_entries_request(vnode, append_entries_request);
     result<replicate_result> process_result(model::offset, model::term_id);
-    bool is_follower_recovering(vnode);
+    bool should_skip_follower_request(vnode);
     clock_type::time_point append_entries_timeout();
     /// This append will happen under the lock
     ss::future<result<storage::append_result>> append_to_self();


### PR DESCRIPTION
When follower is down, depending on the configuration raft group may be
able to still operate as it has majority. In the case when follower
requests timeout (f.e. network partition, follower process is
suspendend) we have to propagate backpressure to replicate_entries_stm
but still allow replication to healthy nodes. In order to do this
without compromising safety and performance we can skip sending append
entries request to not responding followers.

When follower is not responding it will require to be brought back up to
date after failure recovery. Skipping sending append entries requests
prevent requests queue build up and relief memory pressure.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
