### PR TITLE
release: upload RPK assets for beta tags

### DIFF
--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -16,12 +16,13 @@ jobs:
   update-homebrew:
     name: Update Homebrew
     runs-on: ubuntu-latest
-    steps: 
+    steps:
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
     - name: Update the homebrew tap
+      if: contains(steps.get_version.outputs.VERSION, '-beta') == false
       uses: mislav/bump-homebrew-formula-action@v1.8
       with:
         formula-name: redpanda

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -10,7 +10,7 @@
 name: Go
 on:
   push:
-    tags: 
+    tags:
     - 'v2**'
     branches:
       - '*'
@@ -52,7 +52,7 @@ jobs:
         pkg='vectorized/pkg/cli/cmd/version'
         tag=$(echo ${{ github.ref }} | sed 's;refs/tags/;;g')
 
-        GOOS=${{ matrix.os }} GOARCH=amd64 ./build.sh $tag ${{ github.sha }} 
+        GOOS=${{ matrix.os }} GOARCH=amd64 ./build.sh $tag ${{ github.sha }}
 
     - name: Package
       working-directory: src/go/rpk/
@@ -61,16 +61,16 @@ jobs:
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2
-      if: startsWith(github.ref, 'refs/tags/v')  && !contains(github.ref, '-')
+      if: startsWith(github.ref, 'refs/tags/v')
       with:
         name: rpk-archives
         path: |
           src/go/rpk/rpk-*.zip
-  
+
   sign-darwin:
     name: Sign and notarize the darwin release_name
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')  && !contains(github.ref, '-')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-10.15
     steps:
       - name: Checkout
@@ -106,7 +106,7 @@ jobs:
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         run: |
           gon -log-level=info ../src/go/rpk/gon.json
-      
+
       - name: Upload signed Package
         uses: actions/upload-artifact@v2
         with:
@@ -116,7 +116,7 @@ jobs:
   create-release:
     name: Create release
     needs: [build, sign-darwin]
-    if: startsWith(github.ref, 'refs/tags/v')  && !contains(github.ref, '-')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
     - name: Create rpk release
@@ -135,13 +135,13 @@ jobs:
   publish-release-artifacts:
     name: Publish release
     needs: create-release
-    if: startsWith(github.ref, 'refs/tags/v')  && !contains(github.ref, '-')
+    if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         os: [linux, darwin]
     runs-on: ubuntu-latest
     steps:
-    - name: Download compressed rpk artifacts 
+    - name: Download compressed rpk artifacts
       uses: actions/download-artifact@v2
 
     - name: Upload rpk artifacts to release
@@ -149,7 +149,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} 
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
         asset_path: rpk-archives/rpk-${{ matrix.os }}-amd64.zip
         asset_name: rpk-${{ matrix.os }}-amd64.zip
         asset_content_type: application/zip


### PR DESCRIPTION
Uploads RPK release assets for any git tag; skips updating homebrew formula.

fixes #885