### PR TITLE
ducktape: improve interface for initial topic creation

### DIFF
--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -38,6 +38,12 @@ class KafkaCliTools:
             args += ["--config", "cleanup.policy={}".format(cleanup_policy)]
         return self._run("kafka-topics.sh", args)
 
+    def create_topic_from_spec(self, spec):
+        return self.create_topic(spec.name,
+                                 partitions=spec.partitions,
+                                 replication_factor=spec.replication_factor,
+                                 cleanup_policy=spec.cleanup_policy)
+
     def delete_topic(self, topic):
         self._redpanda.logger.debug("Deleting topic: %s", topic)
         args = ["--delete"]

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -54,7 +54,7 @@ class RedpandaService(Service):
         self._context = context
         self._extra_rp_conf = extra_rp_conf
         self._log_level = log_level
-        self._topics = topics or dict()
+        self._topics = topics or ()
         self.v_build_dir = self._context.globals.get("v_build_dir", None)
 
     def start(self):
@@ -75,10 +75,13 @@ class RedpandaService(Service):
             assert set(node.ns) == {"redpanda"}
             assert set(node.ns["redpanda"].topics) == {"controller", "kvstore"}
 
+        self._create_initial_topics()
+
+    def _create_initial_topics(self):
         kafka_tools = KafkaCliTools(self)
-        for topic, cfg in self._topics.items():
-            self.logger.debug("Creating initial topic %s / %s", topic, cfg)
-            kafka_tools.create_topic(topic, **cfg)
+        for spec in self._topics:
+            self.logger.debug(f"Creating initial topic {spec}")
+            kafka_tools.create_topic_from_spec(spec)
 
     def start_node(self, node, override_cfg_params=None):
         node.account.mkdirs(RedpandaService.DATA_DIR)

--- a/tests/rptest/tests/controller_recovery_test.py
+++ b/tests/rptest/tests/controller_recovery_test.py
@@ -26,7 +26,7 @@ class ControllerRecoveryTest(RedpandaTest):
             curr = self.redpanda.controller()
             return curr and curr != prev
 
-        wait_until(lambda: new_controller_elected(),
+        wait_until(new_controller_elected,
                    timeout_sec=30,
                    backoff_sec=2,
                    err_msg="Controller did not failover")

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -6,15 +6,51 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import random
+import string
 
 from ducktape.tests.test import Test
 from rptest.services.redpanda import RedpandaService
+
+
+class TopicSpec:
+    """
+    A topic specification.
+
+    It is often the case that in a test the name of a topic does not matter. To
+    simplify for this case, a random name is generated if none is provided.
+    """
+    CLEANUP_COMPACT = "compact"
+    CLEANUP_DELETE = "delete"
+
+    def __init__(self,
+                 *,
+                 name=None,
+                 partitions=1,
+                 replication_factor=1,
+                 cleanup_policy=None):
+        self.name = name or f"topic-{self._random_topic_suffix()}"
+        self.partitions = partitions
+        self.replication_factor = replication_factor
+        self.cleanup_policy = cleanup_policy
+
+    def __str__(self):
+        return self.name
+
+    def _random_topic_suffix(self, size=4):
+        return "".join(
+            random.choice(string.ascii_lowercase) for _ in range(size))
 
 
 class RedpandaTest(Test):
     """
     Base class for tests that use the Redpanda service.
     """
+
+    # List of topics to be created automatically when the cluster starts. Each
+    # topic is defined by an instance of a TopicSpec.
+    topics = ()
+
     def __init__(self,
                  test_context,
                  num_brokers=3,
@@ -26,8 +62,17 @@ class RedpandaTest(Test):
         self.redpanda = RedpandaService(test_context,
                                         num_brokers=num_brokers,
                                         extra_rp_conf=extra_rp_conf,
-                                        topics=topics,
+                                        topics=self.topics,
                                         log_level=log_level)
+
+    @property
+    def topic(self):
+        """
+        Return the name of the auto-created initial topic. Accessing this
+        property requires exactly one initial topic be configured.
+        """
+        assert len(self.topics) == 1
+        return self.topics[0].name
 
     def setUp(self):
         self.redpanda.start()

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -12,7 +12,7 @@ import collections
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.redpanda_test import RedpandaTest, TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 
@@ -20,36 +20,36 @@ class TopicDeleteTest(RedpandaTest):
     """
     Verify that topic deletion cleans up storage.
     """
+    topics = (TopicSpec(partitions=3,
+                        cleanup_policy=TopicSpec.CLEANUP_COMPACT), )
+
     def __init__(self, test_context):
         extra_rp_conf = dict(log_segment_size=262144, )
 
-        topics = dict(topic=dict(partitions=3, cleanup_policy="compact"))
-
         super(TopicDeleteTest, self).__init__(test_context=test_context,
                                               num_brokers=3,
-                                              extra_rp_conf=extra_rp_conf,
-                                              topics=topics)
+                                              extra_rp_conf=extra_rp_conf)
 
         self.kafka_tools = KafkaCliTools(self.redpanda)
 
     @cluster(num_nodes=3)
     def topic_delete_test(self):
         def produce_until_partitions():
-            self.kafka_tools.produce("topic", 1024, 1024)
+            self.kafka_tools.produce(self.topic, 1024, 1024)
             storage = self.redpanda.storage()
-            return len(list(storage.partitions("kafka", "topic"))) == 9
+            return len(list(storage.partitions("kafka", self.topic))) == 9
 
         wait_until(lambda: produce_until_partitions(),
                    timeout_sec=30,
                    backoff_sec=2,
                    err_msg="Expected partition did not materialize")
 
-        self.kafka_tools.delete_topic("topic")
+        self.kafka_tools.delete_topic(self.topic)
 
         def topic_storage_purged():
             storage = self.redpanda.storage()
             return all(
-                map(lambda n: "topic" not in n.ns["kafka"].topics,
+                map(lambda n: self.topic not in n.ns["kafka"].topics,
                     storage.nodes))
 
         wait_until(lambda: topic_storage_purged(),

--- a/tests/rptest/tests/wait_for_local_consumer_test.py
+++ b/tests/rptest/tests/wait_for_local_consumer_test.py
@@ -10,7 +10,7 @@
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.redpanda_test import RedpandaTest, TopicSpec
 from rptest.services.kaf_producer import KafProducer
 from rptest.services.kaf_consumer import KafConsumer
 
@@ -22,15 +22,14 @@ class WaitForLocalConsumerTest(RedpandaTest):
     """
     NUM_RECORDS = 2000
 
+    topics = (TopicSpec(partitions=1, replication_factor=1), )
+
     def __init__(self, ctx):
-        topics = dict(topic=dict(partitions=1, replication_factor=1))
-
         super(WaitForLocalConsumerTest, self).__init__(test_context=ctx,
-                                                       num_brokers=1,
-                                                       topics=topics)
+                                                       num_brokers=1)
 
-        self._producer = KafProducer(ctx, self.redpanda, "topic")
-        self._consumer = KafConsumer(ctx, self.redpanda, "topic")
+        self._producer = KafProducer(ctx, self.redpanda, self.topic)
+        self._consumer = KafConsumer(ctx, self.redpanda, self.topic)
 
     @cluster(num_nodes=4)
     def test_wait_for_local_consumer(self):


### PR DESCRIPTION
The redpanda ducktape test harness has a convenience parameter to the
constructor for creating initial topics. This interface can be
inconvenient because it requires overloading the constructor in the test
subclass.

This patch adds a TopicSpec object which is a collection of topic
specifications (like name and configuration) and allows initial toipcs
as set of TopicSpecs to be specified as a class variable without
overloading the constructor.