### PR TITLE
Error policy on rpc layer

### DIFF
--- a/src/js/modules/domain/generatedRpc/entitiesDefinition.json
+++ b/src/js/modules/domain/generatedRpc/entitiesDefinition.json
@@ -231,7 +231,7 @@
         },
         {
           "name": "resultRecordBatch",
-          "type": "Array<RecordBatch>"
+          "type": "Optional<Array<RecordBatch>>"
         }
       ]
     },

--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -217,7 +217,7 @@ export class ProcessBatchServer extends SupervisorServer {
     processBatchRequest: ProcessBatchRequestItem,
     error: Error,
     policyError = coprocessor.policyError
-  ): Promise<never> {
+  ): Promise<ProcessBatchReplyItem> {
     const errorMessage = this.createMessageError(
       coprocessor,
       processBatchRequest,
@@ -225,9 +225,17 @@ export class ProcessBatchServer extends SupervisorServer {
     );
     switch (policyError) {
       case PolicyError.Deregister:
-        return Promise.resolve().then(() => Promise.reject(errorMessage));
+        return Promise.resolve({
+          ntp: processBatchRequest.ntp,
+          coprocessorId: coprocessor.globalId,
+          resultRecordBatch: undefined,
+        });
       case PolicyError.SkipOnFailure:
-        return Promise.reject(errorMessage);
+        return Promise.resolve({
+          ntp: processBatchRequest.ntp,
+          coprocessorId: coprocessor.globalId,
+          resultRecordBatch: [],
+        });
       default:
         return Promise.reject(errorMessage);
     }

--- a/src/js/modules/supervisors/Repository.ts
+++ b/src/js/modules/supervisors/Repository.ts
@@ -117,11 +117,13 @@ class Repository {
         `Wasm function (${handle.coprocessor.globalId}) ` +
           `didn't return a Promise<Map<string, RecordBatch>>`
       );
-      return handleError(
-        handle.coprocessor,
-        requestItem,
-        error,
-        PolicyError.Deregister
+      return Promise.reject(
+        handleError(
+          handle.coprocessor,
+          requestItem,
+          error,
+          PolicyError.Deregister
+        )
       );
     }
   }
@@ -208,7 +210,10 @@ class Repository {
                   recordBatch,
                   resultMap
                 )
-              );
+              )
+              .catch((responseError: ProcessBatchReplyItem) => {
+                return responseError;
+              });
           } catch (e) {
             return handleError(handle.coprocessor, requestItem, e);
           }


### PR DESCRIPTION
those changes modify the ProcessBatchReplyItem type, now
the record attribute is a Optional<Array>.

what does it change?
now error policy is going to handle via record value,
for example, if one coprocessor script fails and that
coprocessor has errorPolicy=Deregister, the record
value in ProcessBatchReplyItem is going to be `undefined`,
when redpanda validate that record value, send a
disableCoprocessor request to wasm-engine.

for skipOnFailure policy the record value in ProcessBatchReplyItem
is going to be a empty array.

