### PR TITLE
operator: do not set seastar memory

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -13,11 +13,18 @@ import (
 	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+const (
+	kb	= 1024
+	mb	= 1024 * kb
+	gb	= 1024 * mb
 )
 
 // log is for logging in this package.
@@ -55,6 +62,10 @@ func (r *Cluster) ValidateCreate() error {
 		allErrs = append(allErrs, err...)
 	}
 
+	if err := r.validateMemory(); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -87,6 +98,8 @@ func (r *Cluster) ValidateUpdate(old runtime.Object) error {
 		allErrs = append(allErrs, err...)
 	}
 
+	allErrs = append(allErrs, r.validateMemory()...)
+
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -94,6 +107,21 @@ func (r *Cluster) ValidateUpdate(old runtime.Object) error {
 	return apierrors.NewInvalid(
 		r.GroupVersionKind().GroupKind(),
 		r.Name, allErrs)
+}
+
+// ReserveMemoryString is amount of memory that we reserve for other processes than redpanda in the container
+const ReserveMemoryString = "1M"
+
+// validateMemory verifies that memory limits are aligned with the minimal requirement of redpanda
+// which is 1GB per core
+// to verify this, we need to subtract the 1M we reserve currently for other processes
+func (r *Cluster) validateMemory() field.ErrorList {
+	var allErrs field.ErrorList
+	quantity := resource.MustParse(ReserveMemoryString)
+	if !r.Spec.Configuration.DeveloperMode && (r.Spec.Resources.Limits.Memory().Value()-quantity.Value()) < gb {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("resources").Child("limits").Child("memory"), r.Spec.Resources.Limits.Memory(), "need minimum of 1GB + 1MB of memory per node"))
+	}
+	return allErrs
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
@@ -30,8 +30,7 @@ spec:
             - start
             - --check=false
             - --smp 1
-            - --memory 104857600
-            - --reserve-memory 0M
+            - --reserve-memory 1M
             - --advertise-kafka-addr=internal://$(POD_NAME).cluster-sample.$(POD_NAMESPACE).svc.cluster.local.:9092
               --kafka-addr=internal://$(POD_IP):9092
               --advertise-rpc-addr=$(POD_NAME).cluster-sample.$(POD_NAMESPACE).svc.cluster.local.:33145


### PR DESCRIPTION
The reasoning behind this is that if there's some additional process running in the container -
e.g. tls cert processing, seastar might see less resources available and fail.
We should either not assign all available memory for seastar and reserve a little bit of memory for other processes if needed.

This is the error I was seeing on tls branch:
```
│ KUBERNETES_SERVICE_PORT_HTTPS=443 KUBERNETES_SERVICE_PORT=443 SUPERCRONIC=supercronic-linux-amd64 SUPERCRONIC_SHA1SUM=a2e2d47078a8dafc5949491e5ea7267cc721d67c HOSTNAME= │
│ INFO   redpanda::main - application.cc:65 - Redpanda aaf8c81 - aaf8c81f17251b20d306d9f801a898c9d258303c                                                                  │
│ INFO   redpanda::main - application.cc:73 - kernel=4.19.121-linuxkit, nodename=cluster-sample-tls-0, machine=x86_64                                                      │
│ DEBUG 2021-02-22 10:55:41,898 seastar - Not a cgroups-v2-only system                                                                                                     │
│ DEBUG 2021-02-22 10:55:41,899 seastar - smp::count: 1                                                                                                                    │
│ DEBUG 2021-02-22 10:55:41,899 seastar - latency_goal: 0.00075                                                                                                            │
│ DEBUG 2021-02-22 10:55:41,903 seastar - Not a cgroups-v2-only system                                                                                                     │
│ Could not initialize seastar: std::runtime_error (insufficient physical memory: needed 1200000000 available 1199996928)                                                  │
│ stream closed
```

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
