### PR TITLE
operator: Fix the statefulset replicas

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -149,7 +149,7 @@ func (r *StatefulSetResource) Obj() (k8sclient.Object, error) {
 			Labels:		clusterLabels,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas:		&r.pandaCluster.Status.Replicas,
+			Replicas:		r.pandaCluster.Spec.Replicas,
 			PodManagementPolicy:	appsv1.ParallelPodManagement,
 			Selector:		clusterLabels.AsAPISelector(),
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{


### PR DESCRIPTION
The CI did not found this error as the 2 PRs:
https://github.com/vectorizedio/redpanda/pull/647
https://github.com/vectorizedio/redpanda/pull/598
has different base commit. The CI now fails at the dev branch
due to replicas beeing 0 in the test not hardcoded 1.
The replicas should be taken from specification not status.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
