### PR TITLE
operator/ci: run go tests in verbose mode

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -32,7 +32,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate fmt vet manifests
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.0/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test --race ./... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test --race -v ./... -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet


### PR DESCRIPTION
## Cover letter

Of course this is just matter of taste, but I prefer the verbose output where all tests are listed that were run. Instead of this

```
?   	github.com/vectorizedio/redpanda/src/go/k8s	[no test files]
ok  	github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1	12.450s	coverage: 49.7% of statements
?   	github.com/vectorizedio/redpanda/src/go/k8s/cmd/configurator	[no test files]
ok  	github.com/vectorizedio/redpanda/src/go/k8s/controllers/redpanda	11.922s	coverage: 73.8% of statements
ok  	github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels	2.102s	coverage: 76.2% of statements
ok  	github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources	2.314s	coverage: 22.7% of statements
?   	github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources/certmanager	[no test files]
```

you get this (truncated)

```
=== RUN   TestValidateUpdate
--- PASS: TestValidateUpdate (0.00s)
=== RUN   TestValidateUpdate_NoError
=== RUN   TestValidateUpdate_NoError/same_object_updated
=== RUN   TestValidateUpdate_NoError/scale_up
=== RUN   TestValidateUpdate_NoError/change_image_and_tag
=== RUN   TestValidateUpdate_NoError/collision_in_the_port
=== RUN   TestValidateUpdate_NoError/collision_in_the_port_when_external_connectivity_is_enabled
=== RUN   TestValidateUpdate_NoError/collision_in_the_port_when_external_connectivity_is_enabled#01
=== RUN   TestValidateUpdate_NoError/requireclientauth_true_and_tls_enabled
--- PASS: TestValidateUpdate_NoError (0.00s)
    --- PASS: TestValidateUpdate_NoError/same_object_updated (0.00s)
    --- PASS: TestValidateUpdate_NoError/scale_up (0.00s)
    --- PASS: TestValidateUpdate_NoError/change_image_and_tag (0.00s)
    --- PASS: TestValidateUpdate_NoError/collision_in_the_port (0.00s)
    --- PASS: TestValidateUpdate_NoError/collision_in_the_port_when_external_connectivity_is_enabled (0.00s)
    --- PASS: TestValidateUpdate_NoError/collision_in_the_port_when_external_connectivity_is_enabled#01 (0.00s)
    --- PASS: TestValidateUpdate_NoError/requireclientauth_true_and_tls_enabled (0.00s)
=== RUN   TestCreation
=== RUN   TestCreation/no_collision_in_the_port
=== RUN   TestCreation/collision_in_the_port
=== RUN   TestCreation/collision_in_the_port_when_external_connectivity_is_enabled
=== RUN   TestCreation/collision_in_the_port_when_external_connectivity_is_enabled#01
=== RUN   TestCreation/incorrect_memory
=== RUN   TestCreation/tls_properly_configured
=== RUN   TestCreation/require_client_auth_without_tls_enabled
--- PASS: TestCreation (0.00s)
    --- PASS: TestCreation/no_collision_in_the_port (0.00s)
    --- PASS: TestCreation/collision_in_the_port (0.00s)
    --- PASS: TestCreation/collision_in_the_port_when_external_connectivity_is_enabled (0.00s)
    --- PASS: TestCreation/collision_in_the_port_when_external_connectivity_is_enabled#01 (0.00s)
    --- PASS: TestCreation/incorrect_memory (0.00s)
    --- PASS: TestCreation/tls_properly_configured (0.00s)
    --- PASS: TestCreation/require_client_auth_without_tls_enabled (0.00s)
...
...
```

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
