### PR TITLE
operator: Fix the multi Redpanda node setup

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -95,16 +95,6 @@ func main() {
 	// to form raft group 0
 	if hostIndex == 0 {
 		cfg.Redpanda.SeedServers = []config.SeedServer{}
-	} else {
-		cfg.Redpanda.SeedServers = []config.SeedServer{
-			{
-				Host: config.SocketAddress{
-					// Example address: cluster-sample-0.cluster-sample.default.svc.cluster.local
-					Address: c.hostName + c.svcFQDN,
-					Port:    c.redpandaRPCPort,
-				},
-			},
-		}
 	}
 
 	cfgBytes, err := yaml.Marshal(cfg)

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -80,7 +80,7 @@ func (r *ClusterReconciler) Reconcile(
 	toApply := []resources.Resource{
 		svc,
 		resources.NewNodePortService(r.Client, &redpandaCluster, r.Scheme, log),
-		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme, log),
+		resources.NewConfigMap(r.Client, &redpandaCluster, r.Scheme, svc.HeadlessServiceFQDN(), log),
 		issuer,
 		cert,
 		sts,


### PR DESCRIPTION
Init container wrongly set up seed servers configuration. The first
container has empty seed server, but each subsequent one point to
itself. This change brings back the code removed when init container
was introduced.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
