### PR TITLE
operator: Make helm e2e test serial

### DIFF
--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -16,4 +16,4 @@ commands:
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_helm_e2e_artifacts
 timeout: 300
-parallel: 3
+parallel: 1


### PR DESCRIPTION
The problems with e2e tests are still occurring. The serial execution
should show if this is problem of the helm deployment.