### PR TITLE
treewide: formatted with new yapf version

### DIFF
--- a/src/consistency-testing/gobekli/setup.py
+++ b/src/consistency-testing/gobekli/setup.py
@@ -11,6 +11,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 from setuptools import setup, find_packages
+
 setup(
     name="gobekli",
     version="0.1",

--- a/tests/rptest/tests/chaos/baseline_test.py
+++ b/tests/rptest/tests/chaos/baseline_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import BaselineRecoverableFault

--- a/tests/rptest/tests/chaos/chaos_base_test.py
+++ b/tests/rptest/tests/chaos/chaos_base_test.py
@@ -13,6 +13,7 @@ import os
 
 import traceback
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 

--- a/tests/rptest/tests/chaos/isolate_follower_test.py
+++ b/tests/rptest/tests/chaos/isolate_follower_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import IsolateNodeRecoverableFault

--- a/tests/rptest/tests/chaos/isolate_leader_test.py
+++ b/tests/rptest/tests/chaos/isolate_leader_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import IsolateNodeRecoverableFault

--- a/tests/rptest/tests/chaos/ruinio_follower_test.py
+++ b/tests/rptest/tests/chaos/ruinio_follower_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import RuinIORecoverableFault

--- a/tests/rptest/tests/chaos/ruinio_leader_test.py
+++ b/tests/rptest/tests/chaos/ruinio_leader_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import RuinIORecoverableFault

--- a/tests/rptest/tests/chaos/slowio_follower_test.py
+++ b/tests/rptest/tests/chaos/slowio_follower_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import MakeIOSlowerRecoverableFault

--- a/tests/rptest/tests/chaos/slowio_leader_test.py
+++ b/tests/rptest/tests/chaos/slowio_leader_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import MakeIOSlowerRecoverableFault

--- a/tests/rptest/tests/chaos/suspend_follower_test.py
+++ b/tests/rptest/tests/chaos/suspend_follower_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import SuspendServiceRecoverableFault

--- a/tests/rptest/tests/chaos/suspend_leader_test.py
+++ b/tests/rptest/tests/chaos/suspend_leader_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import SuspendServiceRecoverableFault

--- a/tests/rptest/tests/chaos/terminate_follower_test.py
+++ b/tests/rptest/tests/chaos/terminate_follower_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import TerminateNodeRecoverableFault

--- a/tests/rptest/tests/chaos/terminate_leader_test.py
+++ b/tests/rptest/tests/chaos/terminate_leader_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import sys
+
 sys.path.append("/opt/v/src/consistency-testing/gobekli")
 sys.path.append("/opt/v/src/consistency-testing/chaostest")
 from chaostest.faults import TerminateNodeRecoverableFault


### PR DESCRIPTION
## Cover letter
Formatted python code with new YAPF formatter version.

Change in YAPF version caused all our CI builds to fail at `*.py` format check.




## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
