### PR TITLE
pp/consumer_groups: Introduce consumer group create and subscribe

### DIFF
--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -40,6 +40,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/create_consumer.json.h
 )
 
+seastar_generate_swagger(
+  TARGET subscribe_consumer_swagger
+  VAR subscribe_consumer_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/api/api-doc/subscribe_consumer.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/subscribe_consumer.json.h
+)
+
 v_cc_library(
   NAME rest_application
   SRCS
@@ -70,6 +77,7 @@ add_dependencies(v_rest_application
   get_topics_records_swagger
   post_topics_name_swagger
   create_consumer_swagger
+  subscribe_consumer_swagger
 )
 
 if(CMAKE_BUILD_TYPE MATCHES Release)

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -33,6 +33,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/post_topics_name.json.h
 )
 
+seastar_generate_swagger(
+  TARGET create_consumer_swagger
+  VAR create_consumer_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/api/api-doc/create_consumer.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/create_consumer.json.h
+)
+
 v_cc_library(
   NAME rest_application
   SRCS
@@ -62,6 +69,7 @@ add_dependencies(v_rest_application
   get_topics_names_swagger
   get_topics_records_swagger
   post_topics_name_swagger
+  create_consumer_swagger
 )
 
 if(CMAKE_BUILD_TYPE MATCHES Release)

--- a/src/v/pandaproxy/api/api-doc/create_consumer.json
+++ b/src/v/pandaproxy/api/api-doc/create_consumer.json
@@ -1,0 +1,14 @@
+    "/consumers/{group_name}": {
+      "post": {
+        "summary": "Create a consumer for the group",
+        "operationId": "create_consumer",
+        "parameters": [
+          {
+            "name": "group_name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }

--- a/src/v/pandaproxy/api/api-doc/subscribe_consumer.json
+++ b/src/v/pandaproxy/api/api-doc/subscribe_consumer.json
@@ -1,0 +1,20 @@
+    "/consumers/{group_name}/instances/{instance}/subscription": {
+      "post": {
+        "summary": "Subscribe a consumer group to topics",
+        "operationId": "subscribe_consumer",
+        "parameters": [
+          {
+            "name": "group_name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "instance",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    }

--- a/src/v/pandaproxy/configuration.cc
+++ b/src/v/pandaproxy/configuration.cc
@@ -29,6 +29,12 @@ configuration::configuration()
       "Rest API listen address and port",
       config::required::no,
       unresolved_address("127.0.0.1", 8082))
+  , advertised_pandaproxy_api(
+      *this,
+      "advertised_pandaproxy_api",
+      "Rest API address and port to publish to client",
+      config::required::no,
+      pandaproxy_api)
   , admin_api(
       *this,
       "admin_api",

--- a/src/v/pandaproxy/configuration.h
+++ b/src/v/pandaproxy/configuration.h
@@ -26,6 +26,7 @@ namespace pandaproxy {
 struct configuration final : public config::config_store {
     config::property<bool> developer_mode;
     config::property<unresolved_address> pandaproxy_api;
+    config::property<unresolved_address> advertised_pandaproxy_api;
     config::property<unresolved_address> admin_api;
     config::property<bool> enable_admin_api;
     config::property<ss::sstring> admin_api_doc_dir;

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -10,7 +10,10 @@
 #include "handlers.h"
 
 #include "kafka/protocol/fetch.h"
+#include "kafka/types.h"
 #include "model/fundamental.h"
+#include "pandaproxy/configuration.h"
+#include "pandaproxy/json/requests/create_consumer.h"
 #include "pandaproxy/json/requests/fetch.h"
 #include "pandaproxy/json/requests/produce.h"
 #include "pandaproxy/json/rjson_util.h"
@@ -175,6 +178,28 @@ post_topics_name(server::request_t rq, server::reply_t rp) {
             .throttle{std::chrono::milliseconds{0}}};
 
           auto json_rslt = ppj::rjson_serialize(res.topics[0]);
+          rp.rep->write_body("json", json_rslt);
+          return std::move(rp);
+      });
+}
+
+ss::future<server::reply_t>
+create_consumer(server::request_t rq, server::reply_t rp) {
+    auto req_data = ppj::rjson_parse(
+      rq.req->content.data(), ppj::create_consumer_request_handler());
+    auto group_id = kafka::group_id(rq.req->param["group_name"]);
+
+    return rq.ctx.client.create_consumer(group_id).then(
+      [group_id, rp{std::move(rp)}](kafka::member_id m_id) mutable {
+          auto adv_addr = shard_local_cfg().advertised_pandaproxy_api();
+          json::create_consumer_response res{
+            .instance_id = m_id,
+            .base_uri = fmt::format(
+              "http://{}:{}/consumers/{}",
+              adv_addr.host(),
+              adv_addr.port(),
+              m_id())};
+          auto json_rslt = ppj::rjson_serialize(res);
           rp.rep->write_body("json", json_rslt);
           return std::move(rp);
       });

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -16,6 +16,7 @@
 #include "pandaproxy/json/requests/create_consumer.h"
 #include "pandaproxy/json/requests/fetch.h"
 #include "pandaproxy/json/requests/produce.h"
+#include "pandaproxy/json/requests/subscribe_consumer.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/reply.h"
 #include "raft/types.h"
@@ -201,6 +202,21 @@ create_consumer(server::request_t rq, server::reply_t rp) {
               m_id())};
           auto json_rslt = ppj::rjson_serialize(res);
           rp.rep->write_body("json", json_rslt);
+          return std::move(rp);
+      });
+}
+
+ss::future<server::reply_t>
+subscribe_consumer(server::request_t rq, server::reply_t rp) {
+    auto req_data = ppj::rjson_parse(
+      rq.req->content.data(), ppj::subscribe_consumer_request_handler());
+    auto group_id = kafka::group_id(rq.req->param["group_name"]);
+    auto member_id = kafka::member_id(rq.req->param["instance"]);
+
+    return rq.ctx.client
+      .subscribe_consumer(group_id, member_id, std::move(req_data.topics))
+      .then([group_id, rp{std::move(rp)}]() mutable {
+          // nothing to do!
           return std::move(rp);
       });
 }

--- a/src/v/pandaproxy/handlers.h
+++ b/src/v/pandaproxy/handlers.h
@@ -27,4 +27,7 @@ get_topics_records(server::request_t rq, server::reply_t rp);
 ss::future<server::reply_t>
 post_topics_name(server::request_t rq, server::reply_t rp);
 
+ss::future<server::reply_t>
+create_consumer(server::request_t rq, server::reply_t rp);
+
 } // namespace pandaproxy

--- a/src/v/pandaproxy/handlers.h
+++ b/src/v/pandaproxy/handlers.h
@@ -30,4 +30,7 @@ post_topics_name(server::request_t rq, server::reply_t rp);
 ss::future<server::reply_t>
 create_consumer(server::request_t rq, server::reply_t rp);
 
+ss::future<server::reply_t>
+subscribe_consumer(server::request_t rq, server::reply_t rp);
+
 } // namespace pandaproxy

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "json/json.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/produce.h"
+#include "kafka/types.h"
+#include "pandaproxy/json/iobuf.h"
+#include "seastarx.h"
+#include "utils/string_switch.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <rapidjson/reader.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <string_view>
+
+namespace pandaproxy::json {
+
+struct create_consumer_request {
+    std::optional<ss::sstring> name;
+    ss::sstring format{"binary"};
+    ss::sstring auto_offset_reset;
+    ss::sstring auto_commit_enable;
+    ss::sstring fetch_min_bytes;
+    ss::sstring consumer_request_timeout_ms;
+};
+
+template<typename Encoding = rapidjson::UTF8<>>
+class create_consumer_request_handler {
+private:
+    enum class state {
+        empty = 0,
+        name,
+        format,
+        auto_offset_reset,
+        auto_commit_enable,
+        fetch_min_bytes,
+        timeout_ms
+    };
+
+    state _state = state::empty;
+
+public:
+    using Ch = typename Encoding::Ch;
+    using rjson_parse_result = create_consumer_request;
+    rjson_parse_result result;
+
+    bool Null() { return false; }
+    bool Bool(bool) { return false; }
+    bool Int64(int64_t) { return false; }
+    bool Uint64(uint64_t) { return false; }
+    bool Double(double) { return false; }
+    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
+    bool Int(int) { return false; }
+    bool Uint(unsigned) { return false; }
+    bool StartArray() { return false; }
+    bool EndArray(rapidjson::SizeType) { return false; }
+
+    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+        switch (_state) {
+        case state::empty:
+            return false;
+        case state::name:
+            result.name = {str, len};
+            break;
+        case state::format:
+            result.format = {str, len};
+            break;
+        case state::auto_offset_reset:
+            result.auto_offset_reset = {str, len};
+            break;
+        case state::auto_commit_enable:
+            result.auto_commit_enable = {str, len};
+            break;
+        case state::fetch_min_bytes:
+            result.fetch_min_bytes = {str, len};
+            break;
+        case state::timeout_ms:
+            result.consumer_request_timeout_ms = {str, len};
+            break;
+        }
+        return true;
+    }
+
+    bool Key(const char* str, rapidjson::SizeType len, bool) {
+        _state = string_switch<state>({str, len})
+                   .match("name", state::name)
+                   .match("format", state::format)
+                   .match("auto.offset.reset", state::auto_offset_reset)
+                   .match("auto.commit.enable", state::auto_commit_enable)
+                   .match("fetch.min.bytes", state::fetch_min_bytes)
+                   .match("consumer.request.timeout.ms", state::timeout_ms)
+                   .default_match(state::empty);
+
+        return _state != state::empty;
+    }
+
+    bool StartObject() { return _state == state::empty; }
+
+    bool EndObject(rapidjson::SizeType) { return _state != state::empty; }
+};
+
+struct create_consumer_response {
+    kafka::member_id instance_id;
+    ss::sstring base_uri;
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const create_consumer_response& res) {
+    w.StartObject();
+    w.Key("instance_id");
+    w.String(res.instance_id());
+    w.Key("base_uri");
+    w.String(res.base_uri);
+    w.EndObject();
+}
+
+template<typename Encoding = rapidjson::UTF8<>>
+class create_consumer_response_handler {
+private:
+    enum class state { empty = 0, instance_id, base_uri };
+
+    state _state = state::empty;
+
+public:
+    using Ch = typename Encoding::Ch;
+    using rjson_parse_result = create_consumer_response;
+    rjson_parse_result result;
+
+    bool Null() { return false; }
+    bool Bool(bool) { return false; }
+    bool Int64(int64_t) { return false; }
+    bool Uint64(uint64_t) { return false; }
+    bool Double(double) { return false; }
+    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
+    bool Int(int) { return false; }
+    bool Uint(unsigned) { return false; }
+    bool StartArray() { return false; }
+    bool EndArray(rapidjson::SizeType) { return false; }
+
+    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+        auto str_view{std::string_view{str, len}};
+        switch (_state) {
+        case state::empty:
+            return false;
+        case state::instance_id:
+            result.instance_id = kafka::member_id{ss::sstring{str_view}};
+            break;
+        case state::base_uri:
+            result.base_uri = {str, len};
+            break;
+        }
+        return true;
+    }
+
+    bool Key(const char* str, rapidjson::SizeType len, bool) {
+        _state = string_switch<state>({str, len})
+                   .match("instance_id", state::instance_id)
+                   .match("base_uri", state::base_uri)
+                   .default_match(state::empty);
+
+        return _state != state::empty;
+    }
+
+    bool StartObject() { return _state == state::empty; }
+
+    bool EndObject(rapidjson::SizeType) { return _state != state::empty; }
+};
+
+} // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/requests/subscribe_consumer.h
+++ b/src/v/pandaproxy/json/requests/subscribe_consumer.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "json/json.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/types.h"
+#include "pandaproxy/json/iobuf.h"
+#include "seastarx.h"
+#include "utils/string_switch.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <rapidjson/reader.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <string_view>
+
+namespace pandaproxy::json {
+
+struct subscribe_consumer_request {
+    std::vector<model::topic> topics;
+};
+
+template<typename Encoding = rapidjson::UTF8<>>
+class subscribe_consumer_request_handler {
+private:
+    enum class state {
+        empty = 0,
+        topics,
+        topic_name,
+    };
+
+    state _state = state::empty;
+
+public:
+    using Ch = typename Encoding::Ch;
+    using rjson_parse_result = subscribe_consumer_request;
+    rjson_parse_result result;
+
+    bool Null() { return false; }
+    bool Bool(bool) { return false; }
+    bool Int64(int64_t) { return false; }
+    bool Uint64(uint64_t) { return false; }
+    bool Double(double) { return false; }
+    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
+    bool Int(int) { return false; }
+    bool Uint(unsigned) { return false; }
+
+    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+        if (_state != state::topic_name) {
+            return false;
+        }
+        result.topics.emplace_back(ss::sstring(str, len));
+        return true;
+    }
+
+    bool Key(const char* str, rapidjson::SizeType len, bool) {
+        if (_state != state::topics || std::string_view(str, len) != "topics") {
+            return false;
+        }
+        return true;
+    }
+
+    bool StartArray() {
+        if (_state != state::topics) {
+            return false;
+        }
+        _state = state::topic_name;
+        return true;
+    }
+    bool EndArray(rapidjson::SizeType) {
+        if (_state != state::topic_name) {
+            return false;
+        }
+        _state = state::topics;
+        return true;
+    }
+
+    bool StartObject() {
+        if (_state == state::empty) {
+            _state = state::topics;
+        } else if (_state == state::topics) {
+            _state = state::topic_name;
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    bool EndObject(rapidjson::SizeType) { return _state == state::topics; }
+};
+
+} // namespace pandaproxy::json

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -9,6 +9,7 @@
 
 #include "pandaproxy/proxy.h"
 
+#include "pandaproxy/api/api-doc/create_consumer.json.h"
 #include "pandaproxy/api/api-doc/get_topics_names.json.h"
 #include "pandaproxy/api/api-doc/get_topics_records.json.h"
 #include "pandaproxy/api/api-doc/health.json.h"
@@ -47,6 +48,11 @@ std::vector<server::route_t> get_proxy_routes() {
       ss::httpd::post_topics_name_json::name,
       ss::httpd::post_topics_name_json::post_topics_name,
       post_topics_name});
+
+    routes.emplace_back(server::route_t{
+      ss::httpd::create_consumer_json::name,
+      ss::httpd::create_consumer_json::create_consumer,
+      create_consumer});
 
     return routes;
 }

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -14,6 +14,7 @@
 #include "pandaproxy/api/api-doc/get_topics_records.json.h"
 #include "pandaproxy/api/api-doc/health.json.h"
 #include "pandaproxy/api/api-doc/post_topics_name.json.h"
