### PR TITLE
operator: Change init container that prepare config

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -1,6 +1,7 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= vectorized/redpanda-operator:latest
+CONFIGURATOR_IMG ?= vectorized/configurator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
@@ -78,12 +79,21 @@ docker-build: test
 docker-push:
 	docker push ${IMG}
 
+# Build the docker image
+docker-build-configurator:
+	docker build -f cmd/configurator/Dockerfile -t ${CONFIGURATOR_IMG} ../
+
+# Push the docker image
+docker-push-configurator:
+	docker push ${CONFIGURATOR_IMG}
+
 # Preload controller image to kind cluster
 push-to-kind:
 	kind load docker-image ${IMG}
+	kind load docker-image ${CONFIGURATOR_IMG}
 
 # Execute end to end tests
-e2e-tests: kuttl docker-build
+e2e-tests: kuttl docker-build docker-build-configurator
 	$(KUTTL) test $(TEST_ONLY_FLAG)
 
 # Download controller-gen locally if necessary

--- a/src/go/k8s/cmd/configurator/Dockerfile
+++ b/src/go/k8s/cmd/configurator/Dockerfile
@@ -1,0 +1,30 @@
+# Build the manager binary
+FROM golang:1.15 as builder
+
+# Copy the rpk as a close depedency
+WORKDIR /workspace
+COPY rpk/ rpk/
+
+WORKDIR /workspace/k8s
+# Copy the Go Modules manifests
+COPY k8s/go.mod go.mod
+COPY k8s/go.sum go.sum
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY k8s/cmd/configurator/main.go main.go
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o configurator main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/k8s/configurator .
+USER 65532:65532
+
+ENTRYPOINT ["/configurator"]

--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -1,0 +1,181 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// main package. This line should be remove after merging the following
+// https://github.com/vectorizedio/redpanda/pull/753
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/afero"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	hostNameEnvVar          = "HOSTNAME"
+	svcFQDNEnvVar           = "SERVICE_FQDN"
+	configSourceDirEnvVar   = "CONFIG_SOURCE_DIR"
+	configDestinationEnvVar = "CONFIG_DESTINATION"
+	redpandaRPCPortEnvVar   = "REDPANDA_RPC_PORT"
+)
+
+type configuratorConfig struct {
+	hostName          string
+	svcFQDN           string
+	configSourceDir   string
+	configDestination string
+	redpandaRPCPort   int
+}
+
+var errorMissingEnvironmentVariable = errors.New("missing environment variable")
+
+func main() {
+	log.Printf("The redpanda configurator is starting")
+
+	c, err := checkEnvVars()
+	if err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to get the environment variables: %w", err))
+	}
+
+	fs := afero.NewOsFs()
+	v := config.InitViper(fs)
+	v.AddConfigPath(c.configSourceDir)
+
+	if err = v.ReadInConfig(); err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to read the redpanda configuration file: %w", err))
+	}
+
+	cfg := &config.Config{}
+	decoderConfig := mapstructure.DecoderConfig{
+		Result: cfg,
+		// Sometimes viper will save int values as strings (i.e.
+		// through BindPFlag) so we have to allow mapstructure
+		// to cast them.
+		WeaklyTypedInput: true,
+	}
+
+	decoder, err := mapstructure.NewDecoder(&decoderConfig)
+	if err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to create decoder config: %w", err))
+	}
+
+	err = decoder.Decode(v.AllSettings())
+	if err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to decode: %w", err))
+	}
+
+	log.Printf("Decode done")
+
+	hostIndex, err := hostIndex(c.hostName)
+	if err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to extract host index: %w", err))
+	}
+
+	log.Printf("Host index calculated %d", hostIndex)
+
+	cfg.Redpanda.Id = hostIndex
+
+	// First Redpanda node need to have cleared seed servers in order
+	// to form raft group 0
+	if hostIndex == 0 {
+		cfg.Redpanda.SeedServers = []config.SeedServer{}
+	} else {
+		cfg.Redpanda.SeedServers = []config.SeedServer{
+			{
+				Host: config.SocketAddress{
+					// Example address: cluster-sample-0.cluster-sample.default.svc.cluster.local
+					Address: c.hostName + c.svcFQDN,
+					Port:    c.redpandaRPCPort,
+				},
+			},
+		}
+	}
+
+	cfgBytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to marshal the configuration: %w", err))
+	}
+
+	log.Printf("Config: %s", string(cfgBytes))
+
+	if err := ioutil.WriteFile(c.configDestination, cfgBytes, 0600); err != nil {
+		log.Fatalf("%s", fmt.Errorf("unable to write the destination configuration file: %w", err))
+	}
+
+	log.Printf("Configuration saved to: %s", c.configDestination)
+}
+
+func checkEnvVars() (configuratorConfig, error) {
+	var exist bool
+	var result error
+	c := configuratorConfig{}
+	c.hostName, exist = os.LookupEnv(hostNameEnvVar)
+	if !exist {
+		result = multierror.Append(result, fmt.Errorf("HOSTNAME %w", errorMissingEnvironmentVariable))
+	}
+
+	c.svcFQDN, exist = os.LookupEnv(svcFQDNEnvVar)
+	if !exist {
+		result = multierror.Append(result, fmt.Errorf("SERVICE_FQDN %w", errorMissingEnvironmentVariable))
+	}
+
+	c.configSourceDir, exist = os.LookupEnv(configSourceDirEnvVar)
+	if !exist {
+		result = multierror.Append(result, fmt.Errorf("CONFIG_SOURCE_DIR %w", errorMissingEnvironmentVariable))
+	}
+
+	c.configDestination, exist = os.LookupEnv(configDestinationEnvVar)
+	if !exist {
+		result = multierror.Append(result, fmt.Errorf("CONFIG_DESTINATION %w", errorMissingEnvironmentVariable))
+	}
+
+	rpcPort, exist := os.LookupEnv(redpandaRPCPortEnvVar)
+	if !exist {
+		result = multierror.Append(result, fmt.Errorf("REDPANDA_RPC_PORT %w", errorMissingEnvironmentVariable))
+	}
+
+	var err error
+	c.redpandaRPCPort, err = strconv.Atoi(rpcPort)
+	if err != nil {
+		result = multierror.Append(result, fmt.Errorf("unable to convert rpc port from string to int: %w", err))
+	}
+
+	log.Printf("The configuration:\n"+
+		"hostName: %s\n"+
+		"svcFQDN: %s\n"+
+		"configSourceDir: %s\n"+
+		"configDestination: %s\n"+
+		"redpandaRPCPort: %d\n",
+		c.hostName,
+		c.svcFQDN,
+		c.configSourceDir,
+		c.configDestination,
+		c.redpandaRPCPort)
+
+	return c, result
+}
+
+// hostIndex takes advantage of pod naming convention in Kubernetes StatfulSet
+// the last number is the index of replica. This index is then propagated
+// to redpanda.node_id.
+func hostIndex(hostName string) (int, error) {
+	s := strings.Split(hostName, "-")
+	last := len(s) - 1
+	return strconv.Atoi(s[last])
+}

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -76,7 +76,7 @@ func (r *ClusterReconciler) Reconcile(
 	toApply := []resources.Resource{
 		svc,
 		resources.NewNodePortService(r.Client, &redpandaCluster, r.Scheme, log),
-		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme, svc.HeadlessServiceFQDN(), log),
+		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme, log),
 		sts,
 	}
 

