### PR TITLE
k/produce: fixed assigning log append timestamp

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -35,6 +35,7 @@
 #include <boost/container_hash/extensions.hpp>
 #include <fmt/ostream.h>
 
+#include <chrono>
 #include <string_view>
 
 namespace kafka {
@@ -330,10 +331,8 @@ static ss::future<produce_response::partition> produce_topic_partition(
       model::topic_namespace_view(model::kafka_namespace, topic.name));
 
     if (timestamp_type == model::timestamp_type::append_time) {
-        auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
-          ss::lowres_clock::now().time_since_epoch());
         batch.set_max_timestamp(
-          model::timestamp_type::append_time, model::timestamp(now.count()));
+          model::timestamp_type::append_time, model::timestamp::now());
     }
 
     const auto& hdr = batch.header();


### PR DESCRIPTION
Using `model::timestamp::now()` as a timestamp source for log append time.

In Kafka record batch timestamp is time since UNIX epoch expressed
in milliseconds. In Redpanda record batch timestamp was incorrectly set
with seastar low resolution clock which doesn't represent system clock.

Fixes: #626

Signed-off-by: Michal Maslanka <michal@vectorized.io>
