### PR TITLE
operator: prevent neverending reconcile loop on sts

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -165,6 +165,8 @@ func preparePVCResource(
 	storage redpandav1alpha1.StorageSpec,
 	clusterLabels labels.CommonLabels,
 ) corev1.PersistentVolumeClaim {
+	fileSystemMode := corev1.PersistentVolumeFilesystem
+
 	pvc := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -178,6 +180,7 @@ func preparePVCResource(
 					corev1.ResourceStorage: resource.MustParse(defaultDatadirCapacity),
 				},
 			},
+			VolumeMode: &fileSystemMode,
 		},
 	}
 

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -104,6 +104,8 @@ func TestEnsure(t *testing.T) {
 }
 
 func stsFromCluster(pandaCluster *redpandav1alpha1.Cluster) *v1.StatefulSet {
+	fileSystemMode := corev1.PersistentVolumeFilesystem
+
 	return &v1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pandaCluster.Namespace,
@@ -143,6 +145,7 @@ func stsFromCluster(pandaCluster *redpandav1alpha1.Cluster) *v1.StatefulSet {
 							},
 						},
 						StorageClassName: &pandaCluster.Spec.Storage.StorageClassName,
+						VolumeMode:       &fileSystemMode,
 					},
 				},
 			},


### PR DESCRIPTION
## Cover letter

Currently the patchmaker library was reconciling and patching sts over
and over because it thought there were changes. By the lines introduced
in this PR no changes are detected anymore.

this temporarily resolves #895 but I'll follow up with another PR that will add proper test coverage and will handle filemode in a nicer way.

Currently the patches were generated because:
- it though PVC meta and status changed
- PVC filemode changed
- resourceversion changed

All are covered by the changed lines.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
