### PR TITLE
Pandaproxy json error response improvements

### DIFF
--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -42,4 +42,5 @@ foreach(swagger_dep ${swagger_deps})
 endforeach()
 
 add_subdirectory(json)
+add_subdirectory(parsing)
 add_subdirectory(test)

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -23,6 +23,7 @@ v_cc_library(
   NAME pandaproxy
   SRCS
     configuration.cc
+    error.cc
     handlers.cc
     logger.cc
     probe.cc

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -30,6 +30,8 @@ v_cc_library(
     proxy.cc
     server.cc
   DEPS
+    v::pandaproxy_parsing
+    v::pandaproxy_json
     v::kafka_client
     v::syschecks
     v::kafka

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "error.h"
+
+namespace pandaproxy {
+
+namespace {
+
+struct reply_error_category final : std::error_category {
+    const char* name() const noexcept override { return "pandaproxy"; }
+    std::string message(int ev) const override {
+        switch (static_cast<reply_error_code>(ev)) {
+        case reply_error_code::kafka_bad_request:
+            return "kafka_bad_request";
+        case reply_error_code::kafka_authentication_error:
+            return "kafka_authentication_error";
+        case reply_error_code::kafka_authorization_error:
+            return "kafka_authorization_error";
+        case reply_error_code::topic_not_found:
+            return "topic_not_found";
+        case reply_error_code::partition_not_found:
+            return "partition_not_found";
+        case reply_error_code::consumer_instance_not_found:
+            return "consumer_instance_not_found";
+        case reply_error_code::zookeeper_error:
+            return "zookeeper_error";
+        case reply_error_code::kafka_error:
+            return "kafka_error";
+        case reply_error_code::kafka_retriable_error:
+            return "kafka_retriable_error";
+        case reply_error_code::ssl_unavailable:
+            return "ssl_unavailable";
+        case reply_error_code::broker_not_available:
+            return "broker_not_available";
+        }
+        return "(unrecognized error)";
+    }
+};
+
+const reply_error_category reply_error_category{};
+
+}; // namespace
+
+std::error_condition make_error_condition(reply_error_code ec) {
+    return {static_cast<int>(ec), reply_error_category};
+}
+
+const std::error_category& reply_category() noexcept {
+    return reply_error_category;
+}
+
+} // namespace pandaproxy

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -11,6 +11,9 @@
 
 #include "error.h"
 
+#include "kafka/protocol/errors.h"
+#include "pandaproxy/parsing/error.h"
+
 namespace pandaproxy {
 
 namespace {
@@ -48,6 +51,119 @@ struct reply_error_category final : std::error_category {
 
 const reply_error_category reply_error_category{};
 
+struct kafka_error_category final : std::error_category {
+    const char* name() const noexcept override { return "kafka"; }
+    std::string message(int ec) const override {
+        return std::string(
+          kafka::error_code_to_str(static_cast<kafka::error_code>(ec)));
+    }
+    std::error_condition
+    default_error_condition(int ec) const noexcept override {
+        using rec = reply_error_code;
+        using kec = kafka::error_code;
+
+        switch (static_cast<kec>(ec)) {
+        case kec::none:
+            return {};
+        case kec::offset_out_of_range:
+        case kec::corrupt_message:
+        case kec::invalid_fetch_size:
+        case kec::not_leader_for_partition:
+        case kec::message_too_large:
+        case kec::stale_controller_epoch:
+        case kec::offset_metadata_too_large:
+        case kec::invalid_topic_exception:
+        case kec::record_list_too_large:
+        case kec::illegal_generation:
+        case kec::inconsistent_group_protocol:
+        case kec::invalid_group_id:
+        case kec::invalid_session_timeout:
+        case kec::invalid_commit_offset_size:
+        case kec::invalid_timestamp:
+        case kec::unsupported_sasl_mechanism:
+        case kec::illegal_sasl_state:
+        case kec::unsupported_version:
+        case kec::topic_already_exists:
+        case kec::invalid_partitions:
+        case kec::invalid_replication_factor:
+        case kec::invalid_replica_assignment:
+        case kec::invalid_config:
+        case kec::not_controller:
+        case kec::invalid_request:
+        case kec::unsupported_for_message_format:
+        case kec::policy_violation:
+        case kec::invalid_required_acks:
+        case kec::invalid_producer_epoch:
+        case kec::invalid_txn_state:
+        case kec::invalid_producer_id_mapping:
+        case kec::invalid_transaction_timeout:
+        case kec::concurrent_transactions:
+        case kec::transaction_coordinator_fenced:
+        case kec::security_disabled:
+        case kec::log_dir_not_found:
+        case kec::unknown_producer_id:
+        case kec::delegation_token_not_found:
+        case kec::delegation_token_owner_mismatch:
+        case kec::delegation_token_request_not_allowed:
+        case kec::delegation_token_expired:
+        case kec::invalid_principal_type:
+        case kec::non_empty_group:
+        case kec::group_id_not_found:
+        case kec::fetch_session_id_not_found:
+        case kec::invalid_fetch_session_epoch:
+        case kec::listener_not_found:
+        case kec::topic_deletion_disabled:
+        case kec::fenced_leader_epoch:
+        case kec::unknown_leader_epoch:
+        case kec::unsupported_compression_type:
+        case kec::stale_broker_epoch:
+        case kec::offset_not_available:
+        case kec::member_id_required:
+        case kec::group_max_size_reached:
+        case kec::fenced_instance_id:
+        case kec::invalid_record:
+            return rec::kafka_bad_request;
+        case kec::not_enough_replicas:
+        case kec::coordinator_not_available:
+        case kec::not_coordinator:
+        case kec::not_enough_replicas_after_append:
+        case kec::out_of_order_sequence_number:
+        case kec::duplicate_sequence_number:
+        case kec::operation_not_attempted:
+        case kec::kafka_storage_error:
+        case kec::unknown_server_error:
+            return rec::kafka_error;
+        case kec::network_exception:
+        case kec::coordinator_load_in_progress:
+        case kec::request_timed_out:
+        case kec::rebalance_in_progress:
+        case kec::reassignment_in_progress:
+            return rec::kafka_retriable_error;
+        case kec::unknown_topic_or_partition:
+            return rec::partition_not_found;
+        case kec::unknown_member_id:
+            return rec::consumer_instance_not_found;
+        case kec::leader_not_available:
+        case kec::broker_not_available:
+        case kec::replica_not_available:
+        case kec::preferred_leader_not_available:
+            return rec::broker_not_available;
+        case kec::topic_authorization_failed:
+        case kec::group_authorization_failed:
+        case kec::transactional_id_authorization_failed:
+        case kec::delegation_token_authorization_failed:
+        case kec::cluster_authorization_failed:
+            return rec::kafka_authorization_error;
+        case kec::sasl_authentication_failed:
+        case kec::delegation_token_auth_disabled: // authn / authz? bad requ?
+            return rec::kafka_authentication_error;
+        }
+        return {}; // keep gcc happy
+    }
+};
+
+const kafka_error_category kafka_error_category{};
+
 }; // namespace
 
 std::error_condition make_error_condition(reply_error_code ec) {
@@ -59,3 +175,10 @@ const std::error_category& reply_category() noexcept {
 }
 
 } // namespace pandaproxy
+
+namespace kafka {
+std::error_code make_error_code(kafka::error_code ec) {
+    return {static_cast<int>(ec), pandaproxy::kafka_error_category};
+}
+
+} // namespace kafka

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "kafka/protocol/errors.h"
 #include "seastarx.h"
 
 #include <cstdint>
@@ -42,9 +43,18 @@ const std::error_category& reply_category() noexcept;
 
 } // namespace pandaproxy
 
+namespace kafka {
+
+std::error_code make_error_code(error_code);
+
+}
+
 namespace std {
 
 template<>
 struct is_error_condition_enum<pandaproxy::reply_error_code> : true_type {};
+
+template<>
+struct is_error_code_enum<kafka::error_code> : true_type {};
 
 } // namespace std

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <cstdint>
+#include <system_error>
+
+namespace pandaproxy {
+
+// reply_error_code is a std::error_condition through which errors are returned
+// in the reply.
+//
+// This is the default_error_condition for the proxy; to map other
+// error_codes to this, override its error_category::default_error_condition().
+enum class reply_error_code : uint16_t {
+    kafka_bad_request = 40002,
+    kafka_authentication_error = 40101,
+    kafka_authorization_error = 40301,
+    topic_not_found = 40401,
+    partition_not_found = 40402,
+    consumer_instance_not_found = 40403,
+    zookeeper_error = 50001,
+    kafka_error = 50002,
+    kafka_retriable_error = 50003,
+    ssl_unavailable = 50101,
+    broker_not_available = 50302,
+};
+
+std::error_condition make_error_condition(reply_error_code);
+const std::error_category& reply_category() noexcept;
+
+} // namespace pandaproxy
+
+namespace std {
+
+template<>
+struct is_error_condition_enum<pandaproxy::reply_error_code> : true_type {};
+
+} // namespace std

--- a/src/v/pandaproxy/json/CMakeLists.txt
+++ b/src/v/pandaproxy/json/CMakeLists.txt
@@ -1,2 +1,10 @@
+v_cc_library(
+  NAME pandaproxy_json
+  SRCS
+    error.cc
+  DEPS
+    Seastar::seastar
+)
+
 add_subdirectory(test)
 add_subdirectory(requests)

--- a/src/v/pandaproxy/json/error.cc
+++ b/src/v/pandaproxy/json/error.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "error.h"
+
+#include "pandaproxy/error.h"
+
+namespace pandaproxy::json {
+
+namespace {
+
+struct error_category final : std::error_category {
+    const char* name() const noexcept override { return "pandaproxy::json"; }
+    std::string message(int ev) const override {
+        switch (static_cast<error_code>(ev)) {
+        case error_code::invalid_json:
+            return "invalid json";
+        }
+        return "(unrecognized error)";
+    }
+    std::error_condition
+    default_error_condition(int ec) const noexcept override {
+        switch (static_cast<error_code>(ec)) {
+        case error_code::invalid_json:
+            return reply_error_code::kafka_bad_request;
+        }
+        return {};
+    }
+};
+
+const error_category ppj_error_category{};
+
+}; // namespace
+
+std::error_code make_error_code(error_code e) {
+    return {static_cast<int>(e), ppj_error_category};
+}
+
+} // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/error.h
+++ b/src/v/pandaproxy/json/error.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <system_error>
+
+namespace pandaproxy::json {
+
+enum class error_code : uint16_t {
+    // 0 is success
+    invalid_json = 1,
+};
+
+std::error_code make_error_code(error_code);
+
+} // namespace pandaproxy::json
+
+namespace std {
+
+template<>
+struct is_error_code_enum<pandaproxy::json::error_code> : true_type {};
+
+} // namespace std

--- a/src/v/pandaproxy/json/exceptions.h
+++ b/src/v/pandaproxy/json/exceptions.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/protocol/errors.h"
+#include "pandaproxy/error.h"
+#include "pandaproxy/json/error.h"
+#include "pandaproxy/json/requests/error_reply.h"
+
+#include <fmt/format.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace pandaproxy::json {
+
+struct exception_base : std::exception {
+    exception_base(std::error_code err, std::string_view msg)
+      : std::exception{}
+      , error{err}
+      , msg{msg} {}
+    const char* what() const noexcept final { return msg.c_str(); }
+    std::error_code error;
+    std::string msg;
+};
+
+class parse_error final : public exception_base {
+public:
+    explicit parse_error(size_t offset)
+      : exception_base(
+        make_error_code(error_code::invalid_json),
+        fmt::format("parse error at offset {}", offset)) {}
+};
+
+class serialize_error final : public exception_base {
+public:
+    explicit serialize_error(std::error_code ec, std::string_view msg)
+      : exception_base(ec, msg) {}
+    explicit serialize_error(kafka::error_code ec)
+      : exception_base(make_error_code(ec), kafka::error_code_to_str(ec)) {}
+};
+
+} // namespace pandaproxy::json

--- a/src/v/pandaproxy/json/requests/error_reply.h
+++ b/src/v/pandaproxy/json/requests/error_reply.h
@@ -20,7 +20,7 @@
 namespace pandaproxy::json {
 
 struct error_body {
-    ss::httpd::reply::status_type error_code;
+    std::error_condition ec;
     ss::sstring message;
 };
 
@@ -28,7 +28,7 @@ inline void rjson_serialize(
   rapidjson::Writer<rapidjson::StringBuffer>& w, const error_body& v) {
     w.StartObject();
     w.Key("error_code");
-    ::json::rjson_serialize(w, v.error_code);
+    ::json::rjson_serialize(w, v.ec.value());
     w.Key("message");
     ::json::rjson_serialize(w, v.message);
     w.EndObject();

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -19,8 +19,8 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
+#include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/iobuf.h"
-#include "pandaproxy/json/requests/error_reply.h"
 #include "pandaproxy/json/requests/produce.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/json/types.h"
@@ -79,12 +79,7 @@ public:
         // Eager check for errors
         for (auto& v : res) {
             if (v.partition_response->has_error()) {
-                error_body e{
-                  .error_code = ss::httpd::reply::status_type::not_found,
-                  .message{ss::sstring{
-                    kafka::error_code_to_str(v.partition_response->error)}}};
-                rjson_serialize(w, e);
-                return;
+                throw serialize_error(v.partition_response->error);
             }
         }
 

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "json/json.h"
+#include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/types.h"
 #include "utils/concepts-enabled.h"
 
@@ -25,16 +25,6 @@
 #include <stdexcept>
 
 namespace pandaproxy::json {
-
-class parse_error final : public std::exception {
-public:
-    explicit parse_error(size_t offset)
-      : _what(fmt::format("parse error at offset {}", offset)) {}
-    const char* what() const noexcept final { return _what.data(); }
-
-private:
-    std::string _what;
-};
 
 template<typename T>
 ss::sstring rjson_serialize(const T& v) {

--- a/src/v/pandaproxy/parsing/CMakeLists.txt
+++ b/src/v/pandaproxy/parsing/CMakeLists.txt
@@ -1,0 +1,7 @@
+v_cc_library(
+  NAME pandaproxy_parsing
+  SRCS
+    error.cc
+  DEPS
+    Seastar::seastar
+)

--- a/src/v/pandaproxy/parsing/CMakeLists.txt
+++ b/src/v/pandaproxy/parsing/CMakeLists.txt
@@ -5,3 +5,5 @@ v_cc_library(
   DEPS
     Seastar::seastar
 )
+
+add_subdirectory(test)

--- a/src/v/pandaproxy/parsing/error.cc
+++ b/src/v/pandaproxy/parsing/error.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "error.h"
+
+#include "pandaproxy/error.h"
+
+namespace pandaproxy::parse {
+
+namespace {
+
+struct error_category final : std::error_category {
+    const char* name() const noexcept override { return "pandaproxy::parse"; }
+    std::string message(int ev) const override {
+        switch (static_cast<error_code>(ev)) {
+        case error_code::empty_param:
+            return "empty_param";
+        case error_code::invalid_param:
+            return "invalid_param";
+        }
+        return "(unrecognized error)";
+    }
+
+    std::error_condition
+    default_error_condition(int ec) const noexcept override {
+        switch (static_cast<error_code>(ec)) {
+        case error_code::empty_param:
+        case error_code::invalid_param:
+            return reply_error_code::kafka_bad_request;
+        }
+        return {};
+    }
+};
+
+const error_category ppp_error_category{};
+
+}; // namespace
+
+std::error_code make_error_code(error_code ec) {
+    return {static_cast<int>(ec), ppp_error_category};
+}
+
+} // namespace pandaproxy::parse

--- a/src/v/pandaproxy/parsing/error.h
+++ b/src/v/pandaproxy/parsing/error.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <system_error>
+
+namespace pandaproxy::parse {
+
+enum class error_code : uint16_t {
+    // ok = 0
+    empty_param = 100,
+    invalid_param = 101,
+};
+
+std::error_code make_error_code(error_code);
+
+} // namespace pandaproxy::parse
+
+namespace std {
+
+template<>
+struct is_error_code_enum<pandaproxy::parse::error_code> : true_type {};
+
+} // namespace std

--- a/src/v/pandaproxy/parsing/exceptions.h
+++ b/src/v/pandaproxy/parsing/exceptions.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/parsing/error.h"
+
+#include <fmt/format.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace pandaproxy::parse {
+
+struct exception_base : std::exception {
+    exception_base(error_code err, std::string_view msg)
+      : std::exception{}
+      , error{err}
+      , msg{msg} {}
+    const char* what() const noexcept final { return msg.c_str(); }
+    error_code error;
+    std::string msg;
+};
+
+class error final : public exception_base {
+public:
+    explicit error(error_code ec, std::string_view msg)
+      : exception_base(ec, msg) {}
+};
+
+} // namespace pandaproxy::parse

--- a/src/v/pandaproxy/parsing/from_chars.h
+++ b/src/v/pandaproxy/parsing/from_chars.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "outcome.h"
+#include "reflection/type_traits.h"
+
+#include <charconv>
+#include <chrono>
+#include <type_traits>
+
+namespace pandaproxy::parse {
+
+namespace detail {
+
+template<typename T>
+struct is_duration : std::false_type {};
+
+template<typename Rep, typename Period>
+struct is_duration<std::chrono::duration<Rep, Period>> : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_duration_v = is_duration<T>::value;
+
+} // namespace detail
+
+// from_chars converts from a string_view using std::from_chars.
+//
+// Recurses through several well-known types as a convenience. E.g.:
+// using timeout_ms = named_type<std::chrono::milliseconds, struct T>;
+// parse::from_chars<std::optional<timeout_ms>>{}("42");
+//
+// Returns outcome::result<type, std::error_code>
+//
+// If T (or nested T) is constructable from a string_view, no parsing is done.
+// If input is empty and T is not optional, returns std::errc::invalid_argument
+template<typename T>
+class from_chars {
+public:
+    using type = std::decay_t<T>;
+    using result_type = result<type>;
+
+    static constexpr bool is_optional = reflection::is_std_optional_v<type>;
+    static constexpr bool is_named_type = reflection::is_named_type_v<type>;
+    static constexpr bool is_duration = detail::is_duration_v<type>;
+    static constexpr bool is_arithmetic = std::is_arithmetic_v<type>;
+    static constexpr bool is_constructible_from_string_view
+      = std::is_constructible_v<type, std::string_view>;
+    static constexpr bool is_constructible_from_sstring
+      = std::is_constructible_v<type, ss::sstring>;
+
+    static_assert(
+      is_optional || is_named_type || is_duration || is_arithmetic
+        || is_constructible_from_string_view || is_constructible_from_sstring,
+      "from_chars not defined for T");
+
+    result_type operator()(std::string_view in) noexcept {
+        if constexpr (is_optional) {
+            if (in.empty()) {
+                return std::nullopt;
+            }
+            using value_type = typename type::value_type;
+            return wrap(from_chars<value_type>{}(in));
+        } else if (in.empty()) {
+            return std::errc::invalid_argument;
+        } else if constexpr (is_constructible_from_string_view) {
+            return type(in);
+        } else if constexpr (is_constructible_from_sstring) {
+            return type(ss::sstring(in));
+        } else if constexpr (is_named_type) {
+            using value_type = typename type::type;
+            return wrap(from_chars<value_type>{}(in));
+        } else if constexpr (is_duration) {
+            using value_type = typename type::rep;
+            return wrap(from_chars<value_type>{}(in));
+        } else if constexpr (is_arithmetic) {
+            return do_from_chars(in);
+        }
+        return std::errc::invalid_argument;
+    }
+
+private:
+    result_type do_from_chars(std::string_view in) {
+        type val;
+        const auto [ptr, ec] = std::from_chars(
+          in.data(), in.data() + in.size(), val);
+        if (ec != std::errc()) {
+            return std::errc{ec};
+        } else if (ptr != in.data() + in.size()) {
+            return std::errc::invalid_argument;
+        }
+        return val;
+    }
+
+    template<typename U>
+    result_type wrap(U&& inner) {
+        if (inner) {
+            return type(std::forward<U>(inner).value());
+        }
+        return inner.error();
+    }
+};
+
+} // namespace pandaproxy::parse

--- a/src/v/pandaproxy/parsing/httpd.h
+++ b/src/v/pandaproxy/parsing/httpd.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/parsing/exceptions.h"
+#include "pandaproxy/parsing/from_chars.h"
+
+#include <seastar/http/request.hh>
+
+namespace pandaproxy::parse {
+
+namespace detail {
+
+template<typename T>
+T parse_param(std::string_view type, std::string_view key, ss::sstring value) {
+    if (value.empty()) {
+        throw error(
+          error_code::empty_param,
+          fmt::format("Missing mandatory {} '{}'", type, key));
+    }
+    auto res = parse::from_chars<T>{}(value);
+    if (res.has_error()) {
+        throw error(
+          error_code::invalid_param,
+          fmt::format("Invalid {} '{}' got '{}'", type, key, value));
+    }
+    return res.value();
+}
+
+} // namespace detail
+
+template<typename T>
+T header(const ss::httpd::request& req, const ss::sstring& name) {
+    return detail::parse_param<T>("header", name, req.get_header(name));
+}
+
+template<typename T>
+T request_param(const ss::httpd::request& req, const ss::sstring& name) {
+    return detail::parse_param<T>("parameter", name, req.param[name]);
+}
+
+template<typename T>
+T query_param(const ss::httpd::request& req, const ss::sstring& name) {
+    return detail::parse_param<T>("parameter", name, req.get_query_param(name));
+}
+
+} // namespace pandaproxy::parse

--- a/src/v/pandaproxy/parsing/test/CMakeLists.txt
+++ b/src/v/pandaproxy/parsing/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+rp_test(
+  UNIT_TEST
+  BINARY_NAME pandaproxy_parsing_unit
+  SOURCES
+    from_chars.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES Boost::unit_test_framework v::pandaproxy_parsing
+  LABELS pandaproxy
+)

--- a/src/v/pandaproxy/parsing/test/from_chars.cc
+++ b/src/v/pandaproxy/parsing/test/from_chars.cc
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#define BOOST_TEST_MODULE pandaproxy
+
+#include "pandaproxy/parsing/from_chars.h"
+
+#include "utils/named_type.h"
+
+#include <boost/mpl/list.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <optional>
+#include <ratio>
+#include <system_error>
+
+namespace pp = pandaproxy;
+
+using mini_milliseconds = std::chrono::duration<int8_t, std::milli>;
+
+using integral_test_types = boost::mpl::list<
+  int8_t,
+  uint16_t,
+  named_type<int8_t, struct Tag>,
+  mini_milliseconds,
+  std::optional<int8_t>>;
+
+using string_test_types = boost::mpl::
+  list<std::string, ss::sstring, named_type<ss::sstring, struct Tag>>;
+
+using optional_test_types = boost::mpl::list<
+  std::optional<ss::sstring>,
+  std::optional<int8_t>,
+  std::optional<named_type<ss::sstring, struct Tag>>,
+  std::optional<named_type<mini_milliseconds, struct Tag>>>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(from_chars_to_integral, T, integral_test_types) {
+    constexpr const auto string_literal{"42"};
+    auto res_0 = pp::parse::from_chars<T>{}(string_literal);
+    using result_type = std::decay_t<decltype(res_0.value())>;
+    static_assert(std::is_same_v<result_type, T>);
+    BOOST_REQUIRE(res_0);
+    BOOST_REQUIRE(res_0.has_value());
+    BOOST_REQUIRE(res_0.value() == T{42});
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+  from_chars_overflow_integral, T, integral_test_types) {
+    constexpr const auto string_literal{"65537"};
+    auto res_0 = pp::parse::from_chars<T>{}(string_literal);
+    using result_type = std::decay_t<decltype(res_0.value())>;
+    static_assert(std::is_same_v<result_type, T>);
+    BOOST_REQUIRE(!res_0);
+    BOOST_REQUIRE(res_0.has_error());
+    BOOST_REQUIRE(res_0.error() == std::errc::result_out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+  fron_chars_integral_from_float, T, integral_test_types) {
+    using input_type = named_type<int8_t, struct Tag>;
+    constexpr const auto string_literal{"1.2"};
+    auto res_0 = pp::parse::from_chars<input_type>{}(string_literal);
+    using result_type = std::decay_t<decltype(res_0.value())>;
+    static_assert(std::is_same_v<result_type, input_type>);
+    BOOST_REQUIRE(!res_0);
+    BOOST_REQUIRE(res_0.has_error());
+    BOOST_REQUIRE(res_0.error() == std::errc::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(from_chars_to_string, T, string_test_types) {
+    constexpr const auto string_literal{"string_literal"};
+    auto res_0 = pp::parse::from_chars<T>{}(string_literal);
+    using result_type = std::decay_t<decltype(res_0.value())>;
+    static_assert(std::is_same_v<result_type, T>);
+    BOOST_REQUIRE(res_0);
+    BOOST_REQUIRE(res_0.has_value());
+    BOOST_REQUIRE_EQUAL(res_0.value(), T{string_literal});
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+  from_chars_to_string_empty, T, string_test_types) {
+    constexpr const auto string_literal{""};
+    auto res_0 = pp::parse::from_chars<T>{}(string_literal);
+    using result_type = std::decay_t<decltype(res_0.value())>;
+    static_assert(std::is_same_v<result_type, T>);
+    BOOST_REQUIRE(!res_0);
+    BOOST_REQUIRE(res_0.has_error());
+    BOOST_REQUIRE(res_0.error() == std::errc::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+  from_chars_to_optional_empty, T, optional_test_types) {
+    constexpr const auto string_literal{""};
+    auto res_0 = pp::parse::from_chars<T>{}(string_literal);
+    using result_type = std::decay_t<decltype(res_0.value())>;
+    static_assert(std::is_same_v<result_type, T>);
+    BOOST_REQUIRE(res_0);
+    BOOST_REQUIRE(res_0.has_value());
+    BOOST_REQUIRE(res_0.value() == std::nullopt);
+}

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -67,10 +67,10 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           "records?offset=0&max_bytes=1024&timeout=5000");
 
         BOOST_REQUIRE_EQUAL(
-          res.headers.result(), boost::beast::http::status::ok);
+          res.headers.result(), boost::beast::http::status::not_found);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"({"error_code":404,"message":"unknown_topic_or_partition"})");
+          R"({"error_code":40402,"message":"unknown_topic_or_partition"})");
     }
 
     info("Adding known topic");

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -59,6 +59,36 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
 })");
 
     {
+        info("Fetch with missing request parameter 'offset'");
+        set_client_config("retries", size_t(0));
+        auto res = http_request(
+          client,
+          "/topics//partitions/0/"
+          "records?max_bytes=1024&timeout=5000");
+
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::bad_request);
+        BOOST_REQUIRE_EQUAL(
+          res.body,
+          R"({"error_code":40002,"message":"Missing mandatory parameter 'offset'"})");
+    }
+
+    {
+        info("Fetch with missing path parameter 'topic_name'");
+        set_client_config("retries", size_t(0));
+        auto res = http_request(
+          client,
+          "/topics//partitions/0/"
+          "records?offset=0&max_bytes=1024&timeout=5000");
+
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::bad_request);
+        BOOST_REQUIRE_EQUAL(
+          res.body,
+          R"({"error_code":40002,"message":"Missing mandatory parameter 'topic_name'"})");
+    }
+
+    {
         info("Fetch from unknown topic");
         set_client_config("retries", size_t(0));
         auto res = http_request(

--- a/src/v/reflection/adl.h
+++ b/src/v/reflection/adl.h
@@ -14,6 +14,7 @@
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "reflection/for_each_field.h"
+#include "reflection/type_traits.h"
 #include "seastarx.h"
 #include "utils/named_type.h"
 
@@ -25,33 +26,6 @@
 #include <vector>
 
 namespace reflection {
-template<typename T>
-struct is_std_vector : std::false_type {};
-template<typename... Args>
-struct is_std_vector<std::vector<Args...>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_std_vector_v = is_std_vector<T>::value;
-
-template<typename T>
-struct is_std_optional : std::false_type {};
-template<typename... Args>
-struct is_std_optional<std::optional<Args...>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_std_optional_v = is_std_optional<T>::value;
-
-template<typename T>
-struct is_named_type : std::false_type {};
-template<typename T, typename Tag>
-struct is_named_type<named_type<T, Tag>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_named_type_v = is_named_type<T>::value;
-
-template<typename T>
-struct is_ss_bool : std::false_type {};
-template<typename T>
-struct is_ss_bool<ss::bool_class<T>> : std::true_type {};
-template<typename T>
-inline constexpr bool is_ss_bool_v = is_ss_bool<T>::value;
 
 template<typename T>
 struct adl {

--- a/src/v/reflection/type_traits.h
+++ b/src/v/reflection/type_traits.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "utils/named_type.h"
+
+#include <seastar/util/bool_class.hh>
+
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+namespace reflection {
+
+template<typename T>
+struct is_std_vector : std::false_type {};
+template<typename... Args>
+struct is_std_vector<std::vector<Args...>> : std::true_type {};
+template<typename T>
+inline constexpr bool is_std_vector_v = is_std_vector<T>::value;
+
+template<typename T>
+struct is_std_optional : std::false_type {};
+template<typename... Args>
+struct is_std_optional<std::optional<Args...>> : std::true_type {};
+template<typename T>
+inline constexpr bool is_std_optional_v = is_std_optional<T>::value;
+
+template<typename T>
+struct is_named_type : std::false_type {};
+template<typename T, typename Tag>
+struct is_named_type<named_type<T, Tag>> : std::true_type {};
+template<typename T>
+inline constexpr bool is_named_type_v = is_named_type<T>::value;
+
+template<typename T>
+struct is_ss_bool : std::false_type {};
+template<typename T>
+struct is_ss_bool<ss::bool_class<T>> : std::true_type {};
+template<typename T>
+inline constexpr bool is_ss_bool_v = is_ss_bool<T>::value;
+
+} // namespace reflection


### PR DESCRIPTION
## Cover letter

An error response should be structured as:
```
HTTP/1.1 404 Not Found 
Content-Type: application/vnd.kafka.binary.v2+json

{
    "error_code": 40402,
    "message": "unknown_topic_or_partition"
}
```

Prior to the this patch set, `error_code` was populated with the HTTP status code, and errors weren't properly propagated to the HTTP status code.

This patch set brings up the general infrastructure and uses it with the partition fetch endpoint.

Some useful information on `error_condition` and `default_error_condition` can be found here: https://akrzemi1.wordpress.com/2017/09/04/using-error-codes-effectively/

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/765372cd71116c435d081634384a342c465cfaf5..d21db62e2fe1fb185c93afa396506d9e983de381)
* Appease GCC

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/d21db62e2fe1fb185c93afa396506d9e983de381..70c60e8d7a652d1e19b8c81e092bab440fc21ef0)
* Almost complete rewrite around `std::error_condition`.
* Added `parse::from_chars` for parameter parsing.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/70c60e8d7a652d1e19b8c81e092bab440fc21ef0..a4cf2f1b08efa8234db87b9aacc4edc40a566969)
* Some fixups to switch statements to not have default and and always return to appease gcc
* `from_chars::result` -> `from_chars::result_type` to appease gcc

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/a4cf2f1b08efa8234db87b9aacc4edc40a566969..4c444560931f346d1ef41244d1b20f5679050a2c)
* Rebase - hopefully fix CI builds

## Release notes

Release note: Pandaproxy error response improvements for partition fetch endpoint
