### PR TITLE
operator/controller: Add more logging to ease debugging

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -72,11 +72,11 @@ func (r *ClusterReconciler) Reconcile(
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	sts := resources.NewStatefulSet(r.Client, &redpandaCluster, r.Scheme)
-	svc := resources.NewService(r.Client, &redpandaCluster, r.Scheme)
+	sts := resources.NewStatefulSet(r.Client, &redpandaCluster, r.Scheme, log)
+	svc := resources.NewService(r.Client, &redpandaCluster, r.Scheme, log)
 	toApply := []resources.Resource{
 		svc,
-		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme, svc, r.polymorphicAdvertisedAPI),
+		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme, svc, r.polymorphicAdvertisedAPI, log),
 		sts,
 	}
 


### PR DESCRIPTION
To have a way for tracing tasks done by each resource controller the logger is added with each unique key.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
