### PR TITLE
conf: Update kafka_api to array

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -33,7 +33,7 @@ redpanda:
   
   # Kafka transport
   kafka_api:
-    address: "0.0.0.0"
+  - address: "0.0.0.0"
     port: 9092
 
   admin:


### PR DESCRIPTION
This should fix #672 and also #524

Even though RPK tries to override this default with array and correct type, viper fails on this because of incompatible types https://github.com/spf13/viper/blob/8c894384998e656900b125e674b8c20dbf87cc06/viper.go#L1828

this is where the deb pkg references it https://github.com/vectorizedio/vtools/blob/79cdd85b11c55e66379a9829e28fe059391a14b6/vtools/artifacts/packaging/debian/debian/redpanda.install#L1

Let's try to think if we break older versions by this?

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
