### PR TITLE
kafka: take request context by value in server handlers

### DIFF
--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -26,7 +26,7 @@ namespace kafka {
 
 template<>
 ss::future<response_ptr> alter_configs_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     alter_configs_request request;
     request.decode(ctx.reader(), ctx.header().version);
     klog.trace("Handling request {}", request);

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -104,7 +104,7 @@ api_versions_response api_versions_handler::handle_raw(request_context& ctx) {
 }
 
 ss::future<response_ptr>
-api_versions_handler::handle(request_context&& ctx, ss::smp_service_group) {
+api_versions_handler::handle(request_context ctx, ss::smp_service_group) {
     auto response = handle_raw(ctx);
     return ctx.respond(std::move(response));
 }

--- a/src/v/kafka/server/handlers/api_versions.h
+++ b/src/v/kafka/server/handlers/api_versions.h
@@ -16,7 +16,7 @@ namespace kafka {
 
 struct api_versions_handler : public handler<api_versions_api, 0, 2> {
     static ss::future<response_ptr>
-    handle(request_context&&, ss::smp_service_group);
+      handle(request_context, ss::smp_service_group);
 
     static api_versions_response handle_raw(request_context& ctx);
 };

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -55,7 +55,7 @@ using validators = make_validator_types<
 
 template<>
 ss::future<response_ptr> create_topics_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     kafka::create_topics_request request;
     request.decode(ctx.reader(), ctx.header().version);
     vlog(

--- a/src/v/kafka/server/handlers/delete_groups.cc
+++ b/src/v/kafka/server/handlers/delete_groups.cc
@@ -29,7 +29,7 @@ void delete_groups_response::encode(
 
 template<>
 ss::future<response_ptr> delete_groups_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     return ss::do_with(std::move(ctx), [](request_context& ctx) {
         delete_groups_request request;
         request.decode(ctx.reader(), ctx.header().version);

--- a/src/v/kafka/server/handlers/delete_topics.cc
+++ b/src/v/kafka/server/handlers/delete_topics.cc
@@ -72,8 +72,8 @@ delete_topics_response create_response(std::vector<cluster::topic_result> res) {
 }
 
 template<>
-ss::future<response_ptr> delete_topics_handler::handle(
-  request_context&& ctx, ss::smp_service_group ssg) {
+ss::future<response_ptr>
+delete_topics_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     delete_topics_request request;
     request.decode(ctx.reader(), ctx.header().version);
     vlog(klog.trace, "Handling request {}", request);

--- a/src/v/kafka/server/handlers/describe_acls.cc
+++ b/src/v/kafka/server/handlers/describe_acls.cc
@@ -24,7 +24,7 @@ namespace kafka {
 
 template<>
 ss::future<response_ptr> describe_acls_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     describe_acls_request request;
     request.decode(ctx.reader(), ctx.header().version);
     klog.trace("Handling request {}", request);

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -121,7 +121,7 @@ static void report_broker_config(describe_configs_result& result) {
 
 template<>
 ss::future<response_ptr> describe_configs_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     describe_configs_request request;
     request.decode(ctx.reader(), ctx.header().version);
     klog.trace("Handling request {}", request);

--- a/src/v/kafka/server/handlers/describe_groups.cc
+++ b/src/v/kafka/server/handlers/describe_groups.cc
@@ -41,7 +41,7 @@ struct describe_groups_ctx {
 
 template<>
 ss::future<response_ptr> describe_groups_handler::handle(
-  request_context&& ctx, ss::smp_service_group ssg) {
+  request_context ctx, ss::smp_service_group ssg) {
     describe_groups_request request;
     request.decode(ctx.reader(), ctx.header().version);
     klog.trace("Handling request {}", request);

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -675,7 +675,7 @@ static ss::future<> fetch_topic_partitions(op_context& octx) {
 
 template<>
 ss::future<response_ptr>
-fetch_handler::handle(request_context&& rctx, ss::smp_service_group ssg) {
+fetch_handler::handle(request_context rctx, ss::smp_service_group ssg) {
     return ss::do_with(op_context(std::move(rctx), ssg), [](op_context& octx) {
         // top-level error is used for session-level errors
         if (octx.session_ctx.has_error()) {

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -91,7 +91,7 @@ create_topic(request_context& ctx, cluster::topic_configuration topic) {
 
 template<>
 ss::future<response_ptr> find_coordinator_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     find_coordinator_request request;
     request.decode(ctx.reader(), ctx.header().version);
 

--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -28,7 +28,7 @@ struct handler {
     static constexpr api_version min_supported = api_version(MinSupported);
     static constexpr api_version max_supported = api_version(MaxSupported);
     static ss::future<response_ptr>
-    handle(request_context&&, ss::smp_service_group);
+      handle(request_context, ss::smp_service_group);
 };
 
 // clang-format off

--- a/src/v/kafka/server/handlers/heartbeat.cc
+++ b/src/v/kafka/server/handlers/heartbeat.cc
@@ -26,7 +26,7 @@ void heartbeat_response::encode(const request_context& ctx, response& resp) {
 
 template<>
 ss::future<response_ptr> heartbeat_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     return ss::do_with(std::move(ctx), [](request_context& ctx) {
         heartbeat_request request;
         request.decode(ctx.reader(), ctx.header().version);

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -25,7 +25,7 @@ namespace kafka {
 
 template<>
 ss::future<response_ptr> incremental_alter_configs_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     incremental_alter_configs_request request;
     request.decode(ctx.reader(), ctx.header().version);
     klog.trace("Handling request {}", request);

--- a/src/v/kafka/server/handlers/init_producer_id.cc
+++ b/src/v/kafka/server/handlers/init_producer_id.cc
@@ -26,7 +26,7 @@ namespace kafka {
 
 template<>
 ss::future<response_ptr> init_producer_id_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     return ss::do_with(std::move(ctx), [](request_context& ctx) {
         vlog(klog.trace, "processing init_producer_id");
 

--- a/src/v/kafka/server/handlers/join_group.cc
+++ b/src/v/kafka/server/handlers/join_group.cc
@@ -36,7 +36,7 @@ void join_group_response::encode(const request_context& ctx, response& resp) {
 
 template<>
 ss::future<response_ptr> join_group_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     join_group_request request(ctx);
 
     if (request.data.group_instance_id) {

--- a/src/v/kafka/server/handlers/leave_group.cc
+++ b/src/v/kafka/server/handlers/leave_group.cc
@@ -26,7 +26,7 @@ void leave_group_response::encode(const request_context& ctx, response& resp) {
 
 template<>
 ss::future<response_ptr> leave_group_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     return ss::do_with(
       remote(std::move(ctx)), [](remote<request_context>& remote_ctx) {
           auto& ctx = remote_ctx.get();

--- a/src/v/kafka/server/handlers/list_groups.cc
+++ b/src/v/kafka/server/handlers/list_groups.cc
@@ -23,7 +23,7 @@ void list_groups_response::encode(const request_context& ctx, response& resp) {
 
 template<>
 ss::future<response_ptr> list_groups_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     list_groups_request request{};
     request.decode(ctx.reader(), ctx.header().version);
     klog.trace("Handling request {}", request);

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -196,7 +196,7 @@ list_offsets_topics(list_offsets_ctx& octx) {
 
 template<>
 ss::future<response_ptr>
-list_offsets_handler::handle(request_context&& ctx, ss::smp_service_group ssg) {
+list_offsets_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     list_offsets_request request;
     request.decode(ctx.reader(), ctx.header().version);
     request.compute_duplicate_topics();

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -407,7 +407,7 @@ get_topic_metadata(request_context& ctx, metadata_request& request) {
 
 template<>
 ss::future<response_ptr> metadata_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     return ss::do_with(
       std::move(ctx),
       metadata_response{},

--- a/src/v/kafka/server/handlers/offset_commit.cc
+++ b/src/v/kafka/server/handlers/offset_commit.cc
@@ -54,8 +54,8 @@ struct offset_commit_ctx {
 };
 
 template<>
-ss::future<response_ptr> offset_commit_handler::handle(
-  request_context&& ctx, ss::smp_service_group ssg) {
+ss::future<response_ptr>
+offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     offset_commit_request request;
     request.decode(ctx.reader(), ctx.header().version);
     klog.trace("Handling request {}", request);

--- a/src/v/kafka/server/handlers/offset_fetch.cc
+++ b/src/v/kafka/server/handlers/offset_fetch.cc
@@ -56,7 +56,7 @@ struct offset_fetch_ctx {
 
 template<>
 ss::future<response_ptr>
-offset_fetch_handler::handle(request_context&& ctx, ss::smp_service_group ssg) {
+offset_fetch_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     offset_fetch_request request;
     request.decode(ctx.reader(), ctx.header().version);
     klog.trace("Handling request {}", request);

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -444,7 +444,7 @@ produce_topics(produce_ctx& octx) {
 
 template<>
 ss::future<response_ptr>
-produce_handler::handle(request_context&& ctx, ss::smp_service_group ssg) {
+produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     produce_request request(ctx);
 
     /*

--- a/src/v/kafka/server/handlers/sasl_authenticate.cc
+++ b/src/v/kafka/server/handlers/sasl_authenticate.cc
@@ -17,7 +17,7 @@ namespace kafka {
 
 template<>
 ss::future<response_ptr> sasl_authenticate_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     sasl_authenticate_request request;
     request.decode(ctx.reader(), ctx.header().version);
     vlog(klog.debug, "Received SASL_AUTHENTICATE {}", request);

--- a/src/v/kafka/server/handlers/sasl_handshake.cc
+++ b/src/v/kafka/server/handlers/sasl_handshake.cc
@@ -21,7 +21,7 @@ namespace kafka {
 
 template<>
 ss::future<response_ptr> sasl_handshake_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     sasl_handshake_request request;
     request.decode(ctx.reader(), ctx.header().version);
     vlog(klog.debug, "Received SASL_HANDSHAKE {}", request);

--- a/src/v/kafka/server/handlers/sync_group.cc
+++ b/src/v/kafka/server/handlers/sync_group.cc
@@ -26,7 +26,7 @@ void sync_group_response::encode(const request_context& ctx, response& resp) {
 
 template<>
 ss::future<response_ptr> sync_group_handler::handle(
-  request_context&& ctx, [[maybe_unused]] ss::smp_service_group g) {
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     return ss::do_with(std::move(ctx), [](request_context& ctx) {
         sync_group_request request;
         request.decode(ctx.reader(), ctx.header().version);

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -67,24 +67,13 @@ public:
       : _conn(std::move(conn))
       , _header(std::move(header))
       , _reader(std::move(request))
-      , _throttle_delay(throttle_delay) {
-        // XXX: don't forget to extend the move ctor
-    }
-    ~request_context() noexcept = default;
-    request_context(request_context&& o) noexcept
-      : _conn(std::move(o._conn))
-      , _header(std::move(o._header))
-      , _reader(std::move(o._reader))
-      , _throttle_delay(o._throttle_delay) {}
-    request_context& operator=(request_context&& o) noexcept {
-        if (this != &o) {
-            this->~request_context();
-            new (this) request_context(std::move(o));
-        }
-        return *this;
-    }
+      , _throttle_delay(throttle_delay) {}
+
     request_context(const request_context&) = delete;
     request_context& operator=(const request_context&) = delete;
+    request_context(request_context&& o) noexcept = default;
+    request_context& operator=(request_context&& o) noexcept = default;
+    ~request_context() noexcept = default;
 
     const request_header& header() const { return _header; }
 


### PR DESCRIPTION
As we move towards more pervasive use of coroutines we need to be very
careful about how we treat coroutine parameters, in particular reference
parameters.

1. reference parameters in coroutines _look_ far more safe because the
   coroutine looks like normal blocking code. since we are mixing styles
   this is usually not true.

2. taking reference parameters by value in coroutines treats them
   similarily to what they are in reality: lambda captures. this also
   eliminates the need for hacks to keep copies alive on the stack:

      task foo(type&& ref) {
        auto copy_that_stays_alive = std::move(ref);
        ...
        co_return;
      }

  the parameters themselves are kept alive for the coroutine lifetime.

This patch makes this change for request_context parameter to kafka
server handlers. This type is small and already often moved into a
`do_with` block to keep it alive. This change prepares our kafka
handlers for easier time with transition to coroutines.