### PR TITLE
kafka: add describe acl api scaffolding

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -29,6 +29,7 @@ set(handlers_srcs
   server/handlers/sasl_authenticate.cc
   server/handlers/incremental_alter_configs.cc
   server/handlers/delete_groups.cc
+  server/handlers/describe_acls.cc
   server/handlers/topics/types.cc
   server/handlers/topics/topic_utils.cc
 )

--- a/src/v/kafka/protocol/describe_acls.h
+++ b/src/v/kafka/protocol/describe_acls.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "bytes/iobuf.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/describe_acls_request.h"
+#include "kafka/protocol/schemata/describe_acls_response.h"
+#include "kafka/server/request_context.h"
+#include "kafka/server/response.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/future.hh>
+
+namespace kafka {
+
+struct describe_acls_response;
+
+class describe_acls_api final {
+public:
+    using response_type = describe_acls_response;
+
+    static constexpr const char* name = "describe_acls";
+    static constexpr api_key key = api_key(29);
+};
+
+struct describe_acls_request final {
+    using api_type = describe_acls_api;
+
+    describe_acls_request_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const describe_acls_request& r) {
+    return os << r.data;
+}
+
+struct describe_acls_response final {
+    using api_type = describe_acls_api;
+
+    describe_acls_response_data data;
+
+    void encode(const request_context& ctx, response& resp) {
+        data.encode(resp.writer(), ctx.header().version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const describe_acls_response& r) {
+    return os << r.data;
+}
+
+} // namespace kafka

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -40,7 +40,9 @@ set(schemata
   incremental_alter_configs_request.json
   incremental_alter_configs_response.json
   delete_groups_request.json
-  delete_groups_response.json)
+  delete_groups_response.json
+  describe_acls_request.json
+  describe_acls_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/protocol/schemata/describe_acls_request.json
+++ b/src/v/kafka/protocol/schemata/describe_acls_request.json
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 29,
+  "type": "request",
+  "name": "DescribeAclsRequest",
+  // Version 1 adds resource pattern type.
+  "validVersions": "0-1",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "ResourceType", "type": "int8", "versions": "0+",
+      "about": "The resource type." },
+    { "name": "ResourceNameFilter", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The resource name, or null to match any resource name." },
+    { "name": "ResourcePatternType", "type": "int8", "versions": "1+", "default": "3", "ignorable": false,
+      "about": "The resource pattern to match." },
+    { "name": "PrincipalFilter", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The principal to match, or null to match any principal." },
+    { "name": "HostFilter", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The host to match, or null to match any host." },
+    { "name": "Operation", "type": "int8", "versions": "0+",
+      "about": "The operation to match." },
+    { "name": "PermissionType", "type": "int8", "versions": "0+",
+      "about": "The permission type to match." }
+  ]
+}

--- a/src/v/kafka/protocol/schemata/describe_acls_response.json
+++ b/src/v/kafka/protocol/schemata/describe_acls_response.json
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 29,
+  "type": "response",
+  "name": "DescribeAclsResponse",
+  // Version 1 adds PatternType.
+  // Starting in version 1, on quota violation, brokers send out responses before throttling.
+  "validVersions": "0-1",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The error code, or 0 if there was no error." },
+    { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
+      "about": "The error message, or null if there was no error." },
+    { "name": "Resources", "type": "[]DescribeAclsResource", "versions": "0+",
+      "about": "Each Resource that is referenced in an ACL.", "fields": [
+      { "name": "Type", "type": "int8", "versions": "0+",
+        "about": "The resource type." },
+      { "name": "Name", "type": "string", "versions": "0+",
+        "about": "The resource name." },
+      { "name": "PatternType", "type": "int8", "versions": "1+", "default": "3", "ignorable": false,
+        "about": "The resource pattern type." },
+      { "name": "Acls", "type": "[]AclDescription", "versions": "0+",
+        "about": "The ACLs.", "fields": [
+        { "name": "Principal", "type": "string", "versions": "0+",
+          "about": "The ACL principal." },
+        { "name": "Host", "type": "string", "versions": "0+",
+          "about": "The ACL host." },
+        { "name": "Operation", "type": "int8", "versions": "0+",
+          "about": "The ACL operation." },
+        { "name": "PermissionType", "type": "int8", "versions": "0+",
+          "about": "The ACL permission type." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -263,6 +263,8 @@ STRUCT_TYPES = [
     "CreateableTopicConfig",
     "CreatableTopicConfigs",
     "DeletableGroupResult",
+    "DescribeAclsResource",
+    "AclDescription",
 ]
 
 SCALAR_TYPES = list(basic_type_map.keys())

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -50,7 +50,8 @@ using request_types = make_request_types<
   sasl_authenticate_handler,
   incremental_alter_configs_handler,
   init_producer_id_handler,
-  delete_groups_handler>;
+  delete_groups_handler,
+  describe_acls_handler>;
 
 template<typename RequestType>
 static auto make_api() {

--- a/src/v/kafka/server/handlers/describe_acls.cc
+++ b/src/v/kafka/server/handlers/describe_acls.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/handlers/describe_acls.h"
+
+#include "kafka/protocol/errors.h"
+#include "kafka/server/request_context.h"
+#include "kafka/server/response.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/smp.hh>
+#include <seastar/util/log.hh>
+
+#include <fmt/ostream.h>
+
+namespace kafka {
+
+template<>
+ss::future<response_ptr> describe_acls_handler::handle(
+  request_context&& ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+    describe_acls_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    klog.trace("Handling request {}", request);
+
+    // we do not current implement acls, so we do not have any resources. so
+    // instead of returning an error, we'll return success and an empty set.
+    describe_acls_response_data data;
+    data.error_code = error_code::none;
+
+    describe_acls_response response{
+      .data = std::move(data),
+    };
+
+    return ctx.respond(std::move(response));
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/describe_acls.h
+++ b/src/v/kafka/server/handlers/describe_acls.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/describe_acls.h"
+#include "kafka/server/handlers/handler.h"
+
+namespace kafka {
+
+using describe_acls_handler = handler<describe_acls_api, 0, 1>;
+
+}

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -15,6 +15,7 @@
 #include "kafka/server/handlers/create_topics.h"
 #include "kafka/server/handlers/delete_groups.h"
 #include "kafka/server/handlers/delete_topics.h"
+#include "kafka/server/handlers/describe_acls.h"
 #include "kafka/server/handlers/describe_configs.h"
 #include "kafka/server/handlers/describe_groups.h"
 #include "kafka/server/handlers/fetch.h"

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -237,6 +237,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<incremental_alter_configs_handler>(std::move(ctx), g);
     case delete_groups_handler::api::key:
         return do_process<delete_groups_handler>(std::move(ctx), g);
+    case describe_acls_handler::api::key:
+        return do_process<describe_acls_handler>(std::move(ctx), g);
     };
     return ss::make_exception_future<response_ptr>(
       std::runtime_error(fmt::format("Unsupported API {}", ctx.header().key)));


### PR DESCRIPTION
Adds the bones for kafka describe api and returns an empty set of acl resources.

This enables the ACL view in kafdrop.

Fixes: #764 
