### PR TITLE
kafka: add support for describe log directories api

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -135,6 +135,8 @@ public:
         return _id_allocator_stm;
     }
 
+    size_t size_bytes() const { return _raft->log().size_bytes(); }
+
 private:
     friend partition_manager;
 

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -30,6 +30,7 @@ set(handlers_srcs
   server/handlers/incremental_alter_configs.cc
   server/handlers/delete_groups.cc
   server/handlers/describe_acls.cc
+  server/handlers/describe_log_dirs.cc
   server/handlers/topics/types.cc
   server/handlers/topics/topic_utils.cc
 )

--- a/src/v/kafka/protocol/describe_log_dirs.h
+++ b/src/v/kafka/protocol/describe_log_dirs.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "bytes/iobuf.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/describe_log_dirs_request.h"
+#include "kafka/protocol/schemata/describe_log_dirs_response.h"
+#include "kafka/server/request_context.h"
+#include "kafka/server/response.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/future.hh>
+
+namespace kafka {
+
+struct describe_log_dirs_response;
+
+class describe_log_dirs_api final {
+public:
+    using response_type = describe_log_dirs_response;
+
+    static constexpr const char* name = "describe_log_dirs";
+    static constexpr api_key key = api_key(35);
+};
+
+struct describe_log_dirs_request final {
+    using api_type = describe_log_dirs_api;
+
+    describe_log_dirs_request_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const describe_log_dirs_request& r) {
+    return os << r.data;
+}
+
+struct describe_log_dirs_response final {
+    using api_type = describe_log_dirs_api;
+
+    describe_log_dirs_response_data data;
+
+    void encode(const request_context& ctx, response& resp) {
+        data.encode(resp.writer(), ctx.header().version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const describe_log_dirs_response& r) {
+    return os << r.data;
+}
+
+} // namespace kafka

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -42,7 +42,9 @@ set(schemata
   delete_groups_request.json
   delete_groups_response.json
   describe_acls_request.json
-  describe_acls_response.json)
+  describe_acls_response.json
+  describe_log_dirs_request.json
+  describe_log_dirs_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/protocol/schemata/describe_log_dirs_request.json
+++ b/src/v/kafka/protocol/schemata/describe_log_dirs_request.json
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 35,
+  "type": "request",
+  "name": "DescribeLogDirsRequest",
+  // Version 1 is the same as version 0.
+  "validVersions": "0-1",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "Topics", "type": "[]DescribableLogDirTopic", "versions": "0+", "nullableVersions": "0+",
+      "about": "Each topic that we want to describe log directories for, or null for all topics.", "fields": [
+      { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name" },
+      { "name": "PartitionIndex", "type": "[]int32", "versions": "0+",
+        "about": "The partition indxes." }
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/describe_log_dirs_response.json
+++ b/src/v/kafka/protocol/schemata/describe_log_dirs_response.json
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 35,
+  "type": "response",
+  "name": "DescribeLogDirsResponse",
+  // Starting in version 1, on quota violation, brokers send out responses before throttling.
+  "validVersions": "0-1",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "Results", "type": "[]DescribeLogDirsResult", "versions": "0+",
+      "about": "The log directories.", "fields": [
+      { "name": "ErrorCode", "type": "int16", "versions": "0+",
+        "about": "The error code, or 0 if there was no error." },
+      { "name": "LogDir", "type": "string", "versions": "0+",
+        "about": "The absolute log directory path." },
+      { "name": "Topics", "type": "[]DescribeLogDirsTopic", "versions": "0+",
+        "about": "Each topic.", "fields": [
+        { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+          "about": "The topic name." },
+        { "name": "Partitions", "type": "[]DescribeLogDirsPartition", "versions": "0+", "fields": [
+          { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+            "about": "The partition index." },
+          { "name": "PartitionSize", "type": "int64", "versions": "0+",
+            "about": "The size of the log segments in this partition in bytes." },
+          { "name": "OffsetLag", "type": "int64", "versions": "0+",
+            "about": "The lag of the log's LEO w.r.t. partition's HW (if it is the current log for the partition) or current replica's LEO (if it is the future log for the partition)" },
+          { "name": "IsFutureKey", "type": "bool", "versions": "0+",
+            "about": "True if this log is created by AlterReplicaLogDirsRequest and will replace the current log of the replica in the future." }
+        ]}
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -265,6 +265,10 @@ STRUCT_TYPES = [
     "DeletableGroupResult",
     "DescribeAclsResource",
     "AclDescription",
+    "DescribeLogDirsTopic",
+    "DescribableLogDirTopic",
+    "DescribeLogDirsResult",
+    "DescribeLogDirsPartition",
 ]
 
 SCALAR_TYPES = list(basic_type_map.keys())

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -51,7 +51,8 @@ using request_types = make_request_types<
   incremental_alter_configs_handler,
   init_producer_id_handler,
   delete_groups_handler,
-  describe_acls_handler>;
+  describe_acls_handler,
+  describe_log_dirs_handler>;
 
 template<typename RequestType>
 static auto make_api() {

--- a/src/v/kafka/server/handlers/describe_log_dirs.cc
+++ b/src/v/kafka/server/handlers/describe_log_dirs.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/handlers/describe_log_dirs.h"
+
+#include "cluster/partition_manager.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/server/request_context.h"
+#include "kafka/server/response.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/util/log.hh>
+
+#include <fmt/ostream.h>
+
+namespace kafka {
+
+using partition_dir_set
+  = absl::flat_hash_map<model::topic, std::vector<describe_log_dirs_partition>>;
+
+static describe_log_dirs_partition describe_partition(cluster::partition& p) {
+    // offset_lag is calculated in kafka as std::max(highwatermark -
+    // log_end_offset, 0) which to me looks like it should always be 0 given
+    // that afaict highwatermark has an upper bound of the end of the log.
+    return describe_log_dirs_partition{
+      .partition_index = p.ntp().tp.partition(),
+      .partition_size = static_cast<int64_t>(p.size_bytes()),
+      .offset_lag = 0,
+      .is_future_key = false,
+    };
+}
+
+static partition_dir_set collect_mapper(
+  cluster::partition_manager& pm,
+  const std::optional<std::vector<describable_log_dir_topic>>& topics) {
+    partition_dir_set ret;
+
+    /*
+     * return all partitions
+     */
+    if (!topics) {
+        for (const auto& partition : pm.partitions()) {
+            if (partition.first.ns != model::kafka_namespace) {
+                continue;
+            }
+            ret[partition.first.tp.topic].push_back(
+              describe_partition(*partition.second));
+        }
+        return ret;
+    }
+
+    /*
+     * return only partition matching request
+     */
+    for (const auto& topic : *topics) {
+        for (auto p_id : topic.partition_index) {
+            model::ntp ntp(model::kafka_namespace, topic.topic, p_id);
+            if (auto p = pm.get(ntp); p) {
+                ret[topic.topic].push_back(describe_partition(*p));
+            }
+        }
+    }
+    return ret;
+}
+
+/*
+ * collect log directory information for partitions
+ */
+static ss::future<partition_dir_set> collect(
+  request_context& ctx,
+  std::optional<std::vector<describable_log_dir_topic>> filter) {
+    return ctx.partition_manager().map_reduce0(
+      [filter = std::move(filter)](cluster::partition_manager& pm) {
+          return collect_mapper(pm, filter);
+      },
+      partition_dir_set{},
+      [](partition_dir_set acc, const partition_dir_set& update) {
+          for (auto& topic : update) {
+              for (auto partition : topic.second) {
+                  acc[topic.first].push_back(partition);
+              }
+          }
+          return acc;
+      });
+}
+
+template<>
+ss::future<response_ptr> describe_log_dirs_handler::handle(
+  request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+    describe_log_dirs_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    klog.trace("Handling request {}", request);
+
+    auto partitions = co_await collect(ctx, std::move(request.data.topics));
+
+    describe_log_dirs_response response;
+
+    // redpanda only supports a single data directory right now
+    response.data.results.push_back(describe_log_dirs_result{
+      .error_code = error_code::none,
+      .log_dir = config::shard_local_cfg().data_directory().as_sstring(),
+    });
+
+    while (!partitions.empty()) {
+        auto node = partitions.extract(partitions.begin());
+        response.data.results.back().topics.push_back(describe_log_dirs_topic{
+          .name = std::move(node.key()),
+          .partitions = std::move(node.mapped()),
+        });
+    }
+
+    co_return co_await ctx.respond(std::move(response));
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/describe_log_dirs.h
+++ b/src/v/kafka/server/handlers/describe_log_dirs.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/describe_log_dirs.h"
+#include "kafka/server/handlers/handler.h"
+
+namespace kafka {
+
+using describe_log_dirs_handler = handler<describe_log_dirs_api, 0, 1>;
+
+}

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -18,6 +18,7 @@
 #include "kafka/server/handlers/describe_acls.h"
 #include "kafka/server/handlers/describe_configs.h"
 #include "kafka/server/handlers/describe_groups.h"
+#include "kafka/server/handlers/describe_log_dirs.h"
 #include "kafka/server/handlers/fetch.h"
 #include "kafka/server/handlers/find_coordinator.h"
 #include "kafka/server/handlers/heartbeat.h"

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -239,6 +239,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<delete_groups_handler>(std::move(ctx), g);
     case describe_acls_handler::api::key:
         return do_process<describe_acls_handler>(std::move(ctx), g);
+    case describe_log_dirs_handler::api::key:
+        return do_process<describe_log_dirs_handler>(std::move(ctx), g);
     };
     return ss::make_exception_future<response_ptr>(
       std::runtime_error(fmt::format("Unsupported API {}", ctx.header().key)));

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -76,6 +76,8 @@ public:
     const segment_set& segments() const { return _segs; }
     size_t bytes_left_before_roll() const;
 
+    size_t size_bytes() const override { return _probe.partition_size(); }
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -80,6 +80,8 @@ public:
             return _stm_manager;
         }
 
+        virtual size_t size_bytes() const = 0;
+
     private:
         ntp_config _config;
 
@@ -169,6 +171,8 @@ public:
     };
 
     std::ostream& print(std::ostream& o) const { return _impl->print(o); }
+
+    size_t size_bytes() const { return _impl->size_bytes(); }
 
     impl* get_impl() const { return _impl.get(); }
 

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -365,6 +365,17 @@ struct mem_log_impl final : log::impl {
           .dirty_offset_term = e.term(),
           .last_term_start_offset = last_term_base_offset};
     }
+
+    size_t size_bytes() const override {
+        return std::accumulate(
+          _data.cbegin(),
+          _data.cend(),
+          size_t(0),
+          [](size_t acc, const model::record_batch& b) {
+              return acc + b.size_bytes();
+          });
+    }
+
     struct eviction_monitor {
         ss::promise<model::offset> promise;
         ss::abort_source::subscription subscription;


### PR DESCRIPTION
Supports Kafka's DescribeLogDirs api.

Fixes: https://github.com/vectorizedio/redpanda/issues/903

--

force push 1: https://github.com/vectorizedio/redpanda/compare/c293ea26285a6226e486da2160a018b87ae683ce..243a2c563e2d8e6f3ed9761a1efc55dd26b117a2