### PR TITLE
Swap kafka::client for a kafka::transport to prevent every redpanda node initiating a connection to all brokers  

### DIFF
--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -174,14 +174,7 @@ ss::future<> event_listener::do_start() {
       [this](model::record_batch_reader::data_t& events) {
           /// The stop condition is met when its been detected that the stored
           /// offset has not moved.
-          return ss::repeat([this, &events] {
-                     model::offset initial_offset = _offset;
-                     return poll_topic(events).then([this, initial_offset] {
-                         return initial_offset == _offset
-                                  ? ss::stop_iteration::yes
-                                  : ss::stop_iteration::no;
-                     });
-                 })
+          return ss::repeat([this, &events] { return poll_topic(events); })
             .then(
               [&events] { return decompress_wasm_events(std::move(events)); })
             .then([](std::vector<model::record_batch> events) {
@@ -197,7 +190,7 @@ ss::future<> event_listener::do_start() {
       });
 }
 
-ss::future<>
+ss::future<ss::stop_iteration>
 event_listener::poll_topic(model::record_batch_reader::data_t& events) {
     std::vector<kafka::fetch_request::partition> partitions;
     partitions.push_back(kafka::fetch_request::partition{
@@ -211,11 +204,10 @@ event_listener::poll_topic(model::record_batch_reader::data_t& events) {
     vassert(_client, "Handle to kafka::transport must not be null");
     return _client->dispatch(std::move(req))
       .then([this, &events](kafka::fetch_response response) {
-          if (response.error == kafka::error_code::unknown_topic_or_partition) {
-              return _client->stop().finally([c{std::move(_client)}] {});
-          }
           if (response.error != kafka::error_code::none) {
-              return ss::now();
+              return _client->stop()
+                .then([] { return ss::stop_iteration::yes; })
+                .finally([c{std::move(_client)}] {});
           }
           vassert(
             response.partitions.size() == 1, "Unexpected partition size ");
@@ -225,6 +217,7 @@ event_listener::poll_topic(model::record_batch_reader::data_t& events) {
             "Unexpected topic name");
           vassert(p.responses.size() == 1, "Unexpected responses size");
           auto& pr = p.responses[0];
+          model::offset last_offset = _offset;
           if (!pr.has_error()) {
               auto crs = kafka::batch_reader(std::move(*pr.record_set));
               while (!crs.empty()) {
@@ -240,7 +233,9 @@ event_listener::poll_topic(model::record_batch_reader::data_t& events) {
                   _offset = events.back().last_offset() + model::offset(1);
               }
           }
-          return ss::now();
+          auto should_stop = (_offset == last_offset) ? ss::stop_iteration::yes
+                                                      : ss::stop_iteration::no;
+          return ss::make_ready_future<ss::stop_iteration>(should_stop);
       });
 };
 

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -13,6 +13,7 @@
 #include "coproc/script_dispatcher.h"
 #include "coproc/types.h"
 #include "kafka/client/client.h"
+#include "kafka/client/transport.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
@@ -53,9 +54,11 @@ private:
 
     ss::future<> persist_actions(absl::btree_map<script_id, iobuf>);
 
+    ss::future<> do_connect();
+
 private:
     /// Kafka client used to poll the internal topic
-    kafka::client::client _client;
+    std::unique_ptr<kafka::client::transport> _client;
 
     /// Primitives used to manage the poll loop
     ss::gate _gate;

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -12,7 +12,6 @@
 
 #include "coproc/script_dispatcher.h"
 #include "coproc/types.h"
-#include "kafka/client/client.h"
 #include "kafka/client/transport.h"
 
 #include <seastar/core/abort_source.hh>

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -50,7 +50,8 @@ public:
 private:
     ss::future<> do_start();
 
-    ss::future<> poll_topic(model::record_batch_reader::data_t&);
+    ss::future<ss::stop_iteration>
+    poll_topic(model::record_batch_reader::data_t&);
 
     ss::future<> persist_actions(absl::btree_map<script_id, iobuf>);
 

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "kafka/protocol/create_topics.h"
+#include "kafka/protocol/metadata.h"
 #include "redpanda/tests/fixture.h"
 #include "resource_mgmt/io_priority.h"
 

--- a/src/v/kafka/server/tests/metadata_test.cc
+++ b/src/v/kafka/server/tests/metadata_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "kafka/protocol/errors.h"
+#include "kafka/protocol/metadata.h"
 #include "librdkafka/rdkafkacpp.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -9,9 +9,11 @@
 
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/heartbeat.h"
+#include "kafka/protocol/join_group.h"
 #include "kafka/protocol/leave_group.h"
 #include "kafka/protocol/metadata.h"
 #include "kafka/protocol/produce.h"
+#include "kafka/protocol/sync_group.h"
 #include "redpanda/tests/fixture.h"
 #include "test_utils/fixture.h"
 #include "utils/file_io.h"

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -18,6 +18,7 @@
 #include "cluster/service.h"
 #include "config/configuration.h"
 #include "config/seed_server.h"
+#include "kafka/client/configuration.h"
 #include "kafka/security/scram_algorithm.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
 #include "kafka/server/group_manager.h"

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -17,6 +17,7 @@
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
 #include "kafka/client/transport.h"
+#include "kafka/protocol/fetch.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
 #include "model/metadata.h"
 #include "model/namespace.h"


### PR DESCRIPTION
The kafka::client will connect to every broker in the cluster. Having one event listener per node, this isn't desirable because it will mean that every node has N connections to all other nodes.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
