### PR TITLE
rpk/archival: fix archival fields

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -854,15 +854,22 @@ rpk:
 			name: "shall write config with archival configuration",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.Redpanda.ArchivalStorage = ArchivalStorage{
-					Enabled:                  true,
-					S3AccessKey:              "access",
-					S3SecretKey:              "secret",
-					S3Region:                 "region",
-					S3Bucket:                 "bucket",
-					ReconciliationIntervalMs: 3,
-					MaxConnections:           4,
-				}
+				enabled := true
+				access := "access"
+				bucket := "bucket"
+				region := "region"
+				secret := "secret"
+				interval := 20000
+				conns := 4
+				endpoint := "http"
+				c.Redpanda.ArchivalStorageEnabled = &enabled
+				c.Redpanda.ArchivalStorageS3AccessKey = &access
+				c.Redpanda.ArchivalStorageS3Bucket = &bucket
+				c.Redpanda.ArchivalStorageS3Region = &region
+				c.Redpanda.ArchivalStorageS3SecretKey = &secret
+				c.Redpanda.ArchivalStorageReconciliationIntervalMs = &interval
+				c.Redpanda.ArchivalStorageMaxConnections = &conns
+				c.Redpanda.ArchivalStorageApiEndpoint = &endpoint
 				return c
 			},
 			wantErr: false,
@@ -871,14 +878,14 @@ redpanda:
   admin:
     address: 0.0.0.0
     port: 9644
