### PR TITLE
operator: Ignore artifacts from kuttl tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@
 /build
 /dbuild
 bin
-_artifacts/
+_e2e_artifacts/
 /src/go/k8s/testbin/*
 /src/go/k8s/cm-verifier
 


### PR DESCRIPTION
Change the folder of Redpanda operator e2e artifacts to ignore.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
