### PR TITLE
Alter topic properties

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -62,6 +62,7 @@ static constexpr int8_t create_topic_cmd_type = 0;
 static constexpr int8_t delete_topic_cmd_type = 1;
 static constexpr int8_t move_partition_replicas_cmd_type = 2;
 static constexpr int8_t finish_moving_partition_replicas_cmd_type = 3;
+static constexpr int8_t update_topic_properties_cmd_type = 4;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -85,6 +86,12 @@ using finish_moving_partition_replicas_cmd = controller_command<
   model::ntp,
   std::vector<model::broker_shard>,
   finish_moving_partition_replicas_cmd_type,
+  topic_batch_type()>;
+
+using update_topic_properties_cmd = controller_command<
+  model::topic_namespace,
+  incremental_topic_updates,
+  update_topic_properties_cmd_type,
   topic_batch_type()>;
 
 // typelist utils

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -13,6 +13,7 @@
 
 #include "cluster/fwd.h"
 #include "cluster/topic_table.h"
+#include "cluster/types.h"
 #include "model/fundamental.h"
 #include "outcome.h"
 
@@ -59,6 +60,9 @@ private:
       model::ntp, const partition_assignment&, model::revision_id);
     ss::future<std::error_code> finish_partition_update(
       model::ntp, const partition_assignment&, model::revision_id);
+
+    ss::future<std::error_code>
+      process_partition_properties_update(model::ntp, partition_assignment);
 
     ss::future<std::error_code> create_partition(
       model::ntp,

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -113,6 +113,11 @@ partition::timequery(model::timestamp t, ss::io_priority_class p) {
     return _raft->timequery(cfg);
 }
 
+ss::future<> partition::update_configuration(topic_properties properties) {
+    return _raft->log().update_configuration(
+      properties.get_ntp_cfg_overrides());
+}
+
 std::ostream& operator<<(std::ostream& o, const partition& x) {
     return o << x._raft;
 }

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -136,6 +136,7 @@ public:
     }
 
     size_t size_bytes() const { return _raft->log().size_bytes(); }
+    ss::future<> update_configuration(topic_properties);
 
 private:
     friend partition_manager;

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -33,7 +33,7 @@ namespace cluster {
 ///
 // delta propagated to backend
 struct topic_table_delta {
-    enum class op_type { add, del, update, update_finished };
+    enum class op_type { add, del, update, update_finished, update_properties };
 
     topic_table_delta(
       model::ntp, cluster::partition_assignment, model::offset, op_type);
@@ -81,7 +81,8 @@ public:
       create_topic_cmd,
       delete_topic_cmd,
       move_partition_replicas_cmd,
-      finish_moving_partition_replicas_cmd>{};
+      finish_moving_partition_replicas_cmd,
+      update_topic_properties_cmd>{};
 
     /// State machine applies
     ss::future<std::error_code> apply(create_topic_cmd, model::offset);
@@ -90,7 +91,8 @@ public:
       apply(move_partition_replicas_cmd, model::offset);
     ss::future<std::error_code>
       apply(finish_moving_partition_replicas_cmd, model::offset);
-
+    ss::future<std::error_code>
+      apply(update_topic_properties_cmd, model::offset);
     ss::future<> stop();
 
     /// Delta API

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -83,6 +83,9 @@ topic_updates_dispatcher::apply_update(model::record_batch b) {
             },
             [this, base_offset](finish_moving_partition_replicas_cmd cmd) {
                 return dispatch_updates_to_cores(std::move(cmd), base_offset);
+            },
+            [this, base_offset](update_topic_properties_cmd cmd) {
+                return dispatch_updates_to_cores(std::move(cmd), base_offset);
             });
       });
 }

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -57,7 +57,8 @@ public:
       create_topic_cmd,
       delete_topic_cmd,
       move_partition_replicas_cmd,
-      finish_moving_partition_replicas_cmd>();
+      finish_moving_partition_replicas_cmd,
+      update_topic_properties_cmd>();
 
     bool is_batch_applicable(const model::record_batch& batch) const {
         return batch.header().type == topic_batch_type;

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -56,6 +56,9 @@ public:
       std::vector<model::broker_shard>,
       model::timeout_clock::time_point);
 
