### PR TITLE
Partition movement api

### DIFF
--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -19,6 +19,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/kafka.json.h
 )
 
+seastar_generate_swagger(
+  TARGET partition_swagger
+  VAR partition_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/partition.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/partition.json.h
+)
+
 v_cc_library(
   NAME application
   SRCS application.cc
@@ -37,7 +44,7 @@ add_executable(redpanda
   )
 target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
-add_dependencies(v_application config_swagger raft_swagger kafka_swagger)
+add_dependencies(v_application config_swagger raft_swagger kafka_swagger partition_swagger)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
   include(CheckIPOSupported)

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -1,0 +1,31 @@
+"/v1/kafka/{topic}/{partition}/move_partition": {
+  "post": {
+    "summary": "Move a partition to a node",
+    "operationId": "kafka_move_partition",
+    "parameters": [
+        {
+            "name": "topic",
+            "in": "path",
+            "required": true,
+            "type": "string"
+        },
+        {
+            "name": "partition",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+        },
+        {
+            "name":"target",
+            "in":"query",
+            "required":false,
+            "type":"string"
+        }
+    ],
+    "responses": {
+      "200": {
+        "description": "Partition movement"
+      }
+    }
+  }
+}

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -256,6 +256,24 @@ class RedpandaService(Service):
         assert resp.status_code == 200
         return text_string_to_metric_families(resp.text)
 
+    def shards(self):
+        """
+        Fetch the max shard id for each node.
+        """
+        shards_per_node = {}
+        for node in self.nodes:
+            num_shards = 0
+            metrics = self.metrics(node)
+            for family in metrics:
+                for sample in family.samples:
+                    if sample.name == "vectorized_reactor_utilization":
+                        num_shards = max(num_shards,
+                                         int(sample.labels["shard"]))
+            assert num_shards > 0
+            shards_per_node[self.idx(node)] = num_shards
+        return shards_per_node
+
+
     def partitions(self, topic):
         """
         Return partition metadata for the topic.

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -286,11 +286,10 @@ class RedpandaService(Service):
             index = p["partition"]
             leader_id = p["leader"]
             leader = None if leader_id == -1 else self.get_node(leader_id)
-            replicas = map(lambda r: self.get_node(r["id"]), p["replicas"])
+            replicas = [self.get_node(r["id"]) for r in p["replicas"]]
             return Partition(index, leader, replicas)
 
-        return map(make_partition, topic["partitions"])
-
+        return [make_partition(p) for p in topic["partitions"]]
 
 # a hack to prevent the redpanda service from trying to use a client that
 # doesn't support sasl when the service has sasl enabled. this is a temp fix

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -1,0 +1,145 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import time
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from rptest.clients.kafka_cat import KafkaCat
+import requests
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class PartitionMovementTest(RedpandaTest):
+    """
+    Change a partition's replica set.
+    """
+    topics = (TopicSpec(partition_count=1, replication_factor=1), )
+
+    # TODO: the movement api currently accepts requests for any core and any
+    # node so we cannot yet test for invalid target node and partition.
+    @cluster(num_nodes=3)
+    def test_bad_requests(self):
+        controller = self.redpanda.controller()
+        topic = self.topics[0].name
+        partition = 0
+
+        # verify that we get an error if we attempt to move a partition without
+        # specifying a target replica set. this will be removed later when we
+        # add functionality that can choose automatically.
+        for node in self.redpanda.nodes:
+            host = node.account.hostname
+            base_url = f"http://{host}:9644/v1/kafka/{topic}/{partition}/move_partition"
+            for params in ["", "?", "?target="]:
+                url = f"{base_url}{params}"
+                res = requests.post(url)
+                assert res.status_code == 400
+                assert "Partition movement requires target replica set" in res.text
+
+        # check that errors are returned for invalid target formats
+        for node in self.redpanda.nodes:
+            host = node.account.hostname
+            base_url = f"http://{host}:9644/v1/kafka/{topic}/{partition}/move_partition"
+            for params in [
+                    "1", "a", "1,", "a,", "1,a", "a,1", "1,1,1", "1,1,a",
+                    "a,1,1", "a,1,1,", "1,1,1,a"
+            ]:
+                url = f"{base_url}?target={params}"
+                res = requests.post(url)
+                assert res.status_code == 400
+                assert "Invalid target format" in res.text
+
+        # check for reject request for source partition that does not exist
+        for node in self.redpanda.nodes:
+            host = node.account.hostname
+            url = f"http://{host}:9644/v1/kafka/{topic}/9999/move_partition?target=1,0"
+            res = requests.post(url)
+            assert res.status_code == 400
+            if node == controller:
+                assert "Requested partition does not exist" in res.text
+            else:
+                assert "raft::errc::not_leader" in res.text
+
+        # check for reject request for source topic that does not exist
+        for node in self.redpanda.nodes:
+            host = node.account.hostname
+            url = f"http://{host}:9644/v1/kafka/topic-dne/{partition}/move_partition?target=1,0"
+            res = requests.post(url)
+            assert res.status_code == 400
+            if node == controller:
+                assert "Topic does not exist" in res.text
+            else:
+                assert "raft::errc::not_leader" in res.text
+
+    @cluster(num_nodes=3)
+    def test_cycle_simple(self, rounds=4):
+        """
+        Verifies that an empty partition with one replica can be moved around
+        between random brokers in serveral rounds.
+
+        TODO: when picking the set of eligible nodes we filter out the current
+        node because move-to-self is not yet supported.
+        """
+        controller = self.redpanda.controller()
+        base_url = f"http://{controller.account.hostname}:9644"
+        base_url = f"{base_url}/v1/kafka/{self.topics[0].name}/0/move_partition"
+
+        # shards per node for this cluster
+        shards = self.redpanda.shards()
+
+        def get_partition_shard(node):
+            metrics = self.redpanda.metrics(node)
+            for family in metrics:
+                for sample in family.samples:
+                    if sample.name == "vectorized_storage_log_partition_size" and \
+                            sample.labels["namespace"] == "kafka" and \
+                            sample.labels["topic"] == self.topics[0].name and \
+                            sample.labels["partition"] == "0":
+                        return int(sample.labels["shard"])
+            return None
+
+        def partition_moved(to_node_id, to_shard):
+            partitions = self.redpanda.partitions(self.topics[0].name)
+            if not partitions:
+                return False
+            partition = partitions[0]
+            node_id = self.redpanda.idx(partition.replicas[0])
+            shard = get_partition_shard(partition.replicas[0])
+            self.logger.debug(
+                f"Waiting for partition {to_node_id}:{to_shard} current {node_id}:{shard}"
+            )
+            return to_node_id == node_id and to_shard == shard
+
+        for round in range(rounds):
+            partition = self.redpanda.partitions(self.topics[0].name)[0]
+            eligible = set(self.redpanda.nodes) - set(partition.replicas)
+            target = random.choice(list(eligible))
+
+            from_node_id = self.redpanda.idx(partition.replicas[0])
+            to_node_id = self.redpanda.idx(target)
+            to_shard = random.randint(0, shards[to_node_id])
+
+            self.logger.debug(
+                f"Moving partition round {round}: from node {from_node_id} to {to_node_id}:{to_shard}"
+            )
+
+            url = f"{base_url}?target={to_node_id},{to_shard}"
+            res = requests.post(url)
+            self.logger.debug(
+                f"Requesting partition move {url}: {res.status_code} {res.text}"
+            )
+            assert res.status_code == 200
+
+            wait_until(lambda: partition_moved(to_node_id, to_shard),
+                       timeout_sec=20,
+                       backoff_sec=5,
+                       err_msg="Partition move did not complete")


### PR DESCRIPTION
Thin wrapper around low-level partition movement api that enables us to build out a suite of ducktape tests for partition movement. Also added is initial boilerplate ducktape tests including one test that seems to trigger a behavior that needs fixed within the controller.