### PR TITLE
coproc: Add batch decompression to the wasm_event_listener

### DIFF
--- a/src/v/coproc/errc.h
+++ b/src/v/coproc/errc.h
@@ -13,6 +13,45 @@
 #include <system_error>
 namespace coproc {
 
+namespace wasm {
+
+enum class errc {
+    none = 0,
+    mismatched_checksum,
+    empty_mandatory_field,
+    missing_header_key,
+    unexpected_action_type,
+    unexpected_value
+};
+
+inline std::ostream& operator<<(std::ostream& os, errc err) {
+    switch (err) {
+    case errc::none:
+        os << "none";
+        break;
+    case errc::mismatched_checksum:
+        os << "mismatched_checksum";
+        break;
+    case errc::empty_mandatory_field:
+        os << "empty_mandatory_field";
+        break;
+    case errc::missing_header_key:
+        os << "missing_header_key";
+        break;
+    case errc::unexpected_action_type:
+        os << "unexpected_action_type";
+        break;
+    case errc::unexpected_value:
+        os << "unexpected_value";
+        break;
+    default:
+        os << "missing error type";
+    }
+    return os;
+}
+
+} // namespace wasm
+
 enum class errc {
     success = 0,
     internal_error,
@@ -23,41 +62,6 @@ enum class errc {
     materialized_topic,
     script_id_does_not_exist
 };
-
-enum class wasm_event_errc {
-    none = 0,
-    mismatched_checksum,
-    empty_mandatory_field,
-    missing_header_key,
-    unexpected_action_type,
-    unexpected_value
-};
-
-inline std::ostream& operator<<(std::ostream& os, wasm_event_errc errc) {
-    switch (errc) {
-    case wasm_event_errc::none:
-        os << "none";
-        break;
-    case wasm_event_errc::mismatched_checksum:
-        os << "mismatched_checksum";
-        break;
-    case wasm_event_errc::empty_mandatory_field:
-        os << "empty_mandatory_field";
-        break;
-    case wasm_event_errc::missing_header_key:
-        os << "missing_header_key";
-        break;
-    case wasm_event_errc::unexpected_action_type:
-        os << "unexpected_action_type";
-        break;
-    case wasm_event_errc::unexpected_value:
-        os << "unexpected_value";
-        break;
-    default:
-        os << "missing error type";
-    }
-    return os;
-}
 
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "coproc::errc"; }

--- a/src/v/coproc/tests/utils/wasm_event_generator.cc
+++ b/src/v/coproc/tests/utils/wasm_event_generator.cc
@@ -18,10 +18,10 @@
 #include "random/generators.h"
 #include "storage/record_batch_builder.h"
 
-namespace coproc {
+namespace coproc::wasm {
 
 model::record_header
-create_wasm_header(const ss::sstring& key, const ss::sstring& value) {
+create_header(const ss::sstring& key, const ss::sstring& value) {
     iobuf hkey, hval;
     const auto key_size = key.size();
     const auto val_size = value.size();
@@ -31,8 +31,7 @@ create_wasm_header(const ss::sstring& key, const ss::sstring& value) {
       key_size, std::move(hkey), val_size, std::move(hval));
 }
 
-model::record_header
-create_wasm_header(const ss::sstring& key, const bytes& value) {
+model::record_header create_header(const ss::sstring& key, const bytes& value) {
     iobuf hkey;
     const auto key_size = key.size();
     const auto val_size = value.size();
@@ -42,8 +41,7 @@ create_wasm_header(const ss::sstring& key, const bytes& value) {
       key_size, std::move(hkey), val_size, std::move(hval));
 }
 
-void serialize_wasm_event(
-  storage::record_batch_builder& rbb, const wasm_event& e) {
+void serialize_event(storage::record_batch_builder& rbb, const event& e) {
     iobuf key, value;
     std::vector<model::record_header> headers;
     if (e.name) {
@@ -53,17 +51,16 @@ void serialize_wasm_event(
         value.append(e.script->data(), e.script->length());
     }
     if (e.desc) {
-        headers.emplace_back(create_wasm_header("description", *e.desc));
+        headers.emplace_back(create_header("description", *e.desc));
     }
     if (e.checksum) {
-        headers.emplace_back(create_wasm_header("sha256", *e.checksum));
+        headers.emplace_back(create_header("sha256", *e.checksum));
     }
     if (e.action) {
-        auto action_to_str = [](wasm_event_action action) -> ss::sstring {
-            return (action == wasm_event_action::deploy) ? "deploy" : "remove";
+        auto action_to_str = [](event_action action) -> ss::sstring {
+            return (action == event_action::deploy) ? "deploy" : "remove";
         };
-        headers.emplace_back(
-          create_wasm_header("action", action_to_str(*e.action)));
+        headers.emplace_back(create_header("action", action_to_str(*e.action)));
     }
     rbb.add_raw_kw(std::move(key), std::move(value), std::move(headers));
 }
@@ -71,35 +68,34 @@ void serialize_wasm_event(
 /// Don't call this in a loop, rather use 'make_random_wasm_batch' or
 /// 'make_wasm_batch'. This method is only useful for situations where a single
 /// model::record with exact fields must be serialized
-model::record create_wasm_record(const wasm_event& e) {
+model::record create_record(const event& e) {
     storage::record_batch_builder rbb(raft::data_batch_type, model::offset(0));
-    serialize_wasm_event(rbb, e);
+    serialize_event(rbb, e);
     auto record_batch = std::move(rbb).build();
     vassert(
       record_batch.header().record_count == 1, "Only one record expected");
     return std::move(record_batch.copy_records()[0]);
 }
 
-wasm_event make_random_wasm_event() {
+event make_random_event() {
     auto name = random_generators::gen_alphanum_string(15);
     if (random_generators::get_int(0, 1) == 0) {
-        return wasm_event{
-          .name = std::move(name), .action = wasm_event_action::remove};
+        return event{.name = std::move(name), .action = event_action::remove};
     }
     auto script = random_generators::gen_alphanum_string(15);
     hash_sha256 h;
     h.update(script);
     auto checksum = h.reset();
-    return wasm_event{
+    return event{
       .name = std::move(name),
       .desc = random_generators::gen_alphanum_string(15),
       .script = std::move(script),
       .checksum = bytes(checksum.begin(), checksum.end()),
-      .action = wasm_event_action::deploy};
+      .action = event_action::deploy};
 }
 
 model::record_batch
-make_wasm_batch(model::offset o, std::vector<model::record> events) {
+make_batch(model::offset o, std::vector<model::record> events) {
     storage::record_batch_builder rbb(raft::data_batch_type, o);
     for (size_t i = 0; i < events.size(); ++i) {
         rbb.add_raw_kw(
@@ -110,35 +106,35 @@ make_wasm_batch(model::offset o, std::vector<model::record> events) {
     return std::move(rbb).build();
 }
 
-model::record_batch make_random_wasm_batch(model::offset o) {
+model::record_batch make_random_batch(model::offset o) {
     storage::record_batch_builder rbb(raft::data_batch_type, o);
     auto num_records = random_generators::get_int(2, 30);
     for (int i = 0; i < num_records; ++i) {
-        auto e = make_random_wasm_event();
-        serialize_wasm_event(rbb, e);
+        auto e = make_random_event();
+        serialize_event(rbb, e);
     }
     return std::move(rbb).build();
 }
 
 model::record_batch_reader::data_t
-make_random_wasm_batches(model::offset o, int count) {
+make_random_batches(model::offset o, int count) {
     model::record_batch_reader::data_t batches;
     batches.reserve(count);
     for (int i = 0; i < count; ++i) {
-        auto b = make_random_wasm_batch(o);
+        auto b = make_random_batch(o);
         b.set_term(model::term_id(0));
         batches.push_back(std::move(b));
     }
     return batches;
 }
 
-model::record_batch_reader make_wasm_event_record_batch_reader(
+model::record_batch_reader make_event_record_batch_reader(
   model::offset offset, int batch_size, int n_batches) {
     return model::make_generating_record_batch_reader(
       [offset, batch_size, n_batches]() mutable {
           model::record_batch_reader::data_t batches;
           if (n_batches--) {
-              batches = make_random_wasm_batches(offset, batch_size);
+              batches = make_random_batches(offset, batch_size);
               offset = batches.back().last_offset()++;
           }
           return ss::make_ready_future<model::record_batch_reader::data_t>(
@@ -146,4 +142,4 @@ model::record_batch_reader make_wasm_event_record_batch_reader(
       });
 }
 
-} // namespace coproc
+} // namespace coproc::wasm

--- a/src/v/coproc/tests/utils/wasm_event_generator.h
+++ b/src/v/coproc/tests/utils/wasm_event_generator.h
@@ -34,19 +34,33 @@ struct event {
     opt_action_t action;
 };
 
+/// Let the generator functions fill in the other fields
+struct short_event {
+    ss::sstring name;
+    event_action action;
+    bool compress{false};
+    short_event(ss::sstring name, event_action action, bool compress = false)
+      : name(std::move(name))
+      , action(action)
+      , compress(compress) {}
+};
+
 /// \brief Generates an event that models the 'wasm_event' struct passed in. Any
 /// optional fields aren't serialized into the resultant record, useful for
 /// testing failure cases against malformatted record events
-model::record create_record(const event&);
+model::record make_record(const event&);
 
-/// \brief Makes model::record_batch of a predefined deterministic records list
-model::record_batch make_batch(model::offset o, std::vector<model::record>);
-
-/// \brief A record batch reader that generates random valid wasm_events
+/// \brief Returns a record batch reader that generates random valid wasm_events
 /// @param offset offset to start at
 /// @param batch_size number of record_batches in each batch
 /// @param n_batches num of batches of batches to generate before stream ends
 model::record_batch_reader
-make_event_record_batch_reader(model::offset, int, int);
+make_random_event_record_batch_reader(model::offset, int, int);
+
+/// \brief Returns a record batch reader that generates valid events that
+/// contain generated data constrained by name / action / compressed parameters
+/// per record
+model::record_batch_reader
+  make_event_record_batch_reader(std::vector<std::vector<short_event>>);
 
 } // namespace coproc::wasm

--- a/src/v/coproc/tests/utils/wasm_event_generator.h
+++ b/src/v/coproc/tests/utils/wasm_event_generator.h
@@ -18,13 +18,13 @@
 
 #include <optional>
 
-namespace coproc {
+namespace coproc::wasm {
 
 /// Convienent struct for bundling together data necessary to serialized a
 /// wasm_event into a model::record. Any field set to std::nullopt will be
 /// skipped during serialization
-struct wasm_event {
-    using opt_action_t = std::optional<wasm_event_action>;
+struct event {
+    using opt_action_t = std::optional<event_action>;
     using opt_str_t = std::optional<ss::sstring>;
     using opt_bytes_t = std::optional<bytes>;
     opt_str_t name;
@@ -37,17 +37,16 @@ struct wasm_event {
 /// \brief Generates an event that models the 'wasm_event' struct passed in. Any
 /// optional fields aren't serialized into the resultant record, useful for
 /// testing failure cases against malformatted record events
-model::record create_wasm_record(const wasm_event&);
+model::record create_record(const event&);
 
 /// \brief Makes model::record_batch of a predefined deterministic records list
-model::record_batch
-make_wasm_batch(model::offset o, std::vector<model::record>);
+model::record_batch make_batch(model::offset o, std::vector<model::record>);
 
 /// \brief A record batch reader that generates random valid wasm_events
 /// @param offset offset to start at
 /// @param batch_size number of record_batches in each batch
 /// @param n_batches num of batches of batches to generate before stream ends
 model::record_batch_reader
-make_wasm_event_record_batch_reader(model::offset, int, int);
+make_event_record_batch_reader(model::offset, int, int);
 
-} // namespace coproc
+} // namespace coproc::wasm

--- a/src/v/coproc/tests/wasm_event_listener_tests.cc
+++ b/src/v/coproc/tests/wasm_event_listener_tests.cc
@@ -162,7 +162,10 @@ FIXTURE_TEST(test_copro_internal_topic_do_undo, wasm_event_test_harness) {
        {"444", action::remove},
        {"444", action::deploy},
        {"444", action::remove},
-       {"123", action::deploy}}};
+       {"123", action::deploy}},
+      {{"444", action::remove, true},
+       {"444", action::deploy, true},
+       {"123", action::deploy, true}}};
 
     auto rbr = make_event_record_batch_reader(std::move(events));
 

--- a/src/v/coproc/tests/wasm_event_tests.cc
+++ b/src/v/coproc/tests/wasm_event_tests.cc
@@ -30,7 +30,7 @@ using cp_errc = coproc::wasm::errc;
 
 SEASTAR_THREAD_TEST_CASE(verify_make_event) {
     /// The generator only creates valid events by default
-    auto rbr = coproc::wasm::make_event_record_batch_reader(
+    auto rbr = coproc::wasm::make_random_event_record_batch_reader(
       model::offset(0), 5, 5);
     auto batches = model::consume_reader_to_memory(
                      std::move(rbr), model::no_timeout)
@@ -45,14 +45,14 @@ SEASTAR_THREAD_TEST_CASE(verify_make_event) {
 BOOST_AUTO_TEST_CASE(verify_make_event_failures) {
     {
         /// Empty event
-        model::record r = coproc::wasm::create_record(coproc::wasm::event{});
+        model::record r = coproc::wasm::make_record(coproc::wasm::event{});
         BOOST_CHECK(!coproc::wasm::get_event_name(r));
         BOOST_CHECK_EQUAL(
           cp_errc::empty_mandatory_field, coproc::wasm::validate_event(r));
     }
     {
         /// Missing 'script' field
-        model::record r = coproc::wasm::create_record(coproc::wasm::event{
+        model::record r = coproc::wasm::make_record(coproc::wasm::event{
           .name = random_generators::gen_alphanum_string(15),
           .checksum = random_generators::get_bytes(32),
           .action = coproc::wasm::event_action::deploy});
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(verify_make_event_failures) {
     }
     {
         /// Erroneous checksum
-        model::record r = coproc::wasm::create_record(coproc::wasm::event{
+        model::record r = coproc::wasm::make_record(coproc::wasm::event{
           .name = random_generators::gen_alphanum_string(15),
           .desc = random_generators::gen_alphanum_string(15),
           .script = random_generators::gen_alphanum_string(15),

--- a/src/v/coproc/tests/wasm_event_tests.cc
+++ b/src/v/coproc/tests/wasm_event_tests.cc
@@ -26,18 +26,18 @@
 
 #include <optional>
 
-using cp_errc = coproc::wasm_event_errc;
+using cp_errc = coproc::wasm::errc;
 
 SEASTAR_THREAD_TEST_CASE(verify_make_event) {
     /// The generator only creates valid events by default
-    auto rbr = coproc::make_wasm_event_record_batch_reader(
+    auto rbr = coproc::wasm::make_event_record_batch_reader(
       model::offset(0), 5, 5);
     auto batches = model::consume_reader_to_memory(
                      std::move(rbr), model::no_timeout)
                      .get0();
     for (auto& record_batch : batches) {
         record_batch.for_each_record([](model::record r) {
-            BOOST_CHECK_EQUAL(cp_errc::none, coproc::wasm_event_validate(r));
+            BOOST_CHECK_EQUAL(cp_errc::none, coproc::wasm::validate_event(r));
         });
     }
 }
@@ -45,32 +45,32 @@ SEASTAR_THREAD_TEST_CASE(verify_make_event) {
 BOOST_AUTO_TEST_CASE(verify_make_event_failures) {
     {
         /// Empty event
-        model::record r = create_wasm_record(coproc::wasm_event{});
-        BOOST_CHECK(!coproc::wasm_event_get_name(r));
+        model::record r = coproc::wasm::create_record(coproc::wasm::event{});
+        BOOST_CHECK(!coproc::wasm::get_event_name(r));
         BOOST_CHECK_EQUAL(
-          cp_errc::empty_mandatory_field, coproc::wasm_event_validate(r));
+          cp_errc::empty_mandatory_field, coproc::wasm::validate_event(r));
     }
     {
         /// Missing 'script' field
-        model::record r = create_wasm_record(coproc::wasm_event{
+        model::record r = coproc::wasm::create_record(coproc::wasm::event{
           .name = random_generators::gen_alphanum_string(15),
           .checksum = random_generators::get_bytes(32),
-          .action = coproc::wasm_event_action::deploy});
+          .action = coproc::wasm::event_action::deploy});
         BOOST_CHECK_EQUAL(
           cp_errc::empty_mandatory_field,
-          coproc::wasm_event_verify_checksum(r));
+          coproc::wasm::verify_event_checksum(r));
         BOOST_CHECK_EQUAL(
-          cp_errc::empty_mandatory_field, coproc::wasm_event_validate(r));
+          cp_errc::empty_mandatory_field, coproc::wasm::validate_event(r));
     }
     {
         /// Erroneous checksum
-        model::record r = create_wasm_record(coproc::wasm_event{
+        model::record r = coproc::wasm::create_record(coproc::wasm::event{
           .name = random_generators::gen_alphanum_string(15),
           .desc = random_generators::gen_alphanum_string(15),
           .script = random_generators::gen_alphanum_string(15),
           .checksum = random_generators::get_bytes(32),
-          .action = coproc::wasm_event_action::deploy});
+          .action = coproc::wasm::event_action::deploy});
         BOOST_CHECK_EQUAL(
-          cp_errc::mismatched_checksum, coproc::wasm_event_verify_checksum(r));
+          cp_errc::mismatched_checksum, coproc::wasm::verify_event_checksum(r));
     }
 }

--- a/src/v/coproc/wasm_event.cc
+++ b/src/v/coproc/wasm_event.cc
@@ -124,7 +124,7 @@ wasm::errc validate_event(const model::record& r) {
 }
 
 absl::btree_map<ss::sstring, iobuf>
-reconcile_events(model::record_batch_reader::data_t& events) {
+reconcile_events(std::vector<model::record_batch> events) {
     absl::btree_map<ss::sstring, iobuf> wsas;
     for (auto& record_batch : events) {
         record_batch.for_each_record([&wsas](model::record r) {

--- a/src/v/coproc/wasm_event.cc
+++ b/src/v/coproc/wasm_event.cc
@@ -13,32 +13,33 @@
 #include "bytes/iobuf_parser.h"
 #include "coproc/logger.h"
 #include "hashing/secure.h"
+#include "vlog.h"
 
-namespace coproc {
+namespace coproc::wasm {
 
-std::string_view action_as_string_view(wasm_event_action action) {
+std::string_view action_as_string_view(event_action action) {
     switch (action) {
-    case wasm_event_action::deploy:
+    case event_action::deploy:
         return "deploy";
-    case wasm_event_action::remove:
+    case event_action::remove:
         return "remove";
     }
     __builtin_unreachable();
 }
 
-std::string_view header_as_string_view(wasm_event_header header) {
+std::string_view header_as_string_view(event_header header) {
     switch (header) {
-    case wasm_event_header::action:
+    case event_header::action:
         return "action";
-    case wasm_event_header::description:
+    case event_header::description:
         return "description";
-    case wasm_event_header::checksum:
+    case event_header::checksum:
         return "sha256";
     }
     __builtin_unreachable();
 }
 
-std::optional<ss::sstring> wasm_event_get_name(const model::record& r) {
+std::optional<ss::sstring> get_event_name(const model::record& r) {
     /// Performs a copy
     auto id = iobuf_const_parser(r.key()).read_string(r.key_size());
     if (id.empty()) {
@@ -48,8 +49,7 @@ std::optional<ss::sstring> wasm_event_get_name(const model::record& r) {
 }
 
 std::vector<model::record_header>::const_iterator
-wasm_event_get_value_for_header(
-  const model::record& r, wasm_event_header header) {
+get_value_for_event_header(const model::record& r, event_header header) {
     std::string_view match = header_as_string_view(header);
     return std::find_if(
       r.headers().cbegin(),
@@ -57,25 +57,25 @@ wasm_event_get_value_for_header(
       [&match](const model::record_header& rh) { return rh.key() == match; });
 }
 
-std::variant<wasm_event_errc, wasm_event_action>
-wasm_event_get_action(const model::record& r) {
-    auto itr = wasm_event_get_value_for_header(r, wasm_event_header::action);
+std::variant<wasm::errc, event_action>
+get_event_action(const model::record& r) {
+    auto itr = get_value_for_event_header(r, event_header::action);
     if (itr == r.headers().cend()) {
-        return wasm_event_errc::missing_header_key;
+        return wasm::errc::missing_header_key;
     }
     const auto& action = itr->value();
-    if (action == action_as_string_view(wasm_event_action::deploy)) {
-        return wasm_event_action::deploy;
-    } else if (action == action_as_string_view(wasm_event_action::remove)) {
-        return wasm_event_action::remove;
+    if (action == action_as_string_view(event_action::deploy)) {
+        return event_action::deploy;
+    } else if (action == action_as_string_view(event_action::remove)) {
+        return event_action::remove;
     }
-    return wasm_event_errc::unexpected_action_type;
+    return wasm::errc::unexpected_action_type;
 }
 
-wasm_event_errc wasm_event_verify_checksum(const model::record& r) {
-    auto itr = wasm_event_get_value_for_header(r, wasm_event_header::checksum);
+wasm::errc verify_event_checksum(const model::record& r) {
+    auto itr = get_value_for_event_header(r, event_header::checksum);
     if (itr == r.headers().cend()) {
-        return wasm_event_errc::missing_header_key;
+        return wasm::errc::missing_header_key;
     }
     /// Verify the checksum against the actual wasm script
     const auto checksum
@@ -83,44 +83,44 @@ wasm_event_errc wasm_event_verify_checksum(const model::record& r) {
     /// Performs a copy
     auto script = iobuf_const_parser(r.value()).read_string(r.value_size());
     if (script.empty()) {
-        return wasm_event_errc::empty_mandatory_field;
+        return wasm::errc::empty_mandatory_field;
     }
     hash_sha256 h;
     h.update(script);
     const auto calculated = h.reset();
     return to_bytes_view(calculated) == checksum
-             ? wasm_event_errc::none
-             : wasm_event_errc::mismatched_checksum;
+             ? wasm::errc::none
+             : wasm::errc::mismatched_checksum;
 }
 
-wasm_event_errc wasm_event_validate(const model::record& r) {
-    /// A key field is mandatory for all types of expected wasm_events
+wasm::errc validate_event(const model::record& r) {
+    /// A key field is mandatory for all types of expected events
     if (r.key_size() == 0) {
-        return wasm_event_errc::empty_mandatory_field;
+        return wasm::errc::empty_mandatory_field;
     }
     /// No copy performed here, optional will be false in the case the 'action'
     /// key is missing, or the value provided is unsupported i.e. not 'remove'
     /// or 'deploy'
-    auto action = coproc::wasm_event_get_action(r);
-    if (auto errc = std::get_if<wasm_event_errc>(&action)) {
+    auto action = get_event_action(r);
+    if (auto errc = std::get_if<wasm::errc>(&action)) {
         return *errc;
     }
     /// Technically all a 'remove' event needs to be valid, is a non-empty
     /// key field
-    auto wasm_action = std::get<wasm_event_action>(action);
-    if (wasm_action == coproc::wasm_event_action::deploy) {
+    auto wasm_action = std::get<event_action>(action);
+    if (wasm_action == event_action::deploy) {
         if (r.value_size() == 0) {
-            return wasm_event_errc::empty_mandatory_field;
+            return wasm::errc::empty_mandatory_field;
         }
-        return coproc::wasm_event_verify_checksum(r);
+        return verify_event_checksum(r);
     } else {
         if (r.value_size() > 0) {
             /// A 'remove' should have an empty body
-            return coproc::wasm_event_errc::unexpected_value;
+            return wasm::errc::unexpected_value;
         }
     }
-    /// A description isn't neccessary for either wasm_event type
-    return wasm_event_errc::none;
+    /// A description isn't neccessary for either event type
+    return wasm::errc::none;
 }
 
-} // namespace coproc
+} // namespace coproc::wasm

--- a/src/v/coproc/wasm_event.h
+++ b/src/v/coproc/wasm_event.h
@@ -12,7 +12,6 @@
 #include "bytes/iobuf.h"
 #include "coproc/errc.h"
 #include "model/record.h"
-#include "model/record_batch_reader.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/optimized_optional.hh>
@@ -52,6 +51,6 @@ wasm::errc validate_event(const model::record&);
 /// \brief Returns the newest events and their data blobs if the event has
 /// passed all validators
 absl::btree_map<ss::sstring, iobuf>
-reconcile_events(model::record_batch_reader::data_t&);
+  reconcile_events(std::vector<model::record_batch>);
 
 } // namespace coproc::wasm

--- a/src/v/coproc/wasm_event.h
+++ b/src/v/coproc/wasm_event.h
@@ -9,11 +9,15 @@
  */
 
 #pragma once
+#include "bytes/iobuf.h"
 #include "coproc/errc.h"
 #include "model/record.h"
+#include "model/record_batch_reader.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/optimized_optional.hh>
+
+#include <absl/container/btree_map.h>
 
 #include <optional>
 #include <variant>
@@ -44,5 +48,10 @@ wasm::errc verify_event_checksum(const model::record&);
 
 /// \brief performs the strictest form of validation, 'none' if all checks pass
 wasm::errc validate_event(const model::record&);
+
+/// \brief Returns the newest events and their data blobs if the event has
+/// passed all validators
+absl::btree_map<ss::sstring, iobuf>
+reconcile_events(model::record_batch_reader::data_t&);
 
 } // namespace coproc::wasm

--- a/src/v/coproc/wasm_event.h
+++ b/src/v/coproc/wasm_event.h
@@ -18,32 +18,31 @@
 #include <optional>
 #include <variant>
 
-namespace coproc {
+namespace coproc::wasm {
 
 /// Enumerations for all possible values for keys within the record headers
-enum class wasm_event_header { action, description, checksum };
+enum class event_header { action, description, checksum };
 
 /// Enumerations for all possible values for the 'action' key within the headers
-enum class wasm_event_action { deploy, remove };
+enum class event_action { deploy, remove };
 
 /// \brief returns the id of the event, performs a byte-copy
-std::optional<ss::sstring> wasm_event_get_name(const model::record&);
+std::optional<ss::sstring> get_event_name(const model::record&);
 
 /// \brief returns an iterator to the value in the records header keyed by
 /// the 'wasm_event_header' parameter
 std::vector<model::record_header>::const_iterator
-wasm_event_get_value_for_header(const model::record&, wasm_event_header);
+get_value_for_event_header(const model::record&, event_header);
 
-/// \brief wasm_event_errc if record is malformed, otherwise returns
+/// \brief wasm::errc if record is malformed, otherwise returns
 /// wasm_event_action::deploy or wasm_event_action::remove, representing a
 /// command to change state within the wasm engine
-std::variant<wasm_event_errc, wasm_event_action>
-wasm_event_get_action(const model::record&);
+std::variant<wasm::errc, event_action> get_event_action(const model::record&);
 
 /// \brief errc::none if the record is valid AND the checksum passes validation
-wasm_event_errc wasm_event_verify_checksum(const model::record&);
+wasm::errc verify_event_checksum(const model::record&);
 
 /// \brief performs the strictest form of validation, 'none' if all checks pass
-wasm_event_errc wasm_event_validate(const model::record&);
+wasm::errc validate_event(const model::record&);
 
-} // namespace coproc
+} // namespace coproc::wasm

--- a/src/v/coproc/wasm_event_listener.h
+++ b/src/v/coproc/wasm_event_listener.h
@@ -40,14 +40,9 @@ public:
     const std::filesystem::path& inactive_dir() const { return _inactive_dir; }
 
 private:
-    using wasm_script_actions = absl::btree_map<ss::sstring, iobuf>;
-
     ss::future<> do_start();
 
     ss::future<> poll_topic(model::record_batch_reader::data_t&);
-
-    wasm_script_actions
-    reconcile_wasm_events(model::record_batch_reader::data_t&);
 
     ss::future<> resolve_wasm_script(ss::sstring, iobuf);
 

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -71,7 +71,7 @@ async_transform(Iterator begin, Iterator end, Func&& func) {
 // clang-format off
 template<typename Iterator, typename Func>
 CONCEPT(requires requires(Func f, Iterator i) {
-    *i++;
+    *(++i);
     { i != i } -> std::convertible_to<bool>;
     seastar::futurize_invoke(f, *i).get0();
 })
@@ -142,7 +142,7 @@ inline auto async_transform(Rng& rng, Func&& func) {
 // clang-format off
 template<typename Iterator, typename Func>
 CONCEPT(requires requires(Func f, Iterator i) {
-    *i++;
+    *(++i);
     { i != i } ->std::convertible_to<bool>;
     seastar::futurize_invoke(f, *i).get0().begin();
     seastar::futurize_invoke(f, *i).get0().end();
@@ -199,7 +199,7 @@ inline auto async_flat_transform(Rng& rng, Func&& func) {
 // clang-format off
 template<typename Iterator, typename Func>
 CONCEPT(requires requires(Func f, Iterator i) {
-    *i++;
+    *(++i);
     { i != i } -> std::convertible_to<bool>;
 })
 // clang-format on


### PR DESCRIPTION
`rpk wasm deploy` will push compressed batches to the copro internal topic. This patch adds the ability to decompress batches to the wasm_event_listener class.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
