### PR TITLE
kafka/client: Remove shard_local_cfg()

### DIFF
--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -50,6 +50,7 @@ public:
     virtual void set_value(YAML::Node) = 0;
     virtual void set_value(std::any) = 0;
     virtual std::optional<validation_error> validate() const = 0;
+    base_property(const base_property&) = default;
     virtual base_property& operator=(const base_property&) = 0;
     virtual ~base_property() noexcept = default;
 

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -29,6 +29,18 @@
 
 #include <exception>
 
+namespace {
+
+kafka::client::client make_client() {
+    kafka::client::configuration cfg;
+    cfg.brokers.set_value(std::vector<unresolved_address>{
+      config::shard_local_cfg().kafka_api()[0].address});
+    cfg.retries.set_value(size_t(1));
+    return kafka::client::client{cfg};
+}
+
+} // namespace
+
 namespace coproc::wasm {
 
 static wasm::event_action query_action(const iobuf& source_code) {
@@ -83,7 +95,7 @@ event_listener::persist_actions(absl::btree_map<script_id, iobuf> wsas) {
 }
 
 event_listener::event_listener(ss::sharded<pacemaker>& pacemaker)
-  : _client({config::shard_local_cfg().kafka_api()[0].address})
+  : _client(make_client())
   , _dispatcher(pacemaker, _abort_source) {}
 
 ss::future<> event_listener::start() {

--- a/src/v/coproc/tests/utils/event_publisher.h
+++ b/src/v/coproc/tests/utils/event_publisher.h
@@ -34,7 +34,7 @@ public:
         cpp_enable_payload data;
     };
 
-    event_publisher() = default;
+    event_publisher();
     ~event_publisher() { _client.stop().get(); }
 
     /// Starts up the kafka client and sends out a create_topics request to
@@ -63,7 +63,6 @@ private:
     ss::future<> create_coproc_internal_topic();
 
 private:
-    kafka::client::client _client{
-      {config::shard_local_cfg().kafka_api()[0].address}};
+    kafka::client::client _client;
 };
 } // namespace coproc::wasm

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -38,11 +38,10 @@ struct configuration final : public config::config_store {
     config::property<std::chrono::milliseconds> consumer_heartbeat_interval;
 
     configuration();
-
-    void read_yaml(const YAML::Node& root_node) override;
 };
 
-configuration& shard_local_cfg();
+YAML::Node to_yaml(const configuration& cfg);
+configuration copy_configuration(const configuration& cfg);
 
 using conf_ref = typename std::reference_wrapper<configuration>;
 

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -13,6 +13,7 @@
 
 #include "kafka/client/assignment_plans.h"
 #include "kafka/client/brokers.h"
+#include "kafka/client/configuration.h"
 #include "kafka/client/fetch_session.h"
 #include "kafka/client/logger.h"
 #include "kafka/protocol/describe_groups.h"
@@ -37,8 +38,13 @@ class consumer final : public ss::enable_lw_shared_from_this<consumer> {
     using broker_reqs_t = absl::node_hash_map<shared_broker_t, fetch_request>;
 
 public:
-    consumer(brokers& brokers, shared_broker_t coordinator, group_id group_id)
-      : _brokers(brokers)
+    consumer(
+      const configuration& config,
+      brokers& brokers,
+      shared_broker_t coordinator,
+      group_id group_id)
+      : _config(config)
+      , _brokers(brokers)
       , _coordinator(std::move(coordinator))
       , _group_id(std::move(group_id))
       , _topics() {}
@@ -97,6 +103,7 @@ private:
         });
     }
 
+    const configuration& _config;
     brokers& _brokers;
     shared_broker_t _coordinator;
     ss::abort_source _as;
@@ -126,8 +133,11 @@ private:
 
 using shared_consumer_t = ss::lw_shared_ptr<consumer>;
 
