### PR TITLE
operator: reduce helm test suite to speed up CI

### DIFF
--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -15,4 +15,4 @@ commands:
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_helm_e2e_artifacts
 timeout: 300
-parallel: 1
+parallel: 3

--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -6,7 +6,6 @@ kindContainers:
   - vectorized/redpanda-operator:latest
   - vectorized/configurator:latest
 testDirs:
-  - ./tests/e2e
   - ./tests/e2e-helm
 kindConfig: ./kind.yaml
 commands:


### PR DESCRIPTION
## Cover letter

Until we figure out how to run this in parallel and without flakes, let's drop
this. The remaining test gives us pretty good coverage already and I don't
think the longer CI loop times are justified at this point.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
