### PR TITLE
rpk/debug/info: log errors on debug level

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -156,7 +156,7 @@ func executeInfo(
 	}
 	if errs := grp.Wait(); errs != nil {
 		for _, err := range errs.Errors {
-			log.Info(err)
+			log.Debug(err)
 		}
 	}
 	for _, rows := range results {


### PR DESCRIPTION
Log `rpk debug info` errors at debug level.

Fix #683 