### PR TITLE
operator: enable webhooks and add first validation logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 bin
 _artifacts/
 /src/go/k8s/testbin/*
+/src/go/k8s/cm-verifier
 
 # Test binary, build with `go test -c`
 *.test

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+)
+
+func TestValidateUpdate(t *testing.T) {
+	var replicas1 int32 = 1
+	var replicas2 int32 = 2
+
+	redpandaCluster := &v1alpha1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:		"RedpandaCluster",
+			APIVersion:	"core.vectorized.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:		"test",
+			Namespace:	"",
+		},
+		Spec: v1alpha1.ClusterSpec{
+			Replicas:	pointer.Int32Ptr(replicas2),
+			Configuration: v1alpha1.RedpandaConfig{
+				KafkaAPI: v1alpha1.SocketAddress{Port: 123},
+			},
+		},
+	}
+
+	updatedCluster := redpandaCluster.DeepCopy()
+	updatedCluster.Spec.Replicas = &replicas1
+	updatedCluster.Spec.Configuration = v1alpha1.RedpandaConfig{
+		KafkaAPI: v1alpha1.SocketAddress{Port: 1234},
+	}
+
+	err := updatedCluster.ValidateUpdate(redpandaCluster)
+	if err == nil {
+		t.Fatalf("expecting validation error but got none")
+	}
+
+	// verify the error causes contain all expected fields
+	statusError := err.(*apierrors.StatusError)
+	expectedFields := []string{field.NewPath("spec").Child("configuration").String(), field.NewPath("spec").Child("replicas").String()}
+	for _, ef := range expectedFields {
+		found := false
+		for _, c := range statusError.Status().Details.Causes {
+			if ef == c.Field {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expecting failure on field %s but have %v", ef, statusError.Status().Details.Causes)
+		}
+	}
+}
+
+func TestValidateUpdate_NoError_SameObject(t *testing.T) {
+	var replicas2 int32 = 2
+
+	redpandaCluster := &v1alpha1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:		"RedpandaCluster",
+			APIVersion:	"core.vectorized.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:		"test",
+			Namespace:	"",
+		},
+		Spec: v1alpha1.ClusterSpec{
+			Replicas:	pointer.Int32Ptr(replicas2),
+			Configuration: v1alpha1.RedpandaConfig{
+				KafkaAPI: v1alpha1.SocketAddress{Port: 123},
+			},
+		},
+	}
+	err := redpandaCluster.ValidateUpdate(redpandaCluster)
+	assert.NoError(t, err)
+}

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -69,7 +69,7 @@ func TestValidateUpdate(t *testing.T) {
 	}
 }
 
-func TestValidateUpdate_NoError_SameObject(t *testing.T) {
+func TestValidateUpdate_NoError(t *testing.T) {
 	var replicas2 int32 = 2
 
 	redpandaCluster := &v1alpha1.Cluster{
@@ -88,6 +88,25 @@ func TestValidateUpdate_NoError_SameObject(t *testing.T) {
 			},
 		},
 	}
-	err := redpandaCluster.ValidateUpdate(redpandaCluster)
-	assert.NoError(t, err)
+
+	t.Run("same object updated", func(t *testing.T) {
+		err := redpandaCluster.ValidateUpdate(redpandaCluster)
+		assert.NoError(t, err)
+	})
+
+	t.Run("scale up", func(t *testing.T) {
+		var scaleUp int32 = *redpandaCluster.Spec.Replicas + 1
+		updatedScaleUp := redpandaCluster.DeepCopy()
+		updatedScaleUp.Spec.Replicas = &scaleUp
+		err := updatedScaleUp.ValidateUpdate(redpandaCluster)
+		assert.NoError(t, err)
+	})
+
+	t.Run("change image and tag", func(t *testing.T) {
+		updatedImage := redpandaCluster.DeepCopy()
+		updatedImage.Spec.Image = "differentimage"
+		updatedImage.Spec.Version = "111"
+		err := updatedImage.ValidateUpdate(redpandaCluster)
+		assert.NoError(t, err)
+	})
 }

--- a/src/go/k8s/config/default/kustomization.yaml
+++ b/src/go/k8s/config/default/kustomization.yaml
@@ -18,9 +18,9 @@ bases:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -36,39 +36,39 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/src/go/k8s/config/default/manager_auth_proxy_patch.yaml
+++ b/src/go/k8s/config/default/manager_auth_proxy_patch.yaml
@@ -25,3 +25,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "--webhook-enabled=true"

--- a/src/go/k8s/hack/install-cert-manager.sh
+++ b/src/go/k8s/hack/install-cert-manager.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VERSION="0.1.0"
+
+# TODO: support more OS/architectures as they are needed
+if [ "$(uname)" == 'Darwin' ]; then
+  curl -L https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Darwin_x86_64.tar.gz | tar -xvf -
+else
+  curl -L https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Linux_x86_64.tar.gz | tar -xzvf -
+fi
+
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+./cm-verifier

--- a/src/go/k8s/hack/wait-for-webhook-ready.sh
+++ b/src/go/k8s/hack/wait-for-webhook-ready.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script tries to create sample cluster and waits until it succeeds
+# this way we are able to wait until webhook is ready to serve our content
+
+if ! command -v kubectl &>/dev/null; then
+  echo "required kubectl command NOT found"
+  exit 1
+fi
+
+MAX=50
+CURRENT=0
+
+until $(kubectl create -f ./config/samples/redpanda_v1alpha1_cluster.yaml >/dev/null 2>&1); do
+  CURRENT=$((CURRENT + 1))
+  printf '.'
+  sleep 5
+
+  if [ "$CURRENT" -gt "$MAX" ]; then
+    echo "FAILED: Webhook not ready, giving up."
+    exit 1
+  fi
+done
+
+echo "Webhook is ready!"
+
+kubectl delete -f ./config/samples/redpanda_v1alpha1_cluster.yaml

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -8,6 +8,8 @@ testDirs:
   - ./tests/e2e
 kindConfig: ./kind.yaml
 commands:
-  - command: "kubectl apply -k config/default"
+  - command: "./hack/install-cert-manager.sh"
+  - command: "make deploy"
+  - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_e2e_artifacts
 timeout: 300


### PR DESCRIPTION
This PR adds validation logic preventing people from making changes to our CR that is not currently supported.
- enables webhook configuration through kustomize
- add cert-manager to our e2e tests, this way we're sure that webhook works in e2e scenario
- adds validation logic as per #653 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.

Fixes #653 