### PR TITLE
pp/consumer_groups: Introduce more consumer group endpoints

### DIFF
--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -10,6 +10,7 @@
 #include "kafka/client/fetch_session.h"
 
 #include "kafka/protocol/fetch.h"
+#include "kafka/protocol/schemata/offset_commit_request.h"
 
 #include <fmt/ostream.h>
 
@@ -53,6 +54,29 @@ bool fetch_session::apply(fetch_response& res) {
         topic.second.rehash(topic.second.size());
     }
     return true;
+}
+
+std::vector<offset_commit_request_topic>
+fetch_session::make_offset_commit_request() const {
+    std::vector<offset_commit_request_topic> res;
+    if (_offsets.empty()) {
+        return res;
+    }
+    res.push_back(offset_commit_request_topic{
+      .name{_offsets.begin()->first}, .partitions{}});
+    for (const auto& [t, po] : _offsets) {
+        for (const auto& [p_id, o] : po) {
+            if (res.back().name != t) {
+                res.push_back(
+                  offset_commit_request_topic{.name = t, .partitions{}});
+            }
+            res.back().partitions.push_back(offset_commit_request_partition{
+              .partition_index = p_id,
+              .committed_offset = o - model::offset(1),
+              .committed_leader_epoch = _epoch});
+        }
+    }
+    return res;
 }
 
 std::ostream& operator<<(std::ostream& os, fetch_session const& fs) {

--- a/src/v/kafka/client/fetch_session.h
+++ b/src/v/kafka/client/fetch_session.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "kafka/protocol/schemata/offset_commit_request.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 
@@ -40,6 +41,8 @@ public:
     kafka::fetch_session_epoch epoch() const { return _epoch; }
     model::offset offset(model::topic_partition_view tpv) const;
     bool apply(fetch_response& res);
+    std::vector<kafka::offset_commit_request_topic>
+    make_offset_commit_request() const;
 
     friend std::ostream& operator<<(std::ostream& os, fetch_session const&);
 

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -68,6 +68,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/get_consumer_offsets.json.h
 )
 
