### PR TITLE
Compaction improvements

### DIFF
--- a/src/v/storage/compacted_index_writer.h
+++ b/src/v/storage/compacted_index_writer.h
@@ -70,6 +70,8 @@ public:
           int32_t offset_delta)
           = 0;
 
+        virtual ss::future<> append(compacted_index::entry) = 0;
+
         virtual ss::future<> truncate(model::offset) = 0;
 
         virtual void set_flag(compacted_index::footer_flags) = 0;
@@ -90,6 +92,9 @@ public:
     ss::future<> index(bytes_view, model::offset, int32_t);
     ss::future<> index(const iobuf& key, model::offset, int32_t);
     ss::future<> index(bytes&&, model::offset, int32_t);
+
+    ss::future<> append(compacted_index::entry);
+
     ss::future<> truncate(model::offset);
     ss::future<> close();
     void set_flag(compacted_index::footer_flags);
@@ -132,6 +137,9 @@ inline ss::future<> compacted_index_writer::index(
 }
 inline ss::future<> compacted_index_writer::truncate(model::offset o) {
     return _impl->truncate(o);
+}
+inline ss::future<> compacted_index_writer::append(compacted_index::entry e) {
+    return _impl->append(std::move(e));
 }
 inline ss::future<> compacted_index_writer::close() { return _impl->close(); }
 

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -83,6 +83,14 @@ Roaring compaction_key_reducer::end_of_stream() {
 }
 
 ss::future<ss::stop_iteration>
+index_copy_reducer::operator()(compacted_index::entry&& e) {
+    using stop_t = ss::stop_iteration;
+    return _writer->append(std::move(e)).then([] {
+        return ss::make_ready_future<stop_t>(stop_t::no);
+    });
+}
+
+ss::future<ss::stop_iteration>
 index_filtered_copy_reducer::operator()(compacted_index::entry&& e) {
     using stop_t = ss::stop_iteration;
     const bool should_add = _bm.contains(_natural_index);

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -83,6 +83,18 @@ private:
     compacted_index_writer* _writer;
 };
 
+class index_copy_reducer : public compaction_reducer {
+public:
+    explicit index_copy_reducer(compacted_index_writer& w)
+      : _writer(&w) {}
+
+    ss::future<ss::stop_iteration> operator()(compacted_index::entry&&);
+    void end_of_stream() {}
+
+private:
+    compacted_index_writer* _writer;
+};
+
 class compacted_offset_list_reducer : public compaction_reducer {
 public:
     explicit compacted_offset_list_reducer(model::offset base)

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -629,7 +629,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                           std::move(*a),
                           std::nullopt,
                           seg->has_cache()
-                            ? std::optional(std::move(seg->cache()))
+                            ? std::optional(std::move(seg->cache()->get()))
                             : std::nullopt));
                   });
             });
@@ -655,7 +655,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                           std::move(seg->appender()),
                           std::move(compact),
                           seg->has_cache()
-                            ? std::optional(std::move(seg->cache()))
+                            ? std::optional(std::move(seg->cache()->get()))
                             : std::nullopt));
                   });
             });

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -427,8 +427,7 @@ ss::future<> do_self_compact_segment(
                 auto& [idx, lock] = h;
                 s->index().swap_index_state(std::move(idx));
                 s->force_set_commit_offset_from_index();
-                // FIXME(noah): crashes if we evic the cache
-                // s->cache().purge();
+                s->release_batch_cache_index();
                 return s->index().flush().finally([l = std::move(lock)] {});
             });
       });

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -16,6 +16,7 @@
 #include "model/timeout_clock.h"
 #include "random/generators.h"
 #include "reflection/adl.h"
+#include "ssx/future-util.h"
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
@@ -33,6 +34,7 @@
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/do_with.hh>
 #include <seastar/core/file-types.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/future.hh>
@@ -42,6 +44,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/when_all.hh>
+#include <seastar/util/defer.hh>
 
 #include <absl/container/btree_map.h>
 #include <absl/container/flat_hash_map.h>
@@ -526,7 +529,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
               "Aborting compaction of closed segment: {}", *segment));
         }
     }
-
+    co_await write_concatenated_compacted_index(path, segments, cfg);
     // concatenation process
     auto writer = co_await make_writer_handle(path, cfg.sanitize);
     auto output = co_await ss::make_file_output_stream(std::move(writer));
@@ -576,6 +579,114 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
       std::nullopt,
       std::nullopt,
       std::nullopt);
