### PR TITLE
operator/tls: set dns name when using external connectivity

### DIFF
--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/test/three_node_cluster.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/test/three_node_cluster.yaml
@@ -15,9 +15,6 @@ spec:
     limits:
       cpu: 1
       memory: 1.2Gi
-  externalConnectivity:
-    enabled: true
-    subdomain: "test.subdomain.com"
   configuration:
     rpcServer:
       port: 33145


### PR DESCRIPTION
## Cover letter

When external connectivity is enabled and dns subdomain provided, the tls
certificate has to contain that dns name so that it can be used by external
clients.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
When external connectivity is enabled and subdomain provided, this is now reflected in the tls certificate dnsnames. We currently don’t support external connectivity + tls with clients that don’t ignore server certificate verification.