### PR TITLE
kafka: calculate partition recovery lag for describe log dirs api

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -99,6 +99,10 @@ public:
         return raft::details::next_offset(_raft->last_visible_index());
     }
 
+    model::offset dirty_offset() const {
+        return _raft->log().offsets().dirty_offset;
+    }
+
     const model::ntp& ntp() const { return _raft->ntp(); }
 
     ss::future<std::optional<storage::timequery_result>>

--- a/src/v/kafka/server/handlers/describe_log_dirs.cc
+++ b/src/v/kafka/server/handlers/describe_log_dirs.cc
@@ -29,13 +29,11 @@ using partition_dir_set
   = absl::flat_hash_map<model::topic, std::vector<describe_log_dirs_partition>>;
 
 static describe_log_dirs_partition describe_partition(cluster::partition& p) {
-    // offset_lag is calculated in kafka as std::max(highwatermark -
-    // log_end_offset, 0) which to me looks like it should always be 0 given
-    // that afaict highwatermark has an upper bound of the end of the log.
     return describe_log_dirs_partition{
       .partition_index = p.ntp().tp.partition(),
       .partition_size = static_cast<int64_t>(p.size_bytes()),
-      .offset_lag = 0,
+      .offset_lag = std::max(
+        p.high_watermark()() - p.dirty_offset()(), int64_t(0)),
       .is_future_key = false,
     };
 }


### PR DESCRIPTION
The describe log dirs api incorrectly used a value of 0 for its offset lag value. This fixes that by calculating max(0, HWM - LEO) which effectively represents how far behind a partition is in recovering.

Thank you to @rystsov for explaining this to me.