### PR TITLE
operator: Create new node port service

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -71,10 +71,11 @@ func (r *ClusterReconciler) Reconcile(
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	svc := resources.NewService(r.Client, &redpandaCluster, r.Scheme, log)
+	svc := resources.NewHeadlessService(r.Client, &redpandaCluster, r.Scheme, log)
 	sts := resources.NewStatefulSet(r.Client, &redpandaCluster, r.Scheme, svc.HeadlessServiceFQDN(), svc.Key().Name, log)
 	toApply := []resources.Resource{
 		svc,
+		resources.NewNodePortService(r.Client, &redpandaCluster, r.Scheme, log),
 		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme, svc.HeadlessServiceFQDN(), log),
 		sts,
 	}
@@ -141,5 +142,6 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&redpandav1alpha1.Cluster{}).
 		Owns(&appsv1.StatefulSet{}).
+		Owns(&corev1.Service{}).
 		Complete(r)
 }

--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -38,7 +38,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 	)
 
 	Context("When creating RedpandaCluster", func() {
-		It("Should create Redpanda cluster", func() {
+		It("Should create Redpanda cluster with corresponding resources", func() {
 			resources := corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -53,10 +53,6 @@ var _ = Describe("RedPandaCluster controller", func() {
 				Namespace: "default",
 			}
 			redpandaCluster := &v1alpha1.Cluster{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "RedpandaCluster",
-					APIVersion: "core.vectorized.io/v1alpha1",
-				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      key.Name,
 					Namespace: key.Namespace,
@@ -85,6 +81,18 @@ var _ = Describe("RedPandaCluster controller", func() {
 				err := k8sClient.Get(context.Background(), key, &svc)
 				return err == nil &&
 					svc.Spec.ClusterIP == corev1.ClusterIPNone &&
+					svc.Spec.Ports[0].Port == kafkaPort &&
+					validOwner(redpandaCluster, svc.OwnerReferences)
+			}, timeout, interval).Should(BeTrue())
+
+			By("Creating NodePort Service")
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      key.Name + "-external",
+					Namespace: key.Namespace,
+				}, &svc)
+				return err == nil &&
+					svc.Spec.Type == corev1.ServiceTypeNodePort &&
 					svc.Spec.Ports[0].Port == kafkaPort &&
 					validOwner(redpandaCluster, svc.OwnerReferences)
 			}, timeout, interval).Should(BeTrue())

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -70,7 +70,6 @@ func NewConfigMap(
 }
 
 // Ensure will manage kubernetes v1.ConfigMap for redpanda.vectorized.io CR
-//nolint:dupl // we expect this to not be duplicated when more logic is added
 func (r *ConfigMapResource) Ensure(ctx context.Context) error {
 	var cfgm corev1.ConfigMap
 

--- a/src/go/k8s/pkg/resources/headless_service.go
+++ b/src/go/k8s/pkg/resources/headless_service.go
@@ -1,0 +1,141 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ Resource = &HeadlessServiceResource{}
+
+// HeadlessServiceResource is part of the reconciliation of redpanda.vectorized.io CRD
+// focusing on the internal connectivity management of redpanda cluster
+type HeadlessServiceResource struct {
+	k8sclient.Client
+	scheme       *runtime.Scheme
+	pandaCluster *redpandav1alpha1.Cluster
+	logger       logr.Logger
+}
+
+// NewHeadlessService creates HeadlessServiceResource
+func NewHeadlessService(
+	client k8sclient.Client,
+	pandaCluster *redpandav1alpha1.Cluster,
+	scheme *runtime.Scheme,
+	logger logr.Logger,
+) *HeadlessServiceResource {
+	return &HeadlessServiceResource{
+		client,
+		scheme,
+		pandaCluster,
+		logger.WithValues(
+			"Kind", serviceKind(),
+			"ServiceType", corev1.ServiceTypeClusterIP,
+			"ClusterIP", corev1.ClusterIPNone,
+		),
+	}
+}
+
+// Ensure will manage kubernetes v1.Service for redpanda.vectorized.io custom resource
+func (r *HeadlessServiceResource) Ensure(ctx context.Context) error {
+	var svc corev1.Service
+
+	err := r.Get(ctx, r.Key(), &svc)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error while fetching service resource: %w", err)
+	}
+
+	if errors.IsNotFound(err) {
+		r.logger.Info(fmt.Sprintf("Service %s does not exist, going to create one", r.Key().Name))
+
+		obj, err := r.Obj()
+		if err != nil {
+			return fmt.Errorf("unable to construct service object: %w", err)
+		}
+
+		if err := r.Create(ctx, obj); err != nil {
+			return fmt.Errorf("unable to create service resource: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Obj returns resource managed client.Object
+func (r *HeadlessServiceResource) Obj() (k8sclient.Object, error) {
+	objLabels := labels.ForCluster(r.pandaCluster)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: r.Key().Namespace,
+			Name:      r.Key().Name,
+			Labels:    objLabels,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "kafka-tcp",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       int32(r.pandaCluster.Spec.Configuration.KafkaAPI.Port),
+					TargetPort: intstr.FromInt(r.pandaCluster.Spec.Configuration.KafkaAPI.Port),
+				},
+			},
+			Selector: objLabels.AsAPISelector().MatchLabels,
+		},
+	}
+
+	err := controllerutil.SetControllerReference(r.pandaCluster, svc, r.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return svc, nil
+}
+
+// Key returns namespace/name object that is used to identify object.
+// For reference please visit types.NamespacedName docs in k8s.io/apimachinery
+func (r *HeadlessServiceResource) Key() types.NamespacedName {
+	return types.NamespacedName{Name: r.pandaCluster.Name, Namespace: r.pandaCluster.Namespace}
+}
+
+// Kind returns v1.Service kind
+func (r *HeadlessServiceResource) Kind() string {
+	return serviceKind()
+}
+
+func serviceKind() string {
+	var svc corev1.Service
+	return svc.Kind
+}
+
+// HeadlessServiceFQDN returns fully qualified domain name for headless service.
+// It can be used to communicate between namespaces if the network policy
+// allows it.
+func (r *HeadlessServiceResource) HeadlessServiceFQDN() string {
+	// TODO Retrieve cluster domain dynamically and remove hardcoded cluster.local
+	return fmt.Sprintf("%s%c%s.svc.cluster.local.",
+		r.Key().Name,
+		'.',
+		r.Key().Namespace)
+}

--- a/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
@@ -39,3 +39,28 @@ spec:
             - --default-log-level=debug
 status:
   readyReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-sample
+spec:
+  clusterIP: None
+  ports:
+    - name: kafka-tcp
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-sample-external
+spec:
+  ports:
+    - name: kafka-tcp
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
+  type: NodePort


### PR DESCRIPTION
The node port service is created for assigning unique port to every
Kubernetes node. This port will be used in each Redpanda container
to expose it to the outside word.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
