### PR TITLE
operator/tests: fix loading image for e2e tests

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -40,7 +40,7 @@ uninstall: manifests kustomize
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image vectorized/redpanda-operator=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 # Deploy pre loaded controller in the configured Kind Kubernetes cluster

--- a/src/go/k8s/config/manager/kustomization.yaml
+++ b/src/go/k8s/config/manager/kustomization.yaml
@@ -11,6 +11,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
+- name: vectorized/redpanda-operator
   newName: vectorized/redpanda-operator
   newTag: latest


### PR DESCRIPTION
This got broken recently when introducing the docker hub image. Because
of that, e2e tests no longer run against the latest built image. This
fixes that.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
