### PR TITLE
operator/e2e: Remove non existent ports

### DIFF
--- a/src/go/k8s/tests/e2e/update-image/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image/00-current-image.yaml
@@ -16,11 +16,7 @@ spec:
   configuration:
     rpcServer:
       port: 33145
-    advertisedRpcApi:
-      port: 33145
     kafkaApi:
-      port: 9092
-    advertisedKafkaApi:
       port: 9092
     admin:
       port: 9644


### PR DESCRIPTION
The advertised ports where removed in:
https://github.com/vectorizedio/redpanda/pull/612

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
