### PR TITLE
docs: fix missing h1 in archival.md causing build fail

### DIFF
--- a/docs/www/archival.md
+++ b/docs/www/archival.md
@@ -1,6 +1,7 @@
 ---
 title: Archival
 ---
+# Archival
 ## Overview
 
 Archival subsystem can be used to upload data to S3 (or compatible) storage. This task is performed in the background without interrupting the service. At this point only upload is implemented. This data can be used to restore redpanda cluster from the ground up (this is in progress).


### PR DESCRIPTION
Fixes gatsby build failure due to missing h1