### PR TITLE
Remove unity builds from our build system

### DIFF
--- a/.github/workflows/redpanda-build.yml
+++ b/.github/workflows/redpanda-build.yml
@@ -58,5 +58,5 @@ jobs:
             ccache -p # print the config
             ccache -s # print the stats before reusing
             ccache -z # zero the stats
-            ./build.sh -DCMAKE_UNITY_BUILD=ON
+            ./build.sh
             ccache -s # print the stats after the build


### PR DESCRIPTION
To explain the rational behind this change, when writing some coroutine code and building with UNITY enabled, often I am presented with subobject-linkage errors like this:
```
'coproc::wasm::script_dispatcher::enable_coprocessors(coproc::enable_copros_request)::_ZN6coproc4wasm17script_dispatcher19enable_coprocessorsENS_21enable_copros_requestE.frame' has a field 'coproc::wasm::script_dispatcher::enable_coprocessors(coproc::enable_copros_request)::_ZN6coproc4wasm17script_dispatcher19enable_coprocessorsENS_21enable_copros_requestE.frame::__D.1815276.5.8' whose type has no linkage [-Werror=subobject-linkage]
```
In earlier patches my solution was to move around source code, have a coroutine call non-coroutine code like in this source file  https://github.com/vectorizedio/redpanda/blob/dev/src/v/coproc/offset_storage_utils.cc#L119.

The compiler complains that a coroutine construct has no linkage, so workarounds like tagging the method as static or putting the method in a static namespace do resolve the issue, probably due to sidestepping ODR issues. However this can't be a solution in all cases such as when using coroutines in instance methods of a class that is meant to be publicly accessible.

I am proposing we remove the UNITY build (until it works again with coroutines) because there is no seemingly fundamental issue for why code built without it (on clang and g++) passes, while when building with UNITY it fails other then their being a bug with unity.  When it is resolved we can just readd the feature, the history is in the source tree.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
