### PR TITLE
build/lint: Pin version of yapf to 0.30.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Set up python
       run: |
         sudo apt-get install -y python3 python3-pip
-        sudo pip install yapf
+        sudo pip install yapf==0.30.0
 
     - name: lint python files
       run: find . -name *.py -type f | xargs -n1 yapf -d


### PR DESCRIPTION
## Cover letter

0.31.0 has been released and appears to have different formatting rules.

This is the diff: https://github.com/google/yapf/compare/v0.30.0...v0.31.0 - maybe 0.31.0 is customisable to have the old behaviour.

Signed-off-by: Ben Pope <ben@vectorized.io>
