### PR TITLE
operator: Introduce docker hub container in deployment

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= gcr.io/vectorized/redpanda-k8s-operator:latest
+IMG ?= vectorized/redpanda-operator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/src/go/k8s/README.md
+++ b/src/go/k8s/README.md
@@ -10,6 +10,9 @@ Use all your favorite open source tooling - 10x faster.
 
 ## Getting started
 
+Official Kubernetes quick start documentation can be found at
+[https://vectorized.io/docs/](https://vectorized.io/docs/quick-start-kubernetes)
+
 ### Requirements
 
 * Kubernetes 1.16 or newer
@@ -24,12 +27,6 @@ Optionaly to run operator locally:
 
 #### Local installation
 
-First clone the repo
-
-```
-git clone https://github.com/vectorizedio/redpanda.git
-```
-
 Create local Kubernetes cluster using KIND
 
 ```
@@ -37,21 +34,23 @@ export KUBECONFIG=your/path/to/kubeconfig.yaml
 kind create cluster --config kind.yaml
 ```
 
-You can simply deploy the latest version stored in GCR
+You can simply deploy the Redpanda operator by running the following command
 
 ```
-make deploy
-```
-
-Or you can build and load the container to Kubernetes cluster
-
-```
-# Only if you want to build container from source!
-make docker-build deploy-to-kind
+kubectl apply -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/default
 ```
 
 Install sample RedpandaCluster custom resource
 
 ```
-kubectl apply -f config/samples/redpanda_v1alpha1_cluster.yaml
+kubectl apply -f https://raw.githubusercontent.com/vectorizedio/redpanda/dev/src/go/k8s/config/samples/redpanda_v1alpha1_cluster.yaml
+```
+
+#### Clean up
+
+To remove all resources even the running Redpanda cluster
+please run the following command:
+
+```
+kubectl delete -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/default
 ```

--- a/src/go/k8s/config/default/manager_auth_proxy_patch.yaml
+++ b/src/go/k8s/config/default/manager_auth_proxy_patch.yaml
@@ -20,7 +20,7 @@ spec:
         - containerPort: 8443
           name: https
       - name: manager
-        imagePullPolicy: Never # KIND image pull policy necessary for latest tag to be deployed
+        imagePullPolicy: IfNotPresent
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/src/go/k8s/config/manager/kustomization.yaml
+++ b/src/go/k8s/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: gcr.io/vectorized/redpanda-k8s-operator
+  newName: vectorized/redpanda-operator
   newTag: latest

--- a/src/go/k8s/config/manager/manager.yaml
+++ b/src/go/k8s/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: controller:latest
+        image: vectorized/redpanda-operator:2021022-e853bf3
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -3,7 +3,7 @@ kind: TestSuite
 startKIND: true
 kindNodeCache: true
 kindContainers:
-  - gcr.io/vectorized/redpanda-k8s-operator:latest
+  - vectorized/redpanda-operator:latest
 testDirs:
   - ./tests/e2e
 kindConfig: ./kind.yaml


### PR DESCRIPTION
First version of redpanda operator was released to docker hub.
This gives users ability to install operator without cloning
the repo.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
