### PR TITLE
test: add abstract client for compatibility regression testing

### DIFF
--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -8,7 +8,8 @@
 # by the Apache License, Version 2.0
 
 import subprocess
-from rptest.clients.types import TopicSpec, KafkaClient
+from rptest.clients.types import TopicSpec
+from rptest.clients.kafka_client import KafkaClient
 
 
 class KafkaCliTools(KafkaClient):
@@ -29,6 +30,7 @@ class KafkaCliTools(KafkaClient):
     def instances(cls):
         def make_factory(version):
             return lambda redpanda: cls(redpanda, version)
+
         return list(map(make_factory, cls.VERSIONS))
 
     def create_topic(self, spec):

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -8,9 +8,10 @@
 # by the Apache License, Version 2.0
 
 import subprocess
+from rptest.clients.types import KafkaClient
 
 
-class KafkaCliTools:
+class KafkaCliTools(KafkaClient):
     """
     Wrapper around the Kafka admin command line tools.
     """

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -29,7 +29,7 @@ class KafkaCliTools(KafkaClient):
         self._redpanda.logger.debug("Creating topic: %s", spec.name)
         args = ["--create"]
         args += ["--topic", spec.name]
-        args += ["--partitions", str(spec.partitions)]
+        args += ["--partitions", str(spec.partition_count)]
         args += ["--replication-factor", str(spec.replication_factor)]
         if spec.cleanup_policy:
             args += [

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -25,6 +25,12 @@ class KafkaCliTools(KafkaClient):
         assert self._version is None or \
                 self._version in KafkaCliTools.VERSIONS
 
+    @classmethod
+    def instances(cls):
+        def make_factory(version):
+            return lambda redpanda: cls(redpanda, version)
+        return list(map(make_factory, cls.VERSIONS))
+
     def create_topic(self, spec):
         self._redpanda.logger.debug("Creating topic: %s", spec.name)
         args = ["--create"]

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -24,25 +24,17 @@ class KafkaCliTools:
         assert self._version is None or \
                 self._version in KafkaCliTools.VERSIONS
 
-    def create_topic(self,
-                     topic,
-                     partitions=1,
-                     replication_factor=3,
-                     cleanup_policy=None):
-        self._redpanda.logger.debug("Creating topic: %s", topic)
+    def create_topic(self, spec):
+        self._redpanda.logger.debug("Creating topic: %s", spec.name)
         args = ["--create"]
-        args += ["--topic", topic]
-        args += ["--partitions", str(partitions)]
-        args += ["--replication-factor", str(replication_factor)]
-        if cleanup_policy:
-            args += ["--config", "cleanup.policy={}".format(cleanup_policy)]
+        args += ["--topic", spec.name]
+        args += ["--partitions", str(spec.partitions)]
+        args += ["--replication-factor", str(spec.replication_factor)]
+        if spec.cleanup_policy:
+            args += [
+                "--config", "cleanup.policy={}".format(spec.cleanup_policy)
+            ]
         return self._run("kafka-topics.sh", args)
-
-    def create_topic_from_spec(self, spec):
-        return self.create_topic(spec.name,
-                                 partitions=spec.partitions,
-                                 replication_factor=spec.replication_factor,
-                                 cleanup_policy=spec.cleanup_policy)
 
     def delete_topic(self, topic):
         self._redpanda.logger.debug("Deleting topic: %s", topic)

--- a/tests/rptest/clients/kafka_client.py
+++ b/tests/rptest/clients/kafka_client.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from __future__ import annotations
+from collections.abc import Callable
+from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import RedpandaService
+
+
+class KafkaClient:
+    @classmethod
+    def instances(cls) -> list[Callable[[RedpandaService], KafkaClient]]:
+        raise NotImplementedError
+
+    def create_topic(self, spec: TopicSpec):
+        raise NotImplementedError
+
+    def describe_topic(self, topic: str) -> TopicSpec:
+        raise NotImplementedError

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -6,8 +6,11 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+from __future__ import annotations
 import random
 import string
+from typing import Any
+from collections.abc import Callable
 
 
 class TopicSpec:
@@ -48,6 +51,10 @@ class TopicSpec:
 
 
 class KafkaClient:
+    @classmethod
+    def instances(cls) -> list[Callable[[Any], KafkaClient]]:
+        raise NotImplementedError
+
     def create_topic(self, spec: TopicSpec):
         raise NotImplementedError
 

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -48,8 +48,8 @@ class TopicSpec:
 
 
 class KafkaClient:
-    def create_topic(self, spec):
+    def create_topic(self, spec: TopicSpec):
         raise NotImplementedError
 
-    def describe_topic(self, topic):
+    def describe_topic(self, topic: str) -> TopicSpec:
         raise NotImplementedError

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -37,3 +37,8 @@ class TopicSpec:
     def _random_topic_suffix(self, size=4):
         return "".join(
             random.choice(string.ascii_lowercase) for _ in range(size))
+
+
+class KafkaClient:
+    def create_topic(self, spec):
+        raise NotImplementedError

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -42,3 +42,6 @@ class TopicSpec:
 class KafkaClient:
     def create_topic(self, spec):
         raise NotImplementedError
+
+    def describe_topic(self, topic):
+        raise NotImplementedError

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import random
+import string
+
+
+class TopicSpec:
+    """
+    A topic specification.
+
+    It is often the case that in a test the name of a topic does not matter. To
+    simplify for this case, a random name is generated if none is provided.
+    """
+    CLEANUP_COMPACT = "compact"
+    CLEANUP_DELETE = "delete"
+
+    def __init__(self,
+                 *,
+                 name=None,
+                 partitions=1,
+                 replication_factor=3,
+                 cleanup_policy=None):
+        self.name = name or f"topic-{self._random_topic_suffix()}"
+        self.partitions = partitions
+        self.replication_factor = replication_factor
+        self.cleanup_policy = cleanup_policy
+
+    def __str__(self):
+        return self.name
+
+    def _random_topic_suffix(self, size=4):
+        return "".join(
+            random.choice(string.ascii_lowercase) for _ in range(size))

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -34,6 +34,14 @@ class TopicSpec:
     def __str__(self):
         return self.name
 
+    def __eq__(self, other):
+        if not isinstance(other, TopicSpec):
+            return False
+        return self.name == other.name and \
+                self.partition_count == other.partition_count and \
+                self.replication_factor == other.replication_factor and \
+                self.cleanup_policy == other.cleanup_policy
+
     def _random_topic_suffix(self, size=4):
         return "".join(
             random.choice(string.ascii_lowercase) for _ in range(size))

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -23,11 +23,11 @@ class TopicSpec:
     def __init__(self,
                  *,
                  name=None,
-                 partitions=1,
+                 partition_count=1,
                  replication_factor=3,
                  cleanup_policy=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
-        self.partitions = partitions
+        self.partition_count = partition_count
         self.replication_factor = replication_factor
         self.cleanup_policy = cleanup_policy
 

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -6,11 +6,8 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-from __future__ import annotations
 import random
 import string
-from typing import Any
-from collections.abc import Callable
 
 
 class TopicSpec:
@@ -48,15 +45,3 @@ class TopicSpec:
     def _random_topic_suffix(self, size=4):
         return "".join(
             random.choice(string.ascii_lowercase) for _ in range(size))
-
-
-class KafkaClient:
-    @classmethod
-    def instances(cls) -> list[Callable[[Any], KafkaClient]]:
-        raise NotImplementedError
-
-    def create_topic(self, spec: TopicSpec):
-        raise NotImplementedError
-
-    def describe_topic(self, topic: str) -> TopicSpec:
-        raise NotImplementedError

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -81,7 +81,7 @@ class RedpandaService(Service):
         kafka_tools = KafkaCliTools(self)
         for spec in self._topics:
             self.logger.debug(f"Creating initial topic {spec}")
-            kafka_tools.create_topic_from_spec(spec)
+            kafka_tools.create_topic(spec)
 
     def start_node(self, node, override_cfg_params=None):
         node.account.mkdirs(RedpandaService.DATA_DIR)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -21,7 +21,6 @@ from ducktape.utils.util import wait_until
 from ducktape.cluster.cluster import ClusterNode
 from prometheus_client.parser import text_string_to_metric_families
 
-from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.storage import ClusterStorage, NodeStorage
 
@@ -47,11 +46,13 @@ class RedpandaService(Service):
     def __init__(self,
                  context,
                  num_brokers,
+                 client_type,
                  extra_rp_conf=None,
                  topics=None,
                  log_level='info'):
         super(RedpandaService, self).__init__(context, num_nodes=num_brokers)
         self._context = context
+        self._client_type = client_type
         self._extra_rp_conf = extra_rp_conf
         self._log_level = log_level
         self._topics = topics or ()
@@ -78,10 +79,10 @@ class RedpandaService(Service):
         self._create_initial_topics()
 
     def _create_initial_topics(self):
-        kafka_tools = KafkaCliTools(self)
+        client = self._client_type(self)
         for spec in self._topics:
             self.logger.debug(f"Creating initial topic {spec}")
-            kafka_tools.create_topic(spec)
+            client.create_topic(spec)
 
     def start_node(self, node, override_cfg_params=None):
         node.account.mkdirs(RedpandaService.DATA_DIR)

--- a/tests/rptest/tests/chaos/chaos_base_test.py
+++ b/tests/rptest/tests/chaos/chaos_base_test.py
@@ -26,6 +26,7 @@ from gobekli.workloads import symmetrical_mrsw
 from gobekli.workloads.symmetrical_mrsw import MRSWWorkload
 
 from ducktape.tests.test import Test
+from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.chaos.mount_muservice import MountMuService
 from rptest.chaos.redpanda_muservice import (RedpandaMuService,
@@ -68,7 +69,7 @@ class BaseChaosTest(Test):
         redpanda = RedpandaMuServiceServiceProxy(self.service,
                                                  self.redpanda_mu)
         tools = KafkaCliTools(redpanda, KafkaCliTools.VERSIONS[0])
-        tools.create_topic(KafkaKVMuService.TOPIC)
+        tools.create_topic(TopicSpec(name=KafkaKVMuService.TOPIC))
 
     def tearDown(self):
         self.service.stop()

--- a/tests/rptest/tests/compacted_term_rolled_recovery_test.py
+++ b/tests/rptest/tests/compacted_term_rolled_recovery_test.py
@@ -10,7 +10,8 @@
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
-from rptest.tests.redpanda_test import RedpandaTest, TopicSpec
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 

--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -10,7 +10,8 @@
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
-from rptest.tests.redpanda_test import RedpandaTest, TopicSpec
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -15,7 +15,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 
 class DescribeTopicsTest(RedpandaTest):
-    topics = (TopicSpec(partitions=2, replication_factor=3), )
+    topics = (TopicSpec(partition_count=2, replication_factor=3), )
 
     def test_describe_topics(self):
         tools = KafkaCliTools(self.redpanda)

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -10,13 +10,15 @@
 from ducktape.mark import matrix
 from rptest.tests.redpanda_test import RedpandaTest
 
+from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 
 class DescribeTopicsTest(RedpandaTest):
+    topics = (TopicSpec(partitions=2, replication_factor=3), )
+
     def test_describe_topics(self):
         tools = KafkaCliTools(self.redpanda)
-        tools.create_topic("topic", partitions=2, replication_factor=3)
         output = tools.describe_topics()
         assert "partition_count=2" in output
         assert "replication_factor=3" in output

--- a/tests/rptest/tests/kafka_cli_tools_test.py
+++ b/tests/rptest/tests/kafka_cli_tools_test.py
@@ -10,6 +10,7 @@
 from ducktape.mark import matrix
 from rptest.tests.redpanda_test import RedpandaTest
 
+from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 
@@ -22,5 +23,5 @@ class KafkaCliToolsTest(RedpandaTest):
         tools = KafkaCliTools(self.redpanda, version)
         topics = ["v{}.{}".format(version, i) for i in range(3)]
         for topic in topics:
-            tools.create_topic(topic)
+            tools.create_topic(TopicSpec(name=topic))
         assert set(topics) <= set(tools.list_topics())

--- a/tests/rptest/tests/kafka_client_compat_test.py
+++ b/tests/rptest/tests/kafka_client_compat_test.py
@@ -14,14 +14,13 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 
-class KafkaCliToolsTest(RedpandaTest):
-    """
-    Verify that kafka cli tools works for all supported versions.
-    """
-    @matrix(version=KafkaCliTools.VERSIONS)
-    def test_create_topic(self, version):
-        tools = KafkaCliTools(self.redpanda, version)
-        topics = ["v{}.{}".format(version, i) for i in range(3)]
-        for topic in topics:
-            tools.create_topic(TopicSpec(name=topic))
-        assert set(topics) <= set(tools.list_topics())
+class KafkaClientCompatTest(RedpandaTest):
+    def test_create_topic(self):
+        for client_factory in KafkaCliTools.instances():
+            client = client_factory(self.redpanda)
+            topics = [TopicSpec() for _ in range(3)]
+            for topic in topics:
+                client.create_topic(topic)
+            for topic in topics:
+                spec = client.describe_topic(topic.name)
+                assert spec == topic

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -23,7 +23,7 @@ class LeadershipTransferTest(RedpandaTest):
     """
     Transfer leadership from one node to another.
     """
-    topics = (TopicSpec(partitions=3, replication_factor=3), )
+    topics = (TopicSpec(partition_count=3, replication_factor=3), )
 
     @cluster(num_nodes=3)
     def test_controller_recovery(self):

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -15,7 +15,8 @@ from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
 import requests
 
-from rptest.tests.redpanda_test import RedpandaTest, TopicSpec
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
 
 
 class LeadershipTransferTest(RedpandaTest):

--- a/tests/rptest/tests/librdkafka_test.py
+++ b/tests/rptest/tests/librdkafka_test.py
@@ -38,7 +38,8 @@ class LibrdkafkaTest(Test):
 
     def _start_redpanda(self, num_brokers):
         self._redpanda = RedpandaService(self._context,
-                                         num_brokers=num_brokers,
+                                         num_brokers,
+                                         KafkaCliTools,
                                          extra_rp_conf=self._extra_rp_conf)
         self._redpanda.start()
 

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -92,7 +92,7 @@ class PandaProxyTest(RedpandaTest):
         self.logger.debug("Creating test topic")
         kafka_tools = KafkaCliTools(self.redpanda)
         kafka_tools.create_topic(
-            TopicSpec(name=name, replication_factor=1, partitions=3))
+            TopicSpec(name=name, replication_factor=1, partition_count=3))
 
         self.logger.debug("Waiting for leaders to settle")
         has_leaders = False

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -14,6 +14,7 @@ import time
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
+from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.tests.redpanda_test import RedpandaTest
@@ -59,7 +60,8 @@ class PandaProxyTest(RedpandaTest):
         self.logger.debug("Creating test topics")
         kafka_tools = KafkaCliTools(self.redpanda)
         for name in names:
-            kafka_tools.create_topic(name, replication_factor=1)
+            kafka_tools.create_topic(TopicSpec(name=name,
+                                               replication_factor=1))
 
         curr = set(self._get_topics())
         self.logger.debug("Current topics %s", curr)
@@ -89,7 +91,8 @@ class PandaProxyTest(RedpandaTest):
 
         self.logger.debug("Creating test topic")
         kafka_tools = KafkaCliTools(self.redpanda)
-        kafka_tools.create_topic(name, replication_factor=1, partitions=3)
+        kafka_tools.create_topic(
+            TopicSpec(name=name, replication_factor=1, partitions=3))
 
         self.logger.debug("Waiting for leaders to settle")
         has_leaders = False

--- a/tests/rptest/tests/prefix_truncate_recovery_test.py
+++ b/tests/rptest/tests/prefix_truncate_recovery_test.py
@@ -14,7 +14,8 @@ from ducktape.mark import matrix
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
-from rptest.tests.redpanda_test import RedpandaTest, TopicSpec
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 from storage import storage as vstorage

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -11,6 +11,7 @@ import string
 
 from ducktape.tests.test import Test
 from rptest.services.redpanda import RedpandaService
+from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 
 class RedpandaTest(Test):
@@ -31,7 +32,8 @@ class RedpandaTest(Test):
         super(RedpandaTest, self).__init__(test_context)
 
         self.redpanda = RedpandaService(test_context,
-                                        num_brokers=num_brokers,
+                                        num_brokers,
+                                        KafkaCliTools,
                                         extra_rp_conf=extra_rp_conf,
                                         topics=self.topics,
                                         log_level=log_level)

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -13,35 +13,6 @@ from ducktape.tests.test import Test
 from rptest.services.redpanda import RedpandaService
 
 
-class TopicSpec:
-    """
-    A topic specification.
-
-    It is often the case that in a test the name of a topic does not matter. To
-    simplify for this case, a random name is generated if none is provided.
-    """
-    CLEANUP_COMPACT = "compact"
-    CLEANUP_DELETE = "delete"
-
-    def __init__(self,
-                 *,
-                 name=None,
-                 partitions=1,
-                 replication_factor=1,
-                 cleanup_policy=None):
-        self.name = name or f"topic-{self._random_topic_suffix()}"
-        self.partitions = partitions
-        self.replication_factor = replication_factor
-        self.cleanup_policy = cleanup_policy
-
-    def __str__(self):
-        return self.name
-
-    def _random_topic_suffix(self, size=4):
-        return "".join(
-            random.choice(string.ascii_lowercase) for _ in range(size))
-
-
 class RedpandaTest(Test):
     """
     Base class for tests that use the Redpanda service.

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -12,7 +12,8 @@ import collections
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
-from rptest.tests.redpanda_test import RedpandaTest, TopicSpec
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -21,7 +21,7 @@ class TopicDeleteTest(RedpandaTest):
     """
     Verify that topic deletion cleans up storage.
     """
-    topics = (TopicSpec(partitions=3,
+    topics = (TopicSpec(partition_count=3,
                         cleanup_policy=TopicSpec.CLEANUP_COMPACT), )
 
     def __init__(self, test_context):

--- a/tests/rptest/tests/wait_for_local_consumer_test.py
+++ b/tests/rptest/tests/wait_for_local_consumer_test.py
@@ -10,7 +10,8 @@
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
-from rptest.tests.redpanda_test import RedpandaTest, TopicSpec
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.kaf_producer import KafProducer
 from rptest.services.kaf_consumer import KafConsumer
 

--- a/tests/rptest/tests/wait_for_local_consumer_test.py
+++ b/tests/rptest/tests/wait_for_local_consumer_test.py
@@ -23,7 +23,7 @@ class WaitForLocalConsumerTest(RedpandaTest):
     """
     NUM_RECORDS = 2000
 
-    topics = (TopicSpec(partitions=1, replication_factor=1), )
+    topics = (TopicSpec(partition_count=1, replication_factor=1), )
 
     def __init__(self, ctx):
         super(WaitForLocalConsumerTest, self).__init__(test_context=ctx,


### PR DESCRIPTION
Adds an abstract kafka client and an implementation of the client based on kafka cli tools. A generic test is added that operates over the abstract client to create/describe topics and will be used to run compatibility regression testing over an arbitrary set of (client, version) pairs.