### PR TITLE
Enable ccache in gcb pipelines

### DIFF
--- a/tests/ci/build-pkg.yml
+++ b/tests/ci/build-pkg.yml
@@ -91,7 +91,7 @@ steps:
   name: 'gcr.io/redpandaci/builder'
   entrypoint: bash
   args:
-  - -c
+  - -cex
   - |
     ./build/venv/v/bin/vtools build go --targets=rpk --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
     ./build/venv/v/bin/vtools build redpanda-dashboard --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml

--- a/tests/ci/build-pkg.yml
+++ b/tests/ci/build-pkg.yml
@@ -61,9 +61,27 @@ steps:
   name: 'gcr.io/redpandaci/builder'
   args: ['./build/venv/v/bin/vtools', 'test', 'go', '--conf=vtools/vtools/artifacts/ci/vtools-gcc-release.yml']
 
+- id: 'restore ccache'
+  name: 'docker:20.10.3'
+  args: ['run', '--ipc=host', '--network=cloudbuild', 'gcr.io/redpandaci/restore_cache',
+         '--bucket=gs://redpandaci-ccache', '--key=dev-$_BUILD_TYPE-$_COMPILER']
+
 - id: 'build redpanda'
-  name: 'gcr.io/redpandaci/builder'
-  args: ['./build/venv/v/bin/vtools', 'build', 'cpp', '--conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml', '--skip-external']
+  name: 'docker:20.10.3'
+  args: ['run', '-e', 'CCACHE_DIR=/dev/shm/v', '-v', '/workspace:/workspace', '-w', '/workspace', '--ipc=host', 'gcr.io/redpandaci/builder',
+         './build/venv/v/bin/vtools', 'build', 'cpp', '--conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml', '--skip-external']
+
+- id: 'save ccache (only for dev branch)'
+  name: 'docker:20.10.3'
+  entrypoint: '/bin/sh'
+  args:
+  - '-ec'
+  - |
+    if [[ "$BRANCH_NAME" != "dev" ]]; then
+      exit 0
+    fi
+    docker run --ipc=host --network=cloudbuild gcr.io/redpandaci/save_cache \
+      --bucket=gs://redpandaci-ccache --key=dev-$_BUILD_TYPE-$_COMPILER --out=/dev/shm --path=/dev/shm/v
 
 - id: 'test redpanda'
   name: 'gcr.io/redpandaci/builder'

--- a/tests/ci/build-pkg.yml
+++ b/tests/ci/build-pkg.yml
@@ -36,7 +36,7 @@ steps:
   args:
   - -ec
   - |
-    python3 -mvenv --system-site-packages build/venv/v
+    python3 -mvenv --system-site-packages --upgrade-deps build/venv/v
     source build/venv/v/bin/activate
     pip install vtools/
 

--- a/tests/ci/build-release.yaml
+++ b/tests/ci/build-release.yaml
@@ -37,7 +37,7 @@ steps:
   args:
   - -ec
   - |
-    python3 -mvenv --system-site-packages build/venv/v
+    python3 -mvenv --system-site-packages --upgrade-deps build/venv/v
     source build/venv/v/bin/activate
     pip install vtools/
 

--- a/tests/ci/build-release.yaml
+++ b/tests/ci/build-release.yaml
@@ -75,7 +75,7 @@ steps:
   name: 'gcr.io/redpandaci/builder'
   entrypoint: bash
   args:
-  - -c
+  - -cex
   - |
     ./build/venv/v/bin/vtools build go --targets=rpk --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml
     ./build/venv/v/bin/vtools build redpanda-dashboard --conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml

--- a/tests/ci/build.yaml
+++ b/tests/ci/build.yaml
@@ -61,9 +61,27 @@ steps:
   name: 'gcr.io/redpandaci/builder'
   args: ['./build/venv/v/bin/vtools', 'test', 'go', '--conf=vtools/vtools/artifacts/ci/vtools-gcc-release.yml']
 
+- id: 'restore ccache'
+  name: 'docker:20.10.3'
+  args: ['run', '--ipc=host', '--network=cloudbuild', 'gcr.io/redpandaci/restore_cache',
+         '--bucket=gs://redpandaci-ccache', '--key=dev-$_BUILD_TYPE-$_COMPILER']
+
 - id: 'build redpanda'
-  name: 'gcr.io/redpandaci/builder'
-  args: ['./build/venv/v/bin/vtools', 'build', 'cpp', '--conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml', '--skip-external']
+  name: 'docker:20.10.3'
+  args: ['run', '-e', 'CCACHE_DIR=/dev/shm/v', '-v', '/workspace:/workspace', '-w', '/workspace', '--ipc=host', 'gcr.io/redpandaci/builder',
+         './build/venv/v/bin/vtools', 'build', 'cpp', '--conf=vtools/vtools/artifacts/ci/vtools-$_COMPILER-$_BUILD_TYPE.yml', '--skip-external']
+
+- id: 'save ccache (only for dev branch)'
+  name: 'docker:20.10.3'
+  entrypoint: '/bin/sh'
+  args:
+  - '-ec'
+  - |
+    if [[ "$BRANCH_NAME" != "dev" ]]; then
+      exit 0
+    fi
+    docker run --ipc=host --network=cloudbuild gcr.io/redpandaci/save_cache \
+      --bucket=gs://redpandaci-ccache --key=dev-$_BUILD_TYPE-$_COMPILER --out=/dev/shm --path=/dev/shm/v
 
 - id: 'test redpanda'
   name: 'gcr.io/redpandaci/builder'

--- a/tests/ci/build.yaml
+++ b/tests/ci/build.yaml
@@ -36,7 +36,7 @@ steps:
   args:
   - -ec
   - |
-    python3 -mvenv --system-site-packages build/venv/v
+    python3 -mvenv --system-site-packages --upgrade-deps build/venv/v
     source build/venv/v/bin/activate
     pip install vtools/
 


### PR DESCRIPTION
This PR introduces the use of the [`cloud-builders-community/cache`](https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/cache) images to save/restore ccache to/from a GCS bucket. The content of the cache is
placed in /dev/shm as part of the pipeline, and the CCACHE_DIR variable is set from the pipeline so that it is properly picked by vtools. In the best-case scenario, this saves ~15 mins on clang-release builds.

The cache image was built once (manually), and uploaded to the RP private registry. In addition, the GCS bucket was also manually created.