### PR TITLE
Add support of idempotent producers

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -47,6 +47,7 @@ v_cc_library(
     controller.cc
     partition.cc
     partition_probe.cc
+    seq_stm.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -48,6 +48,7 @@ v_cc_library(
     partition.cc
     partition_probe.cc
     seq_stm.cc
+    id_allocator_stm.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -152,7 +152,7 @@ id_allocator_frontend::do_allocate_id(model::timeout_clock::duration timeout) {
           }
           return stm
             ->allocate_id_and_wait(model::timeout_clock::now() + timeout)
-            .then([](raft::id_allocator_stm::stm_allocation_result r) {
+            .then([](id_allocator_stm::stm_allocation_result r) {
                 if (r.raft_status == raft::errc::success) {
                     return allocate_id_reply{r.id, errc::success};
                 } else {

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -7,19 +7,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "raft/id_allocator_stm.h"
+#include "cluster/id_allocator_stm.h"
 
+#include "cluster/logger.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "raft/consensus.h"
 #include "raft/errc.h"
-#include "raft/logger.h"
 #include "raft/types.h"
 #include "storage/record_batch_builder.h"
 
 #include <seastar/core/future.hh>
 
-namespace raft {
+namespace cluster {
 
 template<typename T>
 model::record_batch serialize_cmd(T t, model::record_batch_type type) {
@@ -260,4 +260,4 @@ id_allocator_stm::replicate(model::record_batch&& batch) {
       raft::replicate_options{raft::consistency_level::quorum_ack});
 }
 
-} // namespace raft
+} // namespace cluster

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -26,7 +26,7 @@ namespace config {
 struct configuration;
 }
 
-namespace raft {
+namespace cluster {
 
 // id_allocator is a service to generate cluster-wide unique id (int64)
 // It is based on a state machine running on top of a raft log. For each
@@ -165,4 +165,4 @@ private:
     std::vector<cached_allocation_cmd> _cache;
 };
 
-} // namespace raft
+} // namespace cluster

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -26,7 +26,7 @@ partition::partition(consensus_ptr r)
   , _probe(*this) {
     auto stm_manager = _raft->log().stm_manager();
     if (is_id_allocator_topic(_raft->ntp())) {
-        _id_allocator_stm = ss::make_lw_shared<raft::id_allocator_stm>(
+        _id_allocator_stm = ss::make_lw_shared<cluster::id_allocator_stm>(
           clusterlog, _raft.get(), config::shard_local_cfg());
     } else {
         if (_raft->log_config().is_collectable()) {

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -29,7 +29,10 @@ partition::partition(consensus_ptr r)
           clusterlog, _raft.get(), config::shard_local_cfg());
     } else if (_raft->log_config().is_collectable()) {
         _nop_stm = std::make_unique<raft::log_eviction_stm>(
-          _raft.get(), clusterlog, _as);
+          _raft.get(),
+          clusterlog,
+          ss::make_lw_shared<storage::stm_manager>(),
+          _as);
     }
 }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/id_allocator_stm.h"
 #include "cluster/partition_probe.h"
 #include "cluster/seq_stm.h"
 #include "cluster/types.h"
@@ -18,7 +19,6 @@
 #include "model/record_batch_reader.h"
 #include "raft/consensus.h"
 #include "raft/group_configuration.h"
-#include "raft/id_allocator_stm.h"
 #include "raft/log_eviction_stm.h"
 #include "raft/types.h"
 #include "storage/types.h"
@@ -127,7 +127,7 @@ public:
         return _raft->get_latest_configuration_offset();
     }
 
-    ss::lw_shared_ptr<raft::id_allocator_stm>& id_allocator_stm() {
+    ss::lw_shared_ptr<cluster::id_allocator_stm>& id_allocator_stm() {
         return _id_allocator_stm;
     }
 
@@ -139,7 +139,7 @@ private:
 private:
     consensus_ptr _raft;
     ss::lw_shared_ptr<raft::log_eviction_stm> _nop_stm;
-    ss::lw_shared_ptr<raft::id_allocator_stm> _id_allocator_stm;
+    ss::lw_shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<seq_stm> _seq_stm;
     ss::abort_source _as;
     partition_probe _probe;

--- a/src/v/cluster/seq_stm.cc
+++ b/src/v/cluster/seq_stm.cc
@@ -1,0 +1,345 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/seq_stm.h"
+
+#include "cluster/logger.h"
+#include "raft/errc.h"
+#include "raft/types.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/future.hh>
+
+#include <filesystem>
+
+namespace cluster {
+
+seq_stm::seq_stm(
+  ss::logger& logger, raft::consensus* c, config::configuration& config)
+  : raft::state_machine(c, logger, ss::default_priority_class())
+  , _c(c)
+  , _snapshot_mgr(
+      std::filesystem::path(c->log_config().work_directory()),
+      "seq",
+      ss::default_priority_class())
+  , _log(logger)
+  , _config(config) {}
+
+ss::future<> seq_stm::hydrate_snapshot(storage::snapshot_reader& reader) {
+    return reader.read_metadata().then([this, &reader](iobuf meta_buf) {
+        iobuf_parser meta_parser(std::move(meta_buf));
+        seq_snapshot_header hdr;
+        hdr.version = reflection::adl<int8_t>{}.from(meta_parser);
+        vassert(
+          hdr.version == seq_snapshot_header::supported_version,
+          "unsupported seq_snapshot_header version {}",
+          hdr.version);
+        hdr.snapshot_size = reflection::adl<int32_t>{}.from(meta_parser);
+
+        return read_iobuf_exactly(reader.input(), hdr.snapshot_size)
+          .then([this](iobuf data_buf) {
+              iobuf_parser data_parser(std::move(data_buf));
+              auto data = reflection::adl<snapshot>{}.from(data_parser);
+              for (auto& entry : data.entries) {
+                  auto pid_seq = _seq_table.find(entry.pid);
+                  if (pid_seq == _seq_table.end()) {
+                      _seq_table.emplace(entry.pid, entry);
+                  } else if (pid_seq->second.seq < entry.seq) {
+                      pid_seq->second = entry;
+                  }
+              }
+              _last_snapshot_offset = data.offset;
+              _insync_offset = data.offset;
+              vlog(
+                clusterlog.trace,
+                "seq_stm snapshot with offset:{} is loaded",
+                data.offset);
+          })
+          .then([this]() { return _snapshot_mgr.remove_partial_snapshots(); });
+    });
+}
+
+ss::future<> seq_stm::wait_for_snapshot_hydrated() {
+    auto f = ss::now();
+    if (unlikely(!_resolved_when_snapshot_hydrated.available())) {
+        f = _resolved_when_snapshot_hydrated.get_shared_future();
+    }
+    return f;
+}
+
+ss::future<> seq_stm::persist_snapshot(iobuf&& data) {
+    seq_snapshot_header header;
+    header.version = seq_snapshot_header::supported_version;
+    header.snapshot_size = data.size_bytes();
+
+    iobuf data_size_buf;
+    reflection::serialize(data_size_buf, header.version, header.snapshot_size);
+
+    return _snapshot_mgr.start_snapshot().then(
+      [this, data = std::move(data), data_size_buf = std::move(data_size_buf)](
+        storage::snapshot_writer writer) mutable {
+          return ss::do_with(
+            std::move(writer),
+            [this,
+             data = std::move(data),
+             data_size_buf = std::move(data_size_buf)](
+              storage::snapshot_writer& writer) mutable {
+                return writer.write_metadata(std::move(data_size_buf))
+                  .then([&writer, data = std::move(data)]() mutable {
+                      return write_iobuf_to_output_stream(
+                        std::move(data), writer.output());
+                  })
+                  .finally([&writer] { return writer.close(); })
+                  .then([this, &writer] {
+                      return _snapshot_mgr.finish_snapshot(writer);
+                  });
+            });
+      });
+}
+
+ss::future<> seq_stm::make_snapshot() {
+    return _op_lock.with([this]() {
+        auto f = wait_for_snapshot_hydrated();
+        return f.then([this] { return do_make_snapshot(); });
+    });
+}
+
+ss::future<> seq_stm::ensure_snapshot_exists(model::offset target_offset) {
+    return _op_lock.with([this, target_offset]() {
+        auto f = wait_for_snapshot_hydrated();
+
+        return f.then([this, target_offset] {
+            if (target_offset <= _last_snapshot_offset) {
+                return ss::now();
+            }
+            return wait(target_offset, model::no_timeout)
+              .then([this, target_offset]() {
+                  vassert(
+                    target_offset <= _insync_offset,
+                    "after we waited for target_offset ({}) _insync_offset "
+                    "({}) should have matched it or bypassed",
+                    target_offset,
+                    _insync_offset);
+                  return do_make_snapshot();
+              });
+        });
+    });
+}
+
+ss::future<> seq_stm::do_make_snapshot() {
+    vlog(clusterlog.trace, "saving seq_stm snapshot");
+    snapshot data;
+    data.offset = _insync_offset;
+    for (auto& entry : _seq_table) {
+        data.entries.push_back(entry.second);
+    }
+
+    iobuf v_buf;
+    reflection::adl<snapshot>{}.to(v_buf, data);
+    return persist_snapshot(std::move(v_buf))
+      .then([this, snapshot_offset = data.offset]() {
+          if (snapshot_offset >= _last_snapshot_offset) {
+              _last_snapshot_offset = snapshot_offset;
+          }
+      });
+}
+
+ss::future<> seq_stm::start() {
+    _oldest_session = model::timestamp::now();
+    return _snapshot_mgr.open_snapshot().then(
+      [this](std::optional<storage::snapshot_reader> reader) {
+          auto f = ss::now();
+          if (reader) {
+              f = ss::do_with(
+                std::move(*reader), [this](storage::snapshot_reader& reader) {
+                    return hydrate_snapshot(reader).finally([this, &reader] {
+                        auto offset = std::max(
+                          _insync_offset, _c->start_offset());
+                        if (offset >= model::offset(0)) {
+                            set_next(offset);
+                        }
+                        _resolved_when_snapshot_hydrated.set_value();
+                        return reader.close();
+                    });
+                });
+          } else {
+              auto offset = _c->start_offset();
+              if (offset >= model::offset(0)) {
+                  set_next(offset);
+              }
+              _resolved_when_snapshot_hydrated.set_value();
+          }
+
+          return f.then([this]() { return state_machine::start(); })
+            .then([this]() {
+                auto offset = _c->meta().commit_index;
+                if (offset >= model::offset(0)) {
+                    (void)ss::with_gate(_gate, [this, offset] {
+                        // saving a snapshot after catchup with the tip of the
+                        // log
+                        return ensure_snapshot_exists(offset);
+                    });
+                }
+            });
+      });
+}
+
+ss::future<> seq_stm::catchup() {
+    if (_insync_term != _c->term()) {
+        if (!_is_catching_up) {
+            _is_catching_up = true;
+            auto meta = _c->meta();
+            return catchup(meta.prev_log_term, meta.prev_log_index)
+              .then([this]() { _is_catching_up = false; });
+        }
+    }
+    return ss::now();
+}
+
+static bool is_sequence(int32_t last_seq, int32_t next_seq) {
+    return (last_seq + 1 == next_seq)
+           || (next_seq == 0 && last_seq == std::numeric_limits<int32_t>::max());
+}
+
+ss::future<checked<raft::replicate_result, kafka::error_code>>
+seq_stm::replicate(
+  model::batch_identity bid,
+  model::record_batch_reader&& r,
+  raft::replicate_options opts) {
+    if (bid.has_idempotent() && bid.first_seq <= bid.last_seq) {
+        if (_insync_term != _c->term()) {
+            (void)ss::with_gate(_gate, [this] { return catchup(); });
+            return seastar::make_ready_future<
+              checked<raft::replicate_result, kafka::error_code>>(
+              kafka::error_code::not_leader_for_partition);
+        }
+        auto pid_seq = _seq_table.find(bid.pid);
+        auto last_write_timestamp = model::timestamp::now().value();
+        if (pid_seq == _seq_table.end()) {
+            if (bid.first_seq != 0) {
+                return seastar::make_ready_future<
+                  checked<raft::replicate_result, kafka::error_code>>(
+                  kafka::error_code::out_of_order_sequence_number);
+            }
+            seq_entry entry{
+              .pid = bid.pid,
+              .seq = bid.last_seq,
+              .last_write_timestamp = last_write_timestamp};
+            _oldest_session = std::min(
+              _oldest_session, model::timestamp(entry.last_write_timestamp));
+            _seq_table.emplace(entry.pid, entry);
+        } else {
+            if (!is_sequence(pid_seq->second.seq, bid.first_seq)) {
+                return seastar::make_ready_future<
+                  checked<raft::replicate_result, kafka::error_code>>(
+                  kafka::error_code::out_of_order_sequence_number);
+            }
+            pid_seq->second.seq += bid.last_seq;
+            pid_seq->second.last_write_timestamp = last_write_timestamp;
+            _oldest_session = std::min(
+              _oldest_session,
+              model::timestamp(pid_seq->second.last_write_timestamp));
+        }
+        return _c->replicate(_insync_term, std::move(r), opts)
+          .then([](result<raft::replicate_result> r) {
+              if (r) {
+                  return checked<raft::replicate_result, kafka::error_code>(
+                    r.value());
+              }
+              return checked<raft::replicate_result, kafka::error_code>(
+                kafka::error_code::unknown_server_error);
+          });
+    }
+    return _c->replicate(std::move(r), std::move(opts))
+      .then([](result<raft::replicate_result> r) {
+          if (r) {
+              return checked<raft::replicate_result, kafka::error_code>(
+                r.value());
+          }
+          return checked<raft::replicate_result, kafka::error_code>(
+            kafka::error_code::unknown_server_error);
+      });
+}
+
+ss::future<>
+seq_stm::catchup(model::term_id last_term, model::offset last_offset) {
+    vlog(
+      _log.trace,
+      "seq_stm is catching up with term:{} and offset:{}",
+      last_term,
+      last_offset);
+    return wait(last_offset, model::no_timeout)
+      .then([this, last_offset, last_term]() {
+          auto meta = _c->meta();
+          vlog(
+            _log.trace,
+            "seq_stm caught up with term:{} and offset:{}; current_term: {} "
+            "current_offset: {} dirty_term: {} dirty_offset: {}",
+            last_term,
+            last_offset,
+            meta.term,
+            meta.commit_index,
+            meta.prev_log_term,
+            meta.prev_log_index);
+          if (last_term <= meta.term) {
+              _insync_term = last_term;
+          }
+      });
+}
+
+void seq_stm::compact_snapshot() {
+    auto cutoff_timestamp
+      = model::timestamp::now().value()
+        - _config.transactional_id_expiration_ms.value().count();
+    if (_oldest_session.value() < cutoff_timestamp) {
+        auto next_oldest_session = model::timestamp::now();
+        for (auto it = _seq_table.cbegin(); it != _seq_table.cend();) {
+            if (it->second.last_write_timestamp < cutoff_timestamp) {
+                _seq_table.erase(it++);
+            } else {
+                next_oldest_session = std::min(
+                  next_oldest_session,
+                  model::timestamp(it->second.last_write_timestamp));
+                ++it;
+            }
+        }
+        _oldest_session = next_oldest_session;
+    }
+}
+
+ss::future<> seq_stm::apply(model::record_batch b) {
+    const auto& hdr = b.header();
+    auto bid = model::batch_identity::from(hdr);
+
+    if (
+      hdr.type == raft::data_batch_type && bid.has_idempotent()
+      && bid.first_seq <= bid.last_seq) {
+        auto pid_seq = _seq_table.find(bid.pid);
+        if (pid_seq == _seq_table.end()) {
+            seq_entry entry{
+              .pid = bid.pid,
+              .seq = bid.last_seq,
+              .last_write_timestamp = hdr.max_timestamp.value()};
+            _seq_table.emplace(bid.pid, entry);
+            _oldest_session = std::min(
+              _oldest_session, model::timestamp(entry.last_write_timestamp));
+        } else if (pid_seq->second.seq < bid.last_seq) {
+            pid_seq->second.seq = bid.last_seq;
+            pid_seq->second.last_write_timestamp = hdr.max_timestamp.value();
+            _oldest_session = std::min(_oldest_session, hdr.max_timestamp);
+        }
+        compact_snapshot();
+    }
+
+    _insync_offset = b.last_offset();
+
+    return ss::now();
+}
+
+} // namespace cluster

--- a/src/v/cluster/seq_stm.h
+++ b/src/v/cluster/seq_stm.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/configuration.h"
+#include "kafka/protocol/errors.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "raft/consensus.h"
+#include "raft/errc.h"
+#include "raft/logger.h"
+#include "raft/state_machine.h"
+#include "raft/types.h"
+#include "storage/snapshot.h"
+#include "utils/expiring_promise.h"
+#include "utils/mutex.h"
+
+#include <absl/container/flat_hash_map.h>
+
+namespace cluster {
+
+struct seq_snapshot_header {
+    static constexpr const int8_t supported_version = 0;
+
+    int8_t version{seq_snapshot_header::supported_version};
+    int32_t snapshot_size{0};
+
+    static constexpr const size_t ondisk_size = sizeof(version)
+                                                + sizeof(snapshot_size);
+};
+
+/**
+ * seq_stm is a layer in front of the log responsible for maintaining
+ * idempotency of the producers. It works by keeping track of the last
+ * event within a session (identified by a producer id and a epoch)
+ * and validating that the next event goes strictly after a current
+ * event where the precedence is defined by sequence number set by
+ * clients.
+ *
+ * Sequence numbers are part of the events and persisted in a
+ * log. To avoid scanning the whole log to reconstruct a map from
+ * sessions to its last sequence number seq_stm uses snapshotting.
+ *
+ * The potential divergence of the session - sequence map is prevented
+ * by using conditional replicate and forcing cache refresh when
+ * a expected term doesn't match the current term thus avoiding the
+ * ABA problem where A and B correspond to different nodes holding
+ * a leadership.
+ */
+class seq_stm final
+  : public raft::state_machine
+  , public storage::snapshotable_stm {
+public:
+    explicit seq_stm(ss::logger&, raft::consensus*, config::configuration&);
+
+    ss::future<> start() final;
+
+    ss::future<> ensure_snapshot_exists(model::offset) final;
+    ss::future<> make_snapshot() final;
+    ss::future<> catchup();
+
+    ss::future<checked<raft::replicate_result, kafka::error_code>> replicate(
+      model::batch_identity,
+      model::record_batch_reader&&,
+      raft::replicate_options);
+
+private:
+    struct seq_entry {
+        model::producer_identity pid;
+        int32_t seq;
+        model::timestamp::type last_write_timestamp;
+    };
+
+    struct snapshot {
+        model::offset offset;
+        std::vector<seq_entry> entries;
+    };
+
+    ss::future<> do_make_snapshot();
+    ss::future<> hydrate_snapshot(storage::snapshot_reader&);
+    /*
+     * Usually start() acts as a barrier and we don't call any methods on the
+     * object before start returns control flow.
+     *
+     * With snapshot-enabled stm we have the following workflow around
+     * partition.h/.cc:
+     *
+     * 1. create consensus
+     * 2. create partition
+     * 3. pass consensus to partition
+     * 4. inside partition:
+     *    - create stm and pass consensus to constructor
+     *    - pass stm to consensus via stm_manager
+     *    - start consensus
+     *    - start stm
+     *
+     * We can't start stm before starting consensus but once consensus has
+     * started it may get a chance to invoke make_snapshot or
+     * ensure_snapshot_exists on stm before it's started.
+     *
+     * `wait_for_snapshot_hydrated` inside those methods protects from this
+     * scenario.
+     */
+    ss::future<> wait_for_snapshot_hydrated();
+    ss::future<> persist_snapshot(iobuf&& data);
+    void compact_snapshot();
+
+    ss::future<> catchup(model::term_id, model::offset);
+
+    model::offset _last_snapshot_offset;
+    absl::flat_hash_map<model::producer_identity, seq_entry> _seq_table;
+    mutex _op_lock;
+    ss::shared_promise<> _resolved_when_snapshot_hydrated;
+    model::timestamp _oldest_session;
+    bool _is_catching_up{false};
+    model::term_id _insync_term{-1};
+    model::offset _insync_offset{-1};
+    raft::consensus* _c;
+    storage::snapshot_manager _snapshot_mgr;
+    ss::logger& _log;
+    config::configuration& _config;
+    ss::future<> apply(model::record_batch b) override;
+};
+
+} // namespace cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -28,7 +28,8 @@ set(srcs
     topic_updates_dispatcher_test.cc
     controller_backend_test.cc
     configuration_change_test.cc
-    seq_stm_tests.cc)
+    seq_stm_tests.cc
+    id_allocator_stm_test.cc)
 
 rp_test(
   UNIT_TEST

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -27,13 +27,14 @@ set(srcs
     topic_table_test.cc
     topic_updates_dispatcher_test.cc
     controller_backend_test.cc
-    configuration_change_test.cc)
+    configuration_change_test.cc
+    seq_stm_tests.cc)
 
 rp_test(
   UNIT_TEST
   BINARY_NAME test_cluster
   SOURCES ${srcs}
-  LIBRARIES v::seastar_testing_main v::application
+  LIBRARIES v::seastar_testing_main v::application v::storage_test_utils
 )
 
 # These 2 files have a `using namespace cluster;` and removing that

--- a/src/v/cluster/tests/id_allocator_stm_test.cc
+++ b/src/v/cluster/tests/id_allocator_stm_test.cc
@@ -7,12 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/id_allocator_stm.h"
 #include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/timeout_clock.h"
 #include "outcome.h"
-#include "raft/id_allocator_stm.h"
 #include "raft/tests/mux_state_machine_fixture.h"
 #include "raft/types.h"
 #include "random/generators.h"
@@ -45,7 +45,7 @@ FIXTURE_TEST(stm_monotonicity_test, mux_state_machine_fixture) {
     cfg.id_allocator_batch_size.set_value(int16_t(1));
     cfg.id_allocator_log_capacity.set_value(int16_t(2));
 
-    raft::id_allocator_stm stm(idstmlog, _raft.get(), cfg);
+    cluster::id_allocator_stm stm(idstmlog, _raft.get(), cfg);
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -72,7 +72,7 @@ FIXTURE_TEST(stm_restart_test, mux_state_machine_fixture) {
     cfg.id_allocator_batch_size.set_value(int16_t(1));
     cfg.id_allocator_log_capacity.set_value(int16_t(2));
 
-    raft::id_allocator_stm stm1(idstmlog, _raft.get(), cfg);
+    cluster::id_allocator_stm stm1(idstmlog, _raft.get(), cfg);
     stm1.start().get0();
     wait_for_leader();
 
@@ -89,7 +89,7 @@ FIXTURE_TEST(stm_restart_test, mux_state_machine_fixture) {
     }
     stm1.stop().get0();
 
-    raft::id_allocator_stm stm2(idstmlog, _raft.get(), cfg);
+    cluster::id_allocator_stm stm2(idstmlog, _raft.get(), cfg);
     stm2.start().get0();
     for (int i = 0; i < 5; i++) {
         auto result

--- a/src/v/cluster/tests/seq_stm_tests.cc
+++ b/src/v/cluster/tests/seq_stm_tests.cc
@@ -42,6 +42,7 @@ FIXTURE_TEST(
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
     wait_for_leader();
+    wait_for_meta_initialized();
 
     stm.catchup().get0();
 
@@ -96,6 +97,7 @@ FIXTURE_TEST(
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
     wait_for_leader();
+    wait_for_meta_initialized();
 
     stm.catchup().get0();
 
@@ -148,6 +150,7 @@ FIXTURE_TEST(test_seq_stm_prevents_duplicates, mux_state_machine_fixture) {
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
     wait_for_leader();
+    wait_for_meta_initialized();
 
     stm.catchup().get0();
 
@@ -203,6 +206,7 @@ FIXTURE_TEST(test_seq_stm_prevents_gaps, mux_state_machine_fixture) {
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
     wait_for_leader();
+    wait_for_meta_initialized();
 
     stm.catchup().get0();
 
@@ -259,6 +263,7 @@ FIXTURE_TEST(
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
 
     wait_for_leader();
+    wait_for_meta_initialized();
 
     auto count = 5;
     auto rdr = random_batches_reader(storage::test::record_batch_spec{

--- a/src/v/cluster/tests/seq_stm_tests.cc
+++ b/src/v/cluster/tests/seq_stm_tests.cc
@@ -1,0 +1,288 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/seq_stm.h"
+#include "finjector/hbadger.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/record.h"
+#include "model/timestamp.h"
+#include "raft/consensus_utils.h"
+#include "raft/tests/mux_state_machine_fixture.h"
+#include "raft/tests/raft_group_fixture.h"
+#include "raft/types.h"
+#include "random/generators.h"
+#include "storage/record_batch_builder.h"
+#include "storage/tests/utils/disk_log_builder.h"
+#include "storage/tests/utils/random_batch.h"
+#include "test_utils/async.h"
+
+#include <seastar/util/defer.hh>
+
+#include <system_error>
+
+ss::logger logger{"append-test"};
+
+FIXTURE_TEST(
+  test_seq_stm_doesnt_interfere_with_out_of_session_messages,
+  mux_state_machine_fixture) {
+    start_raft();
+
+    config::configuration cfg;
+
+    cluster::seq_stm stm(logger, _raft.get(), cfg);
+
+    stm.start().get0();
+    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+
+    wait_for_leader();
+
+    stm.catchup().get0();
+
+    auto count = 5;
+    auto rdr1 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = -1,
+      .base_sequence = 0});
+    auto bid1 = model::batch_identity{
+      .pid = model::producer_identity{.id = -1, .epoch = 0},
+      .first_seq = 0,
+      .last_seq = count - 1};
+    auto r1 = stm
+                .replicate(
+                  bid1,
+                  std::move(rdr1),
+                  raft::replicate_options(raft::consistency_level::quorum_ack))
+                .get0();
+    BOOST_REQUIRE((bool)r1);
+
+    auto rdr2 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(count),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = -1,
+      .base_sequence = 0});
+    auto bid2 = model::batch_identity{
+      .pid = model::producer_identity{.id = -1, .epoch = 0},
+      .first_seq = 0,
+      .last_seq = count - 1};
+    auto r2 = stm
+                .replicate(
+                  bid2,
+                  std::move(rdr2),
+                  raft::replicate_options(raft::consistency_level::quorum_ack))
+                .get0();
+    BOOST_REQUIRE((bool)r2);
+}
+
+FIXTURE_TEST(
+  test_seq_stm_passes_monotonic_in_session_messages,
+  mux_state_machine_fixture) {
+    start_raft();
+
+    config::configuration cfg;
+
+    cluster::seq_stm stm(logger, _raft.get(), cfg);
+
+    stm.start().get0();
+    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+
+    wait_for_leader();
+
+    stm.catchup().get0();
+
+    auto count = 5;
+    auto rdr1 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = 1,
+      .base_sequence = 0});
+    auto bid1 = model::batch_identity{
+      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .first_seq = 0,
+      .last_seq = count - 1};
+    auto r1 = stm
+                .replicate(
+                  bid1,
+                  std::move(rdr1),
+                  raft::replicate_options(raft::consistency_level::quorum_ack))
+                .get0();
+    BOOST_REQUIRE((bool)r1);
+
+    auto rdr2 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(count),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = 1,
+      .base_sequence = count});
+    auto bid2 = model::batch_identity{
+      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .first_seq = count,
+      .last_seq = count + (count - 1)};
+    auto r2 = stm
+                .replicate(
+                  bid2,
+                  std::move(rdr2),
+                  raft::replicate_options(raft::consistency_level::quorum_ack))
+                .get0();
+    BOOST_REQUIRE((bool)r2);
+}
+
+FIXTURE_TEST(test_seq_stm_prevents_duplicates, mux_state_machine_fixture) {
+    start_raft();
+
+    config::configuration cfg;
+
+    cluster::seq_stm stm(logger, _raft.get(), cfg);
+
+    stm.start().get0();
+    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+
+    wait_for_leader();
+
+    stm.catchup().get0();
+
+    auto count = 5;
+    auto rdr1 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = 1,
+      .base_sequence = 0});
+    auto bid1 = model::batch_identity{
+      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .first_seq = 0,
+      .last_seq = count - 1};
+    auto r1 = stm
+                .replicate(
+                  bid1,
+                  std::move(rdr1),
+                  raft::replicate_options(raft::consistency_level::quorum_ack))
+                .get0();
+    BOOST_REQUIRE((bool)r1);
+
+    auto rdr2 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(count),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = 1,
+      .base_sequence = 0});
+    auto bid2 = model::batch_identity{
+      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .first_seq = 0,
+      .last_seq = count - 1};
+    auto r2 = stm
+                .replicate(
+                  bid2,
+                  std::move(rdr2),
+                  raft::replicate_options(raft::consistency_level::quorum_ack))
+                .get0();
+    BOOST_REQUIRE(
+      r2
+      == failure_type<kafka::error_code>(
+        kafka::error_code::out_of_order_sequence_number));
+}
+
+FIXTURE_TEST(test_seq_stm_prevents_gaps, mux_state_machine_fixture) {
+    start_raft();
+
+    config::configuration cfg;
+
+    cluster::seq_stm stm(logger, _raft.get(), cfg);
+
+    stm.start().get0();
+    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+
+    wait_for_leader();
+
+    stm.catchup().get0();
+
+    auto count = 5;
+    auto rdr1 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = 1,
+      .base_sequence = 0});
+    auto bid1 = model::batch_identity{
+      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .first_seq = 0,
+      .last_seq = count - 1};
+    auto r1 = stm
+                .replicate(
+                  bid1,
+                  std::move(rdr1),
+                  raft::replicate_options(raft::consistency_level::quorum_ack))
+                .get0();
+    BOOST_REQUIRE((bool)r1);
+
+    auto rdr2 = random_batch_reader(storage::test::record_batch_spec{
+      .offset = model::offset(count),
+      .allow_compression = true,
+      .count = count,
+      .producer_id = 1,
+      .base_sequence = count + 1});
+    auto bid2 = model::batch_identity{
+      .pid = model::producer_identity{.id = 1, .epoch = 0},
+      .first_seq = count + 1,
+      .last_seq = count + 1 + (count - 1)};
+    auto r2 = stm
+                .replicate(
+                  bid2,
+                  std::move(rdr2),
+                  raft::replicate_options(raft::consistency_level::quorum_ack))
+                .get0();
+    BOOST_REQUIRE(
+      r2
+      == failure_type<kafka::error_code>(
+        kafka::error_code::out_of_order_sequence_number));
+}
+
+FIXTURE_TEST(
+  test_seq_stm_prevents_odd_session_start_off, mux_state_machine_fixture) {
+    start_raft();
+
+    config::configuration cfg;
+
+    cluster::seq_stm stm(logger, _raft.get(), cfg);
+
+    stm.start().get0();
+    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+
+    wait_for_leader();
+
+    auto count = 5;
+    auto rdr = random_batches_reader(storage::test::record_batch_spec{
+      .offset = model::offset(0),
+      .allow_compression = true,
+      .count = count,
+      .enable_idempotence = true,
+      .base_sequence = 1});
+
+    auto bid = model::batch_identity{
+      .pid = model::producer_identity{.id = 0, .epoch = 0},
+      .first_seq = 1,
+      .last_seq = 1 + (count - 1)};
+
+    stm.catchup().get0();
+
+    auto r = stm
+               .replicate(
+                 bid,
+                 std::move(rdr),
+                 raft::replicate_options(raft::consistency_level::quorum_ack))
+               .get0();
+    BOOST_REQUIRE(
+      r
+      == failure_type<kafka::error_code>(
+        kafka::error_code::out_of_order_sequence_number));
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -247,6 +247,12 @@ configuration::configuration()
       "write with the given producer id.",
       required::no,
       10080min)
