### PR TITLE
rpk: Deprecate --prometheus-url from generate grafana command in favor of --metrics-endpoint

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/generate/grafana_test.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/grafana_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/generate"
 )
 
-func TestGrafanaHostNoServer(t *testing.T) {
+func TestPrometheusURLFlagDeprecation(t *testing.T) {
 	var out bytes.Buffer
 	logrus.SetOutput(&out)
 	cmd := generate.NewGrafanaDashboardCmd()
@@ -28,6 +28,18 @@ func TestGrafanaHostNoServer(t *testing.T) {
 		"--prometheus-url", "localhost:8888/metrics",
 		"--datasource", "prometheus",
 	})
+	require.Contains(t, cmd.Flag("prometheus-url").Deprecated, "Use --metrics-endpoint instead")
+}
+
+func TestGrafanaHostNoServer(t *testing.T) {
+	var out bytes.Buffer
+	logrus.SetOutput(&out)
+	cmd := generate.NewGrafanaDashboardCmd()
+	cmd.SetArgs([]string{
+		"--metrics-endpoint", "localhost:8888/metrics",
+		"--datasource", "prometheus",
+	})
+
 	err := cmd.Execute()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Get http://localhost:8888/metrics: dial tcp")
@@ -66,7 +78,7 @@ vectorized_memory_allocated_memory_bytes{shard="1",type="bytes"} 36986880
 	cmd := generate.NewGrafanaDashboardCmd()
 	cmd.SetOutput(&out)
 	cmd.SetArgs([]string{
-		"--prometheus-url", ts.URL,
+		"--metrics-endpoint", ts.URL,
 		"--datasource", "prometheus",
 	})
 	err := cmd.Execute()
@@ -90,7 +102,7 @@ vectorized_vectorized_in
 	cmd := generate.NewGrafanaDashboardCmd()
 	cmd.SetOutput(&out)
 	cmd.SetArgs([]string{
-		"--prometheus-url", ts.URL,
+		"--metrics-endpoint", ts.URL,
 		"--datasource", "prometheus",
 	})
 	err := cmd.Execute()


### PR DESCRIPTION
## Cover letter

The  `--prometheus-url` flag from the `generate grafana-dashboard` command is a bit confusing. 

Its purpose is to ask for the Redpanda metrics endpoint (i.e. `redpanda_host:<admin_port>/metrics`), but as the flag says `prometheus` one might think that it should point to some prometheus endpoint.

This PR deprecates the `--prometheus-url` flag in favor of `--metrics-endpoint`.

Fixes issues: [#913]

