### PR TITLE
operator/ci: do not enable kind cache by default

### DIFF
--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -8,6 +8,7 @@ kindContainers:
 testDirs:
   - ./tests/e2e-helm
 kindConfig: ./kind.yaml
+kindNodeCache: false
 commands:
   - command: "./hack/install-cert-manager.sh"
   - command: "kubectl apply -k ./config/crd"

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -8,10 +8,11 @@ kindContainers:
 testDirs:
   - ./tests/e2e
 kindConfig: ./kind.yaml
+kindNodeCache: false
 commands:
   - command: "./hack/install-cert-manager.sh"
   - command: "make deploy"
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_e2e_artifacts
 timeout: 300
-parallel: 1
+parallel: 3


### PR DESCRIPTION
## Cover letter

With cache enabled, each node has one more volume created. Also this
cache is not really needed for the CI because kind is always started in
clean environment.

Fixes issues: #924 

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
