### PR TITLE
k/server: Support serialisation for fetch v11 (RackId)

### DIFF
--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -68,6 +68,7 @@ struct fetch_request final {
     int32_t session_epoch = final_fetch_session_epoch;      // >= v7
     std::vector<topic> topics;
     std::vector<forgotten_topic> forgotten_topics; // >= v7
+    ss::sstring rack_id;                           // >= v11 ignored
 
     void encode(response_writer& writer, api_version version);
     void decode(request_context& ctx);
@@ -217,6 +218,7 @@ struct fetch_response final {
         model::offset last_stable_offset;                      // >= v4
         model::offset log_start_offset;                        // >= v5
         std::vector<aborted_transaction> aborted_transactions; // >= v4
+        model::node_id preferred_read_replica{-1};             // >= v11 ignored
         std::optional<batch_reader> record_set;
         /*
          * _not part of kafka protocol

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using fetch_handler = handler<fetch_api, 4, 10>;
+using fetch_handler = handler<fetch_api, 4, 11>;
 
 }


### PR DESCRIPTION
## Cover letter

[KIP-392](https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica) introduces fetch v11 with:

* `fetch_rquest::rack_id`
* `fetch_response::partition_response::preferred_read_replica`

Provide serialisation support, but for now these are ignored.

Tested with `librdafka` via `kafkacat`.

librdkafka consume seems to now use v11 instead of v4.

Fixes #883 

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: Serialisation support for [KIP-392](https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica)  / Fetch v11. `RackId` and `PreferredReadReplica` are currently ignored, 
