### PR TITLE
operator: Change the reported DNS names for redpanda

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -51,6 +51,8 @@ type ConfigMapResource struct {
 	k8sclient.Client
 	scheme		*runtime.Scheme
 	pandaCluster	*redpandav1alpha1.Cluster
+
+	svc	*ServiceResource
 }
 
 // NewConfigMap creates ConfigMapResource
@@ -58,9 +60,10 @@ func NewConfigMap(
 	client k8sclient.Client,
 	pandaCluster *redpandav1alpha1.Cluster,
 	scheme *runtime.Scheme,
+	svc *ServiceResource,
 ) *ConfigMapResource {
 	return &ConfigMapResource{
-		client, scheme, pandaCluster,
+		client, scheme, pandaCluster, svc,
 	}
 }
 
@@ -87,7 +90,7 @@ func (r *ConfigMapResource) Ensure(ctx context.Context) error {
 
 // Obj returns resource managed client.Object
 func (r *ConfigMapResource) Obj() (k8sclient.Object, error) {
-	serviceAddress := r.pandaCluster.Name + "." + r.pandaCluster.Namespace + ".svc.cluster.local"
+	serviceAddress := r.svc.HeadlessServiceFQDN()
 	cfg := config.Default()
 	cfg.Redpanda = copyConfig(&r.pandaCluster.Spec.Configuration, &cfg.Redpanda)
 	cfg.Redpanda.Id = 0

--- a/src/go/k8s/pkg/resources/service.go
+++ b/src/go/k8s/pkg/resources/service.go
@@ -12,6 +12,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels"
@@ -107,4 +108,15 @@ func (r *ServiceResource) Key() types.NamespacedName {
 func (r *ServiceResource) Kind() string {
 	var svc corev1.Service
 	return svc.Kind
+}
+
+// HeadlessServiceFQDN returns fully qualified domain name for headless service.
+// It can be used to communicate between namespaces if the network policy
+// allows it.
+func (r ServiceResource) HeadlessServiceFQDN() string {
+	// TODO Retrieve cluster domain dynamically and remove hardcoded cluster.local
+	return fmt.Sprintf("%s%c%s.svc.cluster.local",
+		r.Key().Name,
+		'.',
+		r.Key().Namespace)
 }


### PR DESCRIPTION
If the kubernetes cluster does not have set up Network Policies,
then it should be possible to reach redpanda node from any
namespace. The status.nodes now have FQDN reported for each
container within redpanda cluster.

Reference for Network Policies:
https://kubernetes.io/docs/concepts/services-networking/network-policies/

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
