### PR TITLE
operator/docs: Add cert manager prerequisite

### DIFF
--- a/src/go/k8s/README.md
+++ b/src/go/k8s/README.md
@@ -18,6 +18,7 @@ Official Kubernetes quick start documentation can be found at
 * Kubernetes 1.16 or newer
 * kubectl 1.16 or newer
 * kustomize v3.8.7 or newer
+* cert-manager v1.0.0 or newer
 
 Optionaly to run operator locally:
 
@@ -34,10 +35,26 @@ export KUBECONFIG=your/path/to/kubeconfig.yaml
 kind create cluster --config kind.yaml
 ```
 
-You can simply deploy the Redpanda operator by running the following command
+In order to have validating webhook the cert manager needs to be
+installed. Please follow 
+[the installation guide](https://cert-manager.io/docs/installation/)
+
+The cert manager needs around 1 minute to be ready. The Redpanda
+operator will create Issuer and Certificate custom resource. The
+webhook of cert-manager will prevent from creating mentioned
+resources. To verify that cert manager is ready please follow
+[the verifying the installation](https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation)
+
+You can simply deploy the Redpanda operator with webhook (recommended) by running the following command
 
 ```
 kubectl apply -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/default
+```
+
+You can deploy the Redpanda operator without webhook by running the following command:
+
+```
+kubectl apply -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/without-webhook
 ```
 
 Install sample RedpandaCluster custom resource

--- a/src/go/k8s/config/without-webhook/kustomization.yaml
+++ b/src/go/k8s/config/without-webhook/kustomization.yaml
@@ -1,0 +1,24 @@
+# Adds namespace to all resources.
+namespace: redpanda-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: redpanda-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+
+patchesStrategicMerge:
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
+- manager_auth_proxy_patch.yaml

--- a/src/go/k8s/config/without-webhook/manager_auth_proxy_patch.yaml
+++ b/src/go/k8s/config/without-webhook/manager_auth_proxy_patch.yaml
@@ -1,0 +1,27 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: manager
+        imagePullPolicy: IfNotPresent
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"


### PR DESCRIPTION
The installation description now mentions about cert manager
dependency. To opt-out from having validation webhook user
need to choose different kustomize folder.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
