### PR TITLE
Add sasl authentication to kafka with scram mechanism

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -460,6 +460,18 @@ configuration::configuration()
       "Enable SASL authentication for Kafka connections.",
       required::no,
       false)
+  , static_scram_user(
+      *this,
+      "static_scram_user",
+      "A SASL SCRAM user for testing",
+      required::no,
+      "")
+  , static_scram_pass(
+      *this,
+      "static_scram_pass",
+      "A SASL SCRAM password for testing",
+      required::no,
+      "")
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -454,6 +454,12 @@ configuration::configuration()
       "touching the log until the batch is exhausted.",
       required::no,
       1000)
+  , enable_sasl(
+      *this,
+      "enable_sasl",
+      "Enable SASL authentication for Kafka connections.",
+      required::no,
+      false)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -116,6 +116,7 @@ struct configuration final : public config_store {
     property<size_t> max_compacted_log_segment_size;
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
+    property<bool> enable_sasl;
 
     configuration();
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -117,6 +117,8 @@ struct configuration final : public config_store {
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;
+    property<ss::sstring> static_scram_user;
+    property<ss::sstring> static_scram_pass;
 
     configuration();
 

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_subdirectory(protocol)
 
 set(security_srcs
-    security/scram_algorithm.cc)
+    security/scram_algorithm.cc
+    security/scram_credential.cc)
 
 set(handlers_srcs
   server/handlers/api_versions.cc

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -2,7 +2,8 @@ add_subdirectory(protocol)
 
 set(security_srcs
     security/scram_algorithm.cc
-    security/scram_credential.cc)
+    security/scram_credential.cc
+    security/scram_authenticator.cc)
 
 set(handlers_srcs
   server/handlers/api_versions.cc

--- a/src/v/kafka/protocol/sasl_authenticate.h
+++ b/src/v/kafka/protocol/sasl_authenticate.h
@@ -57,11 +57,8 @@ struct sasl_authenticate_response final {
 
     sasl_authenticate_response_data data;
 
-    explicit sasl_authenticate_response(
-      error_code error, ss::sstring error_msg) {
-        data.error_code = error;
-        data.error_message = std::move(error_msg);
-    }
+    explicit sasl_authenticate_response(sasl_authenticate_response_data data)
+      : data(std::move(data)) {}
 
     void encode(const request_context& ctx, response& resp) {
         data.encode(resp.writer(), ctx.header().version);

--- a/src/v/kafka/protocol/sasl_handshake.h
+++ b/src/v/kafka/protocol/sasl_handshake.h
@@ -57,8 +57,10 @@ struct sasl_handshake_response final {
 
     sasl_handshake_response_data data;
 
-    explicit sasl_handshake_response(error_code error) {
+    sasl_handshake_response(
+      error_code error, std::vector<ss::sstring> mechanisms) {
         data.error_code = error;
+        data.mechanisms = std::move(mechanisms);
     }
 
     void encode(const request_context& ctx, response& resp) {

--- a/src/v/kafka/security/credential_store.h
+++ b/src/v/kafka/security/credential_store.h
@@ -48,7 +48,10 @@ public:
     }
 
 private:
+    // when a second type is supported update `credential_store_test` to include
+    // a mismatched credential type test for get<type>(name).
     using credential_types = std::variant<scram_credential>;
+
     absl::node_hash_map<ss::sstring, credential_types> _credentials;
 };
 

--- a/src/v/kafka/security/credential_store.h
+++ b/src/v/kafka/security/credential_store.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "bytes/bytes.h"
+#include "kafka/security/scram_credential.h"
+#include "utils/concepts-enabled.h"
+
+#include <absl/container/node_hash_map.h>
+
+namespace kafka {
+
+/*
+ * Store for user credentials.
+ *
+ * Credentials can be copied or moved into the store. Reads always return a copy
+ * since the typical use case is that a credential is used in an authentication
+ * process that often spans multiple network round trips and should remain
+ * consistent for the duration of that process.
+ */
+class credential_store {
+public:
+    credential_store() noexcept = default;
+    credential_store(const credential_store&) = delete;
+    credential_store& operator=(const credential_store&) = delete;
+    credential_store(credential_store&&) noexcept = default;
+    credential_store& operator=(credential_store&&) noexcept = default;
+    ~credential_store() noexcept = default;
+
+    template<typename T>
+    void put(const ss::sstring& name, T&& credential) {
+        _credentials.insert_or_assign(name, std::forward<T>(credential));
+    }
+
+    template<typename T>
+    auto get(const ss::sstring& name) -> std::optional<T> const {
+        if (auto it = _credentials.find(name); it != _credentials.end()) {
+            return std::get<T>(it->second);
+        }
+        return std::nullopt;
+    }
+
+private:
+    using credential_types = std::variant<scram_credential>;
+    absl::node_hash_map<ss::sstring, credential_types> _credentials;
+};
+
+} // namespace kafka

--- a/src/v/kafka/security/errc.h
+++ b/src/v/kafka/security/errc.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "outcome.h"
+
+namespace kafka {
+
+enum class errc {
+    success = 0,
+    invalid_credentials,
+    invalid_scram_state,
+};
+
+struct errc_category final : public std::error_category {
+    const char* name() const noexcept final { return "kafka_security::errc"; }
+
+    std::string message(int c) const final {
+        switch (static_cast<errc>(c)) {
+        case errc::success:
+            return "kafka_security: Success";
+        case errc::invalid_credentials:
+            return "kafka_security: Invalid credentials";
+        case errc::invalid_scram_state:
+            return "kafka_security: Invalid SCRAM state";
+        default:
+            return "kafka_security: Unknown error";
+        }
+    }
+};
+
+inline const std::error_category& error_category() noexcept {
+    static errc_category e;
+    return e;
+}
+
+inline std::error_code make_error_code(errc e) noexcept {
+    return std::error_code(static_cast<int>(e), error_category());
+}
+} // namespace kafka
+
+namespace std {
+template<>
+struct is_error_code_enum<kafka::errc> : true_type {};
+} // namespace std

--- a/src/v/kafka/security/sasl_authentication.h
+++ b/src/v/kafka/security/sasl_authentication.h
@@ -1,0 +1,67 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+#include "bytes/bytes.h"
+#include "outcome.h"
+#include "vassert.h"
+
+#include <memory>
+
+namespace kafka {
+
+/*
+ * Generic SASL mechanism interface.
+ */
+class sasl_mechanism {
+public:
+    virtual ~sasl_mechanism() = default;
+    virtual bool complete() const = 0;
+    virtual bool failed() const = 0;
+    virtual result<bytes> authenticate(bytes_view) = 0;
+};
+
+/*
+ * SASL server protocol manager.
+ */
+class sasl_server final {
+public:
+    enum class sasl_state {
+        initial,
+        handshake,
+        authenticate,
+        complete,
+        failed,
+    };
+
+    explicit sasl_server(sasl_state state)
+      : _state(state) {}
+
+    sasl_state state() const { return _state; }
+    void set_state(sasl_state state) { _state = state; }
+
+    bool complete() const { return _state == sasl_state::complete; }
+
+    bool has_mechanism() const { return bool(_mechanism); }
+    sasl_mechanism& mechanism() { return *_mechanism; }
+
+    result<bytes> authenticate(bytes data) {
+        return _mechanism->authenticate(data);
+    }
+
+    void set_mechanism(std::unique_ptr<sasl_mechanism> m) {
+        vassert(!_mechanism, "Cannot change mechanism");
+        _mechanism = std::move(m);
+    }
+
+private:
+    sasl_state _state;
+    std::unique_ptr<sasl_mechanism> _mechanism;
+};
+
+}; // namespace kafka

--- a/src/v/kafka/security/scram_algorithm.h
+++ b/src/v/kafka/security/scram_algorithm.h
@@ -13,6 +13,7 @@
 #include "hashing/secure.h"
 #include "kafka/server/logger.h"
 #include "random/generators.h"
+#include "kafka/security/scram_credential.h"
 
 #include <absl/container/node_hash_map.h>
 
@@ -43,31 +44,6 @@ public:
 
 private:
     ss::sstring _msg;
-};
-
-class scram_credential {
-public:
-    scram_credential() noexcept = default;
-
-    scram_credential(
-      bytes salt, bytes server_key, bytes stored_key, int iterations) noexcept
-      : _salt(std::move(salt))
-      , _server_key(std::move(server_key))
-      , _stored_key(std::move(stored_key))
-      , _iterations(iterations) {}
-
-    const bytes& salt() const { return _salt; }
-    const bytes& server_key() const { return _server_key; }
-    const bytes& stored_key() const { return _stored_key; }
-    int iterations() const { return _iterations; }
-
-private:
-    friend std::ostream& operator<<(std::ostream&, const scram_credential&);
-
-    bytes _salt;
-    bytes _server_key;
-    bytes _stored_key;
-    int _iterations{0};
 };
 
 /**
@@ -185,7 +161,6 @@ private:
     bytes _signature;
 };
 
-std::ostream& operator<<(std::ostream&, const scram_credential&);
 std::ostream& operator<<(std::ostream&, const client_first_message&);
 std::ostream& operator<<(std::ostream&, const server_first_message&);
 std::ostream& operator<<(std::ostream&, const client_final_message&);

--- a/src/v/kafka/security/scram_authenticator.cc
+++ b/src/v/kafka/security/scram_authenticator.cc
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/security/scram_authenticator.h"
+
+#include "kafka/security/errc.h"
+#include "vlog.h"
+
+namespace kafka {
+
+template<typename T>
+result<bytes>
+scram_authenticator<T>::handle_client_first(bytes_view auth_bytes) {
+    // request from client
+    _client_first = std::make_unique<client_first_message>(auth_bytes);
+    vlog(klog.debug, "Received client first message {}", *_client_first);
+
+    // lookup credentials for this user
+    _authid = _client_first->username_normalized();
+    auto credential = _credentials.get<scram_credential>(_authid);
+    if (!credential) {
+        return errc::invalid_credentials;
+    }
+    _credential = std::make_unique<scram_credential>(std::move(*credential));
+
+    if (
+      !_client_first->authzid().empty()
+      && _client_first->authzid() != _authid) {
+        vlog(klog.info, "Invalid authorization id and username pair");
+        return errc::invalid_credentials;
+    }
+
+    if (_credential->iterations() < scram::min_iterations) {
+        vlog(
+          klog.info,
+          "Requested iterations {} less than minimum {}",
+          _credential->iterations(),
+          scram::min_iterations);
+        return errc::invalid_credentials;
+    }
+
+    // build server reply
+    _server_first = std::make_unique<server_first_message>(
+      _client_first->nonce(),
+      random_generators::gen_alphanum_string(nonce_size),
+      _credential->salt(),
+      _credential->iterations());
+
+    _state = state::client_final_message;
+
+    auto reply = _server_first->sasl_message();
+    return bytes(reply.cbegin(), reply.cend());
+}
+
+template<typename T>
+result<bytes>
+scram_authenticator<T>::handle_client_final(bytes_view auth_bytes) {
+    client_final_message client_final(auth_bytes);
+    vlog(klog.debug, "Received client final message {}", client_final);
+
+    auto client_signature = scram::client_signature(
+      _credential->stored_key(), *_client_first, *_server_first, client_final);
+
+    auto computed_stored_key = scram::computed_stored_key(
+      client_signature,
+      bytes(client_final.proof().begin(), client_final.proof().end()));
+
+    if (computed_stored_key != _credential->stored_key()) {
+        vlog(
+          klog.info,
+          "Authentication failed: stored and client submitted credentials do "
+          "not match");
+        return errc::invalid_credentials;
+    }
+
+    const auto username = _client_first->username();
+    vlog(klog.debug, "Authentication key match for user {}", username);
+
+    auto server_signature = scram::server_signature(
+      _credential->server_key(), *_client_first, *_server_first, client_final);
+
+    server_final_message server_final(std::nullopt, server_signature);
+    auto reply = server_final.sasl_message();
+
+    clear_credentials();
+    _state = state::complete;
+
+    return bytes(reply.cbegin(), reply.cend());
+}
+
+template<typename T>
+void scram_authenticator<T>::clear_credentials() {
+    _credential.reset();
+    _client_first.reset();
+    _server_first.reset();
+}
+
+template<typename T>
+result<bytes> scram_authenticator<T>::handle_next(bytes_view auth_bytes) {
+    switch (_state) {
+    case state::client_first_message:
+        return handle_client_first(auth_bytes);
+
+    case state::client_final_message:
+        return handle_client_final(auth_bytes);
+
+    default:
+        return errc::invalid_scram_state;
+    }
+}
+
+template<typename T>
+result<bytes> scram_authenticator<T>::authenticate(bytes_view auth_bytes) {
+    auto ret = handle_next(auth_bytes);
+    if (!ret) {
+        _state = state::failed;
+        clear_credentials();
+    }
+    return ret;
+}
+
+template class scram_authenticator<scram_sha256>;
+template class scram_authenticator<scram_sha512>;
+
+} // namespace kafka

--- a/src/v/kafka/security/scram_authenticator.h
+++ b/src/v/kafka/security/scram_authenticator.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/security/credential_store.h"
+#include "kafka/security/sasl_authentication.h"
+#include "kafka/security/scram_algorithm.h"
+
+namespace kafka {
+
+template<typename ScramMechanism>
+class scram_authenticator final : public sasl_mechanism {
+    static constexpr int nonce_size = 130;
+
+public:
+    explicit scram_authenticator(credential_store& credentials)
+      : _state{state::client_first_message}
+      , _credentials(credentials) {}
+
+    result<bytes> authenticate(bytes_view auth_bytes) override;
+
+    bool complete() const override { return _state == state::complete; }
+    bool failed() const override { return _state == state::failed; }
+
+    const ss::sstring& authid() const {
+        vassert(
+          _state == state::complete,
+          "Authentication id is not valid until auth process complete");
+        return _authid;
+    }
+
+private:
+    using scram = ScramMechanism;
+
+    enum class state {
+        client_first_message,
+        client_final_message,
+        complete,
+        failed,
+    };
+
+    // handlers for client messages
+    result<bytes> handle_client_first(bytes_view);
+    result<bytes> handle_client_final(bytes_view);
+    result<bytes> handle_next(bytes_view);
+
+    void clear_credentials();
+
+    state _state;
+    credential_store& _credentials;
+    ss::sstring _authid;
+
+    // populated during authentication process
+    std::unique_ptr<scram_credential> _credential;
+    std::unique_ptr<client_first_message> _client_first;
+    std::unique_ptr<server_first_message> _server_first;
+};
+
+struct scram_sha256_authenticator {
+    using auth = scram_authenticator<scram_sha256>;
+    static constexpr const char* name = "SCRAM-SHA-256";
+};
+
+struct scram_sha512_authenticator {
+    using auth = scram_authenticator<scram_sha512>;
+    static constexpr const char* name = "SCRAM-SHA-512";
+};
+
+} // namespace kafka

--- a/src/v/kafka/security/scram_credential.cc
+++ b/src/v/kafka/security/scram_credential.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/security/scram_credential.h"
+
+#include <ostream>
+
+namespace kafka {
+
+std::ostream& operator<<(std::ostream& os, const scram_credential& cred) {
+    fmt::print(
+      os,
+      "salt {} server_key {} stored_key {} iterations {}",
+      cred._salt,
+      cred._server_key,
+      cred._stored_key,
+      cred._iterations);
+    return os;
+}
+
+} // namespace kafka

--- a/src/v/kafka/security/scram_credential.cc
+++ b/src/v/kafka/security/scram_credential.cc
@@ -14,15 +14,8 @@
 
 namespace kafka {
 
-std::ostream& operator<<(std::ostream& os, const scram_credential& cred) {
-    fmt::print(
-      os,
-      "salt {} server_key {} stored_key {} iterations {}",
-      cred._salt,
-      cred._server_key,
-      cred._stored_key,
-      cred._iterations);
-    return os;
+std::ostream& operator<<(std::ostream& os, const scram_credential&) {
+    return os << "{scram_credential}";
 }
 
 } // namespace kafka

--- a/src/v/kafka/security/scram_credential.h
+++ b/src/v/kafka/security/scram_credential.h
@@ -31,6 +31,8 @@ public:
     const bytes& stored_key() const { return _stored_key; }
     int iterations() const { return _iterations; }
 
+    bool operator==(const scram_credential&) const = default;
+
 private:
     friend std::ostream& operator<<(std::ostream&, const scram_credential&);
 

--- a/src/v/kafka/security/scram_credential.h
+++ b/src/v/kafka/security/scram_credential.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "bytes/bytes.h"
+
+#include <iosfwd>
+
+namespace kafka {
+
+class scram_credential {
+public:
+    scram_credential() noexcept = default;
+
+    scram_credential(
+      bytes salt, bytes server_key, bytes stored_key, int iterations) noexcept
+      : _salt(std::move(salt))
+      , _server_key(std::move(server_key))
+      , _stored_key(std::move(stored_key))
+      , _iterations(iterations) {}
+
+    const bytes& salt() const { return _salt; }
+    const bytes& server_key() const { return _server_key; }
+    const bytes& stored_key() const { return _stored_key; }
+    int iterations() const { return _iterations; }
+
+private:
+    friend std::ostream& operator<<(std::ostream&, const scram_credential&);
+
+    bytes _salt;
+    bytes _server_key;
+    bytes _stored_key;
+    int _iterations{0};
+};
+
+std::ostream& operator<<(std::ostream&, const kafka::scram_credential&);
+
+} // namespace kafka

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -48,6 +48,7 @@ public:
 
     protocol& server() { return _proto; }
     const ss::sstring& listener() const { return _rs.conn->name(); }
+    sasl_server& sasl() { return _sasl; }
 
     ss::future<> process_one_request();
     bool is_finished_parsing() const;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include "kafka/security/sasl_authentication.h"
 #include "kafka/server/protocol.h"
 #include "kafka/server/response.h"
 #include "rpc/server.h"
@@ -33,9 +34,12 @@ class request_context;
 class connection_context final
   : public ss::enable_lw_shared_from_this<connection_context> {
 public:
-    connection_context(protocol& p, rpc::server::resources&& r) noexcept
+    connection_context(
+      protocol& p, rpc::server::resources&& r, sasl_server sasl) noexcept
       : _proto(p)
-      , _rs(std::move(r)) {}
+      , _rs(std::move(r))
+      , _sasl(std::move(sasl)) {}
+
     ~connection_context() noexcept = default;
     connection_context(const connection_context&) = delete;
     connection_context(connection_context&&) = delete;
@@ -76,6 +80,7 @@ private:
     sequence_id _next_response;
     sequence_id _seq_idx;
     map_t _responses;
+    sasl_server _sasl;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/api_versions.h
+++ b/src/v/kafka/server/handlers/api_versions.h
@@ -14,6 +14,11 @@
 
 namespace kafka {
 
-using api_versions_handler = handler<api_versions_api, 0, 2>;
+struct api_versions_handler : public handler<api_versions_api, 0, 2> {
+    static ss::future<response_ptr>
+    handle(request_context&&, ss::smp_service_group);
 
-}
+    static api_versions_response handle_raw(request_context& ctx);
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/sasl_authenticate.cc
+++ b/src/v/kafka/server/handlers/sasl_authenticate.cc
@@ -9,7 +9,9 @@
 
 #include "kafka/server/handlers/sasl_authenticate.h"
 
+#include "bytes/bytes.h"
 #include "kafka/protocol/errors.h"
+#include "kafka/security/scram_algorithm.h"
 
 namespace kafka {
 
@@ -18,9 +20,24 @@ ss::future<response_ptr> sasl_authenticate_handler::handle(
   request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
     sasl_authenticate_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    return ctx.respond(sasl_authenticate_response(
-      error_code::illegal_sasl_state,
-      "SASL authenticate request received after successful authentication"));
+    vlog(klog.debug, "Received SASL_AUTHENTICATE {}", request);
+
+    auto result = ctx.sasl().authenticate(std::move(request.data.auth_bytes));
+    if (likely(result)) {
+        sasl_authenticate_response_data data{
+          .error_code = error_code::none,
+          .error_message = std::nullopt,
+          .auth_bytes = std::move(result.value()),
+        };
+        return ctx.respond(sasl_authenticate_response(std::move(data)));
+    }
+
+    sasl_authenticate_response_data data{
+      .error_code = error_code::sasl_authentication_failed,
+      .error_message = fmt::format(
+        "SASL authentication failed: {}", result.error().message()),
+    };
+    return ctx.respond(sasl_authenticate_response(std::move(data)));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -40,7 +40,8 @@ protocol::protocol(
   ss::sharded<cluster::partition_manager>& pm,
   ss::sharded<coordinator_ntp_mapper>& coordinator_mapper,
   ss::sharded<fetch_session_cache>& session_cache,
-  ss::sharded<cluster::id_allocator_frontend>& id_allocator_frontend) noexcept
+  ss::sharded<cluster::id_allocator_frontend>& id_allocator_frontend,
+  ss::sharded<credential_store>& credentials) noexcept
   : _smp_group(smp)
   , _topics_frontend(tf)
   , _metadata_cache(meta)
@@ -52,7 +53,8 @@ protocol::protocol(
   , _fetch_session_cache(session_cache)
   , _id_allocator_frontend(id_allocator_frontend)
   , _is_idempotence_enabled(
-      config::shard_local_cfg().enable_idempotence.value()) {}
+      config::shard_local_cfg().enable_idempotence.value())
+  , _credentials(credentials) {}
 
 ss::future<> protocol::apply(rpc::server::resources rs) {
     auto ctx = ss::make_lw_shared<connection_context>(*this, std::move(rs));

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -13,6 +13,7 @@
 
 #include "cluster/fwd.h"
 #include "config/configuration.h"
+#include "kafka/security/credential_store.h"
 #include "kafka/server/fwd.h"
 #include "rpc/server.h"
 
@@ -34,7 +35,8 @@ public:
       ss::sharded<cluster::partition_manager>&,
       ss::sharded<coordinator_ntp_mapper>& coordinator_mapper,
       ss::sharded<fetch_session_cache>&,
-      ss::sharded<cluster::id_allocator_frontend>&) noexcept;
+      ss::sharded<cluster::id_allocator_frontend>&,
+      ss::sharded<credential_store>&) noexcept;
 
     ~protocol() noexcept override = default;
     protocol(const protocol&) = delete;
@@ -71,6 +73,8 @@ public:
     quota_manager& quota_mgr() { return _quota_mgr.local(); }
     bool is_idempotence_enabled() { return _is_idempotence_enabled; }
 
+    credential_store& credentials() { return _credentials.local(); }
+
 private:
     ss::smp_service_group _smp_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
@@ -83,6 +87,7 @@ private:
     ss::sharded<kafka::fetch_session_cache>& _fetch_session_cache;
     ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
     bool _is_idempotence_enabled{false};
+    ss::sharded<kafka::credential_store>& _credentials;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -88,6 +88,8 @@ public:
 
     const request_header& header() const { return _header; }
 
+    ss::lw_shared_ptr<connection_context> connection() { return _conn; }
+
     request_reader& reader() { return _reader; }
 
     const cluster::metadata_cache& metadata_cache() const {

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -152,6 +152,8 @@ public:
     }
 
     const ss::sstring& listener() const { return _conn->listener(); }
+    sasl_server& sasl() { return _conn->sasl(); }
+    credential_store& credentials() { return _conn->server().credentials(); }
 
 private:
     ss::lw_shared_ptr<connection_context> _conn;

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ rp_test(
     timeouts_conversion_test.cc
     types_conversion_tests.cc
     topic_utils_test.cc
+    credential_store_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
   LABELS kafka

--- a/src/v/kafka/server/tests/credential_store_test.cc
+++ b/src/v/kafka/server/tests/credential_store_test.cc
@@ -1,0 +1,59 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "kafka/security/credential_store.h"
+#include "random/generators.h"
+#include "utils/base64.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fmt/ostream.h>
+
+BOOST_AUTO_TEST_CASE(credential_store_test) {
+    const kafka::scram_credential cred0(
+      bytes("salty"),
+      bytes("i'm a server key"),
+      bytes("i'm the stored key"),
+      123456);
+
+    const kafka::scram_credential cred1(
+      bytes("salty2"),
+      bytes("i'm a server key2"),
+      bytes("i'm the stored key2"),
+      1234567);
+
+    auto cred0_copy = cred0;
+    auto cred1_copy = cred1;
+
+    BOOST_REQUIRE_NE(cred0, cred1);
+    BOOST_REQUIRE_NE(cred0_copy, cred1_copy);
+
+    // put new credentials
+    kafka::credential_store store;
+    store.put("copied", cred0);
+    store.put("moved", std::move(cred0_copy));
+
+    BOOST_REQUIRE(store.get<kafka::scram_credential>("moved"));
+    BOOST_REQUIRE_EQUAL(*store.get<kafka::scram_credential>("moved"), cred0);
+
+    BOOST_REQUIRE(store.get<kafka::scram_credential>("copied"));
+    BOOST_REQUIRE_EQUAL(*store.get<kafka::scram_credential>("copied"), cred0);
+
+    // update credentials
+    store.put("copied", cred1);
+    store.put("moved", std::move(cred1_copy));
+
+    BOOST_REQUIRE(store.get<kafka::scram_credential>("moved"));
+    BOOST_REQUIRE_EQUAL(*store.get<kafka::scram_credential>("moved"), cred1);
+
+    BOOST_REQUIRE(store.get<kafka::scram_credential>("copied"));
+    BOOST_REQUIRE_EQUAL(*store.get<kafka::scram_credential>("copied"), cred1);
+}

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -72,9 +72,13 @@ get_request_context(kafka::protocol& proto, ss::input_stream<char>&& input) {
                           /*
                            * build the request context
                            */
+                          kafka::sasl_server sasl(
+                            kafka::sasl_server::sasl_state::complete);
                           auto conn
                             = ss::make_lw_shared<kafka::connection_context>(
-                              proto, rpc::server::resources(nullptr, nullptr));
+                              proto,
+                              rpc::server::resources(nullptr, nullptr),
+                              std::move(sasl));
 
                           return kafka::request_context(
                             conn,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -18,6 +18,7 @@
 #include "cluster/service.h"
 #include "config/configuration.h"
 #include "config/seed_server.h"
+#include "kafka/security/scram_algorithm.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
 #include "kafka/server/group_manager.h"
 #include "kafka/server/group_router.h"
@@ -418,6 +419,25 @@ void application::wire_up_services() {
 
     syschecks::systemd_message("Creating kafka credential store").get();
     construct_service(credentials).get();
+
+    /*
+     * Add in the static scram credential for testing.
+     * - sasl and developer mode needs to be enabled
+     */
+    if (
+      unlikely(config::shard_local_cfg().enable_admin_api())
+      && config::shard_local_cfg().developer_mode()
+      && !config::shard_local_cfg().static_scram_user().empty()
+      && !config::shard_local_cfg().static_scram_pass().empty()) {
+        credentials
+          .invoke_on_all([](kafka::credential_store& store) {
+              store.put(
+                config::shard_local_cfg().static_scram_user(),
+                kafka::scram_sha256::make_credentials(
+                  config::shard_local_cfg().static_scram_pass(), 4096));
+          })
+          .get();
+    }
 
     syschecks::systemd_message("Creating metadata dissemination service").get();
     construct_service(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -416,6 +416,9 @@ void application::wire_up_services() {
       std::ref(controller->get_partition_leaders()))
       .get();
 
+    syschecks::systemd_message("Creating kafka credential store").get();
+    construct_service(credentials).get();
+
     syschecks::systemd_message("Creating metadata dissemination service").get();
     construct_service(
       md_dissemination_service,
@@ -641,7 +644,8 @@ void application::start() {
             partition_manager,
             coordinator_ntp_mapper,
             fetch_session_cache,
-            std::ref(id_allocator_frontend));
+            std::ref(id_allocator_frontend),
+            credentials);
           s.set_protocol(std::move(proto));
       })
       .get();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -16,6 +16,7 @@
 #include "coproc/pacemaker.h"
 #include "coproc/service.h"
 #include "coproc/wasm_event_listener.h"
+#include "kafka/security/credential_store.h"
 #include "raft/group_manager.h"
 #include "resource_mgmt/cpu_scheduling.h"
 #include "resource_mgmt/memory_groups.h"
@@ -65,6 +66,7 @@ public:
     smp_groups smp_service_groups;
     ss::sharded<kafka::quota_manager> quota_mgr;
     ss::sharded<cluster::id_allocator_frontend> id_allocator_frontend;
+    ss::sharded<kafka::credential_store> credentials;
 
 private:
     using deferred_actions

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -78,7 +78,8 @@ public:
           app.partition_manager,
           app.coordinator_ntp_mapper,
           app.fetch_session_cache,
-          app.id_allocator_frontend);
+          app.id_allocator_frontend,
+          app.credentials);
     }
 
     // creates single node with default configuration

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -253,8 +253,9 @@ public:
     }
 
     kafka::request_context make_request_context() {
+        kafka::sasl_server sasl(kafka::sasl_server::sasl_state::complete);
         auto conn = ss::make_lw_shared<kafka::connection_context>(
-          *proto, rpc::server::resources(nullptr, nullptr));
+          *proto, rpc::server::resources(nullptr, nullptr), std::move(sasl));
 
         kafka::request_header header;
         auto encoder_context = kafka::request_context(

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import time
 import os
 import signal
 import tempfile
@@ -271,3 +272,12 @@ class RedpandaService(Service):
             return Partition(index, leader, replicas)
 
         return map(make_partition, topic["partitions"])
+
+
+# a hack to prevent the redpanda service from trying to use a client that
+# doesn't support sasl when the service has sasl enabled. this is a temp fix
+# until we have properly integrated authentication into ducktape clients.
+class NoSaslRedpandaService(RedpandaService):
+    def registered(self, node):
+        time.sleep(3)
+        return True

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from ducktape.errors import DucktapeError
+
+from ducktape.tests.test import Test
+from rptest.services.redpanda import NoSaslRedpandaService
+from rptest.clients.types import TopicSpec
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+
+
+# test that starts a redpanda service without using clients that would otherwise
+# require sasl auth support
+class NoSaslRedpandaTest(Test):
+    def __init__(self,
+                 test_context,
+                 num_brokers=3,
+                 extra_rp_conf=dict(),
+                 log_level='info'):
+        super(NoSaslRedpandaTest, self).__init__(test_context)
+
+        self.redpanda = NoSaslRedpandaService(test_context,
+                                              num_brokers,
+                                              KafkaCliTools,
+                                              extra_rp_conf=extra_rp_conf,
+                                              log_level=log_level)
+
+    def setUp(self):
+        self.redpanda.start()
+
+
+class ScramTest(NoSaslRedpandaTest):
+    def __init__(self, test_context):
+        extra_rp_conf = dict(
+            developer_mode=True,
+            enable_sasl=True,
+            static_scram_user="redpanda_user",
+            static_scram_pass="redpanda_pass",
+        )
+        super(ScramTest, self).__init__(test_context=test_context,
+                                        extra_rp_conf=extra_rp_conf)
+
+    @cluster(num_nodes=3)
+    def test_scram(self):
+        topic = TopicSpec()
+        client = KafkaCliTools(self.redpanda,
+                               user="redpanda_user",
+                               passwd="redpanda_pass")
+        client.create_topic(topic)
+
+        client = KafkaCliTools(self.redpanda,
+                               user="redpanda_user",
+                               passwd="bad_password")
+        try:
+            client.list_topics()
+            assert False, "Listing topics should fail"
+        except Exception:
+            pass
+
+        client = KafkaCliTools(self.redpanda,
+                               user="redpanda_user",
+                               passwd="redpanda_pass")
+        topics = client.list_topics()
+        print(topics)
+        assert topic.name in topics


### PR DESCRIPTION
Adds SASL authentication protocol handling in kafka, along with the scram mechanism. Temporary interfaces and tests are also included which are temporary because proper integration with tools and interfaces for easily manipulating credentials in redpanda are not yet in place.