### PR TITLE
rpk/start: Fix flags-configuration bindings

### DIFF
--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/utils"
 	"gopkg.in/yaml.v2"
@@ -61,8 +60,6 @@ type Manager interface {
 	ReadAsJSON(path string) (string, error)
 	// Generates and writes the node's UUID
 	WriteNodeUUID(conf *Config) error
-	// Binds a flag's value to a configuration key.
-	BindFlag(key string, flag *pflag.Flag) error
 }
 
 type manager struct {
@@ -376,10 +373,6 @@ func checkAndWrite(fs afero.Fs, v *viper.Viper, path string) error {
 		return recover(fs, backup, path, err)
 	}
 	return nil
-}
-
-func (m *manager) BindFlag(key string, flag *pflag.Flag) error {
-	return m.v.BindPFlag(key, flag)
 }
 
 func recover(fs afero.Fs, backup, path string, err error) error {


### PR DESCRIPTION
For some reason, viper is either not detecting the change in the flag values or not merging the new values onto the loaded config, so the values that get written are whatever values existed already in the config file for `redpanda.node_id`.

Assign the values explicitly & add unit tests.
