### PR TITLE
kc/consumer: Introduce fetch_session

### DIFF
--- a/src/v/kafka/client/CMakeLists.txt
+++ b/src/v/kafka/client/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     configuration.cc
     consumer.cc
     fetcher.cc
+    fetch_session.cc
     producer.cc
   DEPS
     v::kafka

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -1,0 +1,67 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/client/fetch_session.h"
+
+#include "kafka/protocol/fetch.h"
+
+#include <fmt/ostream.h>
+
+#include <iostream>
+
+namespace kafka::client {
+
+model::offset fetch_session::offset(model::topic_partition_view tpv) const {
+    auto topic_it = _offsets.find(tpv.topic);
+    if (topic_it == _offsets.end()) {
+        return model::offset{0};
+    }
+    auto part_it = topic_it->second.find(tpv.partition);
+    if (part_it == topic_it->second.end()) {
+        return model::offset{0};
+    }
+    return part_it->second;
+}
+
+bool fetch_session::apply(fetch_response& res) {
+    if (_id == invalid_fetch_session_id) {
+        _id = fetch_session_id{res.session_id};
+    }
+
+    if (res.session_id != _id) {
+        vassert(false, "session mismatch: {}", *this);
+        _id = invalid_fetch_session_id;
+        return false;
+    }
+    ++_epoch;
+    for (auto& part : res) {
+        if (part.partition_response->has_error()) {
+            continue;
+        }
+        const auto& topic = part.partition->name;
+        const auto p_id = part.partition_response->id;
+        auto& record_set = part.partition_response->record_set;
+        if (!record_set || record_set->empty()) {
+            continue;
+        }
+
+        _offsets[topic][p_id] = ++record_set->last_offset();
+    }
+    for (auto& topic : _offsets) {
+        topic.second.rehash(topic.second.size());
+    }
+    return true;
+}
+
+std::ostream& operator<<(std::ostream& os, fetch_session const& fs) {
+    fmt::print(os, "{id={}, epoch={}}", fs.id(), fs.epoch());
+    return os;
+}
+
+} // namespace kafka::client

--- a/src/v/kafka/client/fetch_session.h
+++ b/src/v/kafka/client/fetch_session.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/types.h"
+#include "model/fundamental.h"
+
+#include <absl/container/node_hash_map.h>
+
+#include <iosfwd>
+
+namespace kafka {
+struct fetch_response;
+}
+
+namespace kafka::client {
+
+/// \brief Maintain state for consumer group fetch session.
+class fetch_session {
+public:
+    fetch_session() = default;
+    fetch_session(const fetch_session&) = delete;
+    fetch_session(fetch_session&&) = default;
+    fetch_session& operator=(const fetch_session&) = delete;
+    fetch_session& operator=(fetch_session&&) = default;
+    ~fetch_session() = default;
+
+    void reset_offsets() { _offsets.clear(); }
+    kafka::fetch_session_id id() const { return _id; }
+    void id(kafka::fetch_session_id id) { _id = id; }
+    kafka::fetch_session_epoch epoch() const { return _epoch; }
+    model::offset offset(model::topic_partition_view tpv) const;
+    bool apply(fetch_response& res);
+
+    friend std::ostream& operator<<(std::ostream& os, fetch_session const&);
+
+private:
+    kafka::fetch_session_id _id{kafka::invalid_fetch_session_id};
+    kafka::fetch_session_epoch _epoch{kafka::initial_fetch_session_epoch};
+    absl::node_hash_map<
+      model::topic,
+      absl::node_hash_map<model::partition_id, model::offset>>
+      _offsets;
+};
+
+} // namespace kafka::client

