### PR TITLE
Fix for crash occurring when coprocessor offset snapshot is taken

### DIFF
--- a/src/v/coproc/offset_storage_utils.cc
+++ b/src/v/coproc/offset_storage_utils.cc
@@ -142,7 +142,7 @@ ss::future<ntp_context_cache> recover_offsets(
 ss::future<> save_offsets(
   storage::snapshot_manager& snap, const ntp_context_cache& ntp_cache) {
     vlog(
-      coproclog.info,
+      coproclog.debug,
       "Saving {} coprocessor offsets to disk....",
       ntp_cache.size());
     /// Create the metadata, and data iobuffers


### PR DESCRIPTION
- Crashes have been observed when all shards write to a snapshot file at once. (Actual exception being "File already exists")
- Cause is noted as multiple shards actually using the same shard name. Due to the name including the time_since_epoch of a low_res_clock() it is probable to occur when multiple components trigger a snapshot write at once.