+    ss::future<std::vector<topic_result>> update_topic_properties(
+      std::vector<topic_properties_update>, model::timeout_clock::time_point);
+
 private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
@@ -78,7 +81,8 @@ private:
       model::node_id,
       std::vector<topic_configuration>,
       model::timeout_clock::duration);
-
+    ss::future<topic_result> do_update_topic_properties(
+      topic_properties_update, model::timeout_clock::time_point);
     ss::future<> update_leaders_with_estimates(std::vector<ntp_leader>);
     // returns true if the topic name is valid
     static bool validate_topic_name(const model::topic_namespace&);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -38,6 +38,17 @@ bool topic_properties::has_overrides() const {
            || retention_duration.is_disabled();
 }
 
+storage::ntp_config::default_overrides
+topic_properties::get_ntp_cfg_overrides() const {
+    storage::ntp_config::default_overrides ret;
+    ret.cleanup_policy_bitflags = cleanup_policy_bitflags;
+    ret.compaction_strategy = compaction_strategy;
+    ret.retention_bytes = retention_bytes;
+    ret.retention_time = retention_duration;
+    ret.segment_size = segment_size;
+    return ret;
+}
+
 topic_configuration::topic_configuration(
   model::ns n, model::topic t, int32_t count, int16_t rf)
   : tp_ns(std::move(n), std::move(t))

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -117,8 +117,8 @@ std::ostream& operator<<(std::ostream& o, const topic_configuration& cfg) {
 std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
     fmt::print(
       o,
-      "{compression: {}, cleanup_policy_bitflags: {}, compaction_strategy: {}, "
-      "retention_bytes: {}, retention_duration_ms: {}, segment_size: {}, "
+      "{{ compression: {}, cleanup_policy_bitflags: {}, compaction_strategy: "
+      "{}, retention_bytes: {}, retention_duration_ms: {}, segment_size: {}, "
       "timestamp_type: {} }}",
       properties.compression,
       properties.cleanup_policy_bitflags,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -99,6 +99,8 @@ struct topic_properties {
     bool is_compacted() const;
     bool has_overrides() const;
 
+    storage::ntp_config::default_overrides get_ntp_cfg_overrides() const;
+
     friend std::ostream& operator<<(std::ostream&, const topic_properties&);
 };
 // Structure holding topic configuration, optionals will be replaced by broker

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -103,6 +103,43 @@ struct topic_properties {
 
     friend std::ostream& operator<<(std::ostream&, const topic_properties&);
 };
+
+enum incremental_update_operation : int8_t { none, set, remove };
+template<typename T>
+struct property_update {
+    T value;
+    incremental_update_operation op = incremental_update_operation::none;
+};
+
+template<typename T>
+struct property_update<tristate<T>> {
+    tristate<T> value = tristate<T>(std::nullopt);
+    incremental_update_operation op = incremental_update_operation::none;
+};
+
+struct incremental_topic_updates {
+    property_update<std::optional<model::compression>> compression;
+    property_update<std::optional<model::cleanup_policy_bitflags>>
+      cleanup_policy_bitflags;
+    property_update<std::optional<model::compaction_strategy>>
+      compaction_strategy;
+    property_update<std::optional<model::timestamp_type>> timestamp_type;
+    property_update<std::optional<size_t>> segment_size;
+    property_update<tristate<size_t>> retention_bytes;
+    property_update<tristate<std::chrono::milliseconds>> retention_duration;
+};
+
+/**
+ * Struct representing single topic properties update
+ */
+struct topic_properties_update {
+    explicit topic_properties_update(model::topic_namespace tp_ns)
+      : tp_ns(std::move(tp_ns)) {}
+
+    model::topic_namespace tp_ns;
+    incremental_topic_updates properties;
+};
+
 // Structure holding topic configuration, optionals will be replaced by broker
 // defaults
 struct topic_configuration {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -273,6 +273,13 @@ configuration::configuration()
       "wasn't reached",
       required::no,
       1ms)
+  , alter_topic_cfg_timeout_ms(
+      *this,
+      "alter_topic_cfg_timeout_ms",
+      "Time to wait for entries replication in controller log when executing "
+      "alter configuration requst",
+      required::no,
+      5s)
   , transactional_id_expiration_ms(
       *this,
       "transactional_id_expiration_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -23,6 +23,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include <chrono>
+
 namespace config {
 
 /// Redpanda configuration
@@ -81,6 +83,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> tm_sync_timeout_ms;
     property<model::violation_recovery_policy> tm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
+    property<std::chrono::milliseconds> alter_topic_cfg_timeout_ms;
     // same as transactional.id.expiration.ms in kafka
     property<std::chrono::milliseconds> transactional_id_expiration_ms;
     property<bool> enable_idempotence;

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -9,34 +9,287 @@
 
 #include "kafka/server/handlers/alter_configs.h"
 
+#include "cluster/topics_frontend.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
 #include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/alter_configs_response.h"
+#include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
+#include "kafka/types.h"
 #include "model/metadata.h"
+#include "model/timeout_clock.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/log.hh>
 
+#include <absl/container/node_hash_set.h>
 #include <fmt/ostream.h>
 
 #include <string_view>
 
 namespace kafka {
+/**
+ * Groupped alter_configs_resources
+ *
+ * NOTE:
+ * We do not have to differentiate between broker and broker_logger as
+ * broker_logger is deprecated it will be enough to generate error response.
+ */
+struct groupped_resources {
+    std::vector<alter_configs_resource> topic_changes;
+    std::vector<alter_configs_resource> broker_changes;
+};
+
+groupped_resources
+group_alter_config_resources(std::vector<alter_configs_resource> req) {
+    groupped_resources ret;
+    for (auto& res : req) {
+        switch (config_resource_type(res.resource_type)) {
+        case config_resource_type::topic:
+            ret.topic_changes.push_back(std::move(res));
+            break;
+        default:
+            ret.broker_changes.push_back(std::move(res));
+        };
+    }
+    return ret;
+}
+
+alter_configs_response assemble_alter_config_response(
+  std::vector<std::vector<alter_configs_resource_response>> responses) {
+    alter_configs_response response;
+    for (auto& v : responses) {
+        std::move(
+          v.begin(), v.end(), std::back_inserter(response.data.responses));
+    }
+
+    return response;
+}
+
+alter_configs_resource_response make_error_alter_config_resource_response(
+  alter_configs_resource& resource,
+  kafka::error_code err,
+  std::optional<ss::sstring> msg = {}) {
+    return alter_configs_resource_response{
+      .error_code = err,
+      .error_message = std::move(msg),
+      .resource_type = resource.resource_type,
+      .resource_name = resource.resource_name};
+}
+
+template<typename T>
+void parse_and_set_optional(
+  cluster::property_update<std::optional<T>>& property_update,
+  const std::optional<ss::sstring>& value) {
+    if (!value) {
+        property_update.value = std::nullopt;
+    }
+
+    property_update.value = boost::lexical_cast<T>(*value);
+}
+
+template<typename T>
+void parse_and_set_tristate(
+  cluster::property_update<tristate<T>>& property_update,
+  const std::optional<ss::sstring>& value) {
+    if (!value) {
+        property_update.value = tristate<T>(std::nullopt);
+    }
+
+    auto parsed = boost::lexical_cast<int64_t>(*value);
+    if (parsed <= 0) {
+        property_update.value = tristate<T>{};
+    } else {
+        property_update.value = tristate<T>(std::make_optional<T>(parsed));
+    }
+}
+
+checked<cluster::topic_properties_update, alter_configs_resource_response>
+create_topic_properties_update(alter_configs_resource& resource) {
+    model::topic_namespace tp_ns(
+      model::kafka_namespace, model::topic(resource.resource_name));
+    cluster::topic_properties_update update(tp_ns);
+    /**
+     * Alter topic configuration should override topic properties with values
+     * sent in the request, if given resource value isn't set in the request,
+     * override for this value has to be removed. We override all defaults to
+     * set, even if value for given property isn't set it will override
+     * configuration in topic table
+     */
+    update.properties.cleanup_policy_bitflags.op
+      = cluster::incremental_update_operation::set;
+    update.properties.compaction_strategy.op
+      = cluster::incremental_update_operation::set;
+    update.properties.compression.op
+      = cluster::incremental_update_operation::set;
+    update.properties.segment_size.op
+      = cluster::incremental_update_operation::set;
+    update.properties.timestamp_type.op
+      = cluster::incremental_update_operation::set;
+    update.properties.retention_bytes.op
+      = cluster::incremental_update_operation::set;
+    update.properties.retention_duration.op
+      = cluster::incremental_update_operation::set;
+
+    for (auto& cfg : resource.configs) {
+        try {
+            if (cfg.name == topic_property_cleanup_policy) {
+                parse_and_set_optional(
+                  update.properties.cleanup_policy_bitflags, cfg.value);
+                continue;
+            }
+            if (cfg.name == topic_property_compaction_strategy) {
+                parse_and_set_optional(
+                  update.properties.compaction_strategy, cfg.value);
+                continue;
+            }
+            if (cfg.name == topic_property_compression) {
+                parse_and_set_optional(
+                  update.properties.compression, cfg.value);
+                continue;
+            }
+            if (cfg.name == topic_property_segment_size) {
+                parse_and_set_optional(
+                  update.properties.segment_size, cfg.value);
+                continue;
+            }
+            if (cfg.name == topic_property_timestamp_type) {
+                parse_and_set_optional(
+                  update.properties.timestamp_type, cfg.value);
+                continue;
+            }
+            if (cfg.name == topic_property_retention_bytes) {
+                parse_and_set_tristate(
+                  update.properties.retention_bytes, cfg.value);
+                continue;
+            }
+            if (cfg.name == topic_property_retention_duration) {
+                parse_and_set_tristate(
+                  update.properties.retention_duration, cfg.value);
+                continue;
+            }
+        } catch (const boost::bad_lexical_cast& e) {
+            return make_error_alter_config_resource_response(
+              resource,
+              error_code::invalid_config,
+              fmt::format(
+                "unable to parse property {} value {}", cfg.name, cfg.value));
+        }
+
+        // Unsupported property, return error
+        return make_error_alter_config_resource_response(
+          resource,
+          error_code::invalid_config,
+          fmt::format("invalid topic property: {}", cfg.name));
+    }
+
+    return update;
+}
+
+ss::future<std::vector<alter_configs_resource_response>>
+alter_topics_configuration(
+  request_context& ctx,
+  std::vector<alter_configs_resource> resources,
+  bool validate_only) {
+    std::vector<alter_configs_resource_response> responses;
+    responses.reserve(resources.size());
+
+    absl::node_hash_set<ss::sstring> topic_names;
+    auto valid_end = std::stable_partition(
+      resources.begin(),
+      resources.end(),
+      [&topic_names](alter_configs_resource& r) {
+          return !topic_names.contains(r.resource_name);
+      });
+
+    for (auto& r : boost::make_iterator_range(valid_end, resources.end())) {
+        responses.push_back(make_error_alter_config_resource_response(
+          r,
+          error_code::invalid_config,
+          "duplicated topic {} alter config request"));
+    }
+    std::vector<cluster::topic_properties_update> updates;
+    for (auto& r : boost::make_iterator_range(resources.begin(), valid_end)) {
+        auto res = create_topic_properties_update(r);
+        if (res.has_error()) {
+            responses.push_back(std::move(res.error()));
+        } else {
+            updates.push_back(std::move(res.value()));
+        }
+    }
+
+    if (validate_only) {
+        // all pending updates are valid, just generate responses
+        for (auto& u : updates) {
+            responses.push_back(alter_configs_resource_response{
+              .error_code = error_code::none,
+              .resource_type = static_cast<int8_t>(config_resource_type::topic),
+              .resource_name = u.tp_ns.tp,
+            });
+        }
+
+        co_return responses;
+    }
+
+    auto update_results
+      = co_await ctx.topics_frontend().update_topic_properties(
+        std::move(updates),
+        model::timeout_clock::now()
+          + config::shard_local_cfg().alter_topic_cfg_timeout_ms());
+    for (auto& res : update_results) {
+        responses.push_back(alter_configs_resource_response{
+          .error_code = error_code::none,
+          .resource_type = static_cast<int8_t>(config_resource_type::topic),
+          .resource_name = res.tp_ns.tp(),
+        });
+    }
+    co_return responses;
+}
+
+ss::future<std::vector<alter_configs_resource_response>>
+alter_broker_configuartion(std::vector<alter_configs_resource> resources) {
+    // for now we do not support altering any of brokers config, generate errors
+    std::vector<alter_configs_resource_response> responses;
+    responses.reserve(resources.size());
+    std::transform(
+      resources.begin(),
+      resources.end(),
+      std::back_inserter(responses),
+      [](alter_configs_resource& resource) {
+          return make_error_alter_config_resource_response(
+            resource,
+            error_code::invalid_config,
+            fmt::format(
+              "changing '{}' broker property isn't currently supported",
+              resource.resource_name));
+      });
+
+    co_return responses;
+}
 
 template<>
 ss::future<response_ptr> alter_configs_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     alter_configs_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
 
-    return ss::do_with(
-      std::move(ctx),
-      std::move(request),
-      [](request_context& ctx, alter_configs_request&) {
-          return ctx.respond(alter_configs_response());
-      });
+    auto groupped = group_alter_config_resources(
+      std::move(request.data.resources));
+
+    std::vector<ss::future<std::vector<alter_configs_resource_response>>>
+      futures;
+    futures.reserve(2);
+    futures.push_back(alter_topics_configuration(
+      ctx, std::move(groupped.topic_changes), request.data.validate_only));
+    futures.push_back(
+      alter_broker_configuartion(std::move(groupped.broker_changes)));
+    auto ret = co_await ss::when_all_succeed(futures.begin(), futures.end());
+    co_return co_await ctx.respond(
+      assemble_alter_config_response(std::move(ret)));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -16,12 +16,35 @@
 #include "kafka/server/errors.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
+#include "utils/absl_sstring_hash.h"
 
 #include <absl/container/flat_hash_map.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
 namespace kafka {
+
+/**
+ * We use `flat_hash_map` in here since those map are small and short lived.
+ */
+using config_map_t
+  = absl::flat_hash_map<ss::sstring, ss::sstring, sstring_hash, sstring_eq>;
+/**
+ * Topic properties string names
+ */
+static constexpr std::string_view topic_property_compression
+  = "compression.type";
+static constexpr std::string_view topic_property_cleanup_policy
+  = "cleanup.policy";
+static constexpr std::string_view topic_property_compaction_strategy
+  = "compaction.strategy";
+static constexpr std::string_view topic_property_timestamp_type
+  = "message.timestamp.type";
+static constexpr std::string_view topic_property_segment_size = "segment.bytes";
+static constexpr std::string_view topic_property_retention_bytes
+  = "retention.bytes";
+static constexpr std::string_view topic_property_retention_duration
+  = "retention.ms";
 
 /// \brief Type representing Kafka protocol response from
 /// CreateTopics, DeleteTopics and CreatePartitions requests
@@ -37,8 +60,7 @@ from_cluster_topic_result(const cluster::topic_result& err) {
     return {.name = err.tp_ns.tp, .error_code = map_topic_error_code(err.ec)};
 }
 
-absl::flat_hash_map<ss::sstring, ss::sstring>
-config_map(const std::vector<createable_topic_config>& config);
+config_map_t config_map(const std::vector<createable_topic_config>& config);
 
 cluster::topic_configuration to_cluster_type(const creatable_topic& t);
 

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(srcs
   offset_commit_test.cc
   topic_recreate_test.cc
   fetch_session_test.cc
+  alter_config_test.cc
   produce_consume_test.cc)
 
 rp_test(

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -1,0 +1,252 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/configuration.h"
+#include "kafka/protocol/alter_configs.h"
+#include "kafka/protocol/create_topics.h"
+#include "kafka/protocol/describe_configs.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/alter_configs_request.h"
+#include "kafka/protocol/schemata/describe_configs_request.h"
+#include "kafka/protocol/schemata/describe_configs_response.h"
+#include "kafka/server/handlers/topics/types.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "redpanda/tests/fixture.h"
+
+#include <seastar/core/loop.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/util/defer.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+using namespace std::chrono_literals; // NOLINT
+
+class alter_config_test_fixture : public redpanda_thread_fixture {
+public:
+    void create_topic(model::topic name, int partitions) {
+        model::topic_namespace tp_ns(model::kafka_namespace, std::move(name));
+
+        add_topic(tp_ns, partitions).get();
+
+        ss::parallel_for_each(
+          boost::irange(0, partitions),
+          [this, tp_ns](int i) {
+              return wait_for_partition_offset(
+                model::ntp(tp_ns.ns, tp_ns.tp, model::partition_id(i)),
+                model::offset(0));
+          })
+          .get();
+    }
+
+    template<typename Func>
+    auto do_with_client(Func&& f) {
+        return make_kafka_client().then(
+          [f = std::forward<Func>(f)](kafka::client::transport client) mutable {
+              return ss::do_with(
+                std::move(client),
+                [f = std::forward<Func>(f)](
+                  kafka::client::transport& client) mutable {
+                    return client.connect().then(
+                      [&client, f = std::forward<Func>(f)]() mutable {
+                          return f(client);
+                      });
+                });
+          });
+    }
+
+    kafka::alter_configs_resource make_alter_topic_config_resource(
+      const model::topic& topic,
+      const absl::flat_hash_map<ss::sstring, ss::sstring>& properties) {
+        std::vector<kafka::alterable_config> cfg_list;
+        cfg_list.reserve(properties.size());
+        for (auto& [k, v] : properties) {
+            cfg_list.push_back(kafka::alterable_config{.name = k, .value = v});
+        }
+
+        return kafka::alter_configs_resource{
+          .resource_type = static_cast<int8_t>(
+            kafka::config_resource_type::topic),
+          .resource_name = topic,
+          .configs = std::move(cfg_list),
+        };
+    }
+
+    kafka::describe_configs_response
+    describe_configs(const model::topic& topic) {
+        kafka::describe_configs_request req;
+
+        kafka::describe_configs_resource res{
+          .resource_type = kafka::config_resource_type::topic,
+          .resource_name = topic,
+        };
+        req.data.resources.push_back(std::move(res));
+        return do_with_client([req = std::move(req)](
+                                kafka::client::transport& client) mutable {
+                   return client.dispatch(
+                     std::move(req), kafka::api_version(0));
+               })
+          .get();
+    }
+
+    kafka::alter_configs_response
+    alter_configs(std::vector<kafka::alter_configs_resource> resources) {
+        kafka::alter_configs_request req;
+        req.data.resources = std::move(resources);
+        return do_with_client([req = std::move(req)](
+                                kafka::client::transport& client) mutable {
+                   return client.dispatch(
+                     std::move(req), kafka::api_version(0));
+               })
+          .get();
+    }
+
+    void assert_property_value(
+      const model::topic& topic,
+      const ss::sstring& key,
+      const ss::sstring& value,
+      const kafka::describe_configs_response resp) {
+        auto it = std::find_if(
+          resp.data.results.begin(),
+          resp.data.results.end(),
+          [&topic](const kafka::describe_configs_result& res) {
+              return res.resource_name == topic;
+          });
+        BOOST_REQUIRE(it != resp.data.results.end());
+
+        auto cfg_it = std::find_if(
+          it->configs.begin(),
+          it->configs.end(),
+          [&key](const kafka::describe_configs_resource_result& res) {
+              return res.name == key;
+          });
+        BOOST_REQUIRE(cfg_it != it->configs.end());
+
+        BOOST_REQUIRE_EQUAL(cfg_it->value, value);
+    }
+};
+
+FIXTURE_TEST(test_alter_single_topic_config, alter_config_test_fixture) {
+    wait_for_controller_leadership().get();
+    model::topic test_tp{"topic-1"};
+    create_topic(test_tp, 6);
+
+    absl::flat_hash_map<ss::sstring, ss::sstring> properties;
+    properties.emplace("retention.ms", "1234");
+    properties.emplace("cleanup.policy", "compact");
+
+    auto resp = alter_configs(
+      {make_alter_topic_config_resource(test_tp, properties)});
+
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].resource_name, test_tp);
+
+    auto describe_resp = describe_configs(test_tp);
+    assert_property_value(test_tp, "retention.ms", "1234", describe_resp);
+    assert_property_value(test_tp, "cleanup.policy", "compact", describe_resp);
+}
+
+FIXTURE_TEST(test_alter_multiple_topics_config, alter_config_test_fixture) {
+    wait_for_controller_leadership().get();
+    model::topic topic_1{"topic-1"};
+    model::topic topic_2{"topic-2"};
+    create_topic(topic_1, 1);
+    create_topic(topic_2, 3);
+
+    absl::flat_hash_map<ss::sstring, ss::sstring> properties_1;
+    properties_1.emplace("retention.ms", "1234");
+    properties_1.emplace("cleanup.policy", "compact");
+
+    absl::flat_hash_map<ss::sstring, ss::sstring> properties_2;
+    properties_2.emplace("retention.bytes", "4096");
+
+    auto resp = alter_configs({
+      make_alter_topic_config_resource(topic_1, properties_1),
+      make_alter_topic_config_resource(topic_2, properties_2),
+    });
+
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 2);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[1].error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].resource_name, topic_1);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[1].resource_name, topic_2);
+
+    auto describe_resp_1 = describe_configs(topic_1);
+    assert_property_value(topic_1, "retention.ms", "1234", describe_resp_1);
+    assert_property_value(
+      topic_1, "cleanup.policy", "compact", describe_resp_1);
+
+    auto describe_resp_2 = describe_configs(topic_2);
+    assert_property_value(topic_2, "retention.bytes", "4096", describe_resp_2);
+}
+
+FIXTURE_TEST(test_alter_topic_error, alter_config_test_fixture) {
+    wait_for_controller_leadership().get();
+    model::topic test_tp{"topic-1"};
+    create_topic(test_tp, 6);
+
+    absl::flat_hash_map<ss::sstring, ss::sstring> properties;
+    properties.emplace("not.exists", "1234");
+
+    auto resp = alter_configs(
+      {make_alter_topic_config_resource(test_tp, properties)});
+
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].error_code, kafka::error_code::invalid_config);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].resource_name, test_tp);
+}
+
+FIXTURE_TEST(
+  test_alter_configuration_should_override, alter_config_test_fixture) {
+    wait_for_controller_leadership().get();
+    model::topic test_tp{"topic-1"};
+    create_topic(test_tp, 6);
+    /**
+     * Set custom retention.ms
+     */
+    absl::flat_hash_map<ss::sstring, ss::sstring> properties;
+    properties.emplace("retention.ms", "1234");
+
+    auto resp = alter_configs(
+      {make_alter_topic_config_resource(test_tp, properties)});
+
+    BOOST_REQUIRE_EQUAL(resp.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      resp.data.responses[0].error_code, kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(resp.data.responses[0].resource_name, test_tp);
+
+    auto describe_resp = describe_configs(test_tp);
+    assert_property_value(test_tp, "retention.ms", "1234", describe_resp);
+
+    /**
+     * Set custom retention.bytes, previous settings should be overriden
+     */
+    absl::flat_hash_map<ss::sstring, ss::sstring> new_properties;
+    new_properties.emplace("retention.bytes", "4096");
+
+    alter_configs({make_alter_topic_config_resource(test_tp, new_properties)});
+
+    auto new_describe_resp = describe_configs(test_tp);
+    // retention.ms should be set back to default
+    assert_property_value(
+      test_tp,
+      "retention.ms",
+      fmt::format(
+        "{}", config::shard_local_cfg().delete_retention_ms.value().count()),
+      new_describe_resp);
+    assert_property_value(
+      test_tp, "retention.bytes", "4096", new_describe_resp);
+}

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1003,6 +1003,35 @@ model::offset disk_log_impl::read_start_offset() const {
     return model::offset{};
 }
 
+ss::future<>
+disk_log_impl::update_configuration(ntp_config::default_overrides o) {
+    auto was_compacted = config().is_compacted();
+    mutable_config().set_overrides(o);
+    /**
+     * For most of the settings we always query ntp config, only cleanup_policy
+     * and segment size need special treatment.
+     */
+    if (config().has_overrides()) {
+        if (config().get_overrides().segment_size) {
+            _max_segment_size = *config().get_overrides().segment_size;
+        }
+        // enable compaction
+        if (!was_compacted && config().is_compacted()) {
+            for (auto& s : _segs) {
+                s->mark_as_compacted_segment();
+            }
+        }
+        // disable compaction
+        if (was_compacted && !config().is_compacted()) {
+            for (auto& s : _segs) {
+                s->unmark_as_compacted_segment();
+            }
+        }
+    }
+
+    return ss::now();
+}
+
 std::ostream& disk_log_impl::print(std::ostream& o) const {
     return o << "{offsets:" << offsets()
              << ", max_collectible_offset: " << _max_collectible_offset

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -124,6 +124,8 @@ private:
 
     bool is_front_segment(const segment_set::type&) const;
 
+    compaction_config apply_overrides(compaction_config) const;
+
 private:
     size_t max_segment_size() const;
     struct eviction_monitor {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -77,6 +77,7 @@ public:
     size_t bytes_left_before_roll() const;
 
     size_t size_bytes() const override { return _probe.partition_size(); }
+    ss::future<> update_configuration(ntp_config::default_overrides) final;
 
 private:
     friend class disk_log_appender; // for multi-term appends

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -81,11 +81,14 @@ public:
         }
 
         virtual size_t size_bytes() const = 0;
+        virtual ss::future<>
+          update_configuration(ntp_config::default_overrides) = 0;
 
     private:
         ntp_config _config;
 
     protected:
+        ntp_config& mutable_config() { return _config; }
         ss::lw_shared_ptr<storage::stm_manager> _stm_manager;
     };
 
@@ -169,6 +172,10 @@ public:
     void set_collectible_offset(model::offset o) {
         return _impl->set_collectible_offset(o);
     };
+
+    ss::future<> update_configuration(ntp_config::default_overrides o) {
+        return _impl->update_configuration(o);
+    }
 
     std::ostream& print(std::ostream& o) const { return _impl->print(o); }
 

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -307,6 +307,11 @@ struct mem_log_impl final : log::impl {
         _max_collectible_offset = o;
     }
 
+    ss::future<> update_configuration(ntp_config::default_overrides o) final {
+        mutable_config().set_overrides(o);
+        return ss::now();
+    }
+
     ss::future<model::record_batch_reader>
     make_reader(log_reader_config cfg) final {
         auto it = std::lower_bound(

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -111,6 +111,10 @@ public:
         return with_cache(!has_overrides() || _overrides->cache_enabled);
     }
 
+    void set_overrides(default_overrides o) {
+        _overrides = std::make_unique<default_overrides>(o);
+    }
+
 private:
     model::ntp _ntp;
     /// \brief currently this is the basedir. In the future

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -104,6 +104,7 @@ public:
     bool is_closed() const;
     bool has_compaction_index() const;
     void mark_as_compacted_segment();
+    void unmark_as_compacted_segment();
     bool is_compacted_segment() const;
     void mark_as_finished_self_compaction();
     bool finished_self_compaction() const;
@@ -264,6 +265,9 @@ inline bool segment::has_compaction_index() const {
 }
 inline void segment::mark_as_compacted_segment() {
     _flags |= bitflags::is_compacted_segment;
+}
+inline void segment::unmark_as_compacted_segment() {
+    _flags &= ~bitflags::is_compacted_segment;
 }
 inline bool segment::is_compacted_segment() const {
     return (_flags & bitflags::is_compacted_segment)

--- a/src/v/utils/absl_sstring_hash.h
+++ b/src/v/utils/absl_sstring_hash.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+/**
+ * Transpartent hash & eq functors for ss::sstring
+ */
+#include "seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <absl/hash/hash.h>
+
+#include <string_view>
+#include <type_traits>
+
+struct sstring_hash {
+    using is_transparent = std::true_type;
+
+    size_t operator()(std::string_view v) const {
+        return absl::Hash<std::string_view>{}(v);
+    }
+};
+
+struct sstring_eq {
+    using is_transparent = std::true_type;
+
+    bool operator()(std::string_view lhs, std::string_view rhs) const {
+        return lhs == rhs;
+    }
+};


### PR DESCRIPTION
## Cover letter

Implemented support for changing topics configuration through `ALTER_CONFIG` Kafka API. This PR fixes handling of per topic settings for `retention.time` and `retention.bytes` properties. The `ALTER_CONFIG` ([KIP-133](https://cwiki.apache.org/confluence/display/KAFKA/KIP-133%3A+Describe+and+Alter+Configs+Admin+APIs)) request overrides all properties with request content, for incremental configuration updates we have to implement handling of `INCREMENATL_ALTER_CONFIG` request ([KIP-339](https://cwiki.apache.org/confluence/display/KAFKA/KIP-339%3A+Create+a+new+IncrementalAlterConfigs+API)) we track implementation of this API in #935.

Fixes issues: [#366 , #689 , #671]

## Release notes

This PR will give users ability to change topic configurations. It also fixes per topic setting for partition retention which wasn't correctly handled before.

Release note: 

Added support for changing topic configurations
