### PR TITLE
operator/scheduling: expose nodeSelector and tolerations in Cluster CR

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -36,6 +36,11 @@ type ClusterSpec struct {
 	Resources corev1.ResourceRequirements `json:"resources"`
 	// Configuration represent redpanda specific configuration
 	Configuration RedpandaConfig `json:"configuration,omitempty"`
+	// If specified, Redpanda Pod tolerations
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	// If specified, Redpanda Pod node selectors. For reference please visit
+	// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// ExternalConnectivity enables user to expose Redpanda
 	// nodes outside of a Kubernetes cluster. For more

--- a/src/go/k8s/apis/redpanda/v1alpha1/zz_generated.deepcopy.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/zz_generated.deepcopy.go
@@ -14,7 +14,8 @@
 package v1alpha1
 
 import (
-	"github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	metav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -87,6 +88,20 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	in.Configuration.DeepCopyInto(&out.Configuration)
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.ExternalConnectivity = in.ExternalConnectivity
 	in.Storage.DeepCopyInto(&out.Storage)
 }
@@ -212,7 +227,7 @@ func (in *TLSConfig) DeepCopyInto(out *TLSConfig) {
 	*out = *in
 	if in.IssuerRef != nil {
 		in, out := &in.IssuerRef, &out.IssuerRef
-		*out = new(v1.ObjectReference)
+		*out = new(metav1.ObjectReference)
 		**out = **in
 	}
 }

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -129,6 +129,12 @@ spec:
               image:
                 description: Image is the fully qualified name of the Redpanda container
                 type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: If specified, Redpanda Pod node selectors. For reference
+                  please visit https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node
+                type: object
               replicas:
                 description: Replicas determine how big the cluster will be.
                 format: int32
@@ -176,6 +182,46 @@ spec:
                     description: Storage class name - https://kubernetes.io/docs/concepts/storage/storage-classes/
                     type: string
                 type: object
+              tolerations:
+                description: If specified, Redpanda Pod tolerations
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               version:
                 description: Version is the Redpanda container tag
                 type: string

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -202,6 +202,8 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 	var clusterLabels = labels.ForCluster(r.pandaCluster)
 
 	pvc := preparePVCResource(datadirName, r.pandaCluster.Namespace, r.pandaCluster.Spec.Storage, clusterLabels)
+	tolerations := r.pandaCluster.Spec.Tolerations
+	nodeSelector := r.pandaCluster.Spec.NodeSelector
 
 	ss := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -393,6 +395,8 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 							}, r.secretVolumeMounts()...),
 						},
 					},
+					Tolerations:  tolerations,
+					NodeSelector: nodeSelector,
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/src/go/k8s/tests/e2e/node-select-tolerations/00-taint-node.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/00-taint-node.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- command: kubectl taint nodes kind-worker2 redpanda-node=true:NoSchedule

--- a/src/go/k8s/tests/e2e/node-select-tolerations/01-label-node.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/01-label-node.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- command: kubectl label nodes kind-worker2 redpanda-node=true

--- a/src/go/k8s/tests/e2e/node-select-tolerations/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/02-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: node-select-tolerations-cluster
+status:
+  readyReplicas: 1
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: node-select-tolerations-cluster-0
+spec:
+  containers:
+    - name: redpanda
+      image: "vectorized/redpanda:latest"
+  nodeName: kind-worker2
+  nodeSelector:
+    redpanda-node: "true"
+status:
+  phase: "Running"

--- a/src/go/k8s/tests/e2e/node-select-tolerations/02-cluster-with-tolerations.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/02-cluster-with-tolerations.yaml
@@ -1,0 +1,30 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: node-select-tolerations-cluster
+spec:
+  image: "vectorized/redpanda"
+  version: "latest"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+      port: 9092
+    admin:
+      port: 9644
+    developerMode: true
+  nodeSelector:
+    redpanda-node: "true"
+  tolerations:
+  - key: "redpanda-node"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"

--- a/src/go/k8s/tests/e2e/node-select-tolerations/03-remove-taint.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/03-remove-taint.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- command: kubectl taint nodes kind-worker2 redpanda-node=true:NoSchedule-

--- a/src/go/k8s/tests/e2e/node-select-tolerations/04-remove-label.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/04-remove-label.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- command: kubectl label nodes kind-worker2 redpanda-node-


### PR DESCRIPTION
## Cover letter

Exposes nodeSelector and tolerations. Allows for example to schedule Redpanda pods to particular nodes, while preventing other pods from being schedule on those nodes.

Example with node, `kind-worker2`

```
kubectl taint nodes kind-worker2 redpanda-node=true:NoSchedule
kubectl label nodes kind-worker2 redpanda-node=true
```

In the CR:
```
  nodeSelector:
    redpanda-node: "true"
  tolerations:
  - key: "redpanda-node"
    operator: "Equal"
    value: "true"
    effect: "NoSchedule"
```

## Release notes

Exposes nodeSelector and tolerations to Cluster CR such that 1) Redpanda pods can have a node preference; 2) tolerate node taints. Together, these allow for Redpanda nodes to have near-exclusive use of matching nodes (if those nodes are tainted appropriately).