### PR TITLE
http/s3/archival: Reduce link dependencies

### DIFF
--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ rp_test(
   BINARY_NAME test_archival_manifest
   SOURCES manifest_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils
+  LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::archival v::storage_test_utils
   ARGS "-- -c 1"
 )
 

--- a/src/v/http/tests/CMakeLists.txt
+++ b/src/v/http/tests/CMakeLists.txt
@@ -4,6 +4,6 @@ rp_test(
   BINARY_NAME test_http_client
   SOURCES http_client_test.cc framing_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::http
+  LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::http
   ARGS "-- -c 1"
 )

--- a/src/v/s3/tests/CMakeLists.txt
+++ b/src/v/s3/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ rp_test(
   BINARY_NAME test_aws_signature
   SOURCES signature_test.cc 
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::http v::s3
+  LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::http v::s3
   ARGS "-- -c 1"
 )
 
@@ -13,7 +13,7 @@ rp_test(
   BINARY_NAME test_s3_client
   SOURCES s3_client_test.cc 
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::http v::s3
+  LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::http v::s3
   ARGS "-- -c 1"
 )
 


### PR DESCRIPTION
`v::application` is built very late, anything that depends on it is blocked, reducing parallelism at the end of the build.

`v::application` isn't needed in these tests.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
