### PR TITLE
operator/tls: validation for webhook fields

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -60,6 +60,8 @@ func (r *Cluster) ValidateCreate() error {
 
 	allErrs = append(allErrs, r.validateMemory()...)
 
+	allErrs = append(allErrs, r.validateTLS()...)
+
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -86,6 +88,8 @@ func (r *Cluster) ValidateUpdate(old runtime.Object) error {
 
 	allErrs = append(allErrs, r.validateMemory()...)
 
+	allErrs = append(allErrs, r.validateTLS()...)
+
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -110,6 +114,18 @@ func (r *Cluster) validateMemory() field.ErrorList {
 				field.NewPath("spec").Child("resources").Child("limits").Child("memory"),
 				r.Spec.Resources.Limits.Memory(),
 				"need minimum of 1GB + 1MB of memory per node"))
+	}
+	return allErrs
+}
+
+func (r *Cluster) validateTLS() field.ErrorList {
+	var allErrs field.ErrorList
+	if r.Spec.Configuration.TLS.RequireClientAuth && !r.Spec.Configuration.TLS.KafkaAPIEnabled {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec").Child("configuration").Child("tls").Child("requireclientauth"),
+				r.Spec.Configuration.TLS.RequireClientAuth,
+				"KafkaAPIEnabled has to be set to true for RequireClientAuth to be allowed to be true"))
 	}
 	return allErrs
 }


### PR DESCRIPTION
## Cover letter

To enforce how the TLS api can be used and prevent invalid configuration.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
Webhook now enforces invalid configuration of TLS.