### PR TITLE
Fixes and tests for altering topic properties

### DIFF
--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -24,6 +24,11 @@
             "name": "finish_partition_update",
             "input_type": "finish_partition_update_request",
             "output_type": "finish_partition_update_reply"
+        },
+        {
+            "name": "update_topic_properties",
+            "input_type": "update_topic_properties_request",
+            "output_type": "update_topic_properties_reply"
         }
     ]
 }

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -43,6 +43,9 @@ public:
     ss::future<finish_partition_update_reply> finish_partition_update(
       finish_partition_update_request&&, rpc::streaming_context&) final;
 
+    ss::future<update_topic_properties_reply> update_topic_properties(
+      update_topic_properties_request&&, rpc::streaming_context&) final;
+
 private:
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
@@ -50,6 +53,9 @@ private:
 
     ss::future<finish_partition_update_reply>
     do_finish_partition_update(finish_partition_update_request&&);
+
+    ss::future<update_topic_properties_reply>
+    do_update_topic_properties(update_topic_properties_request&&);
 
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<members_manager>& _members_manager;

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -84,6 +84,10 @@ private:
     ss::future<topic_result> do_update_topic_properties(
       topic_properties_update, model::timeout_clock::time_point);
     ss::future<> update_leaders_with_estimates(std::vector<ntp_leader>);
+
+    ss::future<result<model::offset>>
+      stm_linearizable_barrier(model::timeout_clock::time_point);
+
     // returns true if the topic name is valid
     static bool validate_topic_name(const model::topic_namespace&);
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -322,4 +322,18 @@ adl<cluster::configuration_invariants>::from(iobuf_parser& parser) {
 
     return ret;
 }
+
+void adl<cluster::topic_properties_update>::to(
+  iobuf& out, cluster::topic_properties_update&& r) {
+    reflection::serialize(out, r.tp_ns, r.properties);
+}
+
+cluster::topic_properties_update
+adl<cluster::topic_properties_update>::from(iobuf_parser& parser) {
+    auto tp_ns = adl<model::topic_namespace>{}.from(parser);
+    cluster::topic_properties_update ret(std::move(tp_ns));
+    ret.properties = adl<cluster::incremental_topic_updates>{}.from(parser);
+
+    return ret;
+}
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -208,6 +208,14 @@ struct finish_partition_update_reply {
     cluster::errc result;
 };
 