-  archival_storage:
-    enabled: true
-    max_connections: 4
-    reconciliation_interval_ms: 3
-    s3_access_key: access
-    s3_bucket: bucket
-    s3_region: region
-    s3_secret_key: secret
+  archival_storage_api_endpoint: http
+  archival_storage_enabled: true
+  archival_storage_max_connections: 4
+  archival_storage_reconciliation_interval_ms: 20000
+  archival_storage_s3_access_key: access
+  archival_storage_s3_bucket: bucket
+  archival_storage_s3_region: region
+  archival_storage_s3_secret_key: secret
   data_directory: /var/lib/redpanda/data
   developer_mode: false
   kafka_api:

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -23,29 +23,26 @@ type Config struct {
 }
 
 type RedpandaConfig struct {
-	Directory          string                 `yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
-	RPCServer          SocketAddress          `yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
-	AdvertisedRPCAPI   *SocketAddress         `yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
-	KafkaApi           []NamedSocketAddress   `yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
-	AdvertisedKafkaApi []NamedSocketAddress   `yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
-	KafkaApiTLS        ServerTLS              `yaml:"kafka_api_tls,omitempty" mapstructure:"kafka_api_tls,omitempty" json:"kafkaApiTls"`
-	AdminApi           SocketAddress          `yaml:"admin" mapstructure:"admin" json:"admin"`
-	AdminApiTLS        ServerTLS              `yaml:"admin_api_tls,omitempty" mapstructure:"admin_api_tls,omitempty" json:"adminApiTls"`
-	Id                 int                    `yaml:"node_id" mapstructure:"node_id" json:"id"`
-	SeedServers        []SeedServer           `yaml:"seed_servers" mapstructure:"seed_servers" json:"seedServers"`
-	DeveloperMode      bool                   `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
-	ArchivalStorage    ArchivalStorage        `yaml:"archival_storage,omitempty" mapstructure:"archival_storage,omitempty" json:"archivalStorage"`
-	Other              map[string]interface{} `yaml:",inline" mapstructure:",remain"`
-}
-
-type ArchivalStorage struct {
-	Enabled                  bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
-	S3AccessKey              string `yaml:"s3_access_key" mapstructure:"s3_access_key" json:"s3AccessKey"`
-	S3SecretKey              string `yaml:"s3_secret_key" mapstructure:"s3_secret_key" json:"s3SecretKey"`
-	S3Region                 string `yaml:"s3_region" mapstructure:"s3_region" json:"s3Region"`
-	S3Bucket                 string `yaml:"s3_bucket" mapstructure:"s3_bucket" json:"s3Bucket"`
-	ReconciliationIntervalMs int    `yaml:"reconciliation_interval_ms,omitempty" mapstructure:"reconciliation_interval_ms,omitempty" json:"reconciliationIntervalMs"`
-	MaxConnections           int    `yaml:"max_connections,omitempty" mapstructure:"max_connections,omitempty" json:"maxConnections"`
+	Directory                               string                 `yaml:"data_directory" mapstructure:"data_directory" json:"dataDirectory"`
+	RPCServer                               SocketAddress          `yaml:"rpc_server" mapstructure:"rpc_server" json:"rpcServer"`
+	AdvertisedRPCAPI                        *SocketAddress         `yaml:"advertised_rpc_api,omitempty" mapstructure:"advertised_rpc_api,omitempty" json:"advertisedRpcApi,omitempty"`
+	KafkaApi                                []NamedSocketAddress   `yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
+	AdvertisedKafkaApi                      []NamedSocketAddress   `yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
+	KafkaApiTLS                             ServerTLS              `yaml:"kafka_api_tls,omitempty" mapstructure:"kafka_api_tls,omitempty" json:"kafkaApiTls"`
+	AdminApi                                SocketAddress          `yaml:"admin" mapstructure:"admin" json:"admin"`
+	AdminApiTLS                             ServerTLS              `yaml:"admin_api_tls,omitempty" mapstructure:"admin_api_tls,omitempty" json:"adminApiTls"`
+	Id                                      int                    `yaml:"node_id" mapstructure:"node_id" json:"id"`
+	SeedServers                             []SeedServer           `yaml:"seed_servers" mapstructure:"seed_servers" json:"seedServers"`
+	DeveloperMode                           bool                   `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`
+	ArchivalStorageApiEndpoint              *string                `yaml:"archival_storage_api_endpoint,omitempty" mapstructure:"archival_storage_api_endpoint,omitempty" json:"archivalStorageApiEndpoint,omitempty"`
+	ArchivalStorageEnabled                  *bool                  `yaml:"archival_storage_enabled,omitempty" mapstructure:"archival_storage_enabled,omitempty" json:"archivalStorageEnabled,omitempty"`
+	ArchivalStorageS3AccessKey              *string                `yaml:"archival_storage_s3_access_key,omitempty" mapstructure:"archival_storage_s3_access_key,omitempty" json:"archivalStorageS3AccessKey,omitempty"`
+	ArchivalStorageS3SecretKey              *string                `yaml:"archival_storage_s3_secret_key,omitempty" mapstructure:"archival_storage_s3_secret_key,omitempty" json:"archivalStorageS3SecretKey,omitempty"`
+	ArchivalStorageS3Region                 *string                `yaml:"archival_storage_s3_region,omitempty" mapstructure:"archival_storage_s3_region,omitempty" json:"archivalStorageS3Region,omitempty"`
+	ArchivalStorageS3Bucket                 *string                `yaml:"archival_storage_s3_bucket,omitempty" mapstructure:"archival_storage_s3_bucket,omitempty" json:"archivalStorageS3Bucket,omitempty"`
+	ArchivalStorageReconciliationIntervalMs *int                   `yaml:"archival_storage_reconciliation_interval_ms,omitempty" mapstructure:"archival_storage_reconciliation_interval_ms,omitempty" json:"archivalStorageReconciliationIntervalMs,omitempty"`
+	ArchivalStorageMaxConnections           *int                   `yaml:"archival_storage_max_connections,omitempty" mapstructure:"archival_storage_max_connections,omitempty" json:"archivalStorageMaxConnections,omitempty"`
+	Other                                   map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 
 type SeedServer struct {


### PR DESCRIPTION
The archival configuration is part of the redpanda struct. A previous PR #941 added the archival fields in rpk as a separate struct (contained in the redpanda struct). This was wrong and is fixed here.

Offline testing:
- `go test` under `src/go/rpk/pkg/config/`
- `task v-rpk:test-container`
- Manually tested that Redpanda reads properties (from a manually changed ConfigMap):

redpanda.yaml
```
redpanda:
  ...
  archival_storage_enabled: true
  archival_storage_max_connections: 10
  archival_storage_reconciliation_interval_ms: 1000
  archival_storage_s3_access_key: acc
  archival_storage_s3_bucket: buck
  archival_storage_s3_region: reg
  archival_storage_s3_secret_key: sec
...
```

broker logs
```
INFO  2021-03-25 00:57:42,220 [shard 0] redpanda::main - application.cc:206 - redpanda.archival_storage_max_connections:10	- Max number of simultaneous uploads to S3
INFO  2021-03-25 00:57:42,220 [shard 0] redpanda::main - application.cc:206 - redpanda.archival_storage_s3_secret_key:{sec}	- AWS secret key
INFO  2021-03-25 00:57:42,220 [shard 0] redpanda::main - application.cc:206 - redpanda.archival_storage_s3_access_key:{acc}	- AWS access key
INFO  2021-03-25 00:57:42,220 [shard 0] redpanda::main - application.cc:206 - redpanda.archival_storage_enabled:1	- Enable archival storage
...
INFO  2021-03-25 00:57:42,220 [shard 0] redpanda::main - application.cc:206 - redpanda.archival_storage_s3_region:{reg}	- AWS region that houses the bucket used for storage
...
INFO  2021-03-25 00:57:42,220 [shard 0] redpanda::main - application.cc:206 - redpanda.archival_storage_api_endpoint:{nullopt}	- Optional API endpoint
...
INFO  2021-03-25 00:57:42,220 [shard 0] redpanda::main - application.cc:206 - redpanda.archival_storage_reconciliation_interval_ms:1000	- Interval at which the archival service runs reconciliation (ms)
...
INFO  2021-03-25 00:57:42,220 [shard 0] redpanda::main - application.cc:206 - redpanda.archival_storage_s3_bucket:{buck}	- AWS bucket that should be used to store data
...
```