### PR TITLE
Fix for crash observed when coprocessor must be immediately deregistered

### DIFF
--- a/src/v/coproc/script_dispatcher.cc
+++ b/src/v/coproc/script_dispatcher.cc
@@ -221,9 +221,9 @@ script_dispatcher::enable_coprocessors(enable_copros_request req) {
     /// can register for input topics that don't yet exist
     if (!deregisters.empty()) {
         vlog(coproclog.error, "Immediately deregistering ids {}", deregisters);
+        auto req = disable_copros_request({.ids = std::move(deregisters)});
         auto reply = co_await client->disable_coprocessors(
-          disable_copros_request{.ids = std::move(deregisters)},
-          rpc::client_opts(model::no_timeout));
+          std::move(req), rpc::client_opts(model::no_timeout));
         if (!reply) {
             vlog(
               coproclog.error,

--- a/src/v/coproc/types.cc
+++ b/src/v/coproc/types.cc
@@ -14,17 +14,47 @@
 #include <boost/range/irange.hpp>
 
 namespace coproc {
+
 std::ostream& operator<<(std::ostream& os, const enable_response_code erc) {
-    const auto errc = make_error_code(
-      static_cast<coproc::errc>(static_cast<int8_t>(erc)));
-    os << errc.message();
+    switch (erc) {
+    case enable_response_code::success:
+        os << "success";
+        break;
+    case enable_response_code::internal_error:
+        os << "internal_error";
+        break;
+    case enable_response_code::invalid_ingestion_policy:
+        os << "invalid_ingestion_policy";
+        break;
+    case enable_response_code::script_id_already_exists:
+        os << "script_id_already_exists";
+        break;
+    case enable_response_code::script_contains_invalid_topic:
+        os << "script_contains_invalid_topic";
+        break;
+    case enable_response_code::script_contains_no_topics:
+        os << "script_contains_no_topics";
+        break;
+    default:
+        __builtin_unreachable();
+    };
     return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const disable_response_code drc) {
-    const auto errc = make_error_code(
-      static_cast<coproc::errc>(static_cast<int8_t>(drc)));
-    os << errc.message();
+    switch (drc) {
+    case disable_response_code::success:
+        os << "success";
+        break;
+    case disable_response_code::internal_error:
+        os << "internal_error";
+        break;
+    case disable_response_code::script_id_does_not_exist:
+        os << "script_id_does_not_exist";
+        break;
+    default:
+        __builtin_unreachable();
+    };
     return os;
 }
 


### PR DESCRIPTION
Fixes a memory corruption bug that is observed when the code takes a path when a script must immediately be de-registered. The crash only occurs in gcc debug & release builds and is most likley connected to there being a compiler error with gcc's coroutine implementation. In this patch I implement a workaround that can be removed if the issue is resolved with gcc-11 