### PR TITLE
Fix/rpk coproc generate

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -39,18 +39,24 @@ var manifest = func() map[string][]genFile {
 }
 
 func NewGenerateCommand(fs afero.Fs) *cobra.Command {
-	const localDir = "./"
 	command := &cobra.Command{
-		Use:	"generate",
-		Short:	"Create a npm template project for inline WASM engine",
-		SilenceUsage: true,
+		Use:		"generate <project directory>",
+		Short:		"Create an npm template project for inline WASM engine",
+		SilenceUsage:	true,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf(
+					"no project directory specified",
+				)
+			}
+			return nil
+		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			path, err := filepath.Abs(localDir)
-			rootPath := filepath.Join(path, "wasm")
+			path, err := filepath.Abs(args[0])
 			if err != nil {
 				return err
 			}
-			return executeGenerate(fs, rootPath)
+			return executeGenerate(fs, path)
 		},
 	}
 

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -39,35 +39,20 @@ var manifest = func() map[string][]genFile {
 }
 
 func NewGenerateCommand(fs afero.Fs) *cobra.Command {
-	var dir string
 	const localDir = "./"
 	command := &cobra.Command{
 		Use:	"generate",
 		Short:	"Create a npm template project for inline WASM engine",
+		SilenceUsage: true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if dir == localDir {
-				path, err := filepath.Abs(dir)
-				if err != nil {
-					return err
-				}
-				rootPath := filepath.Join(path, "wasm")
-				return executeGenerate(fs, rootPath)
-
-			}
-			path, err := filepath.Abs(dir)
+			path, err := filepath.Abs(localDir)
+			rootPath := filepath.Join(path, "wasm")
 			if err != nil {
 				return err
 			}
-			return executeGenerate(fs, path)
+			return executeGenerate(fs, rootPath)
 		},
 	}
-
-	command.Flags().StringVar(
-		&dir,
-		"dir",
-		localDir,
-		"The path where the transformer project will be created",
-	)
 
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate_test.go
@@ -62,7 +62,7 @@ func TestWasmCommand(t *testing.T) {
 	}{
 		{
 			name:	"should create an npm template with its folder",
-			args:	[]string{"generate"},
+			args:	[]string{"wasm"},
 			check: func(fs afero.Fs, t *testing.T) {
 				dir := filepath.Join(path, "wasm")
 				checkGeneratedFiles(fs, t, dir)
@@ -70,7 +70,7 @@ func TestWasmCommand(t *testing.T) {
 		}, {
 			name: "should fail if the given dir contains files created by " +
 				"this command*",
-			args:	[]string{"generate"},
+			args:	[]string{"wasm"},
 			before: func(fs afero.Fs) error {
 				absolutePath, err := filepath.Abs(".")
 				folderPath := filepath.Join(absolutePath, "wasm")
@@ -82,11 +82,24 @@ func TestWasmCommand(t *testing.T) {
 				" contains files that could conflict: \n package.json", path),
 		}, {
 			name:	"should create webpack file with executable permission",
-			args:	[]string{"generate"},
+			args:	[]string{"wasm-project"},
 			check: func(fs afero.Fs, t *testing.T) {
-				dir := filepath.Join(path, "wasm", "webpack.js")
+				dir := filepath.Join(path, "wasm-project", "webpack.js")
 				info, _ := fs.Stat(dir)
 				require.True(t, info.Mode() == 0766)
+			},
+		},
+		{
+			name:		"should fail if <project directory> argument isn't passed",
+			args:		[]string{},
+			expectedErrMsg:	fmt.Sprintf("no project directory specified"),
+		}, {
+			name:	"should create <project directory> if it doesn't exist",
+			args:	[]string{"new_folder/new_sub_folder/wasm-project"},
+			check: func(fs afero.Fs, t *testing.T) {
+				absolutePath, _ := filepath.Abs(".")
+				dir := filepath.Join(absolutePath, "new_folder", "new_sub_folder", "wasm-project")
+				checkGeneratedFiles(fs, t, dir)
 			},
 		},
 	}

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate_test.go
@@ -67,41 +67,18 @@ func TestWasmCommand(t *testing.T) {
 				dir := filepath.Join(path, "wasm")
 				checkGeneratedFiles(fs, t, dir)
 			},
-		},
-		{
-			name:	"should create the project at the given path",
-			args:	[]string{"generate", "--dir", "./newFolder"},
-			check: func(fs afero.Fs, t *testing.T) {
-				absolutePath, err := filepath.Abs(".")
-				require.NoError(t, err)
-				newDir := filepath.Join(absolutePath, "newFolder")
-				checkGeneratedFiles(fs, t, newDir)
-			},
-		}, {
-			name: "should create the project at the given path, also" +
-				"if the folder exists",
-			args:	[]string{"generate", "--dir", "./existFolder"},
-			before: func(fs afero.Fs) error {
-				return fs.MkdirAll("./existFolder", 0755)
-			},
-			check: func(fs afero.Fs, t *testing.T) {
-				absolutePath, err := filepath.Abs(".")
-				require.NoError(t, err)
-				newDir := filepath.Join(absolutePath, "existFolder")
-				checkGeneratedFiles(fs, t, newDir)
-			},
 		}, {
 			name: "should fail if the given dir contains files created by " +
 				"this command*",
-			args:	[]string{"generate", "--dir", "./existFolder"},
+			args:	[]string{"generate"},
 			before: func(fs afero.Fs) error {
 				absolutePath, err := filepath.Abs(".")
-				folderPath := filepath.Join(absolutePath, "existFolder")
+				folderPath := filepath.Join(absolutePath, "wasm")
 				err = fs.MkdirAll(folderPath, 0755)
 				_, err = fs.Create(filepath.Join(folderPath, "package.json"))
 				return err
 			},
-			expectedErrMsg: fmt.Sprintf("The directory %s/existFolder/"+
+			expectedErrMsg: fmt.Sprintf("The directory %s/wasm/"+
 				" contains files that could conflict: \n package.json", path),
 		}, {
 			name:	"should create webpack file with executable permission",


### PR DESCRIPTION
add name argument, in order to user define which name should have the resulting project, also change existing `dir` flag to `output`

Fix #570 
