### PR TITLE
wasm engine crashes on startup due to use of unsupported flag

### DIFF
--- a/src/js/modules/rpc/service.ts
+++ b/src/js/modules/rpc/service.ts
@@ -28,7 +28,7 @@ export const closeProcess = (e: Error): Promise<void> => {
     fs.writeFile(
       LogService.getPath(),
       `Error: ${e.message}`,
-      { flag: "+a" },
+      { flag: "a+" },
       (err) => {
         if (err) {
           console.error(


### PR DESCRIPTION
- The fs library throws when it sees '+a' because that is not a valid flag it
expects to see.

- The correct flag is 'a+'

## Checklist
- [ ] Reference related [issue](https://github.com/vectorizedio/redpanda/issues)
- [ ] Update [PendingReleaseNotes.md](https://github.com/dotnwat/redpanda/blob/dev/PendingReleaseNotes.md), if relevant

When referencing a related issue, remember to migrate duplicate stories from the
external tracker. This is not relevant for most users.
