### PR TITLE
operator/helm: Create release process for helm chart

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,52 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+name: release
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    container: quay.io/helmpack/chart-releaser:v1.2.0
+    steps:
+
+    - name: Install Git
+      run: apk update && apk upgrade && apk add --no-cache git
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.4.1
+
+    - name: Package helm chart
+      working-directory: src/go/k8s/helm-chart/charts
+      run: helm package --version ${{ github.event.release.tag_name }} --app-version ${{ github.event.release.tag_name }} redpanda-operator
+
+    - name: Upload helm package to release
+      uses: svenstaro/upload-release-action@2.2.1
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: src/go/k8s/helm-chart/charts/redpanda-operator-${{ github.event.release.tag_name }}.tgz
+        asset_name: redpanda-operator-${{ github.event.release.tag_name }}.tgz
+        tag: ${{ github.event.release.tag_name }}
+
+    - name: Update index
+      run: |
+        cr index -o $GITHUB_ACTOR -r redpanda -c https://charts.vectorized.io/ -i index.yaml -p src/go/k8s/helm-chart/charts -t ${{ secrets.GITHUB_TOKEN }} --push --release-name-template "{{ .Version }}"

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/Chart.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/Chart.yaml
@@ -3,14 +3,11 @@ name: redpanda-operator
 description: Redpanda operator helm chart
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
+# This is the chart version. This is only placeholder that will be set during release process
 version: 0.1.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
+# This is the version number of the application being deployed. This is only placeholder that
+# will be set during release process.
 appVersion: v21.3.4
 
 home: https://vectorized.io

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
@@ -54,7 +54,7 @@ Other instruction will be visible after installation.
 | fullnameOverride | string | `""` | Override the fully qualified app name |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Redpanda Operator image |
 | image.repository | string | `"vectorized/redpanda-operator"` | Repository that Redpanda Operator image is available |
-| image.tag | string | `"latest"` | Define the Redpanda Operator container tag |
+| image.tag | string | `"{{ .Chart.AppVersion }}"` | Define the Redpanda Operator container tag |
 | imagePullSecrets | list | `[]` | Redpanda Operator container registry pullSecret (ex: specify docker registry credentials) |
 | labels | string | `nil` | Allows to assign labels to the resources created by this helm chart |
 | logLevel | string | `"info"` | Set Redpanda Operator log level (debug, info, error, panic, fatal) |

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/deployment.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - containerPort: 8443
           name: https
       - name: manager
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - --health-probe-bind-address=:8081

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
@@ -15,7 +15,8 @@ image:
   # image.repository -- Repository that Redpanda Operator image is available
   repository: vectorized/redpanda-operator
   # image.tag -- Define the Redpanda Operator container tag
-  tag: v21.3.4
+  tag: |-
+    {{ .Chart.AppVersion }}
   # image.pullPolicy -- Define the pullPolicy for Redpanda Operator image
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Cover letter

The gh-pages empty branch was created in redpanda repo using the [following instruction](https://gist.github.com/blattmann/4bc90557c2bc2907e715f45ec35674a2#:~:text=Create%20empty%20branch-,Git%3A%20Empty%20branch.md,with%20your%20desired%20branch%20name.&text=Then%20you%20can%20remove%20all,empty%20branch%2C%20on%20your%20machine.). In my personal fork I test the release process by creating the tag with the release [v21.3.8](https://github.com/RafalKorepta/redpanda/releases/tag/v21.3.8). The [pipeline passed](https://github.com/RafalKorepta/redpanda/runs/2122213668?check_suite_focus=true). In the forks [gh-pages branch](https://github.com/RafalKorepta/redpanda/tree/gh-pages) we can see index.yaml and first redpanda-operator-v21.3.8 release. 

The difference between helm-chart gh-pages and my fork is that the [CNAME file is missing.](https://github.com/vectorizedio/helm-charts/blob/gh-pages/CNAME)

---
**NOTE**

Release and tag should be semver compatible. I run test with test2 release name and[ the pipeline failed with message "Invalid Semantic Version"](https://github.com/RafalKorepta/redpanda/runs/2122084264?check_suite_focus=true).

The `helm package --version test2 redpanda-operator` gives similar output:

> Error: Invalid Semantic Version

---

## Release notes

Using `charts.vectorize.io` chart repository user should be able to install redpanda-operator helm chart.

Release note: `redpanda-operator` chart is available in `charts.vectorized.io` chart repository.
