### PR TITLE
Catch exceptions that may be thrown on reconnect by the kafka::client::client

### DIFF
--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -48,6 +48,7 @@ public:
 
 private:
     ss::future<> do_start();
+    ss::future<> do_ingest();
 
     ss::future<> poll_topic(model::record_batch_reader::data_t&);
 

--- a/src/v/kafka/client/brokers.cc
+++ b/src/v/kafka/client/brokers.cc
@@ -107,4 +107,8 @@ ss::future<> brokers::apply(metadata_response&& res) {
     });
 }
 
+ss::future<bool> brokers::empty() const {
+    return ss::make_ready_future<bool>(_brokers.empty());
+}
+
 } // namespace kafka::client

--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -59,6 +59,9 @@ public:
     /// \brief Apply the given metadata response.
     ss::future<> apply(metadata_response&& res);
 
+    /// \brief Returns true if there are no connected brokers
+    ss::future<bool> empty() const;
+
 private:
     /// \brief Brokers map a model::node_id to a client.
     brokers_t _brokers;

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -133,6 +133,10 @@ public:
 
     ss::future<> update_metadata() { return _wait_or_start_update_metadata(); }
 
+    ss::future<bool> is_connected() const {
+        return _brokers.empty().then(std::logical_not<>());
+    }
+
 private:
     /// \brief Connect and update metdata.
     ss::future<> do_connect(unresolved_address addr);


### PR DESCRIPTION
Although not immediately obvious, `kakfa::client::client::connect()` may throw. In situations where the retry counter decrements to 0 the last seen exception will be observed. This is exactly what is seen in the failing partition_moving_test unit test in dev. The `event_listener` fails to handle this exception, and it percolates eventually crashing redpanda.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
