### PR TITLE
operator: download cert-manager verifier to bin

### DIFF
--- a/src/go/k8s/hack/install-cert-manager.sh
+++ b/src/go/k8s/hack/install-cert-manager.sh
@@ -8,10 +8,10 @@ VERSION="0.1.0"
 
 # TODO: support more OS/architectures as they are needed
 if [ "$(uname)" == 'Darwin' ]; then
-  curl -L https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Darwin_x86_64.tar.gz | tar -xvf -
+  curl -L https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Darwin_x86_64.tar.gz | tar -xvf - -C ./bin
 else
-  curl -L https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Linux_x86_64.tar.gz | tar -xzvf -
+  curl -L https://github.com/alenkacz/cert-manager-verifier/releases/download/v"${VERSION}"/cert-manager-verifier_"${VERSION}"_Linux_x86_64.tar.gz | tar -xzvf - -C ./bin
 fi
 
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
-./cm-verifier
+./bin/cm-verifier


### PR DESCRIPTION
the reason for this is that the cm-verifier package contains readme.md so if you run locally, it overrides our project readme. Also I think bin is proper location for this binary.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
