### PR TITLE
rpk: add `cluster offsets` tool for consumer lag reporting

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -10,6 +10,7 @@
 package cmd
 
 import (
+	"github.com/Shopify/sarama"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/cluster"
@@ -64,7 +65,14 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&brokers,
 	)
 	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure)
-
 	command.AddCommand(cluster.NewInfoCommand(adminClosure))
+
+	// NewOffsetsCommand takes client and admin factories so we can mock both
+	clientClosure := common.CreateClient(fs, brokersClosure, configClosure)
+	adminWrapperClosure := func(client sarama.Client) (sarama.ClusterAdmin, error) {
+		return sarama.NewClusterAdminFromClient(client)
+	}
+	command.AddCommand(cluster.NewOffsetsCommand(clientClosure, adminWrapperClosure))
+
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/cluster/offsets.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/offsets.go
@@ -1,0 +1,223 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+package cluster
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/Shopify/sarama"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/ui"
+)
+
+func NewOffsetsCommand(
+	client func() (sarama.Client, error),
+	admin func(sarama.Client) (sarama.ClusterAdmin, error),
+) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "offsets",
+		Short: "Report cluster offset status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := client()
+			if err != nil {
+				log.Error("Error initializing cluster client")
+				return err
+			}
+
+			admin, err := admin(client)
+			if err != nil {
+				return fmt.Errorf("Error creating admin client: %v", err)
+			}
+			defer admin.Close() // closes underlying client
+
+			return executeOffsetReport(client, admin)
+		},
+	}
+	return cmd
+}
+
+// ConsumerLagRow represents a (group, topic, partition) 3-tuple for reporting
+// consumer lag and will be tagged with the active consumer if one exists.
+type ConsumerLagRow struct {
+	Group           string
+	Topic           string
+	Partition       int32
+	LatestOffset    int64
+	CommittedOffset int64
+	MemberId        string
+}
+
+// executeOffsetReport calculates consumer lag for all consumer groups and
+// reports the summary in table format.
+func executeOffsetReport(
+	client sarama.Client, admin sarama.ClusterAdmin,
+) error {
+	// get all groups and their current members
+	groups, err := describeConsumerGroups(admin)
+	if err != nil {
+		return fmt.Errorf("Error retrieving group information: %v", err)
+	}
+
+	// collect consumer lag information for all groups/members
+	var lastError error
+	var consumers []ConsumerLagRow
+	for _, groupDesc := range groups {
+		c, err := getConsumerLag(client, admin, groupDesc)
+		if err != nil {
+			log.Warnf("Error querying consumers for group %s: %v",
+				groupDesc.GroupId, err)
+			lastError = err
+			continue
+		}
+		consumers = append(consumers, c...)
+	}
+	if len(consumers) == 0 && lastError != nil {
+		return fmt.Errorf("Error listing consumer groups: %v", err)
+	}
+
+	// group output by (group, topic, partition)
+	sort.Slice(consumers, func(i, j int) bool {
+		a := &consumers[i]
+		b := &consumers[j]
+		if a.Group != b.Group {
+			return a.Group < b.Group
+		}
+		if a.Topic != b.Topic {
+			return a.Topic < b.Topic
+		}
+		return a.Partition < b.Partition
+	})
+
+	t := ui.NewRpkTable(log.StandardLogger().Out)
+	t.SetColWidth(80)
+	t.SetAutoWrapText(false)
+
+	header := [...]string{"Group", "Topic", "Partition", "Lag", "Lag %",
+		"Committed", "Latest", "Consumer"}
+	t.SetHeader(header[:])
+
+	for _, consumer := range consumers {
+		consumerId := "-"
+		if consumer.MemberId != "" {
+			consumerId = consumer.MemberId
+		}
+		lag := consumer.LatestOffset - consumer.CommittedOffset
+		lagPct := 1.0 - (float64(consumer.CommittedOffset)+1)/
+			(float64(consumer.LatestOffset)+1)
+		if lagPct < 0 {
+			lagPct = 0
+		} else if lagPct > 1 {
+			lagPct = 1
+		}
+		row := [...]string{
+			consumer.Group,
+			consumer.Topic,
+			fmt.Sprintf("%d", consumer.Partition),
+			fmt.Sprintf("%d", lag),
+			fmt.Sprintf("%f", 100.0*lagPct),
+			fmt.Sprintf("%d", consumer.CommittedOffset),
+			fmt.Sprintf("%d", consumer.LatestOffset),
+			consumerId}
+		t.Append(row[:])
+	}
+
+	t.Render()
+
+	return nil
+}
+
+// describeConsumerGroups returns group description for all groups.
+func describeConsumerGroups(
+	admin sarama.ClusterAdmin,
+) ([]*sarama.GroupDescription, error) {
+	groups, err := admin.ListConsumerGroups()
+	if err != nil {
+		return nil, fmt.Errorf("Error listing consumer groups: %v", err)
+	}
+
+	groupIds := make([]string, 0, len(groups))
+	for groupId := range groups {
+		groupIds = append(groupIds, groupId)
+	}
+
+	descs, err := admin.DescribeConsumerGroups(groupIds)
+	if err != nil {
+		return nil, fmt.Errorf("Error describing groups: %v", err)
+	}
+
+	return descs, nil
+}
+
+// getConsumerLag computes lag for all topic partitions and members associated
+// with the specified group.
+func getConsumerLag(
+	client sarama.Client,
+	admin sarama.ClusterAdmin,
+	groupDesc *sarama.GroupDescription,
+) ([]ConsumerLagRow, error) {
+	groupId := groupDesc.GroupId
+
+	// get committed offset for each topic-partition in this group
+	offsets, err := admin.ListConsumerGroupOffsets(groupId, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Error fetching group offsets: %v", err)
+	}
+
+	// build a reverse lookup table so each topic-partition row that is
+	// reported can be annotated with its consumer id if one exists
+	memberAssignments := map[string]map[int32]string{}
+	for memberId, memberDesc := range groupDesc.Members {
+		assignments, err := memberDesc.GetMemberAssignment()
+		if err != nil {
+			return nil, fmt.Errorf("Error decoding assignments for "+
+				"group %s: %v", groupId, err)
+		}
+		if len(assignments.Topics) == 0 {
+			continue
+		}
+		for topic, partitions := range assignments.Topics {
+			for _, partition := range partitions {
+				if _, ok := memberAssignments[topic]; !ok {
+					memberAssignments[topic] = map[int32]string{}
+				}
+				memberAssignments[topic][partition] = memberId
+			}
+		}
+	}
+
+	// convert each group's topic-partition and committed offset into a consumer
+	// lag row and annotate it with the partition's latest offset and the
+	// consumer id of any group member assigned to the given partition.
+	var consumers []ConsumerLagRow
+	for topic, partitions := range offsets.Blocks {
+		for partition, partitionInfo := range partitions {
+			latestOffset, err := client.GetOffset(topic, partition, sarama.OffsetNewest)
+			if err != nil {
+				return nil, fmt.Errorf("Error listing consumer groups: %v", err)
+			}
+			row := ConsumerLagRow{
+				Group:           groupId,
+				Topic:           topic,
+				Partition:       partition,
+				LatestOffset:    latestOffset,
+				CommittedOffset: partitionInfo.Offset,
+			}
+			if partitions, ok := memberAssignments[topic]; ok {
+				if memberId, ok := partitions[partition]; ok {
+					row.MemberId = memberId
+				}
+			}
+			consumers = append(consumers, row)
+		}
+	}
+
+	return consumers, nil
+}

