### PR TITLE
operator: Add overprovisioned flag to arguments

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -233,6 +233,7 @@ func (r *StatefulSetResource) Obj() (k8sclient.Object, error) {
 								"--smp 1",
 								"--memory " + strconv.FormatInt(memory.Value(), 10),
 								"--reserve-memory 0M",
+								"--overprovisioned",
 								r.portsConfiguration(),
 								"--",
 								"--default-log-level=debug",

--- a/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
@@ -32,6 +32,7 @@ spec:
             - --smp 1
             - --memory 104857600
             - --reserve-memory 0M
+            - --overprovisioned
             - --advertise-kafka-addr=internal://$(POD_NAME).cluster-sample.$(POD_NAMESPACE).svc.cluster.local.:9092
               --kafka-addr=internal://$(POD_IP):9092
               --advertise-rpc-addr=$(POD_NAME).cluster-sample.$(POD_NAMESPACE).svc.cluster.local.:33145


### PR DESCRIPTION
In the containerised environment redpanda process shares
hardware with other processes so it can not appropriate
CPU and memory resource to itself.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
