### PR TITLE
operator: disable wsl linter

### DIFF
--- a/src/go/k8s/.golangci.yml
+++ b/src/go/k8s/.golangci.yml
@@ -80,7 +80,6 @@ linters:
     - nestif
     - prealloc
     - testpackage
-    - wsl
 
   # don't enable:
   # - gochecknoinits # the kubebuilder and kubernetes library enforce using init functions


### PR DESCRIPTION
I am proposing to disable this for now. I feel like with this on, my code is full of whitespaces and not in a good way. I know this is matter of taste so I am opening it up for discussion.

e.g. take a look at this example https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-assign-and-anything (before and after). I feel like the one enforced by the linter is just too many whitespaces.

Right now this particular thing cannot be disabled through golangci lint https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/wsl.go#L40