### PR TITLE
Remove resources related to external connectivity when feature is disabled

### DIFF
--- a/src/go/k8s/pkg/resources/cluster-role-binding.go
+++ b/src/go/k8s/pkg/resources/cluster-role-binding.go
@@ -52,7 +52,11 @@ func NewClusterRoleBinding(
 // Ensure manages v1.ClusterRoleBinding that is assigned to v1.ServiceAccount used in initContainer
 func (r *ClusterRoleBindingResource) Ensure(ctx context.Context) error {
 	if !r.pandaCluster.Spec.ExternalConnectivity {
-		return nil
+		obj, err := r.Obj()
+		if err != nil {
+			return err
+		}
+		return deleteIfExists(ctx, r, obj, "ClusterRoleBinding")
 	}
 
 	var crb v1.ClusterRoleBinding

--- a/src/go/k8s/pkg/resources/cluster-role.go
+++ b/src/go/k8s/pkg/resources/cluster-role.go
@@ -54,7 +54,11 @@ func NewClusterRole(
 // nolint:dupl // The refactor is proposed in https://github.com/vectorizedio/redpanda/pull/779
 func (r *ClusterRoleResource) Ensure(ctx context.Context) error {
 	if !r.pandaCluster.Spec.ExternalConnectivity {
-		return nil
+		obj, err := r.Obj()
+		if err != nil {
+			return err
+		}
+		return deleteIfExists(ctx, r, obj, "ClusterRole")
 	}
 
 	var cr v1.ClusterRole

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -53,7 +53,11 @@ func NewNodePortService(
 // Ensure will manage kubernetes v1.Service for redpanda.vectorized.io custom resource
 func (r *NodePortServiceResource) Ensure(ctx context.Context) error {
 	if !r.pandaCluster.Spec.ExternalConnectivity {
-		return nil
+		obj, err := r.Obj()
+		if err != nil {
+			return err
+		}
+		return deleteIfExists(ctx, r, obj, "Service NodePort")
 	}
 
 	return getOrCreate(ctx, r, &corev1.Service{}, "Service NodePort", r.logger)

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -69,3 +69,16 @@ func getOrCreate(
 
 	return nil
 }
+
+func deleteIfExists(
+	ctx context.Context,
+	r internalResource,
+	checkObj client.Object,
+	resourceName string,
+) error {
+	err := r.Delete(ctx, checkObj)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error while deleting %s resource: %w", resourceName, err)
+	}
+	return nil
+}

--- a/src/go/k8s/pkg/resources/service_account.go
+++ b/src/go/k8s/pkg/resources/service_account.go
@@ -54,7 +54,11 @@ func NewServiceAccount(
 // nolint:dupl // The refactor is proposed in https://github.com/vectorizedio/redpanda/pull/779
 func (s *ServiceAccountResource) Ensure(ctx context.Context) error {
 	if !s.pandaCluster.Spec.ExternalConnectivity {
-		return nil
+		obj, err := s.Obj()
+		if err != nil {
+			return err
+		}
+		return deleteIfExists(ctx, s, obj, "ServiceAccount")
 	}
 
 	var sa corev1.ServiceAccount


### PR DESCRIPTION
## Cover letter

Currently we create couple of resources when people enable external connectivity on their cluster but we never remove them if they disable it. That means that the nodeports would e.g. be still open even if the feature is disabled.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: External connectivity resources get cleaned up after the feature is disabled.
