### PR TITLE
rpk/config: Set the right value for config_file

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1033,7 +1033,7 @@ rpk:
 	}
 }
 
-func TestInitConfig(t *testing.T) {
+func TestReadOrGenerate(t *testing.T) {
 	tests := []struct {
 		name        string
 		setup       func(afero.Fs) error
@@ -1063,6 +1063,10 @@ func TestInitConfig(t *testing.T) {
 			configFile:  Default().ConfigFile,
 			expectError: true,
 		},
+		{
+			name:       "it should set config_file to the right value",
+			configFile: "/some/arbitrary/path/redpanda.yaml",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1079,8 +1083,9 @@ func TestInitConfig(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			_, err = mgr.Read(tt.configFile)
+			conf, err := mgr.Read(tt.configFile)
 			require.NoError(t, err)
+			require.Exactly(t, tt.configFile, conf.ConfigFile)
 		})
 	}
 }

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -115,6 +115,7 @@ func (m *manager) ReadOrGenerate(path string) (*Config, error) {
 		"Couldn't find config file at %s. Generating it.",
 		path,
 	)
+	m.v.Set("config_file", path)
 	err = m.v.WriteConfigAs(path)
 	if err != nil {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
Set the right value for `config_file` in the configuration file when it's generated.

Fix #868

Release note: Fix a bug where rpk would set the default value for `config_file` instead of the one actually used (i.e. the path passed through `--config`).
