### PR TITLE
kafka: clean up consumer groups when topics are deleted

### DIFF
--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -23,6 +23,7 @@ class partition_manager;
 class shard_table;
 class topics_frontend;
 class topic_table;
+struct topic_table_delta;
 class members_manager;
 class members_table;
 class metadata_cache;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -157,6 +157,9 @@ void topic_table::notify_waiters() {
     }
     std::vector<delta> changes;
     changes.swap(_pending_deltas);
+    for (auto& cb : _notifications) {
+        cb.second(changes);
+    }
     std::vector<std::unique_ptr<waiter>> active_waiters;
     active_waiters.swap(_waiters);
     for (auto& w : active_waiters) {

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -32,7 +32,7 @@ topic_table::transform_topics(Func&& f) const {
     return ret;
 }
 
-topic_table::delta::delta(
+topic_table_delta::topic_table_delta(
   model::ntp ntp,
   cluster::partition_assignment p_as,
   model::offset o,

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -31,26 +31,28 @@ namespace cluster {
 /// with topic creation or deletion are executed. Topic table is also
 /// responsible for commiting or removing pending allocations
 ///
+// delta propagated to backend
+struct topic_table_delta {
+    enum class op_type { add, del, update, update_finished };
+
+    topic_table_delta(
+      model::ntp, cluster::partition_assignment, model::offset, op_type);
+    model::ntp ntp;
+    cluster::partition_assignment p_as;
+    model::offset offset;
+    op_type type;
+
+    model::topic_namespace_view tp_ns() const {
+        return model::topic_namespace_view(ntp);
+    }
+
+    friend std::ostream& operator<<(std::ostream&, const topic_table_delta&);
+    friend std::ostream& operator<<(std::ostream&, const op_type&);
+};
+
 class topic_table {
 public:
-    // delta propagated to backend
-    struct delta {
-        enum class op_type { add, del, update, update_finished };
-
-        delta(
-          model::ntp, cluster::partition_assignment, model::offset, op_type);
-        model::ntp ntp;
-        cluster::partition_assignment p_as;
-        model::offset offset;
-        op_type type;
-
-        model::topic_namespace_view tp_ns() const {
-            return model::topic_namespace_view(ntp);
-        }
-
-        friend std::ostream& operator<<(std::ostream&, const delta&);
-        friend std::ostream& operator<<(std::ostream&, const op_type&);
-    };
+    using delta = topic_table_delta;
 
     bool is_batch_applicable(const model::record_batch& b) const {
         return b.header().type == topic_batch_type;

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1447,6 +1447,96 @@ ss::future<error_code> group::remove() {
     co_return error_code::none;
 }
 
+ss::future<>
+group::remove_topic_partitions(const std::vector<model::topic_partition>& tps) {
+    std::vector<std::pair<model::topic_partition, offset_metadata>> removed;
+    for (const auto& tp : tps) {
+        _pending_offset_commits.erase(tp);
+        if (auto offset = _offsets.extract(tp); offset) {
+            removed.emplace_back(
+              std::move(offset.key()), std::move(offset.mapped()));
+        }
+    }
+
+    // if no members and no offsets
+    if (
+      in_state(group_state::empty) && _pending_offset_commits.empty()
+      && _offsets.empty()) {
+        vlog(
+          klog.debug,
+          "Marking group {} as dead at {} generation",
+          _id,
+          generation());
+
+        set_state(group_state::dead);
+    }
+
+    if (removed.empty()) {
+        co_return;
+    }
+
+    _offsets.rehash(0);
+    _pending_offset_commits.rehash(0);
+
+    // build offset tombstones
+    storage::record_batch_builder builder(
+      raft::data_batch_type, model::offset(0));
+
+    // create deletion records for offsets from deleted partitions
+    for (auto& offset : removed) {
+        vlog(
+          klog.trace, "Removing offset for group {} tp {}", _id, offset.first);
+
+        group_log_record_key key{
+          .record_type = group_log_record_key::type::offset_commit,
+          .key = reflection::to_iobuf(group_log_offset_key{
+            _id,
+            offset.first.topic,
+            offset.first.partition,
+          }),
+        };
+
+        builder.add_raw_kv(reflection::to_iobuf(std::move(key)), std::nullopt);
+    }
+
+    // gc the group?
+    if (in_state(group_state::dead) && generation() > 0) {
+        group_log_record_key key{
+          .record_type = group_log_record_key::type::group_metadata,
+          .key = reflection::to_iobuf(_id),
+        };
+        builder.add_raw_kv(reflection::to_iobuf(std::move(key)), std::nullopt);
+    }
+
+    auto batch = std::move(builder).build();
+    auto reader = model::make_memory_record_batch_reader(std::move(batch));
+
+    try {
+        auto result = co_await _partition->replicate(
+          std::move(reader),
+          raft::replicate_options(raft::consistency_level::quorum_ack));
+        if (result) {
+            vlog(
+              klog.trace,
+              "Replicated group cleanup record {} at offset {}",
+              _id,
+              result.value().last_offset);
+        } else {
+            vlog(
+              klog.error,
+              "Error occured replicating group {} cleanup records {}",
+              _id,
+              result.error());
+        }
+    } catch (const std::exception& e) {
+        vlog(
+          klog.error,
+          "Exception occured replicating group {} cleanup records {}",
+          _id,
+          e);
+    }
+}
+
 std::ostream& operator<<(std::ostream& o, const group& g) {
     fmt::print(
       o,

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -420,6 +420,10 @@ public:
     // is returned for the current state.
     ss::future<error_code> remove();
 
+    // remove offsets associated with topic partitions
+    ss::future<>
+    remove_topic_partitions(const std::vector<model::topic_partition>& tps);
+
 private:
     using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
     using protocol_support = absl::node_hash_map<kafka::protocol_name, int>;

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -112,6 +112,7 @@ public:
     group_manager(
       ss::sharded<raft::group_manager>& gm,
       ss::sharded<cluster::partition_manager>& pm,
+      ss::sharded<cluster::topic_table>&,
       config::configuration& conf);
 
     ss::future<> start();
@@ -182,9 +183,15 @@ private:
       _partitions;
 
     cluster::notification_id_type _leader_notify_handle;
+    cluster::notification_id_type _topic_table_notify_handle;
 
     void handle_leader_change(
       ss::lw_shared_ptr<cluster::partition>, std::optional<model::node_id>);
+
+    void handle_topic_delta(const std::vector<cluster::topic_table_delta>&);
+
+    ss::future<> cleanup_removed_topic_partitions(
+      const std::vector<model::topic_partition>&);
 
     ss::future<> handle_partition_leader_change(
       ss::lw_shared_ptr<attached_partition>,
@@ -199,6 +206,7 @@ private:
 
     ss::sharded<raft::group_manager>& _gm;
     ss::sharded<cluster::partition_manager>& _pm;
+    ss::sharded<cluster::topic_table>& _topic_table;
     config::configuration& _conf;
     absl::node_hash_map<group_id, group_ptr> _groups;
     model::broker _self;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -431,6 +431,7 @@ void application::wire_up_services() {
       _group_manager,
       std::ref(raft_group_manager),
       std::ref(partition_manager),
+      std::ref(controller->get_topics_state()),
       std::ref(config::shard_local_cfg()))
       .get();
     syschecks::systemd_message("Creating kafka group shard mapper").get();


### PR DESCRIPTION
The consumer group manager subscribes to topic delete events. A delete event is handled by removing offsets for topic partitions from each group. If the resulting group is empty the group is fully removed.

I have done some manual testing with kafka cli tools. Ducktape tests are forthcoming.