### PR TITLE
docs/docker quick start: Fix the containers' start commands

### DIFF
--- a/docs/www/quick-start-docker.md
+++ b/docs/www/quick-start-docker.md
@@ -35,7 +35,7 @@ docker run -d \
 --net=redpandanet \
 -p 9092:9092 \
 -v "redpanda1:/var/lib/redpanda/data" \
-vectorized/redpanda start \
+vectorized/redpanda redpanda start \
 --smp 1  \
 --memory 1G  \
 --reserve-memory 0M \
@@ -53,7 +53,7 @@ docker run -d \
 --net=redpandanet \
 -p 9093:9093 \
 -v "redpanda2:/var/lib/redpanda/data" \
-vectorized/redpanda start \
+vectorized/redpanda redpanda start \
 --smp 1  \
 --memory 1G  \
 --reserve-memory 0M \
@@ -72,7 +72,7 @@ docker run -d \
 --net=redpandanet \
 -p 9094:9094 \
 -v "redpanda3:/var/lib/redpanda/data" \
-vectorized/redpanda start \
+vectorized/redpanda redpanda start \
 --smp 1  \
 --memory 1G  \
 --reserve-memory 0M \

--- a/docs/www/quick-start-docker.md
+++ b/docs/www/quick-start-docker.md
@@ -59,7 +59,7 @@ vectorized/redpanda start \
 --reserve-memory 0M \
 --overprovisioned \
 --node-id 1 \
---seeds "redpanda-1:33145+0" \
+--seeds "redpanda-1:33145" \
 --check=false \
 --kafka-addr 0.0.0.0:9093 \
 --advertise-kafka-addr 127.0.0.1:9093 \
@@ -78,7 +78,7 @@ vectorized/redpanda start \
 --reserve-memory 0M \
 --overprovisioned \
 --node-id 2 \
---seeds "redpanda-1:33145+0" \
+--seeds "redpanda-1:33145" \
 --check=false \
 --kafka-addr 0.0.0.0:9094 \
 --advertise-kafka-addr 127.0.0.1:9094 \


### PR DESCRIPTION
The <host>:<port>+<id> format for seed addresses was deprecated, and the node ID is no longer supported.

Additionally, update the containers' start command to use `[rpk] redpanda start` instead of the deprecated `[rpk] start`.
