### PR TITLE
Add hash64 id to deploy remove wasm command

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/avast/retry-go v2.6.0+incompatible
 	github.com/aws/aws-sdk-go v1.25.43
 	github.com/burdiyan/kafkautil v0.0.0-20190131162249-eaf83ed22d5b
+	github.com/cespare/xxhash v1.1.0
 	github.com/cockroachdb/crlfmt v0.0.0-20200923085322-b9cb16fe9a33
 	github.com/containerd/containerd v1.4.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.1.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -27,6 +27,7 @@ github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/burdiyan/kafkautil v0.0.0-20190131162249-eaf83ed22d5b h1:gRFujk0F/KYFDEalhpaAbLIwmeiDH53ZgdllJ7UHxyQ=
 github.com/burdiyan/kafkautil v0.0.0-20190131162249-eaf83ed22d5b/go.mod h1:5hrpM9I1h0fZlTk8JhqaaBaCs76EbCGvFcPtm5SxcCU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/crlfmt v0.0.0-20200923085322-b9cb16fe9a33 h1:MQXQgcBw3j3gGAaga+YLXEhwCAZkALCNugxX3kuL7v0=

--- a/src/go/rpk/pkg/cli/cmd/wasm/common.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/common.go
@@ -1,6 +1,7 @@
 package wasm
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
 
 	"github.com/Shopify/sarama"
@@ -58,19 +59,55 @@ func ExistingTopic(admin sarama.ClusterAdmin, topic string) (bool, error) {
 	}
 }
 
-/**
-Create coprocessor message
-*/
-func CreateCoprocessorMessage(
-	name string, message []byte, headers []sarama.RecordHeader,
+func CreateDeployMsg(
+	name string, description string, content []byte,
 ) sarama.ProducerMessage {
+	shaValue := sha256.Sum256(content)
+	var headers = []sarama.RecordHeader{
+		{
+			Key:	[]byte("action"),
+			Value:	[]byte("deploy"),
+		}, {
+			Key:	[]byte("description"),
+			Value:	[]byte(description),
+		}, {
+			Key:	[]byte("file_name"),
+			Value:	[]byte(name),
+		}, {
+			Key:	[]byte("sha256"),
+			Value:	shaValue[:],
+		},
+	}
 	id := xxhash.Sum64([]byte(name))
 	binaryId := make([]byte, 8)
 	binary.LittleEndian.PutUint64(binaryId, id)
 	return sarama.ProducerMessage{
 		Key:		sarama.ByteEncoder(binaryId),
 		Topic:		kafka.CoprocessorTopic,
-		Value:		sarama.ByteEncoder(message),
+		Value:		sarama.ByteEncoder(content),
+		Headers:	headers,
+	}
+}
+
+func CreateRemoveMsg(name string) sarama.ProducerMessage {
+	var headers = []sarama.RecordHeader{
+		{
+			Key:	[]byte("action"),
+			Value:	[]byte("remove"),
+		}, {
+			Key:	[]byte("file_name"),
+			Value:	[]byte(name),
+		},
+	}
+	id := xxhash.Sum64([]byte(name))
+	binaryId := make([]byte, 8)
+	binary.LittleEndian.PutUint64(binaryId, id)
+	return sarama.ProducerMessage{
+		Key:	sarama.ByteEncoder(binaryId),
+		Topic:	kafka.CoprocessorTopic,
+		// create empty message, the remove command doesn't need
+		// information on message, just a key value
+		Value:		sarama.ByteEncoder([]byte{}),
 		Headers:	headers,
 	}
 }

--- a/src/go/rpk/pkg/cli/cmd/wasm/common.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/common.go
@@ -1,7 +1,10 @@
 package wasm
 
 import (
+	"encoding/binary"
+
 	"github.com/Shopify/sarama"
+	"github.com/cespare/xxhash"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
 )
 
@@ -52,5 +55,22 @@ func ExistingTopic(admin sarama.ClusterAdmin, topic string) (bool, error) {
 		return true, err
 	} else {
 		return false, err
+	}
+}
+
+/**
+Create coprocessor message
+*/
+func CreateCoprocessorMessage(
+	name string, message []byte, headers []sarama.RecordHeader,
+) sarama.ProducerMessage {
+	id := xxhash.Sum64([]byte(name))
+	binaryId := make([]byte, 8)
+	binary.LittleEndian.PutUint64(binaryId, id)
+	return sarama.ProducerMessage{
+		Key:		sarama.ByteEncoder(binaryId),
+		Topic:		kafka.CoprocessorTopic,
+		Value:		sarama.ByteEncoder(message),
+		Headers:	headers,
 	}
 }