+seastar_generate_swagger(
+  TARGET post_consumer_offsets_swagger
+  VAR post_consumer_offsets_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/api/api-doc/post_consumer_offsets.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/post_consumer_offsets.json.h
+)
+
 v_cc_library(
   NAME rest_application
   SRCS
@@ -102,6 +109,7 @@ add_dependencies(v_rest_application
   subscribe_consumer_swagger
   consumer_fetch_swagger
   get_consumer_offsets_swagger
+  post_consumer_offsets_swagger
 )
 
 if(CMAKE_BUILD_TYPE MATCHES Release)

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -41,6 +41,13 @@ seastar_generate_swagger(
 )
 
 seastar_generate_swagger(
+  TARGET remove_consumer_swagger
+  VAR remove_consumer_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/api/api-doc/remove_consumer.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/remove_consumer.json.h
+)
+
+seastar_generate_swagger(
   TARGET subscribe_consumer_swagger
   VAR subscribe_consumer_swagger_file
   IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/api/api-doc/subscribe_consumer.json
@@ -84,6 +91,7 @@ add_dependencies(v_rest_application
   get_topics_records_swagger
   post_topics_name_swagger
   create_consumer_swagger
+  remove_consumer_swagger
   subscribe_consumer_swagger
   consumer_fetch_swagger
 )

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -61,6 +61,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/consumer_fetch.json.h
 )
 
+seastar_generate_swagger(
+  TARGET get_consumer_offsets_swagger
+  VAR get_consumer_offsets_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/api/api-doc/get_consumer_offsets.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/api/api-doc/get_consumer_offsets.json.h
+)
+
 v_cc_library(
   NAME rest_application
   SRCS
@@ -94,6 +101,7 @@ add_dependencies(v_rest_application
   remove_consumer_swagger
   subscribe_consumer_swagger
   consumer_fetch_swagger
+  get_consumer_offsets_swagger
 )
 
 if(CMAKE_BUILD_TYPE MATCHES Release)

--- a/src/v/pandaproxy/api/api-doc/get_consumer_offsets.json
+++ b/src/v/pandaproxy/api/api-doc/get_consumer_offsets.json
@@ -1,0 +1,76 @@
+    "/consumers/{group_name}/instances/{instance}/offsets": {
+      "get": {
+        "summary": "Get committed group offsets for given partitions",
+        "operationId": "get_consumer_offsets",
+        "parameters": [
+          {
+            "name": "group_name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "instance",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "offsets",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "partitions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "topic": {
+                        "type": "string"
+                      },
+                      "partition": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "offsets": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "topic": {
+                        "type": "string"
+                      },
+                      "partition": {
+                        "type": "integer"
+                      },
+                      "offset": {
+                        "type": "integer"
+                      },
+                      "metadata": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Consumer not found"
+          }
+        }
+      }
+    }

--- a/src/v/pandaproxy/api/api-doc/post_consumer_offsets.json
+++ b/src/v/pandaproxy/api/api-doc/post_consumer_offsets.json
@@ -1,0 +1,54 @@
+    "/consumers/{group_name}/instances/{instance}/offsets": {
+      "post": {
+        "summary": "Commit offsets for a consumer",
+        "operationId": "post_consumer_offsets",
+        "parameters": [
+          {
+            "name": "group_name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "instance",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "offsets",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "partitions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "topic": {
+                        "type": "string"
+                      },
+                      "partition": {
+                        "type": "integer"
+                      },
+                      "offset": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "404": {
+            "description": "Consumer not found"
+          }
+        }
+      }
+    }

--- a/src/v/pandaproxy/api/api-doc/remove_consumer.json
+++ b/src/v/pandaproxy/api/api-doc/remove_consumer.json
@@ -1,0 +1,28 @@
+    "/consumers/{group_name}/instances/{instance}": {
+      "delete": {
+        "summary": "Remove a consumer for the group",
+        "operationId": "remove_consumer",
+        "parameters": [
+          {
+            "name": "group_name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "instance",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "404": {
+            "description": "Consumer not found"
+          }
+        }
+      }
+    }

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -13,13 +13,17 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/leave_group.h"
+#include "kafka/protocol/offset_commit.h"
 #include "kafka/protocol/offset_fetch.h"
+#include "kafka/protocol/schemata/offset_commit_request.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "pandaproxy/configuration.h"
 #include "pandaproxy/json/requests/create_consumer.h"
 #include "pandaproxy/json/requests/fetch.h"
+#include "pandaproxy/json/requests/offset_commit.h"
 #include "pandaproxy/json/requests/offset_fetch.h"
+#include "pandaproxy/json/requests/partition_offsets.h"
 #include "pandaproxy/json/requests/partitions.h"
 #include "pandaproxy/json/requests/produce.h"
 #include "pandaproxy/json/requests/subscribe_consumer.h"
@@ -285,6 +289,25 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
     ppj::rjson_serialize(w, res);
     ss::sstring json_rslt = str_buf.GetString();
     rp.rep->write_body("json", json_rslt);
+    co_return rp;
+}
+
+ss::future<server::reply_t>
+post_consumer_offsets(server::request_t rq, server::reply_t rp) {
+    auto group_id = kafka::group_id(rq.req->param["group_name"]);
+    auto member_id = kafka::member_id(rq.req->param["instance"]);
+
+    // If the request is empty, commit all offsets
+    auto req_data = rq.req->content.length() == 0
+                      ? std::vector<kafka::offset_commit_request_topic>()
+                      : ppj::partition_offsets_request_to_offset_commit_request(
+                        ppj::rjson_parse(
+                          rq.req->content.data(),
+                          ppj::partition_offsets_request_handler()));
+
+    auto res = co_await rq.ctx.client.consumer_offset_commit(
+      group_id, member_id, std::move(req_data));
+    rp.rep->set_status(ss::httpd::reply::status_type::no_content);
     co_return rp;
 }
 

--- a/src/v/pandaproxy/handlers.h
+++ b/src/v/pandaproxy/handlers.h
@@ -42,4 +42,7 @@ consumer_fetch(server::request_t rq, server::reply_t rp);
 ss::future<server::reply_t>
 get_consumer_offsets(server::request_t rq, server::reply_t rp);
 
+ss::future<server::reply_t>
+post_consumer_offsets(server::request_t rq, server::reply_t rp);
+
 } // namespace pandaproxy

--- a/src/v/pandaproxy/handlers.h
+++ b/src/v/pandaproxy/handlers.h
@@ -39,4 +39,7 @@ subscribe_consumer(server::request_t rq, server::reply_t rp);
 ss::future<server::reply_t>
 consumer_fetch(server::request_t rq, server::reply_t rp);
 
+ss::future<server::reply_t>
+get_consumer_offsets(server::request_t rq, server::reply_t rp);
+
 } // namespace pandaproxy