+  , enable_idempotence(
+      *this,
+      "enable_idempotence",
+      "Enable idempotent producer",
+      required::no,
+      false)
   , delete_retention_ms(
       *this,
       "delete_retention_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -240,6 +240,13 @@ configuration::configuration()
       "wasn't reached",
       required::no,
       1ms)
+  , transactional_id_expiration_ms(
+      *this,
+      "transactional_id_expiration_ms",
+      "Producer ids are expired once this time has elapsed after the last "
+      "write with the given producer id.",
+      required::no,
+      10080min)
   , delete_retention_ms(
       *this,
       "delete_retention_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -76,6 +76,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> group_new_member_join_timeout;
     property<std::chrono::milliseconds> metadata_dissemination_interval_ms;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
+    // same as transactional.id.expiration.ms in kafka
+    property<std::chrono::milliseconds> transactional_id_expiration_ms;
     // same as delete.retention.ms in kafka
     property<std::chrono::milliseconds> delete_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -78,6 +78,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
     // same as transactional.id.expiration.ms in kafka
     property<std::chrono::milliseconds> transactional_id_expiration_ms;
+    property<bool> enable_idempotence;
     // same as delete.retention.ms in kafka
     property<std::chrono::milliseconds> delete_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -99,7 +99,10 @@ private:
         offset_flush_fiber_state()
           : duration(
             config::shard_local_cfg().coproc_offset_flush_interval_ms())
-          , snap(offsets_snapshot_path(), ss::default_priority_class()) {}
+          , snap(
+              offsets_snapshot_path(),
+              storage::snapshot_manager::default_snapshot_filename,
+              ss::default_priority_class()) {}
     };
 
 private:

--- a/src/v/coproc/tests/offset_storage_utils_tests.cc
+++ b/src/v/coproc/tests/offset_storage_utils_tests.cc
@@ -26,7 +26,10 @@ public:
     offset_keeper_fixture()
       : _base_dir(make_base_dir())
       , _api(make_api())
-      , _snap(_base_dir, ss::default_priority_class()) {
+      , _snap(
+          _base_dir,
+          storage::snapshot_manager::default_snapshot_filename,
+          ss::default_priority_class()) {
         _api.start().get();
     }
 

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -49,6 +49,7 @@ using request_types = make_request_types<
   sasl_handshake_handler,
   sasl_authenticate_handler,
   incremental_alter_configs_handler,
+  init_producer_id_handler,
   delete_groups_handler>;
 
 template<typename RequestType>

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -50,7 +50,9 @@ protocol::protocol(
   , _partition_manager(pm)
   , _coordinator_mapper(coordinator_mapper)
   , _fetch_session_cache(session_cache)
-  , _id_allocator_frontend(id_allocator_frontend) {}
+  , _id_allocator_frontend(id_allocator_frontend)
+  , _is_idempotence_enabled(
+      config::shard_local_cfg().enable_idempotence.value()) {}
 
 ss::future<> protocol::apply(rpc::server::resources rs) {
     auto ctx = ss::make_lw_shared<connection_context>(*this, std::move(rs));

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/fwd.h"
+#include "config/configuration.h"
 #include "kafka/server/fwd.h"
 #include "rpc/server.h"
 
@@ -68,6 +69,7 @@ public:
         return _fetch_session_cache.local();
     }
     quota_manager& quota_mgr() { return _quota_mgr.local(); }
+    bool is_idempotence_enabled() { return _is_idempotence_enabled; }
 
 private:
     ss::smp_service_group _smp_group;
@@ -80,6 +82,7 @@ private:
     ss::sharded<kafka::coordinator_ntp_mapper>& _coordinator_mapper;
     ss::sharded<kafka::fetch_session_cache>& _fetch_session_cache;
     ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
+    bool _is_idempotence_enabled{false};
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -105,6 +105,10 @@ public:
         return _conn->server().id_allocator_frontend();
     }
 
+    bool is_idempotence_enabled() {
+        return _conn->server().is_idempotence_enabled();
+    }
+
     int32_t throttle_delay_ms() const {
         return std::chrono::duration_cast<std::chrono::milliseconds>(
                  _throttle_delay)

--- a/src/v/outcome.h
+++ b/src/v/outcome.h
@@ -24,6 +24,9 @@
 
 namespace outcome = boost::outcome_v2;
 
+template<class S>
+using failure_type = outcome::failure_type<S>;
+
 template<
   class R,
   class S = std::error_code,

--- a/src/v/raft/CMakeLists.txt
+++ b/src/v/raft/CMakeLists.txt
@@ -28,7 +28,6 @@ v_cc_library(
     event_manager.cc
     state_machine.cc
     log_eviction_stm.cc
-    id_allocator_stm.cc
     configuration_manager.cc
     group_configuration.cc
     append_entries_buffer.cc

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -64,7 +64,9 @@ consensus::consensus(
       config::shard_local_cfg().recovery_append_timeout_ms())
   , _storage(storage)
   , _snapshot_mgr(
-      std::filesystem::path(_log.config().work_directory()), _io_priority)
+      std::filesystem::path(_log.config().work_directory()),
+      storage::snapshot_manager::default_snapshot_filename,
+      _io_priority)
   , _configuration_manager(std::move(initial_cfg), _group, _storage, _ctxlog)
   , _append_requests_buffer(*this, 256) {
     setup_metrics();

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -188,10 +188,8 @@ public:
      *      d. cache the term
      *      e. continue with step #1
      */
-    ss::future<result<replicate_result>> replicate(
-      model::term_id expected_term,
-      model::record_batch_reader&&,
-      replicate_options);
+    ss::future<result<replicate_result>>
+    replicate(model::term_id, model::record_batch_reader&&, replicate_options);
 
     ss::future<model::record_batch_reader> make_reader(
       storage::log_reader_config,

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -276,6 +276,8 @@ public:
 
     probe& get_probe() { return _probe; };
 
+    storage::log& log() { return _log; }
+
     bool are_heartbeats_suppressed(vnode) const;
 
     void suppress_heartbeats(vnode, follower_req_seq, bool);

--- a/src/v/raft/log_eviction_stm.cc
+++ b/src/v/raft/log_eviction_stm.cc
@@ -17,9 +17,13 @@
 namespace raft {
 
 log_eviction_stm::log_eviction_stm(
-  consensus* raft, ss::logger& logger, ss::abort_source& as)
+  consensus* raft,
+  ss::logger& logger,
+  ss::lw_shared_ptr<storage::stm_manager> stm_manager,
+  ss::abort_source& as)
   : _raft(raft)
   , _logger(logger)
+  , _stm_manager(stm_manager)
   , _as(as) {}
 
 ss::future<> log_eviction_stm::start() {

--- a/src/v/raft/log_eviction_stm.h
+++ b/src/v/raft/log_eviction_stm.h
@@ -10,8 +10,10 @@
  */
 
 #pragma once
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
+#include "storage/types.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
@@ -27,7 +29,11 @@ class consensus;
  */
 class log_eviction_stm {
 public:
-    log_eviction_stm(consensus*, ss::logger&, ss::abort_source&);
+    log_eviction_stm(
+      consensus*,
+      ss::logger&,
+      ss::lw_shared_ptr<storage::stm_manager>,
+      ss::abort_source&);
 
     ss::future<> start();
 
@@ -39,6 +45,7 @@ private:
 
     consensus* _raft;
     ss::logger& _logger;
+    ss::lw_shared_ptr<storage::stm_manager> _stm_manager;
     ss::abort_source& _as;
     ss::gate _gate;
     model::offset _previous_eviction_offset;

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -27,7 +27,6 @@ class replicate_batcher {
 public:
     struct item {
         ss::promise<result<replicate_result>> _promise;
-        replicate_result ret;
         size_t record_count;
         std::vector<model::record_batch> data;
         std::optional<model::term_id> expected_term;

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -31,7 +31,6 @@ set(srcs
     mux_state_machine_test.cc
     mutex_buffer_test.cc
     manual_log_deletion_test.cc
-    id_allocator_stm_test.cc
     state_removal_test.cc
     configuration_manager_test.cc)
 

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -109,6 +109,13 @@ struct mux_state_machine_fixture {
         }).get0();
     }
 
+    void wait_for_meta_initialized() {
+        using namespace std::chrono_literals;
+        tests::cooperative_spin_wait_with_timeout(10s, [this] {
+            return _raft->meta().commit_index >= model::offset(0);
+        }).get0();
+    }
+
     model::node_id _self;
     model::ntp _ntp = model::ntp(
       model::ns("default"), model::topic("test"), model::partition_id(0));

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -484,7 +484,26 @@ private:
 
 static model::record_batch_reader random_batches_reader(int max_batches) {
     auto batches = storage::test::make_random_batches(
-      model::offset(0), max_batches);
+      storage::test::record_batch_spec{
+        .offset = model::offset(0),
+        .allow_compression = true,
+        .count = max_batches});
+    return model::make_memory_record_batch_reader(std::move(batches));
+}
+
+static model::record_batch_reader
+random_batch_reader(storage::test::record_batch_spec spec) {
+    auto batch = storage::test::make_random_batch(spec);
+    ss::circular_buffer<model::record_batch> batches;
+    batches.reserve(1);
+    batch.set_term(model::term_id(0));
+    batches.push_back(std::move(batch));
+    return model::make_memory_record_batch_reader(std::move(batches));
+}
+
+static model::record_batch_reader
+random_batches_reader(storage::test::record_batch_spec spec) {
+    auto batches = storage::test::make_random_batches(spec);
     return model::make_memory_record_batch_reader(std::move(batches));
 }
 

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -179,7 +179,10 @@ struct raft_node {
         consensus->start().get0();
         if (log->config().is_collectable()) {
             _nop_stm = std::make_unique<raft::log_eviction_stm>(
-              consensus.get(), tstlog, _as);
+              consensus.get(),
+              tstlog,
+              ss::make_lw_shared<storage::stm_manager>(),
+              _as);
             _nop_stm->start().get0();
         }
     }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -565,6 +565,7 @@ ss::future<> disk_log_impl::new_segment(
                 }
                 _segs.add(std::move(h));
                 _probe.segment_created();
+                return _stm_manager->make_snapshot();
             });
       });
 }

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -34,6 +34,7 @@ kvstore::kvstore(kvstore_config kv_conf)
   , _ntpc(model::kvstore_ntp(ss::this_shard_id()), _conf.base_dir)
   , _snap(
       std::filesystem::path(_ntpc.work_directory()),
+      snapshot_manager::default_snapshot_filename,
       ss::default_priority_class())
   , _timer([this] { _sem.signal(); }) {}
 

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -37,7 +37,8 @@ public:
     class impl {
     public:
         explicit impl(ntp_config cfg) noexcept
-          : _config(std::move(cfg)) {}
+          : _config(std::move(cfg))
+          , _stm_manager(ss::make_lw_shared<storage::stm_manager>()) {}
         impl(impl&&) noexcept = default;
         impl& operator=(impl&&) noexcept = default;
         impl(const impl&) = delete;
@@ -74,9 +75,15 @@ public:
         virtual ss::future<model::offset>
         monitor_eviction(ss::abort_source&) = 0;
         virtual void set_collectible_offset(model::offset) = 0;
+        ss::lw_shared_ptr<storage::stm_manager> stm_manager() {
+            return _stm_manager;
+        }
 
     private:
         ntp_config _config;
+
+    protected:
+        ss::lw_shared_ptr<storage::stm_manager> _stm_manager;
     };
 
 public:
