### PR TITLE
operator: more log reduction as out of space prevention

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -33,6 +33,7 @@ import (
 var (
 	errNonexistentLastObservesState = errors.New("expecting to have statefulset LastObservedState set but it's nil")
 	errNodePortMissing              = errors.New("the node port is missing from the service")
+	traceLevel                      = 10
 )
 
 // ClusterReconciler reconciles a Cluster object
@@ -70,8 +71,8 @@ func (r *ClusterReconciler) Reconcile(
 ) (ctrl.Result, error) {
 	log := r.Log.WithValues("redpandacluster", req.NamespacedName)
 
-	log.Info(fmt.Sprintf("Starting reconcile loop for %v", req.NamespacedName))
-	defer log.Info(fmt.Sprintf("Finished reconcile loop for %v", req.NamespacedName))
+	log.V(traceLevel).Info(fmt.Sprintf("Starting reconcile loop for %v", req.NamespacedName))
+	defer log.V(traceLevel).Info(fmt.Sprintf("Finished reconcile loop for %v", req.NamespacedName))
 
 	var redpandaCluster redpandav1alpha1.Cluster
 	crb := resources.NewClusterRoleBinding(r.Client, &redpandaCluster, r.Scheme, log)


### PR DESCRIPTION
## Cover letter

This is just temporary until patchmaker fix lands.

The logs will be put back when #895 is addressed

Currently the patchmaker library thinks that something changed on sts and is trying to patch it over and over which triggers huge amount of logs. The applied patches are not restarting statefulset so the redpanda nodes are not affected.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