+#include "pandaproxy/api/api-doc/subscribe_consumer.json.h"
 #include "pandaproxy/configuration.h"
 #include "pandaproxy/handlers.h"
 
@@ -53,6 +54,11 @@ std::vector<server::route_t> get_proxy_routes() {
       ss::httpd::create_consumer_json::name,
       ss::httpd::create_consumer_json::create_consumer,
       create_consumer});
+
+    routes.emplace_back(server::route_t{
+      ss::httpd::subscribe_consumer_json::name,
+      ss::httpd::subscribe_consumer_json::subscribe_consumer,
+      subscribe_consumer});
 
     return routes;
 }

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -34,17 +34,17 @@ std::vector<server::route_t> get_proxy_routes() {
       }});
 
     routes.emplace_back(server::route_t{
-      "get_topics_names",
+      ss::httpd::get_topics_names_json::name,
       ss::httpd::get_topics_names_json::get_topics_names,
       get_topics_names});
 
     routes.emplace_back(server::route_t{
-      "get_topics_records",
+      ss::httpd::get_topics_records_json::name,
       ss::httpd::get_topics_records_json::get_topics_records,
       get_topics_records});
 
     routes.emplace_back(server::route_t{
-      "post_topics_name",
+      ss::httpd::post_topics_name_json::name,
       ss::httpd::post_topics_name_json::post_topics_name,
       post_topics_name});
 

