### PR TITLE
operator/controller: Create selector out of common labels

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels"
 	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,7 +91,7 @@ func (r *ClusterReconciler) Reconcile(
 	var observedPods corev1.PodList
 
 	err := r.List(ctx, &observedPods, &client.ListOptions{
-		LabelSelector:	labels.SelectorFromSet(redpandaCluster.Labels),
+		LabelSelector:	labels.ForCluster(&redpandaCluster).AsSelector(),
 		Namespace:	redpandaCluster.Namespace,
 	})
 	if err != nil {

--- a/src/go/k8s/pkg/labels/labels.go
+++ b/src/go/k8s/pkg/labels/labels.go
@@ -1,7 +1,10 @@
 // Package labels handles label for cluster resource
 package labels
 
-import redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+import (
+	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+)
 
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 // TODO support "app.kubernetes.io/version"
@@ -19,13 +22,24 @@ const (
 	nameKeyVal	= "redpanda"
 )
 
+type CommonLabels map[string]string
+
 // ForCluster returns a set of labels that is a union of cluster labels as well as recommended default labels
 // recommended by the kubernetes documentation https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
-func ForCluster(cluster *redpandav1alpha1.Cluster) map[string]string {
+func ForCluster(cluster *redpandav1alpha1.Cluster) CommonLabels {
 	dl := defaultLabels(cluster)
 	labels := merge(cluster.Labels, dl)
 
 	return labels
+}
+
+// AsSelector returns label selector made out of subset of common labels: name, instance, component
+func (cl CommonLabels) AsSelector() labels.Selector {
+	return labels.SelectorFromSet(map[string]string{
+		NameKey:	cl[NameKey],
+		InstanceKey:	cl[InstanceKey],
+		ComponentKey:	cl[ComponentKey],
+	})
 }
 
 // merge merges two sets of labels


### PR DESCRIPTION
Current solution is not valid anymore if cluster itself does not come with the labels.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