@@ -148,6 +155,10 @@ public:
      */
     ss::future<model::offset> monitor_eviction(ss::abort_source& as) {
         return _impl->monitor_eviction(as);
+    }
+
+    ss::lw_shared_ptr<storage::stm_manager> stm_manager() {
+        return _impl->stm_manager();
     }
     /**
      * Controlls the max offset that may be evicted by log retention policy

--- a/src/v/storage/snapshot.h
+++ b/src/v/storage/snapshot.h
@@ -89,12 +89,15 @@ class snapshot_writer;
  *       mgr.remove_partial_snapshots();
  */
 class snapshot_manager {
-    static constexpr const char* snapshot_filename = "snapshot";
-
 public:
+    static constexpr const char* default_snapshot_filename = "snapshot";
+
     snapshot_manager(
-      std::filesystem::path dir, ss::io_priority_class io_prio) noexcept
-      : _dir(std::move(dir))
+      std::filesystem::path dir,
+      const char* filename,
+      ss::io_priority_class io_prio) noexcept
+      : _filename(filename)
+      , _dir(std::move(dir))
       , _io_prio(io_prio) {}
 
     ss::future<std::optional<snapshot_reader>> open_snapshot();
@@ -103,7 +106,7 @@ public:
     ss::future<> finish_snapshot(snapshot_writer&);
 
     std::filesystem::path snapshot_path() const {
-        return _dir / snapshot_filename;
+        return _dir / _filename.c_str();
     }
 
     ss::future<> remove_partial_snapshots();
