### PR TITLE
kafka: return control batches to clients

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -17,8 +17,10 @@
 #include "likely.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
+#include "model/record_utils.h"
 #include "model/timeout_clock.h"
 #include "resource_mgmt/io_priority.h"
+#include "storage/parser_utils.h"
 #include "utils/to_string.h"
 
 #include <seastar/core/do_with.hh>
@@ -281,6 +283,69 @@ make_partition_response_error(model::partition_id p_id, error_code error) {
     };
 }
 
+int32_t
+control_record_size(int64_t ts_delta, int32_t offset_delta, const iobuf& key) {
+    static constexpr size_t zero_vint_size = vint::vint_size(0);
+    return sizeof(model::record_attributes::type) // attributes
+           + vint::vint_size(ts_delta)            // timestamp delta
+           + vint::vint_size(offset_delta)        // offset_delta
+           + vint::vint_size(key.size_bytes())    // key size
+           + key.size_bytes()                     // key payload
+           + zero_vint_size                       // value size
+           + zero_vint_size;                      // headers size
+}
+
+iobuf make_control_record_batch_key() {
+    iobuf b;
+    response_writer w(b);
+    /**
+     * control record batch schema:
+     *   [version, type]
+     */
+    w.write(model::current_control_record_version);
+    w.write(model::control_record_type::unknown);
+    return b;
+}
+
+/**
+ * here we make sure that our internal control batches are correctly adapted
+ * for Kafka clients
+ */
+model::record_batch adapt_fetch_batch(model::record_batch&& batch) {
+    // pass through data batches
+    if (likely(batch.header().type == raft::data_batch_type)) {
+        return std::move(batch);
+    }
+    /**
+     * We set control type flag and remove payload from internal batch types
+     */
+    batch.header().attrs.set_control_type();
+    iobuf records;
+
+    batch.for_each_record([&records](model::record r) {
+        auto key = make_control_record_batch_key();
+        auto key_size = key.size_bytes();
+        auto r_size = control_record_size(
+          r.timestamp_delta(), r.offset_delta(), key);
+        model::append_record_to_buffer(
+          records,
+          model::record(
+            r_size,
+            r.attributes(),
+            r.timestamp_delta(),
+            r.offset_delta(),
+            key_size,
+            std::move(key),
+            0,
+            iobuf{},
+            std::vector<model::record_header>{}));
+    });
+    auto header = batch.header();
+    storage::internal::reset_size_checksum_metadata(header, records);
+    return model::record_batch(
+      header, std::move(records), model::record_batch::tag_ctor_ng{});
+}
+
 /**
  * Low-level handler for reading from an ntp. Runs on ntp's home core.
  */
@@ -302,27 +367,30 @@ static ss::future<read_result> read_from_partition(
       0,
       config.max_bytes,
       kafka_read_priority(),
-      raft::data_batch_type,
+      std::nullopt,
       std::nullopt,
       std::nullopt);
 
     reader_config.strict_max_bytes = config.strict_max_bytes;
     return pw.make_reader(reader_config)
       .then([hw, lso, foreign_read, deadline](model::record_batch_reader rdr) {
-          // if we are on remote core, we MUST use foreign record batch reader.
-          if (foreign_read) {
-              return model::consume_reader_to_memory(
-                       std::move(rdr), deadline.value_or(model::no_timeout))
-                .then([hw, lso](ss::circular_buffer<model::record_batch> data) {
-                    return read_result(
-                      model::make_foreign_memory_record_batch_reader(
-                        std::move(data)),
-                      hw,
-                      lso);
-                });
-          }
-          return ss::make_ready_future<read_result>(
-            read_result(std::move(rdr), hw, lso));
+          return model::transform_reader_to_memory(
+                   std::move(rdr),
+                   deadline.value_or(model::no_timeout),
+                   adapt_fetch_batch)
+            .then([foreign_read](
+                    ss::circular_buffer<model::record_batch> data) {
+                // if we are on remote core, we MUST use foreign record batch
+                // reader.
+                if (foreign_read) {
+                    return model::make_foreign_memory_record_batch_reader(
+                      std::move(data));
+                }
+                return model::make_memory_record_batch_reader(std::move(data));
+            })
+            .then([hw, lso](model::record_batch_reader rdr) {
+                return read_result(std::move(rdr), hw, lso);
+            });
       });
 }
 
@@ -721,7 +789,8 @@ bool update_fetch_partition(
     if (resp.error != error_code::none) {
         // Partitions with errors are always included in the response.
         // We also set the cached highWatermark to an invalid offset, -1.
-        // This ensures that when the error goes away, we re-send the partition.
+        // This ensures that when the error goes away, we re-send the
+        // partition.
         partition.high_watermark = model::offset{-1};
         include = true;
     }

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -238,6 +238,26 @@ private:
     const model::ntp& _source_or_input;
 };
 
