### PR TITLE
operator/resource: Change the seastar memory value

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -13,7 +13,7 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
@@ -181,7 +181,7 @@ func (r *StatefulSetResource) Obj() (k8sclient.Object, error) {
 							Args: []string{
 								"--check=false",
 								"--smp 1",
-								"--memory " + strings.ReplaceAll(memory.String(), "Gi", "G"),
+								"--memory " + strconv.FormatInt(memory.Value(), 10),
 								"start",
 								"--",
 								"--default-log-level=debug",

--- a/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
@@ -10,5 +10,13 @@ spec:
           env:
             - name: REDPANDA_ENVIRONMENT
               value: kubernetes
+          args:
+          - --check=false
+          - --smp 1
+          - --memory 104857600
+          - start
+          - --
+          - --default-log-level=debug
+          - --reserve-memory 0M
 status:
   readyReplicas: 1

--- a/src/go/k8s/tests/e2e/produce-consume/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-redpanda-cluster.yaml
@@ -12,10 +12,10 @@ spec:
   resources:
     requests:
       cpu: 1
-      memory: 2Gi
+      memory: 100Mi
     limits:
       cpu: 1
-      memory: 2Gi
+      memory: 100Mi
   configuration:
     rpcServer:
       port: 33145


### PR DESCRIPTION
In the kubernetes world the memory quantity can be represented
by Gi, Mi, Ki. The seastar does not understand those suffixes.
Memory parameter now represent absolute value without suffix.

References:
https://github.com/scylladb/seastar/blob/c0d6e042a31c6165d59a581e5802a3d33c4ba33b/src/util/conversions.cc#L32-L47
https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
