### PR TITLE
rpk/config: Use mapstructure

### DIFF
--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/logr v0.3.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/jetstack/cert-manager v1.2.0
-	github.com/mitchellh/mapstructure v1.1.2
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/spf13/afero v1.2.2
@@ -16,7 +16,6 @@ require (
 	github.com/vectorizedio/redpanda/src/go/rpk v0.0.0-00010101000000-000000000000
 	golang.org/x/tools v0.0.0-20210107193943-4ed967dd8eff // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -440,6 +440,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
-	github.com/mitchellh/mapstructure v1.1.2
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -47,7 +47,7 @@ require (
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc
 	google.golang.org/grpc v1.22.0 // indirect
-	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible // indirect
 	mvdan.cc/sh/v3 v3.2.1
 )

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -6,6 +6,7 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiUOryc=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.26.1 h1:3jnfWKD7gVwbB1KSy/lE0szA9duPuSFLViK0o/d3DgA=
 github.com/Shopify/sarama v1.26.1/go.mod h1:NbSGBSSndYaIhRcBtY9V0U7AyH+x71bG668AuWys/yU=
@@ -252,6 +253,7 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
@@ -412,6 +414,8 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -189,6 +189,10 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.2.3 h1:f/MjBEBDLttYCGfRaKBbKSRVF5aV2O6fnBpzknuE3jU=
+github.com/mitchellh/mapstructure v1.2.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c h1:nXxl5PrvVm2L/wCy8dQu6DMTwH4oIuGN8GJDAlqDdVE=

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -249,7 +249,7 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 		)
 	} else {
 		socket := &SocketAddress{}
-		err := v.UnmarshalKey(rpcServerKey, socket)
+		err := unmarshalKey(v, rpcServerKey, socket)
 		if err != nil {
 			errs = append(
 				errs,
@@ -272,7 +272,7 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 		)
 	} else {
 		var kafkaListeners []NamedSocketAddress
-		err := v.UnmarshalKey("redpanda.kafka_api", &kafkaListeners)
+		err := unmarshalKey(v, "redpanda.kafka_api", &kafkaListeners)
 		if err != nil {
 			log.Error(err)
 			err = fmt.Errorf(
@@ -301,7 +301,7 @@ func checkRedpandaConfig(v *viper.Viper) []error {
 	}
 
 	var seedServersSlice []*SeedServer //map[string]interface{}
-	err := v.UnmarshalKey("redpanda.seed_servers", &seedServersSlice)
+	err := unmarshalKey(v, "redpanda.seed_servers", &seedServersSlice)
 	if err != nil {
 		log.Error(err)
 		msg := "redpanda.seed_servers doesn't have the expected structure"
@@ -381,6 +381,14 @@ func decoderConfigOptions() viper.DecoderConfigOption {
 		c.DecodeHook = cfg.DecodeHook
 		c.WeaklyTypedInput = cfg.WeaklyTypedInput
 	}
+}
+
+func unmarshalKey(v *viper.Viper, key string, val interface{}) error {
+	return v.UnmarshalKey(
+		key,
+		val,
+		decoderConfigOptions(),
+	)
 }
 
 func toMap(conf *Config) (map[string]interface{}, error) {

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -212,6 +212,7 @@ func TestDefault(t *testing.T) {
 			}},
 			AdminApi:      SocketAddress{"0.0.0.0", 9644},
 			Id:            0,
+			SeedServers:   []SeedServer{},
 			DeveloperMode: true,
 		},
 		Rpk: RpkConfig{

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -789,6 +789,72 @@ rpk:
   well_known_io: vendor:vm:storage
 `,
 		},
+		{
+			name: "should update an existing config with single kafka_api & advertised_kafka_api obj to a list",
+			existingConf: `config_file: /etc/redpanda/redpanda.yaml
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  admin_api_doc_dir: /usr/share/redpanda/admin-api-doc
+  auto_create_topics_enabled: true
+  data_directory: /var/lib/redpanda/data
+  default_window_sec: 100
+  kafka_api:
+    address: 0.0.0.0
+    port: 9092
+  advertised_kafka_api:
+    address: 1.cluster.redpanda.io
+    port: 9092
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  target_quota_byte_rate: 1000000
+`,
+			conf:    Default,
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  admin_api_doc_dir: /usr/share/redpanda/admin-api-doc
+  advertised_kafka_api:
+  - address: 1.cluster.redpanda.io
+    port: 9092
+  auto_create_topics_enabled: true
+  data_directory: /var/lib/redpanda/data
+  default_window_sec: 100
+  developer_mode: true
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers: []
+  target_quota_byte_rate: 1000000
+rpk:
+  coredump_dir: /var/lib/redpanda/coredump
+  enable_memory_locking: false
+  enable_usage_stats: false
+  overprovisioned: false
+  tune_aio_events: false
+  tune_clocksource: false
+  tune_coredump: false
+  tune_cpu: false
+  tune_disk_irq: false
+  tune_disk_nomerges: false
+  tune_disk_scheduler: false
+  tune_disk_write_cache: false
+  tune_fstrim: false
+  tune_network: false
+  tune_swappiness: false
+  tune_transparent_hugepages: false
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -149,17 +149,10 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 		"redpanda.rpc_server",
 		"redpanda.admin",
 	}
-	unmarshalKey := func(key string, val interface{}) error {
-		return m.v.UnmarshalKey(
-			key,
-			val,
-			decoderConfigOptions(),
-		)
-	}
 	for _, k := range keys {
 		if k == "redpanda.seed_servers" {
 			seeds := &[]SeedServer{}
-			err := unmarshalKey(k, seeds)
+			err := unmarshalKey(m.v, k, seeds)
 			if err != nil {
 				return nil, err
 			}
@@ -175,7 +168,7 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 		}
 		if k == "redpanda.advertised_kafka_api" || k == "redpanda.kafka_api" {
 			addrs := []NamedSocketAddress{}
-			err := unmarshalKey(k, &addrs)
+			err := unmarshalKey(m.v, k, &addrs)
 			if err != nil {
 				return nil, err
 			}
@@ -206,7 +199,7 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 	}
 	for _, k := range compactAddrFields {
 		sa := &SocketAddress{}
-		err := unmarshalKey(k, sa)
+		err := unmarshalKey(m.v, k, sa)
 		if err != nil {
 			return nil, err
 		}

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -267,7 +267,15 @@ func (m *manager) Write(conf *Config) error {
 	// Merge the config into a new viper.Viper instance to prevent
 	// concurrent writes to the underlying config map.
 	v := InitViper(m.fs)
-	v.MergeConfigMap(m.v.AllSettings())
+	current, err := unmarshal(m.v)
+	if err != nil {
+		return err
+	}
+	currentMap, err := toMap(current)
+	if err != nil {
+		return err
+	}
+	v.MergeConfigMap(currentMap)
 	v.MergeConfigMap(confMap)
 	return checkAndWrite(m.fs, v, conf.ConfigFile)
 }

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -153,9 +153,7 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 		return m.v.UnmarshalKey(
 			key,
 			val,
-			func(c *mapstructure.DecoderConfig) {
-				c.TagName = "mapstructure"
-			},
+			decoderConfigOptions(),
 		)
 	}
 	for _, k := range keys {
@@ -388,16 +386,8 @@ func recover(fs afero.Fs, backup, path string, err error) error {
 
 func unmarshal(v *viper.Viper) (*Config, error) {
 	result := &Config{}
-	decoderConfig := mapstructure.DecoderConfig{
-		Result: result,
-		// Sometimes viper will save int values as strings (i.e.
-		// through BindPFlag) so we have to allow mapstructure
-		// to cast them.
-		WeaklyTypedInput: true,
-		DecodeHook: mapstructure.ComposeDecodeHookFunc(
-			v21_1_4MapToNamedSocketAddressSlice,
-		),
-	}
+	decoderConfig := decoderConfig()
+	decoderConfig.Result = result
 	decoder, err := mapstructure.NewDecoder(&decoderConfig)
 	if err != nil {
 		return nil, err

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -12,26 +12,28 @@ package config
 import "path"
 
 type Config struct {
-	NodeUuid     string         `yaml:"node_uuid,omitempty" mapstructure:"node_uuid,omitempty" json:"nodeUuid"`
-	Organization string         `yaml:"organization,omitempty" mapstructure:"organization,omitempty" json:"organization"`
-	LicenseKey   string         `yaml:"license_key,omitempty" mapstructure:"license_key,omitempty" json:"licenseKey"`
-	ClusterId    string         `yaml:"cluster_id,omitempty" mapstructure:"cluster_id,omitempty" json:"clusterId"`
-	ConfigFile   string         `yaml:"config_file" mapstructure:"config_file" json:"configFile"`
-	Redpanda     RedpandaConfig `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
-	Rpk          RpkConfig      `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
+	NodeUuid     string                 `yaml:"node_uuid,omitempty" mapstructure:"node_uuid,omitempty" json:"nodeUuid"`
+	Organization string                 `yaml:"organization,omitempty" mapstructure:"organization,omitempty" json:"organization"`
+	LicenseKey   string                 `yaml:"license_key,omitempty" mapstructure:"license_key,omitempty" json:"licenseKey"`
+	ClusterId    string                 `yaml:"cluster_id,omitempty" mapstructure:"cluster_id,omitempty" json:"clusterId"`
+	ConfigFile   string                 `yaml:"config_file" mapstructure:"config_file" json:"configFile"`
+	Redpanda     RedpandaConfig         `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
+	Rpk          RpkConfig              `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
+	Other        map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 
 type RedpandaConfig struct {
-	Directory          string               `yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
-	RPCServer          SocketAddress        `yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
-	AdvertisedRPCAPI   *SocketAddress       `yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
-	KafkaApi           []NamedSocketAddress `yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
-	AdvertisedKafkaApi []NamedSocketAddress `yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
-	KafkaApiTLS        ServerTLS            `yaml:"kafka_api_tls,omitempty" mapstructure:"kafka_api_tls,omitempty" json:"kafkaApiTls"`
-	AdminApi           SocketAddress        `yaml:"admin" mapstructure:"admin" json:"admin"`
-	Id                 int                  `yaml:"node_id" mapstructure:"node_id" json:"id"`
-	SeedServers        []SeedServer         `yaml:"seed_servers" mapstructure:"seed_servers" json:"seedServers"`
-	DeveloperMode      bool                 `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
+	Directory          string                 `yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
+	RPCServer          SocketAddress          `yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
+	AdvertisedRPCAPI   *SocketAddress         `yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
+	KafkaApi           []NamedSocketAddress   `yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
+	AdvertisedKafkaApi []NamedSocketAddress   `yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
+	KafkaApiTLS        ServerTLS              `yaml:"kafka_api_tls,omitempty" mapstructure:"kafka_api_tls,omitempty" json:"kafkaApiTls"`
+	AdminApi           SocketAddress          `yaml:"admin" mapstructure:"admin" json:"admin"`
+	Id                 int                    `yaml:"node_id" mapstructure:"node_id" json:"id"`
+	SeedServers        []SeedServer           `yaml:"seed_servers" mapstructure:"seed_servers" json:"seedServers"`
+	DeveloperMode      bool                   `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
+	Other              map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 
 type SeedServer struct {


### PR DESCRIPTION
## Cover letter

Use mapstructure to marshal/ unmarshal a map into a `config.Config` instance. The pipeline is:

viper searches for the config file -> viper parses it from yaml to a map (it uses go-yaml underneath) -> the viper decoder hook using mapstructure translates it from map to config.Config. The viper hook itself uses a mapstructure `DecodeHook` which knows how to translate older config formats into the most recent schema.  

Fix #524
Fix #685

## Release notes

Release note: FIxes a bug in rpk where if an existing config file had a single listener, and multiple listeners were passed to rpk start, the new config wouldn't be persisted.

