### PR TITLE
operator: Extract ensure duplicated lines to dedicated func

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -11,7 +11,6 @@ package resources
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
@@ -19,7 +18,6 @@ import (
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -58,25 +56,7 @@ func NewConfigMap(
 
 // Ensure will manage kubernetes v1.ConfigMap for redpanda.vectorized.io CR
 func (r *ConfigMapResource) Ensure(ctx context.Context) error {
-	var cfgm corev1.ConfigMap
-
-	err := r.Get(ctx, r.Key(), &cfgm)
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
-	if errors.IsNotFound(err) {
-		r.logger.Info(fmt.Sprintf("ConfigMap %s does not exist, going to create one", r.Key().Name))
-
-		obj, err := r.Obj()
-		if err != nil {
-			return err
-		}
-
-		return r.Create(ctx, obj)
-	}
-
-	return nil
+	return getOrCreate(ctx, r, &corev1.ConfigMap{}, "ConfigMap", r.logger)
 }
 
 // Obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/headless_service.go
+++ b/src/go/k8s/pkg/resources/headless_service.go
@@ -17,7 +17,6 @@ import (
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -58,27 +57,7 @@ func NewHeadlessService(
 
 // Ensure will manage kubernetes v1.Service for redpanda.vectorized.io custom resource
 func (r *HeadlessServiceResource) Ensure(ctx context.Context) error {
-	var svc corev1.Service
-
-	err := r.Get(ctx, r.Key(), &svc)
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("error while fetching service resource: %w", err)
-	}
-
-	if errors.IsNotFound(err) {
-		r.logger.Info(fmt.Sprintf("Service %s does not exist, going to create one", r.Key().Name))
-
-		obj, err := r.Obj()
-		if err != nil {
-			return fmt.Errorf("unable to construct service object: %w", err)
-		}
-
-		if err := r.Create(ctx, obj); err != nil {
-			return fmt.Errorf("unable to create service resource: %w", err)
-		}
-	}
-
-	return nil
+	return getOrCreate(ctx, r, &corev1.Service{}, "Service Headless", r.logger)
 }
 
 // Obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -12,13 +12,11 @@ package resources
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -55,29 +53,7 @@ func NewNodePortService(
 
 // Ensure will manage kubernetes v1.Service for redpanda.vectorized.io custom resource
 func (r *NodePortServiceResource) Ensure(ctx context.Context) error {
-	var svc corev1.Service
-
-	err := r.Get(ctx, r.Key(), &svc)
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("error while fetching service resource: %w", err)
-	}
-
-	if errors.IsNotFound(err) {
-		r.logger.Info(fmt.Sprintf("Service %s does not exist, going to create one", r.Key().Name))
-
-		obj, err := r.Obj()
-		if err != nil {
-			return fmt.Errorf("unable to construct service object: %w", err)
-		}
-
-		if err := r.Create(ctx, obj); err != nil {
-			return fmt.Errorf("unable to create service resource: %w", err)
-		}
-
-		return nil
-	}
-
-	return nil
+	return getOrCreate(ctx, r, &corev1.Service{}, "Service NodePort", r.logger)
 }
 
 // Obj returns resource managed client.Object


### PR DESCRIPTION
The currently duplicatected linter does not complain about duplicated
lines between 3 resources. However during the external connectivity
development the get or create snippet of code is duplicated across
7 resources. This version is simplified due to a fact that updates
aren't handled in configmap, headless service or node port service.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
