### PR TITLE
operator: Do not inject whole service into other resources

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -72,10 +72,10 @@ func (r *ClusterReconciler) Reconcile(
 	}
 
 	svc := resources.NewService(r.Client, &redpandaCluster, r.Scheme, log)
-	sts := resources.NewStatefulSet(r.Client, &redpandaCluster, r.Scheme, svc, log)
+	sts := resources.NewStatefulSet(r.Client, &redpandaCluster, r.Scheme, svc.HeadlessServiceFQDN(), svc.Key().Name, log)
 	toApply := []resources.Resource{
 		svc,
-		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme, svc, log),
+		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme, svc.HeadlessServiceFQDN(), log),
 		sts,
 	}
 

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -53,8 +53,8 @@ type ConfigMapResource struct {
 	scheme		*runtime.Scheme
 	pandaCluster	*redpandav1alpha1.Cluster
 
-	svc	*ServiceResource
-	logger	logr.Logger
+	serviceFQDN	string
+	logger		logr.Logger
 }
 
 // NewConfigMap creates ConfigMapResource
@@ -62,11 +62,11 @@ func NewConfigMap(
 	client k8sclient.Client,
 	pandaCluster *redpandav1alpha1.Cluster,
 	scheme *runtime.Scheme,
-	svc *ServiceResource,
+	serviceFQDN string,
 	logger logr.Logger,
 ) *ConfigMapResource {
 	return &ConfigMapResource{
-		client, scheme, pandaCluster, svc, logger.WithValues("Kind", configMapKind()),
+		client, scheme, pandaCluster, serviceFQDN, logger.WithValues("Kind", configMapKind()),
 	}
 }
 
@@ -96,7 +96,7 @@ func (r *ConfigMapResource) Ensure(ctx context.Context) error {
 
 // Obj returns resource managed client.Object
 func (r *ConfigMapResource) Obj() (k8sclient.Object, error) {
-	serviceAddress := r.svc.HeadlessServiceFQDN()
+	serviceAddress := r.serviceFQDN
 
 	cfgBytes, err := yaml.Marshal(r.createConfiguration())
 	if err != nil {
@@ -136,7 +136,7 @@ func (r *ConfigMapResource) Obj() (k8sclient.Object, error) {
 }
 
 func (r *ConfigMapResource) createConfiguration() *config.Config {
-	serviceAddress := r.svc.HeadlessServiceFQDN()
+	serviceAddress := r.serviceFQDN
 	cfgRpk := config.Default()
 
 	c := r.pandaCluster.Spec.Configuration

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -44,7 +44,8 @@ type StatefulSetResource struct {
 	k8sclient.Client
 	scheme		*runtime.Scheme
 	pandaCluster	*redpandav1alpha1.Cluster
-	svc		*ServiceResource
+	serviceFQDN	string
+	serviceName	string
 	logger		logr.Logger
 
 	LastObservedState	*appsv1.StatefulSet
@@ -55,11 +56,12 @@ func NewStatefulSet(
 	client k8sclient.Client,
 	pandaCluster *redpandav1alpha1.Cluster,
 	scheme *runtime.Scheme,
-	svc *ServiceResource,
+	serviceFQDN string,
+	serviceName string,
 	logger logr.Logger,
 ) *StatefulSetResource {
 	return &StatefulSetResource{
-		client, scheme, pandaCluster, svc, logger.WithValues("Kind", statefulSetKind()), nil,
+		client, scheme, pandaCluster, serviceFQDN, serviceName, logger.WithValues("Kind", statefulSetKind()), nil,
 	}
 }
 
@@ -372,7 +374,7 @@ func (r *StatefulSetResource) Kind() string {
 func (r *StatefulSetResource) portsConfiguration() string {
 	kafkaAPIPort := r.pandaCluster.Spec.Configuration.KafkaAPI.Port
 	rpcAPIPort := r.pandaCluster.Spec.Configuration.RPCServer.Port
-	svcName := r.svc.Key().Name
+	svcName := r.serviceName
 
 	// In every dns name there is trailing dot to query absolute path
 	// For trailing dot explanation please visit http://www.dns-sd.org/trailingdotsindomainnames.html

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -72,8 +72,7 @@ func TestEnsure(t *testing.T) {
 			assert.NoError(t, err, tt.name)
 		}
 
-		svc := res.NewService(c, tt.pandaCluster, scheme.Scheme, ctrl.Log.WithName("test"))
-		sts := res.NewStatefulSet(c, tt.pandaCluster, scheme.Scheme, svc, ctrl.Log.WithName("test"))
+		sts := res.NewStatefulSet(c, tt.pandaCluster, scheme.Scheme, "cluster.local", "servicename", ctrl.Log.WithName("test"))
 
 		err = sts.Ensure(context.Background())
 		assert.NoError(t, err, tt.name)

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -158,7 +158,7 @@ func (r *StatefulSetResource) ensureRedpandaGroupsReady(
 		return nil
 	}
 
-	headlessServiceWithPort := fmt.Sprintf("%s:%d", r.svc.HeadlessServiceFQDN(),
+	headlessServiceWithPort := fmt.Sprintf("%s:%d", r.serviceFQDN,
 		r.pandaCluster.Spec.Configuration.KafkaAPI.Port)
 
 	addresses := []string{fmt.Sprintf("%s-%d.%s", sts.Name, ordinal, headlessServiceWithPort)}


### PR DESCRIPTION
I see this pattern repeating in so many new PRs. I think this way it's much cleaner and it's nicer even from the testability perspective. We don't need to depend on whole service resource just to be able to retrieve one small string.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
