### PR TITLE
kafka: implement delete consumer groups api

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -40,6 +40,7 @@ v_cc_library(
     server/requests.cc
     server/member.cc
     server/group.cc
+    server/group_router.cc
     server/group_manager.cc
     server/connection_context.cc
     server/protocol.cc

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -26,6 +26,7 @@ set(handlers_srcs
   server/handlers/sasl_handshake.cc
   server/handlers/sasl_authenticate.cc
   server/handlers/incremental_alter_configs.cc
+  server/handlers/delete_groups.cc
   server/handlers/topics/types.cc
   server/handlers/topics/topic_utils.cc
 )

--- a/src/v/kafka/protocol/delete_groups.h
+++ b/src/v/kafka/protocol/delete_groups.h
@@ -8,20 +8,62 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
-
 #pragma once
 #include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/delete_groups_request.h"
+#include "kafka/protocol/schemata/delete_groups_response.h"
 #include "kafka/types.h"
-
-#include <seastar/core/future.hh>
 
 namespace kafka {
 
+struct delete_groups_response;
+
 struct delete_groups_api final {
+    using response_type = delete_groups_response;
+
     static constexpr const char* name = "delete groups";
     static constexpr api_key key = api_key(42);
-    static constexpr api_version min_supported = api_version(0);
-    static constexpr api_version max_supported = api_version(0);
 };
+
+struct delete_groups_request final {
+    using api_type = delete_groups_api;
+
+    delete_groups_request_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const delete_groups_request& r) {
+    return os << r.data;
+}
+
+struct delete_groups_response final {
+    using api_type = delete_groups_api;
+
+    delete_groups_response_data data;
+
+    explicit delete_groups_response(
+      std::vector<deletable_group_result> results) {
+        data.results = std::move(results);
+    }
+
+    void encode(const request_context&, response&);
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const delete_groups_response& r) {
+    return os << r.data;
+}
 
 } // namespace kafka

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -38,7 +38,9 @@ set(schemata
   init_producer_id_request.json
   init_producer_id_response.json
   incremental_alter_configs_request.json
-  incremental_alter_configs_response.json)
+  incremental_alter_configs_response.json
+  delete_groups_request.json
+  delete_groups_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/protocol/schemata/delete_groups_request.json
+++ b/src/v/kafka/protocol/schemata/delete_groups_request.json
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 42,
+  "type": "request",
+  "name": "DeleteGroupsRequest",
+  // Version 1 is the same as version 0.
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
+  "fields": [
+    { "name": "GroupsNames", "type": "[]string", "versions": "0+", "entityType": "groupId",
+      "about": "The group names to delete." }
+  ]
+}

--- a/src/v/kafka/protocol/schemata/delete_groups_response.json
+++ b/src/v/kafka/protocol/schemata/delete_groups_response.json
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 42,
+  "type": "response",
+  "name": "DeleteGroupsResponse",
+  // Starting in version 1, on quota violation, brokers send out responses before throttling.
+  //
+  // Version 2 is the first flexible version.
+  "validVersions": "0-2",
+  "flexibleVersions": "2+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "Results", "type": "[]DeletableGroupResult", "versions": "0+",
+      "about": "The deletion results", "fields": [
+      { "name": "GroupId", "type": "string", "versions": "0+", "mapKey": true, "entityType": "groupId",
+        "about": "The group id" },
+      { "name": "ErrorCode", "type": "int16", "versions": "0+",
+        "about": "The deletion error, or 0 if the deletion succeeded." }
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -262,6 +262,7 @@ STRUCT_TYPES = [
     "CreatableReplicaAssignment",
     "CreateableTopicConfig",
     "CreatableTopicConfigs",
+    "DeletableGroupResult",
 ]
 
 SCALAR_TYPES = list(basic_type_map.keys())

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -32,8 +32,8 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/log.hh>
 
-#include <absl/container/flat_hash_map.h>
-#include <absl/container/flat_hash_set.h>
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
 
 #include <iosfwd>
 #include <optional>
@@ -417,8 +417,8 @@ public:
     ss::future<error_code> remove();
 
 private:
-    using member_map = absl::flat_hash_map<kafka::member_id, member_ptr>;
-    using protocol_support = absl::flat_hash_map<kafka::protocol_name, int>;
+    using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
+    using protocol_support = absl::node_hash_map<kafka::protocol_name, int>;
 
     friend std::ostream& operator<<(std::ostream&, const group&);
 
@@ -431,7 +431,7 @@ private:
     protocol_support _supported_protocols;
     member_map _members;
     int _num_members_joining;
-    absl::flat_hash_set<kafka::member_id> _pending_members;
+    absl::node_hash_set<kafka::member_id> _pending_members;
     std::optional<kafka::protocol_type> _protocol_type;
     std::optional<kafka::protocol_name> _protocol;
     std::optional<kafka::member_id> _leader;
@@ -439,8 +439,8 @@ private:
     bool _new_member_added;
     config::configuration& _conf;
     ss::lw_shared_ptr<cluster::partition> _partition;
-    absl::flat_hash_map<model::topic_partition, offset_metadata> _offsets;
-    absl::flat_hash_map<model::topic_partition, offset_metadata>
+    absl::node_hash_map<model::topic_partition, offset_metadata> _offsets;
+    absl::node_hash_map<model::topic_partition, offset_metadata>
       _pending_offset_commits;
 };
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -412,6 +412,10 @@ public:
     // helper for the kafka api: describe groups
     described_group describe() const;
 
