### PR TITLE
test/pandaproxy: Test Consumer Groups Part 1

### DIFF
--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -210,9 +210,10 @@ create_consumer(server::request_t rq, server::reply_t rp) {
           json::create_consumer_response res{
             .instance_id = m_id,
             .base_uri = fmt::format(
-              "http://{}:{}/consumers/{}",
+              "http://{}:{}/consumers/{}/instances/{}",
               adv_addr.host(),
               adv_addr.port(),
+              group_id(),
               m_id())};
           auto json_rslt = ppj::rjson_serialize(res);
           rp.rep->write_body("json", json_rslt);

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -79,7 +79,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
         req_body_buf.append(req_body.data(), req_body.size());
         auto res = http_request(
           client,
-          fmt::format("/consumers/{})", group_id()),
+          fmt::format("/consumers/{}", group_id()),
           std::move(req_body_buf));
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -91,9 +91,10 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           res_data.base_uri,
           fmt::format(
-            "http://{}:{}/consumers/{}",
+            "http://{}:{}/consumers/{}/instances/{}",
             advertised_address.host(),
             advertised_address.port(),
+            group_id(),
             member_id()));
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -45,6 +45,10 @@ pandaproxy:
     address: "0.0.0.0"
     port: 8082
 
+  advertised_pandaproxy_api:
+    address: "{{node.account.hostname}}"
+    port: 8082
+
   api_doc_dir: {{root}}/usr/share/redpanda/proxy-api-doc
 
 pandaproxy_client:

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -7,10 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import http.client
 import json
+import logging
 import uuid
 import requests
-import time
 from ducktape.mark.resource import cluster
 
 from rptest.clients.types import TopicSpec
@@ -19,47 +20,62 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.tests.redpanda_test import RedpandaTest
 
 
+def create_topic_names(count):
+    return list(f"pandaproxy-topic-{uuid.uuid4()}" for _ in range(count))
+
+
 class PandaProxyTest(RedpandaTest):
     """
     Test pandaproxy against a redpanda cluster.
     """
     def __init__(self, context):
-        super(PandaProxyTest, self).__init__(context,
-                                             num_brokers=3,
-                                             enable_pp=True)
+        super(PandaProxyTest, self).__init__(
+            context,
+            num_brokers=3,
+            enable_pp=True,
+            extra_rp_conf={"auto_create_topics_enabled": False})
+
+        http.client.HTTPConnection.debuglevel = 1
+        logging.basicConfig()
+        requests_log = logging.getLogger("requests.packages.urllib3")
+        requests_log.setLevel(logging.getLogger().level)
+        requests_log.propagate = True
+
+    def _base_uri(self):
+        return f"http://{self.redpanda.nodes[0].account.hostname}:8082"
+
+    def _create_topics(self,
+                       names=create_topic_names(1),
+                       partitions=1,
+                       replicas=1):
+        self.logger.debug(f"Creating topics: {names}")
+        kafka_tools = KafkaCliTools(self.redpanda)
+        for name in names:
+            kafka_tools.create_topic(
+                TopicSpec(name=name,
+                          partition_count=partitions,
+                          replication_factor=replicas))
+        return names
 
     def _get_topics(self):
-        url = "http://{}:8082/topics".format(
-            self.redpanda.nodes[0].account.hostname)
-        return requests.get(url).json()
+        return requests.get(f"{self._base_uri()}/topics").json()
 
     def _produce_topic(self, topic, data):
-        url = "http://{}:8082/topics/{}".format(
-            self.redpanda.nodes[0].account.hostname, topic)
-        self.logger.info(data)
-        return requests.post(url, data).json()
+        return requests.post(f"{self._base_uri()}/topics/{topic}", data).json()
 
     @cluster(num_nodes=3)
     def test_list_topics(self):
         """
         Create some topics and verify that pandaproxy lists them.
         """
-        names = set("pandaproxy-topic-{}".format(uuid.uuid4())
-                    for _ in range(3))
-        self.logger.debug("Topic names %s", names)
-
         prev = set(self._get_topics())