--- a/src/go/rpk/pkg/cli/cmd/cluster/offsets_test.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/offsets_test.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+package cluster
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka/mocks"
+)
+
+func newClientMock() *mocks.MockClient {
+	return &mocks.MockClient{
+		MockGetOffset: func(string, int32, int64) (int64, error) {
+			return 50, nil
+		},
+	}
+}
+
+func newAdminMock() *mocks.MockAdmin {
+	return &mocks.MockAdmin{
+		MockListConsumerGroups: func() (map[string]string, error) {
+			return map[string]string{"group-0": "consumer"}, nil
+		},
+		MockDescribeConsumerGroups: func(groups []string) (descs []*sarama.GroupDescription, err error) {
+			for _, groupId := range groups {
+				descs = append(descs,
+					&sarama.GroupDescription{
+						GroupId: groupId,
+					})
+			}
+			return descs, nil
+		},
+		MockListConsumerGroupOffsets: func(string, map[string][]int32) (*sarama.OffsetFetchResponse, error) {
+			r := sarama.OffsetFetchResponse{}
+			r.Blocks = map[string]map[int32]*sarama.OffsetFetchResponseBlock{}
+			r.Blocks["topic-0"] = map[int32]*sarama.OffsetFetchResponseBlock{}
+			r.Blocks["topic-0"][0] = &sarama.OffsetFetchResponseBlock{
+				Offset: 100,
+			}
+			return &r, nil
+		},
+	}
+}
+
+func TestOffsetsCmd(t *testing.T) {
+	tests := []struct {
+		name           string
+		cmd            func(func() (sarama.Client, error), func(sarama.Client) (sarama.ClusterAdmin, error)) *cobra.Command
+		args           []string
+		expectedOutput string
+		expectedErr    string
+	}{
+		{
+			name: "create should output info about the created topic (custom values)",
+			cmd:  NewOffsetsCommand,
+			expectedOutput: `  GROUP    TOPIC    PARTITION  LAG  LAG %     COMMITTED  LATEST  CONSUMER  
+  group-0  topic-0  0          -50  0.000000  100        50      -         
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := func() (sarama.Client, error) {
+				return newClientMock(), nil
+			}
+			admin := func(_ sarama.Client) (sarama.ClusterAdmin, error) {
+				return newAdminMock(), nil
+			}
+			var out bytes.Buffer
+			cmd := NewOffsetsCommand(client, admin)
+			logrus.SetOutput(&out)
+			err := cmd.Execute()
+			if tt.expectedErr != "" {
+				require.Contains(t, err.Error(), tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Exactly(t, tt.expectedOutput, out.String())
+		})
+	}
+}

--- a/src/go/rpk/pkg/kafka/mocks/client.go
+++ b/src/go/rpk/pkg/kafka/mocks/client.go
@@ -1,0 +1,162 @@
+package mocks
+
+import (
+	"errors"
+
+	"github.com/Shopify/sarama"
+)
+
+type MockClient struct {
+	MockConfig             func() *sarama.Config
+	MockController         func() (*sarama.Broker, error)
+	MockRefreshController  func() (*sarama.Broker, error)
+	MockBrokers            func() []*sarama.Broker
+	MockTopics             func() ([]string, error)
+	MockPartitions         func(topic string) ([]int32, error)
+	MockWritablePartitions func(topic string) ([]int32, error)
+	MockLeader             func(topic string, partitionID int32) (*sarama.Broker, error)
+	MockReplicas           func(topic string, partitionID int32) ([]int32, error)
+	MockInSyncReplicas     func(topic string, partitionID int32) ([]int32, error)
+	MockOfflineReplicas    func(topic string, partitionID int32) ([]int32, error)
+	MockRefreshMetadata    func(topics ...string) error
+	MockGetOffset          func(topic string, partition int32, time int64) (int64, error)
+	MockCoordinator        func(consumerGroup string) (*sarama.Broker, error)
+	MockRefreshCoordinator func(consumerGroup string) error
+	MockInitProducerID     func() (*sarama.InitProducerIDResponse, error)
+	MockClose              func() error
+	MockClosed             func() bool
+}
+
+func (m MockClient) Config() *sarama.Config {
+	if m.MockConfig != nil {
+		return m.MockConfig()
+	}
+	return nil
+}
+
+func (m MockClient) Controller() (*sarama.Broker, error) {
+	if m.MockController != nil {
+		return m.MockController()
+	}
+	return nil, errors.New("Controller unimplemented")
+}
+
+func (m MockClient) RefreshController() (*sarama.Broker, error) {
+	if m.MockRefreshController != nil {
+		return m.MockRefreshController()
+	}
+	return nil, errors.New("RefreshController unimplemented")
+}
+
+func (m MockClient) Brokers() []*sarama.Broker {
+	if m.MockBrokers != nil {
+		return m.MockBrokers()
+	}
+	return nil
+}
+
+func (m MockClient) Topics() ([]string, error) {
+	if m.MockTopics != nil {
+		return m.MockTopics()
+	}
+	return nil, errors.New("Topics unimplemented")
+}
+
+func (m MockClient) Partitions(topic string) ([]int32, error) {
+	if m.MockPartitions != nil {
+		return m.MockPartitions(topic)
+	}
+	return nil, errors.New("Partitions unimplemented")
+}
+
+func (m MockClient) WritablePartitions(topic string) ([]int32, error) {
+	if m.MockWritablePartitions != nil {
+		return m.MockWritablePartitions(topic)
+	}
+	return nil, errors.New("WritablePartitions unimplemented")
+}
+
+func (m MockClient) Leader(
+	topic string, partition int32,
+) (*sarama.Broker, error) {
+	if m.MockLeader != nil {
+		return m.MockLeader(topic, partition)
+	}
+	return nil, errors.New("Leader unimplemented")
+}
+
+func (m MockClient) Replicas(topic string, partition int32) ([]int32, error) {
+	if m.MockReplicas != nil {
+		return m.MockReplicas(topic, partition)
+	}
+	return nil, errors.New("Replicas unimplemented")
+}
+
+func (m MockClient) InSyncReplicas(
+	topic string, partition int32,
+) ([]int32, error) {
+	if m.MockInSyncReplicas != nil {
+		return m.MockInSyncReplicas(topic, partition)
+	}
+	return nil, errors.New("InSyncReplicas unimplemented")
+}
+
+func (m MockClient) OfflineReplicas(
+	topic string, partition int32,
+) ([]int32, error) {
+	if m.MockOfflineReplicas != nil {
+		return m.MockOfflineReplicas(topic, partition)
+	}
+	return nil, errors.New("OfflineReplicas unimplemented")
+}
+
+func (m MockClient) RefreshMetadata(topics ...string) error {
+	if m.MockRefreshMetadata != nil {
+		return m.MockRefreshMetadata(topics...)
+	}
+	return errors.New("RefreshMetadata unimplemented")
+}
+
+func (m MockClient) GetOffset(
+	topic string, partition int32, time int64,
+) (int64, error) {
+	if m.MockGetOffset != nil {
+		return m.MockGetOffset(topic, partition, time)
+	}
+	return -1, errors.New("GetOffset unimplemented")
+}
+
+func (m MockClient) Coordinator(group string) (*sarama.Broker, error) {
+	if m.MockCoordinator != nil {
+		return m.MockCoordinator(group)
+	}
+	return nil, errors.New("Coordinator unimplemented")
+}
+
+func (m MockClient) RefreshCoordinator(group string) error {
+	if m.MockRefreshCoordinator != nil {
+		return m.MockRefreshCoordinator(group)
+	}
+	return errors.New("RefreshCoordinator unimplemented")
+}
+
+func (m MockClient) InitProducerID() (*sarama.InitProducerIDResponse, error) {
+	if m.MockInitProducerID != nil {
+		return m.MockInitProducerID()
+	}
+	return nil, errors.New("InitProducerID unimplemented")
+}
+
+func (m MockClient) Close() error {
+	if m.MockClose != nil {
+		return m.MockClose()
+	}
+	return errors.New("Close unimplemented")
+}
+
+func (m MockClient) Closed() bool {
+	if m.MockClosed != nil {
+		return m.MockClosed()
+	}
+	return false
+}


### PR DESCRIPTION
Adds effectively this:

```
$> rpk cluster offsets
  GROUP    TOPIC   PARTITION  LAG  LAG %    COMMITTED OFFSET  LATEST OFFSET  CONSUMER ID
  grou33   topic0  0          2    0.09     1000004           1000006        -
  grou33   topic0  1          2    0.09     1000004           1000006        -
  grou333  topic0  0          2    0.09     1000004           1000006        rdkafka-33bbfde8-087a-4681-b773-43cff30a97a4
  grou333  topic0  1          2    0.09     1000004           1000006        rdkafka-33bbfde8-087a-4681-b773-43cff30a97a4
  group0   topic0  0          2    0.09     1000004           1000006        -
  group0   topic0  1          2    0.09     1000004           1000006        -
```

Reporting consumer lag is a rather big topic. Here we report a simple offset based metric, but other tools can be found that report a lot more information including other derived metrics such as approximate time lag. In any case, this tools should be fairly easy to extend with other metrics and reporting formats.

Fixes: #642 