### PR TITLE
task/lint: add formatting for cpp via clang-format

### DIFF
--- a/taskfiles/lint.yml
+++ b/taskfiles/lint.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+tasks:
+  cpp:
+    desc: lint cpp code using clang-format
+    cmds:
+    - |
+      PATH="{{.LLVM_INSTALL_PATH}}/bin":$PATH
+      find . -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)$' | xargs -n1 clang-format -i -style=file -fallback-style=none

--- a/taskfiles/main.yml
+++ b/taskfiles/main.yml
@@ -19,5 +19,6 @@ vars:
 includes:
   dashboard: taskfiles/dashboard.yml
   docker: taskfiles/docker.yml
+  lint: taskfiles/lint.yml
   rp: taskfiles/rp.yml
   rpk: taskfiles/rpk.yml


### PR DESCRIPTION
add task to format cpp code using clang-format