### PR TITLE
s/probe: introduced active and removed segments metrics

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -62,6 +62,7 @@ disk_log_impl::disk_log_impl(
             s->mark_as_compacted_segment();
         }
     }
+    _probe.initial_segments_count(_segs.size());
     _probe.setup_metrics(this->config().ntp());
 }
 disk_log_impl::~disk_log_impl() {
@@ -771,7 +772,7 @@ ss::future<> disk_log_impl::remove_segment_permanently(
       .handle_exception([s](std::exception_ptr e) {
           vlog(stlog.error, "Cannot close segment: {} - {}", e, s);
       })
-      .finally([s] {});
+      .finally([this, s] { _probe.segment_removed(); });
 }
 
 ss::future<> disk_log_impl::remove_full_segments(model::offset o) {

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -70,6 +70,16 @@ void probe::setup_metrics(const model::ntp& ntp) {
           sm::description("Number of created log segments"),
           labels),
         sm::make_derive(
+          "log_segments_removed",
+          [this] { return _log_segments_removed; },
+          sm::description("Number of removed log segments"),
+          labels),
+        sm::make_derive(
+          "log_segments_active",
+          [this] { return _log_segments_active; },
+          sm::description("Number of active log segments"),
+          labels),
+        sm::make_derive(
           "batch_parse_errors",
           [this] { return _batch_parse_errors; },
           sm::description("Number of batch parsing (reading) errors"),

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -34,7 +34,17 @@ public:
 
     void corrupted_compaction_index() { ++_corrupted_compaction_index; }
 
-    void segment_created() { ++_log_segments_created; }
+    void segment_created() {
+        ++_log_segments_created;
+        ++_log_segments_active;
+    }
+
+    void segment_removed() {
+        ++_log_segments_removed;
+        --_log_segments_active;
+    }
+
+    void initial_segments_count(size_t cnt) { _log_segments_active = cnt; }
 
     void segment_compacted() { ++_segment_compacted; }
 
@@ -71,6 +81,8 @@ private:
     uint32_t _segment_compacted = 0;
     uint32_t _corrupted_compaction_index = 0;
     uint32_t _log_segments_created = 0;
+    uint32_t _log_segments_removed = 0;
+    uint32_t _log_segments_active = 0;
     uint32_t _batch_parse_errors = 0;
     uint32_t _batch_write_errors = 0;
     ss::metrics::metric_groups _metrics;


### PR DESCRIPTION
Introduced metrics tracking number of active and removed log segments.
This metric is helpful to track log compaction and deletion policies
execution.

Currently log segments metrics have the follwing semantics:

`log_segments_created` - total number of metrics created since boot up,
helpful to present rate of segments creation

`log_segments_removed` - total number of segments removed since
applciation start

`log_segments_active` - current number of log segments in log
segment_set i.e. number of `.log` files

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
