### PR TITLE
operator: temporarily disable update logging

### DIFF
--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -56,6 +56,8 @@ func CreateIfNotExists(
 	return false, nil
 }
 
+const debugLevel = 10
+
 // Update ensures resource is updated if necessary. The method calculates patch
 // and applies it if something changed
 func Update(
@@ -80,7 +82,7 @@ func Update(
 		if err != nil {
 			return err
 		}
-		logger.Info(fmt.Sprintf("StatefulSet changed, updating %s. Diff: %v", modified.GetName(), string(patchResult.Patch)))
+		logger.V(debugLevel).Info(fmt.Sprintf("StatefulSet changed, updating %s. Diff: %v", modified.GetName(), string(patchResult.Patch)))
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(modified); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Cover letter

Until an issue with patchmaker updates are fixed, we should at least not log
this all the time to not fill the logs.

This is until #895 gets resolved.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
