### PR TITLE
Compression type producer

### DIFF
--- a/src/v/compression/compression.cc
+++ b/src/v/compression/compression.cc
@@ -27,8 +27,9 @@ iobuf compressor::compress(const iobuf& io, type t) {
         return internal::lz4_frame_compressor::compress(io);
     case type::zstd:
         return internal::zstd_compressor::compress(io);
+    default:
+        vassert(false, "Cannot compress type {}", t);
     }
-    __builtin_unreachable();
 }
 iobuf compressor::uncompress(const iobuf& io, type t) {
     if (io.empty()) {
@@ -47,8 +48,9 @@ iobuf compressor::uncompress(const iobuf& io, type t) {
         return internal::lz4_frame_compressor::uncompress(io);
     case type::zstd:
         return internal::zstd_compressor::uncompress(io);
+    default:
+        vassert(false, "Cannot uncompress type {}", t);
     }
-    __builtin_unreachable();
 }
 
 } // namespace compression

--- a/src/v/model/compression.h
+++ b/src/v/model/compression.h
@@ -13,12 +13,25 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <limits>
+#include <type_traits>
 
 namespace model {
 
-/// https://kafka.apache.org/documentation/#compression.type
-/// we use the same enum as kafka
-///
+/*
+ * This enum serves three purposes:
+ *
+ * 1. It is used represent batch compression types (eg none, lz4)
+ * 2. It is used represent compression policies (eg producer)
+ *
+ * And (3) the enum values for batch compression types must be identical to
+ * those values used in the encoding of kafka batch attributes.
+ *
+ *    https://kafka.apache.org/documentation/#compression.type
+ *
+ * Compression types like `producer` have values outside the range of values
+ * used in any wire encoded representation and are only used internally.
+ */
 enum class compression : uint8_t {
     none = 0,
     gzip = 1,
@@ -27,7 +40,11 @@ enum class compression : uint8_t {
     // google snappy
     snappy = 2,
     lz4 = 3,
-    zstd = 4
+    zstd = 4,
+
+    // values below must not intersect with the value range used to encode
+    // compression codecs in kafka batch attributes.
+    producer = std::numeric_limits<std::underlying_type_t<compression>>::max()
 };
 
 /// operators needed for boost::lexical_cast<compression>

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -114,6 +114,9 @@ std::ostream& operator<<(std::ostream& os, const compression& c) {
     case compression::zstd:
         os << "zstd";
         break;
+    case compression::producer:
+        os << "producer";
+        break;
     default:
         os << "ERROR";
         break;
@@ -249,7 +252,8 @@ std::istream& operator>>(std::istream& i, compression& c) {
           .match("gzip", compression::gzip)
           .match("snappy", compression::snappy)
           .match("lz4", compression::lz4)
-          .match("zstd", compression::zstd);
+          .match("zstd", compression::zstd)
+          .match("producer", compression::producer);
     return i;
 }
 

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -280,7 +280,8 @@ public:
         return false;
     }
     model::compression compression() const {
-        switch (maskable_value() & compression_mask) {
+        auto value = maskable_value() & compression_mask;
+        switch (value) {
         case 0:
             return compression::none;
         case 1:
@@ -291,8 +292,10 @@ public:
             return compression::lz4;
         case 4:
             return compression::zstd;
+        default:
+            throw std::runtime_error(
+              fmt::format("Unknown compression value: {}", value));
         }
-        throw std::runtime_error("Unknown compression value");
     }
 
     model::timestamp_type timestamp_type() const {


### PR DESCRIPTION
Adds an enumeration value for `producer` compression type which is a
topic/broker level configuration option that states batches should
retain the compression type used by the producer. Since this was
effectively the default behavior before this change but we rejected
configuration value of `producer` this change only needs to accept the
value during topic creation.

Fixes issues: #837 

Release note: Add support for Kafka producer compression type
