### PR TITLE
rpk: make it possible to enable client auth

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -727,6 +727,67 @@ rpk:
   well_known_io: vendor:vm:storage
 `,
 		},
+		{
+			name: "shall write config with tls configuration",
+			conf: func() *Config {
+				c := getValidConfig()
+				c.Redpanda.KafkaApiTLS = ServerTLS{
+					KeyFile:           "/etc/certs/cert.key",
+					TruststoreFile:    "/etc/certs/ca.crt",
+					CertFile:          "/etc/certs/cert.crt",
+					Enabled:           true,
+					RequireClientAuth: true,
+				}
+				return c
+			},
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  data_directory: /var/lib/redpanda/data
+  developer_mode: false
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  kafka_api_tls:
+    cert_file: /etc/certs/cert.crt
+    enabled: true
+    key_file: /etc/certs/cert.key
+    require_client_auth: true
+    truststore_file: /etc/certs/ca.crt
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers:
+  - host:
+      address: 127.0.0.1
+      port: 33145
+  - host:
+      address: 127.0.0.1
+      port: 33146
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_disk_write_cache: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -55,10 +55,11 @@ type TLS struct {
 }
 
 type ServerTLS struct {
-	KeyFile        string `yaml:"key_file,omitempty" mapstructure:"key_file,omitempty" json:"keyFile"`
-	CertFile       string `yaml:"cert_file,omitempty" mapstructure:"cert_file,omitempty" json:"certFile"`
-	TruststoreFile string `yaml:"truststore_file,omitempty" mapstructure:"truststore_file,omitempty" json:"truststoreFile"`
-	Enabled        bool   `yaml:"enabled,omitempty" mapstructure:"enabled,omitempty" json:"enabled"`
+	KeyFile           string `yaml:"key_file,omitempty" mapstructure:"key_file,omitempty" json:"keyFile"`
+	CertFile          string `yaml:"cert_file,omitempty" mapstructure:"cert_file,omitempty" json:"certFile"`
+	TruststoreFile    string `yaml:"truststore_file,omitempty" mapstructure:"truststore_file,omitempty" json:"truststoreFile"`
+	Enabled           bool   `yaml:"enabled,omitempty" mapstructure:"enabled,omitempty" json:"enabled"`
+	RequireClientAuth bool   `yaml:"require_client_auth,omitempty" mapstructure:"require_client_auth,omitempty" json:"requireClientAuth"`
 }
 
 type RpkConfig struct {


### PR DESCRIPTION
To be able to enable client auth on server, we need to be able to serialize that field into config. More context: https://vectorized.io/blog/tls-config/

Currently there's no field like that and within the operator, we're using these strongly typed config structs to create redpanda config. We need this supported to be able to enable client auth.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
