### PR TITLE
rpk/wasm: fix rpk wasm --brokers flag

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -43,16 +43,16 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	command.AddCommand(
 		addKafkaFlags(
 			wasm.NewDeployCommand(fs, producerClosure, adminClosure),
-			configFile,
-			brokers,
+			&configFile,
+			&brokers,
 		),
 	)
 
 	command.AddCommand(
 		addKafkaFlags(
 			wasm.NewRemoveCommand(producerClosure, adminClosure),
-			configFile,
-			brokers,
+			&configFile,
+			&brokers,
 		),
 	)
 
@@ -60,18 +60,18 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 }
 
 func addKafkaFlags(
-	command *cobra.Command, configFile string, brokers []string,
+	command *cobra.Command, configFile *string, brokers *[]string,
 ) *cobra.Command {
 
 	command.Flags().StringSliceVar(
-		&brokers,
+		brokers,
 		"brokers",
 		[]string{},
 		"Comma-separated list of broker ip:port pairs",
 	)
 
 	command.Flags().StringVar(
-		&configFile,
+		configFile,
 		"config",
 		"",
 		"Redpanda config file, if not set the file will be searched for"+


### PR DESCRIPTION
## Cover letter

The problem was the brokers variable was passing by value and
not by reference to deploy and remove wasm command, for that 
reason the broker value always was an empty array. all records 
published on local redpanda instance to show the error.