--- a/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
@@ -1,7 +1,6 @@
 package wasm
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"path/filepath"
 
@@ -94,59 +93,12 @@ func deploy(
 			return err
 		}
 	}
-	// create headers
-	headers, err := createHeaders("deploy", description, fileContent)
-	if err != nil {
-		return err
-	}
 	// create message
-	message := CreateCoprocessorMessage(fileName, fileContent, headers)
+	message := CreateDeployMsg(fileName, description, fileContent)
 	// publish message
 	err = kafka.PublishMessage(producer, &message)
 	if err != nil {
 		return fmt.Errorf("error deploying '%s.js: %v'", fileName, err)
 	}
 	return nil
-}
-
-func createHeaders(
-	action string, description string, content []byte,
-) ([]sarama.RecordHeader, error) {
-	var headersResult []sarama.RecordHeader
-	// create simple struct for key string and value string
-	value := []struct {
-		key	string
-		value	string
-	}{
-		{key: "action", value: action},
-		{key: "description", value: description},
-	}
-	// create RecordHeader and append to headersResult
-	for _, v := range value {
-		keyH := []byte(v.key)
-		valueH := []byte(v.value)
-		headersResult = append(headersResult, struct {
-			Key	[]byte
-			Value	[]byte
-		}{Key: keyH, Value: valueH})
-	}
-	checkSumHeader, err := createCheckSumHeader(content)
-	if err != nil {
-		return nil, err
-	}
-	// append checksum header
-	headersResult = append(headersResult, checkSumHeader)
-
-	return headersResult, nil
-}
-
-func createCheckSumHeader(content []byte) (sarama.RecordHeader, error) {
-	// create key for checksum
-	keySha := []byte("sha256")
-	// create sha256 value for content
-	shaValue := sha256.Sum256(content)
-	return sarama.RecordHeader{
-		Key:	keySha,
-		Value:	shaValue[:],
-	}, nil
 }

