### PR TITLE
ci: Feature/helm ci

### DIFF
--- a/.github/workflows/k8s-build-and-test.yml
+++ b/.github/workflows/k8s-build-and-test.yml
@@ -48,3 +48,37 @@ jobs:
       with:
         name: kuttl test artifacts
         path: src/go/k8s/tests/_e2e_artifacts
+
+  helm-test:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.5.2
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@v2.0.1
+      with:
+        version: v3.3.1
+
+    - name: Run chart-testing (lint)
+      working-directory: src/go/k8s/helm-chart/charts
+      run: ct lint --debug --config ci/ct.yaml
+
+    - name: Unit tests & Integration tests & Helm E2E tests
+      working-directory: src/go/k8s/
+      run: make helm-e2e-tests
+      shell: bash
+
+    - name: Archive test data
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: kuttl helm test artifacts
+        path: src/go/k8s/tests/_helm_e2e_artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /dbuild
 bin
 _e2e_artifacts/
+_helm_e2e_artifacts/
 /src/go/k8s/testbin/*
 /src/go/k8s/cm-verifier
 

--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -96,6 +96,10 @@ push-to-kind:
 e2e-tests: kuttl docker-build docker-build-configurator
 	$(KUTTL) test $(TEST_ONLY_FLAG)
 
+# Execute end to end tests using helm as an installation
+helm-e2e-tests: kuttl docker-build docker-build-configurator
+	$(KUTTL) test --config kuttl-helm-test.yaml $(TEST_ONLY_FLAG)
+
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen:

--- a/src/go/k8s/helm-chart/charts/ci/ct.yaml
+++ b/src/go/k8s/helm-chart/charts/ci/ct.yaml
@@ -1,0 +1,13 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+charts:
+  - redpanda-operator
+target-branch: dev
+helm-extra-args: --timeout 600s
+remote: origin

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
@@ -68,4 +68,4 @@ Other instruction will be visible after installation.
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | The name of the service account to use. If not set name is generated using the fullname template |
 | tolerations | list | `[]` | Allows to schedule Redpanda Operator on tainted nodes |
-| webhook.enabled | bool | `false` |  |
+| webhook.enabled | bool | `true` |  |

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
@@ -1,6 +1,6 @@
 # Redpanda Operator
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v21.3.4](https://img.shields.io/badge/AppVersion-v21.3.4-informational?style=flat-square)
 
 ## Installation
 

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/certificate.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/certificate.yaml
@@ -18,8 +18,8 @@ metadata:
 {{ include "redpanda-operator.labels" . | indent 4 }}
 spec:
   dnsNames:
-    - "redpanda-webhook-service.{{ .Release.Namespace }}.svc"
-    - "redpanda-webhook-service.{{ .Release.Namespace }}.svc.cluster.local"
+    - {{ include "redpanda-operator.name" . }}-webhook-service.{{ .Release.Namespace }}.svc
+    - {{ include "redpanda-operator.name" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: {{ include "redpanda-operator.fullname" . }}-selfsigned-issuer

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/clusterrole.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/clusterrole.yaml
@@ -32,11 +32,34 @@ rules:
   - cert-manager.io
   resources:
   - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - clusterissuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
   - issuers
   verbs:
   - create
+  - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - ""
@@ -48,6 +71,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""
@@ -68,7 +99,40 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
   verbs:
   - create
   - get

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/test/create-topic-with-client-auth.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/test/create-topic-with-client-auth.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rpk-config
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+data:
+  redpanda.yaml: |
+    redpanda:
+    rpk:
+      tls:
+        key_file: /etc/tls/certs/tls.key
+        cert_file: /etc/tls/certs/tls.crt
+        truststore_file: /etc/tls/certs/ca.crt
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-test-topic-tls
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "2"
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tlscert
+          secret:
+            defaultMode: 420
+            secretName: cluster-tls-user-client
+        - name: rpkconfig
+          configMap:
+            name: rpk-config
+      containers:
+        - name: rpk
+          image: vectorized/redpanda:latest
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - rpk topic create test --brokers cluster-tls-0.cluster-tls.$POD_NAMESPACE.svc.cluster.local:9092 -v
+          volumeMounts:
+            - mountPath: /etc/tls/certs
+              name: tlscert
+            - mountPath: /etc/redpanda
+              name: rpkconfig
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/test/three_node_cluster.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/test/three_node_cluster.yaml
@@ -1,0 +1,29 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster-tls
+  annotations:
+    "helm.sh/hook": test
+spec:
+  image: "vectorized/redpanda"
+  version: "latest"
+  replicas: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 1.2Gi
+  externalConnectivity: true
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+      port: 9092
+    admin:
+      port: 9644
+    developerMode: true
+    tls:
+      kafkaApiEnabled: true
+      requireClientAuth: true

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
@@ -44,7 +44,7 @@ rbac:
 
 webhook:
   # webhook.create -- Specifies whether the Webhook resources should configured
-  enabled: false
+  enabled: true
 
 serviceAccount:
   # serviceAccount.create -- Specifies whether a service account should be created

--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+startKIND: true
+kindNodeCache: true
+kindContainers:
+  - vectorized/redpanda-operator:latest
+  - vectorized/configurator:latest
+testDirs:
+  - ./tests/e2e
+  - ./tests/e2e-helm
+kindConfig: ./kind.yaml
+commands:
+  - command: "./hack/install-cert-manager.sh"
+  - command: "kubectl apply -k ./config/crd"
+  - command: "helm install --set image.tag=latest --namespace helm-test --create-namespace redpanda-operator ./helm-chart/charts/redpanda-operator"
+  - command: "./hack/wait-for-webhook-ready.sh"
+artifactsDir: tests/_helm_e2e_artifacts
+timeout: 300

--- a/src/go/k8s/tests/e2e-helm/helm-test/00-helm-test.yaml
+++ b/src/go/k8s/tests/e2e-helm/helm-test/00-helm-test.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: helm test --namespace helm-test redpanda-operator


### PR DESCRIPTION
## Cover letter

This PR introduces helm testing in our CI. 

Additional change is that helm chart has embedded tests. The test is very similar to what we have in e2e test suite in regards to test mTLS. 

The helm chart now enables webhook by default.

`chart testing` tool is introduce to lint. Later will verify helm upgrade process.

## Release notes

The helm chart has now tests that can verify webhook installation. By running `helm test` you should be able to verify that the integration between operator, redpanda and rpk works correctly inside the kubernetes cluster.

Release note: Helm chart enables webhook by default. Tests are embedded in helm release
