### PR TITLE
operator/tests: set parallel e2e tests to 1

### DIFF
--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -11,3 +11,4 @@ commands:
   - command: "kubectl apply -k config/default"
 artifactsDir: tests/e2e/_artifacts
 timeout: 180
+parallel: 1


### PR DESCRIPTION
We're getting Insufficient CPU warning that likely affect the e2e tests. I'm lowering the number of parallel e2e tests to 1.

```
Warning	Pod cluster-sample-0		FailedScheduling	0/3 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 2 Insufficient cpu.
```

Prior to this change we were getting 3/3 of these warnings. Now we get one and the tests run successfully. Perhaps we could also lower the cpu requirement/limit of test pods to 0.5 (created a card).