### PR TITLE
operator: change component label

### DIFF
--- a/src/go/k8s/pkg/labels/labels.go
+++ b/src/go/k8s/pkg/labels/labels.go
@@ -92,7 +92,7 @@ func defaultLabels(cluster *redpandav1alpha1.Cluster) map[string]string {
 	labels := make(map[string]string)
 	labels[NameKey] = nameKeyVal
 	labels[InstanceKey] = cluster.Name
-	labels[ComponentKey] = "database"
+	labels[ComponentKey] = "redpanda"
 	labels[PartOfKey] = nameKeyVal
 	labels[ManagedByKey] = "redpanda-operator"
 

--- a/src/go/k8s/pkg/labels/labels_test.go
+++ b/src/go/k8s/pkg/labels/labels_test.go
@@ -42,7 +42,7 @@ func TestLabels(t *testing.T) {
 		{"empty inherited labels", testCluster, map[string]string{
 			"app.kubernetes.io/name":	"redpanda",
 			"app.kubernetes.io/instance":	"testcluster",
-			"app.kubernetes.io/component":	"database",
+			"app.kubernetes.io/component":	"redpanda",
 			"app.kubernetes.io/part-of":	"redpanda",
 			"app.kubernetes.io/managed-by":	"redpanda-operator",
 		},
@@ -50,7 +50,7 @@ func TestLabels(t *testing.T) {
 		{"some inherited labels", withPartOfDefined, map[string]string{
 			"app.kubernetes.io/name":	"redpanda",
 			"app.kubernetes.io/instance":	"testcluster",
-			"app.kubernetes.io/component":	"database",
+			"app.kubernetes.io/component":	"redpanda",
 			"app.kubernetes.io/part-of":	"part-of-something-else",
 			"app.kubernetes.io/managed-by":	"redpanda-operator",
 		},

--- a/src/go/k8s/tests/e2e/scale-up/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/scale-up/01-assert.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: "redpanda"
     app.kubernetes.io/instance: "scale-up-cluster"
-    app.kubernetes.io/component: database
+    app.kubernetes.io/component: redpanda
     app.kubernetes.io/managed-by: redpanda-operator
     app.kubernetes.io/part-of: redpanda
 status:


### PR DESCRIPTION
There's been several people raising that the database is just wrong. I've looked at what others do and it's mix of everything. Let's stick with redpanda for now rather than come up with something on our own. Just repeating the same name in component is what many do as well, e.g. cockroachdb.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