--- a/src/v/kafka/client/test/CMakeLists.txt
+++ b/src/v/kafka/client/test/CMakeLists.txt
@@ -2,6 +2,7 @@ rp_test(
   UNIT_TEST
   BINARY_NAME test_kafka_client
   SOURCES
+    fetch_session.cc
     produce_batcher.cc
     produce_partition.cc
     retry_with_mitigation.cc

--- a/src/v/kafka/client/test/fetch_session.cc
+++ b/src/v/kafka/client/test/fetch_session.cc
@@ -1,0 +1,133 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/client/fetch_session.h"
+
+#include "kafka/client/test/utils.h"
+#include "kafka/protocol/batch_consumer.h"
+#include "kafka/protocol/batch_reader.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/fetch.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "storage/tests/utils/random_batch.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+namespace k = kafka;
+namespace kc = k::client;
+
+std::optional<kafka::batch_reader>
+make_record_set(model::offset offset, std::optional<size_t> count) {
+    if (!count) {
+        return std::nullopt;
+    }
+    iobuf record_set;
+    auto writer{kafka::response_writer(record_set)};
+    kafka::writer_serialize_batch(writer, make_batch(offset, *count));
+    return kafka::batch_reader{std::move(record_set)};
+}
+
+kafka::fetch_response make_fetch_response(
+  kafka::fetch_session_id s_id,
+  model::topic_partition_view tpv,
+  std::optional<kafka::batch_reader> record_set) {
+    kafka::fetch_response res{
+      .throttle_time = std::chrono::milliseconds{0},
+      .error = kafka::error_code::none,
+      .session_id = s_id,
+      .partitions{}};
+    kafka::fetch_response::partition p(tpv.topic);
+    p.responses.push_back(kafka::fetch_response::partition_response{
+      .id = tpv.partition,
+      .error = kafka::error_code::none,
+      .high_watermark = model::offset{-1},
+      .last_stable_offset = model::offset{-1},
+      .log_start_offset = model::offset{-1},
+      .aborted_transactions = {},
+      .record_set{std::move(record_set)}});
+    res.partitions.push_back(std::move(p));
+    return res;
+}
+
+struct context {
+    const kafka::fetch_session_id fetch_session_id{42};
+    const model::topic_partition tp{
+      model::topic{"test_topic"}, model::partition_id{2}};
+    const size_t record_set_size{0};
+    kafka::fetch_session_epoch expected_epoch{
+      kafka::initial_fetch_session_epoch};
+    model::offset expected_offset{0};
+
+    bool
+    apply_fetch_response(kc::fetch_session& s, std::optional<size_t> count) {
+        auto res = make_fetch_response(
+          fetch_session_id, tp, make_record_set(expected_offset, count));
+        expected_offset += count.value_or(0);
+        ++expected_epoch;
+        return s.apply(res);
+    }
+};
+
+SEASTAR_THREAD_TEST_CASE(test_fetch_session) {
+    context ctx;
+    kc::fetch_session s;
+
+    BOOST_REQUIRE_EQUAL(s.id(), kafka::invalid_fetch_session_id);
+    BOOST_REQUIRE_EQUAL(s.epoch(), kafka::initial_fetch_session_epoch);
+    BOOST_REQUIRE_EQUAL(s.offset(ctx.tp), model::offset{0});
+
+    // Apply some records
+    BOOST_REQUIRE(ctx.apply_fetch_response(s, 8));
+    BOOST_REQUIRE_EQUAL(s.id(), ctx.fetch_session_id);
+    BOOST_REQUIRE_EQUAL(s.epoch(), ctx.expected_epoch);
+    BOOST_REQUIRE_EQUAL(s.offset(ctx.tp), ctx.expected_offset);
+
+    // Apply more records
+    BOOST_REQUIRE(ctx.apply_fetch_response(s, 8));
+    BOOST_REQUIRE_EQUAL(s.id(), ctx.fetch_session_id);
+    BOOST_REQUIRE_EQUAL(s.epoch(), ctx.expected_epoch);
+    BOOST_REQUIRE_EQUAL(s.offset(ctx.tp), ctx.expected_offset);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_fetch_session_null_record_set) {
+    context ctx;
+    kc::fetch_session s;
+
+    // Apply some records
+    BOOST_REQUIRE(ctx.apply_fetch_response(s, 8));
+    BOOST_REQUIRE_EQUAL(s.id(), ctx.fetch_session_id);
+    BOOST_REQUIRE_EQUAL(s.epoch(), ctx.expected_epoch);
+    BOOST_REQUIRE_EQUAL(s.offset(ctx.tp), ctx.expected_offset);
+
+    // Apply nullopt record_set
+    BOOST_REQUIRE(ctx.apply_fetch_response(s, std::nullopt));
+    BOOST_REQUIRE_EQUAL(s.id(), ctx.fetch_session_id);
+    BOOST_REQUIRE_EQUAL(s.epoch(), ctx.expected_epoch);
+    BOOST_REQUIRE_EQUAL(s.offset(ctx.tp), ctx.expected_offset);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_fetch_session_empty_record_set) {
+    context ctx;
+    kc::fetch_session s;
+
+    // Apply some records
+    BOOST_REQUIRE(ctx.apply_fetch_response(s, 8));
+    BOOST_REQUIRE_EQUAL(s.id(), ctx.fetch_session_id);
+    BOOST_REQUIRE_EQUAL(s.epoch(), ctx.expected_epoch);
+    BOOST_REQUIRE_EQUAL(s.offset(ctx.tp), ctx.expected_offset);
+
+    // Apply 0 records
+    BOOST_REQUIRE(ctx.apply_fetch_response(s, 0));
+    BOOST_REQUIRE_EQUAL(s.id(), ctx.fetch_session_id);
+    BOOST_REQUIRE_EQUAL(s.epoch(), ctx.expected_epoch);
+    BOOST_REQUIRE_EQUAL(s.offset(ctx.tp), ctx.expected_offset);
+}


### PR DESCRIPTION
This holds the state for consumer group fetch.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
