### PR TITLE
operator/lint: fix ST1016 error

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -92,6 +92,6 @@ func init() {
 }
 
 // FullImageName returns image name including version
-func (c *Cluster) FullImageName() string {
-	return fmt.Sprintf("%s:%s", c.Spec.Image, c.Spec.Version)
+func (r *Cluster) FullImageName() string {
+	return fmt.Sprintf("%s:%s", r.Spec.Image, r.Spec.Version)
 }


### PR DESCRIPTION
We missed the linter test failing in #715.
```
Error: ST1016: methods on the same type should have the same receiver name (seen 1x "c", 5x "r") (stylecheck)
73
```
