### PR TITLE
operator/api: do not use omitempty for replicas in status

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -42,7 +42,7 @@ type ClusterStatus struct {
 
 	// Replicas show how many nodes are working in the cluster
 	// +optional
-	Replicas	int32	`json:"replicas,omitempty"`
+	Replicas	int32	`json:"replicas"`
 	// Nodes of the provisioned redpanda nodes
 	// +optional
 	Nodes	[]string	`json:"nodes,omitempty"`


### PR DESCRIPTION
That way we're aligned with https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/staging/src/k8s.io/api/apps/v1beta1/types.go#L231

Before this change:
```
  status:
    nodes:
    - cluster-sample-0
```

After this change 

```
  status:
    nodes:
    - cluster-sample-0
    replicas: 0
```

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