@@ -111,6 +114,7 @@ public:
     ss::future<> remove_snapshot();
 
 private:
+    ss::sstring _filename;
     std::filesystem::path _dir;
     ss::io_priority_class _io_prio;
 };

--- a/src/v/storage/tests/snapshot_test.cc
+++ b/src/v/storage/tests/snapshot_test.cc
@@ -14,13 +14,19 @@
 #include <seastar/testing/thread_test_case.hh>
 
 SEASTAR_THREAD_TEST_CASE(missing_snapshot_is_not_error) {
-    storage::snapshot_manager mgr("d/n/e", ss::default_priority_class());
+    storage::snapshot_manager mgr(
+      "d/n/e",
+      storage::snapshot_manager::default_snapshot_filename,
+      ss::default_priority_class());
     auto reader = mgr.open_snapshot().get0();
     BOOST_REQUIRE(!reader);
 }
 
 SEASTAR_THREAD_TEST_CASE(reading_from_empty_snapshot_is_error) {
-    storage::snapshot_manager mgr(".", ss::default_priority_class());
+    storage::snapshot_manager mgr(
+      ".",
+      storage::snapshot_manager::default_snapshot_filename,
+      ss::default_priority_class());
     try {
         ss::remove_file(mgr.snapshot_path().string()).get();
     } catch (...) {
@@ -47,7 +53,10 @@ SEASTAR_THREAD_TEST_CASE(reading_from_empty_snapshot_is_error) {
 }
 
 SEASTAR_THREAD_TEST_CASE(reader_verifies_header_crc) {
-    storage::snapshot_manager mgr(".", ss::default_priority_class());
+    storage::snapshot_manager mgr(
+      ".",
+      storage::snapshot_manager::default_snapshot_filename,
+      ss::default_priority_class());
     try {
         ss::remove_file(mgr.snapshot_path().string()).get();
     } catch (...) {
@@ -81,7 +90,10 @@ SEASTAR_THREAD_TEST_CASE(reader_verifies_header_crc) {
 }
 
 SEASTAR_THREAD_TEST_CASE(reader_verifies_metadata_crc) {
-    storage::snapshot_manager mgr(".", ss::default_priority_class());
+    storage::snapshot_manager mgr(
+      ".",
+      storage::snapshot_manager::default_snapshot_filename,
+      ss::default_priority_class());
     try {
         ss::remove_file(mgr.snapshot_path().string()).get();
     } catch (...) {
@@ -117,7 +129,10 @@ SEASTAR_THREAD_TEST_CASE(reader_verifies_metadata_crc) {
 }
 
 SEASTAR_THREAD_TEST_CASE(read_write) {
-    storage::snapshot_manager mgr(".", ss::default_priority_class());
+    storage::snapshot_manager mgr(
+      ".",
+      storage::snapshot_manager::default_snapshot_filename,
+      ss::default_priority_class());
     try {
         ss::remove_file(mgr.snapshot_path().string()).get();
     } catch (...) {
@@ -144,7 +159,10 @@ SEASTAR_THREAD_TEST_CASE(read_write) {
 }
 
 SEASTAR_THREAD_TEST_CASE(remove_partial_snapshots) {
-    storage::snapshot_manager mgr(".", ss::default_priority_class());
+    storage::snapshot_manager mgr(
+      ".",
+      storage::snapshot_manager::default_snapshot_filename,
+      ss::default_priority_class());
 
     auto mk_partial = [&] {
         auto writer = mgr.start_snapshot().get0();

--- a/src/v/storage/tests/utils/random_batch.cc
+++ b/src/v/storage/tests/utils/random_batch.cc
@@ -82,27 +82,45 @@ model::record_batch make_random_batch(
   int num_records,
   bool allow_compression,
   model::record_batch_type bt) {
-    auto ts = model::timestamp::now()() - (num_records - 1);
+    return make_random_batch(record_batch_spec{
+      .offset = o,
+      .allow_compression = allow_compression,
+      .count = num_records,
+      .bt = bt});
+}
+
+model::record_batch
+make_random_batch(model::offset o, int num_records, bool allow_compression) {
+    return make_random_batch(
+      o, num_records, allow_compression, model::record_batch_type(1));
+}
+
+model::record_batch make_random_batch(record_batch_spec spec) {
+    auto ts = model::timestamp::now()() - (spec.count - 1);
     auto header = model::record_batch_header{
       .size_bytes = 0, // computed later
-      .base_offset = o,
-      .type = bt,
+      .base_offset = spec.offset,
+      .type = spec.bt,
       .crc = 0, // we-reassign later
       .attrs = model::record_batch_attributes(
-        get_int<int16_t>(0, allow_compression ? 4 : 0)),
-      .last_offset_delta = num_records - 1,
+        get_int<int16_t>(0, spec.allow_compression ? 4 : 0)),
+      .last_offset_delta = spec.count - 1,
       .first_timestamp = model::timestamp(ts),
-      .max_timestamp = model::timestamp(ts + num_records - 1),
-      .producer_id = 0,
-      .producer_epoch = 0,
+      .max_timestamp = model::timestamp(ts + spec.count - 1),
+      .producer_id = spec.producer_id,
+      .producer_epoch = spec.producer_epoch,
       .base_sequence = 0,
-      .record_count = num_records};
+      .record_count = spec.count};
+
+    if (spec.enable_idempotence) {
+        header.base_sequence = spec.base_sequence;
+    }
 
     auto size = model::packed_record_batch_header_size;
     model::record_batch::records_type records;
     auto rs = model::record_batch::uncompressed_records();
-    rs.reserve(num_records);
-    for (int i = 0; i < num_records; ++i) {
+    rs.reserve(spec.count);
+    for (int i = 0; i < spec.count; ++i) {
         rs.emplace_back(make_random_record(i));
     }
     if (header.attrs.compression() != model::compression::none) {
@@ -133,7 +151,8 @@ model::record_batch make_random_batch(
 
 model::record_batch make_random_batch(model::offset o, bool allow_compression) {
     auto num_records = get_int(2, 30);
-    return make_random_batch(o, num_records, allow_compression);
+    return make_random_batch(
+      o, num_records, allow_compression, model::record_batch_type(1));
 }
 
 ss::circular_buffer<model::record_batch>
@@ -142,6 +161,9 @@ make_random_batches(model::offset o, int count, bool allow_compression) {
     ss::circular_buffer<model::record_batch> ret;
     ret.reserve(count);
     for (int i = 0; i < count; i++) {
+        // TODO: it looks like a bug: make_random_batch adds
+        // random number of records like we increment offset
+        // always by one
         auto b = make_random_batch(o, allow_compression);
         o = b.last_offset() + model::offset(1);
         b.set_term(model::term_id(0));
@@ -151,17 +173,52 @@ make_random_batches(model::offset o, int count, bool allow_compression) {
 }
 
 ss::circular_buffer<model::record_batch> make_random_batches(model::offset o) {
-    return make_random_batches(o, get_int(2, 30));
+    return make_random_batches(o, get_int(2, 30), true);
+}
+
+ss::circular_buffer<model::record_batch>
+make_random_batches(record_batch_spec spec) {
+    // start offset + count
+    ss::circular_buffer<model::record_batch> ret;
+    ret.reserve(spec.count);
+    model::offset o = spec.offset;
+    int32_t base_sequence = spec.base_sequence;
+    for (int i = 0; i < spec.count; i++) {
+        auto num_records = get_int(2, 30);
+        auto batch_spec = spec;
+        batch_spec.offset = o;
+        batch_spec.count = num_records;
+        if (spec.enable_idempotence) {
+            batch_spec.base_sequence = base_sequence;
+            base_sequence += num_records;
+        }
+        auto b = make_random_batch(batch_spec);
+        o = b.last_offset() + model::offset(num_records);
+        b.set_term(model::term_id(0));
+        ret.push_back(std::move(b));
+    }
+    return ret;
 }
 
 model::record_batch_reader make_random_memory_record_batch_reader(
   model::offset offset, int batch_size, int n_batches, bool allow_compression) {
+    return make_random_memory_record_batch_reader(
+      record_batch_spec{
+        .offset = offset,
+        .allow_compression = allow_compression,
+        .count = batch_size},
+      n_batches);
+}
+
+model::record_batch_reader
+make_random_memory_record_batch_reader(record_batch_spec spec, int n_batches) {
     return model::make_generating_record_batch_reader(
-      [offset, batch_size, n_batches, allow_compression]() mutable {
+      [offset = spec.offset, spec, n_batches]() mutable {
           model::record_batch_reader::data_t batches;
           if (n_batches--) {
-              batches = make_random_batches(
-                offset, batch_size, allow_compression);
+              auto batch_spec = spec;
+              batch_spec.offset = offset;
+              batches = make_random_batches(batch_spec);
               offset = batches.back().last_offset()++;
           }
           return ss::make_ready_future<model::record_batch_reader::data_t>(

--- a/src/v/storage/tests/utils/random_batch.h
+++ b/src/v/storage/tests/utils/random_batch.h
@@ -13,8 +13,22 @@
 
 #include "model/record.h"
 #include "model/record_batch_reader.h"
+#include "random/generators.h"
 
 namespace storage::test {
+using namespace random_generators; // NOLINT
+
+struct record_batch_spec {
+    model::offset offset{0};
+    bool allow_compression{true};
+    int count{0};
+    model::record_batch_type bt{1};
+    bool enable_idempotence{false};
+    int64_t producer_id{0};
+    int16_t producer_epoch{0};
+    int32_t base_sequence{0};
+};
+
 /**
  * Makes random batch starting at requested offset.
  *
@@ -24,7 +38,12 @@ model::record_batch make_random_batch(
   model::offset o,
   int num_records,
   bool allow_compression,
-  model::record_batch_type bt = model::record_batch_type(1));
+  model::record_batch_type bt);
+
+model::record_batch
+make_random_batch(model::offset o, int num_records, bool allow_compression);
+
+model::record_batch make_random_batch(record_batch_spec);
 
 model::record_batch
 make_random_batch(model::offset o, bool allow_compression = true);
@@ -35,7 +54,13 @@ make_random_batches(model::offset o, int count, bool allow_compression = true);
 ss::circular_buffer<model::record_batch>
 make_random_batches(model::offset o = model::offset(0));
 
+ss::circular_buffer<model::record_batch>
+make_random_batches(record_batch_spec spec);
+
 model::record_batch_reader make_random_memory_record_batch_reader(
   model::offset, int, int, bool allow_compression = true);
+
+model::record_batch_reader
+make_random_memory_record_batch_reader(record_batch_spec, int);
 
 } // namespace storage::test


### PR DESCRIPTION
Idempotent producer feature is based on using a pair of pid & epoch to identify a session and the sequential (seq) numbers to identify a message within a session. seq_stm keeps the last used seq number per session and enforces that the seq numbers within a session form a increasing sequence without the gaps.