### PR TITLE
Miscellaneous fixes and clean-up

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,3 @@
+{
+    "clangd.path": "vbuild/llvm/llvm-bin/bin/clangd"
+}

--- a/src/v/bytes/details/io_byte_iterator.h
+++ b/src/v/bytes/details/io_byte_iterator.h
@@ -30,7 +30,8 @@ public:
     using reference = const char&;
     using iterator_category = std::forward_iterator_tag;
 
-    io_byte_iterator(io_const_iterator begin, io_const_iterator end) noexcept
+    io_byte_iterator(
+      const io_const_iterator& begin, const io_const_iterator& end) noexcept
       : _frag(begin)
       , _frag_end(end) {
         if (_frag != _frag_end) {
@@ -43,8 +44,8 @@ public:
         }
     }
     io_byte_iterator(
-      io_const_iterator begin,
-      io_const_iterator end,
+      const io_const_iterator& begin,
+      const io_const_iterator& end,
       const char* frag_index,
       const char* frag_index_end) noexcept
       : _frag(begin)

--- a/src/v/kafka/server/coordinator_ntp_mapper.h
+++ b/src/v/kafka/server/coordinator_ntp_mapper.h
@@ -43,7 +43,7 @@ namespace kafka {
  */
 class coordinator_ntp_mapper {
 public:
-    coordinator_ntp_mapper(ss::sharded<cluster::metadata_cache>& md)
+    explicit coordinator_ntp_mapper(ss::sharded<cluster::metadata_cache>& md)
       : _md(md)
       , _tp_ns(model::kafka_internal_namespace, model::kafka_group_topic) {}
 

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -51,25 +51,25 @@ group::group(
   group_state s,
   config::configuration& conf,
   ss::lw_shared_ptr<cluster::partition> partition)
-  : _id(id)
+  : _id(std::move(id))
   , _state(s)
   , _state_timestamp(clock_type::now())
   , _generation(0)
   , _num_members_joining(0)
   , _new_member_added(false)
   , _conf(conf)
-  , _partition(partition) {}
+  , _partition(std::move(partition)) {}
 
 group::group(
   kafka::group_id id,
   group_log_group_metadata& md,
   config::configuration& conf,
   ss::lw_shared_ptr<cluster::partition> partition)
-  : _id(id)
+  : _id(std::move(id))
   , _num_members_joining(0)
   , _new_member_added(false)
   , _conf(conf)
-  , _partition(partition) {
+  , _partition(std::move(partition)) {
     _state = md.members.empty() ? group_state::empty : group_state::stable;
     _generation = md.generation;
     _protocol_type = md.protocol_type;

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -40,7 +40,7 @@ public:
 
     ~protocol() noexcept override = default;
     protocol(const protocol&) = delete;
-    protocol& operator=(const protocol&&) = delete;
+    protocol& operator=(const protocol&) = delete;
     protocol(protocol&&) noexcept = default;
     protocol& operator=(protocol&&) noexcept = delete;
 

--- a/src/v/rpc/response_handler.h
+++ b/src/v/rpc/response_handler.h
@@ -18,8 +18,7 @@
 
 #include <seastar/core/future.hh>
 
-namespace rpc {
-namespace internal {
+namespace rpc::internal {
 class response_handler {
 public:
     using response_ptr = result<std::unique_ptr<streaming_context>>;
@@ -75,5 +74,4 @@ private:
     promise_t _promise;
     timer_ptr _timeout_timer;
 };
-} // namespace internal
-} // namespace rpc
+} // namespace rpc::internal

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -9,7 +9,10 @@
 
 #include "batch_cache.h"
 
+#include "utils/to_string.h"
 #include "vassert.h"
+
+#include <fmt/ostream.h>
 
 namespace storage {
 
@@ -242,6 +245,18 @@ void batch_cache_index::truncate(model::offset offset) {
         });
         _index.erase(it, _index.end());
     }
+}
+
+std::ostream&
+operator<<(std::ostream& os, const batch_cache::reclaim_options& opts) {
+    fmt::print(
+      os,
+      "growth window {} stable window {} min_size {} max_size {}",
+      opts.growth_window,
+      opts.stable_window,
+      opts.min_size,
+      opts.max_size);
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& o, const batch_cache& b) {

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -92,7 +92,7 @@ class batch_cache_index;
  */
 class batch_cache {
     /// Minimum size reclaimed in low-memory situations.
-    static constexpr size_t min_reclaim_size = 128 << 10;
+    static constexpr size_t min_reclaim_size = 128U << 10U;
 
     using reclaimer = ss::memory::reclaimer;
     using reclaim_scope = ss::memory::reclaimer_scope;

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -170,7 +170,7 @@ public:
 
     using entry_ptr = ss::weak_ptr<entry>;
 
-    batch_cache(const reclaim_options& opts)
+    explicit batch_cache(const reclaim_options& opts)
       : _reclaimer(
         [this](reclaimer::request r) { return reclaim(r); },
         reclaim_scope::sync)
@@ -301,6 +301,7 @@ private:
     ss::lowres_clock::time_point _last_reclaim;
     size_t _reclaim_size;
 
+    friend std::ostream& operator<<(std::ostream&, const reclaim_options&);
     friend std::ostream& operator<<(std::ostream&, const batch_cache&);
 };
 

--- a/src/v/storage/batch_cache.h
+++ b/src/v/storage/batch_cache.h
@@ -174,7 +174,8 @@ public:
       : _reclaimer(
         [this](reclaimer::request r) { return reclaim(r); },
         reclaim_scope::sync)
-      , _reclaim_opts(opts) {}
+      , _reclaim_opts(opts)
+      , _reclaim_size(_reclaim_opts.min_size) {}
 
     batch_cache(const batch_cache&) = delete;
     batch_cache& operator=(const batch_cache&) = delete;
@@ -194,7 +195,8 @@ public:
           reclaim_scope::sync)
       , _is_reclaiming(o._is_reclaiming)
       , _size_bytes(o._size_bytes)
-      , _reclaim_opts(o._reclaim_opts) {
+      , _reclaim_opts(o._reclaim_opts)
+      , _reclaim_size(_reclaim_opts.min_size) {
         o._size_bytes = 0;
         o._is_reclaiming = false;
     }

--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -76,32 +76,32 @@ struct compacted_index {
         int32_t delta;
     };
 };
-[[gnu::always_inline]] static inline compacted_index::footer_flags
+[[gnu::always_inline]] inline compacted_index::footer_flags
 operator|(compacted_index::footer_flags a, compacted_index::footer_flags b) {
     return compacted_index::footer_flags(
       std::underlying_type_t<compacted_index::footer_flags>(a)
       | std::underlying_type_t<compacted_index::footer_flags>(b));
 }
 
-[[gnu::always_inline]] static inline void
+[[gnu::always_inline]] inline void
 operator|=(compacted_index::footer_flags& a, compacted_index::footer_flags b) {
     a = (a | b);
 }
 
-[[gnu::always_inline]] static inline compacted_index::footer_flags
+[[gnu::always_inline]] inline compacted_index::footer_flags
 operator~(compacted_index::footer_flags a) {
     return compacted_index::footer_flags(
       ~std::underlying_type_t<compacted_index::footer_flags>(a));
 }
 
-[[gnu::always_inline]] static inline compacted_index::footer_flags
+[[gnu::always_inline]] inline compacted_index::footer_flags
 operator&(compacted_index::footer_flags a, compacted_index::footer_flags b) {
     return compacted_index::footer_flags(
       std::underlying_type_t<compacted_index::footer_flags>(a)
       & std::underlying_type_t<compacted_index::footer_flags>(b));
 }
 
-[[gnu::always_inline]] static inline void
+[[gnu::always_inline]] inline void
 operator&=(compacted_index::footer_flags& a, compacted_index::footer_flags b) {
     a = (a & b);
 }

--- a/src/v/storage/fs_utils.h
+++ b/src/v/storage/fs_utils.h
@@ -49,7 +49,7 @@ struct segment_path {
     /// Parse metadata from a segment filename.
     static std::optional<metadata>
     parse_segment_filename(const ss::sstring& name) {
-        const std::regex re("^(\\d+)-(\\d+)-([\\x00-\\x7F]+).log$");
+        const std::regex re(R"(^(\d+)-(\d+)-([\x00-\x7F]+).log$)");
         std::cmatch match;
         if (!std::regex_match(name.c_str(), match, re)) {
             return std::nullopt;

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -30,7 +30,7 @@ static ss::logger lg("kvstore");
 namespace storage {
 
 kvstore::kvstore(kvstore_config kv_conf)
-  : _conf(kv_conf)
+  : _conf(std::move(kv_conf))
   , _ntpc(model::kvstore_ntp(ss::this_shard_id()), _conf.base_dir)
   , _snap(
       std::filesystem::path(_ntpc.work_directory()),

--- a/src/v/storage/snapshot.h
+++ b/src/v/storage/snapshot.h
@@ -94,9 +94,9 @@ public:
 
     snapshot_manager(
       std::filesystem::path dir,
-      const char* filename,
+      ss::sstring filename,
       ss::io_priority_class io_prio) noexcept
-      : _filename(filename)
+      : _filename(std::move(filename))
       , _dir(std::move(dir))
       , _io_prio(io_prio) {}
 

--- a/src/v/utils/gate_guard.h
+++ b/src/v/utils/gate_guard.h
@@ -27,7 +27,7 @@
 ///             assert(gate.get_count() == 1);
 ///          }
 ///          assert(gate.get_count() == 0);
-struct gate_guard {
+struct gate_guard final {
     explicit gate_guard(ss::gate& g)
       : _g(&g) {
         _g->enter();

--- a/src/v/utils/gate_guard.h
+++ b/src/v/utils/gate_guard.h
@@ -46,7 +46,7 @@ struct gate_guard final {
     }
     gate_guard(const gate_guard&) = delete;
     gate_guard& operator=(const gate_guard&) = delete;
-    ~gate_guard() {
+    ~gate_guard() noexcept {
         if (_g) {
             _g->leave();
         }

--- a/src/v/utils/memory_data_source.h
+++ b/src/v/utils/memory_data_source.h
@@ -23,7 +23,7 @@ public:
     using value_type = ss::temporary_buffer<char>;
     using vector_type = std::vector<value_type>;
     explicit memory_data_source(vector_type buffers)
-      : capacity(std::accumulate(
+      : _capacity(std::accumulate(
         buffers.begin(),
         buffers.end(),
         size_t(0),
@@ -31,11 +31,11 @@ public:
       , _buffers(std::move(buffers)) {}
 
     ss::future<value_type> skip(uint64_t n) final {
-        _byte_offset = std::min(_byte_offset + n, capacity);
+        _byte_offset = std::min(_byte_offset + n, _capacity);
         return get();
     }
     ss::future<value_type> get() final {
-        if (_byte_offset >= capacity) {
+        if (_byte_offset >= _capacity) {
             return ss::make_ready_future<value_type>();
         }
         int64_t offset = _byte_offset;
@@ -52,9 +52,8 @@ public:
         return ss::make_ready_future<value_type>();
     }
 
-    const size_t capacity;
-
 private:
+    const size_t _capacity;
     vector_type _buffers;
     size_t _byte_offset = 0;
 };


### PR DESCRIPTION
- Mostly clang-tidy warnings
- Project-specific vim settings for llvm binaries
- Accidental batch_cache creation via non-explicit constructor