### PR TITLE
WIP: operator: update resources after cluster CR update

### DIFF
--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v0.3.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/jetstack/cert-manager v1.2.0
+	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -71,10 +71,6 @@ func (r *NodePortServiceResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error while fetching Service resource: %w", err)
 	}
-	updatedService := obj.(*corev1.Service)
-	// this needs to be set to the existing otherwise the update will try to
-	// remove this field which is immutable
-	updatedService.Spec.ClusterIP = svc.Spec.ClusterIP
 	return Update(ctx, &svc, obj, r.Client, r.logger)
 }
 

--- a/src/go/k8s/pkg/resources/patch/ignore_clusterip.go
+++ b/src/go/k8s/pkg/resources/patch/ignore_clusterip.go
@@ -1,0 +1,45 @@
+package patch
+
+import (
+	"fmt"
+
+	"github.com/banzaicloud/k8s-objectmatcher/patch"
+	json "github.com/json-iterator/go"
+)
+
+// IgnoreClusterIPFields ...
+func IgnoreClusterIPFields() patch.CalculateOption {
+	return func(current, modified []byte) ([]byte, []byte, error) {
+		current, err := deleteClusterIP(current)
+		if err != nil {
+			return []byte{}, []byte{}, fmt.Errorf("could not delete clusterip field from current byte sequence: %w", err)
+		}
+
+		modified, err = deleteClusterIP(modified)
+		if err != nil {
+			return []byte{}, []byte{}, fmt.Errorf("could not delete clusterip field from modified byte sequence. %w", err)
+		}
+
+		return current, modified, nil
+	}
+}
+
+func deleteClusterIP(obj []byte) ([]byte, error) {
+	resource := map[string]interface{}{}
+	err := json.Unmarshal(obj, &resource)
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not unmarshal byte sequence: %w", err)
+	}
+
+	if spec, ok := resource["spec"]; ok {
+		if spec, ok := spec.(map[string]interface{}); ok {
+			spec["clusterIp"] = ""
+		}
+	}
+	obj, err = json.ConfigCompatibleWithStandardLibrary.Marshal(resource)
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not marshal byte sequence: %w", err)
+	}
+
+	return obj, nil
+}

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -85,12 +85,12 @@ func Update(
 	}
 	if !patchResult.IsEmpty() {
 		// need to set current version first otherwise the request would get rejected
-		logger.Info(fmt.Sprintf("StatefulSet changed, updating %s. Diff: %v", modified.GetName(), string(patchResult.Patch)))
+		logger.Info(fmt.Sprintf("Resource changed, updating %s. Diff: %v", modified.GetName(), string(patchResult.Patch)))
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(modified); err != nil {
 			return err
 		}
 		if err := c.Update(ctx, modified); err != nil {
-			return fmt.Errorf("failed to update StatefulSet: %w", err)
+			return fmt.Errorf("failed to update resource: %w", err)
 		}
 	}
 	return nil

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/go-logr/logr"
+	ppatch "github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources/patch"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,6 +79,7 @@ func Update(
 	opts := []patch.CalculateOption{
 		patch.IgnoreStatusFields(),
 		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
+		ppatch.IgnoreClusterIPFields(),
 	}
 	patchResult, err := patch.DefaultPatchMaker.Calculate(current, modified, opts...)
 	if err != nil {

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -5,12 +5,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 	res "github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources"
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/deprecated/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -121,5 +123,53 @@ func TestEnsure_HeadlessService(t *testing.T) {
 	assert.NoError(t, err)
 	if actual.ResourceVersion != originalResourceVersion {
 		t.Fatalf("second ensure: expecting version %s but got %s", originalResourceVersion, actual.GetResourceVersion())
+	}
+}
+
+func TestEnsure_ConfigMap(t *testing.T) {
+	cluster := pandaCluster()
+	cluster = cluster.DeepCopy()
+	cluster.Name = "ensure-integration-cm-cluster"
+
+	cm := res.NewConfigMap(
+		c,
+		cluster,
+		scheme.Scheme,
+		"cluster.local",
+		ctrl.Log.WithName("test"))
+
+	err := cm.Ensure(context.Background())
+	assert.NoError(t, err)
+
+	actual := &corev1.ConfigMap{}
+	err = c.Get(context.Background(), cm.Key(), actual)
+	assert.NoError(t, err)
+	originalResourceVersion := actual.ResourceVersion
+
+	// calling ensure for second time to see the resource does not get updated
+	err = cm.Ensure(context.Background())
+	assert.NoError(t, err)
+
+	err = c.Get(context.Background(), cm.Key(), actual)
+	assert.NoError(t, err)
+	if actual.ResourceVersion != originalResourceVersion {
+		t.Fatalf("second ensure: expecting version %s but got %s", originalResourceVersion, actual.GetResourceVersion())
+	}
+
+	// verify the update patches the config
+	cluster.Spec.Configuration.KafkaAPI.Port = 1111
+	cluster.Spec.Configuration.TLS.KafkaAPIEnabled = true
+
+	err = cm.Ensure(context.Background())
+	assert.NoError(t, err)
+
+	err = c.Get(context.Background(), cm.Key(), actual)
+	assert.NoError(t, err)
+	if actual.ResourceVersion == originalResourceVersion {
+		t.Fatalf("expecting version to get updated after resource update but is %s", originalResourceVersion)
+	}
+	data := actual.Data["redpanda.yaml"]
+	if !strings.Contains(data, "cert_file") || !strings.Contains(data, "port: 1111") {
+		t.Fatalf("expecting configmap updated but got %v", data)
 	}
 }

--- a/src/go/k8s/tests/e2e/update/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/04-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: update-cluster
+spec:
+  clusterIP: None
+  ports:
+    - name: kafka-tcp
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+  type: ClusterIP

--- a/src/go/k8s/tests/e2e/update/04-change-port.yaml
+++ b/src/go/k8s/tests/e2e/update/04-change-port.yaml
@@ -1,0 +1,8 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster
+spec:
+  configuration:
+    kafkaApi:
+        port: 9093


### PR DESCRIPTION
## Cover letter

Currently if you create new redpanda cluster, all resources get set up for you properly but updating properties and configuration of the cluster did not work in many cases because we were not issuing patch request on couple of resources. After this PR is merged, updates in port and configuration should get reflected .

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
Updating of redpanda cluster CR is reflected in underlying resources.