### PR TITLE
rpk/archival: add archival configuration

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -790,6 +790,71 @@ rpk:
 `,
 		},
 		{
+			name: "shall write config with archival configuration",
+			conf: func() *Config {
+				c := getValidConfig()
+				c.Redpanda.ArchivalStorage = ArchivalStorage{
+					Enabled:                  true,
+					S3AccessKey:              "access",
+					S3SecretKey:              "secret",
+					S3Region:                 "region",
+					S3Bucket:                 "bucket",
+					ReconciliationIntervalMs: 3,
+					MaxConnections:           4,
+				}
+				return c
+			},
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  archival_storage:
+    enabled: true
+    max_connections: 4
+    reconciliation_interval_ms: 3
+    s3_access_key: access
+    s3_bucket: bucket
+    s3_region: region
+    s3_secret_key: secret
+  data_directory: /var/lib/redpanda/data
+  developer_mode: false
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers:
+  - host:
+      address: 127.0.0.1
+      port: 33145
+  - host:
+      address: 127.0.0.1
+      port: 33146
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_disk_write_cache: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
+`,
+		},
+		{
 			name: "should update an existing config with single kafka_api & advertised_kafka_api obj to a list",
 			existingConf: `config_file: /etc/redpanda/redpanda.yaml
 redpanda:

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -33,7 +33,18 @@ type RedpandaConfig struct {
 	Id                 int                    `yaml:"node_id" mapstructure:"node_id" json:"id"`
 	SeedServers        []SeedServer           `yaml:"seed_servers" mapstructure:"seed_servers" json:"seedServers"`
 	DeveloperMode      bool                   `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
+	ArchivalStorage    ArchivalStorage        `yaml:"archival_storage,omitempty" mapstructure:"archival_storage,omitempty" json:"archivalStorage"`
 	Other              map[string]interface{} `yaml:",inline" mapstructure:",remain"`
+}
+
+type ArchivalStorage struct {
+	Enabled                  bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
+	S3AccessKey              string `yaml:"s3_access_key" mapstructure:"s3_access_key" json:"s3AccessKey"`
+	S3SecretKey              string `yaml:"s3_secret_key" mapstructure:"s3_secret_key" json:"s3SecretKey"`
+	S3Region                 string `yaml:"s3_region" mapstructure:"s3_region" json:"s3Region"`
+	S3Bucket                 string `yaml:"s3_bucket" mapstructure:"s3_bucket" json:"s3Bucket"`
+	ReconciliationIntervalMs int    `yaml:"reconciliation_interval_ms,omitempty" mapstructure:"reconciliation_interval_ms,omitempty" json:"reconciliationIntervalMs"`
+	MaxConnections           int    `yaml:"max_connections,omitempty" mapstructure:"max_connections,omitempty" json:"maxConnections"`
 }
 
 type SeedServer struct {


### PR DESCRIPTION
## Cover letter

Adds configuration to rpk for Redpanda's archival feature.

Archival configuration:
- https://vectorized.io/docs/data-archiving/#Configuring-data-archiving
- [redpanda configuration source](https://github.com/vectorizedio/redpanda/blob/821e36bbbb7cb7c29c5be4239db69d8fdabdcd67/src/v/config/configuration.cc#L523-L570)

## Release notes

S3 archival fields become available in the rpk configuration.