### PR TITLE
operator: Fix the configurator environment variable logging

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -87,7 +87,7 @@ func main() {
 		log.Fatalf("%s", fmt.Errorf("unable to get the environment variables: %w", err))
 	}
 
-	log.Print(c)
+	log.Print(c.String())
 
 	fs := afero.NewOsFs()
 	v := config.InitViper(fs)


### PR DESCRIPTION
## Cover letter

The log.Print does not respect stringer interface. The log.Printf("%v")
does. This change just call String function explicitly.