### PR TITLE
rpk/config/manager: Unexport ReadOrGenerate

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1077,7 +1077,7 @@ func TestReadOrGenerate(t *testing.T) {
 				err := tt.setup(fs)
 				require.NoError(t, err)
 			}
-			_, err := mgr.ReadOrGenerate(tt.configFile)
+			_, err := readOrGenerate(InitViper(fs), tt.configFile)
 			if tt.expectError {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
Manager#ReadOrFind was only used internally, so it's unexported now.
