### PR TITLE
r/tests: removed log truncation from tests to prevent races

### DIFF
--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -202,11 +202,10 @@ FIXTURE_TEST(test_empty_node_recovery, raft_test_fixture) {
         if (gr.get_leader_id() != id) {
             disabled_id = id;
             // truncate the node log
-            m.log
-              ->truncate(storage::truncate_config(
-                model::offset(0), ss::default_priority_class()))
-              .get();
+            auto path = m.log->config().work_directory();
+            // remove node directory
             gr.disable_node(id);
+            std::filesystem::remove_all(std::filesystem::path(path));
             break;
         }
     }
@@ -235,12 +234,10 @@ FIXTURE_TEST(test_empty_node_recovery_relaxed_consistency, raft_test_fixture) {
         // disable one of the non leader nodes
         if (gr.get_leader_id() != id) {
             disabled_id = id;
-            // truncate the node log
-            m.log
-              ->truncate(storage::truncate_config(
-                model::offset(0), ss::default_priority_class()))
-              .get();
+            auto path = m.log->config().work_directory();
+            // remove node directory
             gr.disable_node(id);
+            std::filesystem::remove_all(std::filesystem::path(path));
             break;
         }
     }


### PR DESCRIPTION
Tests concerning empty node recovery were using truncation to simulate
node log loss. Accessing log interface outside of the raft internal
mutex caused concurrent operations on segment, leading to assertion
being triggered in segment appender. Fixed the issue by replacing log
truncation with simple folder deletion.

Fixes: #614 

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