--- a/src/v/pandaproxy/test/CMakeLists.txt
+++ b/src/v/pandaproxy/test/CMakeLists.txt
@@ -5,6 +5,7 @@ rp_test(
     fetch.cc
     list_topics.cc
     produce.cc
+    consumer_group.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::application v::rest_application v::http
   LABELS pandaproxy

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -1,0 +1,90 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "http/client.h"
+#include "kafka/protocol/join_group.h"
+#include "kafka/types.h"
+#include "pandaproxy/configuration.h"
+#include "pandaproxy/json/requests/create_consumer.h"
+#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/test/pandaproxy_fixture.h"
+#include "pandaproxy/test/utils.h"
+#include "utils/unresolved_address.h"
+
+#include <boost/beast/http/field.hpp>
+#include <boost/beast/http/status.hpp>
+#include <boost/beast/http/verb.hpp>
+#include <boost/test/tools/old/interface.hpp>
+
+namespace pp = pandaproxy;
+namespace ppj = pp::json;
+
+FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Waiting for leadership");
+    wait_for_controller_leadership().get();
+
+    info("Connecting client");
+    auto client = make_client();
+
+    auto advertised_address{unresolved_address{"proxy.example.com", 8080}};
+    pp::shard_local_cfg().advertised_pandaproxy_api.set_value(
+      advertised_address);
+
+    kafka::group_id group_id{"test_group"};
+    kafka::member_id member_id{kafka::no_member};
+    {
+        info("Create consumer");
+        ss::sstring req_body(R"({
+  "format": "binary",
+  "auto.offset.reset": "earliest",
+  "auto.commit.enable": "false",
+  "fetch.min.bytes": "1",
+  "consumer.request.timeout.ms": "10000"
+})");
+        iobuf req_body_buf;
+        req_body_buf.append(req_body.data(), req_body.size());
+        auto res = http_request(
+          client,
+          fmt::format("/consumers/{})", group_id()),
+          std::move(req_body_buf));
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        auto res_data = ppj::rjson_parse(
+          res.body.data(), ppj::create_consumer_response_handler());
+        BOOST_REQUIRE(res_data.instance_id != kafka::no_member);
+        member_id = res_data.instance_id;
+        BOOST_REQUIRE_EQUAL(
+          res_data.base_uri,
+          fmt::format(
+            "http://{}:{}/consumers/{}",
+            advertised_address.host(),
+            advertised_address.port(),
+            member_id()));
+        BOOST_REQUIRE_EQUAL(
+          res.headers.at(boost::beast::http::field::content_type),
+          "application/vnd.kafka.binary.v2+json");
+    }
+    info("Member id: {}", member_id);
+
+    info("Adding known topic");
+    auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
+    auto ntp = make_default_ntp(tp.topic, tp.partition);
+    add_topic(model::topic_namespace_view(ntp)).get();
+
+    {
+        info("List known topics");
+        auto res = http_request(client, "/topics");
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(res.body, R"(["t"])");
+    }
+}

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -87,4 +87,22 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(res.body, R"(["t"])");
     }
+    {
+        info("Subscribe consumer");
+        ss::sstring req_body(R"(
+{
+  "topics": [
+    "t"
+  ]
+})");
+        iobuf req_body_buf;
+        req_body_buf.append(req_body.data(), req_body.size());
+        auto res = http_request(
+          client,
+          fmt::format(
+            "/consumers/{}/instances/{}/subscription", group_id(), member_id()),
+          std::move(req_body_buf));
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
 }


### PR DESCRIPTION
Pandaproxy:  wiring and serde to `kafka/client` for:
* Create Consumer
* Subscribe Consumer

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
