### PR TITLE
operator/tests: move artifacts to a different folder

### DIFF
--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -9,5 +9,5 @@ testDirs:
 kindConfig: ./kind.yaml
 commands:
   - command: "kubectl apply -k config/default"
-artifactsDir: tests/e2e/_artifacts
+artifactsDir: tests/_e2e_artifacts
 timeout: 300


### PR DESCRIPTION
E2e folder is folder that kuttl uses to looks for tests, by having artifacts in the same folder, repeated local runs causes that the folder is interpreted as another test that is empty and skipped. This prevents kuttl from needing to parse that folder as we move it one level up.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
