### PR TITLE
Improved describing topic configuration properties

### DIFF
--- a/src/v/archival/manifest.cc
+++ b/src/v/archival/manifest.cc
@@ -278,42 +278,44 @@ void topic_manifest::update(const rapidjson::Document& m) {
     cluster::topic_configuration conf(ns, tp, partitions, rf);
     // optional
     if (!m["compression"].IsNull()) {
-        conf.compression = boost::lexical_cast<model::compression>(
+        conf.properties.compression = boost::lexical_cast<model::compression>(
           m["compression"].GetString());
     }
     if (!m["cleanup_policy_bitflags"].IsNull()) {
-        conf.cleanup_policy_bitflags
+        conf.properties.cleanup_policy_bitflags
           = boost::lexical_cast<model::cleanup_policy_bitflags>(
             m["cleanup_policy_bitflags"].GetString());
     }
     if (!m["compaction_strategy"].IsNull()) {
-        conf.compaction_strategy
+        conf.properties.compaction_strategy
           = boost::lexical_cast<model::compaction_strategy>(
             m["compaction_strategy"].GetString());
     }
     if (!m["timestamp_type"].IsNull()) {
-        conf.timestamp_type = boost::lexical_cast<model::timestamp_type>(
-          m["timestamp_type"].GetString());
+        conf.properties.timestamp_type
+          = boost::lexical_cast<model::timestamp_type>(
+            m["timestamp_type"].GetString());
     }
     if (!m["segment_size"].IsNull()) {
-        conf.segment_size = m["segment_size"].GetInt64();
+        conf.properties.segment_size = m["segment_size"].GetInt64();
     }
     // tristate
     if (m.HasMember("retention_bytes")) {
         if (!m["retention_bytes"].IsNull()) {
-            conf.retention_bytes = tristate<size_t>(
+            conf.properties.retention_bytes = tristate<size_t>(
               m["retention_bytes"].GetInt64());
         } else {
-            conf.retention_bytes = tristate<size_t>(std::nullopt);
+            conf.properties.retention_bytes = tristate<size_t>(std::nullopt);
         }
     }
     if (m.HasMember("retention_duration")) {
         if (!m["retention_duration"].IsNull()) {
-            conf.retention_duration = tristate<std::chrono::milliseconds>(
-              std::chrono::milliseconds(m["retention_duration"].GetInt64()));
+            conf.properties.retention_duration
+              = tristate<std::chrono::milliseconds>(
+                std::chrono::milliseconds(m["retention_duration"].GetInt64()));
         } else {
-            conf.retention_duration = tristate<std::chrono::milliseconds>(
-              std::nullopt);
+            conf.properties.retention_duration
+              = tristate<std::chrono::milliseconds>(std::nullopt);
         }
     }
     _topic_config = conf;
@@ -353,35 +355,36 @@ void topic_manifest::serialize(std::ostream& out) const {
     // - key set to null - optional is nullopt
     // - key is not null - optional has value
     w.Key("compression");
-    if (_topic_config->compression.has_value()) {
-        w.String(boost::lexical_cast<std::string>(*_topic_config->compression));
+    if (_topic_config->properties.compression.has_value()) {
+        w.String(boost::lexical_cast<std::string>(
+          *_topic_config->properties.compression));
     } else {
         w.Null();
     }
     w.Key("cleanup_policy_bitflags");
-    if (_topic_config->cleanup_policy_bitflags.has_value()) {
+    if (_topic_config->properties.cleanup_policy_bitflags.has_value()) {
         w.String(boost::lexical_cast<std::string>(
-          *_topic_config->cleanup_policy_bitflags));
+          *_topic_config->properties.cleanup_policy_bitflags));
     } else {
         w.Null();
     }
     w.Key("compaction_strategy");
-    if (_topic_config->compaction_strategy.has_value()) {
+    if (_topic_config->properties.compaction_strategy.has_value()) {
         w.String(boost::lexical_cast<std::string>(
-          *_topic_config->compaction_strategy));
+          *_topic_config->properties.compaction_strategy));
     } else {
         w.Null();
     }
     w.Key("timestamp_type");
-    if (_topic_config->timestamp_type.has_value()) {
-        w.String(
-          boost::lexical_cast<std::string>(*_topic_config->timestamp_type));
+    if (_topic_config->properties.timestamp_type.has_value()) {
+        w.String(boost::lexical_cast<std::string>(
+          *_topic_config->properties.timestamp_type));
     } else {
         w.Null();
     }
     w.Key("segment_size");
-    if (_topic_config->segment_size.has_value()) {
-        w.Int64(*_topic_config->segment_size);
+    if (_topic_config->properties.segment_size.has_value()) {
+        w.Int64(*_topic_config->properties.segment_size);
     } else {
         w.Null();
     }
@@ -391,18 +394,19 @@ void topic_manifest::serialize(std::ostream& out) const {
     // - key not present - tristate is disabled
     // - key set to null - tristate is enabled but not set
     // - key is not null - tristate is enabled and set
-    if (!_topic_config->retention_bytes.is_disabled()) {
+    if (!_topic_config->properties.retention_bytes.is_disabled()) {
         w.Key("retention_bytes");
-        if (_topic_config->retention_bytes.has_value()) {
-            w.Int64(_topic_config->retention_bytes.value());
+        if (_topic_config->properties.retention_bytes.has_value()) {
+            w.Int64(_topic_config->properties.retention_bytes.value());
         } else {
             w.Null();
         }
     }
-    if (!_topic_config->retention_duration.is_disabled()) {
+    if (!_topic_config->properties.retention_duration.is_disabled()) {
         w.Key("retention_duration");
-        if (_topic_config->retention_duration.has_value()) {
-            w.Int64(_topic_config->retention_duration.value().count());
+        if (_topic_config->properties.retention_duration.has_value()) {
+            w.Int64(
+              _topic_config->properties.retention_duration.value().count());
         } else {
             w.Null();
         }

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -190,7 +190,8 @@ ss::future<bool> id_allocator_frontend::try_create_id_allocator_topic() {
       1,
       config::shard_local_cfg().default_topic_replication()};
 
-    topic.cleanup_policy_bitflags = model::cleanup_policy_bitflags::none;
+    topic.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::none;
 
     return _controller->get_topics_frontend()
       .local()

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -13,6 +13,7 @@
 #include "cluster/partition_leaders_table.h"
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
@@ -104,4 +105,38 @@ std::optional<model::node_id> metadata_cache::get_controller_leader_id() {
     return _leaders.local().get_leader(model::controller_ntp);
 }
 
+/**
+ * hard coded defaults
+ */
+model::compression metadata_cache::get_default_compression() const {
+    return model::compression::producer;
+}
+model::cleanup_policy_bitflags
+metadata_cache::get_default_cleanup_policy_bitflags() const {
+    return model::cleanup_policy_bitflags::deletion;
+}
+model::compaction_strategy
+metadata_cache::get_default_compaction_strategy() const {
+    return model::compaction_strategy::offset;
+}
+model::timestamp_type metadata_cache::get_default_timestamp_type() const {
+    return model::timestamp_type::create_time;
+}
+/**
+ * We use configuration directly to access default topic properties, in future
+ * those values are going to be runtime configurable
+ */
+size_t metadata_cache::get_default_segment_size() const {
+    return config::shard_local_cfg().log_segment_size();
+}
+size_t metadata_cache::get_default_compacted_topic_segment_size() const {
+    return config::shard_local_cfg().compacted_log_segment_size();
+}
+std::optional<size_t> metadata_cache::get_default_retention_bytes() const {
+    return config::shard_local_cfg().retention_bytes();
+}
+std::optional<std::chrono::milliseconds>
+metadata_cache::get_default_retention_duration() const {
+    return config::shard_local_cfg().delete_retention_ms();
+}
 } // namespace cluster

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -110,6 +110,16 @@ public:
     /// If present returns a leader of raft0 group
     std::optional<model::node_id> get_controller_leader_id();
 
+    model::compression get_default_compression() const;
+    model::cleanup_policy_bitflags get_default_cleanup_policy_bitflags() const;
+    model::compaction_strategy get_default_compaction_strategy() const;
+    model::timestamp_type get_default_timestamp_type() const;
+    size_t get_default_segment_size() const;
+    size_t get_default_compacted_topic_segment_size() const;
+    std::optional<size_t> get_default_retention_bytes() const;
+    std::optional<std::chrono::milliseconds>
+    get_default_retention_duration() const;
+
 private:
     ss::sharded<topic_table>& _topics_state;
     ss::sharded<members_table>& _members_table;

--- a/src/v/cluster/tests/autocreate_test.cc
+++ b/src/v/cluster/tests/autocreate_test.cc
@@ -45,8 +45,10 @@ void validate_topic_metadata(cluster::metadata_cache& cache) {
         BOOST_REQUIRE_EQUAL(cfg->partition_count, t_cfg.partition_count);
         BOOST_REQUIRE_EQUAL(cfg->replication_factor, t_cfg.replication_factor);
         BOOST_REQUIRE_EQUAL(
-          cfg->compaction_strategy, t_cfg.compaction_strategy);
-        BOOST_REQUIRE_EQUAL(cfg->compression, t_cfg.compression);
+          cfg->properties.compaction_strategy,
+          t_cfg.properties.compaction_strategy);
+        BOOST_REQUIRE_EQUAL(
+          cfg->properties.compression, t_cfg.properties.compression);
     }
 }
 

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -38,10 +38,10 @@ struct cmd_test_fixture {
         cluster::topic_configuration cfg(
           test_ns, model::topic(topic), partitions, replication_factor);
 
-        cfg.segment_size = 100_MiB;
-        cfg.cleanup_policy_bitflags
+        cfg.properties.segment_size = 100_MiB;
+        cfg.properties.cleanup_policy_bitflags
           = model::cleanup_policy_bitflags::compaction;
-        cfg.compression = model::compression::gzip;
+        cfg.properties.compression = model::compression::gzip;
 
         auto pas = allocate(cfg);
 
@@ -91,13 +91,18 @@ FIXTURE_TEST(test_create_topic_cmd_serialization, cmd_test_fixture) {
                    .get0();
     ss::visit(deser, [&cmd](cluster::create_topic_cmd c) {
         BOOST_REQUIRE_EQUAL(c.key.tp, cmd.key.tp);
-        BOOST_REQUIRE_EQUAL(c.value.cfg.compression, cmd.value.cfg.compression);
         BOOST_REQUIRE_EQUAL(
-          c.value.cfg.cleanup_policy_bitflags,
-          cmd.value.cfg.cleanup_policy_bitflags);
+          c.value.cfg.properties.compression,
+          cmd.value.cfg.properties.compression);
         BOOST_REQUIRE_EQUAL(
-          c.value.cfg.segment_size, cmd.value.cfg.segment_size);
-        BOOST_REQUIRE_EQUAL(c.value.cfg.compression, cmd.value.cfg.compression);
+          c.value.cfg.properties.cleanup_policy_bitflags,
+          cmd.value.cfg.properties.cleanup_policy_bitflags);
+        BOOST_REQUIRE_EQUAL(
+          c.value.cfg.properties.segment_size,
+          cmd.value.cfg.properties.segment_size);
+        BOOST_REQUIRE_EQUAL(
+          c.value.cfg.properties.compression,
+          cmd.value.cfg.properties.compression);
         BOOST_REQUIRE_EQUAL(
           c.value.assignments.size(), cmd.value.assignments.size());
     });

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -24,13 +24,15 @@ SEASTAR_THREAD_TEST_CASE(topic_config_rt_test) {
     cluster::topic_configuration cfg(
       model::ns("test"), model::topic{"a_topic"}, 3, 1);
 
-    cfg.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion
-                                  | model::cleanup_policy_bitflags::compaction;
-    cfg.compaction_strategy = model::compaction_strategy::offset;
-    cfg.compression = model::compression::snappy;
-    cfg.segment_size = std::optional<size_t>(1_GiB);
-    cfg.retention_bytes = tristate<size_t>{};
-    cfg.retention_duration = tristate<std::chrono::milliseconds>(10h);
+    cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::deletion
+        | model::cleanup_policy_bitflags::compaction;
+    cfg.properties.compaction_strategy = model::compaction_strategy::offset;
+    cfg.properties.compression = model::compression::snappy;
+    cfg.properties.segment_size = std::optional<size_t>(1_GiB);
+    cfg.properties.retention_bytes = tristate<size_t>{};
+    cfg.properties.retention_duration = tristate<std::chrono::milliseconds>(
+      10h);
 
     auto d = serialize_roundtrip_rpc(std::move(cfg));
 
@@ -38,16 +40,16 @@ SEASTAR_THREAD_TEST_CASE(topic_config_rt_test) {
     BOOST_REQUIRE_EQUAL(model::topic("a_topic"), d.tp_ns.tp);
     BOOST_REQUIRE_EQUAL(3, d.partition_count);
     BOOST_REQUIRE_EQUAL(1, d.replication_factor);
-    BOOST_REQUIRE_EQUAL(model::compression::snappy, d.compression);
+    BOOST_REQUIRE_EQUAL(model::compression::snappy, d.properties.compression);
     BOOST_REQUIRE_EQUAL(
       model::cleanup_policy_bitflags::deletion
         | model::cleanup_policy_bitflags::compaction,
-      d.cleanup_policy_bitflags);
+      d.properties.cleanup_policy_bitflags);
 
     BOOST_REQUIRE_EQUAL(
-      model::compaction_strategy::offset, d.compaction_strategy);
-    BOOST_CHECK(10h == d.retention_duration.value());
-    BOOST_REQUIRE_EQUAL(tristate<size_t>{}, d.retention_bytes);
+      model::compaction_strategy::offset, d.properties.compaction_strategy);
+    BOOST_CHECK(10h == d.properties.retention_duration.value());
+    BOOST_REQUIRE_EQUAL(tristate<size_t>{}, d.properties.retention_bytes);
 }
 
 SEASTAR_THREAD_TEST_CASE(broker_metadata_rt_test) {

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -79,13 +79,14 @@ struct topic_table_fixture {
 
     void create_topics() {
         auto cmd_1 = make_create_topic_cmd("test_tp_1", 1, 3);
-        cmd_1.value.cfg.compaction_strategy
+        cmd_1.value.cfg.properties.compaction_strategy
           = model::compaction_strategy::offset;
-        cmd_1.value.cfg.cleanup_policy_bitflags
+        cmd_1.value.cfg.properties.cleanup_policy_bitflags
           = model::cleanup_policy_bitflags::compaction;
-        cmd_1.value.cfg.compression = model::compression::lz4;
-        cmd_1.value.cfg.retention_bytes = tristate(std::make_optional(2_GiB));
-        cmd_1.value.cfg.retention_duration = tristate(
+        cmd_1.value.cfg.properties.compression = model::compression::lz4;
+        cmd_1.value.cfg.properties.retention_bytes = tristate(
+          std::make_optional(2_GiB));
+        cmd_1.value.cfg.properties.retention_duration = tristate(
           std::make_optional(std::chrono::milliseconds(3600000)));
         auto cmd_2 = make_create_topic_cmd("test_tp_2", 12, 3);
         auto cmd_3 = make_create_topic_cmd("test_tp_3", 8, 1);

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -94,14 +94,16 @@ FIXTURE_TEST(get_getting_config, topic_table_fixture) {
     BOOST_REQUIRE(cfg.has_value());
     auto v = cfg.value();
     BOOST_REQUIRE_EQUAL(
-      v.compaction_strategy, model::compaction_strategy::offset);
+      v.properties.compaction_strategy, model::compaction_strategy::offset);
 
     BOOST_REQUIRE_EQUAL(
-      v.cleanup_policy_bitflags, model::cleanup_policy_bitflags::compaction);
-    BOOST_REQUIRE_EQUAL(v.compression, model::compression::lz4);
-    BOOST_REQUIRE_EQUAL(v.retention_bytes, tristate(std::make_optional(2_GiB)));
+      v.properties.cleanup_policy_bitflags,
+      model::cleanup_policy_bitflags::compaction);
+    BOOST_REQUIRE_EQUAL(v.properties.compression, model::compression::lz4);
     BOOST_REQUIRE_EQUAL(
-      v.retention_duration,
+      v.properties.retention_bytes, tristate(std::make_optional(2_GiB)));
+    BOOST_REQUIRE_EQUAL(
+      v.properties.retention_duration,
       tristate(std::make_optional(std::chrono::milliseconds(3600000))));
 }
 

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -25,13 +25,14 @@ struct topic_table_updates_dispatcher_fixture : topic_table_fixture {
 
     void create_topics() {
         auto cmd_1 = make_create_topic_cmd("test_tp_1", 1, 3);
-        cmd_1.value.cfg.compaction_strategy
+        cmd_1.value.cfg.properties.compaction_strategy
           = model::compaction_strategy::offset;
-        cmd_1.value.cfg.cleanup_policy_bitflags
+        cmd_1.value.cfg.properties.cleanup_policy_bitflags
           = model::cleanup_policy_bitflags::compaction;
-        cmd_1.value.cfg.compression = model::compression::lz4;
-        cmd_1.value.cfg.retention_bytes = tristate(std::make_optional(2_GiB));
-        cmd_1.value.cfg.retention_duration = tristate(
+        cmd_1.value.cfg.properties.compression = model::compression::lz4;
+        cmd_1.value.cfg.properties.retention_bytes = tristate(
+          std::make_optional(2_GiB));
+        cmd_1.value.cfg.properties.retention_duration = tristate(
           std::make_optional(std::chrono::milliseconds(3600000)));
         auto cmd_2 = make_create_topic_cmd("test_tp_2", 12, 3);
         auto cmd_3 = make_create_topic_cmd("test_tp_3", 8, 1);

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -224,7 +224,7 @@ topic_table::get_topic_cfg(model::topic_namespace_view tp) const {
 std::optional<model::timestamp_type>
 topic_table::get_topic_timestamp_type(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {
-        return it->second.cfg.timestamp_type;
+        return it->second.cfg.properties.timestamp_type;
     }
     return {};
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -83,6 +83,24 @@ struct partition_assignment {
     friend std::ostream& operator<<(std::ostream&, const partition_assignment&);
 };
 
+/**
+ * Structure holding topic properties overrides, empty values will be replaced
+ * with defaults
+ */
+struct topic_properties {
+    std::optional<model::compression> compression;
+    std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
+    std::optional<model::compaction_strategy> compaction_strategy;
+    std::optional<model::timestamp_type> timestamp_type;
+    std::optional<size_t> segment_size;
+    tristate<size_t> retention_bytes;
+    tristate<std::chrono::milliseconds> retention_duration;
+
+    bool is_compacted() const;
+    bool has_overrides() const;
+
+    friend std::ostream& operator<<(std::ostream&, const topic_properties&);
+};
 // Structure holding topic configuration, optionals will be replaced by broker
 // defaults
 struct topic_configuration {
@@ -105,20 +123,7 @@ struct topic_configuration {
     // using signed integer because Kafka protocol defines it as signed int
     int16_t replication_factor;
 
-    std::optional<model::compression> compression;
-    std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
-    std::optional<model::compaction_strategy> compaction_strategy;
-    std::optional<model::timestamp_type> timestamp_type;
-    std::optional<size_t> segment_size;
-
-    // Tristate fields
-    // Mapped according to the following policy:
-    //
-    // Kafka topic configuration value: -1 -> tristate disabled
-    // Kafka topic configuration value: preset -> tristate with value
-    // Kafka topic configuration value: not set -> tristate with std::nullopt
-    tristate<size_t> retention_bytes;
-    tristate<std::chrono::milliseconds> retention_duration;
+    topic_properties properties;
 
     friend std::ostream& operator<<(std::ostream&, const topic_configuration&);
 };

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -85,7 +85,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> transactional_id_expiration_ms;
     property<bool> enable_idempotence;
     property<bool> enable_transactions;
-    // same as delete.retention.ms in kafka
+    // same as log.retention.ms in kafka
     property<std::chrono::milliseconds> delete_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;
     // same as retention.size in kafka - TODO: size not implemented

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -170,7 +170,11 @@ ss::future<response_ptr> describe_configs_handler::handle(
             add_config(
               result,
               "cleanup.policy",
-              describe_topic_cleanup_policy(topic_config),
+              describe_topic_cleanup_policy(
+                topic_config,
+                ctx.metadata_cache().get_default_cleanup_policy_bitflags()),
+              describe_configs_source::topic);
+
               describe_configs_source::topic);
 
             break;

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -122,7 +122,7 @@ ss::future<response_ptr> find_coordinator_handler::handle(
             config::shard_local_cfg().group_topic_partitions(),
             config::shard_local_cfg().default_topic_replication()};
 
-          topic.cleanup_policy_bitflags
+          topic.properties.cleanup_policy_bitflags
             = model::cleanup_policy_bitflags::compaction;
 
           return create_topic(ctx, std::move(topic))

--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -12,6 +12,7 @@
 #include "cluster/errc.h"
 #include "cluster/metadata_cache.h"
 #include "kafka/protocol/errors.h"
+#include "model/fundamental.h"
 
 namespace kafka {
 
@@ -54,36 +55,36 @@ ss::future<std::vector<model::node_id>> wait_for_leaders(
 }
 
 ss::sstring describe_topic_cleanup_policy(
-  const std::optional<cluster::topic_configuration>& topic_config) {
-    ss::sstring cleanup_policy;
-
-    if (topic_config->properties.cleanup_policy_bitflags) {
-        auto compaction
-          = (topic_config->properties.cleanup_policy_bitflags.value()
-             & model::cleanup_policy_bitflags::compaction)
-            == model::cleanup_policy_bitflags::compaction;
-        auto deletion
-          = (topic_config->properties.cleanup_policy_bitflags.value()
-             & model::cleanup_policy_bitflags::deletion)
-            == model::cleanup_policy_bitflags::deletion;
-
-        if (compaction) {
-            cleanup_policy = "compact";
-        }
-
-        if (deletion) {
-            if (cleanup_policy.empty()) {
-                cleanup_policy = "delete";
-            } else {
-                cleanup_policy = fmt::format("{},delete", cleanup_policy);
-            }
-        }
+  const std::optional<cluster::topic_configuration>& topic_config,
+  model::cleanup_policy_bitflags default_policy) {
+    auto effective_policy = default_policy;
+    if (topic_config && topic_config->properties.cleanup_policy_bitflags) {
+        effective_policy = *topic_config->properties.cleanup_policy_bitflags;
+    }
+    // there is no `none` policy in Kafka, fallback to default
+    if (effective_policy == model::cleanup_policy_bitflags::none) {
+        effective_policy = default_policy;
     }
 
-    // optional cleanup policy case. report kafka default. it doesn't
-    // appear that there is an unset value case.
-    if (cleanup_policy.empty()) {
-        cleanup_policy = "delete";
+    ss::sstring cleanup_policy;
+
+    auto compaction = (effective_policy
+                       & model::cleanup_policy_bitflags::compaction)
+                      == model::cleanup_policy_bitflags::compaction;
+    auto deletion = (effective_policy
+                     & model::cleanup_policy_bitflags::deletion)
+                    == model::cleanup_policy_bitflags::deletion;
+
+    if (compaction) {
+        cleanup_policy = "compact";
+    }
+
+    if (deletion) {
+        if (cleanup_policy.empty()) {
+            cleanup_policy = "delete";
+        } else {
+            cleanup_policy = fmt::format("{},delete", cleanup_policy);
+        }
     }
 
     return cleanup_policy;

--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -57,13 +57,15 @@ ss::sstring describe_topic_cleanup_policy(
   const std::optional<cluster::topic_configuration>& topic_config) {
     ss::sstring cleanup_policy;
 
-    if (topic_config->cleanup_policy_bitflags) {
-        auto compaction = (topic_config->cleanup_policy_bitflags.value()
-                           & model::cleanup_policy_bitflags::compaction)
-                          == model::cleanup_policy_bitflags::compaction;
-        auto deletion = (topic_config->cleanup_policy_bitflags.value()
-                         & model::cleanup_policy_bitflags::deletion)
-                        == model::cleanup_policy_bitflags::deletion;
+    if (topic_config->properties.cleanup_policy_bitflags) {
+        auto compaction
+          = (topic_config->properties.cleanup_policy_bitflags.value()
+             & model::cleanup_policy_bitflags::compaction)
+            == model::cleanup_policy_bitflags::compaction;
+        auto deletion
+          = (topic_config->properties.cleanup_policy_bitflags.value()
+             & model::cleanup_policy_bitflags::deletion)
+            == model::cleanup_policy_bitflags::deletion;
 
         if (compaction) {
             cleanup_policy = "compact";

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -186,6 +186,7 @@ ss::future<std::vector<model::node_id>> wait_for_leaders(
   model::timeout_clock::time_point);
 
 ss::sstring describe_topic_cleanup_policy(
-  const std::optional<cluster::topic_configuration>&);
+  const std::optional<cluster::topic_configuration>&,
+  model::cleanup_policy_bitflags);
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -65,8 +65,12 @@ static tristate<T> get_tristate_value(
   const absl::flat_hash_map<ss::sstring, ss::sstring>& config,
   const ss::sstring& key) {
     auto v = get_config_value<int64_t>(config, key);
-    // diabled case
-    if (v && *v <= 0) {
+    // no value set
+    if (!v) {
+        return tristate<T>(std::nullopt);
+    }
+    // disabled case
+    if (v <= 0) {
         return tristate<T>{};
     }
     return tristate<T>(std::make_optional<T>(*v));

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -82,21 +82,23 @@ cluster::topic_configuration to_cluster_type(const creatable_topic& t) {
 
     auto config_entries = config_map(t.configs);
     // Parse topic configuration
-    cfg.compression = get_config_value<model::compression>(
+    cfg.properties.compression = get_config_value<model::compression>(
       config_entries, "compression.type");
-    cfg.cleanup_policy_bitflags
+    cfg.properties.cleanup_policy_bitflags
       = get_config_value<model::cleanup_policy_bitflags>(
         config_entries, "cleanup.policy");
-    cfg.timestamp_type = get_config_value<model::timestamp_type>(
+    cfg.properties.timestamp_type = get_config_value<model::timestamp_type>(
       config_entries, "message.timestamp.type");
-    cfg.segment_size = get_config_value<size_t>(
+    cfg.properties.segment_size = get_config_value<size_t>(
       config_entries, "segment.bytes");
-    cfg.compaction_strategy = get_config_value<model::compaction_strategy>(
-      config_entries, "compaction.strategy");
-    cfg.retention_bytes = get_tristate_value<size_t>(
+    cfg.properties.compaction_strategy
+      = get_config_value<model::compaction_strategy>(
+        config_entries, "compaction.strategy");
+    cfg.properties.retention_bytes = get_tristate_value<size_t>(
       config_entries, "retention.bytes");
-    cfg.retention_duration = get_tristate_value<std::chrono::milliseconds>(
-      config_entries, "retention.ms");
+    cfg.properties.retention_duration
+      = get_tristate_value<std::chrono::milliseconds>(
+        config_entries, "retention.ms");
 
     return cfg;
 }

--- a/src/v/kafka/server/tests/topic_utils_test.cc
+++ b/src/v/kafka/server/tests/topic_utils_test.cc
@@ -211,26 +211,28 @@ BOOST_AUTO_TEST_CASE(shall_return_errors_for_all_requests) {
 };
 
 BOOST_AUTO_TEST_CASE(describe_topics_cleanup_policy_test) {
-    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy({}), "delete");
+    model::cleanup_policy_bitflags def
+      = model::cleanup_policy_bitflags::deletion;
+    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy({}, def), "delete");
 
     cluster::topic_configuration config(
       model::ns("ns"), model::topic("topic"), 1, 1);
 
     config.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::none;
-    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config), "delete");
+    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config, def), "delete");
 
     config.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::compaction;
-    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config), "compact");
+    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config, def), "compact");
 
     config.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::deletion;
-    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config), "delete");
+    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config, def), "delete");
 
     config.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::deletion
         | model::cleanup_policy_bitflags::compaction;
     BOOST_REQUIRE_EQUAL(
-      describe_topic_cleanup_policy(config), "compact,delete");
+      describe_topic_cleanup_policy(config, def), "compact,delete");
 };

--- a/src/v/kafka/server/tests/topic_utils_test.cc
+++ b/src/v/kafka/server/tests/topic_utils_test.cc
@@ -216,16 +216,19 @@ BOOST_AUTO_TEST_CASE(describe_topics_cleanup_policy_test) {
     cluster::topic_configuration config(
       model::ns("ns"), model::topic("topic"), 1, 1);
 
-    config.cleanup_policy_bitflags = model::cleanup_policy_bitflags::none;
+    config.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::none;
     BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config), "delete");
 
-    config.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    config.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
     BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config), "compact");
 
-    config.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    config.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::deletion;
     BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config), "delete");
 
-    config.cleanup_policy_bitflags
+    config.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::deletion
         | model::cleanup_policy_bitflags::compaction;
     BOOST_REQUIRE_EQUAL(

--- a/src/v/kafka/server/tests/types_conversion_tests.cc
+++ b/src/v/kafka/server/tests/types_conversion_tests.cc
@@ -54,17 +54,18 @@ BOOST_AUTO_TEST_CASE(test_all_additional_options) {
     BOOST_REQUIRE_EQUAL(
       cluster_tp_config.replication_factor, all_options.replication_factor);
     BOOST_REQUIRE_EQUAL(
-      cluster_tp_config.compression, model::compression::snappy);
+      cluster_tp_config.properties.compression, model::compression::snappy);
     BOOST_REQUIRE_EQUAL(
-      cluster_tp_config.compaction_strategy,
+      cluster_tp_config.properties.compaction_strategy,
       model::compaction_strategy::header);
-    BOOST_REQUIRE_EQUAL(cluster_tp_config.retention_bytes.is_disabled(), true);
+    BOOST_REQUIRE_EQUAL(
+      cluster_tp_config.properties.retention_bytes.is_disabled(), true);
     using namespace std::chrono_literals;
     BOOST_REQUIRE_EQUAL(
-      cluster_tp_config.retention_duration.value().count(),
+      cluster_tp_config.properties.retention_duration.value().count(),
       (86400000ms).count());
     BOOST_REQUIRE_EQUAL(
-      cluster_tp_config.cleanup_policy_bitflags,
+      cluster_tp_config.properties.cleanup_policy_bitflags,
       model::cleanup_policy_bitflags::compaction
         | model::cleanup_policy_bitflags::deletion);
 }

--- a/src/v/model/compression.h
+++ b/src/v/model/compression.h
@@ -50,7 +50,6 @@ enum class compression : uint8_t {
 /// operators needed for boost::lexical_cast<compression>
 /// inline to prevent library depdency with the v::compression module
 inline std::ostream& operator<<(std::ostream& os, const compression& c) {
-    os << "{compression: ";
     switch (c) {
     case compression::none:
         os << "none";
@@ -74,7 +73,7 @@ inline std::ostream& operator<<(std::ostream& os, const compression& c) {
         os << "ERROR";
         break;
     }
-    return os << "}";
+    return os;
 }
 std::istream& operator>>(std::istream&, compression&);
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -125,9 +125,9 @@ operator<<(std::ostream& o, const model::topic_namespace_view& tp_ns) {
 std::ostream& operator<<(std::ostream& os, timestamp_type ts) {
     switch (ts) {
     case timestamp_type::append_time:
-        return os << "{append_time}";
+        return os << "append_time";
     case timestamp_type::create_time:
-        return os << "{create_time}";
+        return os << "create_time";
     }
     return os << "{unknown timestamp:" << static_cast<int>(ts) << "}";
 }


### PR DESCRIPTION
## Cover letter

Previously redpanda sent only some of the topic configuration properties as a response to `DESCRIBE_CONFIGS` request. Implemented describing all available properties of given topic.  This change makes Redpanda response consistent with Kakfa's one. Additionally fixed bug leading to incorrect parsing of `retention.ms` and `retention.bytes` properties.

Fixes issues: []
## Release notes
`rpk topic describe` will present all topic configuration properties in a way that is consistent with Kafka broker