+struct update_topic_properties_request {
+    std::vector<topic_properties_update> updates;
+};
+
+struct update_topic_properties_reply {
+    std::vector<topic_result> results;
+};
+
 template<typename T>
 struct patch {
     std::vector<T> additions;
@@ -315,6 +323,12 @@ template<>
 struct adl<cluster::configuration_invariants> {
     void to(iobuf&, cluster::configuration_invariants&&);
     cluster::configuration_invariants from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::topic_properties_update> {
+    void to(iobuf&, cluster::topic_properties_update&&);
+    cluster::topic_properties_update from(iobuf_parser&);
 };
 
 } // namespace reflection

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -118,7 +118,7 @@ ss::future<std::vector<R>> do_alter_topics_configuration(
           + config::shard_local_cfg().alter_topic_cfg_timeout_ms());
     for (auto& res : update_results) {
         responses.push_back(R{
-          .error_code = error_code::none,
+          .error_code = map_topic_error_code(res.ec),
           .resource_type = static_cast<int8_t>(config_resource_type::topic),
           .resource_name = res.tp_ns.tp(),
         });

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -13,6 +13,7 @@
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
+#include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
 #include "model/fundamental.h"
@@ -35,11 +36,11 @@ namespace kafka {
 template<typename T>
 static void add_config(
   describe_configs_result& result,
-  const char* name,
+  std::string_view name,
   T value,
   describe_configs_source source) {
     result.configs.push_back(describe_configs_resource_result{
-      .name = name,
+      .name = ss::sstring(name),
       .value = fmt::format("{}", value),
       .config_source = source,
     });
@@ -193,7 +194,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
 
             add_config(
               result,
-              "cleanup.policy",
+              topic_property_cleanup_policy,
               describe_topic_cleanup_policy(
                 topic_config,
                 ctx.metadata_cache().get_default_cleanup_policy_bitflags()),
@@ -201,14 +202,14 @@ ss::future<response_ptr> describe_configs_handler::handle(
 
             add_config(
               result,
-              "compression.type",
+              topic_property_compression,
               topic_config->properties.compression.value_or(
                 ctx.metadata_cache().get_default_compression()),
               describe_configs_source::topic);
 
             add_config(
               result,
-              "segment.bytes",
+              topic_property_segment_size,
               topic_config->properties.segment_size.value_or(
                 topic_config->properties.is_compacted()
                   ? ctx.metadata_cache()
@@ -218,7 +219,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
 
             add_config(
               result,
-              "retention.ms",
+              topic_property_retention_duration,
               describe_retention_duration(
                 topic_config->properties.retention_duration,
                 ctx.metadata_cache().get_default_retention_duration()),
@@ -226,7 +227,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
 
             add_config(
               result,
-              "retention.bytes",
+              topic_property_retention_bytes,
               describe_retention_bytes(
                 topic_config->properties.retention_bytes,
                 ctx.metadata_cache().get_default_retention_bytes()),
@@ -234,7 +235,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
 
             add_config(
               result,
-              "timestamp.type",
+              topic_property_timestamp_type,
               topic_config->properties.timestamp_type.value_or(
                 ctx.metadata_cache().get_default_timestamp_type()),
               describe_configs_source::topic);

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -123,11 +123,15 @@ operator<<(std::ostream& o, const model::topic_namespace_view& tp_ns) {
 }
 
 std::ostream& operator<<(std::ostream& os, timestamp_type ts) {
+    /**
+     * We need to use specific string representations of timestamp_type as this
+     * is related with protocol correctness
+     */
     switch (ts) {
     case timestamp_type::append_time:
-        return os << "append_time";
+        return os << "LogAppendTime";
     case timestamp_type::create_time:
-        return os << "create_time";
+        return os << "CreateTime";
     }
     return os << "{unknown timestamp:" << static_cast<int>(ts) << "}";
 }

--- a/src/v/model/tests/CMakeLists.txt
+++ b/src/v/model/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ rp_test(
   UNIT_TEST
   BINARY_NAME model
   SOURCES
-    compression_lexical_cast_test.cc
+    lexical_cast_tests.cc
     ntp_path_test.cc
     topic_view_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK

--- a/src/v/model/tests/lexical_cast_tests.cc
+++ b/src/v/model/tests/lexical_cast_tests.cc
@@ -69,3 +69,19 @@ BOOST_AUTO_TEST_CASE(removing_compression) {
     attr.remove_compression();
     BOOST_CHECK_EQUAL(attr.compression(), model::compression::none);
 };
+
+BOOST_AUTO_TEST_CASE(timestamp_type_cast_from_string) {
+    BOOST_CHECK_EQUAL(
+      boost::lexical_cast<model::timestamp_type>("CreateTime"),
+      model::timestamp_type::create_time);
+    BOOST_CHECK_EQUAL(
+      boost::lexical_cast<model::timestamp_type>("LogAppendTime"),
+      model::timestamp_type::append_time);
+};
+
+BOOST_AUTO_TEST_CASE(timestamp_type_printing) {
+    BOOST_CHECK_EQUAL(
+      "CreateTime", fmt::format("{}", model::timestamp_type::create_time));
+    BOOST_CHECK_EQUAL(
+      "LogAppendTime", fmt::format("{}", model::timestamp_type::append_time));
+};

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -129,4 +129,12 @@ ss::future<> state_machine::write_last_applied(model::offset o) {
     return _raft->write_last_applied(o);
 }
 
+ss::future<result<model::offset>> state_machine::instert_linerizable_barrier(
+  model::timeout_clock::time_point timeout) {
+    return ss::with_timeout(timeout, _raft->linearizable_barrier())
+      .handle_exception_type([](const ss::timed_out_error&) {
+          return result<model::offset>(errc::timeout);
+      });
+}
+
 } // namespace raft

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -88,6 +88,16 @@ public:
     ss::future<result<replicate_result>>
       quorum_write_empty_batch(model::timeout_clock::time_point);
 
+    /**
+     * Sends a round of heartbeats to followers, when majority of followers
+     * replied with success to either this of any following request all reads up
+     * to returned offsets are linearizable. (i.e. majority of followers have
+     * updated their commit indices to at least reaturned offset). For more
+     * details see paragraph 6.4 of Raft protocol dissertation.
+     */
+    ss::future<result<model::offset>>
+      instert_linerizable_barrier(model::timeout_clock::time_point);
+
     virtual ~state_machine() {}
 
 protected:

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -90,14 +90,15 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
                 configs = part[8:]
 
         def maybe_int(key, value):
-            if key in ["partition_count", "replication_factor"]:
+            if key in [
+                    "partition_count", "replication_factor", "retention_ms",
+                    "retention_bytes", 'segment_bytes'
+            ]:
                 value = int(value)
             return value
 
         def fix_key(key):
-            if key == "cleanup.policy":
-                return "cleanup_policy"
-            return key
+            return key.replace(".", "_")
 
         self._redpanda.logger.debug(f"Describe topics configs: {configs}")
         configs = [config.split("=") for config in configs.split(",")]

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -113,6 +113,17 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
         self._redpanda.logger.debug("Describe brokers config result: %s", res)
         return res
 
+    def alter_topic_config(self, topic, configuration_map):
+        self._redpanda.logger.debug("Altering topic %s configuration with %s",
+                                    topic, configuration_map)
+        args = ["--topic", topic, "--alter"]
+        args.append("--add-config")
+        args.append(",".join(
+            map(lambda item: f"{item[0]}={item[1]}",
+                configuration_map.items())))
+
+        return self._run("kafka-configs.sh", args)
+
     def produce(self,
                 topic,
                 num_records,

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -20,16 +20,48 @@ class TopicSpec:
     CLEANUP_COMPACT = "compact"
     CLEANUP_DELETE = "delete"
 
-    def __init__(self,
-                 *,
-                 name=None,
-                 partition_count=1,
-                 replication_factor=3,
-                 cleanup_policy=CLEANUP_DELETE):
+    PROPERTY_COMPRESSSION = "compression.type"
+    PROPERTY_CLEANUP_POLICY = "cleanup.policy"
+    PROPERTY_COMPACTION_STRATEGY = "compaction.strategy"
+    PROPERTY_TIMESTAMP_TYPE = "message.timestamp.type"
+    PROPERTY_SEGMENT_SIZE = "segment.bytes"
+    PROPERTY_RETENTION_BYTES = "retention.bytes"
+    PROPERTY_RETENTION_TIME = "retention.ms"
+
+    # compression types
+    COMPRESSION_NONE = "none"
+    COMPRESSION_PRODUCER = "producer"
+    COMPRESSION_GZIP = "gzip"
+    COMPRESSION_LZ4 = "lz4"
+    COMPRESSION_SNAPPY = "snappy"
+    COMPRESSION_ZSTD = "zstd"
+
+    # timestamp types
+    TIMESTAMP_CREATE_TIME = "CreateTime"
+    TIMESTAMP_LOG_APPEND_TIME = "LogAppendTime"
+
+    def __init__(
+            self,
+            *,
+            name=None,
+            partition_count=1,
+            replication_factor=3,
+            cleanup_policy=CLEANUP_DELETE,
+            compression_type=COMPRESSION_PRODUCER,
+            message_timestamp_type=TIMESTAMP_CREATE_TIME,
+            segment_bytes=1 * (2 ^ 30),
+            retention_bytes=-1,
+            retention_ms=(7 * 24 * 3600 * 1000)  # one week
+    ):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
         self.cleanup_policy = cleanup_policy
+        self.compression_type = compression_type
+        self.message_timestamp_type = message_timestamp_type
+        self.segment_bytes = segment_bytes
+        self.retention_bytes = retention_bytes
+        self.retention_ms = retention_ms
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -1,0 +1,89 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import string
+import time
+
+from ducktape.mark.resource import cluster
+from ducktape.mark import parametrize
+from ducktape.tests.test import test_logger
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class AlterTopicConfiguration(RedpandaTest):
+    """
+    Change a partition's replica set.
+    """
+    topics = (TopicSpec(partition_count=1, replication_factor=3), )
+    log_level = 'trace'
+
+    def __init__(self, test_context):
+        super(AlterTopicConfiguration,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             topics=self.topics,
+                             log_level='trace')
+
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+
+    @cluster(num_nodes=3)
+    @parametrize(property=TopicSpec.PROPERTY_CLEANUP_POLICY, value="compact")
+    @parametrize(property=TopicSpec.PROPERTY_SEGMENT_SIZE,
+                 value=10 * (2 << 20))
+    @parametrize(property=TopicSpec.PROPERTY_RETENTION_BYTES,
+                 value=200 * (2 << 20))
+    @parametrize(property=TopicSpec.PROPERTY_RETENTION_TIME, value=360000)
+    @parametrize(property=TopicSpec.PROPERTY_TIMESTAMP_TYPE,
+                 value="LogAppendTime")
+    def test_altering_topic_configuration(self, property, value):
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        res = kafka_tools.alter_topic_config(topic, {property: value})
+        spec = kafka_tools.describe_topic(topic)
+
+    @cluster(num_nodes=3)
+    def test_altering_multiple_topic_configurations(self):
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        res = kafka_tools.alter_topic_config(
+            topic, {
+                TopicSpec.PROPERTY_SEGMENT_SIZE: 1024,
+                TopicSpec.PROPERTY_RETENTION_TIME: 360000,
+                TopicSpec.PROPERTY_TIMESTAMP_TYPE: "LogAppendTime"
+            })
+        spec = kafka_tools.describe_topic(topic)
+
+        assert spec.segment_bytes == 1024
+        assert spec.retention_ms == 360000
+        assert spec.message_timestamp_type == "LogAppendTime"
+
+    def random_string(self, size):
+        return ''.join(
+            random.choice(string.ascii_uppercase + string.digits)
+            for _ in range(size))
+
+    @cluster(num_nodes=3)
+    def test_configuration_properties_name_validation(self):
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        spec = kafka_tools.describe_topic(topic)
+        for i in range(0, 5):
+            key = self.random_string(5)
+            try:
+                res = kafka_tools.alter_topic_config(topic, {key: "123"})
+            except Exception as inst:
+                test_logger.info("exception %s", inst)
+
+        new_spec = kafka_tools.describe_topic(topic)
+        # topic spec shouldn't change
+        assert new_spec == spec


### PR DESCRIPTION
## Cover letter

This PR fixes handling of `AlterConfigs` and `IncrementalAlterConfigs` by allowing those requests to be called from any of the brokers. Additionally it minimizes duration between leader and follower state updates.

This PR introduces `ducktape` tests for altering topic configuration.

Fixes #282 #935 #689 

## Release notes

Full support for altering topic configurations

Release note: [1-2 sentences of what this PR changes]
