### PR TITLE
operator/test: reduce test parallelism from 8 (default) to 3

### DIFF
--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -14,3 +14,4 @@ commands:
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_e2e_artifacts
 timeout: 300
+parallel: 3


### PR DESCRIPTION
As we've been adding e2e tests (from 3-4 to more than 8), there has been some instability in k8s tests. Lack of resources may be part of the problem, hence reducing parallelism from 8 to 3.