### PR TITLE
operator/linter: Change golint confidence in golangci-lint

### DIFF
--- a/src/go/k8s/.golangci.yml
+++ b/src/go/k8s/.golangci.yml
@@ -17,7 +17,10 @@ linters-settings:
       - performance
       - style
   golint:
-    min-confidence: 0
+    # The package comment is false positive so the min-confidance needs to be
+    # set to at least 0.3
+    # Ref https://github.com/golangci/golangci-lint/issues/1556#issuecomment-744021989
+    min-confidence: 0.3
   gomnd:
     settings:
       mnd:

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-// Package v1alpha1 represent Custom Resource definition of the vectorized.io redpanda group
 package v1alpha1
 
 import (

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-// Package v1alpha1 represent Custom Resource definition of the vectorized.io redpanda group
 package v1alpha1
 
 import (

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-// Package resources contains reconciliation logic for redpanda.vectorized.io CRD
 package resources
 
 import (

--- a/src/go/k8s/pkg/resources/service.go
+++ b/src/go/k8s/pkg/resources/service.go
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-// Package resources contains reconciliation logic for redpanda.vectorized.io CRD
 package resources
 
 import (

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-// Package resources contains reconciliation logic for redpanda.vectorized.io CRD
 package resources
 
 import (

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-// Package resources contains reconciliation logic for redpanda.vectorized.io CRD
 package resources
 
 import (


### PR DESCRIPTION
The minimal confidence set to 0 causes golint to report false
possitive message about package godoc. It can be disabled
by changing the confidence.

Message: "should have a package comment, unless it's in another file
for this package (golint)"

REF: https://github.com/golangci/golangci-lint/issues/1556#issuecomment-744021989

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