+}
+
+ss::future<std::vector<compacted_index_reader>> make_indices_readers(
+  std::vector<ss::lw_shared_ptr<segment>>& segments,
+  ss::io_priority_class io_pc,
+  storage::debug_sanitize_files sanitize) {
+    return ssx::async_transform(
+      segments.begin(),
+      segments.end(),
+      [io_pc, sanitize](ss::lw_shared_ptr<segment>& seg) {
+          const auto path = compacted_index_path(
+            seg->reader().filename().c_str());
+          return make_reader_handle(path, sanitize)
+            .then([path, io_pc](auto reader_fd) {
+                return make_file_backed_compacted_reader(
+                  path.string(), reader_fd, io_pc, 64_KiB);
+            });
+      });
+}
+
+ss::future<> rewrite_concatenated_indicies(
+  compacted_index_writer writer, std::vector<compacted_index_reader>& readers) {
+    return ss::do_with(
+      std::move(writer), [&readers](compacted_index_writer& writer) {
+          return ss::do_with(
+            index_copy_reducer{writer},
+            [&readers, &writer](index_copy_reducer& reducer) {
+                return ss::do_for_each(
+                         readers.begin(),
+                         readers.end(),
+                         [&reducer](compacted_index_reader& rdr) {
+                             vlog(
+                               stlog.trace,
+                               "concatenating index: "
+                               "{}",
+                               rdr.filename());
+                             return rdr.consume(reducer, model::no_timeout);
+                         })
+                  .finally([&writer] { return writer.close(); });
+            });
+      });
+}
+
+ss::future<> do_write_concatenated_compacted_index(
+  std::filesystem::path target_path,
+  std::vector<ss::lw_shared_ptr<segment>>& segments,
+  compaction_config cfg) {
+    return make_indices_readers(segments, cfg.iopc, cfg.sanitize)
+      .then([cfg, target_path = std::move(target_path)](
+              std::vector<compacted_index_reader> readers) mutable {
+          vlog(stlog.debug, "concatenating {} indicies", readers.size());
+          return ss::do_with(
+            std::move(readers),
+            [cfg, target_path = std::move(target_path)](
+              std::vector<compacted_index_reader>& readers) mutable {
+                return ss::parallel_for_each(
+                         readers.begin(),
+                         readers.end(),
+                         [](compacted_index_reader& reader) {
+                             return reader.verify_integrity();
+                         })
+                  .then([] { return true; })
+                  .handle_exception([](const std::exception_ptr& e) {
+                      vlog(
+                        stlog.info,
+                        "compacted index is corrupted, skipping concatenation "
+                        "- {}",
+                        e);
+                      return false;
+                  })
+                  .then([cfg, target_path = std::move(target_path), &readers](
+                          bool verified_successfully) {
+                      if (!verified_successfully) {
+                          return ss::now();
+                      }
+
+                      return make_compacted_index_writer(
+                               target_path, cfg.sanitize, cfg.iopc)
+                        .then([&readers](compacted_index_writer writer) {
+                            return rewrite_concatenated_indicies(
+                              std::move(writer), readers);
+                        });
+                  })
+                  .finally([&readers] {
+                      return ss::parallel_for_each(
+                        readers,
+                        [](compacted_index_reader& r) { return r.close(); });
+                  });
+            });
+      });
+}
+
+ss::future<> write_concatenated_compacted_index(
+  std::filesystem::path target_path,
+  std::vector<ss::lw_shared_ptr<segment>> segments,
+  compaction_config cfg) {
+    if (segments.empty()) {
+        return ss::now();
+    }
+    std::vector<compacted_index_reader> readers;
+    readers.reserve(segments.size());
+    return ss::do_with(
+      std::move(segments),
+      [cfg, target_path = std::move(target_path)](
+        std::vector<ss::lw_shared_ptr<segment>>& segments) mutable {
+          return do_write_concatenated_compacted_index(
+            std::move(target_path), segments, cfg);
+      });
 }
 
 ss::future<std::vector<ss::rwlock::holder>> transfer_segment(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -57,6 +57,11 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
   std::vector<ss::lw_shared_ptr<segment>>,
   compaction_config);
 
+ss::future<> write_concatenated_compacted_index(
+  std::filesystem::path,
+  std::vector<ss::lw_shared_ptr<segment>>,
+  compaction_config);
+
 ss::future<std::vector<ss::rwlock::holder>> transfer_segment(
   ss::lw_shared_ptr<segment> to,
   ss::lw_shared_ptr<segment> from,

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -168,6 +168,12 @@ ss::future<> spill_key_index::spill(
       std::move(payload), [this](iobuf& buf) { return _appender.append(buf); });
 }
 
+ss::future<> spill_key_index::append(compacted_index::entry e) {
+    return ss::do_with(std::move(e), [this](compacted_index::entry& e) {
+        return spill(e.type, e.key, value_type{e.offset, e.delta});
+    });
+}
+
 ss::future<> spill_key_index::drain_all_keys() {
     return ss::do_until(
       [this] {

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -58,6 +58,7 @@ public:
     ss::future<> index(bytes_view, model::offset, int32_t) final;
     ss::future<> index(bytes&&, model::offset, int32_t) final;
     ss::future<> truncate(model::offset) final;
+    ss::future<> append(compacted_index::entry) final;
     ss::future<> close() final;
     void print(std::ostream&) const final;
     void set_flag(compacted_index::footer_flags) final;


### PR DESCRIPTION
Implemented following improvements to compaction:
- merging compacted indices instead of dropping them when creating concatenated segment for adjacent segments compaction
- releasing batch cache index of segment after compaction.

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vectorizedio/redpanda/803)
<!-- Reviewable:end -->
