### PR TITLE
coproc: Durably store coprocessors respective offsets

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -85,6 +85,12 @@ configuration::configuration()
       "Maximum amount of bytes to read from one topic read",
       required::no,
       32_KiB)
+  , coproc_offset_flush_interval_ms(
+      *this,
+      "coproc_offset_flush_interval_ms",
+      "Interval for which all coprocessor offsets are flushed to disk",
+      required::no,
+      300000ms) // five minutes
   , node_id(
       *this,
       "node_id",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -46,6 +46,7 @@ struct configuration final : public config_store {
     property<std::size_t> coproc_max_inflight_bytes;
     property<std::size_t> coproc_max_ingest_bytes;
     property<std::size_t> coproc_max_batch_size;
+    property<std::chrono::milliseconds> coproc_offset_flush_interval_ms;
 
     // Raft
     property<int32_t> node_id;

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -22,6 +22,7 @@ v_cc_library(
     service.cc
     script_context.cc
     pacemaker.cc
+    offset_storage_utils.cc
     wasm_event.cc
     wasm_event_listener.cc
   DEPS

--- a/src/v/coproc/ntp_context.h
+++ b/src/v/coproc/ntp_context.h
@@ -34,6 +34,8 @@ struct ntp_context {
         model::offset last_acked{model::model_limits<model::offset>::min()};
     };
 
+    using offset_tracker = absl::btree_map<script_id, offset_pair>;
+
     explicit ntp_context(storage::log lg)
       : log(std::move(lg)) {}
 
@@ -42,7 +44,7 @@ struct ntp_context {
     /// Reference to the storage layer for reading from the input ntp
     storage::log log;
     /// Interested scripts write their last read offset of the input ntp
-    absl::btree_map<script_id, offset_pair> offsets;
+    offset_tracker offsets;
 };
 
 using ntp_context_cache

--- a/src/v/coproc/offset_storage_utils.cc
+++ b/src/v/coproc/offset_storage_utils.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/offset_storage_utils.h"
+
+#include "bytes/iobuf.h"
+#include "coproc/logger.h"
+#include "coproc/ntp_context.h"
+#include "model/fundamental.h"
+#include "reflection/adl.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/util/defer.hh>
+
+#include <bits/stdint-intn.h>
+
+#include <optional>
+
+namespace reflection {
+
+template<>
+struct adl<coproc::ntp_context::offset_tracker> {
+    void to(iobuf& out, coproc::ntp_context::offset_tracker&& offsets) {
+        reflection::serialize(out, static_cast<int32_t>(offsets.size()));
+        for (const auto& e : offsets) {
+            reflection::serialize(
+              out, e.first, e.second.last_read, e.second.last_acked);
+        }
+    }
+
+    coproc::ntp_context::offset_tracker from(iobuf_parser& in) {
+        coproc::ntp_context::offset_tracker offsets;
+        auto size = reflection::adl<int32_t>{}.from(in);
+        for (auto i = 0; i < size; ++i) {
+            auto id = reflection::adl<coproc::script_id>{}.from(in);
+            auto last_read = reflection::adl<model::offset>{}.from(in);
+            auto last_acked = reflection::adl<model::offset>{}.from(in);
+            offsets.emplace(
+              id,
+              coproc::ntp_context::offset_pair{
+                .last_read = last_read, .last_acked = last_acked});
+        }
+        return offsets;
+    }
+};
+
+} // namespace reflection
+
+namespace coproc {
+
+using iresults_map
+  = absl::flat_hash_map<model::ntp, ntp_context::offset_tracker>;
+
+ss::future<iresults_map> deserialize_data_field(iobuf data) {
+    return ss::do_with(
+      iresults_map(),
+      iobuf_parser(std::move(data)),
+      [](iresults_map& irm, iobuf_parser& p) {
+          const int32_t n_elements = reflection::adl<int32_t>{}.from(p);
+          auto range = boost::irange<int32_t>(0, n_elements);
+          return ss::do_for_each(
+                   range,
+                   [&irm, &p](int32_t) {
+                       model::ntp key = reflection::adl<model::ntp>{}.from(p);
+                       ntp_context::offset_tracker offsets
+                         = reflection::adl<ntp_context::offset_tracker>{}.from(
+                           p);
+                       irm.emplace(std::move(key), std::move(offsets));
+                   })
+            .then([&irm] { return std::move(irm); });
+      });
+}
+
+ss::future<iobuf> serialize_data_field(const ntp_context_cache& ntp_cache) {
+    return ss::do_with(iobuf(), [&ntp_cache](iobuf& data) {
+        reflection::serialize(data, static_cast<int32_t>(ntp_cache.size()));
+        return ss::do_for_each(
+                 ntp_cache,
+                 [&data](const ntp_context_cache::value_type& p) {
+                     reflection::serialize(
+                       data,
+                       model::ntp(p.first),
+                       ntp_context::offset_tracker(p.second->offsets));
+                 })
+          .then([&data] { return std::move(data); });
+    });
+}
+
+ss::future<ntp_context_cache> recover_offsets(
+  storage::snapshot_manager& snap, storage::log_manager& log_mgr) {
+    ntp_context_cache recovered;
+    auto optional_snap_reader = co_await snap.open_snapshot();
+    if (!optional_snap_reader) {
+        co_return recovered;
+    }
+    storage::snapshot_reader& reader = *optional_snap_reader;
+    /// Read the metadata which contains the total number of elements
+    iobuf metadata = co_await reader.read_metadata();
+    const int8_t version = iobuf_const_parser(metadata).consume_type<int8_t>();
+    if (version != 1) {
+        vlog(coproclog.error, "Incorrect version in recover_offsets snapshot");
+        co_await reader.close();
+        co_return recovered;
+    }
+    /// Query the total size, and read the rest of the data
+    const size_t size = co_await reader.get_snapshot_size();
+    iobuf data = co_await read_iobuf_exactly(reader.input(), size);
+    co_await reader.close();
+    /// Deserialize the data
+    iresults_map irm = co_await deserialize_data_field(std::move(data));
+    vlog(coproclog.info, "Recovered {} coprocessor offsets....", irm.size());
+    /// Match the offsets map with the corresponding storage::log queried from
+    /// the log_manager, building the completed ntp_context_cache
+    for (auto& [key, offsets] : irm) {
+        std::optional<storage::log> log = log_mgr.get(key);
+        if (!log) {
+            vlog(
+              coproclog.error,
+              "Coult not recover ntp {}, for some reason it does not exist in "
+              "the log_manager",
+              key);
+        } else {
+            auto [itr, _] = recovered.emplace(
+              std::move(key), ss::make_lw_shared<ntp_context>(std::move(*log)));
+            itr->second->offsets = std::move(offsets);
+        }
+    }
+    co_return recovered;
+}
+
+ss::future<> save_offsets(
+  storage::snapshot_manager& snap, const ntp_context_cache& ntp_cache) {
+    vlog(
+      coproclog.info,
+      "Saving {} coprocessor offsets to disk....",
+      ntp_cache.size());
+    /// Create the metadata, and data iobuffers
+    iobuf metadata = reflection::to_iobuf(static_cast<int8_t>(1));
+    iobuf data = co_await serialize_data_field(ntp_cache);
+
+    /// Serialize this to disk via the snapshot_manager
+    storage::snapshot_writer writer = co_await snap.start_snapshot();
+    co_await writer.write_metadata(std::move(metadata));
+    co_await write_iobuf_to_output_stream(std::move(data), writer.output());
+    co_await writer.close();
+    co_await snap.finish_snapshot(writer);
+}
+
+} // namespace coproc

--- a/src/v/coproc/offset_storage_utils.h
+++ b/src/v/coproc/offset_storage_utils.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "config/configuration.h"
+#include "coproc/ntp_context.h"
+#include "storage/log_manager.h"
+#include "storage/snapshot.h"
+
+#include <filesystem>
+
+namespace coproc {
+
+inline std::filesystem::path offsets_snapshot_path() {
+    return config::shard_local_cfg().data_directory().path
+           / ".coprocessor_offset_checkpoints";
+}
+
+/// Reads the snapshot on disk (if one exists) and returns an initialized
+/// ntp_context_cache with all proper storage::logs and stored offsets
+ss::future<ntp_context_cache>
+recover_offsets(storage::snapshot_manager&, storage::log_manager&);
+
+/// Writes all offsets to disk using the snapshot manager
+ss::future<> save_offsets(storage::snapshot_manager&, const ntp_context_cache&);
+
+} // namespace coproc

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -11,11 +11,14 @@
 
 #pragma once
 
+#include "config/configuration.h"
 #include "coproc/ntp_context.h"
+#include "coproc/offset_storage_utils.h"
 #include "coproc/script_context.h"
 #include "coproc/types.h"
 #include "rpc/reconnect_transport.h"
 #include "storage/api.h"
+#include "storage/snapshot.h"
 
 #include <seastar/core/sharded.hh>
 #include <seastar/net/inet_address.hh>
@@ -38,6 +41,11 @@ public:
      * @param reference to the storage layer
      */
     pacemaker(ss::socket_address, ss::sharded<storage::api>&);
+
+    /**
+     * Begins the offset tracking fiber
+     */
+    ss::future<> start();
 
     /**
      * Gracefully stops and deregisters all coproc scripts
@@ -82,6 +90,18 @@ private:
       std::vector<errc>& acks,
       const std::vector<topic_namespace_policy>&);
 
+    struct offset_flush_fiber_state {
+        ss::gate gate;
+        ss::timer<ss::lowres_clock> timer;
+        model::timeout_clock::duration duration;
+        storage::snapshot_manager snap;
+
+        offset_flush_fiber_state()
+          : duration(
+            config::shard_local_cfg().coproc_offset_flush_interval_ms())
+          , snap(offsets_snapshot_path(), ss::default_priority_class()) {}
+    };
+
 private:
     /// Data to be referenced by script_contexts on the current shard
     shared_script_resources _shared_res;
@@ -91,6 +111,9 @@ private:
 
     /// Referencable cache of active ntps
     ntp_context_cache _ntps;
+
+    /// Responsible for timed persistence of offsets to disk
+    offset_flush_fiber_state _offs;
 };
 
 } // namespace coproc

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -30,7 +30,9 @@ rp_test(
 rp_test(
   UNIT_TEST
   BINARY_NAME router_unit_tests
-  SOURCES router_test.cc
+  SOURCES
+    router_test.cc
+    offset_storage_utils_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::coproc_test_utils
   LABELS coproc

--- a/src/v/coproc/tests/offset_storage_utils_tests.cc
+++ b/src/v/coproc/tests/offset_storage_utils_tests.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/ntp_context.h"
+#include "coproc/offset_storage_utils.h"
+#include "model/namespace.h"
+#include "storage/snapshot.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <chrono>
+#include <filesystem>
+
+class offset_keeper_fixture {
+public:
+    offset_keeper_fixture()
+      : _base_dir(make_base_dir())
+      , _api(make_api())
+      , _snap(_base_dir, ss::default_priority_class()) {
+        _api.start().get();
+    }
+
+    ~offset_keeper_fixture() {
+        _api.stop().get();
+        std::filesystem::remove_all(_base_dir);
+    }
+
+    /// Create some logs to properly initialize a valid ntp_context_cache
+    coproc::ntp_context_cache create_test_cache(std::size_t n) {
+        coproc::ntp_context_cache ntpcc;
+        for (auto i = 0; i < n; ++i) {
+            model::ntp ntp(
+              model::kafka_namespace,
+              model::topic(fmt::format("test_topic_{}", i)),
+              model::partition_id(0));
+            storage::log log = _api.log_mgr()
+                                 .manage(
+                                   storage::ntp_config(ntp, _base_dir.string()))
+                                 .get();
+            auto [itr, _] = ntpcc.emplace(
+              ntp, ss::make_lw_shared<coproc::ntp_context>(log));
+            /// Insert some test data
+            itr->second->offsets.emplace(
+              coproc::script_id(4444),
+              coproc::ntp_context::offset_pair{
+                .last_read = model::offset(5), .last_acked = model::offset(3)});
+            itr->second->offsets.emplace(
+              coproc::script_id(3333),
+              coproc::ntp_context::offset_pair{
+                .last_read = model::offset(10),
+                .last_acked = model::offset(10)});
+        }
+        return ntpcc;
+    }
+
+    storage::log_manager& log_mgr() { return _api.log_mgr(); }
+    storage::snapshot_manager& snapshot_mgr() { return _snap; }
+
+private:
+    static std::filesystem::path make_base_dir() {
+        return std::filesystem::current_path()
+               / fmt::format("coproc_test.dir_{}", time(0)) / "data_dir";
+    }
+
+    storage::api make_api() const {
+        storage::log_config conf{
+          storage::log_config::storage_type::disk,
+          ss::sstring(_base_dir.string()),
+          1024,
+          storage::debug_sanitize_files::yes};
+        return storage::api(
+          storage::kvstore_config(
+            1_MiB, 10ms, conf.base_dir, storage::debug_sanitize_files::yes),
+          conf);
+    }
+
+    std::filesystem::path _base_dir;
+    storage::api _api;
+    storage::snapshot_manager _snap;
+};
+
+namespace coproc {
+bool operator==(
+  const ntp_context::offset_pair& a, const ntp_context::offset_pair& b) {
+    return a.last_acked == b.last_acked && a.last_read == b.last_read;
+}
+} // namespace coproc
+
+FIXTURE_TEST(offset_keeper_saved_offsets, offset_keeper_fixture) {
+    coproc::ntp_context_cache cache, retrieved_cache;
+    cache = create_test_cache(50);
+
+    /// Write these offsets to disk
+    coproc::save_offsets(snapshot_mgr(), cache).get();
+
+    /// Attempt to retrieve all stored offsets
+    retrieved_cache = coproc::recover_offsets(snapshot_mgr(), log_mgr()).get0();
+
+    const size_t total_offsets = std::accumulate(
+      retrieved_cache.cbegin(),
+      retrieved_cache.cend(),
+      size_t(0),
+      [](size_t acc, const coproc::ntp_context_cache::value_type& p) {
+          return acc + p.second->offsets.size();
+      });
+    /// Created test cache with 50 static topics...
+    BOOST_CHECK_EQUAL(retrieved_cache.size(), 50);
+    /// and for every topic 2 scripts are tracking offsets for 100 total
+    BOOST_CHECK_EQUAL(total_offsets, 100);
+}

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -614,7 +614,6 @@ void application::start() {
     vlog(
       _log.info, "Started Kafka API server listening at {}", conf.kafka_api());
 
-    /// Start client listening for events on the internal coprocessor topic
     if (coproc_enabled()) {
         /// Temporarily disable retries for the new client until we create a
         /// more granular way to configure this per client or per request.
@@ -623,6 +622,8 @@ void application::start() {
           _wasm_event_listener,
           config::shard_local_cfg().data_directory.value().path);
         _wasm_event_listener->start().get();
+        /// Start the pacemakers offset keeper
+        pacemaker.invoke_on_all(&coproc::pacemaker::start).get();
     }
 
     vlog(_log.info, "Successfully started Redpanda!");


### PR DESCRIPTION
This PR lays the ground work for storing tracked offsets of coprocessors to disk. The kvstore is used to persist the offsets to disk however not the instance that resides in storage::api. A separate instance is created per shard in order to avoid possibly negatively affecting the performance characteristics of other existing systems that leverage that kvstore.

A new class is introduced that simply iterates over the collection of all copros, and serializes their respective offsets to disk. This operation is run on 5 minute intervals.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.