--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -5,8 +5,11 @@ go 1.15
 require (
 	github.com/Shopify/sarama v1.26.1
 	github.com/go-logr/logr v0.3.0
+	github.com/hashicorp/go-multierror v1.1.0
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
+	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.6.1
 	github.com/vectorizedio/redpanda/src/go/rpk v0.0.0-00010101000000-000000000000
 	golang.org/x/tools v0.0.0-20210107193943-4ed967dd8eff // indirect

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -254,7 +254,9 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -4,6 +4,7 @@ startKIND: true
 kindNodeCache: true
 kindContainers:
   - vectorized/redpanda-operator:latest
+  - vectorized/configurator:latest
 testDirs:
   - ./tests/e2e
 kindConfig: ./kind.yaml

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -208,17 +208,6 @@ func (r *StatefulSetResource) podImageIdenticalToClusterImage(
 		return containerHasWrongImageError(podName, container.Name, container.Image, newImage)
 	}
 
-	container, err = findContainer(pod.Spec.InitContainers, configuratorContainerName)
-	if err != nil {
-		return err
-	}
-
-	if container.Image != newImage {
-		r.logger.Info("Init container image not updated to cluster image", "pod", pod.Name,
-			"container", container.Name, "container image", container.Image, "cluster image", newImage)
-		return containerHasWrongImageError(podName, container.Name, container.Image, newImage)
-	}
-
 	if !podIsReady(&pod) {
 		r.logger.Info("Pod not ready yet", "pod", pod.Name)
 		return podNotReadyError(pod.Name)
@@ -248,15 +237,7 @@ func (r *StatefulSetResource) rollingUpdatePartition(
 func (r *StatefulSetResource) modifyPodImage(
 	stsSpec *corev1.PodSpec, newImage string,
 ) error {
-	if err := modifyContainerImage(stsSpec.InitContainers, configuratorContainerName, newImage); err != nil {
-		return err
-	}
-
-	if err := modifyContainerImage(stsSpec.Containers, redpandaContainerName, newImage); err != nil {
-		return err
-	}
-
-	return nil
+	return modifyContainerImage(stsSpec.Containers, redpandaContainerName, newImage)
 }
 
 func modifyContainerImage(


### PR DESCRIPTION
To over come problem with managing distinct Redpanda
nodes using statfulset the init container is used to dynamically
set the seed server and node ID. Later the external listener
will be configured by fetching the node information from Kuberntes
API server.

To not complicate bash script the new version written in golang is
created to harden the security and create more flexible tool.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
