### PR TITLE
Fix partition movement test

### DIFF
--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -65,7 +65,8 @@ private:
       raft::group_id,
       model::revision_id,
       std::vector<model::broker>);
-    ss::future<> add_to_shard_table(model::ntp, raft::group_id, ss::shard_id);
+    ss::future<> add_to_shard_table(
+      model::ntp, raft::group_id, ss::shard_id, model::revision_id);
     ss::future<std::error_code>
       delete_partition(model::ntp, model::revision_id);
     ss::future<std::error_code> update_partition_replica_set(

--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -41,8 +41,11 @@ static ss::future<consensus_ptr> create_raft0(
           // Add raft 0 to shard table
           return st
             .invoke_on_all([gr = p->group()](shard_table& local_st) {
-                local_st.insert(model::controller_ntp, controller_stm_shard);
-                local_st.insert(gr, controller_stm_shard);
+                local_st.update(
+                  model::controller_ntp,
+                  gr,
+                  controller_stm_shard,
+                  model::revision_id(0));
             })
             .then([p] { return p; });
       });

--- a/src/v/cluster/shard_table.h
+++ b/src/v/cluster/shard_table.h
@@ -17,18 +17,23 @@
 
 #include <seastar/core/reactor.hh> // shard_id
 
-#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 namespace cluster {
 /// \brief this is populated by consensus::controller
 /// every core will have a _full_ copy of all indexes
 class shard_table final {
+    struct shard_revision {
+        ss::shard_id shard;
+        model::revision_id revision;
+    };
+
 public:
     bool contains(const raft::group_id& group) {
         return _group_idx.find(group) != _group_idx.end();
     }
     ss::shard_id shard_for(const raft::group_id& group) {
-        return _group_idx.find(group)->second;
+        return _group_idx.find(group)->second.shard;
     }
 
     /**
@@ -36,24 +41,78 @@ public:
      */
     std::optional<ss::shard_id> shard_for(const model::ntp& ntp) {
         if (auto it = _ntp_idx.find(ntp); it != _ntp_idx.end()) {
-            return it->second;
+            return it->second.shard;
         }
         return std::nullopt;
     }
-    void insert(model::ntp ntp, ss::shard_id i) {
-        _ntp_idx.insert({std::move(ntp), i});
-    }
-    void insert(raft::group_id g, ss::shard_id i) { _group_idx.insert({g, i}); }
 
-    void erase(const model::ntp& ntp, raft::group_id g) {
+    bool insert(model::ntp ntp, ss::shard_id i, model::revision_id rev) {
+        auto [_, success] = _ntp_idx.insert(
+          {std::move(ntp), shard_revision{i, rev}});
+        return success;
+    }
+
+    bool insert(raft::group_id g, ss::shard_id i, model::revision_id rev) {
+        auto [_, success] = _group_idx.insert({g, shard_revision{i, rev}});
+        return success;
+    }
+
+    void update(
+      const model::ntp& ntp,
+      raft::group_id g,
+      ss::shard_id shard,
+      model::revision_id rev) {
+        if (auto it = _ntp_idx.find(ntp); it != _ntp_idx.end()) {
+            if (it->second.revision > rev) {
+                return;
+            }
+        }
+        if (auto it = _group_idx.find(g); it != _group_idx.end()) {
+            if (it->second.revision > rev) {
+                return;
+            }
+        }
+
+        _ntp_idx.insert_or_assign(ntp, shard_revision{shard, rev});
+        _group_idx.insert_or_assign(g, shard_revision{shard, rev});
+    }
+
+    void
+    erase(const model::ntp& ntp, raft::group_id g, model::revision_id rev) {
+        if (auto it = _ntp_idx.find(ntp); it != _ntp_idx.end()) {
+            if (it->second.revision > rev) {
+                return;
+            }
+        }
+        if (auto it = _group_idx.find(g); it != _group_idx.end()) {
+            if (it->second.revision > rev) {
+                return;
+            }
+        }
+
         _ntp_idx.erase(ntp);
         _group_idx.erase(g);
     }
 
 private:
+    /**
+     * Controller backend executes per NTP reconciliation loop on every core of
+     * every node in the cluster. Depending on requested replica set update and
+     * current state it performs operations, without coordination with other
+     * cores. Reconciliation is initiated by controller state machine
+     * propagating requested deltas to all controller backend instances. Only
+     * point where all controller backend instances on single node have to
+     * synchronize is cluster::shard_table. Shard table contains mapping from
+     * model::ntp and group id to shard where instances of consensus and log are
+     * instantiated. In order to synchronize updates coming from different
+     * shards we use MVCC i.e. stale updates are ignored. This way even if one
+     * of the cores is behind with its reconciliation loop we can guarantee that
+     * cluster::shard_table state isn't corrupted.
+     */
+
     // kafka index
-    absl::flat_hash_map<model::ntp, ss::shard_id> _ntp_idx;
+    absl::node_hash_map<model::ntp, shard_revision> _ntp_idx;
     // raft index
-    absl::flat_hash_map<raft::group_id, ss::shard_id> _group_idx;
+    absl::node_hash_map<raft::group_id, shard_revision> _group_idx;
 };
 } // namespace cluster

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -139,10 +139,16 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
         return ss::make_ready_future<std::error_code>(
           errc::partition_not_exists);
     }
+    partition_assignment delta_assignment{
+      .group = current_assignment_it->group,
+      .id = current_assignment_it->id,
+      .replicas = std::move(cmd.value),
+    };
+
     // notify backend about finished update
     _pending_deltas.emplace_back(
       std::move(cmd.key),
-      *current_assignment_it,
+      std::move(delta_assignment),
       o,
       delta::op_type::update_finished);
 


### PR DESCRIPTION
## Cover letter

This PR contains fixes for problems we were seeing in Partition movement tests. 

Fixed incorrectly set partition assignment when propagating `update_finished` delta to controller backend.

Introduced `shard_table` concurrency control mechanism based on revision. 


Fixes issues: [#NNN, #NNN, ...]

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
