### PR TITLE
operator/helm-test: reduce helm test parallelism from 8 (default) to 3

### DIFF
--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -16,3 +16,4 @@ commands:
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_helm_e2e_artifacts
 timeout: 300
+parallel: 3


### PR DESCRIPTION
As we've been adding e2e tests (from 3-4 to more than 8), there has been some instability in k8s tests. Lack of resources may be part of the problem, hence reducing parallelism from 8 to 3.

PR https://github.com/vectorizedio/redpanda/pull/867 took care of the "regular" kuttl tests, this one takes care of the helm kuttl tests.