### PR TITLE
Fixes for topic offsets metadata

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -18,6 +18,7 @@
 #include "model/metadata.h"
 #include "model/record_batch_reader.h"
 #include "raft/consensus.h"
+#include "raft/consensus_utils.h"
 #include "raft/group_configuration.h"
 #include "raft/log_eviction_stm.h"
 #include "raft/types.h"
@@ -86,7 +87,7 @@ public:
      * kafka clients, simply report the next offset.
      */
     model::offset last_stable_offset() const {
-        return _raft->last_stable_offset() + model::offset(1);
+        return raft::details::next_offset(_raft->last_stable_offset());
     }
 
     /**

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -15,6 +15,7 @@
 #include "cluster/partition_probe.h"
 #include "cluster/seq_stm.h"
 #include "cluster/types.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record_batch_reader.h"
 #include "raft/consensus.h"
@@ -91,10 +92,12 @@ public:
     }
 
     /**
-     * Greatest offset visible to consumers. Named high_watermark to be
-     * consistent with Kafka nomenclature.
+     * All batches with offets smaller than high watermark are visible to
+     * consumers. Named high_watermark to be consistent with Kafka nomenclature.
      */
-    model::offset high_watermark() const { return _raft->last_visible_index(); }
+    model::offset high_watermark() const {
+        return raft::details::next_offset(_raft->last_visible_index());
+    }
 
     const model::ntp& ntp() const { return _raft->ntp(); }
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -437,10 +437,8 @@ ss::future<read_result> read_from_ntp(
     }
 
     auto high_watermark = partition->high_watermark();
-    auto max_offset = high_watermark < model::offset(0)
-                        ? model::offset(0)
-
-                        : high_watermark + model::offset(1);
+    auto max_offset = high_watermark < model::offset(0) ? model::offset(0)
+                                                        : high_watermark;
     if (
       config.start_offset < partition->start_offset()
       || config.start_offset > max_offset) {

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -147,6 +147,11 @@ struct partition_metadata {
     friend std::ostream& operator<<(std::ostream&, const partition_metadata&);
 };
 
+enum class isolation_level : int8_t {
+    read_uncommitted = 0,
+    read_committed = 1,
+};
+
 struct topic_namespace_view {
     topic_namespace_view(const model::ns& n, const model::topic& t)
       : ns(n)


### PR DESCRIPTION
Fixed returning incorrect offset values in `LIST_OFFSETS` Kafka API.


Closes: #725 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
