### PR TITLE
ci: prevent duplicate runs of k8s build

### DIFF
--- a/.github/workflows/k8s-build-and-test.yml
+++ b/.github/workflows/k8s-build-and-test.yml
@@ -8,8 +8,13 @@
 # by the Apache License, Version 2.0
 
 name: K8S build and test
-on: [push, pull_request]
-
+on: 
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Cover letter

Currently we have two runs triggered on every PR.

Reference: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
