### PR TITLE
operator/test: Fix the path to publish e2e artifacts

### DIFF
--- a/.github/workflows/k8s-build-and-test.yml
+++ b/.github/workflows/k8s-build-and-test.yml
@@ -47,4 +47,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: kuttl test artifacts
-        path: src/go/k8s/tests/e2e/_artifacts
+        path: src/go/k8s/tests/_e2e_artifacts


### PR DESCRIPTION
I discover that failed e2e tests doesn't have artifact folder uploded.

REF: 
https://github.com/vectorizedio/redpanda/actions/runs/621154206
https://github.com/vectorizedio/redpanda/pull/666

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