-        self.logger.debug("Existing topics %s", prev)
+        self.logger.debug(f"Existing topics: {prev}")
+        names = create_topic_names(3)
         assert prev.isdisjoint(names)
-
-        self.logger.debug("Creating test topics")
-        kafka_tools = KafkaCliTools(self.redpanda)
-        for name in names:
-            kafka_tools.create_topic(TopicSpec(name=name,
-                                               replication_factor=1))
-
+        self.logger.info(f"Creating test topics: {names}")
+        names = set(self._create_topics(names))
         curr = set(self._get_topics())
-        self.logger.debug("Current topics %s", curr)
+        self.logger.debug(f"Current topics: {curr}")
         assert names <= curr
 
     @cluster(num_nodes=3)
@@ -67,16 +83,17 @@ class PandaProxyTest(RedpandaTest):
         """
         Create a topic and verify that pandaproxy can produce to it.
         """
-        name = "pandaproxy-topic-{}".format(uuid.uuid4())
-        self.logger.debug("Topic name %s", name)
+        name = create_topic_names(1)[0]
+        data = '''
+        {
+            "records": [
+                {"value": "dmVjdG9yaXplZA==", "partition": 0},
+                {"value": "cGFuZGFwcm94eQ==", "partition": 1},
+                {"value": "bXVsdGlicm9rZXI=", "partition": 2}
+            ]
+        }'''
 
-        prev = set(self._get_topics())
-        self.logger.debug("Existing topics %s", prev)
-        assert prev.isdisjoint(name)
-
-        data = '{"records": [{"value": "dmVjdG9yaXplZA==", "partition": 0},{"value": "cGFuZGFwcm94eQ==", "partition": 1},{"value": "bXVsdGlicm9rZXI=", "partition": 2}]}'
-
-        self.logger.debug("Producing to non-existant topic")
+        self.logger.info(f"Producing to non-existant topic: {name}")
         produce_result = self._produce_topic(name, data)
         for o in produce_result["offsets"]:
             assert o["error_code"] == 3
@@ -84,10 +101,8 @@ class PandaProxyTest(RedpandaTest):
 
         kc = KafkaCat(self.redpanda)
 
-        self.logger.debug("Creating test topic")
-        kafka_tools = KafkaCliTools(self.redpanda)
-        kafka_tools.create_topic(
-            TopicSpec(name=name, replication_factor=1, partition_count=3))
+        self.logger.info(f"Creating test topic: {name}")
+        self._create_topics([name], partitions=3)
 
         self.logger.debug("Waiting for leaders to settle")
         has_leaders = False
@@ -106,13 +121,12 @@ class PandaProxyTest(RedpandaTest):
         #  The retry logic for produce should have sufficient time for this
         #  additional settle time.
 
-        self.logger.debug("Producing to topic")
+        self.logger.info(f"Producing to topic: {name}")
         produce_result = self._produce_topic(name, data)
-        self.logger.debug("Producing to topic: %s", produce_result)
         for o in produce_result["offsets"]:
             assert o["offset"] == 1, f'error_code {o["error_code"]}'
 
-        self.logger.debug(f"Consuming topic: {name}")
+        self.logger.info(f"Consuming from topic: {name}")
         assert kc.consume_one(name, 0, 1)["payload"] == "vectorized"
         assert kc.consume_one(name, 1, 1)["payload"] == "pandaproxy"
         assert kc.consume_one(name, 2, 1)["payload"] == "multibroker"


### PR DESCRIPTION
## Cover letter

Improve testing and test consumer groups `create`, `subscribe`, and `remove`

Improve test logging:
* Add logging for http
* Don't explicitly log http req/res
* Improve log levels
* Use new style string interpolation

Other test improvements:
* Extract useful functions
* Don't auto create topics

Pandaproxy:
* Fix `base_uri` for `create_consumer`
* Ducktape tests for `Create`, `Subscribe`, `Remove` consumer

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/3ba6cf4c73dfb9fa99b6157391cd819f5532a1e4..5692c8da62022c6ea10ebf5dda929d4f4d1bead7)
* Fix the `pandaproxy_fixture_test` for `base_uri`

## Release notes

Release note: Pandaproxy: Fix `base_uri` for `create_consumer`
