### PR TITLE
operator: handle cases where crb does not exist

### DIFF
--- a/src/go/k8s/pkg/resources/cluster-role-binding.go
+++ b/src/go/k8s/pkg/resources/cluster-role-binding.go
@@ -148,6 +148,10 @@ func (r *ClusterRoleBindingResource) RemoveSubject(
 	var crb v1.ClusterRoleBinding
 
 	err := r.Get(ctx, r.Key(), &crb)
+	if errors.IsNotFound(err) {
+		// if CRB does not exist, there is nothing to remove
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("error while fetching ClusterRoleBinding resource: %w", err)
 	}


### PR DESCRIPTION
## Cover letter

Currently this is throwing errors on clusters where CRB was not created (e.g.
because external connectivity was never enabled).

Fixes issues: #819

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
