### PR TITLE
Implementing auto-deregistration policy for coprocessor scripts

### DIFF
--- a/src/v/coproc/ntp_context.h
+++ b/src/v/coproc/ntp_context.h
@@ -26,8 +26,27 @@
 #include <absl/container/node_hash_map.h>
 
 #include <chrono>
+#include <exception>
+
 using namespace std::chrono_literals;
+
 namespace coproc {
+
+class script_failed_exception final : public std::exception {
+public:
+    script_failed_exception(script_id id, ss::sstring msg)
+      : _id(id)
+      , _msg(std::move(msg)) {}
+
+    const char* what() const noexcept final { return _msg.c_str(); }
+
+    script_id get_id() const noexcept { return _id; }
+
+private:
+    script_id _id;
+    ss::sstring _msg;
+};
+
 /// Structure representing state about input topics that scripts will subscribe
 /// to. ss::shared_ptrs to ntp_contexts will be used as there may be many
 /// subscribers to an input ntp

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -33,7 +33,7 @@ namespace coproc {
  * reads data from its interested topics, sends to the wasm engine, and
  * processes the response (almost always a write to a materialized log)
  */
-class pacemaker {
+class pacemaker final : public ss::peering_sharded_service<pacemaker> {
 public:
     /**
      * class constructor
@@ -94,7 +94,6 @@ private:
       const std::vector<topic_namespace_policy>&);
 
     struct offset_flush_fiber_state {
-        ss::gate gate;
         ss::timer<ss::lowres_clock> timer;
         model::timeout_clock::duration duration;
         storage::snapshot_manager snap;
@@ -120,6 +119,9 @@ private:
 
     /// Responsible for timed persistence of offsets to disk
     offset_flush_fiber_state _offs;
+
+    /// All async actions pacemaker starts are within the context of this gate
+    ss::gate _gate;
 };
 
 } // namespace coproc

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -55,10 +55,10 @@ public:
 
     ~script_context() noexcept = default;
 
-    /**
-     * Starts up a single managed fiber responsible for maintaining the pace of
-     * the run loop described in the comment above
-     */
+    /// Startups up a single managed fiber responsible for maintaining the pace
+    /// of the run loop.
+    /// Returns a future which returns when the script fiber
+    /// has completed or throws \ref script_failed_exception
     ss::future<> start();
 
     /**

--- a/src/v/coproc/types.cc
+++ b/src/v/coproc/types.cc
@@ -73,15 +73,17 @@ ss::future<> async_adl<coproc::process_batch_reply::data>::to(
   iobuf& out, coproc::process_batch_reply::data&& r) {
     reflection::serialize<coproc::script_id>(out, std::move(r.id));
     reflection::serialize<model::ntp>(out, std::move(r.ntp));
-    return async_adl<model::record_batch_reader>{}.to(out, std::move(r.reader));
+    return async_adl<std::optional<model::record_batch_reader>>{}.to(
+      out, std::move(r.reader));
 }
 
 ss::future<coproc::process_batch_reply::data>
 async_adl<coproc::process_batch_reply::data>::from(iobuf_parser& in) {
     auto id = adl<coproc::script_id>{}.from(in);
     auto ntp = adl<model::ntp>{}.from(in);
-    return async_adl<model::record_batch_reader>{}.from(in).then(
-      [id, ntp = std::move(ntp)](model::record_batch_reader rbr) mutable {
+    return async_adl<std::optional<model::record_batch_reader>>{}.from(in).then(
+      [id, ntp = std::move(ntp)](
+        std::optional<model::record_batch_reader> rbr) mutable {
           return coproc::process_batch_reply::data{
             .id = id, .ntp = std::move(ntp), .reader = std::move(rbr)};
       });

--- a/src/v/coproc/types.h
+++ b/src/v/coproc/types.h
@@ -108,7 +108,7 @@ struct process_batch_reply {
     struct data {
         script_id id;
         model::ntp ntp;
-        model::record_batch_reader reader;
+        std::optional<model::record_batch_reader> reader;
     };
     std::vector<data> resps;
 };


### PR DESCRIPTION
There is an option within the coprocessor API that allows users to automatically de-register their scripts if their apply method throws or for other types of errors. Before our architectural change recently introduced there didn't need to be special support for this, as redpanda had an rpc::service used for register and de-register events, and if the wasm engine wanted to do this, it was as simple as a call to that service.

Now that this service has been removed we are re-introducing this feature. To implement it we change the type of the record_batch_reader in the process_batch_reply to be an optional type. If the batch is set to nullopt we interpret this as a signal to de-register the script.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
