### PR TITLE
gcb: print vtools/ repo sha1 after cloning it

### DIFF
--- a/tests/ci/cloudbuild.yaml
+++ b/tests/ci/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
       --depth=1 \
       --branch=release \
       https://$_GITHUB_API_TOKEN@github.com/vectorizedio/vtools
+    git -C vtools/ rev-parse HEAD
     cp vtools/taskfiles/main.yml Taskfile.yml
 
 - id: install task


### PR DESCRIPTION
show commit of vtools repo to keep track of which version was used for a build