### PR TITLE
operator: Remove unnecessary advertised ports

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -71,12 +71,10 @@ type ClusterList struct {
 
 // RedpandaConfig is the definition of the main configuration
 type RedpandaConfig struct {
-	RPCServer		SocketAddress	`json:"rpcServer,omitempty"`
-	AdvertisedRPCAPI	SocketAddress	`json:"advertisedRpcApi,omitempty"`
-	KafkaAPI		SocketAddress	`json:"kafkaApi,omitempty"`
-	AdvertisedKafkaAPI	SocketAddress	`json:"advertisedKafkaApi,omitempty"`
-	AdminAPI		SocketAddress	`json:"admin,omitempty"`
-	DeveloperMode		bool		`json:"developerMode,omitempty"`
+	RPCServer	SocketAddress	`json:"rpcServer,omitempty"`
+	KafkaAPI	SocketAddress	`json:"kafkaApi,omitempty"`
+	AdminAPI	SocketAddress	`json:"admin,omitempty"`
+	DeveloperMode	bool		`json:"developerMode,omitempty"`
 }
 
 // SocketAddress provide the way to configure the port

--- a/src/go/k8s/apis/redpanda/v1alpha1/zz_generated.deepcopy.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/zz_generated.deepcopy.go
@@ -122,9 +122,7 @@ func (in *ClusterStatus) DeepCopy() *ClusterStatus {
 func (in *RedpandaConfig) DeepCopyInto(out *RedpandaConfig) {
 	*out = *in
 	out.RPCServer = in.RPCServer
-	out.AdvertisedRPCAPI = in.AdvertisedRPCAPI
 	out.KafkaAPI = in.KafkaAPI
-	out.AdvertisedKafkaAPI = in.AdvertisedKafkaAPI
 	out.AdminAPI = in.AdminAPI
 }
 

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -45,18 +45,6 @@ spec:
                       port:
                         type: integer
                     type: object
-                  advertisedKafkaApi:
-                    description: SocketAddress provide the way to configure the port
-                    properties:
-                      port:
-                        type: integer
-                    type: object
-                  advertisedRpcApi:
-                    description: SocketAddress provide the way to configure the port
-                    properties:
-                      port:
-                        type: integer
-                    type: object
                   developerMode:
                     type: boolean
                   kafkaApi:

--- a/src/go/k8s/config/samples/redpanda_v1alpha1_cluster.yaml
+++ b/src/go/k8s/config/samples/redpanda_v1alpha1_cluster.yaml
@@ -19,11 +19,7 @@ spec:
   configuration:
     rpcServer:
       port: 33145
-    advertisedRpcApi:
-      port: 33145
     kafkaApi:
-      port: 9092
-    advertisedKafkaApi:
       port: 9092
     admin:
       port: 9644

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -181,7 +181,7 @@ func (r *ConfigMapResource) createConfiguration() interface{} {
 				},
 				AdvertisedRPCAPI: &config.SocketAddress{
 					Address:	"0.0.0.0",
-					Port:		getPort(c.AdvertisedRPCAPI.Port, cr.RPCServer.Port),
+					Port:		getPort(c.RPCServer.Port, cr.RPCServer.Port),
 				},
 				KafkaAPI: config.SocketAddress{
 					Address:	"0.0.0.0",
@@ -189,7 +189,7 @@ func (r *ConfigMapResource) createConfiguration() interface{} {
 				},
 				AdvertisedKafkaAPI: config.SocketAddress{
 					Address:	"0.0.0.0",
-					Port:		getPort(c.AdvertisedKafkaAPI.Port, defaultKafkaAPIPort),
+					Port:		getPort(c.KafkaAPI.Port, defaultKafkaAPIPort),
 				},
 				AdminAPI: config.SocketAddress{
 					Address:	"0.0.0.0",
@@ -202,7 +202,7 @@ func (r *ConfigMapResource) createConfiguration() interface{} {
 						Host: config.SocketAddress{
 							// Example address: cluster-sample-0.cluster-sample.default.svc.cluster.local
 							Address:	r.pandaCluster.Name + "-0." + serviceAddress,
-							Port:		getPort(c.AdvertisedRPCAPI.Port, cr.RPCServer.Port),
+							Port:		getPort(c.RPCServer.Port, cr.RPCServer.Port),
 						},
 					},
 				},
@@ -212,7 +212,7 @@ func (r *ConfigMapResource) createConfiguration() interface{} {
 	}
 
 	cr.RPCServer.Port = getPort(c.RPCServer.Port, cr.RPCServer.Port)
-	cr.AdvertisedRPCAPI.Port = getPort(c.AdvertisedRPCAPI.Port, cr.AdvertisedRPCAPI.Port)
+	cr.AdvertisedRPCAPI.Port = getPort(c.RPCServer.Port, cr.AdvertisedRPCAPI.Port)
 	cr.AdminApi.Port = getPort(c.AdminAPI.Port, cr.AdminApi.Port)
 	cr.RPCServer.Port = getPort(c.RPCServer.Port, cr.RPCServer.Port)
 	cr.DeveloperMode = c.DeveloperMode
@@ -221,7 +221,7 @@ func (r *ConfigMapResource) createConfiguration() interface{} {
 			Host: config.SocketAddress{
 				// Example address: cluster-sample-0.cluster-sample.default.svc.cluster.local
 				Address:	r.pandaCluster.Name + "-0." + serviceAddress,
-				Port:		getPort(c.AdvertisedRPCAPI.Port, cr.AdvertisedRPCAPI.Port),
+				Port:		getPort(c.RPCServer.Port, cr.AdvertisedRPCAPI.Port),
 			},
 		},
 	}

--- a/src/go/k8s/tests/e2e/produce-consume/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-redpanda-cluster.yaml
@@ -19,11 +19,7 @@ spec:
   configuration:
     rpcServer:
       port: 33145
-    advertisedRpcApi:
-      port: 33145
     kafkaApi:
-      port: 9092
-    advertisedKafkaApi:
       port: 9092
     admin:
       port: 9644

--- a/src/go/k8s/tests/e2e/update/01-one-replica.yaml
+++ b/src/go/k8s/tests/e2e/update/01-one-replica.yaml
@@ -16,11 +16,7 @@ spec:
   configuration:
     rpcServer:
       port: 33145
-    advertisedRpcApi:
-      port: 33145
     kafkaApi:
-      port: 9092
-    advertisedKafkaApi:
       port: 9092
     admin:
       port: 9644


### PR DESCRIPTION
In the kubernetes environment the ports will be handled
in the service abstraction not in redpanda itself. The both
advertised_kafka_api and kafka_api ports will be always the same.

For posterity why advertised ports are needed:
https://www.confluent.io/blog/kafka-listeners-explained/

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
