### PR TITLE
Implementing a failure recovery mechanism for coprocessors

### DIFF
--- a/src/js/modules/domain/generatedRpc/entitiesDefinition.json
+++ b/src/js/modules/domain/generatedRpc/entitiesDefinition.json
@@ -353,6 +353,15 @@
           "type": "int8"
         }
       ]
+    },
+    {
+      "className": "EmptyResponse",
+      "fields": [
+        {
+          "name": "empty",
+          "type": "int8"
+        }
+      ]
     }
   ]
 }

--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -15,6 +15,7 @@ import {
   DisableCoprosReply,
   DisableCoprosRequest,
   EmptyRequest,
+  EmptyResponse,
   EnableCoprocessor,
   EnableCoprocessorRequestData,
   EnableCoprosReply,
@@ -96,6 +97,10 @@ export class ProcessBatchServer extends SupervisorServer {
     }));
     this.logger.info(`Disable all wasm scripts: ${ids}`);
     return Promise.resolve({ responses });
+  }
+
+  heartbeat(input: EmptyRequest): Promise<EmptyResponse> {
+    return Promise.resolve({ empty: 0 });
   }
 
   validateEnableCoprocInput(

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -53,7 +53,13 @@ static wasm::event_action query_action(const iobuf& source_code) {
                                : wasm::event_action::deploy;
 }
 
+static ss::future<> remove_copro_state(ss::sharded<pacemaker>& svc) {
+    return svc.invoke_on_all(
+      [](pacemaker& p) { return p.remove_all_sources().discard_result(); });
+}
+
 ss::future<> event_listener::stop() {
+    vlog(coproclog.info, "Stopping coproc::wasm::event_listener");
     _abort_source.request_abort();
     return _gate.close().then([this] { return _client.stop(); });
 }
@@ -110,6 +116,7 @@ ss::future<> event_listener::persist_actions(
 
 event_listener::event_listener(ss::sharded<pacemaker>& pacemaker)
   : _client(make_client())
+  , _pacemaker(pacemaker)
   , _dispatcher(pacemaker, _abort_source) {}
 
 ss::future<> event_listener::start() {
@@ -118,7 +125,7 @@ ss::future<> event_listener::start() {
           [this] { return _abort_source.abort_requested(); },
           [this] {
               return do_start().then([this] {
-                  return ss::sleep_abortable(2s, _abort_source)
+                  return ss::sleep_abortable(1s, _abort_source)
                     .handle_exception_type([](const ss::sleep_aborted&) {});
               });
           });
@@ -137,18 +144,51 @@ decompress_wasm_events(model::record_batch_reader::data_t events) {
 
 ss::future<> event_listener::do_start() {
     bool connected = co_await _client.is_connected();
-    if (connected) {
-        co_await do_ingest();
-    } else {
+    if (!connected) {
         try {
+            /// Connect may throw if it cannot establish a connection within the
+            /// pre-defined global retry policy
             co_await _client.connect();
         } catch (const kafka::client::broker_error& e) {
             vlog(
               coproclog.warn,
               "Failed to connect to a broker within the retry policy: {}",
               e);
+            co_return;
         }
     }
+    bool heartbeat = co_await _dispatcher.heartbeat();
+    if (!heartbeat) {
+        vlog(
+          coproclog.error,
+          "Wasm engine failed to reply to heartbeat within the "
+          "expected "
+          "interval");
+        _last_heartbeat_failed = true;
+        bool has_active = co_await _pacemaker.map_reduce0(
+          [](pacemaker& p) { return p.n_registered_scripts(); },
+          bool(false),
+          std::logical_or<>());
+        if (has_active) {
+            vlog(
+              coproclog.info, "Shutting down all coprocessor script_contexts");
+            co_await remove_copro_state(_pacemaker);
+        }
+        co_return;
+    }
+    /// If the wasm engine has awaken from restart, reset all state
+    /// within the wasm engine, and set the offset to 0 to begin
+    /// reconciling scripts
+    if (heartbeat && _last_heartbeat_failed) {
+        if (co_await _dispatcher.disable_all_coprocessors()) {
+            /// Unlikely to occur but if heartbeat checks pass but a request to
+            /// invalidate the wasm engines state fails, do not proceed
+            co_return;
+        }
+        _offset = model::offset(0);
+        _last_heartbeat_failed = false;
+    }
+    co_await do_ingest();
 }
 
 ss::future<> event_listener::do_ingest() {

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -50,7 +50,8 @@ private:
     ss::future<> do_start();
     ss::future<> do_ingest();
 
-    ss::future<> poll_topic(model::record_batch_reader::data_t&);
+    ss::future<ss::stop_iteration>
+    poll_topic(model::record_batch_reader::data_t&);
 
     ss::future<> persist_actions(absl::btree_map<script_id, iobuf>);
 

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -53,7 +53,8 @@ private:
     ss::future<ss::stop_iteration>
     poll_topic(model::record_batch_reader::data_t&);
 
-    ss::future<> persist_actions(absl::btree_map<script_id, iobuf>);
+    ss::future<>
+      persist_actions(absl::btree_map<script_id, iobuf>, model::offset);
 
 private:
     /// Kafka client used to poll the internal topic

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -70,8 +70,14 @@ private:
     /// Set of known script ids to be active
     absl::btree_set<script_id> _active_ids;
 
+    ss::sharded<coproc::pacemaker>& _pacemaker;
+
     /// Used to make requests to the wasm engine
     script_dispatcher _dispatcher;
+
+    /// Used to determine if wasm engine is recovering from failure. Initialized
+    /// to true to initiate recovery at every startup
+    bool _last_heartbeat_failed{true};
 };
 
 } // namespace coproc::wasm

--- a/src/v/coproc/gen.json
+++ b/src/v/coproc/gen.json
@@ -25,6 +25,11 @@
             "name": "process_batch",
             "input_type": "process_batch_request",
             "output_type": "process_batch_reply"
+        },
+        {
+            "name": "heartbeat",
+            "input_type": "empty_request",
+            "output_type": "empty_response"
         }
     ]
 }

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -74,6 +74,11 @@ public:
     ss::future<errc> remove_source(script_id);
 
     /**
+     * Removes all script_ids from the pacemaker.
+     */
+    ss::future<absl::btree_map<script_id, errc>> remove_all_sources();
+
+    /**
      * @returns true if a matching script id exists on 'this' shard
      */
     bool local_script_id_exists(script_id);

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -88,6 +88,9 @@ public:
      */
     bool ntp_is_registered(const model::ntp&);
 
+    /// returns the number of running / registered fibers
+    size_t n_registered_scripts() const { return _scripts.size(); }
+
     /// returns a handle to the reconnect transport
     shared_script_resources& resources() { return _shared_res; }
 

--- a/src/v/coproc/script_dispatcher.cc
+++ b/src/v/coproc/script_dispatcher.cc
@@ -154,16 +154,16 @@ script_dispatcher::add_sources(
     });
 }
 