--- a/src/v/pandaproxy/handlers.h
+++ b/src/v/pandaproxy/handlers.h
@@ -31,6 +31,9 @@ ss::future<server::reply_t>
 create_consumer(server::request_t rq, server::reply_t rp);
 
 ss::future<server::reply_t>
+remove_consumer(server::request_t rq, server::reply_t rp);
+
+ss::future<server::reply_t>
 subscribe_consumer(server::request_t rq, server::reply_t rp);
 
 ss::future<server::reply_t>

--- a/src/v/pandaproxy/json/requests/offset_commit.h
+++ b/src/v/pandaproxy/json/requests/offset_commit.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "json/json.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/offset_commit.h"
+#include "kafka/protocol/offset_fetch.h"
+#include "kafka/protocol/schemata/offset_commit_request.h"
+#include "pandaproxy/json/requests/partition_offsets.h"
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+namespace pandaproxy::json {
+
+inline std::vector<kafka::offset_commit_request_topic>
+partition_offsets_request_to_offset_commit_request(
+  std::vector<topic_partition_offset> tps) {
+    std::vector<kafka::offset_commit_request_topic> res;
+    if (tps.empty()) {
+        return res;
+    }
+
+    std::sort(tps.begin(), tps.end());
+    res.push_back(kafka::offset_commit_request_topic{tps.front().topic, {}});
+    for (auto& tp : tps) {
+        if (tp.topic != res.back().name) {
+            res.push_back(
+              kafka::offset_commit_request_topic{std::move(tp.topic), {}});
+        }
+        res.back().partitions.push_back(kafka::offset_commit_request_partition{
+          .partition_index = tp.partition, .committed_offset = tp.offset});
+    }
+    return res;
+}
+
+} // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/requests/offset_fetch.h
+++ b/src/v/pandaproxy/json/requests/offset_fetch.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "json/json.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/offset_fetch.h"
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+namespace pandaproxy::json {
+
+inline std::vector<kafka::offset_fetch_request_topic>
+partitions_request_to_offset_request(std::vector<model::topic_partition> tps) {
+    std::vector<kafka::offset_fetch_request_topic> res;
+    if (tps.empty()) {
+        return res;
+    }
+
+    std::sort(tps.begin(), tps.end());
+    res.push_back(kafka::offset_fetch_request_topic{tps.front().topic, {}});
+    for (auto& tp : tps) {
+        if (tp.topic != res.back().name) {
+            res.push_back(
+              kafka::offset_fetch_request_topic{std::move(tp.topic), {}});
+        }
+        res.back().partition_indexes.push_back(tp.partition);
+    }
+    return res;
+}
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const kafka::offset_fetch_response_topic& v) {
+    for (const auto& p : v.partitions) {
+        w.StartObject();
+        w.Key("topic");
+        w.String(v.name());
+        w.Key("partition");
+        w.Int(p.partition_index);
+        w.Key("offset");
+        w.Int(p.committed_offset);
+        w.Key("metadata");
+        w.String(p.metadata.value_or(""));
+        w.EndObject();
+    }
+}
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const kafka::offset_fetch_response& v) {
+    w.StartObject();
+    w.Key("offsets");
+    w.StartArray();
+    for (const auto& t : v.data.topics) {
+        rjson_serialize(w, t);
+    }
+    w.EndArray();
+    w.EndObject();
+}
+
+} // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/requests/partition_offsets.h
+++ b/src/v/pandaproxy/json/requests/partition_offsets.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "json/json.h"
+#include "model/fundamental.h"
+#include "pandaproxy/json/types.h"
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <rapidjson/encodings.h>
+
+namespace pandaproxy::json {
+
+struct topic_partition_offset {
+    model::topic topic;
+    model::partition_id partition;
+    model::offset offset;
+    bool operator<(const topic_partition_offset& other) const {
+        return std::tie(topic, partition)
+               < std::tie(other.topic, other.partition);
+    };
+};
+
+template<typename Encoding = rapidjson::UTF8<>>
+class partition_offsets_request_handler {
+private:
+    enum class state {
+        empty = 0,
+        partitions,
+        tpo,
+        topic,
+        partition,
+        offset,
+    };
+
+    serialization_format _fmt = serialization_format::none;
+    state state = state::empty;
+
+public:
+    using Ch = typename Encoding::Ch;
+    using rjson_parse_result = std::vector<topic_partition_offset>;
+    rjson_parse_result result;
+
+    bool Null() { return false; }
+    bool Bool(bool) { return false; }
+    bool Int64(int64_t) { return false; }
+    bool Uint64(uint64_t) { return false; }
+    bool Double(double) { return false; }
+    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
+
+    bool Int(int i) {
+        switch (state) {
+        case state::partition:
+            result.back().partition = model::partition_id(i);
+            state = state::tpo;
+            return true;
+        case state::offset:
+            result.back().offset = model::offset(i);
+            state = state::tpo;
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    bool Uint(unsigned u) {
+        switch (state) {
+        case state::partition:
+            result.back().partition = model::partition_id(u);
+            state = state::tpo;
+            return true;
+        case state::offset:
+            result.back().offset = model::offset(u);
+            state = state::tpo;
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+        if (state == state::topic) {
+            result.back().topic = model::topic(ss::sstring(str, len));
+            state = state::tpo;
+            return true;
+        }
+        return false;
+    }
+
+    bool Key(const char* str, rapidjson::SizeType len, bool) {
+        auto key = std::string_view(str, len);
+        if (state == state::empty && key == "partitions") {
+            state = state::partitions;
+            return true;
+        }
+        if (state == state::tpo) {
+            if (key == "topic") {
+                state = state::topic;
+            } else if (key == "partition") {
+                state = state::partition;
+            } else if (key == "offset") {
+                state = state::offset;
+            } else {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    bool StartObject() {
+        if (state == state::empty) {
+            return true;
+        }
+        if (state == state::partitions) {
+            result.emplace_back();
+            state = state::tpo;
+            return true;
+        }
+        return false;
+    }
+
+    bool EndObject(rapidjson::SizeType size) {
+        if (state == state::tpo) {
+            state = state::partitions;
+            return size == 3;
+        }
+        if (state == state::partitions) {
+            state = state::empty;
+            return true;
+        }
+        return false;
+    }
+
+    bool StartArray() { return state == state::partitions; }
+
+    bool EndArray(rapidjson::SizeType) { return state == state::partitions; }
+};
+
+} // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/requests/partitions.h
+++ b/src/v/pandaproxy/json/requests/partitions.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "json/json.h"
+#include "model/fundamental.h"
+#include "pandaproxy/json/types.h"
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <rapidjson/encodings.h>
+
+namespace pandaproxy::json {
+
+template<typename Encoding = rapidjson::UTF8<>>
+class partitions_request_handler {
+private:
+    enum class state {
+        empty = 0,
+        partitions,
+        topic_partition,
+        topic,
+        partition,
+    };
+
+    serialization_format _fmt = serialization_format::none;
+    state state = state::empty;
+
+public:
+    using Ch = typename Encoding::Ch;
+    using rjson_parse_result = std::vector<model::topic_partition>;
+    rjson_parse_result result;
+
+    bool Null() { return false; }
+    bool Bool(bool) { return false; }
+    bool Int64(int64_t) { return false; }
+    bool Uint64(uint64_t) { return false; }
+    bool Double(double) { return false; }
+    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
+
+    bool Int(int i) {
+        if (state == state::partition) {
+            result.back().partition = model::partition_id(i);
+            state = state::topic_partition;
+            return true;
+        }
+        return false;
+    }
+
+    bool Uint(unsigned u) {
+        if (state == state::partition) {
+            result.back().partition = model::partition_id(u);
+            state = state::topic_partition;
+            return true;
+        }
+        return false;
+    }
+
+    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+        if (state == state::topic) {
+            result.back().topic = model::topic(ss::sstring(str, len));
+            state = state::topic_partition;
+            return true;
+        }
+        return false;
+    }
+
+    bool Key(const char* str, rapidjson::SizeType len, bool) {
+        auto key = std::string_view(str, len);
+        if (state == state::empty && key == "partitions") {
+            state = state::partitions;
+            return true;
+        }
+        if (state == state::topic_partition) {
+            if (key == "topic") {
+                state = state::topic;
+            } else if (key == "partition") {
+                state = state::partition;
+            } else {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    bool StartObject() {
+        if (state == state::empty) {
+            return true;
+        }
+        if (state == state::partitions) {
+            result.push_back(model::topic_partition{});
+            state = state::topic_partition;
+            return true;
+        }
+        return false;
+    }
+
+    bool EndObject(rapidjson::SizeType size) {
+        if (state == state::topic_partition) {
+            state = state::partitions;
+            return size == 2;
+        }
+        if (state == state::partitions) {
+            state = state::empty;
+            return true;
+        }
+        return false;
+    }
+
+    bool StartArray() { return state == state::partitions; }
+
+    bool EndArray(rapidjson::SizeType) { return state == state::partitions; }
+};
+
+} // namespace pandaproxy::json

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -11,6 +11,7 @@
 
 #include "pandaproxy/api/api-doc/consumer_fetch.json.h"
 #include "pandaproxy/api/api-doc/create_consumer.json.h"
+#include "pandaproxy/api/api-doc/get_consumer_offsets.json.h"
 #include "pandaproxy/api/api-doc/get_topics_names.json.h"
 #include "pandaproxy/api/api-doc/get_topics_records.json.h"
 #include "pandaproxy/api/api-doc/health.json.h"
@@ -71,6 +72,11 @@ std::vector<server::route_t> get_proxy_routes() {
       ss::httpd::consumer_fetch_json::name,
       ss::httpd::consumer_fetch_json::consumer_fetch,
       consumer_fetch});
+
+    routes.emplace_back(server::route_t{
+      ss::httpd::get_consumer_offsets_json::name,
+      ss::httpd::get_consumer_offsets_json::get_consumer_offsets,
+      get_consumer_offsets});
 
     return routes;
 }

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -15,6 +15,7 @@
 #include "pandaproxy/api/api-doc/get_topics_names.json.h"
 #include "pandaproxy/api/api-doc/get_topics_records.json.h"
 #include "pandaproxy/api/api-doc/health.json.h"
+#include "pandaproxy/api/api-doc/post_consumer_offsets.json.h"
 #include "pandaproxy/api/api-doc/post_topics_name.json.h"
 #include "pandaproxy/api/api-doc/remove_consumer.json.h"
 #include "pandaproxy/api/api-doc/subscribe_consumer.json.h"
@@ -77,6 +78,11 @@ std::vector<server::route_t> get_proxy_routes() {
       ss::httpd::get_consumer_offsets_json::name,
       ss::httpd::get_consumer_offsets_json::get_consumer_offsets,
       get_consumer_offsets});
+
+    routes.emplace_back(server::route_t{
+      ss::httpd::post_consumer_offsets_json::name,
+      ss::httpd::post_consumer_offsets_json::post_consumer_offsets,
+      post_consumer_offsets});
 
     return routes;
 }

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -15,6 +15,7 @@
 #include "pandaproxy/api/api-doc/get_topics_records.json.h"
 #include "pandaproxy/api/api-doc/health.json.h"
 #include "pandaproxy/api/api-doc/post_topics_name.json.h"
+#include "pandaproxy/api/api-doc/remove_consumer.json.h"
 #include "pandaproxy/api/api-doc/subscribe_consumer.json.h"
 #include "pandaproxy/configuration.h"
 #include "pandaproxy/handlers.h"
@@ -55,6 +56,11 @@ std::vector<server::route_t> get_proxy_routes() {
       ss::httpd::create_consumer_json::name,
       ss::httpd::create_consumer_json::create_consumer,
       create_consumer});
+
+    routes.emplace_back(server::route_t{
+      ss::httpd::remove_consumer_json::name,
+      ss::httpd::remove_consumer_json::remove_consumer,
+      remove_consumer});
 
     routes.emplace_back(server::route_t{
       ss::httpd::subscribe_consumer_json::name,

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -153,6 +153,31 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
     }
 
     {
+        info("Get consumer offsets (expect -1)");
+        const ss::sstring get_offsets_body(R"({
+   "partitions":[
+      {
+         "topic":"t",
+         "partition":0
+      }
+   ]
+})");
+        auto body = iobuf();
+        body.append(get_offsets_body.data(), get_offsets_body.size());
+        auto res = http_request(
+          client,
+          fmt::format(
+            "/consumers/{}/instances/{}/offsets", group_id(), member_id()),
+          std::move(body),
+          boost::beast::http::verb::get);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(
+          res.body,
+          R"({"offsets":[{"topic":"t","partition":0,"offset":-1,"metadata":""}]})");
+    }
+
+    {
         info("Remove consumer (expect no_content)");
         auto res = http_request(
           client,

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -151,4 +151,24 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           res.body,
           R"([{"topic":"t","key":"AAD//w==","value":"","partition":0,"offset":0},{"topic":"t","key":"","value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":"","value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":"","value":"bXVsdGlicm9rZXI=","partition":0,"offset":3}])");
     }
+
+    {
+        info("Remove consumer (expect no_content)");
+        auto res = http_request(
+          client,
+          fmt::format("/consumers/{}/instances/{}", group_id(), member_id()),
+          boost::beast::http::verb::delete_);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::no_content);
+    }
+
+    {
+        info("Remove consumer (expect not_found)");
+        auto res = http_request(
+          client,
+          fmt::format("/consumers/{}/instances/{}", group_id(), member_id()),
+          boost::beast::http::verb::delete_);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::not_found);
+    }
 }

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -26,6 +26,32 @@ namespace pp = pandaproxy;
 namespace ppj = pp::json;
 namespace kc = kafka::client;
 
+namespace {
+
+auto get_consumer_offsets(
+  http::client& client,
+  const kafka::group_id& g_id,
+  const kafka::member_id& m_id) {
+    const ss::sstring get_offsets_body(R"({
+   "partitions":[
+      {
+         "topic":"t",
+         "partition":0
+      }
+   ]
+})");
+    auto body = iobuf();
+    body.append(get_offsets_body.data(), get_offsets_body.size());
+    auto res = http_request(
+      client,
+      fmt::format("/consumers/{}/instances/{}/offsets", g_id(), m_id()),
+      std::move(body),
+      boost::beast::http::verb::get);
+    return res;
+};
+
+} // namespace
+
 FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
     using namespace std::chrono_literals;
 
