### PR TITLE
archival: Add archival scheduler service

### DIFF
--- a/src/v/archival/CMakeLists.txt
+++ b/src/v/archival/CMakeLists.txt
@@ -10,5 +10,11 @@ v_cc_library(
     v::bytes
     v::http
     v::s3
+    v::json
+    v::model
+    v::storage
+    v::cluster
+    v::config
+    v::rphashing
 )
 add_subdirectory(tests)

--- a/src/v/archival/CMakeLists.txt
+++ b/src/v/archival/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   NAME archival
   SRCS
     archival_policy.cc
+    service.cc
     ntp_archiver_service.cc
     manifest.cc
   DEPS

--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -44,7 +44,6 @@ public:
               .size_bytes = segment->size_bytes(),
               .base_offset = segment->offsets().base_offset,
               .committed_offset = segment->offsets().committed_offset,
-              .is_deleted_locally = false,
             };
             auto path = std::filesystem::path(segment->reader().filename());
             auto seg_name = path.filename().string();

--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -10,89 +10,176 @@
 
 #include "archival/archival_policy.h"
 
+#include "archival/logger.h"
 #include "storage/disk_log_impl.h"
+#include "storage/fs_utils.h"
 #include "storage/segment.h"
 #include "storage/segment_set.h"
+#include "storage/version.h"
+#include "vlog.h"
+
+#include <seastar/core/shared_ptr.hh>
 
 namespace archival {
 
-class arch_policy_non_compacted_impl {
-public:
-    arch_policy_non_compacted_impl(
-      model::ntp ntp, const model::revision_id& rev)
-      : _ntp(std::move(ntp))
-      , _rev(rev) {}
-
-    std::optional<manifest> make_local_manifest(storage::log_manager& lm) {
-        manifest tmp(_ntp, _rev);
-        std::optional<storage::log> log = lm.get(_ntp);
-        if (!log) {
-            return std::nullopt;
-        }
-        auto plog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
-        if (plog == nullptr) {
-            return std::nullopt;
-        }
-        for (const auto& segment : plog->segments()) {
-            bool closed = !segment->has_appender();
-            bool compacted = segment->is_compacted_segment();
-            if (!closed || compacted) {
-                continue;
-            }
-            manifest::segment_meta meta{
-              .is_compacted = segment->is_compacted_segment(),
-              .size_bytes = segment->size_bytes(),
-              .base_offset = segment->offsets().base_offset,
-              .committed_offset = segment->offsets().committed_offset,
-            };
-            auto path = std::filesystem::path(segment->reader().filename());
-            auto seg_name = path.filename().string();
-            // generate segment path
-            tmp.add(segment_name(seg_name), meta);
-        }
-        return tmp;
-    }
-
-private:
-    model::ntp _ntp;
-    model::revision_id _rev;
-};
-
-template<class PolicyImpl>
-class manifest_based_policy final
-  : public PolicyImpl
-  , public archival_policy_base {
-public:
-    manifest_based_policy(const model::ntp& ntp, const model::revision_id& rev)
-      : PolicyImpl(ntp, rev) {}
-
-    std::optional<manifest> generate_upload_set(
-      const manifest& remote, storage::log_manager& lm) final {
-        auto local = PolicyImpl::make_local_manifest(lm);
-        if (!local) {
-            return local;
-        }
-        return local->difference(remote);
-    }
-
-    std::optional<manifest> generate_delete_set(
-      const manifest& remote, storage::log_manager& lm) final {
-        auto local = PolicyImpl::make_local_manifest(lm);
-        if (!local) {
-            return local;
-        }
-        return remote.difference(*local);
-    }
-};
-
-using manifest_based_policy_non_compacted
-  = manifest_based_policy<arch_policy_non_compacted_impl>;
-
-std::unique_ptr<archival_policy_base> make_archival_policy(
-  [[maybe_unused]] upload_policy_selector e,
-  [[maybe_unused]] delete_policy_selector d,
-  model::ntp ntp,
-  model::revision_id rev) {
-    return std::make_unique<manifest_based_policy_non_compacted>(ntp, rev);
+std::ostream& operator<<(std::ostream& s, const upload_candidate& c) {
+    s << "{ exposed_name: " << c.exposed_name
+      << ", starting_offset: " << c.starting_offset
+      << ", segment_file_name: " << c.source->reader().filename() << " }";
+    return s;
 }
+
+archival_policy::archival_policy(model::ntp ntp)
+  : _ntp(std::move(ntp)) {}
+
+archival_policy::lookup_result archival_policy::find_segment(
+  model::offset last_offset, storage::log_manager& lm) {
+    vlog(
+      archival_log.trace,
+      "Upload policy for {} invoked, last-offset: {}",
+      _ntp,
+      last_offset);
+    std::optional<storage::log> log = lm.get(_ntp);
+    if (!log) {
+        vlog(archival_log.trace, "Upload policy for {} no such ntp", _ntp);
+        return {};
+    }
+    auto plog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
+    // NOTE: we need to break encapsulation here to access underlying
+    // implementation because upload policy and archival subsystem needs to
+    // access individual log segments (disk backed).
+    if (plog == nullptr || plog->segment_count() == 0) {
+        vlog(
+          archival_log.trace,
+          "Upload policy for {} no segments or in-memory log",
+          _ntp);
+        return {};
+    }
+    const auto& set = plog->segments();
+    const auto& ntp_conf = plog->config();
+    auto it = set.lower_bound(last_offset);
+    if (it == set.end() || (*it)->is_compacted_segment()) {
+        // Skip forward if we hit a gap or compacted segment
+        for (auto i = set.begin(); i != set.end(); i++) {
+            const auto& sg = *i;
+            if (last_offset < sg->offsets().base_offset) {
+                // Move last offset forward
+                it = i;
+                last_offset = sg->offsets().base_offset;
+                break;
+            }
+        }
+    }
+    if (it == set.end()) {
+        vlog(
+          archival_log.trace,
+          "Upload policy for {}, upload candidate is not found",
+          _ntp);
+        return {};
+    }
+    // Invariant: it != set.end()
+    bool closed = !(*it)->has_appender();
+    if (!closed) {
+        // Fast path, next upload candidate is not yet sealed. We may want to
+        // optimize this case because it's expected to happen pretty often. This
+        // can be done by saving weak_ptr to the segment inside the policy
+        // object. The segment must be changed to derive from
+        // ss::weakly_referencable.
+        vlog(
+          archival_log.trace,
+          "Upload policy for {}, upload candidate is not closed",
+          _ntp);
+        return {};
+    }
+    return {.segment = *it, .ntp_conf = &ntp_conf};
+}
+
+/// \brief Initializes upload_candidate structure taking into account
+///        possible segment overlaps at 'off'
+///
+/// \param off is a last_offset from manifest
+/// \param segment is a segment that has this offset
+/// \param ntp_conf is a ntp_config of the partition
+///
+/// \note Normally, the segments on a single node doesn't overlap,
+///       but when leadership changes the new node will have to deal
+///       with the situaiton when 'last_offset' doesn't match base
+///       offset of any segment. In this situation we need to find
+///       the segment that contains the 'last_offset' and find the
+///       exact location of the 'last_offset' inside the segment (
+///       or nearset offset, because index is sampled). Then we need
+///       to compute file offset of the upload, content length and
+///       new base offset (and new segment name for S3).
+///       Example: last_offset is 1000, and we have segment with the
+///       name '900-1-v1.log'. We should find offset 1000 inside it
+///       and upload starting from it. The resulting file should have
+///       a name '1000-1-v1.log'. If we were only able to find offset
+///       990 instead of 1000, we will upload starting from it and
+///       the name will be '990-1-v1.log'.
+static upload_candidate create_upload_candidate(
+  model::offset off,
+  const ss::lw_shared_ptr<storage::segment>& segment,
+  const storage::ntp_config* ntp_conf) {
+    auto term = segment->offsets().term;
+    auto version = storage::record_version_type::v1;
+    auto meta = storage::segment_path::parse_segment_filename(
+      segment->reader().filename());
+    if (meta) {
+        version = meta->version;
+    }
+    size_t fsize = segment->reader().file_size();
+    auto ix = segment->index().find_nearest(off);
+    if (ix.has_value() == false || segment->offsets().base_offset == off) {
+        // Fast path, base_offset matches the query or we can't lookup offsets
+        // because there is no index
+        auto orig_path = std::filesystem::path(segment->reader().filename());
+        vlog(
+          archival_log.debug,
+          "Uploading full segment {} offset {}",
+          segment->reader().filename(),
+          off);
+        return {
+          .source = segment,
+          .exposed_name = segment_name(orig_path.filename().string()),
+          .starting_offset = segment->offsets().base_offset,
+          .file_offset = 0,
+          .content_length = fsize};
+    }
+    size_t pos = ix ? ix->filepos : 0;
+    model::offset exposed_offset = ix ? ix->offset : meta->base_offset;
+    size_t clen = fsize - pos;
+    auto path = storage::segment_path::make_segment_path(
+      *ntp_conf, exposed_offset, term, version);
+    vlog(
+      archival_log.debug,
+      "Uploading part of the segment {} starting from offset {}, file offset: "
+      "{}, length: {}, new path: {}",
+      segment->reader().filename(),
+      exposed_offset,
+      pos,
+      clen,
+      path);
+    return {
+      .source = segment,
+      .exposed_name = segment_name(path.filename().string()),
+      .starting_offset = exposed_offset,
+      .file_offset = pos,
+      .content_length = clen};
+}
+
+upload_candidate archival_policy::get_next_candidate(
+  model::offset last_offset, storage::log_manager& lm) {
+    auto [segment, ntp_conf] = find_segment(last_offset, lm);
+    if (segment.get() == nullptr || ntp_conf == nullptr) {
+        return {};
+    }
+    // Invariant: segment is not compacted (segment->is_compacted_segment() ==
+    // false)
+    auto end = segment->offsets().committed_offset;
+    if (end > last_offset) {
+        return create_upload_candidate(last_offset, segment, ntp_conf);
+    }
+    return {};
+}
+
 } // namespace archival

--- a/src/v/archival/manifest.cc
+++ b/src/v/archival/manifest.cc
@@ -14,15 +14,18 @@
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iobuf_ostreambuf.h"
-#include "hashing/murmur.h"
+#include "cluster/types.h"
+#include "hashing/xx.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/timestamp.h"
 #include "storage/ntp_config.h"
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/ostreamwrapper.h>
@@ -31,18 +34,32 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 
 namespace archival {
 
 manifest::manifest()
   : _ntp()
-  , _rev() {}
+  , _rev()
+  , _last_offset(0) {}
 
 manifest::manifest(model::ntp ntp, model::revision_id rev)
   : _ntp(std::move(ntp))
-  , _rev(rev) {}
+  , _rev(rev)
+  , _last_offset(0) {}
 
-remote_manifest_path manifest::get_manifest_path() const {
+// NOTE: the methods that generate remote paths use the xxhash function
+// to randomize the prefix. S3 groups the objects into chunks based on
+// these prefixes. It also applies rate limit to chunks so if all segments
+// and manifests will have the same prefix we will be able to do around
+// 3000-5000 req/sec. AWS doc mentions that having only two prefix
+// characters should be enough for most workloads
+// (https://aws.amazon.com/blogs/aws/amazon-s3-performance-tips-tricks-seattle-hiring-event/)
+// We're using eight because it's free and because AWS S3 is not the only
+// backend and other S3 API implementations might benefit from that.
+
+static remote_manifest_path generate_partition_manifest_path(
+  const model::ntp& ntp, model::revision_id rev) {
     // NOTE: the idea here is to split all possible hash values into
     // 16 bins. Every bin should have lowest 28-bits set to 0.
     // As result, for segment names all prefixes are possible, but
@@ -50,20 +67,26 @@ remote_manifest_path manifest::get_manifest_path() const {
     // are used. This will allow us to quickly find all manifests
     // that S3 bucket contains.
     constexpr uint32_t bitmask = 0xF0000000;
-    auto path = fmt::format("{}_{}", _ntp.path(), _rev());
-    uint32_t hash = bitmask & murmurhash3_x86_32(path.data(), path.size());
-    return remote_manifest_path(fmt::format(
-      "{:08x}/meta/{}_{}/manifest.json", hash, _ntp.path(), _rev()));
+    auto path = fmt::format("{}_{}", ntp.path(), rev());
+    uint32_t hash = bitmask & xxhash_32(path.data(), path.size());
+    return remote_manifest_path(
+      fmt::format("{:08x}/meta/{}_{}/manifest.json", hash, ntp.path(), rev()));
+}
+
+remote_manifest_path manifest::get_manifest_path() const {
+    return generate_partition_manifest_path(_ntp, _rev);
 }
 
 remote_segment_path
 manifest::get_remote_segment_path(const segment_name& name) const {
     auto path = fmt::format("{}_{}/{}", _ntp.path(), _rev(), name());
-    uint32_t hash = murmurhash3_x86_32(path.data(), path.size());
+    uint32_t hash = xxhash_32(path.data(), path.size());
     return remote_segment_path(fmt::format("{:08x}/{}", hash, path));
 }
 
 const model::ntp& manifest::get_ntp() const { return _ntp; }
+
+const model::offset manifest::get_last_offset() const { return _last_offset; }
 
 model::revision_id manifest::get_revision_id() const { return _rev; }
 
@@ -79,6 +102,7 @@ bool manifest::contains(const segment_name& obj) const {
 
 bool manifest::add(const segment_name& key, const segment_meta& meta) {
     auto [it, ok] = _segments.insert(std::make_pair(key, meta));
+    _last_offset = std::max(meta.committed_offset, _last_offset);
     return ok;
 }
 
@@ -130,11 +154,16 @@ ss::future<> manifest::update(ss::input_stream<char>&& is) {
 
 void manifest::update(const rapidjson::Document& m) {
     using namespace rapidjson;
+    auto ver = model::partition_id(m["version"].GetInt());
+    if (ver != static_cast<int>(manifest_version::v1)) {
+        throw std::runtime_error("manifest version not supported");
+    }
     auto ns = model::ns(m["namespace"].GetString());
     auto tp = model::topic(m["topic"].GetString());
     auto pt = model::partition_id(m["partition"].GetInt());
     _rev = model::revision_id(m["revision"].GetInt());
     _ntp = model::ntp(ns, tp, pt);
+    _last_offset = model::offset(m["last_offset"].GetInt64());
     segment_map tmp;
     if (m.HasMember("segments")) {
         const auto& s = m["segments"].GetObject();
@@ -148,7 +177,6 @@ void manifest::update(const rapidjson::Document& m) {
               .size_bytes = static_cast<size_t>(size_bytes),
               .base_offset = model::offset(boffs),
               .committed_offset = model::offset(coffs),
-              .is_deleted_locally = it->value["deleted"].GetBool(),
             };
             tmp.insert(std::make_pair(name, meta));
         }
@@ -156,14 +184,15 @@ void manifest::update(const rapidjson::Document& m) {
     std::swap(tmp, _segments);
 }
 
-std::tuple<ss::input_stream<char>, size_t> manifest::serialize() const {
+serialized_json_stream manifest::serialize() const {
     iobuf serialized;
     iobuf_ostreambuf obuf(serialized);
     std::ostream os(&obuf);
     serialize(os);
     size_t size_bytes = serialized.size_bytes();
-    return std::make_tuple(
-      make_iobuf_input_stream(std::move(serialized)), size_bytes);
+    return {
+      .stream = make_iobuf_input_stream(std::move(serialized)),
+      .size_bytes = size_bytes};
 }
 
 void manifest::serialize(std::ostream& out) const {
@@ -171,6 +200,8 @@ void manifest::serialize(std::ostream& out) const {
     OStreamWrapper wrapper(out);
     Writer<OStreamWrapper> w(wrapper);
     w.StartObject();
+    w.Key("version");
+    w.Int(static_cast<int>(manifest_version::v1));
     w.Key("namespace");
     w.String(_ntp.ns().c_str());
     w.Key("topic");
@@ -179,6 +210,8 @@ void manifest::serialize(std::ostream& out) const {
     w.Int64(_ntp.tp.partition());
     w.Key("revision");
     w.Int64(_rev());
+    w.Key("last_offset");
+    w.Int64(_last_offset());
     if (!_segments.empty()) {
         w.Key("segments");
         w.StartObject();
@@ -193,8 +226,6 @@ void manifest::serialize(std::ostream& out) const {
             w.Int64(meta.committed_offset());
             w.Key("base_offset");
             w.Int64(meta.base_offset());
-            w.Key("deleted");
-            w.Bool(meta.is_deleted_locally);
             w.EndObject();
         }
         w.EndObject();
@@ -211,13 +242,198 @@ bool manifest::delete_permanently(const segment_name& name) {
     return false;
 }
 
-bool manifest::mark_as_deleted(const segment_name& name) {
-    auto it = _segments.find(name);
-    if (it != _segments.end() && it->second.is_deleted_locally == false) {
-        it->second.is_deleted_locally = true;
-        return true;
+topic_manifest::topic_manifest(
+  const cluster::topic_configuration& cfg, model::revision_id rev)
+  : _topic_config(cfg)
+  , _rev(rev) {}
+
+topic_manifest::topic_manifest()
+  : _topic_config(std::nullopt) {}
+
+ss::future<> topic_manifest::update(ss::input_stream<char>&& is) {
+    using namespace rapidjson;
+    iobuf result;
+    auto os = make_iobuf_ref_output_stream(result);
+    co_await ss::copy(is, os);
+    iobuf_istreambuf ibuf(result);
+    std::istream stream(&ibuf);
+    Document m;
+    IStreamWrapper wrapper(stream);
+    m.ParseStream(wrapper);
+    update(m);
+    co_return;
+}
+
+void topic_manifest::update(const rapidjson::Document& m) {
+    using namespace rapidjson;
+    auto ver = m["version"].GetInt();
+    if (ver != static_cast<int>(topic_manifest_version::v1)) {
+        throw std::runtime_error("topic manifest version not supported");
     }
-    return false;
+    auto ns = model::ns(m["namespace"].GetString());
+    auto tp = model::topic(m["topic"].GetString());
+    int32_t partitions = m["partition_count"].GetInt();
+    int16_t rf = m["replication_factor"].GetInt();
+    int32_t rev = m["revision_id"].GetInt();
+    cluster::topic_configuration conf(ns, tp, partitions, rf);
+    // optional
+    if (!m["compression"].IsNull()) {
+        conf.compression = boost::lexical_cast<model::compression>(
+          m["compression"].GetString());
+    }
+    if (!m["cleanup_policy_bitflags"].IsNull()) {
+        conf.cleanup_policy_bitflags
+          = boost::lexical_cast<model::cleanup_policy_bitflags>(
+            m["cleanup_policy_bitflags"].GetString());
+    }
+    if (!m["compaction_strategy"].IsNull()) {
+        conf.compaction_strategy
+          = boost::lexical_cast<model::compaction_strategy>(
+            m["compaction_strategy"].GetString());
+    }
+    if (!m["timestamp_type"].IsNull()) {
+        conf.timestamp_type = boost::lexical_cast<model::timestamp_type>(
+          m["timestamp_type"].GetString());
+    }
+    if (!m["segment_size"].IsNull()) {
+        conf.segment_size = m["segment_size"].GetInt64();
+    }
+    // tristate
+    if (m.HasMember("retention_bytes")) {
+        if (!m["retention_bytes"].IsNull()) {
+            conf.retention_bytes = tristate<size_t>(
+              m["retention_bytes"].GetInt64());
+        } else {
+            conf.retention_bytes = tristate<size_t>(std::nullopt);
+        }
+    }
+    if (m.HasMember("retention_duration")) {
+        if (!m["retention_duration"].IsNull()) {
+            conf.retention_duration = tristate<std::chrono::milliseconds>(
+              std::chrono::milliseconds(m["retention_duration"].GetInt64()));
+        } else {
+            conf.retention_duration = tristate<std::chrono::milliseconds>(
+              std::nullopt);
+        }
+    }
+    _topic_config = conf;
+    _rev = model::revision_id(rev);
+}
+
+serialized_json_stream topic_manifest::serialize() const {
+    iobuf serialized;
+    iobuf_ostreambuf obuf(serialized);
+    std::ostream os(&obuf);
+    serialize(os);
+    size_t size_bytes = serialized.size_bytes();
+    return {
+      .stream = make_iobuf_input_stream(std::move(serialized)),
+      .size_bytes = size_bytes};
+}
+
+void topic_manifest::serialize(std::ostream& out) const {
+    using namespace rapidjson;
+    OStreamWrapper wrapper(out);
+    Writer<OStreamWrapper> w(wrapper);
+    w.StartObject();
+    w.Key("version");
+    w.Int(static_cast<int>(manifest_version::v1));
+    w.Key("namespace");
+    w.String(_topic_config->tp_ns.ns());
+    w.Key("topic");
+    w.String(_topic_config->tp_ns.tp());
+    w.Key("partition_count");
+    w.Int(_topic_config->partition_count);
+    w.Key("replication_factor");
+    w.Int(_topic_config->replication_factor);
+    w.Key("revision_id");
+    w.Int(_rev());
+
+    // optional values are encoded in the following manner:
+    // - key set to null - optional is nullopt
+    // - key is not null - optional has value
+    w.Key("compression");
+    if (_topic_config->compression.has_value()) {
+        w.String(boost::lexical_cast<std::string>(*_topic_config->compression));
+    } else {
+        w.Null();
+    }
+    w.Key("cleanup_policy_bitflags");
+    if (_topic_config->cleanup_policy_bitflags.has_value()) {
+        w.String(boost::lexical_cast<std::string>(
+          *_topic_config->cleanup_policy_bitflags));
+    } else {
+        w.Null();
+    }
+    w.Key("compaction_strategy");
+    if (_topic_config->compaction_strategy.has_value()) {
+        w.String(boost::lexical_cast<std::string>(
+          *_topic_config->compaction_strategy));
+    } else {
+        w.Null();
+    }
+    w.Key("timestamp_type");
+    if (_topic_config->timestamp_type.has_value()) {
+        w.String(
+          boost::lexical_cast<std::string>(*_topic_config->timestamp_type));
+    } else {
+        w.Null();
+    }
+    w.Key("segment_size");
+    if (_topic_config->segment_size.has_value()) {
+        w.Int64(*_topic_config->segment_size);
+    } else {
+        w.Null();
+    }
+    // NOTE: manifest_object_name is intentionaly ommitted
+
+    // tristate values are encoded in the following manner:
+    // - key not present - tristate is disabled
+    // - key set to null - tristate is enabled but not set
+    // - key is not null - tristate is enabled and set
+    if (!_topic_config->retention_bytes.is_disabled()) {
+        w.Key("retention_bytes");
+        if (_topic_config->retention_bytes.has_value()) {
+            w.Int64(_topic_config->retention_bytes.value());
+        } else {
+            w.Null();
+        }
+    }
+    if (!_topic_config->retention_duration.is_disabled()) {
+        w.Key("retention_duration");
+        if (_topic_config->retention_duration.has_value()) {
+            w.Int64(_topic_config->retention_duration.value().count());
+        } else {
+            w.Null();
+        }
+    }
+    w.EndObject();
+}
+
+remote_manifest_path topic_manifest::get_manifest_path() const {
+    // The path is <prefix>/meta/<ns>/<topic>/topic_manifest.json
+    vassert(_topic_config, "Topic config is not set");
+    constexpr uint32_t bitmask = 0xF0000000;
+    auto path = fmt::format(
+      "{}/{}", _topic_config->tp_ns.ns(), _topic_config->tp_ns.tp());
+    uint32_t hash = bitmask & xxhash_32(path.data(), path.size());
+    return remote_manifest_path(
+      fmt::format("{:08x}/meta/{}/topic_manifest.json", hash, path));
+}
+
+std::vector<remote_manifest_path>
+topic_manifest::get_partition_manifests() const {
+    std::vector<remote_manifest_path> result;
+    int32_t npart = _topic_config->partition_count;
+    for (int32_t i = 0; i < npart; i++) {
+        model::ntp ntp(
+          _topic_config->tp_ns.ns(),
+          _topic_config->tp_ns.tp(),
+          model::partition_id(i));
+        auto path = generate_partition_manifest_path(ntp, _rev);
+        result.emplace_back(std::move(path));
+    }
+    return result;
 }
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -64,7 +64,7 @@ ss::future<bool> ntp_archiver::download_manifest() {
         auto resp = co_await client.get_object(_bucket, path);
         co_await _remote.update(resp->as_input_stream());
     } catch (const s3::rest_error_response& err) {
-        if (err.code() == "NoSuchKey") {
+        if (err.code() == s3::s3_error_code::no_such_key) {
             // This can happen when we're dealing with new partition for which
             // manifest wasn't uploaded. But also, this can appen if we uploaded
             // the first segment and crashed before we were able to upload the

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -19,49 +19,68 @@
 #include "utils/gate_guard.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/file.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/when_all.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 #include <fmt/format.h>
 
+#include <exception>
 #include <stdexcept>
 
 namespace archival {
+
+std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
+    fmt::print(
+      o,
+      "{{bucket_name: {}, interval: {}, client_config: {}, connection_limit: "
+      "{}}}",
+      cfg.bucket_name,
+      cfg.interval.count(),
+      cfg.client_config,
+      cfg.connection_limit);
+    return o;
+}
 
 ntp_archiver::ntp_archiver(
   const storage::ntp_config& ntp, const configuration& conf)
   : _ntp(ntp.ntp())
   , _rev(ntp.get_revision())
   , _client_conf(conf.client_config)
-  , _policy(
-      make_archival_policy(conf.upload_policy, conf.delete_policy, _ntp, _rev))
+  , _policy(_ntp)
   , _bucket(conf.bucket_name)
   , _remote(_ntp, _rev)
   , _gate() {
     vlog(archival_log.trace, "Create ntp_archiver {}", _ntp.path());
 }
 
-ss::future<> ntp_archiver::stop() { return _gate.close(); }
+ss::future<> ntp_archiver::stop() {
+    _as.request_abort();
+    return _gate.close();
+}
 
 const model::ntp& ntp_archiver::get_ntp() const { return _ntp; }
+
+model::revision_id ntp_archiver::get_revision_id() const { return _rev; }
 
 const ss::lowres_clock::time_point ntp_archiver::get_last_upload_time() const {
     return _last_upload_time;
 }
 
-const ss::lowres_clock::time_point ntp_archiver::get_last_delete_time() const {
-    return _last_delete_time;
-}
-
-ss::future<bool> ntp_archiver::download_manifest() {
+ss::future<download_manifest_result> ntp_archiver::download_manifest() {
     gate_guard guard{_gate};
     auto key = _remote.get_manifest_path();
-    vlog(archival_log.trace, "Download manifest {}", key());
+    vlog(archival_log.debug, "Download manifest {}", key());
     auto path = s3::object_key(key());
-    s3::client client(_client_conf);
+    s3::client client(_client_conf, _as);
+    auto result = download_manifest_result::success;
     try {
         auto resp = co_await client.get_object(_bucket, path);
+        vlog(archival_log.debug, "Receive OK response from {}", path);
         co_await _remote.update(resp->as_input_stream());
     } catch (const s3::rest_error_response& err) {
         if (err.code() == s3::s3_error_code::no_such_key) {
@@ -70,220 +89,247 @@ ss::future<bool> ntp_archiver::download_manifest() {
             // the first segment and crashed before we were able to upload the
             // manifest. This shouldn't be the problem though. We will just
             // re-upload this segment for once.
-            co_return false;
+            vlog(archival_log.debug, "NoSuchKey response received {}", path);
+            result = download_manifest_result::notfound;
+        } else if (err.code() == s3::s3_error_code::slow_down) {
+            // This can happen when we're dealing with high request rate to the
+            // manifest's prefix.
+            vlog(archival_log.debug, "SlowDown response received {}", path);
+            result = download_manifest_result::backoff;
+        } else {
+            throw;
         }
-        throw;
     }
     co_await client.shutdown();
-    co_return true;
+    co_return result;
 }
 
 ss::future<> ntp_archiver::upload_manifest() {
     gate_guard guard{_gate};
+    vlog(archival_log.debug, "Uploading manifest for {}", _ntp);
+    ss::lowres_clock::duration backoff = 4ms;
+    int backoff_quota = 8; // max backoff time should be close to 10s
     auto key = _remote.get_manifest_path();
     vlog(archival_log.trace, "Upload manifest {}", key());
     auto path = s3::object_key(key());
-    auto [is, size] = _remote.serialize();
-    s3::client client(_client_conf);
-    co_await client.put_object(_bucket, path, size, std::move(is));
-    co_await client.shutdown();
+    std::vector<s3::object_tag> tags = {{"rp-type", "partition-manifest"}};
+    while (!_gate.is_closed() && backoff_quota-- > 0) {
+        bool slowdown = false;
+        s3::client client(_client_conf, _as);
+        try {
+            auto [is, size] = _remote.serialize();
+            co_await client.put_object(
+              _bucket, path, size, std::move(is), tags);
+            co_await client.shutdown();
+        } catch (const s3::rest_error_response& err) {
+            vlog(
+              archival_log.error,
+              "Uploading manifest for {}, {} error detected, code: {}, "
+              "request_id: {}, resource: {}",
+              _ntp,
+              err.message(),
+              err.code_string(),
+              err.request_id(),
+              err.resource());
+            if (err.code() == s3::s3_error_code::slow_down) {
+                slowdown = true;
+            } else {
+                throw;
+            }
+        } catch (...) {
+            vlog(
+              archival_log.error,
+              "Uploading manifest for {}, unexpected error: {}",
+              _ntp,
+              std::current_exception());
+        }
+        if (slowdown) {
+            // Apply exponential backoff because S3 asked us
+            vlog(
+              archival_log.debug,
+              "Uploading manifest for {}, {}ms backoff required",
+              _ntp,
+              backoff.count());
+            co_await ss::sleep_abortable(
+              backoff + _backoff.next_jitter_duration(), _as);
+            backoff *= 2;
+            continue;
+        }
+        break;
+    }
+    if (backoff_quota == 0) {
+        // We exceded backoff quota, warn user and continue. The manifest
+        // should be re-uploaded with the next uploaded segment.
+        vlog(
+          archival_log.warn,
+          "Uploading manifest for {}, backoff quota exceded, manifest {} not "
+          "uploaded",
+          _ntp,
+          path);
+    }
     co_return;
 }
 
 const manifest& ntp_archiver::get_remote_manifest() const { return _remote; }
 
-/// Returns true if segment matches the metadata
-static bool validate_metadata(
-  const ss::lw_shared_ptr<storage::segment>& segment,
-  const manifest::segment_meta& meta) {
-    // If the metadata don't match the segment then the
-    // local manifest needs to be updated. This can happen when
-    // segment was compacted after updated_local_manifest was
-    // called.
-    //
-    // We shouldn't upload this segment right away because it
-    // might not match the policy.
-    return meta.is_compacted == segment->is_compacted_segment()
-           && meta.size_bytes == segment->size_bytes()
-           && meta.base_offset == segment->offsets().base_offset
-           && meta.committed_offset == segment->offsets().committed_offset;
-}
-
 ss::future<bool> ntp_archiver::upload_segment(
-  manifest::segment_map::value_type target, storage::log_manager& lm) {
-    vlog(archival_log.trace, "Upload {} segments", target.first);
-    s3::client client(_client_conf);
-    const auto& [sname, meta] = target;
-    auto segment = get_segment(sname, lm);
-    if (segment) {
-        // match segment with metadata
-        if (!validate_metadata(segment, meta)) {
-            co_return false;
-        }
-        auto stream = segment->offset_data_stream(
-          meta.base_offset, ss::default_priority_class());
-        auto s3path = _remote.get_remote_segment_path(sname);
-        vlog(archival_log.trace, "Uploading segment \"{}\" to S3", s3path());
+  ss::semaphore& req_limit, upload_candidate candidate) {
+    gate_guard guard{_gate};
+    vlog(
+      archival_log.debug,
+      "Uploading segment for {}, exposed name {} offset {}, length {}",
+      _ntp,
+      candidate.exposed_name,
+      candidate.starting_offset,
+      candidate.content_length);
+    ss::lowres_clock::duration backoff = 4ms;
+    int backoff_quota = 8; // max backoff time should be close to 10s
+    auto s3path = _remote.get_remote_segment_path(
+      segment_name(candidate.exposed_name));
+    std::vector<s3::object_tag> tags = {{"rp-type", "segment"}};
+    while (!_gate.is_closed() && backoff_quota-- > 0) {
+        auto units = co_await ss::get_units(req_limit, 1);
+        s3::client client(_client_conf, _as);
+        auto stream = candidate.source->reader().data_stream(
+          candidate.file_offset, ss::default_priority_class());
+        bool slowdown = false;
+        vlog(
+          archival_log.debug,
+          "Uploading segment for {}, path {}",
+          _ntp,
+          s3path);
         try {
+            // Segment upload attempt
             co_await client.put_object(
               _bucket,
               s3::object_key(s3path()),
-              segment->size_bytes(),
-              std::move(stream));
+              candidate.content_length,
+              std::move(stream),
+              tags);
+            co_await client.shutdown();
+        } catch (const s3::rest_error_response& err) {
             vlog(
-              archival_log.trace, "Completed segment \"{}\" to S3", s3path());
-            _remote.add(sname, meta);
+              archival_log.error,
+              "Uploading segment for {}, path {}, {} error detected, code: {}, "
+              "request_id: {}, resource: {}",
+              _ntp,
+              s3path,
+              err.message(),
+              err.code_string(),
+              err.request_id(),
+              err.resource());
+            if (err.code() == s3::s3_error_code::slow_down) {
+                slowdown = true;
+            } else {
+                co_return false;
+            }
         } catch (...) {
             vlog(
               archival_log.error,
-              "Failed to upload {} to S3. Reason: {}",
-              sname,
+              "Failed to upload segment for {}, path {}. Reason: {}",
+              _ntp,
+              s3path,
               std::current_exception());
             co_return false;
         }
-    } else {
-        vlog(archival_log.error, "Can't find segment {}", sname());
+        if (slowdown) {
+            // Apply exponential backoff because S3 asked us
+            vlog(
+              archival_log.debug,
+              "Uploading segment for {}, {}ms backoff required",
+              _ntp,
+              backoff.count());
+            co_await ss::sleep_abortable(
+              backoff + _backoff.next_jitter_duration(), _as);
+            backoff *= 2;
+            continue;
+        }
+        break;
     }
     co_return true;
 }
 
-ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidate(
+ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
   ss::semaphore& req_limit, storage::log_manager& lm) {
-    vlog(archival_log.trace, "Uploading next candidate called");
+    vlog(archival_log.debug, "Uploading next candidates called for {}", _ntp);
     gate_guard guard{_gate};
-    // calculate candidate set
-    auto candidates = _policy->generate_upload_set(_remote, lm);
-    if (!candidates) {
-        vlog(archival_log.error, "Failed to generate upload candidates");
-        co_return batch_result{};
-    }
-    auto num_candidates = std::min(
-      static_cast<ssize_t>(candidates->size()), req_limit.available_units());
-    if (num_candidates == 0) {
-        co_return batch_result{};
-    }
-    // NOTE: here consume API is used because we don't want the number of
-    // available semaphore units to change.
-    auto sem_units = ss::consume_units(req_limit, num_candidates);
-    std::vector<manifest::segment_map::value_type> upload_set;
-    std::copy_n(
-      candidates->begin(), num_candidates, std::back_inserter(upload_set));
-    vlog(archival_log.trace, "Upload {} elements", upload_set.size());
-    s3::client client(_client_conf);
-    batch_result result{};
-    auto fut = ss::parallel_for_each(
-      upload_set,
-      [this, &lm, &result](manifest::segment_map::value_type target) {
-          return upload_segment(std::move(target), lm).then([&result](bool ok) {
-              if (ok) {
-                  result.succeded++;
-              } else {
-                  result.failed++;
-              }
-          });
-      });
-    co_await std::move(fut);
-    if (num_candidates) {
-        vlog(archival_log.trace, "Completed S3 upload");
-        co_await client.shutdown();
-        co_await upload_manifest();
-        _last_upload_time = ss::lowres_clock::now();
-    }
-    co_return result;
-}
-
-ss::future<bool> ntp_archiver::delete_segment(
-  manifest::segment_map::value_type target, storage::log_manager& lm) {
-    const auto& [sname, meta] = target;
-    auto segment = get_segment(sname, lm);
-    if (!segment) {
-        s3::client client(_client_conf);
-        auto s3path = _remote.get_remote_segment_path(sname);
-        vlog(archival_log.trace, "Delete segment \"{}\" from S3", s3path());
-        try {
-            co_await client.delete_object(_bucket, s3::object_key(s3path()));
-            _remote.delete_permanently(sname);
-        } catch (...) {
-            vlog(
-              archival_log.error,
-              "Failed to delete {} from S3. Reason: {}",
-              sname,
-              std::current_exception());
-            co_return false;
-        }
-    }
-    co_return true;
-}
-
-ss::future<ntp_archiver::batch_result> ntp_archiver::delete_next_candidate(
-  ss::semaphore& req_limit, storage::log_manager& lm) {
-    vlog(archival_log.trace, "Delete next candidate called");
-    gate_guard guard{_gate};
-    // calculate candidate set
-    auto candidates = _policy->generate_delete_set(_remote, lm);
-    if (!candidates) {
-        vlog(archival_log.error, "Failed to generate candidates for deletion");
-        co_return batch_result{};
-    }
-    auto num_candidates = std::min(
-      static_cast<ssize_t>(candidates->size()), req_limit.available_units());
-    if (num_candidates == 0) {
-        co_return batch_result{};
-    }
-    std::vector<manifest::segment_map::value_type> delete_set;
-    std::copy_n(
-      candidates->begin(), num_candidates, std::back_inserter(delete_set));
-    vlog(archival_log.trace, "Delete {} elements", delete_set.size());
-    // upload segments in parallel
-    batch_result result{};
-    s3::client client(_client_conf);
-    auto fut = ss::parallel_for_each(
-      delete_set,
-      [this, &lm, &result](manifest::segment_map::value_type target) {
-          return delete_segment(std::move(target), lm).then([&result](bool ok) {
-              if (ok) {
-                  result.succeded++;
-              } else {
-                  result.failed++;
-              }
-          });
-      });
-    co_await std::move(fut);
-    if (num_candidates) {
-        vlog(archival_log.trace, "Completed S3 upload");
-        co_await client.shutdown();
-        co_await upload_manifest();
-        _last_upload_time = ss::lowres_clock::now();
-    }
-    co_return result;
-}
-
-ss::lw_shared_ptr<storage::segment>
-ntp_archiver::get_segment(segment_name path, storage::log_manager& lm) {
-    std::optional<storage::log> log = lm.get(_ntp);
-    if (!log) {
-        vlog(archival_log.trace, "log for {} not found", _ntp);
-        return nullptr;
-    }
-    auto plog = dynamic_cast<storage::disk_log_impl*>(log->get_impl());
-    if (plog == nullptr) {
-        return nullptr;
-    }
-    std::filesystem::path target_path(path());
-    for (auto& segment : plog->segments()) {
-        auto segment_path = std::filesystem::path(segment->reader().filename())
-                              .filename()
-                              .string();
+    auto mlock = co_await ss::get_units(_mutex, 1);
+    ntp_archiver::batch_result total{};
+    // We have to increment last offset to guarantee progress.
+    // The manifest's last offset contains committed_offset of the
+    // latest uploaded segment but '_policy' requires offset that
+    // belongs to the next offset or the gap. No need to do this
+    // if there is no segments.
+    auto offset = _remote.size() ? _remote.get_last_offset() + model::offset(1)
+                                 : model::offset(0);
+    std::vector<ss::future<bool>> flist;
+    std::vector<manifest::segment_meta> meta;
+    std::vector<ss::sstring> names;
+    for (size_t i = 0; i < _concurrency; i++) {
         vlog(
-          archival_log.trace,
-          "comparing segment names {} and {}",
-          segment_path,
-          target_path);
-        if (segment_path == target_path) {
-            return segment;
+          archival_log.debug,
+          "Uploading next candidates for {}, trying offset {}",
+          _ntp,
+          offset);
+        auto upload = _policy.get_next_candidate(offset, lm);
+        if (upload.source.get() == nullptr) {
+            vlog(
+              archival_log.debug,
+              "Uploading next candidates for {}, ...skip",
+              _ntp);
+            break;
         }
+        if (_remote.contains(upload.exposed_name)) {
+            // This sholdn't happen normally and indicates an error (e.g.
+            // manifest doesn't match the actual data because it was uploaded by
+            // different cluster or altered). We can just skip the segment.
+            vlog(
+              archival_log.warn,
+              "Uploading next candidates for {}, attempt to re-upload {}",
+              _ntp,
+              upload);
+            const auto& meta = _remote.get(upload.exposed_name);
+            offset = meta->committed_offset + model::offset(1);
+            continue;
+        }
+        offset = upload.source->offsets().committed_offset + model::offset(1);
+        flist.emplace_back(upload_segment(req_limit, upload));
+        manifest::segment_meta m{
+          .is_compacted = upload.source->is_compacted_segment(),
+          .size_bytes
+          = upload.source->size_bytes()
+            - (upload.starting_offset - upload.source->offsets().base_offset),
+          .base_offset = upload.starting_offset,
+          .committed_offset = upload.source->offsets().committed_offset,
+        };
+        meta.emplace_back(m);
+        names.emplace_back(upload.exposed_name);
     }
-    return nullptr;
+    if (flist.empty()) {
+        vlog(
+          archival_log.debug,
+          "Uploading next candidates for {}, no uploads started ...skip",
+          _ntp);
+        co_return total;
+    }
+    auto results = co_await ss::when_all_succeed(begin(flist), end(flist));
+    total.num_succeded = std::count(begin(results), end(results), true);
+    total.num_failed = std::count(begin(results), end(results), false);
+    for (size_t i = 0; i < results.size(); i++) {
+        if (!results[i]) {
+            break;
+        }
+        _remote.add(segment_name(names[i]), meta[i]);
+    }
+    if (total.num_succeded != 0) {
+        vlog(
+          archival_log.debug,
+          "Uploading next candidates for {}, re-uploading manifest file",
+          _ntp);
+        co_await upload_manifest();
+        _last_upload_time = ss::lowres_clock::now();
+    }
+    co_return total;
 }
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -75,7 +75,7 @@ ss::future<download_manifest_result> ntp_archiver::download_manifest() {
     gate_guard guard{_gate};
     auto key = _remote.get_manifest_path();
     vlog(archival_log.debug, "Download manifest {}", key());
-    auto path = s3::object_key(key());
+    auto path = s3::object_key(key().string());
     s3::client client(_client_conf, _as);
     auto result = download_manifest_result::success;
     try {
@@ -111,7 +111,7 @@ ss::future<> ntp_archiver::upload_manifest() {
     int backoff_quota = 8; // max backoff time should be close to 10s
     auto key = _remote.get_manifest_path();
     vlog(archival_log.trace, "Upload manifest {}", key());
-    auto path = s3::object_key(key());
+    auto path = s3::object_key(key().string());
     std::vector<s3::object_tag> tags = {{"rp-type", "partition-manifest"}};
     while (!_gate.is_closed() && backoff_quota-- > 0) {
         bool slowdown = false;
@@ -202,7 +202,7 @@ ss::future<bool> ntp_archiver::upload_segment(
             // Segment upload attempt
             co_await client.put_object(
               _bucket,
-              s3::object_key(s3path()),
+              s3::object_key(s3path().string()),
               candidate.content_length,
               std::move(stream),
               tags);

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "archival/archival_policy.h"
 #include "archival/manifest.h"
+#include "archival/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "s3/client.h"
@@ -19,12 +20,13 @@
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/semaphore.hh>
+
+#include <map>
 
 namespace archival {
 
-/// Number of simultaneous connections to S3
-using s3_connection_limit
-  = named_type<size_t, struct archival_s3_connection_limit_t>;
+using namespace std::chrono_literals;
 
 /// Archiver service configuration
 struct configuration {
@@ -32,10 +34,6 @@ struct configuration {
     s3::configuration client_config;
     /// Bucket used to store all archived data
     s3::bucket_name bucket_name;
-    /// Policy for choosing candidates for archiving
-    upload_policy_selector upload_policy;
-    /// Policy for choosing candidates for removing from S3
-    delete_policy_selector delete_policy;
     /// Time interval to run uploads & deletes
     ss::lowres_clock::duration interval;
     /// Time interval to run GC
@@ -43,6 +41,8 @@ struct configuration {
     /// Number of simultaneous S3 uploads
     s3_connection_limit connection_limit;
 };
+
+std::ostream& operator<<(std::ostream& o, const configuration& cfg);
 
 /// This class performs per-ntp arhcival workload. Every ntp can be
 /// processed independently, without the knowledge about others. All
@@ -74,14 +74,16 @@ public:
     /// Get NTP
     const model::ntp& get_ntp() const;
 
+    /// Get revision id
+    model::revision_id get_revision_id() const;
+
     /// Get timestamp
     const ss::lowres_clock::time_point get_last_upload_time() const;
-    const ss::lowres_clock::time_point get_last_delete_time() const;
 
     /// Download manifest from pre-defined S3 locatnewion
     ///
     /// \return future that returns true if the manifest was found in S3
-    ss::future<bool> download_manifest();
+    ss::future<download_manifest_result> download_manifest();
 
     /// Upload manifest to the pre-defined S3 location
     ss::future<> upload_manifest();
@@ -89,64 +91,42 @@ public:
     const manifest& get_remote_manifest() const;
 
     struct batch_result {
-        size_t succeded;
-        size_t failed;
+        size_t num_succeded;
+        size_t num_failed;
     };
 
-    /// \brief Upload next segment to S3 (if any)
+    /// \brief Upload next set of segments to S3 (if any)
     /// The semaphore is used to track number of parallel uploads. The method
-    /// will pick not more than 'req_limit.available_units()' candidates for
-    /// upload and consme one unit for every candidate (non-blocking).
+    /// will pick not more than '_concurrency' candidates and start
+    /// uploading them.
     ///
     /// \param req_limit is used to limit number of parallel uploads
     /// \param lm is a log manager instance
     /// \return future that returns number of uploaded/failed segments
     ss::future<batch_result>
-    upload_next_candidate(ss::semaphore& req_limit, storage::log_manager& lm);
-
-    /// \brief Delete next segment from S3
-    ///
-    /// \param req_limit is used to limit number of parallel operations
-    /// \param lm is a log manager instance
-    /// \return future that returns number of deleted/failed segments
-    ss::future<batch_result>
-    delete_next_candidate(ss::semaphore& req_limit, storage::log_manager& lm);
+    upload_next_candidates(ss::semaphore& req_limit, storage::log_manager& lm);
 
 private:
-    /// Get segment from log_manager instance by path
-    ///
-    /// \param path is a segment path (from the manifest)
-    /// \param lm is a log manager instance
-    /// \return pointer to segment instance or null
-    ss::lw_shared_ptr<storage::segment>
-    get_segment(segment_name path, storage::log_manager& lm);
-
-    /// Upload individual segment to S3. Locate the segment in 'lm' and adjust
-    /// 'req_limit' accordingly.
+    /// Upload individual segment to S3.
     ///
     /// \return true on success and false otherwise
-    ss::future<bool> upload_segment(
-      manifest::segment_map::value_type target, storage::log_manager& lm);
-
-    /// Delete segment from S3. Locate the segment in 'lm' and adjust
-    /// 'req_limit' accordingly.
-    ///
-    /// \return true on success and false otherwise
-    ss::future<bool> delete_segment(
-      manifest::segment_map::value_type target, storage::log_manager& lm);
+    ss::future<bool>
+    upload_segment(ss::semaphore& req_limit, upload_candidate candidate);
 
     model::ntp _ntp;
     model::revision_id _rev;
     s3::configuration _client_conf;
-
-    std::unique_ptr<archival_policy_base> _policy;
+    archival_policy _policy;
     s3::bucket_name _bucket;
     /// Remote manifest contains representation of the data stored in S3 (it
     /// gets uploaded to the remote location)
     manifest _remote;
     ss::gate _gate;
+    ss::abort_source _as;
+    ss::semaphore _mutex{1};
+    simple_time_jitter<ss::lowres_clock> _backoff{100ms};
+    size_t _concurrency{4};
     ss::lowres_clock::time_point _last_upload_time;
-    ss::lowres_clock::time_point _last_delete_time;
 };
 
 } // namespace archival

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -117,8 +117,14 @@ scheduler_service_impl::get_archival_service_config() {
     auto region = s3::aws_region_name(get_value_or_throw(
       config::shard_local_cfg().archival_storage_s3_region,
       "archival_storage_s3_region"));
+    std::optional<s3::endpoint_url> endpoint;
+    if (auto optep
+        = config::shard_local_cfg().archival_storage_api_endpoint.value();
+        optep.has_value()) {
+        endpoint = s3::endpoint_url(*optep);
+    }
     auto s3_conf = co_await s3::configuration::make_configuration(
-      access_key, secret_key, region);
+      access_key, secret_key, region, endpoint);
     archival::configuration cfg{
       .client_config = std::move(s3_conf),
       .bucket_name = s3::bucket_name(get_value_or_throw(

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -1,0 +1,456 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/service.h"
+
+#include "archival/logger.h"
+#include "archival/ntp_archiver_service.h"
+#include "cluster/partition_manager.h"
+#include "cluster/topic_table.h"
+#include "config/configuration.h"
+#include "config/property.h"
+#include "likely.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "s3/client.h"
+#include "s3/error.h"
+#include "s3/signature.h"
+#include "storage/disk_log_impl.h"
+#include "storage/fs_utils.h"
+#include "storage/log.h"
+#include "utils/gate_guard.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/when_all.hh>
+
+#include <boost/iterator/counting_iterator.hpp>
+
+#include <algorithm>
+#include <exception>
+#include <stdexcept>
+
+using namespace std::chrono_literals;
+
+namespace archival::internal {
+
+ntp_upload_queue::iterator ntp_upload_queue::begin() {
+    return _archivers.begin();
+}
+
+ntp_upload_queue::iterator ntp_upload_queue::end() { return _archivers.end(); }
+
+void ntp_upload_queue::insert(ntp_upload_queue::value archiver) {
+    auto key = archiver->get_ntp();
+    auto [it, ok] = _archivers.insert(
+      std::make_pair(key, upload_queue_item{.archiver = archiver}));
+    if (ok) {
+        // We only need to insert new element into the queue if the insert
+        // into the map is actually happend. We don't need to overwrite any
+        // existing archiver.
+        _upload_queue.push_back(it->second);
+    }
+}
+
+void ntp_upload_queue::erase(const ntp_upload_queue::key& ntp) {
+    _archivers.erase(ntp);
+}
+
+bool ntp_upload_queue::contains(const key& ntp) const {
+    return _archivers.contains(ntp);
+}
+
+size_t ntp_upload_queue::size() const noexcept { return _archivers.size(); }
+
+ntp_upload_queue::value ntp_upload_queue::get_upload_candidate() {
+    auto& candidate = _upload_queue.front();
+    candidate._upl_hook.unlink();
+    _upload_queue.push_back(candidate);
+    return candidate.archiver;
+}
+
+ntp_upload_queue::value ntp_upload_queue::operator[](const key& ntp) const {
+    auto it = _archivers.find(ntp);
+    if (it == _archivers.end()) {
+        return nullptr;
+    }
+    return it->second.archiver;
+}
+
+static ss::sstring get_value_or_throw(
+  const config::property<std::optional<ss::sstring>>& prop, const char* name) {
+    auto opt = prop.value();
+    if (!opt) {
+        vlog(
+          archival_log.error,
+          "Configuration property {} is required to enable archival storage",
+          name);
+        throw std::runtime_error(
+          fmt::format("configuration property {} is not set", name));
+    }
+    return *opt;
+}
+
+/// Use shard-local configuration to generate configuration
+ss::future<archival::configuration>
+scheduler_service_impl::get_archival_service_config() {
+    vlog(archival_log.debug, "Generating archival configuration");
+    auto secret_key = s3::private_key_str(get_value_or_throw(
+      config::shard_local_cfg().archival_storage_s3_secret_key,
+      "archival_storage_s3_secret_key"));
+    auto access_key = s3::public_key_str(get_value_or_throw(
+      config::shard_local_cfg().archival_storage_s3_access_key,
+      "archival_storage_s3_access_key"));
+    auto region = s3::aws_region_name(get_value_or_throw(
+      config::shard_local_cfg().archival_storage_s3_region,
+      "archival_storage_s3_region"));
+    auto s3_conf = co_await s3::configuration::make_configuration(
+      access_key, secret_key, region);
+    archival::configuration cfg{
+      .client_config = std::move(s3_conf),
+      .bucket_name = s3::bucket_name(get_value_or_throw(
+        config::shard_local_cfg().archival_storage_s3_bucket,
+        "archival_storage_s3_bucket")),
+      .interval
+      = config::shard_local_cfg().archival_storage_reconciliation_ms.value(),
+      .connection_limit = s3_connection_limit(
+        config::shard_local_cfg().archival_storage_max_connections.value())};
+    vlog(archival_log.debug, "Archival configuration generated: {}", cfg);
+    co_return cfg;
+}
+
+scheduler_service_impl::scheduler_service_impl(
+  const configuration& conf,
+  ss::sharded<storage::api>& api,
+  ss::sharded<cluster::partition_manager>& pm,
+  ss::sharded<cluster::topic_table>& tt)
+  : _conf(conf)
+  , _partition_manager(pm)
+  , _topic_table(tt)
+  , _storage_api(api)
+  , _jitter(conf.interval, 1ms)
+  , _gc_jitter(conf.gc_interval, 1ms)
+  , _conn_limit(conf.connection_limit())
+  , _stop_limit(conf.connection_limit()) {}
+
+scheduler_service_impl::scheduler_service_impl(
+  ss::sharded<storage::api>& api,
+  ss::sharded<cluster::partition_manager>& pm,
+  ss::sharded<cluster::topic_table>& tt,
+  ss::sharded<archival::configuration>& config)
+  : scheduler_service_impl(config.local(), api, pm, tt) {}
+
+void scheduler_service_impl::rearm_timer() {
+    (void)ss::with_gate(_gate, [this] {
+        return reconcile_archivers()
+          .finally([this] {
+              if (_gate.is_closed()) {
+                  return;
+              }
+              _timer.rearm(_jitter());
+          })
+          .handle_exception([](std::exception_ptr e) {
+              vlog(archival_log.info, "Error in timer callback: {}", e);
+          });
+    });
+}
+ss::future<> scheduler_service_impl::start() {
+    _timer.set_callback([this] { rearm_timer(); });
+    _timer.rearm(_jitter());
+    (void)run_uploads();
+    return ss::now();
+}
+
+ss::future<> scheduler_service_impl::stop() {
+    vlog(archival_log.info, "Scheduler service stop");
+    _timer.cancel();
+    _as.request_abort();
+    std::vector<ss::future<>> outstanding;
+    for (auto& it : _queue) {
+        auto fut = ss::with_semaphore(
+          _stop_limit, 1, [it] { return it.second.archiver->stop(); });
+        outstanding.emplace_back(std::move(fut));
+    }
+    return ss::do_with(
+      std::move(outstanding), [this](std::vector<ss::future<>>& outstanding) {
+          return ss::when_all_succeed(outstanding.begin(), outstanding.end())
+            .then([this] { return _gate.close(); });
+      });
+}
+
+ss::lw_shared_ptr<ntp_archiver> scheduler_service_impl::get_upload_candidate() {
+    return _queue.get_upload_candidate();
+}
+
+ss::future<> scheduler_service_impl::upload_topic_manifest(
+  model::topic_namespace_view view, model::revision_id rev) {
+    gate_guard gg(_gate);
+    auto cfg = _topic_table.local().get_topic_cfg(view);
+    if (cfg) {
+        try {
+            auto units = co_await ss::get_units(_conn_limit, 1);
+            vlog(archival_log.info, "Uploading topic manifest {}", view);
+            s3::client client(_conf.client_config, _as);
+            topic_manifest tm(*cfg, rev);
+            auto [istr, size_bytes] = tm.serialize();
+            auto key = tm.get_manifest_path();
+            vlog(archival_log.debug, "Topic manifest object key is '{}'", key);
+            std::vector<s3::object_tag> tags = {{"rp-type", "topic-manifest"}};
+            co_await client.put_object(
+              _conf.bucket_name,
+              s3::object_key(key),
+              size_bytes,
+              std::move(istr),
+              tags);
+            co_await client.shutdown();
+        } catch (const s3::rest_error_response& err) {
+            vlog(
+              archival_log.error,
+              "REST API error occured during topic manifest upload: "
+              "{}, code: {}, request-id: {}, resource: {}",
+              err.message(),
+              err.code(),
+              err.request_id(),
+              err.resource());
+        } catch (...) {
+            vlog(
+              archival_log.error,
+              "Exception occured during topic manifest upload: "
+              "{}",
+              std::current_exception());
+        }
+    }
+}
+
+ss::future<>
+scheduler_service_impl::create_archivers(std::vector<model::ntp> to_create) {
+    return ss::do_with(
+      std::move(to_create), [this](std::vector<model::ntp>& to_create) {
+          return ss::parallel_for_each(
+            to_create, [this](const model::ntp& ntp) {
+                storage::api& api = _storage_api.local();
+                storage::log_manager& lm = api.log_mgr();
+                auto log = lm.get(ntp);
+                if (!log.has_value()) {
+                    return ss::now();
+                }
+                auto svc = ss::make_lw_shared<ntp_archiver>(
+                  log->config(), _conf);
+                return ss::repeat([this, svc, ntp] {
+                    return svc->download_manifest()
+                      .then(
+                        [this, svc](download_manifest_result result)
+                          -> ss::future<ss::stop_iteration> {
+                            switch (result) {
+                            case download_manifest_result::success:
+                                _queue.insert(svc);
+                                vlog(
+                                  archival_log.info,
+                                  "Found manifest for partition {}",
+                                  svc->get_ntp());
+                                return ss::make_ready_future<
+                                  ss::stop_iteration>(ss::stop_iteration::yes);
+                            case download_manifest_result::notfound:
+                                _queue.insert(svc);
+                                vlog(
+                                  archival_log.info,
+                                  "Start archiving new partition {}",
+                                  svc->get_ntp());
+                                (void)upload_topic_manifest(
+                                  model::topic_namespace_view(svc->get_ntp()),
+                                  svc->get_revision_id());
+                                return ss::make_ready_future<
+                                  ss::stop_iteration>(ss::stop_iteration::yes);
+                            case download_manifest_result::backoff:
+                                vlog(
+                                  archival_log.trace,
+                                  "Manifest download exponential backoff");
+                                return ss::sleep_abortable(
+                                         _backoff.next_jitter_duration(), _as)
+                                  .then([] {
+                                      return ss::make_ready_future<
+                                        ss::stop_iteration>(
+                                        ss::stop_iteration::no);
+                                  })
+                                  .handle_exception_type(
+                                    [](const ss::abort_requested_exception&) {
+                                        return ss::make_ready_future<
+                                          ss::stop_iteration>(
+                                          ss::stop_iteration::yes);
+                                    });
+                            }
+                            return ss::make_ready_future<ss::stop_iteration>(
+                              ss::stop_iteration::yes);
+                        })
+                      .handle_exception_type(
+                        [ntp](const s3::rest_error_response& err) {
+                            vlog(
+                              archival_log.error,
+                              "Manifest download for partition {}, failed, "
+                              "error: ",
+                              ntp.path(),
+                              err.what());
+                            return ss::make_ready_future<ss::stop_iteration>(
+                              ss::stop_iteration::yes);
+                        });
+                });
+            });
+      });
+} // namespace archival::internal
+
+ss::future<>
+scheduler_service_impl::remove_archivers(std::vector<model::ntp> to_remove) {
+    return ss::parallel_for_each(
+      to_remove, [this](const model::ntp& ntp) -> ss::future<> {
+          vlog(archival_log.info, "removing archiver for {}", ntp.path());
+          auto archiver = _queue[ntp];
+          return ss::with_semaphore(
+                   _conn_limit, 1, [archiver] { return archiver->stop(); })
+            .finally([this, ntp] {
+                vlog(archival_log.info, "archiver stopped {}", ntp.path());
+                _queue.erase(ntp);
+            });
+      });
+}
+
+ss::future<> scheduler_service_impl::reconcile_archivers() {
+    gate_guard g(_gate);
+    cluster::partition_manager& pm = _partition_manager.local();
+    storage::api& api = _storage_api.local();
+    storage::log_manager& lm = api.log_mgr();
+    auto snapshot = lm.get_all_ntps();
+    std::vector<model::ntp> to_remove;
+    std::vector<model::ntp> to_create;
+    // find ntps that exist in _svc_per_ntp but no longer present in log_manager
+    _queue.copy_if(
+      std::back_inserter(to_remove), [&snapshot, &pm](const model::ntp& ntp) {
+          auto p = pm.get(ntp);
+          return !snapshot.contains(ntp) || !p || !p->is_leader();
+      });
+    // find new ntps that present in the snapshot only
+    std::copy_if(
+      snapshot.begin(),
+      snapshot.end(),
+      std::back_inserter(to_create),
+      [this, &pm](const model::ntp& ntp) {
+          auto p = pm.get(ntp);
+          return ntp.ns != model::redpanda_ns && !_queue.contains(ntp) && p
+                 && p->is_leader();
+      });
+    // epxect to_create & to_remove be empty most of the time
+    if (unlikely(!to_remove.empty() || !to_create.empty())) {
+        // run in parallel
+        ss::future<> fremove = ss::now();
+        if (!to_remove.empty()) {
+            fremove = remove_archivers(std::move(to_remove));
+        }
+        ss::future<> fcreate = ss::now();
+        if (!to_create.empty()) {
+            fcreate = create_archivers(std::move(to_create));
+        }
+        auto [remove_fut, create_fut] = co_await ss::when_all(
+          std::move(fremove), std::move(fcreate));
+        if (remove_fut.failed()) {
+            vlog(archival_log.error, "Failed to remove archivers");
+        }
+        if (create_fut.failed()) {
+            vlog(archival_log.error, "Failed to create archivers");
+        }
+    }
+}
+
+ss::future<> scheduler_service_impl::run_uploads() {
+    gate_guard g(_gate);
+    try {
+        const ss::lowres_clock::duration initial_backoff = 10ms;
+        const ss::lowres_clock::duration max_backoff = 5s;
+        ss::lowres_clock::duration backoff = initial_backoff;
+        while (!_gate.is_closed()) {
+            int quota = _queue.size();
+            std::vector<ss::future<ntp_archiver::batch_result>> flist;
+
+            std::transform(
+              boost::make_counting_iterator(0),
+              boost::make_counting_iterator(quota),
+              std::back_inserter(flist),
+              [this](int) {
+                  auto archiver = _queue.get_upload_candidate();
+                  storage::api& api = _storage_api.local();
+                  storage::log_manager& lm = api.log_mgr();
+                  vlog(
+                    archival_log.debug,
+                    "Checking {} for S3 upload candidates",
+                    archiver->get_ntp());
+                  return archiver->upload_next_candidates(_conn_limit, lm);
+              });
+
+            auto results = co_await ss::when_all_succeed(
+              flist.begin(), flist.end());
+
+            auto total = std::accumulate(
+              results.begin(),
+              results.end(),
+              ntp_archiver::batch_result(),
+              [](
+                const ntp_archiver::batch_result& lhs,
+                const ntp_archiver::batch_result& rhs) {
+                  return ntp_archiver::batch_result{
+                    .num_succeded = lhs.num_succeded + rhs.num_succeded,
+                    .num_failed = lhs.num_failed + rhs.num_failed};
+              });
+
+            if (total.num_succeded == 0 && total.num_failed == 0) {
+                // The backoff algorithm here is used to prevent high CPU
+                // utilization when redpanda is not receiving any data and there
+                // is nothing to update. We want to limit max backoff duration
+                // to some reasonable value (e.g. 5s) because otherwise it can
+                // grow very large disabling the archival storage
+                vlog(
+                  archival_log.trace,
+                  "Nothing to upload, applying backoff algorithm");
+                co_await ss::sleep_abortable(
+                  backoff + _backoff.next_jitter_duration(), _as);
+                backoff *= 2;
+                if (backoff > max_backoff) {
+                    backoff = max_backoff;
+                }
+                continue;
+            } else if (total.num_failed != 0) {
+                vlog(
+                  archival_log.error,
+                  "Failed to upload {} segments out of {}",
+                  total.num_failed,
+                  total.num_succeded);
+            } else {
+                vlog(
+                  archival_log.debug,
+                  "Successfuly upload {} segments",
+                  total.num_succeded);
+            }
+            // TODO: use probe to report num_succeded and num_failed
+        }
+    } catch (const ss::sleep_aborted&) {
+        vlog(archival_log.debug, "Upload loop aborted");
+    } catch (...) {
+        vlog(
+          archival_log.error,
+          "Upload loop error: {}",
+          std::current_exception());
+        throw;
+    }
+}
+
+} // namespace archival::internal

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+#include "archival/manifest.h"
+#include "archival/ntp_archiver_service.h"
+#include "cluster/partition_manager.h"
+#include "model/fundamental.h"
+#include "s3/client.h"
+#include "storage/api.h"
+#include "storage/log_manager.h"
+#include "storage/ntp_config.h"
+#include "storage/segment.h"
+#include "storage/segment_set.h"
+#include "utils/intrusive_list_helpers.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/weak_ptr.hh>
+
+#include <absl/container/node_hash_map.h>
+
+#include <queue>
+
+namespace archival {
+namespace internal {
+
+using namespace std::chrono_literals;
+
+class ntp_upload_queue {
+    struct upload_queue_item {
+        ss::lw_shared_ptr<ntp_archiver> archiver;
+        intrusive_list_hook _upl_hook;
+    };
+    using hash_map = absl::node_hash_map<model::ntp, upload_queue_item>;
+
+public:
+    using value = ss::lw_shared_ptr<ntp_archiver>;
+    using key = model::ntp;
+    using iterator = hash_map::iterator;
+
+    ntp_upload_queue() = default;
+
+    // Iteration
+    iterator begin();
+    iterator end();
+
+    /// Insert new item into the queue
+    void insert(value archiver);
+    void erase(const key& ntp);
+    bool contains(const key& ntp) const;
+    value operator[](const key& ntp) const;
+    /// Copy all archiver ntp into output iterator
+    template<class FwdIt, class Func>
+    void copy_if(FwdIt it, const Func& pred) const;
+
+    /// Return number of archivers that queue contains
+    size_t size() const noexcept;
+
+    /// Get next upload candidate
+    value get_upload_candidate();
+
+private:
+    hash_map _archivers;
+    intrusive_list<upload_queue_item, &upload_queue_item::_upl_hook>
+      _upload_queue;
+};
+
+template<class FwdIt, class Func>
+void ntp_upload_queue::copy_if(FwdIt out, const Func& pred) const {
+    for (const auto& [ntp, _] : _archivers) {
+        if (pred(ntp)) {
+            *out++ = ntp;
+        }
+    }
+}
+
+/// Shard-local archiver service.
+/// The service maintains a working set of archivers. Every archiver maintains a
+/// single partition. The working set get reconciled periodically. Unused
+/// archivers gets removed and new are added. The service runs a simple
+/// workflow on its working set:
+/// - Reconcile working set
+/// - Choose next candidate(s) archiver(s)
+/// - Start configured number of uploads
+/// - Re-upload manifest(s)
+/// - Reset timer
+class scheduler_service_impl {
+public:
+    /// \brief create scheduler service
+    ///
+    /// \param configuration is a archival cnfiguration
+    /// \param api is a storage api service instance
+    /// \param pm is a partition_manager service instance
+    scheduler_service_impl(
+      const configuration& conf,
+      ss::sharded<storage::api>& api,
+      ss::sharded<cluster::partition_manager>& pm,
+      ss::sharded<cluster::topic_table>& tt);
+    scheduler_service_impl(
+      ss::sharded<storage::api>& api,
+      ss::sharded<cluster::partition_manager>& pm,
+      ss::sharded<cluster::topic_table>& tt,
+      ss::sharded<archival::configuration>& configs);
+
+    /// \brief Configure scheduler service
+    ///
+    /// \param c is a service configuration
+    /// \note two step initialization is needed when the
+    ///       service is initialized in ss::sharded container
+    void configure(configuration c);
+
+    /// \brief create scheduler service config
+    /// This mehtod will use shard-local redpanda configuration
+    /// to generate the configuration.
+    static ss::future<archival::configuration> get_archival_service_config();
+
+    /// Start archiver
+    ss::future<> start();
+
+    /// Stop archiver
+    ss::future<> stop();
+
+    void rearm_timer();
+
+    /// Get next upload or delete candidate
+    ss::lw_shared_ptr<ntp_archiver> get_upload_candidate();
+
+    /// Run next round of uploads
+    ss::future<> run_uploads();
+
+    /// \brief Sync ntp-archivers with the content of the partition_manager
+    ///
+    /// This method can invoke asynchronous operations that can potentially
+    /// be blocked on the semaphore. The operations are ntp_archiver::stop,
+    /// and ntp_archiver::download_manifest. This only happens when new ntp
+    /// appers in partition_manager or got removed from it.
+    ss::future<> reconcile_archivers();
+
+    /// Return range with all available ntps
+    bool contains(const model::ntp& ntp) const { return _queue.contains(ntp); }
+
+private:
+    /// Remove archivers from the workingset
+    ss::future<> remove_archivers(std::vector<model::ntp> to_remove);
+    ss::future<> create_archivers(std::vector<model::ntp> to_create);
+    ss::future<> upload_topic_manifest(
+      model::topic_namespace_view view, model::revision_id rev);
+
+    configuration _conf;
+    ss::sharded<cluster::partition_manager>& _partition_manager;
+    ss::sharded<cluster::topic_table>& _topic_table;
+    ss::sharded<storage::api>& _storage_api;
+    simple_time_jitter<ss::lowres_clock> _jitter;
+    simple_time_jitter<ss::lowres_clock> _gc_jitter;
+    ss::timer<ss::lowres_clock> _timer;
+    ss::timer<ss::lowres_clock> _gc_timer;
+    ss::gate _gate;
+    ss::abort_source _as;
+    ss::semaphore _conn_limit;
+    ss::semaphore _stop_limit;
+    ntp_upload_queue _queue;
+    simple_time_jitter<ss::lowres_clock> _backoff{100ms};
+};
+
+} // namespace internal
+
+/// Archiver service implementation
+class scheduler_service : internal::scheduler_service_impl {
+public:
+    /// \brief create scheduler service
+    ///
+    /// \param configuration is a archival cnfiguration
+    /// \param api is a storage api service instance
+    /// \param pm is a partition_manager service instance
+    using internal::scheduler_service_impl::scheduler_service_impl;
+
+    /// Start service
+    using internal::scheduler_service_impl::start;
+
+    /// Stop service
+    using internal::scheduler_service_impl::stop;
+
+    /// \brief Configure scheduler service
+    ///
+    /// \param c is a service configuration
+    /// \note two step initialization is needed when the
+    ///       service is initialized in ss::sharded container
+    using internal::scheduler_service_impl::configure;
+
+    /// Generate configuration
+    using internal::scheduler_service_impl::get_archival_service_config;
+};
+
+} // namespace archival

--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ rp_test(
 rp_test(
   UNIT_TEST
   BINARY_NAME test_archival_service
-  SOURCES service_fixture.cc ntp_archiver_test.cc
+  SOURCES service_fixture.cc ntp_archiver_test.cc service_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils
   ARGS "-- -c 1"

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -367,7 +367,6 @@ void segment_matcher<Fixture>::verify_manifest(const archival::manifest& man) {
         BOOST_REQUIRE_EQUAL(comm, m->committed_offset);
         BOOST_REQUIRE_EQUAL(size, m->size_bytes);
         BOOST_REQUIRE_EQUAL(comp, m->is_compacted);
-        BOOST_REQUIRE_EQUAL(false, m->is_deleted_locally);
     }
 }
 

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -13,7 +13,6 @@
 #include "archival/manifest.h"
 #include "archival/ntp_archiver_service.h"
 #include "cluster/partition_leaders_table.h"
-#include "cluster/tests/utils.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "model/fundamental.h"

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/ntp_archiver_service.h"
+#include "archival/service.h"
+#include "archival/tests/service_fixture.h"
+#include "cluster/commands.h"
+#include "storage/types.h"
+#include "test_utils/async.h"
+#include "utils/unresolved_address.h"
+
+#include <seastar/core/deleter.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/metrics.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/http/request.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/log.hh>
+
+#include <boost/algorithm/string.hpp>
+
+#include <type_traits>
+
+inline seastar::logger arch_svc_log("SVC-TEST");
+static const model::ns test_ns = model::ns("test-namespace");
+using namespace std::chrono_literals;
+
+FIXTURE_TEST(test_reconciliation_manifest_download, archiver_fixture) {
+    wait_for_controller_leadership().get();
+    auto topic1 = model::topic("topic_1");
+    auto topic2 = model::topic("topic_2");
+    auto pid0 = model::ntp(test_ns, topic1, model::partition_id(0));
+    auto pid1 = model::ntp(test_ns, topic2, model::partition_id(0));
+    std::array<const char*, 3> urls = {
+      "/10000000/meta/test-namespace/topic_1/0_2/manifest.json",
+      "/60000000/meta/test-namespace/topic_2/0_4/manifest.json",
+      "/20000000/meta/test-namespace/topic_2/topic_manifest.json",
+    };
+    ss::sstring manifest_json = R"json({
+        "version": 1,
+        "namespace": "test-namespace",
+        "topic": "test_1",
+        "partition": 0,
+        "revision": 1,
+        "last_offset": 2,
+        "segments": {
+            "1-1-v1.log": { 
+                "is_compacted": false,
+                "size_bytes": 10,
+                "base_offset": 1,
+                "committed_offset": 2
+            }
+        }
+    })json";
+    set_expectations_and_listen({
+      {.url = urls[0], .body = manifest_json},
+      {.url = urls[1], .body = std::nullopt},
+      {.url = urls[2], .body = std::nullopt},
+    });
+
+    add_topic_with_random_data(pid0, 20);
+    add_topic_with_random_data(pid1, 20);
+    wait_for_partition_leadership(pid0);
+    wait_for_partition_leadership(pid1);
+
+    auto config = get_configuration();
+    auto& pm = app.partition_manager;
+    auto& api = app.storage;
+    auto& topics = app.controller->get_topics_state();
+    archival::internal::scheduler_service_impl service(config, api, pm, topics);
+    service.reconcile_archivers().get();
+    BOOST_REQUIRE(service.contains(pid0));
+    BOOST_REQUIRE(service.contains(pid1));
+    service.stop().get();
+}
+
+FIXTURE_TEST(test_reconciliation_drop_ntp, archiver_fixture) {
+    wait_for_controller_leadership().get();
+
+    auto topic = model::topic("topic_2");
+    auto ntp = model::ntp(test_ns, topic, model::partition_id(0));
+
+    const char* url = "/50000000/meta/test-namespace/topic_2/0_2/manifest.json";
+    const char* topic_url
+      = "/20000000/meta/test-namespace/topic_2/topic_manifest.json";
+    set_expectations_and_listen({
+      {.url = url, .body = std::nullopt},
+      {.url = topic_url, .body = std::nullopt},
+    });
+
+    add_topic_with_random_data(ntp, 20);
+
+    wait_for_partition_leadership(ntp);
+
+    auto config = get_configuration();
+    auto& pm = app.partition_manager;
+    auto& api = app.storage;
+    auto& topics = app.controller->get_topics_state();
+    archival::internal::scheduler_service_impl service(config, api, pm, topics);
+
+    service.reconcile_archivers().get();
+    BOOST_REQUIRE(service.contains(ntp));
+
+    // delete topic
+    delete_topic(ntp.ns, ntp.tp.topic);
+
+    wait_for_topic_deletion(ntp);
+
+    service.reconcile_archivers().get();
+    BOOST_REQUIRE(!service.contains(ntp));
+    service.stop().get();
+}
+
+FIXTURE_TEST(test_segment_upload, archiver_fixture) {
+    wait_for_controller_leadership().get();
+
+    auto topic = model::topic("topic_3");
+    auto ntp = model::ntp(test_ns, topic, model::partition_id(0));
+
+    const char* manifest_url
+      = "/c0000000/meta/test-namespace/topic_3/0_2/manifest.json";
+    const char* topic_url
+      = "/00000000/meta/test-namespace/topic_3/topic_manifest.json";
+    const char* seg000 = "/e34f82da/test-namespace/topic_3/0_2/0-0-v1.log";
+    const char* seg100 = "/dd2813e1/test-namespace/topic_3/0_2/100-0-v1.log";
+    set_expectations_and_listen({
+      {.url = manifest_url, .body = std::nullopt},
+      {.url = topic_url, .body = std::nullopt},
+      {.url = seg000, .body = std::nullopt},
+      {.url = seg100, .body = std::nullopt},
+    });
+
+    auto builder = get_started_log_builder(ntp, model::revision_id(2));
+    using namespace storage; // NOLINT
+    (*builder) | add_segment(model::offset(0))
+      | add_random_batch(model::offset(0), 100, maybe_compress_batches::no)
+      | add_segment(model::offset(100))
+      | add_random_batch(model::offset(100), 100, maybe_compress_batches::no)
+      | stop();
+    vlog(
+      arch_svc_log.trace,
+      "{} bytes written to log {}",
+      builder->bytes_written(),
+      ntp.path());
+    builder.reset();
+    add_topic(model::topic_namespace_view(ntp)).get();
+
+    wait_for_partition_leadership(ntp);
+
+    auto config = get_configuration();
+    auto& pm = app.partition_manager;
+    auto& api = app.storage;
+    auto& topics = app.controller->get_topics_state();
+    archival::internal::scheduler_service_impl service(config, api, pm, topics);
+
+    service.reconcile_archivers().get();
+    BOOST_REQUIRE(service.contains(ntp));
+
+    (void)service.run_uploads();
+
+    // 2 partition manifests, 1 topic manifest, 2 segments
+    const size_t num_requests_expected = 5;
+    tests::cooperative_spin_wait_with_timeout(10s, [this] {
+        return get_requests().size() == num_requests_expected;
+    }).get();
+    BOOST_REQUIRE(get_requests().size() == num_requests_expected);
+
+    auto manifest_req = get_targets().equal_range(manifest_url);
+    BOOST_REQUIRE(manifest_req.first != manifest_req.second);
+    for (auto it = manifest_req.first; it != manifest_req.second; it++) {
+        if (it->second._method == "PUT") {
+            BOOST_REQUIRE(it->second._method == "PUT");
+            verify_manifest_content(it->second.content);
+        } else {
+            BOOST_REQUIRE(it->second._method == "GET");
+        }
+    }
+
+    BOOST_REQUIRE(get_targets().count(seg000) == 1);
+    auto put_seg000 = get_targets().find(seg000);
+    BOOST_REQUIRE(put_seg000->second._method == "PUT");
+    verify_segment(
+      ntp, archival::segment_name("0-0-v1.log"), put_seg000->second.content);
+
+    BOOST_REQUIRE(get_targets().count(seg100) == 1);
+    auto put_seg100 = get_targets().find(seg100);
+    BOOST_REQUIRE(put_seg100->second._method == "PUT");
+    verify_segment(
+      ntp, archival::segment_name("100-0-v1.log"), put_seg100->second.content);
+    service.stop().get();
+}

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "seastar/core/sstring.hh"
+#include "seastarx.h"
+#include "utils/named_type.h"
+
+namespace archival {
+
+/// Segment file name without working directory,
+/// expected format: <base-offset>-<term-id>-<revision>.log
+using segment_name = named_type<ss::sstring, struct archival_segment_name_t>;
+/// Segment path in S3, expected format:
+/// <prefix>/<ns>/<topic>/<part-id>_<rev>/<base-offset>-<term-id>-<revision>.log
+using remote_segment_path
+  = named_type<ss::sstring, struct archival_remote_segment_path_t>;
+using remote_manifest_path
+  = named_type<ss::sstring, struct archival_remote_manifest_path_t>;
+/// Local segment path, expected format:
+/// <work-dir>/<ns>/<topic>/<part-id>_<rev>/<base-offset>-<term-id>-<revision>.log
+using local_segment_path
+  = named_type<ss::sstring, struct archival_local_segment_path_t>;
+/// Number of simultaneous connections to S3
+using s3_connection_limit
+  = named_type<size_t, struct archival_s3_connection_limit_t>;
+
+enum class download_manifest_result : int32_t {
+    success,
+    notfound,
+    backoff,
+};
+
+enum class manifest_version : int32_t {
+    v1 = 1,
+};
+
+enum class topic_manifest_version : int32_t {
+    v1 = 1,
+};
+
+} // namespace archival

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -14,6 +14,8 @@
 #include "seastarx.h"
 #include "utils/named_type.h"
 
+#include <filesystem>
+
 namespace archival {
 
 /// Segment file name without working directory,
@@ -22,13 +24,13 @@ using segment_name = named_type<ss::sstring, struct archival_segment_name_t>;
 /// Segment path in S3, expected format:
 /// <prefix>/<ns>/<topic>/<part-id>_<rev>/<base-offset>-<term-id>-<revision>.log
 using remote_segment_path
-  = named_type<ss::sstring, struct archival_remote_segment_path_t>;
+  = named_type<std::filesystem::path, struct archival_remote_segment_path_t>;
 using remote_manifest_path
-  = named_type<ss::sstring, struct archival_remote_manifest_path_t>;
+  = named_type<std::filesystem::path, struct archival_remote_manifest_path_t>;
 /// Local segment path, expected format:
 /// <work-dir>/<ns>/<topic>/<part-id>_<rev>/<base-offset>-<term-id>-<revision>.log
 using local_segment_path
-  = named_type<ss::sstring, struct archival_local_segment_path_t>;
+  = named_type<std::filesystem::path, struct archival_local_segment_path_t>;
 /// Number of simultaneous connections to S3
 using s3_connection_limit
   = named_type<size_t, struct archival_s3_connection_limit_t>;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -466,6 +466,54 @@ configuration::configuration()
       "A SASL SCRAM password for testing",
       required::no,
       "")
+  , archival_storage_enabled(
+      *this,
+      "archival_storage_enabled",
+      "Enable archival storage",
+      required::no,
+      false)
+  , archival_storage_s3_access_key(
+      *this,
+      "archival_storage_s3_access_key",
+      "AWS access key",
+      required::no,
+      std::nullopt)
+  , archival_storage_s3_secret_key(
+      *this,
+      "archival_storage_s3_secret_key",
+      "AWS secret key",
+      required::no,
+      std::nullopt)
+  , archival_storage_s3_region(
+      *this,
+      "archival_storage_s3_region",
+      "AWS region that houses the bucket used for storage",
+      required::no,
+      std::nullopt)
+  , archival_storage_s3_bucket(
+      *this,
+      "archival_storage_s3_bucket",
+      "AWS bucket that should be used to store data",
+      required::no,
+      std::nullopt)
+  , archival_storage_api_endpoint(
+      *this,
+      "archival_storage_api_endpoint",
+      "Optional API endpoint",
+      required::no,
+      std::nullopt)
+  , archival_storage_reconciliation_ms(
+      *this,
+      "archival_storage_reconciliation_interval_ms",
+      "Interval at which the archival service runs reconciliation (ms)",
+      required::no,
+      10s)
+  , archival_storage_max_connections(
+      *this,
+      "archival_storage_max_connections",
+      "Max number of simultaneous uploads to S3",
+      required::no,
+      20)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -119,6 +119,16 @@ struct configuration final : public config_store {
     property<ss::sstring> static_scram_user;
     property<ss::sstring> static_scram_pass;
 
+    // Archival storage
+    property<bool> archival_storage_enabled;
+    property<std::optional<ss::sstring>> archival_storage_s3_access_key;
+    property<std::optional<ss::sstring>> archival_storage_s3_secret_key;
+    property<std::optional<ss::sstring>> archival_storage_s3_region;
+    property<std::optional<ss::sstring>> archival_storage_s3_bucket;
+    property<std::optional<ss::sstring>> archival_storage_api_endpoint;
+    property<std::chrono::milliseconds> archival_storage_reconciliation_ms;
+    property<int16_t> archival_storage_max_connections;
+
     configuration();
 
     void read_yaml(const YAML::Node& root_node) override;

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -20,6 +20,7 @@
 #include "rpc/types.h"
 #include "seastarx.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
@@ -62,6 +63,9 @@ public:
     using verb = boost::beast::http::verb;
 
     explicit client(const rpc::base_transport::configuration& cfg);
+    client(
+      const rpc::base_transport::configuration& cfg,
+      const ss::abort_source& as);
 
     ss::future<> shutdown();
 
@@ -185,6 +189,11 @@ private:
     template<class BufferSeq>
     static ss::future<>
     forward(rpc::batched_output_stream& stream, BufferSeq&& seq);
+
+    /// Throw exception if _as is aborted
+    void check() const;
+
+    const ss::abort_source* _as;
 };
 
 template<class BufferSeq>

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -29,6 +29,7 @@ v_cc_library(
     v::kafka
     v::coproc
     v::pandaproxy
+    v::archival
   )
 
 add_executable(redpanda

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "archival/service.h"
 #include "cluster/controller.h"
 #include "cluster/fwd.h"
 #include "coproc/event_listener.h"
@@ -76,6 +77,7 @@ public:
     ss::sharded<kafka::quota_manager> quota_mgr;
     ss::sharded<cluster::id_allocator_frontend> id_allocator_frontend;
     ss::sharded<kafka::credential_store> credentials;
+    ss::sharded<archival::scheduler_service> archival_scheduler;
 
 private:
     using deferred_actions
@@ -94,6 +96,8 @@ private:
         const auto& cfg = config::shard_local_cfg();
         return cfg.developer_mode() && cfg.enable_coproc();
     }
+
+    bool archival_storage_enabled();
 
     template<typename Service, typename... Args>
     ss::future<> construct_service(ss::sharded<Service>& s, Args&&... args) {

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -53,13 +53,23 @@ struct aws_header_values {
 
 // configuration //
 
+static ss::sstring make_endpoint_url(
+  const aws_region_name& region,
+  const std::optional<endpoint_url>& url_override) {
+    if (url_override) {
+        return url_override.value();
+    }
+    return fmt::format("s3.{}.amazonaws.com", region());
+}
+
 ss::future<configuration> configuration::make_configuration(
   const public_key_str& pkey,
   const private_key_str& skey,
-  const aws_region_name& region) {
+  const aws_region_name& region,
+  const std::optional<endpoint_url>& url_override) {
     configuration client_cfg;
     ss::tls::credentials_builder cred_builder;
-    const auto endpoint_uri = fmt::format("s3.{}.amazonaws.com", region());
+    const auto endpoint_uri = make_endpoint_url(region, url_override);
     // Setup credentials for TLS
     ss::tls::credentials_builder builder;
     client_cfg.access_key = pkey;

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -104,7 +104,7 @@ result<http::client::request_header> request_creator::make_get_object_request(
     // Authorization:{signature}
     // x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     auto host = fmt::format("{}.{}", name(), _ap());
-    auto target = fmt::format("/{}", key());
+    auto target = fmt::format("/{}", key().string());
     std::string emptysig
       = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
     header.method(boost::beast::http::verb::get);
@@ -138,7 +138,7 @@ request_creator::make_unsigned_put_object_request(
     // [11434 bytes of object data]
     http::client::request_header header{};
     auto host = fmt::format("{}.{}", name(), _ap());
-    auto target = fmt::format("/{}", key());
+    auto target = fmt::format("/{}", key().string());
     std::string sig = "UNSIGNED-PAYLOAD";
     header.method(boost::beast::http::verb::put);
     header.target(target);
@@ -188,15 +188,10 @@ request_creator::make_list_objects_v2_request(
     header.insert(boost::beast::http::field::content_length, "0");
     header.insert(aws_header_names::x_amz_content_sha256, emptysig);
     if (prefix) {
-        header.insert(
-          aws_header_names::prefix,
-          boost::beast::string_view{(*prefix)().data(), (*prefix)().size()});
+        header.insert(aws_header_names::prefix, (*prefix)().string());
     }
     if (start_after) {
-        header.insert(
-          aws_header_names::start_after,
-          boost::beast::string_view{
-            (*start_after)().data(), (*start_after)().size()});
+        header.insert(aws_header_names::start_after, (*start_after)().string());
     }
     if (max_keys) {
         header.insert(aws_header_names::start_after, std::to_string(*max_keys));
@@ -221,7 +216,7 @@ request_creator::make_delete_object_request(
     //
     // NOTE: x-amz-mfa, x-amz-bypass-governance-retention are not used for now
     auto host = fmt::format("{}.{}", name(), _ap());
-    auto target = fmt::format("/{}", key());
+    auto target = fmt::format("/{}", key().string());
     std::string emptysig
       = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
     header.method(boost::beast::http::verb::delete_);

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -24,7 +24,7 @@ namespace s3 {
 
 using access_point_uri = named_type<ss::sstring, struct s3_access_point_uri>;
 using bucket_name = named_type<ss::sstring, struct s3_bucket_name>;
-using object_key = named_type<ss::sstring, struct s3_object_key>;
+using object_key = named_type<std::filesystem::path, struct s3_object_key>;
 
 struct object_tag {
     ss::sstring key;

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -25,6 +25,7 @@ namespace s3 {
 using access_point_uri = named_type<ss::sstring, struct s3_access_point_uri>;
 using bucket_name = named_type<ss::sstring, struct s3_bucket_name>;
 using object_key = named_type<std::filesystem::path, struct s3_object_key>;
+using endpoint_url = named_type<ss::sstring, struct s3_endpoint_url>;
 
 struct object_tag {
     ss::sstring key;
@@ -49,11 +50,14 @@ struct configuration : rpc::base_transport::configuration {
     /// \param pkey is an AWS access key
     /// \param skey is an AWS secret key
     /// \param region is an AWS region code
+    /// \param url_override is an http endpoint that should be used
+    ///        instead of the AWS endpoint, the 'region' will be ignored
     /// \return future that returns initialized configuration
     static ss::future<configuration> make_configuration(
       const public_key_str& pkey,
       const private_key_str& skey,
-      const aws_region_name& region);
+      const aws_region_name& region,
+      const std::optional<endpoint_url>& url_override = std::nullopt);
 };
 
 std::ostream& operator<<(std::ostream& o, const configuration& c);

--- a/src/v/s3/error.cc
+++ b/src/v/s3/error.cc
@@ -10,26 +10,423 @@
 
 #include "s3/error.h"
 
+#include <boost/lexical_cast.hpp>
+
 namespace s3 {
 
 struct s3_error_category final : std::error_category {
     const char* name() const noexcept final { return "s3"; }
     std::string message(int ec) const final {
-        switch (static_cast<s3_error_codes>(ec)) {
-        case s3_error_codes::invalid_uri:
+        switch (static_cast<s3_client_error_code>(ec)) {
+        case s3_client_error_code::invalid_uri:
             return "Target URI shouldn't be empty or include domain name";
-        case s3_error_codes::invalid_uri_params:
+        case s3_client_error_code::invalid_uri_params:
             return "Target URI contains invalid query parameters";
-        case s3_error_codes::not_enough_arguments:
+        case s3_client_error_code::not_enough_arguments:
             return "Can't make request, not enough arguments";
         }
         return "unknown";
     }
 };
 
-std::error_code make_error_code(s3_error_codes ec) noexcept {
+std::error_code make_error_code(s3_client_error_code ec) noexcept {
     static s3_error_category ecat;
     return {static_cast<int>(ec), ecat};
+}
+
+std::ostream& operator<<(std::ostream& o, s3_error_code code) {
+    switch (code) {
+    case s3_error_code::access_denied:
+        o << "AccessDenied";
+        break;
+    case s3_error_code::account_problem:
+        o << "AccountProblem";
+        break;
+    case s3_error_code::all_access_disabled:
+        o << "AllAccessDisabled";
+        break;
+    case s3_error_code::ambiguous_grant_by_email_address:
+        o << "AmbiguousGrantByEmailAddress";
+        break;
+    case s3_error_code::authorization_header_malformed:
+        o << "AuthorizationHeaderMalformed";
+        break;
+    case s3_error_code::bad_digest:
+        o << "BadDigest";
+        break;
+    case s3_error_code::bucket_already_exists:
+        o << "BucketAlreadyExists";
+        break;
+    case s3_error_code::bucket_already_owned_by_you:
+        o << "BucketAlreadyOwnedByYou";
+        break;
+    case s3_error_code::bucket_not_empty:
+        o << "BucketNotEmpty";
+        break;
+    case s3_error_code::credentials_not_supported:
+        o << "CredentialsNotSupported";
+        break;
+    case s3_error_code::cross_location_logging_prohibited:
+        o << "CrossLocationLoggingProhibited";
+        break;
+    case s3_error_code::entity_too_small:
+        o << "EntityTooSmall";
+        break;
+    case s3_error_code::entity_too_large:
+        o << "EntityTooLarge";
+        break;
+    case s3_error_code::expired_token:
+        o << "ExpiredToken";
+        break;
+    case s3_error_code::illegal_location_constraint_exception:
+        o << "IllegalLocationConstraintException";
+        break;
+    case s3_error_code::illegal_versioning_configuration_exception:
+        o << "IllegalVersioningConfigurationException";
+        break;
+    case s3_error_code::incomplete_body:
+        o << "IncompleteBody";
+        break;
+    case s3_error_code::incorrect_number_of_files_in_post_request:
+        o << "IncorrectNumberOfFilesInPostRequest";
+        break;
+    case s3_error_code::inline_data_too_large:
+        o << "InlineDataTooLarge";
+        break;
+    case s3_error_code::internal_error:
+        o << "InternalError";
+        break;
+    case s3_error_code::invalid_access_key_id:
+        o << "InvalidAccessKeyId";
+        break;
+    case s3_error_code::invalid_access_point:
+        o << "InvalidAccessPoint";
+        break;
+    case s3_error_code::invalid_addressing_header:
+        o << "InvalidAddressingHeader";
+        break;
+    case s3_error_code::invalid_argument:
+        o << "InvalidArgument";
+        break;
+    case s3_error_code::invalid_bucket_name:
+        o << "InvalidBucketName";
+        break;
+    case s3_error_code::invalid_bucket_state:
+        o << "InvalidBucketState";
+        break;
+    case s3_error_code::invalid_digest:
+        o << "InvalidDigest";
+        break;
+    case s3_error_code::invalid_encryption_algorithm_error:
+        o << "InvalidEncryptionAlgorithmError";
+        break;
+    case s3_error_code::invalid_location_constraint:
+        o << "InvalidLocationConstraint";
+        break;
+    case s3_error_code::invalid_object_state:
+        o << "InvalidObjectState";
+        break;
+    case s3_error_code::invalid_part:
+        o << "InvalidPart";
+        break;
+    case s3_error_code::invalid_part_order:
+        o << "InvalidPartOrder";
+        break;
+    case s3_error_code::invalid_payer:
+        o << "InvalidPayer";
+        break;
+    case s3_error_code::invalid_policy_document:
+        o << "InvalidPolicyDocument";
+        break;
+    case s3_error_code::invalid_range:
+        o << "InvalidRange";
+        break;
+    case s3_error_code::invalid_request:
+        o << "InvalidRequest";
+        break;
+    case s3_error_code::invalid_security:
+        o << "InvalidSecurity";
+        break;
+    case s3_error_code::invalid_soaprequest:
+        o << "InvalidSOAPRequest";
+        break;
+    case s3_error_code::invalid_storage_class:
+        o << "InvalidStorageClass";
+        break;
+    case s3_error_code::invalid_target_bucket_for_logging:
+        o << "InvalidTargetBucketForLogging";
+        break;
+    case s3_error_code::invalid_token:
+        o << "InvalidToken";
+        break;
+    case s3_error_code::invalid_uri:
+        o << "InvalidURI";
+        break;
+    case s3_error_code::key_too_long_error:
+        o << "KeyTooLongError";
+        break;
+    case s3_error_code::malformed_aclerror:
+        o << "MalformedACLError";
+        break;
+    case s3_error_code::malformed_postrequest:
+        o << "MalformedPOSTRequest";
+        break;
+    case s3_error_code::malformed_xml:
+        o << "MalformedXML";
+        break;
+    case s3_error_code::max_message_length_exceeded:
+        o << "MaxMessageLengthExceeded";
+        break;
+    case s3_error_code::max_post_pre_data_length_exceeded_error:
+        o << "MaxPostPreDataLengthExceededError";
+        break;
+    case s3_error_code::metadata_too_large:
+        o << "MetadataTooLarge";
+        break;
+    case s3_error_code::method_not_allowed:
+        o << "MethodNotAllowed";
+        break;
+    case s3_error_code::missing_attachment:
+        o << "MissingAttachment";
+        break;
+    case s3_error_code::missing_content_length:
+        o << "MissingContentLength";
+        break;
+    case s3_error_code::missing_request_body_error:
+        o << "MissingRequestBodyError";
+        break;
+    case s3_error_code::missing_security_element:
+        o << "MissingSecurityElement";
+        break;
+    case s3_error_code::missing_security_header:
+        o << "MissingSecurityHeader";
+        break;
+    case s3_error_code::no_logging_status_for_key:
+        o << "NoLoggingStatusForKey";
+        break;
+    case s3_error_code::no_such_bucket:
+        o << "NoSuchBucket";
+        break;
+    case s3_error_code::no_such_bucket_policy:
+        o << "NoSuchBucketPolicy";
+        break;
+    case s3_error_code::no_such_key:
+        o << "NoSuchKey";
+        break;
+    case s3_error_code::no_such_lifecycle_configuration:
+        o << "NoSuchLifecycleConfiguration";
+        break;
+    case s3_error_code::no_such_tag_set:
+        o << "NoSuchTagSet";
+        break;
+    case s3_error_code::no_such_upload:
+        o << "NoSuchUpload";
+        break;
+    case s3_error_code::no_such_version:
+        o << "NoSuchVersion";
+        break;
+    case s3_error_code::not_implemented:
+        o << "NotImplemented";
+        break;
+    case s3_error_code::not_signed_up:
+        o << "NotSignedUp";
+        break;
+    case s3_error_code::operation_aborted:
+        o << "OperationAborted";
+        break;
+    case s3_error_code::permanent_redirect:
+        o << "PermanentRedirect";
+        break;
+    case s3_error_code::precondition_failed:
+        o << "PreconditionFailed";
+        break;
+    case s3_error_code::redirect:
+        o << "Redirect";
+        break;
+    case s3_error_code::request_header_section_too_large:
+        o << "RequestHeaderSectionTooLarge";
+        break;
+    case s3_error_code::request_is_not_multi_part_content:
+        o << "RequestIsNotMultiPartContent";
+        break;
+    case s3_error_code::request_timeout:
+        o << "RequestTimeout";
+        break;
+    case s3_error_code::request_time_too_skewed:
+        o << "RequestTimeTooSkewed";
+        break;
+    case s3_error_code::request_torrent_of_bucket_error:
+        o << "RequestTorrentOfBucketError";
+        break;
+    case s3_error_code::restore_already_in_progress:
+        o << "RestoreAlreadyInProgress";
+        break;
+    case s3_error_code::server_side_encryption_configuration_not_found_error:
+        o << "ServerSideEncryptionConfigurationNotFoundError";
+        break;
+    case s3_error_code::service_unavailable:
+        o << "ServiceUnavailable";
+        break;
+    case s3_error_code::signature_does_not_match:
+        o << "SignatureDoesNotMatch";
+        break;
+    case s3_error_code::slow_down:
+        o << "SlowDown";
+        break;
+    case s3_error_code::temporary_redirect:
+        o << "TemporaryRedirect";
+        break;
+    case s3_error_code::token_refresh_required:
+        o << "TokenRefreshRequired";
+        break;
+    case s3_error_code::too_many_access_points:
+        o << "TooManyAccessPoints";
+        break;
+    case s3_error_code::too_many_buckets:
+        o << "TooManyBuckets";
+        break;
+    case s3_error_code::unexpected_content:
+        o << "UnexpectedContent";
+        break;
+    case s3_error_code::unresolvable_grant_by_email_address:
+        o << "UnresolvableGrantByEmailAddress";
+        break;
+    case s3_error_code::user_key_must_be_specified:
+        o << "UserKeyMustBeSpecified";
+        break;
+    case s3_error_code::no_such_access_point:
+        o << "NoSuchAccessPoint";
+        break;
+    case s3_error_code::invalid_tag:
+        o << "InvalidTag";
+        break;
+    case s3_error_code::malformed_policy:
+        o << "MalformedPolicy";
+        break;
+    case s3_error_code::_unknown:
+        o << "_unknown_error_code_";
+        break;
+    }
+    return o;
+}
+
+// NOLINTNEXTLINE
+static const std::map<ss::sstring, s3_error_code> known_aws_error_codes = {
+  {"AccessDenied", s3_error_code::access_denied},
+  {"AccountProblem", s3_error_code::account_problem},
+  {"AllAccessDisabled", s3_error_code::all_access_disabled},
+  {"AmbiguousGrantByEmailAddress",
+   s3_error_code::ambiguous_grant_by_email_address},
+  {"AuthorizationHeaderMalformed",
+   s3_error_code::authorization_header_malformed},
+  {"BadDigest", s3_error_code::bad_digest},
+  {"BucketAlreadyExists", s3_error_code::bucket_already_exists},
+  {"BucketAlreadyOwnedByYou", s3_error_code::bucket_already_owned_by_you},
+  {"BucketNotEmpty", s3_error_code::bucket_not_empty},
+  {"CredentialsNotSupported", s3_error_code::credentials_not_supported},
+  {"CrossLocationLoggingProhibited",
+   s3_error_code::cross_location_logging_prohibited},
+  {"EntityTooSmall", s3_error_code::entity_too_small},
+  {"EntityTooLarge", s3_error_code::entity_too_large},
+  {"ExpiredToken", s3_error_code::expired_token},
+  {"IllegalLocationConstraintException",
+   s3_error_code::illegal_location_constraint_exception},
+  {"IllegalVersioningConfigurationException",
+   s3_error_code::illegal_versioning_configuration_exception},
+  {"IncompleteBody", s3_error_code::incomplete_body},
+  {"IncorrectNumberOfFilesInPostRequest",
+   s3_error_code::incorrect_number_of_files_in_post_request},
+  {"InlineDataTooLarge", s3_error_code::inline_data_too_large},
+  {"InternalError", s3_error_code::internal_error},
+  {"InvalidAccessKeyId", s3_error_code::invalid_access_key_id},
+  {"InvalidAccessPoint", s3_error_code::invalid_access_point},
+  {"InvalidAddressingHeader", s3_error_code::invalid_addressing_header},
+  {"InvalidArgument", s3_error_code::invalid_argument},
+  {"InvalidBucketName", s3_error_code::invalid_bucket_name},
+  {"InvalidBucketState", s3_error_code::invalid_bucket_state},
+  {"InvalidDigest", s3_error_code::invalid_digest},
+  {"InvalidEncryptionAlgorithmError",
+   s3_error_code::invalid_encryption_algorithm_error},
+  {"InvalidLocationConstraint", s3_error_code::invalid_location_constraint},
+  {"InvalidObjectState", s3_error_code::invalid_object_state},
+  {"InvalidPart", s3_error_code::invalid_part},
+  {"InvalidPartOrder", s3_error_code::invalid_part_order},
+  {"InvalidPayer", s3_error_code::invalid_payer},
+  {"InvalidPolicyDocument", s3_error_code::invalid_policy_document},
+  {"InvalidRange", s3_error_code::invalid_range},
+  {"InvalidRequest", s3_error_code::invalid_request},
+  {"InvalidSecurity", s3_error_code::invalid_security},
+  {"InvalidSOAPRequest", s3_error_code::invalid_soaprequest},
+  {"InvalidStorageClass", s3_error_code::invalid_storage_class},
+  {"InvalidTargetBucketForLogging",
+   s3_error_code::invalid_target_bucket_for_logging},
+  {"InvalidToken", s3_error_code::invalid_token},
+  {"InvalidURI", s3_error_code::invalid_uri},
+  {"KeyTooLongError", s3_error_code::key_too_long_error},
+  {"MalformedACLError", s3_error_code::malformed_aclerror},
+  {"MalformedPOSTRequest", s3_error_code::malformed_postrequest},
+  {"MalformedXML", s3_error_code::malformed_xml},
+  {"MaxMessageLengthExceeded", s3_error_code::max_message_length_exceeded},
+  {"MaxPostPreDataLengthExceededError",
+   s3_error_code::max_post_pre_data_length_exceeded_error},
+  {"MetadataTooLarge", s3_error_code::metadata_too_large},
+  {"MethodNotAllowed", s3_error_code::method_not_allowed},
+  {"MissingAttachment", s3_error_code::missing_attachment},
+  {"MissingContentLength", s3_error_code::missing_content_length},
+  {"MissingRequestBodyError", s3_error_code::missing_request_body_error},
+  {"MissingSecurityElement", s3_error_code::missing_security_element},
+  {"MissingSecurityHeader", s3_error_code::missing_security_header},
+  {"NoLoggingStatusForKey", s3_error_code::no_logging_status_for_key},
+  {"NoSuchBucket", s3_error_code::no_such_bucket},
+  {"NoSuchBucketPolicy", s3_error_code::no_such_bucket_policy},
+  {"NoSuchKey", s3_error_code::no_such_key},
+  {"NoSuchLifecycleConfiguration",
+   s3_error_code::no_such_lifecycle_configuration},
+  {"NoSuchTagSet", s3_error_code::no_such_tag_set},
+  {"NoSuchUpload", s3_error_code::no_such_upload},
+  {"NoSuchVersion", s3_error_code::no_such_version},
+  {"NotImplemented", s3_error_code::not_implemented},
+  {"NotSignedUp", s3_error_code::not_signed_up},
+  {"OperationAborted", s3_error_code::operation_aborted},
+  {"PermanentRedirect", s3_error_code::permanent_redirect},
+  {"PreconditionFailed", s3_error_code::precondition_failed},
+  {"Redirect", s3_error_code::redirect},
+  {"RequestHeaderSectionTooLarge",
+   s3_error_code::request_header_section_too_large},
+  {"RequestIsNotMultiPartContent",
+   s3_error_code::request_is_not_multi_part_content},
+  {"RequestTimeout", s3_error_code::request_timeout},
+  {"RequestTimeTooSkewed", s3_error_code::request_time_too_skewed},
+  {"RequestTorrentOfBucketError",
+   s3_error_code::request_torrent_of_bucket_error},
+  {"RestoreAlreadyInProgress", s3_error_code::restore_already_in_progress},
+  {"ServerSideEncryptionConfigurationNotFoundError",
+   s3_error_code::server_side_encryption_configuration_not_found_error},
+  {"ServiceUnavailable", s3_error_code::service_unavailable},
+  {"SignatureDoesNotMatch", s3_error_code::signature_does_not_match},
+  {"SlowDown", s3_error_code::slow_down},
+  {"TemporaryRedirect", s3_error_code::temporary_redirect},
+  {"TokenRefreshRequired", s3_error_code::token_refresh_required},
+  {"TooManyAccessPoints", s3_error_code::too_many_access_points},
+  {"TooManyBuckets", s3_error_code::too_many_buckets},
+  {"UnexpectedContent", s3_error_code::unexpected_content},
+  {"UnresolvableGrantByEmailAddress",
+   s3_error_code::unresolvable_grant_by_email_address},
+  {"UserKeyMustBeSpecified", s3_error_code::user_key_must_be_specified},
+  {"NoSuchAccessPoint", s3_error_code::no_such_access_point},
+  {"InvalidTag", s3_error_code::invalid_tag},
+  {"MalformedPolicy", s3_error_code::malformed_policy}};
+
+std::istream& operator>>(std::istream& i, s3_error_code& code) {
+    ss::sstring c;
+    i >> c;
+    auto it = known_aws_error_codes.find(c);
+    if (it != known_aws_error_codes.end()) {
+        code = it->second;
+    } else {
+        code = s3_error_code::_unknown;
+    }
+    return i;
 }
 
 rest_error_response::rest_error_response(
@@ -37,7 +434,8 @@ rest_error_response::rest_error_response(
   std::string_view message,
   std::string_view request_id,
   std::string_view resource)
-  : _code(code)
+  : _code(boost::lexical_cast<s3_error_code>(code))
+  , _code_str(code)
   , _message(message)
   , _request_id(request_id)
   , _resource(resource) {}
@@ -45,7 +443,10 @@ rest_error_response::rest_error_response(
 const char* rest_error_response::what() const noexcept {
     return _message.c_str();
 }
-std::string_view rest_error_response::code() const noexcept { return _code; }
+s3_error_code rest_error_response::code() const noexcept { return _code; }
+std::string_view rest_error_response::code_string() const noexcept {
+    return _code_str;
+}
 std::string_view rest_error_response::message() const noexcept {
     return _message;
 }

--- a/src/v/s3/error.h
+++ b/src/v/s3/error.h
@@ -17,17 +17,119 @@
 
 #include <exception>
 #include <system_error>
+#include <variant>
 
 namespace s3 {
 
-/// Internal s3 client error codes
-enum class s3_error_codes : int {
+/// \brief Internal s3 client error code
+enum class s3_client_error_code : int {
     invalid_uri,
     invalid_uri_params,
     not_enough_arguments,
 };
 
-std::error_code make_error_code(s3_error_codes ec) noexcept;
+std::error_code make_error_code(s3_client_error_code ec) noexcept;
+
+/// \brief AWS S3 error codes
+///
+/// \note GCS uses these codes but adds it's own so implementation
+///       needs to be ready for that
+enum class s3_error_code {
+    access_denied,
+    account_problem,
+    all_access_disabled,
+    ambiguous_grant_by_email_address,
+    authorization_header_malformed,
+    bad_digest,
+    bucket_already_exists,
+    bucket_already_owned_by_you,
+    bucket_not_empty,
+    credentials_not_supported,
+    cross_location_logging_prohibited,
+    entity_too_small,
+    entity_too_large,
+    expired_token,
+    illegal_location_constraint_exception,
+    illegal_versioning_configuration_exception,
+    incomplete_body,
+    incorrect_number_of_files_in_post_request,
+    inline_data_too_large,
+    internal_error,
+    invalid_access_key_id,
+    invalid_access_point,
+    invalid_addressing_header,
+    invalid_argument,
+    invalid_bucket_name,
+    invalid_bucket_state,
+    invalid_digest,
+    invalid_encryption_algorithm_error,
+    invalid_location_constraint,
+    invalid_object_state,
+    invalid_part,
+    invalid_part_order,
+    invalid_payer,
+    invalid_policy_document,
+    invalid_range,
+    invalid_request,
+    invalid_security,
+    invalid_soaprequest,
+    invalid_storage_class,
+    invalid_target_bucket_for_logging,
+    invalid_token,
+    invalid_uri,
+    key_too_long_error,
+    malformed_aclerror,
+    malformed_postrequest,
+    malformed_xml,
+    max_message_length_exceeded,
+    max_post_pre_data_length_exceeded_error,
+    metadata_too_large,
+    method_not_allowed,
+    missing_attachment,
+    missing_content_length,
+    missing_request_body_error,
+    missing_security_element,
+    missing_security_header,
+    no_logging_status_for_key,
+    no_such_bucket,
+    no_such_bucket_policy,
+    no_such_key,
+    no_such_lifecycle_configuration,
+    no_such_tag_set,
+    no_such_upload,
+    no_such_version,
+    not_implemented,
+    not_signed_up,
+    operation_aborted,
+    permanent_redirect,
+    precondition_failed,
+    redirect,
+    request_header_section_too_large,
+    request_is_not_multi_part_content,
+    request_timeout,
+    request_time_too_skewed,
+    request_torrent_of_bucket_error,
+    restore_already_in_progress,
+    server_side_encryption_configuration_not_found_error,
+    service_unavailable,
+    signature_does_not_match,
+    slow_down,
+    temporary_redirect,
+    token_refresh_required,
+    too_many_access_points,
+    too_many_buckets,
+    unexpected_content,
+    unresolvable_grant_by_email_address,
+    user_key_must_be_specified,
+    no_such_access_point,
+    invalid_tag,
+    malformed_policy,
+    _unknown
+};
+
+/// Operators to use with lexical_cast
+std::ostream& operator<<(std::ostream& o, s3_error_code code);
+std::istream& operator>>(std::istream& i, s3_error_code& code);
 
 /// Error received in a response from the server
 class rest_error_response : std::exception {
@@ -40,13 +142,17 @@ public:
 
     const char* what() const noexcept override;
 
-    std::string_view code() const noexcept;
+    s3_error_code code() const noexcept;
+    std::string_view code_string() const noexcept;
     std::string_view message() const noexcept;
     std::string_view request_id() const noexcept;
     std::string_view resource() const noexcept;
 
 private:
-    ss::sstring _code;
+    s3_error_code _code;
+    /// Error code string representation, this string is almost always short
+    /// enough for SSA
+    ss::sstring _code_str;
     ss::sstring _message;
     ss::sstring _request_id;
     ss::sstring _resource;

--- a/src/v/s3/signature.cc
+++ b/src/v/s3/signature.cc
@@ -146,7 +146,7 @@ static ss::sstring uri_encode(const ss::sstring& input, bool encode_slash) {
 static result<ss::sstring> get_canonical_uri(ss::sstring target) {
     if (target.empty() || target[0] != '/') {
         vlog(s3_log.error, "invalid URI {}", target);
-        return make_error_code(s3_error_codes::invalid_uri);
+        return make_error_code(s3_client_error_code::invalid_uri);
     }
     auto pos = target.find('?');
     if (pos != ss::sstring::npos) {
@@ -172,7 +172,7 @@ static result<ss::sstring> get_canonical_uri(ss::sstring target) {
 static result<ss::sstring> get_canonical_query_string(ss::sstring target) {
     if (target.empty() || target[0] != '/') {
         vlog(s3_log.error, "invalid URI {}", target);
-        return make_error_code(s3_error_codes::invalid_uri);
+        return make_error_code(s3_client_error_code::invalid_uri);
     }
     auto pos = target.find('?');
     if (pos == ss::sstring::npos || pos == target.size() - 1) {
@@ -190,7 +190,8 @@ static result<ss::sstring> get_canonical_query_string(ss::sstring target) {
         } else {
             if (p == 0) {
                 // parameter value can be empty but name can't
-                return make_error_code(s3_error_codes::invalid_uri_params);
+                return make_error_code(
+                  s3_client_error_code::invalid_uri_params);
             }
             ss::sstring pname = param.substr(0, p);
             ss::sstring pvalue = param.substr(p + 1);

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -48,7 +48,8 @@ static constexpr const char* expected_payload
 static const size_t expected_payload_size = std::strlen(expected_payload);
 static constexpr const char* error_payload
   = "<?xml version=\"1.0\" "
-    "encoding=\"UTF-8\"?><Error><Code>Error.Code</Code><Message>Error.Message</"
+    "encoding=\"UTF-8\"?><Error><Code>InternalError</"
+    "Code><Message>Error.Message</"
     "Message><Resource>Error.Resource</Resource><RequestId>Error.RequestId</"
     "RequestId></Error>";
 static constexpr const char* list_objects_payload = R"xml(
@@ -214,7 +215,7 @@ SEASTAR_TEST_CASE(test_put_object_failure) {
                 std::move(payload_stream))
               .get();
         } catch (const s3::rest_error_response& err) {
-            BOOST_REQUIRE_EQUAL(err.code(), "Error.Code");
+            BOOST_REQUIRE_EQUAL(err.code(), s3::s3_error_code::internal_error);
             BOOST_REQUIRE_EQUAL(err.message(), "Error.Message");
             BOOST_REQUIRE_EQUAL(err.request_id(), "Error.RequestId");
             BOOST_REQUIRE_EQUAL(err.resource(), "Error.Resource");
@@ -257,7 +258,7 @@ SEASTAR_TEST_CASE(test_get_object_failure) {
                                      s3::object_key("test-error"))
                                    .get0();
         } catch (const s3::rest_error_response& err) {
-            BOOST_REQUIRE_EQUAL(err.code(), "Error.Code");
+            BOOST_REQUIRE_EQUAL(err.code(), s3::s3_error_code::internal_error);
             BOOST_REQUIRE_EQUAL(err.message(), "Error.Message");
             BOOST_REQUIRE_EQUAL(err.request_id(), "Error.RequestId");
             BOOST_REQUIRE_EQUAL(err.resource(), "Error.Resource");
@@ -291,7 +292,7 @@ SEASTAR_TEST_CASE(test_delete_object_failure) {
                 s3::bucket_name("test-bucket"), s3::object_key("test-error"))
               .get0();
         } catch (const s3::rest_error_response& err) {
-            BOOST_REQUIRE_EQUAL(err.code(), "Error.Code");
+            BOOST_REQUIRE_EQUAL(err.code(), s3::s3_error_code::internal_error);
             BOOST_REQUIRE_EQUAL(err.message(), "Error.Message");
             BOOST_REQUIRE_EQUAL(err.request_id(), "Error.RequestId");
             BOOST_REQUIRE_EQUAL(err.resource(), "Error.Resource");
@@ -348,7 +349,7 @@ SEASTAR_TEST_CASE(test_list_objects_failure) {
                            s3::object_key("test-error"))
                          .get0();
         } catch (const s3::rest_error_response& err) {
-            BOOST_REQUIRE_EQUAL(err.code(), "Error.Code");
+            BOOST_REQUIRE_EQUAL(err.code(), s3::s3_error_code::internal_error);
             BOOST_REQUIRE_EQUAL(err.message(), "Error.Message");
             BOOST_REQUIRE_EQUAL(err.request_id(), "Error.RequestId");
             BOOST_REQUIRE_EQUAL(err.resource(), "Error.Resource");

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -285,6 +285,14 @@ log_manager::get(const model::topic_namespace& tn) {
     return r;
 }
 
+absl::flat_hash_set<model::ntp> log_manager::get_all_ntps() const {
+    absl::flat_hash_set<model::ntp> r;
+    for (const auto& p : _logs) {
+        r.insert(p.first);
+    }
+    return r;
+}
+
 std::ostream& operator<<(std::ostream& o, log_config::storage_type t) {
     switch (t) {
     case log_config::storage_type::memory:

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -32,6 +32,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 
 #include <array>
 #include <chrono>
@@ -202,6 +203,9 @@ public:
 
     /// Returns the logs that match a model::topic_namespace
     absl::flat_hash_map<model::ntp, log> get(const model::topic_namespace&);
+
+    /// Returns all ntp's managed by this instance
+    absl::flat_hash_set<model::ntp> get_all_ntps() const;
 
 private:
     using logs_type = absl::flat_hash_map<model::ntp, log_housekeeping_meta>;


### PR DESCRIPTION
Add archival scheduler service

The service is responsible for triggering uploads and deletions of individual segments in S3. It maintains a queue of `ntp_archiver` instances and supposed to keep it up to date with redpanda state.

The GC algorithm is not implemented yet. The segments are only deleted from S3 when local segments are deleted by retention. When the whole topic is deleted it remains in S3 bucket until the GC kicks in (which is never, as for now). The GC is supposed to be implemented in future PRs.

The algorithms used for selection of upload and delete candidates is supposed to be controlled by configurable policies. In this PR only one policy for both upload and delete is implemented.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
