### PR TITLE
archival: Fix Google Cloud Storage compatibility issue

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -19,6 +19,7 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/net/tls.hh>
 
 #include <boost/beast/core/buffer_traits.hpp>
 
@@ -56,10 +57,16 @@ client::make_request(client::request_header&& header) {
         return ss::make_ready_future<request_response_t>(
           std::make_tuple(req, res));
     }
-    return connect().then([req, res] {
-        return ss::make_ready_future<request_response_t>(
-          std::make_tuple(req, res));
-    });
+    return connect()
+      .then([req, res] {
+          return ss::make_ready_future<request_response_t>(
+            std::make_tuple(req, res));
+      })
+      .handle_exception_type([this](const ss::tls::verification_error& err) {
+          return shutdown().then([err] {
+              return ss::make_exception_future<client::request_response_t>(err);
+          });
+      });
 }
 
 ss::future<> client::shutdown() { return stop(); }
@@ -133,8 +140,8 @@ ss::future<iobuf> client::response_stream::recv_some() {
         // can only be called once.
         return ss::make_ready_future<iobuf>(std::move(_prefetch));
     }
-    return _client->_in.read().then(
-      [this](ss::temporary_buffer<char> chunk) mutable {
+    return _client->_in.read()
+      .then([this](ss::temporary_buffer<char> chunk) mutable {
           vlog(http_log.trace, "chunk received, chunk length {}", chunk.size());
           if (chunk.empty()) {
               // NOTE: to make the parser stop we need to use the 'put_eof'
@@ -195,6 +202,10 @@ ss::future<iobuf> client::response_stream::recv_some() {
                 ec);
           }
           return ss::make_ready_future<iobuf>(std::move(out));
+      })
+      .handle_exception_type([this](const ss::tls::verification_error& err) {
+          return _client->shutdown().then(
+            [err] { return ss::make_exception_future<iobuf>(err); });
       });
 }
 
@@ -262,7 +273,12 @@ ss::future<> client::request_stream::send_some(iobuf&& seq) {
           return _client->_out.write(std::move(scattered))
             .then([this, seq = std::move(seq)]() mutable {
                 return forward(_client->_out, _chunk_encode(std::move(seq)));
-            });
+            })
+            .handle_exception_type(
+              [this](const ss::tls::verification_error& err) {
+                  return _client->shutdown().then(
+                    [err] { return ss::make_exception_future<>(err); });
+              });
       });
 }
 

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -70,6 +70,9 @@ ss::future<configuration> configuration::make_configuration(
     configuration client_cfg;
     ss::tls::credentials_builder cred_builder;
     const auto endpoint_uri = make_endpoint_url(region, url_override);
+    if (url_override.has_value()) {
+        client_cfg.tls_sni_hostname = *url_override;
+    }
     // Setup credentials for TLS
     ss::tls::credentials_builder builder;
     client_cfg.access_key = pkey;


### PR DESCRIPTION
## Cover letter

This PR fixes GCS compatibility issue. The difference between AWS endpoint and GCS endpoint is that with GCS the TLS server name should be specified and AWS doesn't need it.

Also, it improves error logging in archival subsystem and fixes bug in http. The bug was caused by the TLS implementation that delayed handshake until the actual send or recv. 

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
