### PR TITLE
rpk: Remove unneeded logs

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prometheus/common/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -163,9 +162,6 @@ func TestModeCommand(t *testing.T) {
 			require.NoError(t, err)
 			output := out.String()
 			require.Contains(t, strings.TrimSpace(output), tt.expectedOutput)
-			bs, err := afero.ReadFile(fs, configPath)
-			log.Info(string(bs))
-			require.NoError(t, err)
 			conf, err := mgr.Read(path)
 			require.NoError(t, err)
 			require.Exactly(t, tt.expectedConfig, conf)

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -745,7 +745,6 @@ func parseNamedAddresses(
 			as = append(as, *a)
 		}
 	}
-	log.Info(as)
 	return as, nil
 }
 


### PR DESCRIPTION
Remove unneeded logs in tests and at startup.

Fix #686 