### PR TITLE
operator: Add missing configurator container tag

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -254,7 +254,7 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 					InitContainers: []corev1.Container{
 						{
 							Name:            configuratorContainerName,
-							Image:           configuratorContainerImage,
+							Image:           configuratorContainerImage + ":" + r.configuratorTag,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Env: []corev1.EnvVar{
 								{


### PR DESCRIPTION
## Cover letter

The main has configurator tag feature flag introduced in
https://github.com/vectorizedio/redpanda/pull/782/commits/764f452da722c35bc17f1eb08fed33f864939115
commit.

The problem was it was not used in the statefulset definition.

## Release notes

The configurator was wrongly defined. Only latest tag was used.

Release note: Fix the configurator tag propagation.
