### PR TITLE
operator: run tests not in parallel

### DIFF
--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -14,4 +14,4 @@ commands:
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_e2e_artifacts
 timeout: 300
-parallel: 3
+parallel: 1


### PR DESCRIPTION
## Cover letter

This is not a real fix, I am just trying to see if it makes the CI green to unblock others. We need to figure out what's consuming the space anyway.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
