### PR TITLE
rpc/transport: keep socket alive after connection timeout was triggered

### DIFF
--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -66,18 +66,21 @@ transport::transport(
 
 ss::future<ss::connected_socket> connect_with_timeout(
   const seastar::socket_address& address, rpc::clock_type::time_point timeout) {
-    return ss::do_with(
-      ss::engine().net().socket(), [address, timeout](seastar::socket& sock) {
-          auto f = sock.connect(
-            address,
-            ss::socket_address(sockaddr_in{AF_INET, INADDR_ANY, {0}}),
-            ss::transport::TCP);
-          return ss::with_timeout(timeout, std::move(f))
-            .handle_exception([&sock, address](const std::exception_ptr& e) {
-                rpclog.warn("error connecting to {} - {}", address, e);
-                sock.shutdown();
-                return ss::make_exception_future<ss::connected_socket>(e);
-            });
+    auto socket = ss::make_lw_shared<ss::socket>(ss::engine().net().socket());
+
+    auto f = socket
+               ->connect(
+                 address,
+                 ss::socket_address(sockaddr_in{AF_INET, INADDR_ANY, {0}}),
+                 ss::transport::TCP)
+               .finally([socket] {
+
+               });
+    return ss::with_timeout(timeout, std::move(f))
+      .handle_exception([socket, address](const std::exception_ptr& e) {
+          rpclog.warn("error connecting to {} - {}", address, e);
+          socket->shutdown();
+          return ss::make_exception_future<ss::connected_socket>(e);
       });
 }
 


### PR DESCRIPTION
Fixed removing socket after timeout was triggered but connection was
eventually created. In this case we can not remove the socket structure
until the future is finished. When timeout occurs, we shutdown all
connection attempts and already created connections so even if
connection was established it will be safely closed.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
