### PR TITLE
Introduce consumer groups fetch and wire it up to Pandaproxy

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -186,8 +186,9 @@ ss::future<member_id> client::create_consumer(const group_id& group_id) {
           return make_broker(
             res.data.node_id, unresolved_address(res.data.host, res.data.port));
       })
-      .then([group_id](shared_broker_t coordinator) mutable {
-          return make_consumer(std::move(coordinator), std::move(group_id));
+      .then([this, group_id](shared_broker_t coordinator) mutable {
+          return make_consumer(
+            _brokers, std::move(coordinator), std::move(group_id));
       })
       .then([this](shared_consumer_t c) {
           auto m_id = c->member_id();

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -21,6 +21,7 @@
 #include "kafka/protocol/leave_group.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
+#include "model/timeout_clock.h"
 #include "seastarx.h"
 #include "ssx/future-util.h"
 #include "utils/unresolved_address.h"
@@ -262,6 +263,23 @@ ss::future<offset_commit_response> client::consumer_offset_commit(
       .then([topics{std::move(topics)}](shared_consumer_t c) mutable {
           return c->offset_commit(std::move(topics));
       });
+}
+
+ss::future<kafka::fetch_response> client::consumer_fetch(
+  const group_id& g_id,
+  const member_id& m_id,
+  std::chrono::milliseconds timeout,
+  int32_t max_bytes) {
+    auto end = model::timeout_clock::now() + timeout;
+    return gated_retry_with_mitigation([this, g_id, m_id, end, max_bytes]() {
+        return get_consumer(g_id, m_id)
+          .then([end, max_bytes](shared_consumer_t c) {
+              auto timeout = std::max(
+                model::timeout_clock::duration{0},
+                end - model::timeout_clock::now());
+              return c->fetch(timeout, max_bytes);
+          });
+    });
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -20,6 +20,7 @@
 #include "kafka/client/producer.h"
 #include "kafka/client/retry_with_mitigation.h"
 #include "kafka/client/transport.h"
+#include "kafka/protocol/fetch.h"
 #include "kafka/types.h"
 #include "utils/retry.h"
 #include "utils/unresolved_address.h"
@@ -130,6 +131,12 @@ public:
       const group_id& g_id,
       const member_id& m_id,
       std::vector<offset_commit_request_topic> topics);
+
+    ss::future<fetch_response> consumer_fetch(
+      const group_id& g_id,
+      const member_id& m_id,
+      std::chrono::milliseconds timeout,
+      int32_t max_bytes);
 
     ss::future<> update_metadata() { return _wait_or_start_update_metadata(); }
 

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -9,12 +9,15 @@
 
 #include "kafka/client/consumer.h"
 
+#include "bytes/iobuf_parser.h"
 #include "kafka/client/assignment_plans.h"
+#include "kafka/client/broker.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/exceptions.h"
 #include "kafka/client/logger.h"
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/errors.h"
+#include "kafka/protocol/fetch.h"
 #include "kafka/protocol/find_coordinator.h"
 #include "kafka/protocol/heartbeat.h"
 #include "kafka/protocol/join_group.h"
@@ -22,7 +25,12 @@
 #include "kafka/protocol/metadata.h"
 #include "kafka/protocol/sync_group.h"
 #include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/record_utils.h"
 
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/sleep.hh>
 
 #include <chrono>
@@ -59,6 +67,17 @@ struct partition_comp {
       const metadata_response::partition& rhs) const {
         return lhs.index < rhs.index;
     }
+};
+
+fetch_response
+reduce_fetch_response(fetch_response result, fetch_response val) {
+    result.throttle_time += val.throttle_time;
+    result.partitions.insert(
+      result.partitions.end(),
+      std::make_move_iterator(val.partitions.begin()),
+      std::make_move_iterator(val.partitions.end()));
+
+    return result;
 };
 
 } // namespace detail
@@ -310,10 +329,73 @@ consumer::offset_commit(std::vector<offset_commit_request_topic> topics) {
     return req_res(std::move(req_builder));
 }
 
-ss::future<shared_consumer_t>
-make_consumer(shared_broker_t coordinator, group_id group_id) {
+ss::future<fetch_response>
+consumer::dispatch_fetch(broker_reqs_t::value_type br) {
+    auto& [broker, req] = br;
+    kclog.trace("Consumer: {}, fetch_req: {}", *this, req);
+    auto res = co_await broker->dispatch(std::move(req));
+    kclog.trace("Consumer: {}, fetch_res: {}", *this, res);
+
+    if (res.error != error_code::none) {
+        throw broker_error(broker->id(), res.error);
+    }
+
+    _fetch_sessions[broker].apply(res);
+    co_return res;
+}
+
+ss::future<fetch_response>
+consumer::fetch(std::chrono::milliseconds timeout, int32_t max_bytes) {
+    // Split requests by broker
+    broker_reqs_t broker_reqs;
+    for (auto const& [t, ps] : _assignment) {
+        for (const auto& p : ps) {
+            auto tp = model::topic_partition{t, p};
+            auto broker = co_await _brokers.find(tp);
+            auto& session = _fetch_sessions[broker];
+
+            auto& req = broker_reqs
+                          .try_emplace(
+                            broker,
+                            fetch_request{
+                              .replica_id = consumer_replica_id,
+                              .max_wait_time = timeout,
+                              .min_bytes = 1,
+                              .max_bytes = max_bytes,
+                              .isolation_level = 0, // READ_UNCOMMITTED
+                              .session_id = session.id(),
+                              .session_epoch = session.epoch(),
+                            })
+                          .first->second;
+
+            if (req.topics.empty() || req.topics.back().name != t) {
+                req.topics.push_back(fetch_request::topic{.name{t}});
+            }
+
+            req.topics.back().partitions.push_back(fetch_request::partition{
+              .id = p,
+              .fetch_offset = session.offset(tp),
+              .partition_max_bytes = max_bytes});
+        }
+    }
+
+    co_return co_await ss::map_reduce(
+      std::make_move_iterator(broker_reqs.begin()),
+      std::make_move_iterator(broker_reqs.end()),
+      [this](broker_reqs_t::value_type br) {
+          return dispatch_fetch(std::move(br));
+      },
+      fetch_response{
+        .throttle_time{},
+        .error = error_code::none,
+        .session_id = kafka::invalid_fetch_session_id},
+      detail::reduce_fetch_response);
+}
+
+ss::future<shared_consumer_t> make_consumer(
+  brokers& brokers, shared_broker_t coordinator, group_id group_id) {
     auto c = ss::make_lw_shared<consumer>(
-      std::move(coordinator), std::move(group_id));
+      brokers, std::move(coordinator), std::move(group_id));
     return c->join().then([c]() mutable { return std::move(c); });
 }
 

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -12,15 +12,18 @@
 #pragma once
 
 #include "kafka/client/assignment_plans.h"
-#include "kafka/client/broker.h"
+#include "kafka/client/brokers.h"
+#include "kafka/client/fetch_session.h"
 #include "kafka/client/logger.h"
 #include "kafka/protocol/describe_groups.h"
+#include "kafka/protocol/fetch.h"
 #include "kafka/protocol/offset_commit.h"
 #include "kafka/protocol/offset_fetch.h"
 #include "kafka/types.h"
 
 #include <seastar/core/shared_ptr.hh>
 
+#include <absl/container/node_hash_map.h>
 #include <absl/hash/hash.h>
 
 #include <chrono>
@@ -31,10 +34,12 @@ namespace kafka::client {
 // consumer manages the lifetime of a consumer within a group.
 class consumer final : public ss::enable_lw_shared_from_this<consumer> {
     using assignment_t = client::assignment;
+    using broker_reqs_t = absl::node_hash_map<shared_broker_t, fetch_request>;
 
 public:
-    consumer(shared_broker_t coordinator, group_id group_id)
-      : _coordinator(std::move(coordinator))
+    consumer(brokers& brokers, shared_broker_t coordinator, group_id group_id)
+      : _brokers(brokers)
+      , _coordinator(std::move(coordinator))
       , _group_id(std::move(group_id))
       , _topics() {}
 
@@ -50,6 +55,8 @@ public:
     offset_fetch(std::vector<offset_fetch_request_topic> topics);
     ss::future<offset_commit_response>
     offset_commit(std::vector<offset_commit_request_topic> topics);
+    ss::future<fetch_response>
+    fetch(std::chrono::milliseconds timeout, int32_t max_bytes);
 
 private:
     bool is_leader() const {
@@ -70,6 +77,8 @@ private:
 
     ss::future<describe_groups_response> describe_group();
 
+    ss::future<fetch_response> dispatch_fetch(broker_reqs_t::value_type br);
+
     template<typename RequestFactory>
     ss::future<
       typename std::invoke_result_t<RequestFactory>::api_type::response_type>
@@ -88,6 +97,7 @@ private:
         });
     }
 
+    brokers& _brokers;
     shared_broker_t _coordinator;
     ss::abort_source _as;
     ss::gate _gate{};
@@ -102,6 +112,7 @@ private:
     std::vector<model::topic> _subscribed_topics{};
     std::unique_ptr<assignment_plan> _plan{};
     assignment_t _assignment{};
+    absl::node_hash_map<shared_broker_t, fetch_session> _fetch_sessions;
 
     friend std::ostream& operator<<(std::ostream& os, const consumer& c) {
         fmt::print(
@@ -116,7 +127,7 @@ private:
 using shared_consumer_t = ss::lw_shared_ptr<consumer>;
 
 ss::future<shared_consumer_t>
-make_consumer(shared_broker_t coordinator, group_id group_id);
+make_consumer(brokers& brokers, shared_broker_t coordinator, group_id group_id);
 
 namespace detail {
 

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -33,12 +33,8 @@ bool fetch_session::apply(fetch_response& res) {
     if (_id == invalid_fetch_session_id) {
         _id = fetch_session_id{res.session_id};
     }
+    vassert(res.session_id == _id, "session mismatch: {}", *this);
 
-    if (res.session_id != _id) {
-        vassert(false, "session mismatch: {}", *this);
-        _id = invalid_fetch_session_id;
-        return false;
-    }
     ++_epoch;
     for (auto& part : res) {
         if (part.partition_response->has_error()) {

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -13,6 +13,7 @@
 
 #include "kafka/client/exceptions.h"
 #include "kafka/client/logger.h"
+#include "kafka/protocol/types.h"
 #include "model/fundamental.h"
 #include "seastar/core/gate.hh"
 
@@ -35,7 +36,7 @@ fetch_request make_fetch_request(
       .name{tp.topic}, .partitions{std::move(partitions)}});
 
     return fetch_request{
-      .replica_id{model::node_id{-1}},
+      .replica_id{consumer_replica_id},
       .max_wait_time{timeout},
       .min_bytes = 0,
       .max_bytes = max_bytes,

--- a/src/v/kafka/protocol/types.h
+++ b/src/v/kafka/protocol/types.h
@@ -11,9 +11,12 @@
 #pragma once
 #include "kafka/protocol/fwd.h"
 #include "kafka/types.h"
+#include "model/metadata.h"
 #include "utils/concepts-enabled.h"
 
 namespace kafka {
+
+static constexpr model::node_id consumer_replica_id{-1};
 
 // clang-format off
 CONCEPT(

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -47,6 +47,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/subscribe_consumer.json.h
 )
 
+seastar_generate_swagger(
+  TARGET consumer_fetch_swagger
+  VAR consumer_fetch_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/api/api-doc/consumer_fetch.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/consumer_fetch.json.h
+)
+
 v_cc_library(
   NAME rest_application
   SRCS
@@ -78,6 +85,7 @@ add_dependencies(v_rest_application
   post_topics_name_swagger
   create_consumer_swagger
   subscribe_consumer_swagger
+  consumer_fetch_swagger
 )
 
 if(CMAKE_BUILD_TYPE MATCHES Release)

--- a/src/v/pandaproxy/api/api-doc/consumer_fetch.json
+++ b/src/v/pandaproxy/api/api-doc/consumer_fetch.json
@@ -1,0 +1,32 @@
+    "/consumers/{group_name}/instances/{instance}/records": {
+      "get": {
+        "summary": "Fetch data for the consumer assignments",
+        "operationId": "consumer_fetch",
+        "parameters": [
+          {
+            "name": "group_name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "instance",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "max_bytes",
+            "in": "query",
+            "required": false,
+            "type": "integer"
+          }
+        ]
+      }
+    }

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -215,7 +215,7 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
 
     return rq.ctx.client
       .subscribe_consumer(group_id, member_id, std::move(req_data.topics))
-      .then([group_id, rp{std::move(rp)}]() mutable {
+      .then([rp{std::move(rp)}]() mutable {
           // nothing to do!
           return std::move(rp);
       });

--- a/src/v/pandaproxy/handlers.h
+++ b/src/v/pandaproxy/handlers.h
@@ -33,4 +33,7 @@ create_consumer(server::request_t rq, server::reply_t rp);
 ss::future<server::reply_t>
 subscribe_consumer(server::request_t rq, server::reply_t rp);
 
+ss::future<server::reply_t>
+consumer_fetch(server::request_t rq, server::reply_t rp);
+
 } // namespace pandaproxy

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -9,6 +9,7 @@
 
 #include "pandaproxy/proxy.h"
 
+#include "pandaproxy/api/api-doc/consumer_fetch.json.h"
 #include "pandaproxy/api/api-doc/create_consumer.json.h"
 #include "pandaproxy/api/api-doc/get_topics_names.json.h"
 #include "pandaproxy/api/api-doc/get_topics_records.json.h"
@@ -59,6 +60,11 @@ std::vector<server::route_t> get_proxy_routes() {
       ss::httpd::subscribe_consumer_json::name,
       ss::httpd::subscribe_consumer_json::subscribe_consumer,
       subscribe_consumer});
+
+    routes.emplace_back(server::route_t{
+      ss::httpd::consumer_fetch_json::name,
+      ss::httpd::consumer_fetch_json::consumer_fetch,
+      consumer_fetch});
 
     return routes;
 }


### PR DESCRIPTION
Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/3aa9cd6d494a7d0953c078a413b42dbac34f68db..62e01e3da446579369d60f3f93f53e043970dc77)

* Testing for `kafka::client` module
* Add for retry failed `consumer_fetch`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/62e01e3da446579369d60f3f93f53e043970dc77..8fab81723778b0b23f17eaaeb4d911ae0ccbf0a4)
* Rebase due to conflict in #645 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/8fab81723778b0b23f17eaaeb4d911ae0ccbf0a4..0b63d5532569832b5b64b572f0fa4fcb78c28a15)
* Constrain fetch `timeout  >= 0`

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