+/**
+ * Enum describing Kafka's control record types. The Control record key schema
+ * is defined as a tuple of [version: int16_t, type: control_record_type].
+ * Currently Kafka protocol uses version 0 of control record schema.
+ *
+ * Internal redpanda control records are propagated with unknown type.
+ * Unknown control records are expected to be ignored by Kafka clients
+ *
+ */
+enum class control_record_type : int16_t {
+    tx_abort = 0,
+    tx_commit = 1,
+    unknown = -1
+};
+
+using control_record_version
+  = named_type<int16_t, struct control_record_version_tag>;
+
+static constexpr control_record_version current_control_record_version{0};
+
 } // namespace model
 
 namespace std {

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -255,6 +255,7 @@ public:
     static constexpr uint16_t compression_mask = 0x7;
     static constexpr uint16_t timestamp_type_mask = 0x8;
     static constexpr uint16_t transactional_mask = 0x10;
+    static constexpr uint16_t control_mask = 0x20;
 
     using type = int16_t;
 
@@ -264,6 +265,8 @@ public:
       : _attributes(v) {}
 
     type value() const { return static_cast<type>(_attributes.to_ulong()); }
+
+    bool is_control() const { return maskable_value() & control_mask; }
 
     bool is_transactional() const {
         return maskable_value() & transactional_mask;
@@ -299,6 +302,8 @@ public:
     void set_timestamp_type(model::timestamp_type t) {
         _attributes.set(3, t == timestamp_type::append_time);
     }
+
+    void set_control_type() { _attributes |= control_mask; }
 
     bool operator==(const record_batch_attributes& other) const {
         return _attributes == other._attributes;

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -283,7 +283,7 @@ make_memory_record_batch_reader(model::record_batch b) {
 // clang-format off
 template<typename Func>
 CONCEPT(requires requires(Func f, model::record_batch&& batch) {
-    { f(batch) } -> std::same_as<model::record_batch>;
+    { f(std::move(batch)) } -> std::same_as<model::record_batch>;
 })
 // clang-format on
 ss::future<record_batch_reader::data_t> transform_reader_to_memory(

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -280,6 +280,36 @@ make_memory_record_batch_reader(model::record_batch b) {
     return make_memory_record_batch_reader(std::move(batches));
 }
 
+// clang-format off
+template<typename Func>
+CONCEPT(requires requires(Func f, model::record_batch&& batch) {
+    { f(batch) } -> std::same_as<model::record_batch>;
+})
+// clang-format on
+ss::future<record_batch_reader::data_t> transform_reader_to_memory(
+  record_batch_reader reader, timeout_clock::time_point timeout, Func&& f) {
+    using data_t = record_batch_reader::data_t;
+    class consumer {
+    public:
+        explicit consumer(Func f)
+          : _func(std::move(f)) {}
+
+        ss::future<ss::stop_iteration> operator()(model::record_batch b) {
+            _result.push_back(_func(std::move(b)));
+            return ss::make_ready_future<ss::stop_iteration>(
+              ss::stop_iteration::no);
+        }
+        record_batch_reader::data_t end_of_stream() {
+            return std::move(_result);
+        }
+
+    private:
+        data_t _result;
+        Func _func;
+    };
+    return std::move(reader).consume(consumer(std::forward<Func>(f)), timeout);
+}
+
 record_batch_reader make_foreign_memory_record_batch_reader(record_batch);
 
 record_batch_reader

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -93,7 +93,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
     }
 
     {
-        info("Fetch offset 0 - expect offsets 1-3");
+        info("Fetch offset 0 - expect offsets 0-3");
         kc::shard_local_cfg().retries.set_value(size_t(0));
         auto res = http_request(
           client,
@@ -104,7 +104,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":"","value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":"","value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":"","value":"bXVsdGlicm9rZXI=","partition":0,"offset":3}])");
+          R"([{"topic":"t","key":"AAD//w==","value":"","partition":0,"offset":0},{"topic":"t","key":"","value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":"","value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":"","value":"bXVsdGlicm9rZXI=","partition":0,"offset":3}])");
     }
 
     {


### PR DESCRIPTION
Added correct handling for control records. Control recoirds are now returned to the client in fetch response to achieve correct offset accounting. We remove payload from redpanda specific control batches in order not to leak any sensitive internal information. 

Kafka reference: 
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java

Librdkafka handling of control records:
https://github.com/edenhill/librdkafka/blob/52c7e353b0122d923d9b89237b266d00701bd7c8/src/rdkafka_msgset_reader.c#L764

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
