### PR TITLE
coproc: Within ifdef glibcxx macro an incorrect name was defined

### DIFF
--- a/src/v/utils/functional.h
+++ b/src/v/utils/functional.h
@@ -52,7 +52,7 @@ namespace xform {
 /// Even though std::identity is in the spec for C++20 seems as though clang
 /// devs haven't gotten around to implementing it yet.
 #ifdef __GLIBCXX__
-using just = std::identity;
+using identity = std::identity;
 #else
 struct identity {
     template<typename T>


### PR DESCRIPTION
## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
