### PR TITLE
operator: remove methods from Resource interface

### DIFF
--- a/src/go/k8s/pkg/resources/certmanager/certificate.go
+++ b/src/go/k8s/pkg/resources/certmanager/certificate.go
@@ -73,7 +73,8 @@ func (r *CertificateResource) Ensure(ctx context.Context) error {
 		return fmt.Errorf("unable to construct object: %w", err)
 	}
 
-	return resources.CreateIfNotExists(ctx, r, obj, r.logger)
+	_, err = resources.CreateIfNotExists(ctx, r, obj, r.logger)
+	return err
 }
 
 var errorMissingIssuerRef = errors.New("expecting not nil issuerRef")

--- a/src/go/k8s/pkg/resources/certmanager/certificate.go
+++ b/src/go/k8s/pkg/resources/certmanager/certificate.go
@@ -67,13 +67,19 @@ func (r *CertificateResource) Ensure(ctx context.Context) error {
 	if !r.pandaCluster.Spec.Configuration.TLS.KafkaAPIEnabled {
 		return nil
 	}
-	return resources.GetOrCreate(ctx, r, &cmapiv1.Certificate{}, "Certificate", r.logger)
+
+	obj, err := r.obj()
+	if err != nil {
+		return fmt.Errorf("unable to construct object: %w", err)
+	}
+
+	return resources.CreateIfNotExists(ctx, r, obj, r.logger)
 }
 
 var errorMissingIssuerRef = errors.New("expecting not nil issuerRef")
 