@@ -154,27 +180,66 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
 
     {
         info("Get consumer offsets (expect -1)");
-        const ss::sstring get_offsets_body(R"({
-   "partitions":[
-      {
-         "topic":"t",
-         "partition":0
-      }
-   ]
-})");
-        auto body = iobuf();
-        body.append(get_offsets_body.data(), get_offsets_body.size());
-        auto res = http_request(
-          client,
-          fmt::format(
-            "/consumers/{}/instances/{}/offsets", group_id(), member_id()),
-          std::move(body),
-          boost::beast::http::verb::get);
+        auto res = get_consumer_offsets(client, group_id, member_id);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
           R"({"offsets":[{"topic":"t","partition":0,"offset":-1,"metadata":""}]})");
+    }
+
+    {
+        info("Commit 1 consumer offset");
+        const ss::sstring commit_offsets_body(R"({
+   "partitions":[
+      {
+         "topic":"t",
+         "partition":0,
+         "offset": 1
+      }
+   ]
+})");
+        auto body = iobuf();
+        body.append(commit_offsets_body.data(), commit_offsets_body.size());
+        auto res = http_request(
+          client,
+          fmt::format(
+            "/consumers/{}/instances/{}/offsets", group_id(), member_id()),
+          std::move(body),
+          boost::beast::http::verb::post);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::no_content);
+    }
+
+    {
+        info("Get consumer offsets (expect 1)");
+        auto res = get_consumer_offsets(client, group_id, member_id);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(
+          res.body,
+          R"({"offsets":[{"topic":"t","partition":0,"offset":1,"metadata":""}]})");
+    }
+
+    {
+        info("Commit all consumer offsets");
+        auto res = http_request(
+          client,
+          fmt::format(
+            "/consumers/{}/instances/{}/offsets", group_id(), member_id()),
+          boost::beast::http::verb::post);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::no_content);
+    }
+
+    {
+        info("Get consumer offsets (expect 3)");
+        auto res = get_consumer_offsets(client, group_id, member_id);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(
+          res.body,
+          R"({"offsets":[{"topic":"t","partition":0,"offset":3,"metadata":""}]})");
     }
 
     {


### PR DESCRIPTION
* remove_consumer
* consumer_offset_fetch
* consumer_offset_commit

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/7626c0961e0602673588459d620e2b428fb7cfb8..4aaefb7e9a70e0e6416435b7d5bd26b86a7e5cef)
* Rebase (#679 merged)

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/4aaefb7e9a70e0e6416435b7d5bd26b86a7e5cef..2cab0774a48af6f9ed3af9ad56f979b271323b73)

* Swagger fixes
  * partitions are integer
  * Add response definitions
* Handlers
  * handle consumer_error at the top-level
  * Switch to coroutines
  * post_consumer_offsets returns 204

Left for another PR
* parser handler base
* `group_by` algorithm - they're all similar but I can''t quite extract a concept
  * The calls to reserve, since the length isn't known without a pre-processing step.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