-ss::future<> script_dispatcher::enable_coprocessors(enable_copros_request req) {
+ss::future<std::error_code>
+script_dispatcher::enable_coprocessors(enable_copros_request req) {
     auto client = co_await get_client();
     if (!client) {
-        co_return;
+        co_return rpc::make_error_code(rpc::errc::disconnected_endpoint);
     }
     auto reply = co_await client->enable_coprocessors(
       std::move(req), rpc::client_opts(model::no_timeout));
     if (!reply) {
-        vlog(coproclog.error, "Could not complete enable_coprocessors request");
-        co_return;
+        co_return reply.error();
     }
     std::vector<script_id> deregisters;
     for (enable_copros_reply::data& r : reply.value().data.acks) {
@@ -227,10 +227,12 @@ ss::future<> script_dispatcher::enable_coprocessors(enable_copros_request req) {
         if (!reply) {
             vlog(
               coproclog.error,
-              "Failed to deregister scripts for which had topics that didn't "
-              "already exist");
+              "Failed to immediately deregister some ids, wasm engine will "
+              "have some scripts which will never recieve data");
+            co_return rpc::make_error_code(rpc::errc::disconnected_endpoint);
         }
     }
+    co_return rpc::make_error_code(rpc::errc::success);
 }
 
 ss::future<std::vector<coproc::errc>>
@@ -238,18 +240,16 @@ script_dispatcher::remove_sources(script_id id) {
     return _pacemaker.map([id](pacemaker& p) { return p.remove_source(id); });
 }
 
-ss::future<>
+ss::future<std::error_code>
 script_dispatcher::disable_coprocessors(disable_copros_request req) {
     auto client = co_await get_client();
     if (!client) {
-        co_return;
+        co_return rpc::make_error_code(rpc::errc::disconnected_endpoint);
     }
     auto reply = co_await client->disable_coprocessors(
       std::move(req), rpc::client_opts(model::no_timeout));
     if (!reply) {
-        vlog(
-          coproclog.error, "Could not complete disable_coprocessors request");
-        co_return;
+        co_return reply.error();
     }
     for (const auto& [id, code] : reply.value().data.acks) {
         if (code != disable_response_code::success) {
@@ -271,6 +271,7 @@ script_dispatcher::disable_coprocessors(disable_copros_request req) {
             vlog(coproclog.info, "Successfully deregistered script: {}", id);
         }
     }
+    co_return rpc::make_error_code(rpc::errc::success);
 }
 
 ss::future<> script_dispatcher::remove_all_sources() {
@@ -278,7 +279,7 @@ ss::future<> script_dispatcher::remove_all_sources() {
       .discard_result();
 }
 
-ss::future<> script_dispatcher::disable_all_coprocessors() {
+ss::future<std::error_code> script_dispatcher::disable_all_coprocessors() {
     struct error_cnt {
         size_t n_success{0};
         size_t n_internal_error{0};
@@ -286,15 +287,12 @@ ss::future<> script_dispatcher::disable_all_coprocessors() {
     };
     auto client = co_await get_client();
     if (!client) {
-        co_return;
+        co_return rpc::make_error_code(rpc::errc::disconnected_endpoint);
     }
     auto reply = co_await client->disable_all_coprocessors(
       empty_request(), rpc::client_opts(model::no_timeout));
     if (!reply) {
-        vlog(
-          coproclog.error,
-          "Could not complete disable_all_coprocessors request");
-        co_return;
+        co_return reply.error();
     }
     error_cnt cnt = std::accumulate(
       reply.value().data.acks.cbegin(),
@@ -319,6 +317,7 @@ ss::future<> script_dispatcher::disable_all_coprocessors() {
       cnt.n_internal_error,
       cnt.n_script_dnes);
     co_await remove_all_sources();
+    co_return rpc::make_error_code(rpc::errc::success);
 }
 
 ss::future<bool> script_dispatcher::heartbeat() {

--- a/src/v/coproc/script_dispatcher.cc
+++ b/src/v/coproc/script_dispatcher.cc
@@ -273,6 +273,11 @@ script_dispatcher::disable_coprocessors(disable_copros_request req) {
     }
 }
 
+ss::future<> script_dispatcher::remove_all_sources() {
+    return _pacemaker.map([](pacemaker& p) { return p.remove_all_sources(); })
+      .discard_result();
+}
+
 ss::future<> script_dispatcher::disable_all_coprocessors() {
     struct error_cnt {
         size_t n_success{0};
@@ -313,6 +318,7 @@ ss::future<> script_dispatcher::disable_all_coprocessors() {
       cnt.n_success,
       cnt.n_internal_error,
       cnt.n_script_dnes);
+    co_await remove_all_sources();
 }
 
 ss::future<std::optional<coproc::supervisor_client_protocol>>

--- a/src/v/coproc/script_dispatcher.h
+++ b/src/v/coproc/script_dispatcher.h
@@ -46,6 +46,9 @@ public:
     /// state from the wasm engine.
     ss::future<> disable_all_coprocessors();
 
+    /// Invoke this to query weather the wasm engine is up or not
+    ss::future<bool> heartbeat();
+
 private:
     /// The following methods are introduced to sidestep an issue detected when
     /// using .map/invoke_on_all within the context of a coroutine

--- a/src/v/coproc/script_dispatcher.h
+++ b/src/v/coproc/script_dispatcher.h
@@ -33,18 +33,18 @@ public:
     /// The wasm engine will be sent the list of coprocessors to enable
     /// Upon retrival of each successful ack, the script will be registered with
     /// the pacemaker.
-    ss::future<> enable_coprocessors(enable_copros_request);
+    ss::future<std::error_code> enable_coprocessors(enable_copros_request);
 
     /// Called when removal commands arrive on the coproc_internal_topic
     ///
     /// The wasm engine will be send the list of coprocessor ids to remove from
     /// its internal map. Upon retrival of each successful ack, the script will
     /// be deregistered from the pacemaker.
-    ss::future<> disable_coprocessors(disable_copros_request);
+    ss::future<std::error_code> disable_coprocessors(disable_copros_request);
 
     /// Invoke this after fatal error has occurred and its desired to clear all
     /// state from the wasm engine.
-    ss::future<> disable_all_coprocessors();
+    ss::future<std::error_code> disable_all_coprocessors();
 
     /// Invoke this to query weather the wasm engine is up or not
     ss::future<bool> heartbeat();

--- a/src/v/coproc/script_dispatcher.h
+++ b/src/v/coproc/script_dispatcher.h
@@ -52,6 +52,7 @@ private:
     ss::future<std::vector<std::vector<coproc::errc>>>
       add_sources(script_id, std::vector<topic_namespace_policy>);
     ss::future<std::vector<coproc::errc>> remove_sources(script_id);
+    ss::future<> remove_all_sources();
 
     /// Return std::nullopt only when the abort source is triggered,
     /// otherwise will forever loop attempting to re-connect to the wasm

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ rp_test(
   BINARY_NAME coproc_fixture
   SOURCES
     ${fixture_srcs}
+    failure_recovery_tests.cc
     router_test.cc
     offset_storage_utils_tests.cc
     wasm_event_tests.cc

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(fixture_srcs
     utils/event_publisher.cc
     utils/supervisor.cc
+    utils/coproc_slim_fixture.cc
     utils/coproc_test_fixture.cc
     utils/router_test_fixture.cc
     utils/wasm_event_generator.cc

--- a/src/v/coproc/tests/failure_recovery_tests.cc
+++ b/src/v/coproc/tests/failure_recovery_tests.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/tests/utils/coproc_test_fixture.h"
+#include "coproc/tests/utils/coprocessor.h"
+#include "coproc/tests/utils/router_test_fixture.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "storage/tests/utils/random_batch.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/core/when_all.hh>
+
+FIXTURE_TEST(test_wasm_engine_restart, router_test_fixture) {
+    model::topic single_input("plain_topic");
+    setup({{single_input, 5}}).get();
+    enable_coprocessors(
+      {{.id = 599872,
+        .data{
+          .tid = coproc::registry::type_identifier::identity_coprocessor,
+          .topics = {single_input}}}})
+      .get();
+    std::vector<model::ntp> inputs;
+    std::vector<model::ntp> outputs;
+    for (auto i = 0; i < 5; ++i) {
+        inputs.emplace_back(
+          model::kafka_namespace, single_input, model::partition_id(i));
+        outputs.emplace_back(
+          model::kafka_namespace,
+          model::to_materialized_topic(
+            single_input, identity_coprocessor::identity_topic),
+          model::partition_id(i));
+    }
+
+    auto push_inputs =
+      [this](const std::vector<model::ntp>& ntps) -> ss::future<> {
+        std::vector<ss::future<model::offset>> fs;
+        for (const auto& ntp : ntps) {
+            fs.emplace_back(push(
+              ntp,
+              storage::test::make_random_memory_record_batch_reader(
+                model::offset(0), 10, 2)));
+        }
+        return ss::when_all_succeed(fs.begin(), fs.end()).discard_result();
+    };
+    /// Push some data...
+    push_inputs(inputs).get();
+
+    /// Cause an implied crash, redpanda should begin its recovery phase
+    set_delay_heartbeat(true).get();
+    ss::sleep(2s).get();
+    set_delay_heartbeat(false).get();
+
+    /// Push some more data...
+    push_inputs(inputs).get();
+
+    /// Ensure at-least 10 * 2 * N-Ntps batches were read. Why at least? Because
+    /// due to the offset commit interval within coproc, coprocessor scripts
+    /// themselves have an at-least-once durability guarantee, so it would be
+    /// more likely that a script processed a duplicate record. The wider the
+    /// commit interval, the more likely this is.
+    std::vector<ss::future<coproc_test_fixture::opt_reader_data_t>> fs;
+    for (const auto& ntp : outputs) {
+        fs.emplace_back(drain(ntp, 20));
+    }
+    auto data = ss::when_all_succeed(fs.begin(), fs.end()).get0();
+    BOOST_CHECK(!data.empty() && data[0]);
+}

--- a/src/v/coproc/tests/script_dispatcher_tests.cc
+++ b/src/v/coproc/tests/script_dispatcher_tests.cc
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/tests/utils/coproc_slim_fixture.h"
+#include "coproc/tests/utils/supervisor_test_fixture.h"
+#include "coproc/types.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <algorithm>
+
+class script_dispatcher_fixture
+  : public coproc_slim_fixture
+  , public supervisor_test_fixture {
+public:
+    ss::future<> enable_scripts(
+      std::vector<std::tuple<uint64_t, std::vector<model::topic>>> data) {
+        std::vector<coproc::enable_copros_request::data> d;
+        std::transform(
+          data.begin(), data.end(), std::back_inserter(d), [](const auto& dp) {
+              /// Generate a random coprocessor payload
+              coproc::wasm::cpp_enable_payload payload{
+                .tid = coproc::registry::type_identifier::identity_coprocessor,
+                .topics = std::get<1>(dp)};
+              return coproc::enable_copros_request::data{
+                .id = coproc::script_id(std::get<0>(dp)),
+                .source_code = reflection::to_iobuf(std::move(payload))};
+          });
+        return get_script_dispatcher()->enable_coprocessors(
+          coproc::enable_copros_request{.inputs = std::move(d)});
+    }
+
+    ss::future<> disable_scripts(std::vector<coproc::script_id> ids) {
+        return get_script_dispatcher()->disable_coprocessors(
+          coproc::disable_copros_request{.ids = std::move(ids)});
+    }
+
+    ss::future<size_t> scripts_across_shards(coproc::script_id id) {
+        return get_pacemaker().map_reduce0(
+          [id](coproc::pacemaker& p) {
+              return p.local_script_id_exists(id) ? 1 : 0;
+          },
+          size_t(0),
+          std::plus<>());
+    }
+};
+
+FIXTURE_TEST(test_register, script_dispatcher_fixture) {
+    model::topic foo("foo");
+    model::topic bar("bar");
+    setup({{foo, 3}, {bar, 2}}).get();
+    coproc::script_id foo_subber(8753);
+    coproc::script_id bar_subber(32);
+    coproc::script_id all_subbed(623);
+    enable_scripts(
+      {{foo_subber, {foo}}, {bar_subber, {bar}}, {all_subbed, {foo, bar}}})
+      .get();
+    auto foos = shards_for_topic(foo).get();
+    auto bars = shards_for_topic(bar).get();
+    BOOST_CHECK_EQUAL(scripts_across_shards(foo_subber).get(), foos.size());
+    BOOST_CHECK_EQUAL(scripts_across_shards(bar_subber).get(), bars.size());
+    /// A script that subscribes to multiple topics which may share shards
+    /// cannot just assume the solution is the sum of shards_for_topic over each
+    /// topic, since topics may reside on the same shard (common case). The
+    /// solution is the union of unique shards
+    std::set<ss::shard_id> unique;
+    std::set_union(
+      foos.begin(),
+      foos.end(),
+      bars.begin(),
+      bars.end(),
+      std::inserter(unique, unique.begin()));
+    BOOST_CHECK_EQUAL(scripts_across_shards(all_subbed).get(), unique.size());
+}
+
+FIXTURE_TEST(test_deregister, script_dispatcher_fixture) {
+    model::topic foo("foo");
+    model::topic bar("bar");
+    model::topic baz("baz");
+    model::topic boom("boom");
+    setup({{foo, 10}, {bar, 4}, {baz, 5}, {boom, 10}}).get();
+    coproc::script_id a(1);
+    coproc::script_id b(2);
+    coproc::script_id c(3);
+    coproc::script_id d(4);
+    enable_scripts(
+      {{a, {foo, bar}}, {b, {bar}}, {c, {foo, bar, baz}}, {d, {foo, boom}}})
+      .get();
+    disable_scripts({b, d}).get();
+    BOOST_CHECK_EQUAL(scripts_across_shards(b).get(), 0);
+    BOOST_CHECK_EQUAL(scripts_across_shards(d).get(), 0);
+    get_script_dispatcher()->disable_all_coprocessors().get();
+    BOOST_CHECK_EQUAL(scripts_across_shards(a).get(), 0);
+    BOOST_CHECK_EQUAL(scripts_across_shards(b).get(), 0);
+    BOOST_CHECK_EQUAL(scripts_across_shards(c).get(), 0);
+    BOOST_CHECK_EQUAL(scripts_across_shards(d).get(), 0);
+}
+
+/// A sanity check to ensure the unit test frameworks delayed heartbeat
+/// mechanism is working as expected
+FIXTURE_TEST(test_heartbeat, script_dispatcher_fixture) {
+    setup({}).get();
+    auto& dispatcher = get_script_dispatcher();
+    BOOST_CHECK(dispatcher->heartbeat().get());
+    set_delay_heartbeat(true).get();
+    BOOST_CHECK(!dispatcher->heartbeat().get());
+}

--- a/src/v/coproc/tests/utils/coproc_slim_fixture.cc
+++ b/src/v/coproc/tests/utils/coproc_slim_fixture.cc
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/tests/utils/coproc_slim_fixture.h"
+
+#include "coproc/types.h"
+#include "model/namespace.h"
+#include "storage/kvstore.h"
+#include "storage/ntp_config.h"
+#include "storage/types.h"
+
+coproc_slim_fixture::coproc_slim_fixture() {
+    std::filesystem::create_directory(_data_dir);
+}
+
+coproc_slim_fixture::~coproc_slim_fixture() {
+    stop().get();
+    std::filesystem::remove_all(_data_dir);
+}
+
+ss::future<> coproc_slim_fixture::setup(log_layout_map llm) {
+    return start().then([this, llm = std::move(llm)]() mutable {
+        return ss::do_with(std::move(llm), [this](const auto& llm) {
+            return ss::do_for_each(llm, [this](const auto& item) {
+                return add_ntps(item.first, item.second);
+            });
+        });
+    });
+}
+
+ss::future<std::set<ss::shard_id>>
+coproc_slim_fixture::shards_for_topic(const model::topic& t) {
+    model::topic_namespace tn(model::kafka_namespace, t);
+    return _storage.map_reduce0(
+      [tn](storage::api& api) -> std::optional<ss::shard_id> {
+          return api.log_mgr().get(tn).empty()
+                   ? std::nullopt
+                   : std::optional<ss::shard_id>(ss::this_shard_id());
+      },
+      std::set<ss::shard_id>(),
+      [](std::set<ss::shard_id> acc, std::optional<ss::shard_id> opt) {
+          if (opt) {
+              acc.insert(*opt);
+          }
+          return acc;
+      });
+}
+
+ss::future<> coproc_slim_fixture::start() {
+    return _storage.start(kvstore_config(), log_config())
+      .then([this] { return _storage.invoke_on_all(&storage::api::start); })
+      .then([this] {
+          return _pacemaker.start(
+            ss::socket_address(ss::net::inet_address("127.0.0.1"), 43189),
+            std::ref(_storage));
+      })
+      .then(
+        [this] { return _pacemaker.invoke_on_all(&coproc::pacemaker::start); })
+      .then([this] {
+          _script_dispatcher
+            = std::make_unique<coproc::wasm::script_dispatcher>(
+              _pacemaker, _abort_src);
+      });
+}
+
+ss::future<> coproc_slim_fixture::stop() {
+    _abort_src.request_abort();
+    { auto sd = std::move(_script_dispatcher); }
+    return _pacemaker.stop().then([this] { return _storage.stop(); });
+}
+
+ss::future<>
+coproc_slim_fixture::add_ntps(const model::topic& topic, size_t n) {
+    auto r = boost::irange<size_t>(0, n);
+    return ss::do_for_each(r, [this, topic](size_t i) {
+        model::ntp ntp(model::kafka_namespace, topic, model::partition_id(i));
+        auto shard_id = std::hash<model::ntp>{}(ntp) % ss::smp::count;
+        return _storage.invoke_on(
+          shard_id, [ntp, dir = _data_dir](storage::api& api) {
+              return api.log_mgr()
+                .manage(storage::ntp_config(ntp, dir.string()))
+                .discard_result();
+          });
+    });
+}
+
+storage::kvstore_config coproc_slim_fixture::kvstore_config() const {
+    return storage::kvstore_config(
+      16_MiB,
+      std::chrono::milliseconds(10),
+      _data_dir.string(),
+      storage::debug_sanitize_files::no);
+}
+
+storage::log_config coproc_slim_fixture::log_config() const {
+    return storage::log_config(
+      storage::log_config::storage_type::disk,
+      _data_dir.string(),
+      1_GiB,
+      storage::debug_sanitize_files::no);
+}

--- a/src/v/coproc/tests/utils/coproc_slim_fixture.h
+++ b/src/v/coproc/tests/utils/coproc_slim_fixture.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/pacemaker.h"
+#include "coproc/script_dispatcher.h"
+#include "coproc/tests/utils/coproc_test_fixture.h"
+#include "model/metadata.h"
+#include "storage/api.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/sharded.hh>
+
+#include <filesystem>
+#include <set>
+
+/// This fixture sets up the mininum viable framework neccessary to test the
+/// script_dispatcher without using the redpanda_thread_fixture as that starts
+/// an entire application stack.
+class coproc_slim_fixture {
+public:
+    /// Class constructor, sets up the data_dir
+    coproc_slim_fixture();
+
+    /// Disabling move & copy assignment
+    coproc_slim_fixture(const coproc_slim_fixture&) = delete;
+    coproc_slim_fixture(coproc_slim_fixture&&) = delete;
+    coproc_slim_fixture& operator=(const coproc_slim_fixture&) = delete;
+    coproc_slim_fixture& operator=(coproc_slim_fixture&&) = delete;
+
+    /// Class destructor, destroys resources in order, and rm's data_dir
+    ~coproc_slim_fixture();
+
+    /// Call to define the state-of-the-world
+    ///
+    /// This is the current ntps registered within the log manger. Since theres
+    /// no shard_table, a trivial hashing scheme is internally used to map ntps
+    /// to shards.
+    ss::future<> setup(log_layout_map);
+
+    /// Query what shards contain an ntp with the given topic
+    //
+    /// Useful for testing to know what stateful effect setup had. This can then
+    /// be compared or used for verification during the test.
+    ss::future<std::set<ss::shard_id>> shards_for_topic(const model::topic&);
+
+protected:
+    std::unique_ptr<coproc::wasm::script_dispatcher>& get_script_dispatcher() {
+        return _script_dispatcher;
+    }
+    ss::sharded<coproc::pacemaker>& get_pacemaker() { return _pacemaker; }
+
+private:
+    ss::future<> start();
+    ss::future<> stop();
+    ss::future<> add_ntps(const model::topic&, size_t);
+
+    storage::kvstore_config kvstore_config() const;
+    storage::log_config log_config() const;
+
+private:
+    std::filesystem::path _data_dir{
+      std::filesystem::current_path() / "coproc_test"};
+    ss::sharded<storage::api> _storage;
+    ss::sharded<coproc::pacemaker> _pacemaker;
+    ss::abort_source _abort_src;
+    std::unique_ptr<coproc::wasm::script_dispatcher> _script_dispatcher;
+};

--- a/src/v/coproc/tests/utils/supervisor.h
+++ b/src/v/coproc/tests/utils/supervisor.h
@@ -36,7 +36,10 @@ public:
     /// Reference to sharded state map is passed so unit tests can query it
     /// poking and proding the internal state of the service for validity
     supervisor(
-      ss::scheduling_group, ss::smp_service_group, ss::sharded<script_map_t>&);
+      ss::scheduling_group,
+      ss::smp_service_group,
+      ss::sharded<script_map_t>&,
+      ss::sharded<ss::lw_shared_ptr<bool>>&);
 
     /// Called when new coprocessor(s) are to be deployed
     ///
@@ -64,9 +67,7 @@ public:
 
     /// Called to verify the supervisor is up
     ss::future<empty_response>
-    heartbeat(empty_request&&, rpc::streaming_context&) final {
-        return ss::make_ready_future<empty_request>();
-    }
+    heartbeat(empty_request&&, rpc::streaming_context&) final;
 
 private:
     ss::future<disable_copros_reply::ack> disable_coprocessor(script_id);
@@ -87,5 +88,9 @@ private:
 private:
     /// Map of coprocessors organized by their global identifiers
     ss::sharded<script_map_t>& _coprocessors;
+
+    /// When set to true, send a return heartbeat > 2s to trigger failure
+    /// mechanism
+    ss::sharded<ss::lw_shared_ptr<bool>>& _delay_heartbeat;
 };
 } // namespace coproc

--- a/src/v/coproc/tests/utils/supervisor.h
+++ b/src/v/coproc/tests/utils/supervisor.h
@@ -62,6 +62,12 @@ public:
     ss::future<process_batch_reply>
     process_batch(process_batch_request&&, rpc::streaming_context&) final;
 
+    /// Called to verify the supervisor is up
+    ss::future<empty_response>
+    heartbeat(empty_request&&, rpc::streaming_context&) final {
+        return ss::make_ready_future<empty_request>();
+    }
+
 private:
     ss::future<disable_copros_reply::ack> disable_coprocessor(script_id);
     ss::future<enable_copros_reply::data> enable_coprocessor(script_id, iobuf);

--- a/src/v/coproc/types.h
+++ b/src/v/coproc/types.h
@@ -77,6 +77,7 @@ struct enable_copros_reply {
 
 /// Stub for what should be 0 parameter method, 'disable_all_coprocessors'
 using empty_request = named_type<int8_t, struct empty_req_tag>;
+using empty_response = named_type<int8_t, struct empty_resp_tag>;
 
 /// \brief deregistration request, remove all topics registered to a coprocessor
 /// with id 'script_id'.

--- a/tools/ts-generator/example/functions.ts
+++ b/tools/ts-generator/example/functions.ts
@@ -8,29 +8,29 @@
  * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
  */
 
-import {IOBuf} from "../../../src/js/modules/utilities/IOBuf";
+import { IOBuf } from "../../../src/js/modules/utilities/IOBuf";
 import {
-    Record,
-    RecordBatch,
-    RecordBatchHeader,
+  Record,
+  RecordBatch,
+  RecordBatchHeader,
 } from "../../../src/js/modules/domain/generatedRpc/generatedClasses";
-import {calculate} from "fast-crc32c";
+import { calculate } from "fast-crc32c";
 
 // receive int64 and return Uint64
 const encodeZigzag = (field: bigint): bigint => {
-    // Create Bigint with 64 bytes length and sign 63
-    const digits = BigInt.asUintN(64, BigInt(63));
-    // Create Bigint with 64 bytes length and sign 1
-    const lsb = BigInt.asUintN(64, BigInt(1));
-    return BigInt.asUintN(64, (field << lsb) ^ (field >> digits));
+  // Create Bigint with 64 bytes length and sign 63
+  const digits = BigInt.asUintN(64, BigInt(63));
+  // Create Bigint with 64 bytes length and sign 1
+  const lsb = BigInt.asUintN(64, BigInt(1));
+  return BigInt.asUintN(64, (field << lsb) ^ (field >> digits));
 };
 
 // receive Uint64 and return int64
 const decodeZigzag = (field: bigint): bigint => {
-    const lsb = BigInt.asIntN(64, BigInt(1));
-    return (
-        BigInt.asIntN(64, field >> lsb) ^ BigInt.asIntN(64, ~(field & lsb) + lsb)
-    );
+  const lsb = BigInt.asIntN(64, BigInt(1));
+  return (
+    BigInt.asIntN(64, field >> lsb) ^ BigInt.asIntN(64, ~(field & lsb) + lsb)
+  );
 };
 
 /** Serialization **/
@@ -43,251 +43,246 @@ type ToBytes<T> = (value: T, buffer: IOBuf) => number;
 export type Optional<T> = undefined | T;
 
 const writeInt8LE: WriteFn<number> = (field, buffer) => {
-    return buffer.appendInt8(field);
+  return buffer.appendInt8(field);
 };
 
 const writeInt16LE: WriteFn<number> = (field, buffer) => {
-    return buffer.appendInt16LE(field);
+  return buffer.appendInt16LE(field);
 };
 
 const writeInt32LE: WriteFn<number> = (field, buffer) => {
-    return buffer.appendInt32LE(field);
+  return buffer.appendInt32LE(field);
 };
 
 const writeInt64LE: WriteFn<bigint> = (field, buffer) => {
-    return buffer.appendBigInt64LE(field);
+  return buffer.appendBigInt64LE(field);
 };
 
 const writeUInt8LE: WriteFn<number> = (field, buffer) => {
-    return buffer.appendUInt8(field);
+  return buffer.appendUInt8(field);
 };
 
 const writeUInt16LE: WriteFn<number> = (field, buffer) => {
-    return buffer.appendUInt16LE(field);
+  return buffer.appendUInt16LE(field);
 };
 
 const writeUInt32LE: WriteFn<number> = (field, buffer) => {
-    return buffer.appendUInt32LE(field);
+  return buffer.appendUInt32LE(field);
 };
 
 const writeUInt64LE: WriteFn<bigint> = (field, buffer) => {
-    return buffer.appendBigUInt64LE(field);
+  return buffer.appendBigUInt64LE(field);
 };
 
 const writeVarint: WriteFn<bigint> = (field, buffer) => {
-    let value = encodeZigzag(field);
-    let writtenBytes = 0;
-    if (value < 0x80) {
-        return buffer.appendUInt8(Number(value));
-    }
+  let value = encodeZigzag(field);
+  let writtenBytes = 0;
+  if (value < 0x80) {
+    return buffer.appendUInt8(Number(value));
+  }
+  writtenBytes += buffer.appendUInt8(
+    Number((value & BigInt(255)) | BigInt(0x80))
+  );
+  value >>= BigInt(7);
+  if (value < 0x80) {
+    writtenBytes += buffer.appendUInt8(Number(value));
+  }
+  do {
     writtenBytes += buffer.appendUInt8(
-        Number((value & BigInt(255)) | BigInt(0x80))
+      Number((value & BigInt(255)) | BigInt(0x80))
     );
     value >>= BigInt(7);
-    if (value < 0x80) {
-        writtenBytes += buffer.appendUInt8(Number(value));
-    }
-    do {
-        writtenBytes += buffer.appendUInt8(
-            Number((value & BigInt(255)) | BigInt(0x80))
-        );
-        value >>= BigInt(7);
-    } while (value >= 0x80);
-    writtenBytes += buffer.appendUInt8(Number(value));
-    return writtenBytes;
+  } while (value >= 0x80);
+  writtenBytes += buffer.appendUInt8(Number(value));
+  return writtenBytes;
 };
 
 const writeVarintBuffer = (field: bigint, buffer: Buffer) => {
-    let value = encodeZigzag(field);
-    let writtenBytes = 0;
-    if (value < 0x80) {
-        buffer.writeUInt8(Number(value));
-        return 1;
-    }
-    buffer.writeUInt8(Number((value & BigInt(255)) | BigInt(0x80)));
-    writtenBytes = 1;
-    value >>= BigInt(7);
-    if (value < 0x80) {
-        buffer.writeUInt8(Number(value), writtenBytes);
-        writtenBytes += 1;
-        return writtenBytes;
-    }
-    do {
-        buffer.writeUInt8(
-            Number((value & BigInt(255)) | BigInt(0x80)),
-            writtenBytes
-        );
-        writtenBytes += 1;
-        value >>= BigInt(7);
-    } while (value >= 0x80);
+  let value = encodeZigzag(field);
+  let writtenBytes = 0;
+  if (value < 0x80) {
+    buffer.writeUInt8(Number(value));
+    return 1;
+  }
+  buffer.writeUInt8(Number((value & BigInt(255)) | BigInt(0x80)));
+  writtenBytes = 1;
+  value >>= BigInt(7);
+  if (value < 0x80) {
     buffer.writeUInt8(Number(value), writtenBytes);
     writtenBytes += 1;
     return writtenBytes;
+  }
+  do {
+    buffer.writeUInt8(
+      Number((value & BigInt(255)) | BigInt(0x80)),
+      writtenBytes
+    );
+    writtenBytes += 1;
+    value >>= BigInt(7);
+  } while (value >= 0x80);
+  buffer.writeUInt8(Number(value), writtenBytes);
+  writtenBytes += 1;
+  return writtenBytes;
 };
 
 const writeBoolean: WriteFn<boolean> = (field, buffer) => {
-    return buffer.appendInt8(field ? 1 : 0);
+  return buffer.appendInt8(field ? 1 : 0);
 };
 
 const writeString: WriteFn<string> = (field, buffer) => {
-    buffer.appendInt32LE(Buffer.byteLength(field));
-    const stringSize = buffer.appendString(field);
-    return 4 + stringSize;
+  buffer.appendInt32LE(Buffer.byteLength(field));
+  const stringSize = buffer.appendString(field);
+  return 4 + stringSize;
 };
 
 const writeBuffer: WriteFn<Buffer> = (field, buffer, offset) => {
-    buffer.appendInt32LE(Buffer.byteLength(field));
-    const bufferBuffer = buffer.appendBuffer(field);
-    return 4 + bufferBuffer;
+  buffer.appendInt32LE(Buffer.byteLength(field));
+  const bufferBuffer = buffer.appendBuffer(field);
+  return 4 + bufferBuffer;
 };
 
 /**
  * @param appendSize, define if writeArray puts an int32 (array size) in buffer
  */
 const writeArray = (appendSize?: boolean) => <T>(
-    fields: T[],
-    buffer: IOBuf,
-    fn: WriteFn<T>
+  fields: T[],
+  buffer: IOBuf,
+  fn: WriteFn<T>
 ): number => {
-    let writtenBytes = 0;
-    if (appendSize) {
-        buffer.appendInt32LE(fields.length);
-        writtenBytes += 4;
-    }
-    for (const item of fields) {
-        writtenBytes += fn(item, buffer);
-    }
-    return writtenBytes;
+  let writtenBytes = 0;
+  if (appendSize) {
+    buffer.appendInt32LE(fields.length);
+    writtenBytes += 4;
+  }
+  for (const item of fields) {
+    writtenBytes += fn(item, buffer);
+  }
+  return writtenBytes;
 };
 
-const writeOptional = <T>(
-    buffer: IOBuf,
-    item: Optional<T>,
-    fn: WriteFn<T>
-) => {
+const writeOptional = <T>(buffer: IOBuf, item: Optional<T>, fn: WriteFn<T>) => {
+  let writtenBytes = 1;
+  const noneValue = 0;
+  const someValue = 1;
 
-    let writtenBytes = 1;
-    const noneValue = 0;
-    const someValue = 1;
-
-    if (item == undefined) {
-        buffer.appendInt8(noneValue);
-        return writtenBytes;
-    } else {
-        buffer.appendInt8(someValue);
-        writtenBytes += fn(item, buffer);
-        return writtenBytes;
-    }
-}
+  if (item == undefined) {
+    buffer.appendInt8(noneValue);
+    return writtenBytes;
+  } else {
+    buffer.appendInt8(someValue);
+    writtenBytes += fn(item, buffer);
+    return writtenBytes;
+  }
+};
 
 const writeObject = <T>(
-    buffer: IOBuf,
-    type: { toBytes: ToBytes<T> },
-    object: T
+  buffer: IOBuf,
+  type: { toBytes: ToBytes<T> },
+  object: T
 ): number => {
-    return type.toBytes(object, buffer);
+  return type.toBytes(object, buffer);
 };
 
 /** Deserializer **/
 
 type FromBytes<T> = { fromBytes: (Buffer, number) => [T, number] };
 type ReadFunction<T> = (
-    buffer: Buffer,
-    offset: number,
-    obj?: FromBytes<T>,
-    type?: T
+  buffer: Buffer,
+  offset: number,
+  obj?: FromBytes<T>,
+  type?: T
 ) => [T, number];
 
 const readInt8LE: ReadFunction<number> = (buffer: Buffer, offset) => {
-    const value = buffer.readInt8(offset);
-    offset += 1;
-    return [value, offset];
+  const value = buffer.readInt8(offset);
+  offset += 1;
+  return [value, offset];
 };
 
 const readInt16LE: ReadFunction<number> = (buffer: Buffer, offset) => {
-    const value = buffer.readInt16LE(offset);
-    offset += 2;
-    return [value, offset];
+  const value = buffer.readInt16LE(offset);
+  offset += 2;
+  return [value, offset];
 };
 
 const readInt32LE: ReadFunction<number> = (buffer: Buffer, offset) => {
-    const value = buffer.readInt32LE(offset);
-    offset += 4;
-    return [value, offset];
+  const value = buffer.readInt32LE(offset);
+  offset += 4;
+  return [value, offset];
 };
 
 const readInt64LE: ReadFunction<bigint> = (buffer: Buffer, offset) => {
-    const value = buffer.readBigInt64LE(offset);
-    offset += 8;
-    return [BigInt(value), offset];
+  const value = buffer.readBigInt64LE(offset);
+  offset += 8;
+  return [BigInt(value), offset];
 };
 
 const readUInt8LE: ReadFunction<number> = (buffer: Buffer, offset) => {
-    const value = buffer.readUInt8(offset);
-    offset += 1;
-    return [value, offset];
+  const value = buffer.readUInt8(offset);
+  offset += 1;
+  return [value, offset];
 };
 
 const readUInt16LE: ReadFunction<number> = (buffer: Buffer, offset) => {
-    const value = buffer.readUInt16LE(offset);
-    offset += 2;
-    return [value, offset];
+  const value = buffer.readUInt16LE(offset);
+  offset += 2;
+  return [value, offset];
 };
 
 const readUInt32LE: ReadFunction<number> = (buffer: Buffer, offset) => {
-    const value = buffer.readUInt32LE(offset);
-    offset += 4;
-    return [value, offset];
+  const value = buffer.readUInt32LE(offset);
+  offset += 4;
+  return [value, offset];
 };
 
 const readUInt64LE: ReadFunction<bigint> = (buffer: Buffer, offset) => {
-    const value = buffer.readBigUInt64LE(offset);
-    offset += 8;
-    return [BigInt(value), offset];
+  const value = buffer.readBigUInt64LE(offset);
+  offset += 8;
+  return [BigInt(value), offset];
 };
 
 const readVarint: ReadFunction<bigint> = (buffer: Buffer, offset: number) => {
-    let result = BigInt.asUintN(64, BigInt(0));
-    let shift = 0;
-    let initialOffset = offset;
-    for (
-        let src = buffer.readInt8(initialOffset);
-        shift <= 63;
-        src = buffer.readInt8(initialOffset)
-    ) {
-        initialOffset += 1;
-        // check if byte read is (1000 0000) has the first bit in 1
-        if (src & 128) {
-            result |= BigInt.asUintN(64, BigInt(src & 127)) << BigInt(shift);
-        } else {
-            result |= BigInt.asUintN(7, BigInt(src & 127)) << BigInt(shift);
-            break;
-        }
-        shift += 7;
+  let result = BigInt.asUintN(64, BigInt(0));
+  let shift = 0;
+  let initialOffset = offset;
+  for (
+    let src = buffer.readInt8(initialOffset);
+    shift <= 63;
+    src = buffer.readInt8(initialOffset)
+  ) {
+    initialOffset += 1;
+    // check if byte read is (1000 0000) has the first bit in 1
+    if (src & 128) {
+      result |= BigInt.asUintN(64, BigInt(src & 127)) << BigInt(shift);
+    } else {
+      result |= BigInt.asUintN(7, BigInt(src & 127)) << BigInt(shift);
+      break;
     }
-    return [decodeZigzag(result), initialOffset];
+    shift += 7;
+  }
+  return [decodeZigzag(result), initialOffset];
 };
 
 const readBoolean: ReadFunction<boolean> = (buffer: Buffer, offset: number) => {
-    const value = buffer.readInt8(offset);
-    offset += 1;
-    return [Boolean(value), offset];
+  const value = buffer.readInt8(offset);
+  offset += 1;
+  return [Boolean(value), offset];
 };
 
 const readString: ReadFunction<string> = (buffer: Buffer, offset) => {
-    const size = buffer.readInt32LE(offset);
-    offset += 4;
-    const value = buffer.toString(undefined, offset, offset + size);
-    offset += size;
-    return [value, offset];
+  const size = buffer.readInt32LE(offset);
+  offset += 4;
+  const value = buffer.toString(undefined, offset, offset + size);
+  offset += size;
+  return [value, offset];
 };
 
 const readBuffer: ReadFunction<Buffer> = (buffer: Buffer, offset: number) => {
-    const size = buffer.readInt32LE(offset);
-    offset += 4;
-    const value = buffer.slice(offset, offset + size);
-    offset += size;
-    return [value, offset];
+  const size = buffer.readInt32LE(offset);
+  offset += 4;
+  const value = buffer.slice(offset, offset + size);
+  offset += size;
+  return [value, offset];
 };
 
 /**
@@ -295,164 +290,164 @@ const readBuffer: ReadFunction<Buffer> = (buffer: Buffer, offset: number) => {
  * otherwise, the array size is passed
  */
 const readArray = (readSize?: number) => <T>(
-    buffer: Buffer,
-    offset: number,
-    fn: ReadFunction<T>,
-    obj?: FromBytes<T>
+  buffer: Buffer,
+  offset: number,
+  fn: ReadFunction<T>,
+  obj?: FromBytes<T>
 ): [T[], number] => {
-    const array: T[] = [];
-    let arraySize = readSize;
-    if (arraySize === undefined) {
-        arraySize = buffer.readInt32LE(offset);
-        offset += 4;
-    }
-    for (let i = 0; i < arraySize; i++) {
-        const [value, newOffset] = fn(buffer, offset, obj);
-        offset = newOffset;
-        array.push(value);
-    }
-    return [array, offset];
+  const array: T[] = [];
+  let arraySize = readSize;
+  if (arraySize === undefined) {
+    arraySize = buffer.readInt32LE(offset);
+    offset += 4;
+  }
+  for (let i = 0; i < arraySize; i++) {
+    const [value, newOffset] = fn(buffer, offset, obj);
+    offset = newOffset;
+    array.push(value);
+  }
+  return [array, offset];
 };
 
 const readObject = <T>(
-    buffer: Buffer,
-    offset: number,
-    obj: FromBytes<T>
+  buffer: Buffer,
+  offset: number,
+  obj: FromBytes<T>
 ): [T, number] => {
-    return obj.fromBytes(buffer, offset);
+  return obj.fromBytes(buffer, offset);
 };
 
 const readOptional = <T>(
-    buffer: Buffer,
-    offset: number,
-    fn: ReadFunction<T>,
-    obj?: FromBytes<T>
+  buffer: Buffer,
+  offset: number,
+  fn: ReadFunction<T>,
+  obj?: FromBytes<T>
 ): [Optional<T>, number] => {
-    const isNull = buffer.readInt8(offset) === 0;
-    offset += 1;
-    if (isNull) {
-        return [undefined, offset]
-    } else {
-        return fn(buffer, offset, obj);
-    }
+  const isNull = buffer.readInt8(offset) === 0;
+  offset += 1;
+  if (isNull) {
+    return [undefined, offset];
+  } else {
+    return fn(buffer, offset, obj);
+  }
 };
 
 const extendRecords = (records: Record[], seed = 0): number => {
-    const auxBuffer = Buffer.alloc(8);
-    return records.reduce((prev, record) => {
-        let size;
-        size = writeVarintBuffer(BigInt(record.length), auxBuffer);
-        const lengthCrc = calculate(auxBuffer.slice(0, size), prev);
-        size = writeVarintBuffer(BigInt(record.attributes), auxBuffer);
-        const attrCrc = calculate(auxBuffer.slice(0, size), lengthCrc);
-        size = writeVarintBuffer(record.timestampDelta, auxBuffer);
-        const timesStampCrc = calculate(auxBuffer.slice(0, size), attrCrc);
-        size = writeVarintBuffer(BigInt(record.offsetDelta), auxBuffer);
-        const offsetDeltaCrc = calculate(auxBuffer.slice(0, size), timesStampCrc);
-        size = writeVarintBuffer(BigInt(record.keyLength), auxBuffer);
-        const keyLengthCrc = calculate(auxBuffer.slice(0, size), offsetDeltaCrc);
-        const keyCrc = calculate(record.key, keyLengthCrc);
-        size = writeVarintBuffer(BigInt(record.valueLen), auxBuffer);
-        const valueLengthCrc = calculate(auxBuffer.slice(0, size), keyCrc);
-        const valueCrc = calculate(record.value, valueLengthCrc);
-        size = writeVarintBuffer(BigInt(record.headers.length), auxBuffer);
-        const headerLengthCrc = calculate(auxBuffer.slice(0, size), valueCrc);
-        return record.headers.reduce<number>((crcHeader, header) => {
-            size = writeVarintBuffer(BigInt(header.headerKeyLength), auxBuffer);
-            const keyLengthCrc = calculate(auxBuffer.slice(0, size), crcHeader);
-            const keyCrc = calculate(header.headerKey, keyLengthCrc);
-            size = writeVarintBuffer(BigInt(header.headerValueLength), auxBuffer);
-            const valueLengthCrc = calculate(auxBuffer.slice(0, size), keyCrc);
-            return calculate(header.value, valueLengthCrc);
-        }, headerLengthCrc);
-    }, seed);
+  const auxBuffer = Buffer.alloc(8);
+  return records.reduce((prev, record) => {
+    let size;
+    size = writeVarintBuffer(BigInt(record.length), auxBuffer);
+    const lengthCrc = calculate(auxBuffer.slice(0, size), prev);
+    size = writeVarintBuffer(BigInt(record.attributes), auxBuffer);
+    const attrCrc = calculate(auxBuffer.slice(0, size), lengthCrc);
+    size = writeVarintBuffer(record.timestampDelta, auxBuffer);
+    const timesStampCrc = calculate(auxBuffer.slice(0, size), attrCrc);
+    size = writeVarintBuffer(BigInt(record.offsetDelta), auxBuffer);
+    const offsetDeltaCrc = calculate(auxBuffer.slice(0, size), timesStampCrc);
+    size = writeVarintBuffer(BigInt(record.keyLength), auxBuffer);
+    const keyLengthCrc = calculate(auxBuffer.slice(0, size), offsetDeltaCrc);
+    const keyCrc = calculate(record.key, keyLengthCrc);
+    size = writeVarintBuffer(BigInt(record.valueLen), auxBuffer);
+    const valueLengthCrc = calculate(auxBuffer.slice(0, size), keyCrc);
+    const valueCrc = calculate(record.value, valueLengthCrc);
+    size = writeVarintBuffer(BigInt(record.headers.length), auxBuffer);
+    const headerLengthCrc = calculate(auxBuffer.slice(0, size), valueCrc);
+    return record.headers.reduce<number>((crcHeader, header) => {
+      size = writeVarintBuffer(BigInt(header.headerKeyLength), auxBuffer);
+      const keyLengthCrc = calculate(auxBuffer.slice(0, size), crcHeader);
+      const keyCrc = calculate(header.headerKey, keyLengthCrc);
+      size = writeVarintBuffer(BigInt(header.headerValueLength), auxBuffer);
+      const valueLengthCrc = calculate(auxBuffer.slice(0, size), keyCrc);
+      return calculate(header.value, valueLengthCrc);
+    }, headerLengthCrc);
+  }, seed);
 };
 
 const recordBatchEncode = (value: RecordBatch, buffer: IOBuf): number => {
-    let wroteBytes = 0;
-    // write header some attribute on BE format
-    const bufferHeaderCrc = Buffer.allocUnsafe(40);
-    bufferHeaderCrc.writeInt16BE(value.header.attrs, 0);
-    bufferHeaderCrc.writeInt32BE(value.header.lastOffsetDelta, 2);
-    bufferHeaderCrc.writeBigInt64BE(value.header.firstTimestamp, 6);
-    bufferHeaderCrc.writeBigInt64BE(value.header.maxTimestamp, 14);
-    bufferHeaderCrc.writeBigInt64BE(value.header.producerId, 22);
-    bufferHeaderCrc.writeInt16BE(value.header.producerEpoch, 30);
-    bufferHeaderCrc.writeInt32BE(value.header.baseSequence, 32);
-    bufferHeaderCrc.writeInt32BE(value.header.recordCount, 36);
+  let wroteBytes = 0;
+  // write header some attribute on BE format
+  const bufferHeaderCrc = Buffer.allocUnsafe(40);
+  bufferHeaderCrc.writeInt16BE(value.header.attrs, 0);
+  bufferHeaderCrc.writeInt32BE(value.header.lastOffsetDelta, 2);
+  bufferHeaderCrc.writeBigInt64BE(value.header.firstTimestamp, 6);
+  bufferHeaderCrc.writeBigInt64BE(value.header.maxTimestamp, 14);
+  bufferHeaderCrc.writeBigInt64BE(value.header.producerId, 22);
+  bufferHeaderCrc.writeInt16BE(value.header.producerEpoch, 30);
+  bufferHeaderCrc.writeInt32BE(value.header.baseSequence, 32);
+  bufferHeaderCrc.writeInt32BE(value.header.recordCount, 36);
 
-    // reserve record batch header, term, isCompressed.
-    const reserver = buffer.getReserve(70);
-    // create auxiliary iobuf
+  // reserve record batch header, term, isCompressed.
+  const reserver = buffer.getReserve(70);
+  // create auxiliary iobuf
 
-    wroteBytes += writeObject(reserver, RecordBatchHeader, value.header);
-    wroteBytes += writeArray(false)(value.records, buffer, (item, auxBuffer) =>
-        writeObject(auxBuffer, Record, item)
-    );
-    // Get buffer instance from iobuf
-    const headerBuffer = reserver.getIterable().slice(70);
-    // Calculate header crc, it depends on records and, some header attributes
-    const crc = extendRecords(value.records, calculate(bufferHeaderCrc));
-    // 17 is the byte position for crc attribute on Record Batch Header
-    headerBuffer.writeUInt32LE(crc, 17);
-    /**
-     * for headerCrc we need to calculate:
-     * sizeBytes (4)
-     * baseOffset (12)
-     * recordBatchType (20)
-     * crc (21)
-     * attrs (25)
-     * lastOffsetDelta (27)
-     * firstTimestamp (31)
-     * maxTimestamp (39)
-     * producerId (47)
-     * producerEpoch (55)
-     * baseSequence (57)
-     * recordCount (61)
-     *
-     * 4 -> 61 is the range of the bytes on Buffer that we need for
-     * calculate headerCrc
-     */
-    const headerCrc = calculate(headerBuffer.slice(4, 61));
-    headerBuffer.writeUInt32LE(headerCrc, 0);
-    reserver.clean();
-    reserver.appendBuffer(headerBuffer);
+  wroteBytes += writeObject(reserver, RecordBatchHeader, value.header);
+  wroteBytes += writeArray(false)(value.records, buffer, (item, auxBuffer) =>
+    writeObject(auxBuffer, Record, item)
+  );
+  // Get buffer instance from iobuf
+  const headerBuffer = reserver.getIterable().slice(70);
+  // Calculate header crc, it depends on records and, some header attributes
+  const crc = extendRecords(value.records, calculate(bufferHeaderCrc));
+  // 17 is the byte position for crc attribute on Record Batch Header
+  headerBuffer.writeUInt32LE(crc, 17);
+  /**
+   * for headerCrc we need to calculate:
+   * sizeBytes (4)
+   * baseOffset (12)
+   * recordBatchType (20)
+   * crc (21)
+   * attrs (25)
+   * lastOffsetDelta (27)
+   * firstTimestamp (31)
+   * maxTimestamp (39)
+   * producerId (47)
+   * producerEpoch (55)
+   * baseSequence (57)
+   * recordCount (61)
+   *
+   * 4 -> 61 is the range of the bytes on Buffer that we need for
+   * calculate headerCrc
+   */
+  const headerCrc = calculate(headerBuffer.slice(4, 61));
+  headerBuffer.writeUInt32LE(headerCrc, 0);
+  reserver.clean();
+  reserver.appendBuffer(headerBuffer);
 
-    return wroteBytes;
+  return wroteBytes;
 };
 
 export default {
-    writeInt8LE,
-    writeInt16LE,
-    writeInt32LE,
-    writeInt64LE,
-    writeUInt8LE,
-    writeUInt16LE,
-    writeUInt32LE,
-    writeUInt64LE,
-    writeString,
-    writeBoolean,
-    writeArray,
-    writeObject,
-    writeVarint,
-    writeBuffer,
-    writeVarintBuffer,
-    writeOptional,
-    readInt8LE,
-    readInt16LE,
-    readInt32LE,
-    readInt64LE,
-    readUInt8LE,
-    readUInt16LE,
-    readUInt32LE,
-    readUInt64LE,
-    readString,
-    readBoolean,
-    readObject,
-    readVarint,
-    readArray,
-    readBuffer,
-    readOptional,
-    recordBatchEncode,
-    extendRecords,
+  writeInt8LE,
+  writeInt16LE,
+  writeInt32LE,
+  writeInt64LE,
+  writeUInt8LE,
+  writeUInt16LE,
+  writeUInt32LE,
+  writeUInt64LE,
+  writeString,
+  writeBoolean,
+  writeArray,
+  writeObject,
+  writeVarint,
+  writeBuffer,
+  writeVarintBuffer,
+  writeOptional,
+  readInt8LE,
+  readInt16LE,
+  readInt32LE,
+  readInt64LE,
+  readUInt8LE,
+  readUInt16LE,
+  readUInt32LE,
+  readUInt64LE,
+  readString,
+  readBoolean,
+  readObject,
+  readVarint,
+  readArray,
+  readBuffer,
+  readOptional,
+  recordBatchEncode,
+  extendRecords,
 };

--- a/tools/ts-generator/example/test.ts
+++ b/tools/ts-generator/example/test.ts
@@ -1,5 +1,5 @@
-import {IOBuf} from "../../../src/js/modules/utilities/IOBuf";
-import {Class1, Class2, Class3} from "./generated";
+import { IOBuf } from "../../../src/js/modules/utilities/IOBuf";
+import { Class1, Class2, Class3 } from "./generated";
 import * as assert from "assert";
 
 const classSigned: Class2 = {
@@ -28,18 +28,20 @@ const class1: Class1 = {
 };
 
 type GeneratorTest = {
-  test: string,
-  assertFn: (ws: number, classResult: Class1, rs: number) => void
-}
-const tests: GeneratorTest[] = [{
-  test: "the write result size should same to read result size",
-  assertFn: (ws, classResult, rs) => {
-    assert.strictEqual(ws, rs);
-  }
-}]
+  test: string;
+  assertFn: (ws: number, classResult: Class1, rs: number) => void;
+};
+const tests: GeneratorTest[] = [
+  {
+    test: "the write result size should same to read result size",
+    assertFn: (ws, classResult, rs) => {
+      assert.strictEqual(ws, rs);
+    },
+  },
+];
 
 describe("Generator Code", () => {
-  tests.forEach(({test, assertFn}) => {
+  tests.forEach(({ test, assertFn }) => {
     const preTest = (): [number, Class1, number] => {
       // Create buffer where the binary data is going to be save
       const io = new IOBuf();
@@ -48,10 +50,10 @@ describe("Generator Code", () => {
       // Read data from the buffer
       const bufferResult = io.getIterable().slice(writtenByteSize);
       const result = Class1.fromBytes(bufferResult);
-      return [writtenByteSize, ...result]
-    }
+      return [writtenByteSize, ...result];
+    };
     it(test, function () {
-      assertFn(...preTest())
+      assertFn(...preTest());
     });
-  })
-})
+  });
+});

--- a/tools/ts-generator/readme.md
+++ b/tools/ts-generator/readme.md
@@ -1,9 +1,11 @@
-#Rpc typescript generator code
-`rpcgen_js.py` is typescript code generator, it receives a file with classes 
-definition, in order to create a serializable classes with Redpanda binary data
-format. those classes are save in file, 
+# Typescript v/RPC code generator
 
-##Class definition
+`rpcgen_js.py` is typescript code generator. It takes as input, a structured json
+file with a class per entry, in order to create the typescript classes (containing
+the correct custom serializers and deserializers) for use with Redpanda's binary
+data format.
+
+## Class definition
 ```json
 {
   "classes": [
@@ -20,7 +22,7 @@ format. those classes are save in file,
 }
 ```
 
-##Types Support
+## Types Supported
 * int8
 * int16
 * int32
@@ -32,9 +34,10 @@ format. those classes are save in file,
 * Array\<**T**>
 * boolean
 * Buffer
-* Classes definitions, example `ClassExample`
+* Any custom class
 
-##How can run generator?
+## How can I run the generator?
+
 ```commandline
 python rpcgen_js.py --entities-define-file path_definition_class 
                     --out-file path_destination

--- a/tools/ts-generator/types/functions.ts
+++ b/tools/ts-generator/types/functions.ts
@@ -40,7 +40,7 @@ const decodeZigzag = (field: bigint): bigint => {
  */
 type WriteFn<T> = (field: T, buffer: IOBuf, object?) => number;
 type ToBytes<T> = (value: T, buffer: IOBuf) => number;
-export type Optional<T> = undefined | T ;
+export type Optional<T> = undefined | T;
 
 const writeInt8LE: WriteFn<number> = (field, buffer) => {
   return buffer.appendInt8(field);
@@ -160,12 +160,7 @@ const writeArray = (appendSize?: boolean) => <T>(
   return writtenBytes;
 };
 
-const writeOptional = <T>(
-    buffer: IOBuf,
-    item: Optional<T>,
-    fn: WriteFn<T>
-) => {
-
+const writeOptional = <T>(buffer: IOBuf, item: Optional<T>, fn: WriteFn<T>) => {
   let writtenBytes = 1;
   const noneValue = 0;
   const someValue = 1;
@@ -178,7 +173,7 @@ const writeOptional = <T>(
     writtenBytes += fn(item, buffer);
     return writtenBytes;
   }
-}
+};
 
 const writeObject = <T>(
   buffer: IOBuf,
@@ -323,15 +318,15 @@ const readObject = <T>(
 };
 
 const readOptional = <T>(
-    buffer: Buffer,
-    offset: number,
-    fn: ReadFunction<T>,
-    obj?: FromBytes<T>
+  buffer: Buffer,
+  offset: number,
+  fn: ReadFunction<T>,
+  obj?: FromBytes<T>
 ): [Optional<T>, number] => {
   const isNull = buffer.readInt8(offset) === 0;
   offset += 1;
   if (isNull) {
-    return [undefined, offset]
+    return [undefined, offset];
   } else {
     return fn(buffer, offset, obj);
   }

--- a/tools/ts-generator/types/test.ts
+++ b/tools/ts-generator/types/test.ts
@@ -222,23 +222,29 @@ describe("Buffer functions test", function () {
     }
   );
 
-  it('should write and read an Optional on buffer', function () {
-      const io = new IOBuf();
-      const string = "valid string"
-      const writtenBytes = BF.writeOptional(io, string, (item, auxBuffer) => BF.writeString(item, auxBuffer));
-      const writtenBytesUndefined = BF.writeOptional(io, undefined, (item, auxBuffer) => BF.writeString(item, auxBuffer));
-      const ioIterable = io.getIterable();
-      const [optionalResult,] = BF.readOptional(
-          ioIterable.slice(writtenBytes),
-          0,
-          (auxBuffer, auxOffset ) => BF.readString(auxBuffer, auxOffset)
-      );
-      const [optionalResultUndefined,] = BF.readOptional(
-          ioIterable.slice(writtenBytesUndefined),
-          0,
-          (auxBuffer, auxOffset) => BF.readString(auxBuffer, auxOffset)
-      );
-      asserts.deepStrictEqual(string, optionalResult);
-      asserts.strictEqual(undefined, optionalResultUndefined);
+  it("should write and read an Optional on buffer", function () {
+    const io = new IOBuf();
+    const string = "valid string";
+    const writtenBytes = BF.writeOptional(io, string, (item, auxBuffer) =>
+      BF.writeString(item, auxBuffer)
+    );
+    const writtenBytesUndefined = BF.writeOptional(
+      io,
+      undefined,
+      (item, auxBuffer) => BF.writeString(item, auxBuffer)
+    );
+    const ioIterable = io.getIterable();
+    const [optionalResult] = BF.readOptional(
+      ioIterable.slice(writtenBytes),
+      0,
+      (auxBuffer, auxOffset) => BF.readString(auxBuffer, auxOffset)
+    );
+    const [optionalResultUndefined] = BF.readOptional(
+      ioIterable.slice(writtenBytesUndefined),
+      0,
+      (auxBuffer, auxOffset) => BF.readString(auxBuffer, auxOffset)
+    );
+    asserts.deepStrictEqual(string, optionalResult);
+    asserts.strictEqual(undefined, optionalResultUndefined);
   });
 });


### PR DESCRIPTION
This change introduces the correct failure recovery mechanisms for the coprocessor implementation to be fault tolerant. In summary there are two small changes.

1. On startup of redpanda we call wasm engines `disable_all_coprocessors` RPC endpoint, before reading from the internal coprocessor topic. This ensures that if redpanda crashed and restarted, that there would be no inconsistencies between the state within the wasm engine, and what scrips are actually registered within redpanda (there will be none at startup).
2. A new heartbeat mechanism. If the wasm engine fails to respond within the heartbeat timeout redpanda will wait for it to restart, and then begin a restart procedure. This involves the same steps as above, (clearing all state, reconciling scripts from offset 0), however redpanda must also shutdown all active script fibers, which is akin to clearing its in-memory knowledge of all scripts. 

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