-// Obj returns resource managed client.Object
-func (r *CertificateResource) Obj() (k8sclient.Object, error) {
+// obj returns resource managed client.Object
+func (r *CertificateResource) obj() (k8sclient.Object, error) {
 	if r.issuerRef == nil {
 		return nil, fmt.Errorf("%v %w", r.Key(), errorMissingIssuerRef)
 	}

--- a/src/go/k8s/pkg/resources/certmanager/certificate.go
+++ b/src/go/k8s/pkg/resources/certmanager/certificate.go
@@ -114,11 +114,6 @@ func (r *CertificateResource) Key() types.NamespacedName {
 	return r.key
 }
 
-// Kind returns cert-manager v1.Certificate kind
-func (r *CertificateResource) Kind() string {
-	return certificateKind()
-}
-
 func certificateKind() string {
 	var obj cmapiv1.Certificate
 	return obj.Kind

--- a/src/go/k8s/pkg/resources/certmanager/issuer.go
+++ b/src/go/k8s/pkg/resources/certmanager/issuer.go
@@ -64,7 +64,8 @@ func (r *IssuerResource) Ensure(ctx context.Context) error {
 		return fmt.Errorf("unable to construct object: %w", err)
 	}
 
-	return resources.CreateIfNotExists(ctx, r, obj, r.logger)
+	_, err = resources.CreateIfNotExists(ctx, r, obj, r.logger)
+	return err
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/certmanager/issuer.go
+++ b/src/go/k8s/pkg/resources/certmanager/issuer.go
@@ -112,11 +112,6 @@ func (r *IssuerResource) Key() types.NamespacedName {
 	return r.key
 }
 
-// Kind returns cert-manager v1.Issuer kind
-func (r *IssuerResource) Kind() string {
-	return issuerKind()
-}
-
 // objRef returns the issuer's object reference
 func (r *IssuerResource) objRef() *cmetav1.ObjectReference {
 	return &cmetav1.ObjectReference{

--- a/src/go/k8s/pkg/resources/certmanager/issuer.go
+++ b/src/go/k8s/pkg/resources/certmanager/issuer.go
@@ -11,6 +11,7 @@ package certmanager
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	cmapiv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
@@ -58,11 +59,16 @@ func (r *IssuerResource) Ensure(ctx context.Context) error {
 		return nil
 	}
 
-	return resources.GetOrCreate(ctx, r, &cmapiv1.Issuer{}, "Issuer", r.logger)
+	obj, err := r.obj()
+	if err != nil {
+		return fmt.Errorf("unable to construct object: %w", err)
+	}
+
+	return resources.CreateIfNotExists(ctx, r, obj, r.logger)
 }
 
-// Obj returns resource managed client.Object
-func (r *IssuerResource) Obj() (k8sclient.Object, error) {
+// obj returns resource managed client.Object
+func (r *IssuerResource) obj() (k8sclient.Object, error) {
 	objLabels := labels.ForCluster(r.pandaCluster)
 	objectMeta := metav1.ObjectMeta{
 		Name:      r.Key().Name,

--- a/src/go/k8s/pkg/resources/cluster_role.go
+++ b/src/go/k8s/pkg/resources/cluster_role.go
@@ -104,11 +104,6 @@ func (r *ClusterRoleResource) Key() types.NamespacedName {
 	return types.NamespacedName{Name: "redpanda-init-configurator", Namespace: ""}
 }
 
-// Kind returns v1.ClusterRole kind
-func (r *ClusterRoleResource) Kind() string {
-	return clusterRoleKind()
-}
-
 func clusterRoleKind() string {
 	var r v1.ClusterRole
 	return r.Kind

--- a/src/go/k8s/pkg/resources/cluster_role.go
+++ b/src/go/k8s/pkg/resources/cluster_role.go
@@ -51,7 +51,6 @@ func NewClusterRole(
 }
 
 // Ensure manages v1.ClusterRole that is assigned to v1.ServiceAccount used in initContainer
-// nolint:dupl // The refactor is proposed in https://github.com/vectorizedio/redpanda/pull/779
 func (r *ClusterRoleResource) Ensure(ctx context.Context) error {
 	if !r.pandaCluster.Spec.ExternalConnectivity {
 		return nil
@@ -67,10 +66,7 @@ func (r *ClusterRoleResource) Ensure(ctx context.Context) error {
 	if errors.IsNotFound(err) {
 		r.logger.Info(fmt.Sprintf("ClusterRole %s does not exist, going to create one", r.Key().Name))
 
-		obj, err := r.Obj()
-		if err != nil {
-			return fmt.Errorf("unable to construct ClusterRole object: %w", err)
-		}
+		obj := r.obj()
 
 		if err := r.Create(ctx, obj); err != nil {
 			return fmt.Errorf("unable to create ClusterRole resource: %w", err)
@@ -80,10 +76,10 @@ func (r *ClusterRoleResource) Ensure(ctx context.Context) error {
 	return nil
 }
 
-// Obj returns resource managed client.Object
+// obj returns resource managed client.Object
 // The cluster.redpanda.vectorized.io custom resource is namespaced resource, that's
 // why v1.ClusterRole can not have assigned controller reference.
-func (r *ClusterRoleResource) Obj() (k8sclient.Object, error) {
+func (r *ClusterRoleResource) obj() k8sclient.Object {
 	return &v1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			// metav1.ObjectMeta can NOT have namespace set as
@@ -98,7 +94,7 @@ func (r *ClusterRoleResource) Obj() (k8sclient.Object, error) {
 				Resources: []string{"nodes"},
 			},
 		},
-	}, nil
+	}
 }
 
 // Key returns namespace/name object that is used to identify object.

--- a/src/go/k8s/pkg/resources/cluster_role.go
+++ b/src/go/k8s/pkg/resources/cluster_role.go
@@ -53,7 +53,8 @@ func (r *ClusterRoleResource) Ensure(ctx context.Context) error {
 	if !r.pandaCluster.Spec.ExternalConnectivity {
 		return nil
 	}
-	return CreateIfNotExists(ctx, r, r.obj(), r.logger)
+	_, err := CreateIfNotExists(ctx, r, r.obj(), r.logger)
+	return err
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/cluster_role.go
+++ b/src/go/k8s/pkg/resources/cluster_role.go
@@ -11,13 +11,11 @@ package resources
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -55,25 +53,7 @@ func (r *ClusterRoleResource) Ensure(ctx context.Context) error {
 	if !r.pandaCluster.Spec.ExternalConnectivity {
 		return nil
 	}
-
-	var cr v1.ClusterRole
-
-	err := r.Get(ctx, r.Key(), &cr)
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("error while fetching ClusterRole resource: %w", err)
-	}
-
-	if errors.IsNotFound(err) {
-		r.logger.Info(fmt.Sprintf("ClusterRole %s does not exist, going to create one", r.Key().Name))
-
-		obj := r.obj()
-
-		if err := r.Create(ctx, obj); err != nil {
-			return fmt.Errorf("unable to create ClusterRole resource: %w", err)
-		}
-	}
-
-	return nil
+	return CreateIfNotExists(ctx, r, r.obj(), r.logger)
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/cluster_role_binding.go
+++ b/src/go/k8s/pkg/resources/cluster_role_binding.go
@@ -65,7 +65,7 @@ func (r *ClusterRoleBindingResource) Ensure(ctx context.Context) error {
 	if errors.IsNotFound(err) {
 		r.logger.Info(fmt.Sprintf("ClusterRoleBinding %s does not exist, going to create one", r.Key().Name))
 
-		obj, err := r.Obj()
+		obj, err := r.obj()
 		if err != nil {
 			return fmt.Errorf("unable to construct ClusterRoleBinding object: %w", err)
 		}
@@ -100,10 +100,10 @@ func (r *ClusterRoleBindingResource) Ensure(ctx context.Context) error {
 	return nil
 }
 
-// Obj returns resource managed client.Object
+// obj returns resource managed client.Object
 // The cluster.redpanda.vectorized.io custom resource is namespaced resource, that's
 // why v1.ClusterRoleBinding can not have assigned controller reference.
-func (r *ClusterRoleBindingResource) Obj() (k8sclient.Object, error) {
+func (r *ClusterRoleBindingResource) obj() (k8sclient.Object, error) {
 	role := &ClusterRoleResource{}
 	sa := &ServiceAccountResource{pandaCluster: r.pandaCluster}
 

--- a/src/go/k8s/pkg/resources/cluster_role_binding.go
+++ b/src/go/k8s/pkg/resources/cluster_role_binding.go
@@ -65,7 +65,7 @@ func (r *ClusterRoleBindingResource) Ensure(ctx context.Context) error {
 	if errors.IsNotFound(err) {
 		r.logger.Info(fmt.Sprintf("ClusterRoleBinding %s does not exist, going to create one", r.Key().Name))
 
-		obj, err := r.obj()
+		obj, err := r.Obj()
 		if err != nil {
 			return fmt.Errorf("unable to construct ClusterRoleBinding object: %w", err)
 		}
@@ -100,10 +100,10 @@ func (r *ClusterRoleBindingResource) Ensure(ctx context.Context) error {
 	return nil
 }
 
-// obj returns resource managed client.Object
+// Obj returns resource managed client.Object
 // The cluster.redpanda.vectorized.io custom resource is namespaced resource, that's
 // why v1.ClusterRoleBinding can not have assigned controller reference.
-func (r *ClusterRoleBindingResource) obj() (k8sclient.Object, error) {
+func (r *ClusterRoleBindingResource) Obj() (k8sclient.Object, error) {
 	role := &ClusterRoleResource{}
 	sa := &ServiceAccountResource{pandaCluster: r.pandaCluster}
 
@@ -134,11 +134,6 @@ func (r *ClusterRoleBindingResource) obj() (k8sclient.Object, error) {
 // Note that Namespace can not be set as this is cluster scoped resource
 func (r *ClusterRoleBindingResource) Key() types.NamespacedName {
 	return types.NamespacedName{Name: "redpanda-init-configurator", Namespace: ""}
-}
-
-// Kind returns v1.ClusterRoleBinding kind
-func (r *ClusterRoleBindingResource) Kind() string {
-	return clusterRoleBindingKind()
 }
 
 // RemoveSubject removes ServiceAccount from the ClusterRoleBinding subject list

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -167,11 +167,6 @@ func ConfigMapKey(pandaCluster *redpandav1alpha1.Cluster) types.NamespacedName {
 	return types.NamespacedName{Name: pandaCluster.Name + baseSuffix, Namespace: pandaCluster.Namespace}
 }
 
-// Kind returns v1.ConfigMap kind
-func (r *ConfigMapResource) Kind() string {
-	return configMapKind()
-}
-
 func configMapKind() string {
 	var cfg corev1.ConfigMap
 	return cfg.Kind

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -70,7 +70,8 @@ func (r *ConfigMapResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to construct object: %w", err)
 	}
-	return CreateIfNotExists(ctx, r, obj, r.logger)
+	_, err = CreateIfNotExists(ctx, r, obj, r.logger)
+	return err
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -66,11 +66,15 @@ func NewConfigMap(
 
 // Ensure will manage kubernetes v1.ConfigMap for redpanda.vectorized.io CR
 func (r *ConfigMapResource) Ensure(ctx context.Context) error {
-	return GetOrCreate(ctx, r, &corev1.ConfigMap{}, "ConfigMap", r.logger)
+	obj, err := r.obj()
+	if err != nil {
+		return fmt.Errorf("unable to construct object: %w", err)
+	}
+	return CreateIfNotExists(ctx, r, obj, r.logger)
 }
 
-// Obj returns resource managed client.Object
-func (r *ConfigMapResource) Obj() (k8sclient.Object, error) {
+// obj returns resource managed client.Object
+func (r *ConfigMapResource) obj() (k8sclient.Object, error) {
 	cfgBytes, err := yaml.Marshal(r.createConfiguration())
 	if err != nil {
 		return nil, err

--- a/src/go/k8s/pkg/resources/headless_service.go
+++ b/src/go/k8s/pkg/resources/headless_service.go
@@ -102,11 +102,6 @@ func (r *HeadlessServiceResource) Key() types.NamespacedName {
 	return types.NamespacedName{Name: r.pandaCluster.Name, Namespace: r.pandaCluster.Namespace}
 }
 
-// Kind returns v1.Service kind
-func (r *HeadlessServiceResource) Kind() string {
-	return serviceKind()
-}
-
 func serviceKind() string {
 	var svc corev1.Service
 	return svc.Kind

--- a/src/go/k8s/pkg/resources/headless_service.go
+++ b/src/go/k8s/pkg/resources/headless_service.go
@@ -57,11 +57,15 @@ func NewHeadlessService(
 
 // Ensure will manage kubernetes v1.Service for redpanda.vectorized.io custom resource
 func (r *HeadlessServiceResource) Ensure(ctx context.Context) error {
-	return GetOrCreate(ctx, r, &corev1.Service{}, "Service Headless", r.logger)
+	obj, err := r.obj()
+	if err != nil {
+		return fmt.Errorf("unable to construct object: %w", err)
+	}
+	return CreateIfNotExists(ctx, r, obj, r.logger)
 }
 
-// Obj returns resource managed client.Object
-func (r *HeadlessServiceResource) Obj() (k8sclient.Object, error) {
+// obj returns resource managed client.Object
+func (r *HeadlessServiceResource) obj() (k8sclient.Object, error) {
 	objLabels := labels.ForCluster(r.pandaCluster)
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/src/go/k8s/pkg/resources/headless_service.go
+++ b/src/go/k8s/pkg/resources/headless_service.go
@@ -61,7 +61,8 @@ func (r *HeadlessServiceResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to construct object: %w", err)
 	}
-	return CreateIfNotExists(ctx, r, obj, r.logger)
+	_, err = CreateIfNotExists(ctx, r, obj, r.logger)
+	return err
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -122,8 +122,3 @@ func CalculateExternalPort(kafkaInternalPort int) int {
 func (r *NodePortServiceResource) Key() types.NamespacedName {
 	return types.NamespacedName{Name: r.pandaCluster.Name + "-external", Namespace: r.pandaCluster.Namespace}
 }
-
-// Kind returns v1.Service kind
-func (r *NodePortServiceResource) Kind() string {
-	return serviceKind()
-}

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -11,6 +11,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
@@ -56,11 +57,16 @@ func (r *NodePortServiceResource) Ensure(ctx context.Context) error {
 		return nil
 	}
 
-	return GetOrCreate(ctx, r, &corev1.Service{}, "Service NodePort", r.logger)
+	obj, err := r.obj()
+	if err != nil {
+		return fmt.Errorf("unable to construct object: %w", err)
+	}
+
+	return CreateIfNotExists(ctx, r, obj, r.logger)
 }
 
-// Obj returns resource managed client.Object
-func (r *NodePortServiceResource) Obj() (k8sclient.Object, error) {
+// obj returns resource managed client.Object
+func (r *NodePortServiceResource) obj() (k8sclient.Object, error) {
 	objLabels := labels.ForCluster(r.pandaCluster)
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -62,7 +62,8 @@ func (r *NodePortServiceResource) Ensure(ctx context.Context) error {
 		return fmt.Errorf("unable to construct object: %w", err)
 	}
 
-	return CreateIfNotExists(ctx, r, obj, r.logger)
+	_, err = CreateIfNotExists(ctx, r, obj, r.logger)
+	return err
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -30,9 +30,6 @@ type Resource interface {
 	// Key returns namespace/name object that is used to identify object.
 	// For reference please visit types.NamespacedName docs in k8s.io/apimachinery
 	Key() types.NamespacedName
-
-	// Kind returns the canonical name of the kubernetes managed resource
-	Kind() string
 }
 
 // Reconciler implements reconciliation logic

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -42,6 +42,9 @@ type Reconciler interface {
 func CreateIfNotExists(
 	ctx context.Context, c client.Client, obj client.Object, l logr.Logger,
 ) error {
+	if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(obj); err != nil {
+		return fmt.Errorf("unable to add last applied annotation to %s: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
+	}
 	err := c.Create(ctx, obj)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("unable to create %s resource: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)

--- a/src/go/k8s/pkg/resources/service_account.go
+++ b/src/go/k8s/pkg/resources/service_account.go
@@ -102,11 +102,6 @@ func (s *ServiceAccountResource) Key() types.NamespacedName {
 	return types.NamespacedName{Name: s.pandaCluster.Name, Namespace: s.pandaCluster.Namespace}
 }
 
-// Kind returns v1.ServiceAccount kind
-func (s *ServiceAccountResource) Kind() string {
-	return serviceAccountKind()
-}
-
 func serviceAccountKind() string {
 	var sa corev1.ServiceAccount
 	return sa.Kind

--- a/src/go/k8s/pkg/resources/service_account.go
+++ b/src/go/k8s/pkg/resources/service_account.go
@@ -60,7 +60,8 @@ func (s *ServiceAccountResource) Ensure(ctx context.Context) error {
 		return fmt.Errorf("unable to construct ServiceAccount object: %w", err)
 	}
 
-	return CreateIfNotExists(ctx, s, obj, s.logger)
+	_, err = CreateIfNotExists(ctx, s, obj, s.logger)
+	return err
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/service_account.go
+++ b/src/go/k8s/pkg/resources/service_account.go
@@ -51,7 +51,6 @@ func NewServiceAccount(
 }
 
 // Ensure manages ServiceAccount that is used in initContainer
-// nolint:dupl // The refactor is proposed in https://github.com/vectorizedio/redpanda/pull/779
 func (s *ServiceAccountResource) Ensure(ctx context.Context) error {
 	if !s.pandaCluster.Spec.ExternalConnectivity {
 		return nil
@@ -67,7 +66,7 @@ func (s *ServiceAccountResource) Ensure(ctx context.Context) error {
 	if errors.IsNotFound(err) {
 		s.logger.Info(fmt.Sprintf("ServiceAccount %s does not exist, going to create one", s.Key().Name))
 
-		obj, err := s.Obj()
+		obj, err := s.obj()
 		if err != nil {
 			return fmt.Errorf("unable to construct ServiceAccount object: %w", err)
 		}
@@ -80,8 +79,8 @@ func (s *ServiceAccountResource) Ensure(ctx context.Context) error {
 	return nil
 }
 
-// Obj returns resource managed client.Object
-func (s *ServiceAccountResource) Obj() (k8sclient.Object, error) {
+// obj returns resource managed client.Object
+func (s *ServiceAccountResource) obj() (k8sclient.Object, error) {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.Key().Name,

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -126,9 +126,9 @@ func (r *StatefulSetResource) Ensure(ctx context.Context) error {
 	if k8serrors.IsNotFound(err) {
 		r.logger.Info(fmt.Sprintf("StatefulSet %s does not exist, going to create one", r.Key().Name))
 
-		obj, objErr := r.Obj()
+		obj, objErr := r.obj()
 		if objErr != nil {
-			return fmt.Errorf("unable to construct StatefulSet object: %w", err)
+			return fmt.Errorf("unable to construct StatefulSet object: %w", objErr)
 		}
 
 		// this needs to be set when object gets created to be able to generate patches later
@@ -155,7 +155,7 @@ func (r *StatefulSetResource) Ensure(ctx context.Context) error {
 			return fmt.Errorf("failed to run partitioned update: %w", err)
 		}
 	} else {
-		modified, err := r.Obj()
+		modified, err := r.obj()
 		if err != nil {
 			return err
 		}
@@ -199,9 +199,9 @@ func preparePVCResource(
 	return pvc
 }
 
-// Obj returns resource managed client.Object
-// nolint:funlen // The complexity of Obj function will be address in the next version TODO
-func (r *StatefulSetResource) Obj() (k8sclient.Object, error) {
+// obj returns resource managed client.Object
+// nolint:funlen // The complexity of obj function will be address in the next version TODO
+func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 	var configMapDefaultMode int32 = 0754
 
 	var clusterLabels = labels.ForCluster(r.pandaCluster)

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -473,11 +473,6 @@ func (r *StatefulSetResource) Key() types.NamespacedName {
 	return types.NamespacedName{Name: r.pandaCluster.Name, Namespace: r.pandaCluster.Namespace}
 }
 
-// Kind returns v1.StatefulSet kind
-func (r *StatefulSetResource) Kind() string {
-	return statefulSetKind()
-}
-
 func (r *StatefulSetResource) portsConfiguration() string {
 	rpcAPIPort := r.pandaCluster.Spec.Configuration.RPCServer.Port
 	svcName := r.serviceName

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -270,7 +270,7 @@ func (r *StatefulSetResource) rollingUpdatePartition(
 ) error {
 	r.logger.Info("Call update on statefulset", "ordinal", ordinal)
 
-	modified, err := r.Obj()
+	modified, err := r.obj()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Cover letter

We started with Resource interface that has many fields that make sense for resources but it turned out to be premature generalization as we're not really using these methods. This PR drops Obj() as well as Kind() and changes implementation of GetOrCreate to CreateIfNotExists with much simpler code.

I've kept the Key() method there as that's used at least somewhere and makes sense to me (to have that identifiable) but it's up for discussion. If we decide, we can remove it as well. In this or follow-up PR.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
