### PR TITLE
rpk/debug/info: Change error msg

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -195,6 +195,9 @@ func getMetrics(
 ) (*metricsResult, error) {
 	res := &metricsResult{[][]string{}, nil}
 	m, err := system.GatherMetrics(fs, timeout, conf)
+	if system.IsErrRedpandaDown(err) {
+		return res, errors.Wrap(err, "Omitting runtime metrics")
+	}
 	if err != nil {
 		return res, errors.Wrap(err, "Error gathering metrics")
 	}

--- a/src/go/rpk/pkg/cli/cmd/debug/info_test.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info_test.go
@@ -103,7 +103,7 @@ power management:
 		},
 		{
 			name:        "doesn't print the CPU% if no pid file is found",
-			expectedOut: "open /var/lib/redpanda/data/pid.lock: file does not exist",
+			expectedOut: "Omitting runtime metrics: the local redpanda process isn't running.",
 			before:      defaultSetup,
 		},
 		{
@@ -158,7 +158,7 @@ power management:
 			expectedOut: "Usage stats reporting is disabled, so" +
 				" nothing will be sent. To enable it, run" +
 				" `rpk config set rpk.enable_usage_stats true`.",
-			expectedErr: "open /var/lib/redpanda/data/pid.lock: file does not exist",
+			expectedErr: "Omitting runtime metrics: the local redpanda process isn't running.",
 			args:        []string{"--send"},
 			before: func(fs afero.Fs) error {
 				conf := getConfig()

--- a/src/go/rpk/pkg/system/metrics_test.go
+++ b/src/go/rpk/pkg/system/metrics_test.go
@@ -39,7 +39,7 @@ func TestGatherMetrics(t *testing.T) {
 		expectedErrMsg: "/proc/4194304/stat",
 	}, {
 		name:           "it should fail if the PID file doesn't exist",
-		expectedErrMsg: "/var/lib/redpanda/data/pid.lock",
+		expectedErrMsg: "the local redpanda process isn't running.",
 	}, {
 		name: "it should fail if the CPU utime can't be parsed",
 		before: func(fs afero.Fs) error {


### PR DESCRIPTION
## Cover letter

When redpanda isn't running, its PID file isn't created. The file is needed by `rpk debug info` to know the local redpanda process' PID, which it uses to gather runtime metrics such as memory & CPU % used. However, seeing a message like

```
Error gathering metrics: 1 error occurred:
    * open /var/lib/redpanda/data/pid.lock: no such file or directory
```

can be alarming and misleading.

This changeset makes `rpk debug info` print a more telling message when redpanda isn't running: `Omitting runtime metrics: the local redpanda process isn't running.`

Fix #688 
