### PR TITLE
Exit early on invariants change

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -75,6 +75,10 @@ ss::future<> controller::start() {
             std::ref(_as));
       })
       .then([this] {
+          // validate configuration invariants to exit early
+          return _members_manager.local().validate_configuration_invariants();
+      })
+      .then([this] {
           return _stm.start_single(
             std::ref(clusterlog),
             _raft0.get(),

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -55,15 +55,13 @@ members_manager::members_manager(
 
 ss::future<> members_manager::start() {
     vlog(clusterlog.info, "starting cluster::members_manager...");
-    // validate node id change
-    return validate_configuration_invariants().then([this] {
-        // join raft0
-        if (!is_already_member()) {
-            join_raft0();
-        }
 
-        return start_config_changes_watcher();
-    });
+    // join raft0
+    if (!is_already_member()) {
+        join_raft0();
+    }
+
+    return start_config_changes_watcher();
 }
 
 ss::future<> members_manager::start_config_changes_watcher() {

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -44,7 +44,7 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
-
+    ss::future<> validate_configuration_invariants();
     ss::future<result<join_reply>> handle_join_request(model::broker);
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -75,7 +75,7 @@ private:
     // Raft 0 config updates
     ss::future<> handle_raft0_cfg_update(raft::group_configuration);
     ss::future<> update_connections(patch<broker_ptr>);
-    ss::future<> validate_configuration_invariants();
+
     ss::future<> start_config_changes_watcher();
 
     ss::future<> maybe_update_current_node_configuration();

--- a/src/v/cluster/partition_allocator.cc
+++ b/src/v/cluster/partition_allocator.cc
@@ -182,8 +182,12 @@ void partition_allocator::update_allocation_state(
       [](const model::broker_shard& l, const model::broker_shard& r) {
           return l.node_id > r.node_id;
       });
-
-    auto it = find_node(std::cbegin(shards)->node_id);
+    auto node_id = std::cbegin(shards)->node_id;
+    auto it = find_node(node_id);
+    vassert(
+      it != _machines.end(),
+      "node: {} must exists in partition allocator, it currenlty does not",
+      node_id);
     for (auto const& bs : shards) {
         // Thanks to shards being sorted we need to do only
         //  as many lookups as there are brokers


### PR DESCRIPTION
In order to make the configuration invariant change detector effective we have to exit early if any of the invariants have changed. Previous approach lead us to the situation in which some services were already started and they accessed invalid configuration causing a segfault.

Fixes: #742

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
