### PR TITLE
operator/controller: Add REDPANDA_ENVIRONMENT variable

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -113,6 +113,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 
 			Expect(sts.Spec.Template.Spec.Containers[0].Resources.Requests).Should(Equal(resources))
 			Expect(sts.Spec.Template.Spec.Containers[0].Resources.Limits).Should(Equal(resources))
+			Expect(sts.Spec.Template.Spec.Containers[0].Env).Should(ContainElement(corev1.EnvVar{Name: "REDPANDA_ENVIRONMENT", Value: "kubernetes"}))
 		})
 	})
 })

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -178,6 +178,12 @@ func (r *StatefulSetResource) Obj() (k8sclient.Object, error) {
 								"--default-log-level=debug",
 								"--reserve-memory 0M",
 							},
+							Env: []corev1.EnvVar{
+								{
+									Name:	"REDPANDA_ENVIRONMENT",
+									Value:	"kubernetes",
+								},
+							},
 							Ports: []corev1.ContainerPort{
 								{
 									Name:		"admin",

--- a/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
@@ -2,5 +2,13 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: cluster-sample
+spec:
+  template:
+    spec:
+      containers:
+        - name: redpanda
+          env:
+            - name: REDPANDA_ENVIRONMENT
+              value: kubernetes
 status:
   readyReplicas: 1


### PR DESCRIPTION
Based on the environment, on which redpanda runs, the `REDPANDA_ENVIRONMENT` is set to kubernetes for the operator deployment.

Reference #565

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