+    // transition group to `dead` state if empty, otherwise an appropriate error
+    // is returned for the current state.
+    ss::future<error_code> remove();
+
 private:
     using member_map = absl::flat_hash_map<kafka::member_id, member_ptr>;
     using protocol_support = absl::flat_hash_map<kafka::protocol_name, int>;

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -33,7 +33,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 
-#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 #include <cluster/partition_manager.h>
 
 namespace kafka {
@@ -184,7 +184,7 @@ private:
           , partition(std::move(p)) {}
     };
 
-    absl::flat_hash_map<model::ntp, ss::lw_shared_ptr<attached_partition>>
+    absl::node_hash_map<model::ntp, ss::lw_shared_ptr<attached_partition>>
       _partitions;
 
     cluster::notification_id_type _leader_notify_handle;
@@ -206,7 +206,7 @@ private:
     ss::sharded<raft::group_manager>& _gm;
     ss::sharded<cluster::partition_manager>& _pm;
     config::configuration& _conf;
-    absl::flat_hash_map<group_id, group_ptr> _groups;
+    absl::node_hash_map<group_id, group_ptr> _groups;
     model::broker _self;
 };
 
@@ -289,12 +289,12 @@ namespace kafka {
  * deduplicate both group and commit metadata snapshots.
  */
 struct recovery_batch_consumer_state {
-    absl::flat_hash_map<kafka::group_id, group_log_group_metadata>
+    absl::node_hash_map<kafka::group_id, group_log_group_metadata>
       loaded_groups;
 
     absl::flat_hash_set<kafka::group_id> removed_groups;
 
-    absl::flat_hash_map<
+    absl::node_hash_map<
       group_log_offset_key,
       std::pair<model::offset, group_log_offset_metadata>>
       loaded_offsets;

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -291,8 +291,8 @@ struct recovery_batch_consumer {
     ss::future<ss::stop_iteration> operator()(model::record_batch batch);
 
     ss::future<> handle_record(model::record);
-    ss::future<> handle_group_metadata(iobuf key_buf, iobuf val_buf);
-    ss::future<> handle_offset_metadata(iobuf key_buf, iobuf val_buf);
+    ss::future<> handle_group_metadata(iobuf, std::optional<iobuf>);
+    ss::future<> handle_offset_metadata(iobuf, std::optional<iobuf>);
 
     recovery_batch_consumer end_of_stream() { return std::move(*this); }
 

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -13,6 +13,7 @@
 #include "cluster/cluster_utils.h"
 #include "cluster/partition_manager.h"
 #include "config/configuration.h"
+#include "kafka/protocol/delete_groups.h"
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/heartbeat.h"
@@ -149,6 +150,9 @@ public:
     std::pair<bool, std::vector<listed_group>> list_groups() const;
 
     described_group describe_group(const model::ntp&, const kafka::group_id&);
+
+    ss::future<std::vector<deletable_group_result>>
+      delete_groups(std::vector<std::pair<model::ntp, group_id>>);
 
 public:
     error_code validate_group_status(

--- a/src/v/kafka/server/group_router.cc
+++ b/src/v/kafka/server/group_router.cc
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/group_router.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/core/with_scheduling_group.hh>
+
+namespace kafka {
+
+ss::future<std::vector<deletable_group_result>>
+group_router::route_delete_groups(
+  ss::shard_id shard, std::vector<std::pair<model::ntp, group_id>> groups) {
+    return ss::with_scheduling_group(
+      _sg, [this, shard, groups = std::move(groups)]() mutable {
+          return _group_manager.invoke_on(
+            shard,
+            _ssg,
+            [groups = std::move(groups)](group_manager& mgr) mutable {
+                return mgr.delete_groups(std::move(groups));
+            });
+      });
+}
+
+ss::future<> group_router::parallel_route_delete_groups(
+  std::vector<deletable_group_result>& results,
+  sharded_groups& groups_by_shard) {
+    return ss::parallel_for_each(
+      groups_by_shard, [this, &results](sharded_groups::value_type& groups) {
+          return route_delete_groups(groups.first, std::move(groups.second))
+            .then([&results](std::vector<deletable_group_result> new_results) {
+                results.insert(
+                  results.end(), new_results.begin(), new_results.end());
+            });
+      });
+}
+
+ss::future<std::vector<deletable_group_result>>
+group_router::delete_groups(std::vector<group_id> groups) {
+    // partial results
+    std::vector<deletable_group_result> results;
+
+    // partition groups by owner shard
+    sharded_groups groups_by_shard;
+    for (auto& group : groups) {
+        if (auto m = shard_for(group); m) {
+            groups_by_shard[m->second].emplace_back(
+              std::make_pair(std::move(m->first), std::move(group)));
+        } else {
+            results.push_back(deletable_group_result{
+              .group_id = std::move(group),
+              .error_code = error_code::not_coordinator,
+            });
+        }
+    }
+
+    return ss::do_with(
+      std::move(results),
+      std::move(groups_by_shard),
+      [this](
+        std::vector<deletable_group_result>& results,
+        sharded_groups& groups_by_shard) {
+          return parallel_route_delete_groups(results, groups_by_shard)
+            .then([&results] { return std::move(results); });
+      });
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -143,7 +143,7 @@ public:
 
 private:
     using sharded_groups = absl::
-      flat_hash_map<ss::shard_id, std::vector<std::pair<model::ntp, group_id>>>;
+      node_hash_map<ss::shard_id, std::vector<std::pair<model::ntp, group_id>>>;
 
     std::optional<std::pair<model::ntp, ss::shard_id>>
     shard_for(const group_id& group) {

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -48,7 +48,8 @@ using request_types = make_request_types<
   describe_groups_handler,
   sasl_handshake_handler,
   sasl_authenticate_handler,
-  incremental_alter_configs_handler>;
+  incremental_alter_configs_handler,
+  delete_groups_handler>;
 
 template<typename RequestType>
 static auto make_api() {

--- a/src/v/kafka/server/handlers/delete_groups.cc
+++ b/src/v/kafka/server/handlers/delete_groups.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/handlers/delete_groups.h"
+
+#include "kafka/protocol/schemata/delete_groups_response.h"
+#include "kafka/server/group_manager.h"
+#include "kafka/server/group_router.h"
+#include "kafka/server/request_context.h"
+#include "kafka/server/response.h"
+#include "utils/remote.h"
+#include "utils/to_string.h"
+
+#include <seastar/core/print.hh>
+
+namespace kafka {
+
+void delete_groups_response::encode(
+  const request_context& ctx, response& resp) {
+    data.encode(resp.writer(), ctx.header().version);
+}
+
+template<>
+ss::future<response_ptr> delete_groups_handler::handle(
+  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+    return ss::do_with(std::move(ctx), [](request_context& ctx) {
+        delete_groups_request request;
+        request.decode(ctx.reader(), ctx.header().version);
+        vlog(klog.debug, "Handling delete groups: {}", request);
+
+        return ctx.groups()
+          .delete_groups(std::move(request.data.groups_names))
+          .then([&ctx](std::vector<deletable_group_result> results) {
+              return ctx.respond(delete_groups_response(std::move(results)));
+          });
+    });
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/delete_groups.h
+++ b/src/v/kafka/server/handlers/delete_groups.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/delete_groups.h"
+#include "kafka/server/handlers/handler.h"
+
+namespace kafka {
+
+using delete_groups_handler = handler<delete_groups_api, 0, 1>;
+
+}

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -13,6 +13,7 @@
 #include "kafka/server/handlers/alter_configs.h"
 #include "kafka/server/handlers/api_versions.h"
 #include "kafka/server/handlers/create_topics.h"
+#include "kafka/server/handlers/delete_groups.h"
 #include "kafka/server/handlers/delete_topics.h"
 #include "kafka/server/handlers/describe_configs.h"
 #include "kafka/server/handlers/describe_groups.h"

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -115,6 +115,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<init_producer_id_handler>(std::move(ctx), g);
     case incremental_alter_configs_handler::api::key:
         return do_process<incremental_alter_configs_handler>(std::move(ctx), g);
+    case delete_groups_handler::api::key:
+        return do_process<delete_groups_handler>(std::move(ctx), g);
     };
     return ss::make_exception_future<response_ptr>(
       std::runtime_error(fmt::format("Unsupported API {}", ctx.header().key)));

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -189,6 +189,7 @@ public:
     const iobuf& value() const { return _value; }
     iobuf release_value() { return std::exchange(_value, {}); }
     iobuf share_value() { return _value.share(0, _value.size_bytes()); }
+    bool has_value() const { return _val_size >= 0; }
 
     const std::vector<record_header>& headers() const { return _headers; }
     std::vector<record_header>& headers() { return _headers; }

--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -49,7 +49,7 @@ model::record_batch record_batch_builder::build() && {
     for (auto& sr : _records) {
         auto rec_sz = record_size(offset_delta, sr);
         auto kz = sr.key.size_bytes();
-        auto vz = sr.value.size_bytes();
+        auto vz = sr.encoded_value_size;
         auto r = model::record(
           rec_sz,
           model::record_attributes{},
@@ -76,7 +76,7 @@ uint32_t record_batch_builder::record_size(
                     + vint::vint_size(offset_delta)         // offset_delta
                     + vint::vint_size(r.key.size_bytes())   // key size
                     + r.key.size_bytes()                    // key
-                    + vint::vint_size(r.value.size_bytes()) // value size
+                    + vint::vint_size(r.encoded_value_size) // value size
                     + r.value.size_bytes()                  // value
                     + vint::vint_size(r.headers.size());    // headers size
     for (const auto& h : r.headers) {

--- a/src/v/storage/record_batch_builder.h
+++ b/src/v/storage/record_batch_builder.h
@@ -24,12 +24,15 @@ public:
     record_batch_builder& operator=(record_batch_builder&&) = default;
     record_batch_builder& operator=(const record_batch_builder&) = delete;
 
-    virtual record_batch_builder& add_raw_kv(iobuf&& key, iobuf&& value) {
+    virtual record_batch_builder&
+    add_raw_kv(iobuf&& key, std::optional<iobuf>&& value) {
         _records.emplace_back(std::move(key), std::move(value));
         return *this;
     }
     virtual record_batch_builder& add_raw_kw(
-      iobuf&& key, iobuf&& value, std::vector<model::record_header> headers) {
+      iobuf&& key,
+      std::optional<iobuf>&& value,
+      std::vector<model::record_header> headers) {
         _records.emplace_back(
           std::move(key), std::move(value), std::move(headers));
         return *this;
@@ -42,15 +45,22 @@ private:
     struct serialized_record {
         serialized_record(
           iobuf k,
-          iobuf v,
+          std::optional<iobuf> v,
           std::vector<model::record_header> hdrs
           = std::vector<model::record_header>())
           : key(std::move(k))
-          , value(std::move(v))
-          , headers(std::move(hdrs)) {}
+          , headers(std::move(hdrs)) {
+            if (likely(v)) {
+                value = std::move(*v);
+                encoded_value_size = value.size_bytes();
+            } else {
+                encoded_value_size = -1;
+            }
+        }
 
         iobuf key;
         iobuf value;
+        int32_t encoded_value_size;
         std::vector<model::record_header> headers;
 
         uint32_t size_bytes() const {

--- a/src/v/storage/record_batch_builder.h
+++ b/src/v/storage/record_batch_builder.h
@@ -62,10 +62,6 @@ private:
         iobuf value;
         int32_t encoded_value_size;
         std::vector<model::record_header> headers;
-
-        uint32_t size_bytes() const {
-            return key.size_bytes() + value.size_bytes();
-        }
     };
 
     uint32_t record_size(int32_t offset_delta, const serialized_record& r);


### PR DESCRIPTION
Adds group deletion via the kafka api. The API is routed to the consumer groups manager where state for each group is removed, and a tombstone is written to the metadata log. These tombstones are handled on recovery to skip/clean-up group state.

A separate PR will tackle automatic clean-up when topics are deleted (see #582)