--- a/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
@@ -44,7 +44,6 @@ func NewDeployCommand(
 			if err != nil {
 				return err
 			}
-
 			return deploy(
 				fullFileName,
 				fileContent,
@@ -100,10 +99,12 @@ func deploy(
 	if err != nil {
 		return err
 	}
+	// create message
+	message := CreateCoprocessorMessage(fileName, fileContent, headers)
 	// publish message
-	error := kafka.PublishMessage(producer, fileContent, fileName, kafka.CoprocessorTopic, headers)
-	if error != nil {
-		return fmt.Errorf("error deploying '%s.js: %v'", fileName, error)
+	err = kafka.PublishMessage(producer, &message)
+	if err != nil {
+		return fmt.Errorf("error deploying '%s.js: %v'", fileName, err)
 	}
 	return nil
 }

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove.go
@@ -61,16 +61,11 @@ func remove(
 	}
 	// create empty message, the remove command doesn't need
 	// information on message, just a key value
-	var emptyMessage []byte
 	header := createHeader("remove")
+	// create message
+	message := CreateCoprocessorMessage(name, []byte{}, []sarama.RecordHeader{header})
 	//publish message
-	return kafka.PublishMessage(
-		producer,
-		emptyMessage,
-		name,
-		kafka.CoprocessorTopic,
-		[]sarama.RecordHeader{header},
-	)
+	return kafka.PublishMessage(producer, &message)
 }
 
 func createHeader(action string) sarama.RecordHeader {

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove.go
@@ -59,22 +59,8 @@ func remove(
 			return err
 		}
 	}
-	// create empty message, the remove command doesn't need
-	// information on message, just a key value
-	header := createHeader("remove")
 	// create message
-	message := CreateCoprocessorMessage(name, []byte{}, []sarama.RecordHeader{header})
+	message := CreateRemoveMsg(name)
 	//publish message
 	return kafka.PublishMessage(producer, &message)
-}
-
-func createHeader(action string) sarama.RecordHeader {
-	// create key
-	key := []byte("action")
-	// create value
-	value := []byte(action)
-	return sarama.RecordHeader{
-		Key:	key,
-		Value:	value,
-	}
 }

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove.go
@@ -1,6 +1,8 @@
 package wasm
 
 import (
+	"fmt"
+
 	"github.com/Shopify/sarama"
 	"github.com/spf13/cobra"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
@@ -14,7 +16,14 @@ func NewRemoveCommand(
 	command := &cobra.Command{
 		Use:	"remove <name>",
 		Short:	"remove inline WASM function",
-		Args:	cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf(
+					"no wasm script name specified",
+				)
+			}
+			return nil
+		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
 			producer, err := createProduce(false, -1)

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove_test.go
@@ -1,0 +1,76 @@
+package wasm
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
+	kafkaMocks "github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka/mocks"
+)
+
+func TestNewRemoveCommand(t *testing.T) {
+	tests := []struct {
+		name		string
+		producer	kafkaMocks.MockProducer
+		filename	string
+		args		[]string
+		expectedOutput	[]string
+		expectedErr	string
+		admin		kafkaMocks.MockAdmin
+	}{
+		{
+			name:	"it should publish a message with correct format",
+			args:	[]string{"filename.js"},
+		}, {
+			name:		"it should a error if the name arg doesn't set",
+			args:		[]string{},
+			expectedErr:	"no wasm script name specified",
+		}, {
+			name:	"it should publish a message with correct format with valid headers",
+			args:	[]string{"filename.js"},
+			producer: kafkaMocks.MockProducer{
+				MockSendMessage: func(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
+					require.Equal(t, msg.Topic, kafka.CoprocessorTopic)
+					expectHeader := []sarama.RecordHeader{
+						{
+							Key:	[]byte("action"),
+							Value:	[]byte("remove"),
+						}, {
+							Key:	[]byte("file_name"),
+							Value:	[]byte("filename.js"),
+						},
+					}
+					require.Equal(t, expectHeader, msg.Headers)
+					return 0, 0, nil
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			createProduce := func(_ bool, _ int32) (sarama.SyncProducer, error) {
+				return tt.producer, nil
+			}
+			admin := func() (sarama.ClusterAdmin, error) {
+				return tt.admin, nil
+			}
+			var out bytes.Buffer
+			logrus.SetOutput(&out)
+			logrus.SetLevel(logrus.DebugLevel)
+			cmd := NewRemoveCommand(createProduce, admin)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if tt.expectedErr != "" {
+				require.Error(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			for _, ln := range tt.expectedOutput {
+				require.Contains(t, out.String(), ln)
+			}
+		})
+	}
+}

--- a/src/go/rpk/pkg/kafka/mocks/producer.go
+++ b/src/go/rpk/pkg/kafka/mocks/producer.go
@@ -1,0 +1,33 @@
+package mocks
+
+import "github.com/Shopify/sarama"
+
+type MockProducer struct {
+	// add the specific funcs we'll need
+	MockSendMessage		func(msg *sarama.ProducerMessage) (partition int32, offset int64, err error)
+	MockSendMessages	func(msgs []*sarama.ProducerMessage) error
+	MockClose		func() error
+}
+
+func (m MockProducer) SendMessage(
+	msg *sarama.ProducerMessage,
+) (partition int32, offset int64, err error) {
+	if m.MockSendMessage != nil {
+		return m.MockSendMessage(msg)
+	}
+	return int32(0), 0, nil
+}
+
+func (m MockProducer) SendMessages(msg []*sarama.ProducerMessage) (err error) {
+	if m.MockSendMessages != nil {
+		return m.MockSendMessages(msg)
+	}
+	return nil
+}
+
+func (m MockProducer) Close() (err error) {
+	if m.MockClose != nil {
+		return m.MockClose()
+	}
+	return nil
+}

--- a/src/go/rpk/pkg/kafka/utils.go
+++ b/src/go/rpk/pkg/kafka/utils.go
@@ -11,28 +11,14 @@ import (
 const CoprocessorTopic = "coprocessor_internal_topic"
 
 func PublishMessage(
-	producer sarama.SyncProducer,
-	message []byte,
-	key string,
-	topic string,
-	header []sarama.RecordHeader,
+	producer sarama.SyncProducer, produceMessage *sarama.ProducerMessage,
 ) error {
-
-	k := sarama.StringEncoder(key)
 	ts := time.Now()
-
-	msg := &sarama.ProducerMessage{
-		Topic:		topic,
-		Key:		k,
-		Timestamp:	ts,
-		Value:		sarama.ByteEncoder(message),
-		Headers:	header,
-	}
-
+	produceMessage.Timestamp = ts
 	retryConf := DefaultConfig().Producer.Retry
 	part, offset, err := RetrySend(
 		producer,
-		msg,
+		produceMessage,
 		uint(retryConf.Max),
 		retryConf.Backoff,
 	)


### PR DESCRIPTION
Add xxhash dependency for coprocessor ids, this id is going the key on record that produces `rpk wasm deploy/remove`, also we move filename to record headers because it could be used to us when we need to debug the `coprocessor_internal_topic`
