### PR TITLE
vim: fix clangd path

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,3 +1,3 @@
 {
-    "clangd.path": "vbuild/llvm/llvm-bin/bin/clangd"
+    "clangd.path": "vbuild/llvm/install/bin/clangd"
 }


### PR DESCRIPTION
fix path to clangd for vim