### PR TITLE
ssx: Introduce sformat

### DIFF
--- a/src/v/ssx/sformat.h
+++ b/src/v/ssx/sformat.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+
+#include <fmt/format.h>
+
+template<>
+struct fmt::formatter<seastar::sstring> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
+    template<typename FormatContext>
+    auto format(const seastar::sstring& s, FormatContext& ctx) {
+        return format_to(ctx.out(), "{}", std::string_view(s));
+    }
+};
+
+namespace ssx {
+
+template<typename... Args>
+seastar::sstring sformat(fmt::string_view format_str, Args&&... args) {
+    auto size = fmt::formatted_size(format_str, std::forward<Args>(args)...);
+    seastar::sstring buffer(seastar::sstring::initialized_later{}, size);
+    fmt::format_to(buffer.data(), format_str, args...);
+    return buffer;
+}
+
+} // namespace ssx

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -1,7 +1,18 @@
 rp_test(
   UNIT_TEST
-  BINARY_NAME async_transforms
-  SOURCES async_transforms.cc
+  BINARY_NAME ssx_unit
+  SOURCES
+    async_transforms.cc
+    sformat.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::ssx
+  LABELS ssx
+)
+
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME ssx_bench
+  SOURCES sformat_bench.cc
+  LIBRARIES Seastar::seastar_perf_testing v::ssx
+  LABELS ssx
 )

--- a/src/v/ssx/tests/sformat.cc
+++ b/src/v/ssx/tests/sformat.cc
@@ -1,0 +1,29 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/sformat.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <seastarx.h>
+
+SEASTAR_THREAD_TEST_CASE(ssx_sformat_simple) {
+    ss::sstring foo("foo");
+    BOOST_REQUIRE_EQUAL(ssx::sformat("{}", foo), "foo");
+}
+
+SEASTAR_THREAD_TEST_CASE(fmt_format_join) {
+    std::vector<ss::sstring> vec{"foo", "bar", "baz"};
+    BOOST_REQUIRE_EQUAL(fmt::format("{}", fmt::join(vec, ",")), "foo,bar,baz");
+}
+
+SEASTAR_THREAD_TEST_CASE(ssx_sformat_join) {
+    std::vector<ss::sstring> vec{"foo", "bar", "baz"};
+    BOOST_REQUIRE_EQUAL(ssx::sformat("{}", fmt::join(vec, ",")), "foo,bar,baz");
+}

--- a/src/v/ssx/tests/sformat_bench.cc
+++ b/src/v/ssx/tests/sformat_bench.cc
@@ -1,0 +1,61 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "seastarx.h"
+#include "ssx/sformat.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+const auto identifier = fmt::format("{}", boost::uuids::random_generator()());
+
+struct fmt_format {
+    template<typename... Args>
+    auto operator()(Args... args) {
+        return fmt::format(std::forward<Args>(args)...);
+    }
+};
+
+struct ssx_sformat {
+    template<typename... Args>
+    auto operator()(Args... args) {
+        return ssx::sformat(std::forward<Args>(args)...);
+    }
+};
+
+template<typename Ret, typename Val, typename Fun>
+void run_test(Fun fun, size_t data_size) {
+    std::vector<Val> vec;
+    vec.reserve(data_size);
+    perf_tests::start_measuring_time();
+    for (int i = 0; i < data_size; ++i) {
+        vec.emplace_back(fun("{}", identifier));
+    }
+    perf_tests::do_not_optimize(Ret{fun("{}", fmt::join(vec, ","))});
+    perf_tests::stop_measuring_time();
+}
+
+// std::string thoughout
+PERF_TEST(std_std_fmt_1K, join) {
+    run_test<std::string, std::string>(fmt_format{}, 1 << 10);
+}
+
+// ss::sstring, but fmt::format uses std::string
+PERF_TEST(ss_ss_fmt_1K, join) {
+    run_test<ss::sstring, ss::sstring>(fmt_format{}, 1 << 10);
+}
+
+// ss::sstring thoughout
+PERF_TEST(ss_ss_ssx_1K, join) {
+    run_test<ss::sstring, ss::sstring>(ssx_sformat{}, 1 << 10);
+}


### PR DESCRIPTION
`fmt::format` returns a `std::string`, maybe we'd prefer an `ss::sstring`

`ssx::sformat` returns an `ss::sstring`

Some benchmarks inspired by recent code I saw:

```
test                                      iterations      median         mad         min         max
std_std_fmt_1K.join                            12378    70.144us   960.832ns    69.011us    76.224us
ss_ss_fmt_1K.join                              10553    82.447us   835.085ns    81.612us    87.803us
ss_ss_ssx_1K.join                              20521    38.806us   412.838ns    37.988us    39.219us
```

The test creates a vector of 1024 UUIDs as strings, and then joins them.

The test name format is:

`<return type>_<container_val>_<fmt_type>`

Where:
`ss`:  `ss::sstring`
`std`: `std::string`
`fmt`: `fmt::format`
`ssx`: `ssx::sformat`

So `ss_ss_fmt`:
* uses `fmt::format` to
* emplace into a vector of `ss::sstring` and then
* join them with `fmt::format` and
* return into an `ss::sstring`

A formatter is also provided for `ss::sstring`, allowing `fmt::join`
to work on our favourite string type.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
