### PR TITLE
Feature/remove coproc on apply

### DIFF
--- a/src/js/modules/supervisors/Repository.ts
+++ b/src/js/modules/supervisors/Repository.ts
@@ -68,9 +68,9 @@ class Repository {
    * remove a handle from the handle map
    * @param handle
    */
-  remove = (handle: Handle): void => {
+  remove(handle: Handle): void {
     this.handles.delete(handle.coprocessor.globalId);
-  };
+  }
 
   /**
    * returns a handle list by given ids
@@ -118,12 +118,7 @@ class Repository {
           `didn't return a Promise<Map<string, RecordBatch>>`
       );
       return Promise.reject(
-        handleError(
-          handle.coprocessor,
-          requestItem,
-          error,
-          PolicyError.Deregister
-        )
+        handleError(handle, requestItem, error, PolicyError.Deregister)
       );
     }
   }
@@ -215,7 +210,7 @@ class Repository {
                 return responseError;
               });
           } catch (e) {
-            return handleError(handle.coprocessor, requestItem, e);
+            return handleError(handle, requestItem, e);
           }
         });
         return prev.concat(apply);

--- a/src/js/test/rpc/server.test.ts
+++ b/src/js/test/rpc/server.test.ts
@@ -658,9 +658,9 @@ describe("Server", function () {
     );
 
     it(
-      "should response undefined in record on request_process_replay if" +
-        "there is a error on coprocessor script, and its policy error is " +
-        "Deregister",
+      "It should send an undefined record list on request_process_replay " +
+        "and remove the script from the repository if there is an error " +
+        "executing the script and its policy error is 'Deregister'",
       () => {
         const handle = createHandle();
         // add unhandle expetion to coprocessor function
@@ -671,6 +671,10 @@ describe("Server", function () {
         const repositoryMock = sinonInstance.stub(
           Repository.prototype,
           "getHandlesByCoprocessorIds"
+        );
+        const removeRepositoryMock = sinonInstance.stub(
+          Repository.prototype,
+          "remove"
         );
         repositoryMock.returns([handle]);
 
@@ -700,6 +704,8 @@ describe("Server", function () {
               const result = results.result[0];
               assert.deepStrictEqual(result.resultRecordBatch, undefined);
               assert.strictEqual(result.coprocessorId, BigInt(1));
+              assert(removeRepositoryMock.called);
+              assert(removeRepositoryMock.withArgs(handle));
             })
             .finally(() => {
               client.close();


### PR DESCRIPTION
## Cover letter

Currently, the wasm engine doesn't remove a coproc from memory when the "deregister" error policy is activated. This changeset makes the wasm engine remove the coproc from memory before signaling redpanda to unregister it itself.