-ss::future<shared_consumer_t>
-make_consumer(brokers& brokers, shared_broker_t coordinator, group_id group_id);
+ss::future<shared_consumer_t> make_consumer(
+  const configuration& config,
+  brokers& brokers,
+  shared_broker_t coordinator,
+  group_id group_id);
 
 namespace detail {
 

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -108,8 +108,8 @@ producer::send(model::topic_partition tp, model::record_batch&& batch) {
              std::move(batch),
              [this, tp](model::record_batch& batch) mutable {
                  return retry_with_mitigation(
-                   shard_local_cfg().retries(),
-                   shard_local_cfg().retry_base_backoff(),
+                   _config.retries(),
+                   _config.retry_base_backoff(),
                    [this, tp{std::move(tp)}, &batch]() {
                        return do_send(tp, batch.share());
                    },

--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -30,8 +30,12 @@ public:
     using partitions_t
       = absl::flat_hash_map<model::topic_partition, shared_produce_partition>;
 
-    producer(brokers& brokers, error_handler&& error_handler)
-      : _partitions{}
+    producer(
+      const configuration& config,
+      brokers& brokers,
+      error_handler&& error_handler)
+      : _config{config}
+      , _partitions{}
       , _error_handler(std::move(error_handler))
       , _brokers(brokers) {}
 
@@ -61,10 +65,13 @@ private:
             return it->second;
         }
         return _partitions
-          .emplace(tp, ss::make_lw_shared<produce_partition>(make_consumer(tp)))
+          .emplace(
+            tp,
+            ss::make_lw_shared<produce_partition>(_config, make_consumer(tp)))
           .first->second;
     }
 
+    const configuration& _config;
     absl::flat_hash_map<model::topic_partition, shared_produce_partition>
       _partitions;
     error_handler _error_handler;

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -87,9 +87,9 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
     wait_for_controller_leadership().get();
 
     info("Connecting client");
-    kc::shard_local_cfg().retry_base_backoff.set_value(10ms);
-    kc::shard_local_cfg().retries.set_value(size_t(10));
     auto client = make_connected_client();
+    client.config().retry_base_backoff.set_value(10ms);
+    client.config().retries.set_value(size_t(10));
     client.connect().get();
     auto stop_client = ss::defer([&client]() { client.stop().get(); });
 

--- a/src/v/kafka/client/test/fetch.cc
+++ b/src/v/kafka/client/test/fetch.cc
@@ -37,9 +37,9 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
     wait_for_controller_leadership().get();
 
     info("Connecting client");
-    kc::shard_local_cfg().retry_base_backoff.set_value(10ms);
-    kc::shard_local_cfg().retries.set_value(size_t(1));
     auto client = make_connected_client();
+    client.config().retry_base_backoff.set_value(10ms);
+    client.config().retries.set_value(size_t(1));
     client.connect().get();
 
     {
@@ -65,7 +65,7 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
 
     {
         info("Fetching from nonempty known topic");
-        kc::shard_local_cfg().retries.set_value(size_t(3));
+        client.config().retries.set_value(size_t(3));
         auto res{
           client.fetch_partition(ntp.tp, model::offset(0), 1024, 1000ms).get()};
         const auto& p = res.partitions[0];

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -33,8 +33,10 @@ public:
     }
 
     kc::client make_client() {
-        return kc::client(std::vector<unresolved_address>{
+        kc::configuration cfg;
+        cfg.brokers.set_value(std::vector<unresolved_address>{
           config::shard_local_cfg().kafka_api()[0].address});
+        return kc::client{cfg};
     }
     kc::client make_connected_client() {
         auto client = make_client();

--- a/src/v/kafka/client/test/produce.cc
+++ b/src/v/kafka/client/test/produce.cc
@@ -29,11 +29,10 @@ FIXTURE_TEST(produce_reconnect, kafka_client_fixture) {
     info("Waiting for leadership");
     wait_for_controller_leadership().get();
 
-    kc::shard_local_cfg().retry_base_backoff.set_value(10ms);
-    kc::shard_local_cfg().retries.set_value(size_t(0));
-
     auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
     auto client = make_connected_client();
+    client.config().retry_base_backoff.set_value(10ms);
+    client.config().retries.set_value(size_t(0));
 
     info("Connecting client");
     wait_for_controller_leadership().get();
@@ -56,16 +55,16 @@ FIXTURE_TEST(produce_reconnect, kafka_client_fixture) {
     BOOST_REQUIRE_EQUAL(res.topics.size(), 1);
     BOOST_REQUIRE_EQUAL(res.topics[0].name(), "t");
 
-    kc::shard_local_cfg().produce_batch_record_count.set_value(3);
-    kc::shard_local_cfg().produce_batch_size_bytes.set_value(1024);
-    kc::shard_local_cfg().produce_batch_delay.set_value(1000ms);
+    client.config().produce_batch_record_count.set_value(3);
+    client.config().produce_batch_size_bytes.set_value(1024);
+    client.config().produce_batch_delay.set_value(1000ms);
 
     auto bat0 = make_batch(model::offset(0), 2);
     auto bat1 = make_batch(model::offset(2), 1);
     auto bat2 = make_batch(model::offset(3), 3);
 
-    kc::shard_local_cfg().retry_base_backoff.set_value(10ms);
-    kc::shard_local_cfg().retries.set_value(size_t(10));
+    client.config().retry_base_backoff.set_value(10ms);
+    client.config().retries.set_value(size_t(10));
 
     info("Producing to known topic");
     auto req0_fut = client.produce_record_batch(tp, std::move(bat0));

--- a/src/v/kafka/client/test/produce_partition.cc
+++ b/src/v/kafka/client/test/produce_partition.cc
@@ -32,12 +32,13 @@ SEASTAR_THREAD_TEST_CASE(test_produce_partition_record_count) {
         consumed_batches.push_back(std::move(batch));
     };
 
+    auto cfg = kc::configuration{};
     // large
-    kc::shard_local_cfg().produce_batch_size_bytes.set_value(1024);
+    cfg.produce_batch_size_bytes.set_value(1024);
     // configuration under test
-    kc::shard_local_cfg().produce_batch_record_count.set_value(3);
+    cfg.produce_batch_record_count.set_value(3);
 
-    kc::produce_partition producer(consumer);
+    kc::produce_partition producer(cfg, consumer);
 
     auto c_res0_fut = producer.produce(make_batch(model::offset(0), 2));
     auto c_res1_fut = producer.produce(make_batch(model::offset(2), 1));

--- a/src/v/kafka/client/test/reconnect.cc
+++ b/src/v/kafka/client/test/reconnect.cc
@@ -28,11 +28,10 @@ FIXTURE_TEST(reconnect, kafka_client_fixture) {
     info("Waiting for leadership");
     wait_for_controller_leadership().get();
 
-    kc::shard_local_cfg().retry_base_backoff.set_value(10ms);
-    kc::shard_local_cfg().retries.set_value(size_t(0));
-
     auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
     auto client = make_connected_client();
+    client.config().retry_base_backoff.set_value(10ms);
+    client.config().retries.set_value(size_t(0));
 
     {
         info("Checking no topics");
@@ -65,7 +64,7 @@ FIXTURE_TEST(reconnect, kafka_client_fixture) {
     }
 
     {
-        kc::shard_local_cfg().retries.set_value(size_t(5));
+        client.config().retries.set_value(size_t(5));
         info("Checking for known topic - controller ready");
         auto res = client.dispatch(make_list_topics_req()).get();
         BOOST_REQUIRE_EQUAL(res.topics.size(), 1);

--- a/src/v/pandaproxy/application.h
+++ b/src/v/pandaproxy/application.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "kafka/client/configuration.h"
 #include "pandaproxy/admin/api-doc/config.json.h"
 #include "pandaproxy/proxy.h"
 #include "seastarx.h"
@@ -28,7 +29,7 @@ class application {
 public:
     int run(int, char**);
 
-    void initialize();
+    void initialize(const kafka::client::configuration& cfg);
     void check_environment();
     void configure_admin_server();
     void wire_up_services();
@@ -39,6 +40,8 @@ public:
             _deferred.pop_back();
         }
     }
+
+    ss::future<> set_client_config(ss::sstring name, std::any val);
 
 private:
     using deferred_actions
@@ -64,6 +67,7 @@ private:
     ss::sharded<pandaproxy::proxy> _proxy;
     // run these first on destruction
     deferred_actions _deferred;
+    kafka::client::configuration _client_config;
 };
 
 } // namespace pandaproxy

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -96,8 +96,9 @@ static server::context_t make_context(kafka::client::client& client) {
 }
 
 proxy::proxy(
-  ss::socket_address listen_addr, std::vector<unresolved_address> broker_addrs)
-  : _client(std::move(broker_addrs))
+  ss::socket_address listen_addr,
+  const kafka::client::configuration& client_config)
+  : _client(client_config)
   , _ctx(make_context(_client))
   , _server(
       "pandaproxy",
@@ -117,6 +118,10 @@ ss::future<> proxy::start() {
 
 ss::future<> proxy::stop() {
     return _server.stop().finally([this]() { return _client.stop(); });
+}
+
+kafka::client::configuration& proxy::client_config() {
+    return _client.config();
 }
 
 } // namespace pandaproxy

--- a/src/v/pandaproxy/proxy.h
+++ b/src/v/pandaproxy/proxy.h
@@ -26,10 +26,12 @@ class proxy {
 public:
     proxy(
       ss::socket_address listen_addr,
-      std::vector<unresolved_address> broker_addrs);
+      const kafka::client::configuration& client_config);
 
     ss::future<> start();
     ss::future<> stop();
+
+    kafka::client::configuration& client_config();
 
 private:
     kafka::client::client _client;

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -135,7 +135,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
 
     {
         info("Produce to topic");
-        kc::shard_local_cfg().retries.set_value(size_t(5));
+        set_client_config("retries", size_t(5));
         const ss::sstring produce_body(R"({
    "records":[
       {

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -22,8 +22,8 @@ namespace kc = kafka::client;
 FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
     using namespace std::chrono_literals;
 
-    kc::shard_local_cfg().retry_base_backoff.set_value(10ms);
-    kc::shard_local_cfg().produce_batch_delay.set_value(0ms);
+    set_client_config("retry_base_backoff_ms", 10ms);
+    set_client_config("produce_batch_delay_ms", 0ms);
 
     info("Waiting for leadership");
     wait_for_controller_leadership().get();
@@ -60,7 +60,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
 
     {
         info("Fetch from unknown topic");
-        kc::shard_local_cfg().retries.set_value(size_t(0));
+        set_client_config("retries", size_t(0));
         auto res = http_request(
           client,
           "/topics/t/partitions/0/"
@@ -81,7 +81,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
     {
         info("Produce to known topic - offsets 1-3");
         // Will require a metadata update
-        kc::shard_local_cfg().retries.set_value(size_t(5));
+        set_client_config("retries", size_t(5));
         auto body = iobuf();
         body.append(batch_1_body.data(), batch_1_body.size());
         auto res = http_request(client, "/topics/t", std::move(body));
@@ -94,7 +94,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
 
     {
         info("Fetch offset 0 - expect offsets 0-3");
-        kc::shard_local_cfg().retries.set_value(size_t(0));
+        set_client_config("retries", size_t(0));
         auto res = http_request(
           client,
           "/topics/t/partitions/0/"
@@ -109,7 +109,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
 
     {
         info("Produce to known topic - offset 4");
-        kc::shard_local_cfg().retries.set_value(size_t(0));
+        set_client_config("retries", size_t(0));
         auto body = iobuf();
         body.append(batch_2_body.data(), batch_2_body.size());
         auto res = http_request(client, "/topics/t", std::move(body));

--- a/src/v/pandaproxy/test/produce.cc
+++ b/src/v/pandaproxy/test/produce.cc
@@ -22,8 +22,8 @@ namespace kc = kafka::client;
 FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
     using namespace std::chrono_literals;
 
-    kc::shard_local_cfg().retry_base_backoff.set_value(10ms);
-    kc::shard_local_cfg().produce_batch_delay.set_value(0ms);
+    set_client_config("retry_base_backoff_ms", 10ms);
+    set_client_config("produce_batch_delay_ms", 0ms);
 
     info("Waiting for leadership");
     wait_for_controller_leadership().get();
@@ -50,7 +50,7 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
 
     {
         info("Produce without topic");
-        kc::shard_local_cfg().retries.set_value(size_t(0));
+        set_client_config("retries", size_t(0));
         auto body = iobuf();
         body.append(produce_body.data(), produce_body.size());
         auto res = http_request(client, "/topics/t", std::move(body));
@@ -73,7 +73,7 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
     {
         info("Produce to known topic");
         // Will require a metadata update
-        kc::shard_local_cfg().retries.set_value(size_t(5));
+        set_client_config("retries", size_t(5));
         auto body = iobuf();
         body.append(produce_body.data(), produce_body.size());
         auto res = http_request(client, "/topics/t", std::move(body));
@@ -86,7 +86,7 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
 
     {
         info("Produce to known topic");
-        kc::shard_local_cfg().retries.set_value(size_t(0));
+        set_client_config("retries", size_t(0));
         auto body = iobuf();
         body.append(produce_body.data(), produce_body.size());
         auto res = http_request(client, "/topics/t", std::move(body));

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -640,9 +640,6 @@ void application::start() {
       _log.info, "Started Kafka API server listening at {}", conf.kafka_api());
 
     if (coproc_enabled()) {
-        /// Temporarily disable retries for the new client until we create a
-        /// more granular way to configure this per client or per request.
-        kafka::client::shard_local_cfg().retries.set_value(size_t(1));
         construct_single_service(_wasm_event_listener, std::ref(pacemaker));
         _wasm_event_listener->start().get();
         pacemaker.invoke_on_all(&coproc::pacemaker::start).get();


### PR DESCRIPTION
The global configuration prevents use of kafka::client instances
from multiple subsystems simultaneously.

kafka::client is now constructed with a configuration, which it
takes a copy of. The configuration is exposed to allow changes
during runtime. Sub-components of kafka::client can observe the
configuration via a const&.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
