### PR TITLE
Use ssx sformat

### DIFF
--- a/src/v/archival/manifest.cc
+++ b/src/v/archival/manifest.cc
@@ -19,6 +19,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
+#include "ssx/sformat.h"
 #include "storage/ntp_config.h"
 #include "vlog.h"
 
@@ -67,7 +68,7 @@ static remote_manifest_path generate_partition_manifest_path(
     // are used. This will allow us to quickly find all manifests
     // that S3 bucket contains.
     constexpr uint32_t bitmask = 0xF0000000;
-    auto path = fmt::format("{}_{}", ntp.path(), rev());
+    auto path = ssx::sformat("{}_{}", ntp.path(), rev());
     uint32_t hash = bitmask & xxhash_32(path.data(), path.size());
     return remote_manifest_path(
       fmt::format("{:08x}/meta/{}_{}/manifest.json", hash, ntp.path(), rev()));
@@ -79,7 +80,7 @@ remote_manifest_path manifest::get_manifest_path() const {
 
 remote_segment_path
 manifest::get_remote_segment_path(const segment_name& name) const {
-    auto path = fmt::format("{}_{}/{}", _ntp.path(), _rev(), name());
+    auto path = ssx::sformat("{}_{}/{}", _ntp.path(), _rev(), name());
     uint32_t hash = xxhash_32(path.data(), path.size());
     return remote_segment_path(fmt::format("{:08x}/{}", hash, path));
 }

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -75,7 +75,7 @@ static const auto manifest_ntp = model::ntp(                    // NOLINT
   manifest_topic,
   manifest_partition);
 static const auto manifest_revision = model::revision_id(0); // NOLINT
-static const ss::sstring manifest_url = fmt::format(         // NOLINT
+static const ss::sstring manifest_url = ssx::sformat(        // NOLINT
   "/20000000/meta/{}_{}/manifest.json",
   manifest_ntp.path(),
   manifest_revision());

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -84,7 +84,7 @@ public:
             proxy_port,
             coproc_supervisor_port,
             seeds,
-            fmt::format("{}.{}", _base_dir, node_id()),
+            ssx::sformat("{}.{}", _base_dir, node_id()),
             get_scheduling_groups(),
             false));
     }

--- a/src/v/cluster/tests/partition_allocator_tester.h
+++ b/src/v/cluster/tests/partition_allocator_tester.h
@@ -48,7 +48,7 @@ struct partition_allocator_tester {
         std::vector<model::topic_metadata> ret;
         for (int t = 0; t < topics; t++) {
             model::topic_metadata t_md(model::topic_namespace(
-              model::ns("default"), model::topic(fmt::format("topic_{}", t))));
+              model::ns("default"), model::topic(ssx::sformat("topic_{}", t))));
             for (int p = 0; p < partitions; p++) {
                 std::vector<model::broker_shard> replicas;
                 for (int r = 0; r < max_nodes; r++) {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -301,7 +301,7 @@ public:
     explicit configuration_invariants_changed(
       const configuration_invariants& expected,
       const configuration_invariants& current)
-      : _msg(fmt::format(
+      : _msg(ssx::sformat(
         "Configuration invariants changed. Expected: {}, current: {}",
         expected,
         current)) {}

--- a/src/v/coproc/tests/offset_storage_utils_tests.cc
+++ b/src/v/coproc/tests/offset_storage_utils_tests.cc
@@ -45,7 +45,7 @@ public:
         for (auto i = 0; i < n; ++i) {
             model::ntp ntp(
               model::kafka_namespace,
-              model::topic(fmt::format("test_topic_{}", i)),
+              model::topic(ssx::sformat("test_topic_{}", i)),
               model::partition_id(0));
             storage::log log = _api.log_mgr()
                                  .manage(

--- a/src/v/coproc/tests/router_test.cc
+++ b/src/v/coproc/tests/router_test.cc
@@ -239,7 +239,7 @@ FIXTURE_TEST(test_coproc_router_giant_one_to_many, router_test_fixture) {
     log_layout_map outputs;
     for (std::size_t i = 0; i < n_copros; ++i) {
         auto materialized_topic = model::to_materialized_topic(
-          source_topic, model::topic(fmt::format("identity_topic_{}", i)));
+          source_topic, model::topic(ssx::sformat("identity_topic_{}", i)));
         outputs.emplace(materialized_topic, n_partitions);
     }
     setup(inputs).get();

--- a/src/v/coproc/tests/utils/coprocessor.h
+++ b/src/v/coproc/tests/utils/coprocessor.h
@@ -12,6 +12,7 @@
 #include "coproc/types.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
+#include "ssx/sformat.h"
 #include "vassert.h"
 
 #include <seastar/core/circular_buffer.hh>
@@ -112,8 +113,8 @@ struct identity_coprocessor : public coprocessor {
 struct unique_identity_coprocessor : public coprocessor {
     unique_identity_coprocessor(coproc::script_id sid, input_set input)
       : coprocessor(sid, std::move(input))
-      , _identity_topic(model::topic(fmt::format("identity_topic_{}", sid()))) {
-    }
+      , _identity_topic(
+          model::topic(ssx::sformat("identity_topic_{}", sid()))) {}
 
     ss::future<coprocessor::result> apply(
       const model::topic&,

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -47,7 +47,7 @@ public:
 
     model::topic_namespace
     make_data(model::revision_id rev, int partitions = 1, int topic = 0) {
-        auto topic_name = fmt::format("my_topic_{}", topic);
+        auto topic_name = ssx::sformat("my_topic_{}", topic);
         auto tp_ns = model::topic_namespace(
           model::kafka_namespace, model::topic{topic_name});
 

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1347,7 +1347,7 @@ kafka::member_id group::generate_member_id(const join_group_request& r) {
     auto id = r.data.group_instance_id ? (*r.data.group_instance_id)()
                                        : client_id;
     boost::uuids::uuid uuid = boost::uuids::random_generator()();
-    return kafka::member_id(fmt::format("{}-{}", id, uuid));
+    return kafka::member_id(ssx::sformat("{}-{}", id, uuid));
 }
 
 described_group group::describe() const {

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -27,8 +27,7 @@
 #include <seastar/core/smp.hh>
 #include <seastar/util/log.hh>
 
-#include <boost/algorithm/string/join.hpp>
-#include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
 #include <charconv>
 #include <string_view>
@@ -178,7 +177,7 @@ kafka_endpoint_format(const std::vector<model::broker_endpoint>& endpoints) {
             ep.address.host(),
             ep.address.port());
       });
-    return boost::algorithm::join(uris, ",");
+    return ssx::sformat("{}", fmt::join(uris, ","));
 }
 
 static void

--- a/src/v/kafka/server/handlers/sasl_authenticate.cc
+++ b/src/v/kafka/server/handlers/sasl_authenticate.cc
@@ -34,7 +34,7 @@ ss::future<response_ptr> sasl_authenticate_handler::handle(
 
     sasl_authenticate_response_data data{
       .error_code = error_code::sasl_authentication_failed,
-      .error_message = fmt::format(
+      .error_message = ssx::sformat(
         "SASL authentication failed: {}", result.error().message()),
     };
     return ctx.respond(sasl_authenticate_response(std::move(data)));

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -12,13 +12,13 @@
 #pragma once
 
 #include "seastarx.h"
+#include "ssx/sformat.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
 
 #include <boost/container_hash/hash.hpp>
-#include <fmt/core.h>
 
 #include <cstdint>
 #include <limits>
@@ -117,7 +117,7 @@ inline model::topic get_source_topic(const model::topic& topic) {
 
 inline model::topic
 to_materialized_topic(const model::topic& src, const model::topic& dest) {
-    return model::topic(fmt::format("{}.${}$", src(), dest()));
+    return model::topic(ssx::sformat("{}.${}$", src(), dest()));
 }
 
 /// \brief namespace is reserved in c++;  use ns

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -218,7 +218,7 @@ std::ostream& operator<<(std::ostream& os, const record_batch& batch) {
 }
 
 ss::sstring ntp::path() const {
-    return fmt::format("{}/{}/{}", ns(), tp.topic(), tp.partition());
+    return ssx::sformat("{}/{}/{}", ns(), tp.topic(), tp.partition());
 }
 
 std::filesystem::path ntp::topic_path() const {

--- a/src/v/model/tests/materialized_type_test.cc
+++ b/src/v/model/tests/materialized_type_test.cc
@@ -19,7 +19,7 @@
 #include <vector>
 
 ss::sstring as_dest(const std::string_view& sv) {
-    return fmt::format("${}$", sv);
+    return ssx::sformat("${}$", sv);
 }
 ss::sstring as_dest(ss::sstring&& str) {
     return as_dest(std::string_view(str));

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -214,7 +214,7 @@ create_consumer(server::request_t rq, server::reply_t rp) {
           auto adv_addr = rq.ctx.config.advertised_pandaproxy_api();
           json::create_consumer_response res{
             .instance_id = m_id,
-            .base_uri = fmt::format(
+            .base_uri = ssx::sformat(
               "http://{}:{}/consumers/{}/instances/{}",
               adv_addr.host(),
               adv_addr.port(),

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -298,7 +298,7 @@ int main(int args, char** argv, char** env) {
                   connection_cache,
                   cfg["peers"].as<std::vector<ss::sstring>>());
             }
-            const ss::sstring workdir = fmt::format(
+            const ss::sstring workdir = ssx::sformat(
               "{}/greetings-{}", cfg["workdir"].as<ss::sstring>(), self_id);
             vlog(kvelldblog.info, "Work directory:{}", workdir);
             auto hbeat_interval = std::chrono::milliseconds(

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -415,7 +415,7 @@ FIXTURE_TEST(test_compacted_log_recovery, raft_test_fixture) {
       10_MiB);
 
     auto cfg = storage::log_builder_config();
-    cfg.base_dir = fmt::format("{}/{}", gr.get_data_dir(), 0);
+    cfg.base_dir = ssx::sformat("{}/{}", gr.get_data_dir(), 0);
 
     // for now, as compaction isn't yet ready we simulate it with log builder
     auto ntp = node_ntp(raft::group_id(0), model::node_id(0));

--- a/src/v/raft/tests/mutex_buffer_test.cc
+++ b/src/v/raft/tests/mutex_buffer_test.cc
@@ -43,7 +43,8 @@ FIXTURE_TEST(test_requests_buffering, fixture) {
     {
         auto u = lock.get_units().get0();
         for (auto i = 0; i < 5; ++i) {
-            enqueued.push_back(buf.enqueue(request{fmt::format("test-{}", i)}));
+            enqueued.push_back(
+              buf.enqueue(request{ssx::sformat("test-{}", i)}));
         }
         BOOST_REQUIRE(enqueued[0].available() == false);
     }
@@ -51,7 +52,7 @@ FIXTURE_TEST(test_requests_buffering, fixture) {
     auto i = 0;
     for (auto& f : enqueued) {
         BOOST_REQUIRE_EQUAL(
-          f.get0().content, fmt::format("test-{}-response", i));
+          f.get0().content, ssx::sformat("test-{}-response", i));
         i++;
     }
 
@@ -84,7 +85,8 @@ FIXTURE_TEST(should_propagate_exception, fixture) {
         auto u = lock.get_units().get0();
 
         for (auto i = 0; i < 5; ++i) {
-            enqueued.push_back(buf.enqueue(request{fmt::format("test-{}", i)}));
+            enqueued.push_back(
+              buf.enqueue(request{ssx::sformat("test-{}", i)}));
         }
     }
     auto i = 0;
@@ -95,7 +97,7 @@ FIXTURE_TEST(should_propagate_exception, fixture) {
             BOOST_REQUIRE_THROW(f.get(), std::runtime_error);
         } else {
             BOOST_REQUIRE_EQUAL(
-              f.get().content, fmt::format("test-{}-response", i - 1));
+              f.get().content, ssx::sformat("test-{}-response", i - 1));
         }
     }
 

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -303,7 +303,7 @@ struct raft_node {
 static model::ntp node_ntp(raft::group_id gr_id, model::node_id n_id) {
     return model::ntp(
       model::ns("test"),
-      model::topic(fmt::format("group_{}", gr_id())),
+      model::topic(ssx::sformat("group_{}", gr_id())),
       model::partition_id(n_id()));
 }
 
@@ -355,7 +355,7 @@ struct raft_group {
           _id,
           raft::group_configuration(_initial_brokers, model::revision_id(0)),
           raft::timeout_jitter(heartbeat_interval * 2),
-          fmt::format("{}/{}", _storage_dir, node_id()),
+          ssx::sformat("{}/{}", _storage_dir, node_id()),
           _storage_type,
           [this, node_id](raft::leadership_status st) {
               election_callback(node_id, st);
@@ -376,7 +376,7 @@ struct raft_group {
           _id,
           raft::group_configuration({}, model::revision_id(0)),
           raft::timeout_jitter(heartbeat_interval * 2),
-          fmt::format("{}/{}", _storage_dir, node_id()),
+          ssx::sformat("{}/{}", _storage_dir, node_id()),
           _storage_type,
           [this, node_id](raft::leadership_status st) {
               election_callback(node_id, st);
@@ -757,8 +757,8 @@ make_compactible_batches(int keys, size_t batches, model::timestamp ts) {
           raft::data_batch_type, model::offset(0));
         iobuf k_buf;
         iobuf v_buf;
-        ss::sstring k_str = fmt::format("key-{}", k);
-        ss::sstring v_str = fmt::format("key-{}-value-{}", k, b);
+        ss::sstring k_str = ssx::sformat("key-{}", k);
+        ss::sstring v_str = ssx::sformat("key-{}-value-{}", k, b);
         reflection::serialize(k_buf, k_str);
         reflection::serialize(v_buf, v_str);
         builder.add_raw_kv(std::move(k_buf), std::move(v_buf));

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -288,7 +288,7 @@ int main(int args, char** argv, char** env) {
                   connection_cache,
                   cfg["peers"].as<std::vector<ss::sstring>>());
             }
-            const ss::sstring workdir = fmt::format(
+            const ss::sstring workdir = ssx::sformat(
               "{}/greetings-{}",
               cfg["workdir"].as<ss::sstring>(),
               cfg["node-id"].as<int32_t>());

--- a/src/v/raft/tron/service.h
+++ b/src/v/raft/tron/service.h
@@ -18,6 +18,7 @@
 #include "raft/tron/types.h"
 #include "raft/types.h"
 #include "seastarx.h"
+#include "ssx/sformat.h"
 
 namespace raft::tron {
 // clang-format off
@@ -59,7 +60,7 @@ struct service final : trongen_service {
                               f.get();
                               ret.success = true;
                           } catch (...) {
-                              ret.failure_reason = fmt::format(
+                              ret.failure_reason = ssx::sformat(
                                 "{}", std::current_exception());
                               tronlog.error(
                                 "failed to replicate: {}", ret.failure_reason);

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -53,7 +53,7 @@ public:
       ss::sstring base_dir,
       std::optional<scheduling_groups> sch_groups,
       bool remove_on_shutdown)
-      : app(fmt::format("redpanda-{}", node_id()))
+      : app(ssx::sformat("redpanda-{}", node_id()))
       , data_dir(std::move(base_dir))
       , remove_on_shutdown(remove_on_shutdown) {
         configure(
@@ -96,7 +96,7 @@ public:
         8082,
         43189,
         {},
-        fmt::format("test.dir_{}", time(0)),
+        ssx::sformat("test.dir_{}", time(0)),
         std::nullopt,
         true) {}
 
@@ -249,7 +249,7 @@ public:
     }
 
     model::ntp make_data(model::revision_id rev) {
-        auto topic_name = fmt::format("my_topic_{}", 0);
+        auto topic_name = ssx::sformat("my_topic_{}", 0);
         model::ntp ntp(
           model::kafka_namespace,
           model::topic(topic_name),

--- a/src/v/rpc/probes.cc
+++ b/src/v/rpc/probes.cc
@@ -10,6 +10,7 @@
 #include "prometheus/prometheus_sanitize.h"
 #include "rpc/client_probe.h"
 #include "rpc/server_probe.h"
+#include "ssx/sformat.h"
 
 #include <seastar/core/metrics.hh>
 #include <seastar/net/inet_address.hh>
@@ -27,56 +28,56 @@ void server_probe::setup_metrics(
           "active_connections",
           [this] { return _connections; },
           sm::description(
-            fmt::format("{}: Currently active connections", proto))),
+            ssx::sformat("{}: Currently active connections", proto))),
         sm::make_derive(
           "connects",
           [this] { return _connects; },
           sm::description(
-            fmt::format("{}: Number of accepted connections", proto))),
+            ssx::sformat("{}: Number of accepted connections", proto))),
         sm::make_derive(
           "connection_close_errors",
           [this] { return _connection_close_error; },
-          sm::description(fmt::format(
+          sm::description(ssx::sformat(
             "{}: Number of errors when shutting down the connection", proto))),
         sm::make_derive(
           "requests_completed",
           [this] { return _requests_completed; },
           sm::description(
-            fmt::format("{}: Number of successfull requests", proto))),
+            ssx::sformat("{}: Number of successfull requests", proto))),
         sm::make_total_bytes(
           "received_bytes",
           [this] { return _in_bytes; },
-          sm::description(fmt::format(
+          sm::description(ssx::sformat(
             "{}: Number of bytes received from the clients in valid requests",
             proto))),
         sm::make_total_bytes(
           "sent_bytes",
           [this] { return _out_bytes; },
           sm::description(
-            fmt::format("{}: Number of bytes sent to clients", proto))),
+            ssx::sformat("{}: Number of bytes sent to clients", proto))),
         sm::make_derive(
           "method_not_found_errors",
           [this] { return _method_not_found_errors; },
-          sm::description(fmt::format(
+          sm::description(ssx::sformat(
             "{}: Number of requests with not available RPC method", proto))),
         sm::make_derive(
           "corrupted_headers",
           [this] { return _corrupted_headers; },
-          sm::description(fmt::format(
+          sm::description(ssx::sformat(
             "{}: Number of requests with corrupted headers", proto))),
         sm::make_derive(
           "service_errors",
           [this] { return _corrupted_headers; },
-          sm::description(fmt::format("{}: Number of service errors", proto))),
+          sm::description(ssx::sformat("{}: Number of service errors", proto))),
         sm::make_derive(
           "requests_blocked_memory",
           [this] { return _requests_blocked_memory; },
-          sm::description(fmt::format(
+          sm::description(ssx::sformat(
             "{}: Number of requests blocked in memory backpressure", proto))),
         sm::make_gauge(
           "requests_pending",
           [this] { return _requests_received - _requests_completed; },
-          sm::description(fmt::format(
+          sm::description(ssx::sformat(
             "{}: Number of requests being processed by server", proto))),
       });
 }
@@ -102,7 +103,7 @@ void client_probe::setup_metrics(
     namespace sm = ss::metrics;
     auto target = sm::label("target");
     std::vector<sm::label_instance> labels = {
-      target(fmt::format("{}:{}", target_addr.addr(), target_addr.port()))};
+      target(ssx::sformat("{}:{}", target_addr.addr(), target_addr.port()))};
     if (service_name) {
         labels.push_back(sm::label("service_name")(*service_name));
     }

--- a/src/v/rpc/server.cc
+++ b/src/v/rpc/server.cc
@@ -14,6 +14,7 @@
 #include "rpc/logger.h"
 #include "rpc/parse_utils.h"
 #include "rpc/types.h"
+#include "ssx/sformat.h"
 #include "vassert.h"
 #include "vlog.h"
 
@@ -21,8 +22,6 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/net/api.hh>
-
-#include <fmt/format.h>
 
 namespace rpc {
 
@@ -165,15 +164,15 @@ void server::setup_metrics() {
          "max_service_mem_bytes",
          [this] { return cfg.max_service_memory_per_core; },
          sm::description(
-           fmt::format("{}: Maximum memory allowed for RPC", cfg.name))),
+           ssx::sformat("{}: Maximum memory allowed for RPC", cfg.name))),
        sm::make_total_bytes(
          "consumed_mem_bytes",
          [this] { return cfg.max_service_memory_per_core - _memory.current(); },
-         sm::description(
-           fmt::format("{}: Memory consumed by request processing", cfg.name))),
+         sm::description(ssx::sformat(
+           "{}: Memory consumed by request processing", cfg.name))),
        sm::make_histogram(
          "dispatch_handler_latency",
          [this] { return _hist.seastar_histogram_logform(); },
-         sm::description(fmt::format("{}: Latency ", cfg.name)))});
+         sm::description(ssx::sformat("{}: Latency ", cfg.name)))});
 }
 } // namespace rpc

--- a/src/v/rpc/service.h
+++ b/src/v/rpc/service.h
@@ -16,6 +16,7 @@
 #include "rpc/parse_utils.h"
 #include "rpc/types.h"
 #include "seastarx.h"
+#include "ssx/sformat.h"
 
 #include <seastar/core/reactor.hh>
 #include <seastar/core/scheduling.hh>
@@ -41,7 +42,7 @@ class rpc_internal_body_parsing_exception : public std::exception {
 public:
     explicit rpc_internal_body_parsing_exception(const std::exception_ptr& e)
       : _what(
-        fmt::format("Unable to parse received RPC request payload - {}", e)) {}
+        ssx::sformat("Unable to parse received RPC request payload - {}", e)) {}
 
     const char* what() const noexcept final { return _what.c_str(); }
 

--- a/src/v/rpc/test/rpc_integration_fixture.h
+++ b/src/v/rpc/test/rpc_integration_fixture.h
@@ -54,12 +54,12 @@ struct echo_impl final : echo::echo_service {
     ss::future<echo::echo_resp>
     prefix_echo(echo::echo_req&& req, rpc::streaming_context&) final {
         return ss::make_ready_future<echo::echo_resp>(
-          echo::echo_resp{.str = fmt::format("prefix_{}", req.str)});
+          echo::echo_resp{.str = ssx::sformat("prefix_{}", req.str)});
     }
     ss::future<echo::echo_resp>
     suffix_echo(echo::echo_req&& req, rpc::streaming_context&) final {
         return ss::make_ready_future<echo::echo_resp>(
-          echo::echo_resp{.str = fmt::format("{}_suffix", req.str)});
+          echo::echo_resp{.str = ssx::sformat("{}_suffix", req.str)});
     }
 
     ss::future<echo::echo_resp>

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -16,6 +16,7 @@
 #include "s3/error.h"
 #include "s3/logger.h"
 #include "s3/signature.h"
+#include "ssx/sformat.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
@@ -29,7 +30,6 @@
 #include <boost/beast/core/error.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
-#include <fmt/core.h>
 #include <gnutls/crypto.h>
 
 #include <exception>
@@ -59,7 +59,7 @@ static ss::sstring make_endpoint_url(
     if (url_override) {
         return url_override.value();
     }
-    return fmt::format("s3.{}.amazonaws.com", region());
+    return ssx::sformat("s3.{}.amazonaws.com", region());
 }
 
 ss::future<configuration> configuration::make_configuration(

--- a/src/v/security/scram_algorithm.cc
+++ b/src/v/security/scram_algorithm.cc
@@ -1,5 +1,6 @@
 #include "security/scram_algorithm.h"
 
+#include "ssx/sformat.h"
 #include "utils/base64.h"
 #include "utils/to_string.h"
 #include "utils/utf8.h"
@@ -201,7 +202,7 @@ client_first_message::client_first_message(bytes_view data) {
     auto match = parse_client_first(view);
     if (unlikely(!match)) {
         throw scram_exception(fmt_with_ctx(
-          fmt::format, "Invalid SCRAM client first message: {}", view));
+          ssx::sformat, "Invalid SCRAM client first message: {}", view));
     }
 
     _authzid = std::move(match->authzid);
@@ -223,7 +224,7 @@ client_first_message::client_first_message(bytes_view data) {
         auto it = std::find(pair.cbegin(), pair.cend(), '=');
         if (unlikely(it == pair.cend())) {
             throw scram_exception(fmt_with_ctx(
-              fmt::format, "Invalid SCRAM client first message: {}", view));
+              ssx::sformat, "Invalid SCRAM client first message: {}", view));
         }
         _extensions.emplace(
           ss::sstring(pair.cbegin(), it), ss::sstring(it + 1, pair.cend()));
@@ -236,7 +237,7 @@ ss::sstring client_first_message::username_normalized() const {
     boost::replace_all(normalized, "=3D", "=");
     if (std::count(normalized.cbegin(), normalized.cend(), '=') != num_eq) {
         throw scram_exception(
-          fmt_with_ctx(fmt::format, "Invalid SCRAM username: {}", _username));
+          fmt_with_ctx(ssx::sformat, "Invalid SCRAM username: {}", _username));
     }
     return normalized;
 }
@@ -259,7 +260,7 @@ std::ostream& operator<<(std::ostream& os, const client_first_message& msg) {
 }
 
 ss::sstring server_first_message::sasl_message() const {
-    return fmt::format(
+    return ssx::sformat(
       "r={},s={},i={}", _nonce, bytes_to_base64(_salt), _iterations);
 }
 
@@ -281,7 +282,7 @@ client_final_message::client_final_message(bytes_view data) {
     auto match = parse_client_final(view);
     if (unlikely(!match)) {
         throw scram_exception(fmt_with_ctx(
-          fmt::format, "Invalid SCRAM client final message: {}", view));
+          ssx::sformat, "Invalid SCRAM client final message: {}", view));
     }
 
     _channel_binding = std::move(match->channel_binding);
@@ -291,7 +292,7 @@ client_final_message::client_final_message(bytes_view data) {
 }
 
 ss::sstring client_final_message::msg_no_proof() const {
-    return fmt::format("c={},r={}", bytes_to_base64(_channel_binding), _nonce);
+    return ssx::sformat("c={},r={}", bytes_to_base64(_channel_binding), _nonce);
 }
 
 std::ostream& operator<<(std::ostream& os, const client_final_message& msg) {
@@ -307,9 +308,9 @@ std::ostream& operator<<(std::ostream& os, const client_final_message& msg) {
 
 ss::sstring server_final_message::sasl_message() const {
     if (_error) {
-        return fmt::format("e={}", *_error);
+        return ssx::sformat("e={}", *_error);
     }
-    return fmt::format("v={}", bytes_to_base64(_signature));
+    return ssx::sformat("v={}", bytes_to_base64(_signature));
 }
 
 std::ostream& operator<<(std::ostream& os, const server_final_message& msg) {

--- a/src/v/security/scram_algorithm.h
+++ b/src/v/security/scram_algorithm.h
@@ -13,6 +13,7 @@
 #include "hashing/secure.h"
 #include "random/generators.h"
 #include "security/scram_credential.h"
+#include "ssx/sformat.h"
 
 #include <absl/container/node_hash_map.h>
 
@@ -64,7 +65,7 @@ public:
     const ss::sstring& nonce() const { return _nonce; }
 
     ss::sstring bare_message() const {
-        return fmt::format("n={},r={}", _username, _nonce);
+        return ssx::sformat("n={},r={}", _username, _nonce);
     }
 
     bool token_authenticated() const;
@@ -264,7 +265,7 @@ private:
       const client_first_message& client_first,
       const server_first_message& server_first,
       const client_final_message& client_final) {
-        return fmt::format(
+        return ssx::sformat(
           "{},{},{}",
           client_first.bare_message(),
           server_first.sasl_message(),

--- a/src/v/security/tests/scram_algorithm_test.cc
+++ b/src/v/security/tests/scram_algorithm_test.cc
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
     // specified</kafka>
     {
         client_first_message m(
-          bytes(fmt::format("n,,n=testuser,r={}", nonce).c_str()));
+          bytes(ssx::sformat("n,,n=testuser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
     // <kafka>Username containing comma, encoded as =2C</kafka>
     {
         client_first_message m(
-          bytes(fmt::format("n,,n=test=2Cuser,r={}", nonce).c_str()));
+          bytes(ssx::sformat("n,,n=test=2Cuser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "test=2Cuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
     // <kafka>Username containing equals, encoded as =3D</kafka>
     {
         client_first_message m(
-          bytes(fmt::format("n,,n=test=3Duser,r={}", nonce).c_str()));
+          bytes(ssx::sformat("n,,n=test=3Duser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "test=3Duser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -94,8 +94,8 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
 
     // <kafka>Optional authorization id specified</kafka>
     {
-        client_first_message m(
-          bytes(fmt::format("n,a=testauthzid,n=testuser,r={}", nonce).c_str()));
+        client_first_message m(bytes(
+          ssx::sformat("n,a=testauthzid,n=testuser,r={}", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "testauthzid");
@@ -104,8 +104,8 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
 
     // <kafka>Optional reserved value specified</kafka>
     for (auto reserved : valid_reserved()) {
-        client_first_message m(
-          bytes(fmt::format("n,,{},n=testuser,r={}", reserved, nonce).c_str()));
+        client_first_message m(bytes(
+          ssx::sformat("n,,{},n=testuser,r={}", reserved, nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
     // <kafka>Optional extension specified</kafka>
     for (auto extension : valid_extensions()) {
         client_first_message m(bytes(
-          fmt::format("n,,n=testuser,r={},{}", nonce, extension).c_str()));
+          ssx::sformat("n,,n=testuser,r={},{}", nonce, extension).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_valid) {
     // <kafka>optional tokenauth specified as extensions</kafka>
     {
         client_first_message m(bytes(
-          fmt::format("n,,n=testuser,r={},tokenauth=true", nonce).c_str()));
+          ssx::sformat("n,,n=testuser,r={},tokenauth=true", nonce).c_str()));
         BOOST_REQUIRE_EQUAL(m.username(), "testuser");
         BOOST_REQUIRE_EQUAL(m.nonce(), nonce);
         BOOST_REQUIRE_EQUAL(m.authzid(), "");
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_invalid) {
     // <kafka>Invalid entry in gs2-header</kafka>
     BOOST_REQUIRE_EXCEPTION(
       client_first_message(
-        bytes(fmt::format("n,x=something,n=testuser,r={}", nonce).c_str())),
+        bytes(ssx::sformat("n,x=something,n=testuser,r={}", nonce).c_str())),
       scram_exception,
       [](const scram_exception& e) {
           return std::string(e.what()).find(
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_invalid) {
     for (auto reserved : invalid_reserved()) {
         BOOST_REQUIRE_EXCEPTION(
           client_first_message(bytes(
-            fmt::format("n,,{},n=testuser,r={}", reserved, nonce).c_str())),
+            ssx::sformat("n,,{},n=testuser,r={}", reserved, nonce).c_str())),
           scram_exception,
           [](const scram_exception& e) {
               return std::string(e.what()).find(
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(client_first_message_invalid) {
     for (auto extension : invalid_extensions()) {
         BOOST_REQUIRE_EXCEPTION(
           client_first_message(bytes(
-            fmt::format("n,,n=testuser,r={},{}", nonce, extension).c_str())),
+            ssx::sformat("n,,n=testuser,r={},{}", nonce, extension).c_str())),
           scram_exception,
           [](const scram_exception& e) {
               return std::string(e.what()).find(
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(server_first_message_ctor) {
     server_first_message m(client_nonce, server_nonce, salt, iterations);
     BOOST_REQUIRE_EQUAL(
       m.sasl_message(),
-      fmt::format(
+      ssx::sformat(
         "r={}{},s={},i={}",
         client_nonce,
         server_nonce,
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_valid) {
     // proof are specified</kafka>
     {
         client_final_message m(
-          bytes(fmt::format("c={},r={},p={}", channel_binding, nonce, proof)
+          bytes(ssx::sformat("c={},r={},p={}", channel_binding, nonce, proof)
                   .c_str()));
         BOOST_REQUIRE_EQUAL(
           base64_to_bytes(channel_binding), m.channel_binding());
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_valid) {
     // <kafka>Optional extension specified</kafka>
     for (auto extension : valid_extensions()) {
         client_final_message m(
-          bytes(fmt::format(
+          bytes(ssx::sformat(
                   "c={},r={},{},p={}", channel_binding, nonce, extension, proof)
                   .c_str()));
         BOOST_REQUIRE_EQUAL(
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_invalid) {
     // <kafka>Invalid channel binding</kafka>
     BOOST_REQUIRE_EXCEPTION(
       client_final_message(
-        bytes(fmt::format("c=ab,r={},p={}", nonce, proof).c_str())),
+        bytes(ssx::sformat("c=ab,r={},p={}", nonce, proof).c_str())),
       scram_exception,
       [](const scram_exception& e) {
           return std::string(e.what()).find(
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_invalid) {
     // <kafka>Invalid proof</kafka>
     BOOST_REQUIRE_EXCEPTION(
       client_final_message(
-        bytes(fmt::format("c={},r={},p=123", channel_binding, nonce).c_str())),
+        bytes(ssx::sformat("c={},r={},p=123", channel_binding, nonce).c_str())),
       scram_exception,
       [](const scram_exception& e) {
           return std::string(e.what()).find(
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(client_final_message_invalid) {
     for (auto extension : invalid_extensions()) {
         BOOST_REQUIRE_EXCEPTION(
           client_final_message(bytes(
-            fmt::format(
+            ssx::sformat(
               "c={},r={},{},p={}", channel_binding, nonce, extension, proof)
               .c_str())),
           scram_exception,
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(server_final_message_ctor) {
     {
         server_final_message m(std::nullopt, signature);
         BOOST_REQUIRE_EQUAL(
-          m.sasl_message(), fmt::format("v={}", bytes_to_base64(signature)));
+          m.sasl_message(), ssx::sformat("v={}", bytes_to_base64(signature)));
     }
 
     {

--- a/src/v/ssx/sformat.h
+++ b/src/v/ssx/sformat.h
@@ -28,9 +28,9 @@ namespace ssx {
 
 template<typename... Args>
 seastar::sstring sformat(fmt::string_view format_str, Args&&... args) {
-    auto size = fmt::formatted_size(format_str, std::forward<Args>(args)...);
+    auto size = fmt::formatted_size(format_str, args...);
     seastar::sstring buffer(seastar::sstring::initialized_later{}, size);
-    fmt::format_to(buffer.data(), format_str, args...);
+    fmt::format_to(buffer.data(), format_str, std::forward<Args>(args)...);
     return buffer;
 }
 

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "ssx/sformat.h"
 #include "tristate.h"
 
 #include <seastar/core/sstring.hh>
@@ -100,7 +101,7 @@ public:
     }
 
     ss::sstring work_directory() const {
-        return fmt::format("{}/{}_{}", _base_dir, _ntp.path(), _revision_id);
+        return ssx::sformat("{}/{}_{}", _base_dir, _ntp.path(), _revision_id);
     }
 
     std::filesystem::path topic_directory() const {

--- a/src/v/storage/opfuzz/opfuzz_test.cc
+++ b/src/v/storage/opfuzz/opfuzz_test.cc
@@ -108,7 +108,7 @@ FIXTURE_TEST(test_random_remove, storage_test_fixture) {
         ntps_to_fuzz.emplace_back(ntp);
     }
     for (const auto& ntp : ntps_to_fuzz) {
-        auto directory = fmt::format(
+        auto directory = ssx::sformat(
           "{}/{}", mngr.config().base_dir, ntp.path());
         auto log = mngr.manage(storage::ntp_config(ntp, directory)).get0();
         logs_to_fuzz.emplace_back(

--- a/src/v/storage/tests/disk_log_builder_test.cc
+++ b/src/v/storage/tests/disk_log_builder_test.cc
@@ -69,17 +69,17 @@ FIXTURE_TEST(test_valid_segment_name_with_zeroes_data, log_builder_fixture) {
     const ss::sstring dir = ncfg.work_directory();
     // 1. write valid segment names in the namespace with 0 data so crc passes
     recursive_touch_directory(dir).get();
-    do_write_zeroes(fmt::format("{}/270-1850-v1.log", dir));
-    do_write_zeroes(fmt::format("{}/270-1850-v1.base_index", dir));
-    do_write_garbage(fmt::format("{}/271-1850-v1.log", dir));
-    do_write_garbage(fmt::format("{}/271-1850-v1.base_index", dir));
+    do_write_zeroes(ssx::sformat("{}/270-1850-v1.log", dir));
+    do_write_zeroes(ssx::sformat("{}/270-1850-v1.base_index", dir));
+    do_write_garbage(ssx::sformat("{}/271-1850-v1.log", dir));
+    do_write_garbage(ssx::sformat("{}/271-1850-v1.base_index", dir));
 
     b | start(ntp);
     auto stats = get_stats().get0();
     b | stop();
 
     BOOST_REQUIRE(
-      !ss::file_exists(fmt::format("{}/270-1850-v1.log", dir)).get0());
+      !ss::file_exists(ssx::sformat("{}/270-1850-v1.log", dir)).get0());
     BOOST_TEST(stats.seg_count == 0);
     BOOST_TEST(stats.batch_count == 0);
     BOOST_TEST(stats.record_count >= 0);

--- a/src/v/storage/tests/kvstore_test.cc
+++ b/src/v/storage/tests/kvstore_test.cc
@@ -32,7 +32,8 @@ static storage::kvstore_config get_conf(ss::sstring dir) {
 SEASTAR_THREAD_TEST_CASE(key_space) {
     set_configuration("disable_metrics", true);
 
-    auto dir = fmt::format("kvstore_test_{}", random_generators::get_int(4000));
+    auto dir = ssx::sformat(
+      "kvstore_test_{}", random_generators::get_int(4000));
 
     auto conf = get_conf(dir);
 
@@ -90,7 +91,8 @@ SEASTAR_THREAD_TEST_CASE(key_space) {
 SEASTAR_THREAD_TEST_CASE(kvstore_empty) {
     set_configuration("disable_metrics", true);
 
-    auto dir = fmt::format("kvstore_test_{}", random_generators::get_int(4000));
+    auto dir = ssx::sformat(
+      "kvstore_test_{}", random_generators::get_int(4000));
 
     auto conf = get_conf(dir);
 
@@ -156,7 +158,8 @@ SEASTAR_THREAD_TEST_CASE(kvstore_empty) {
 SEASTAR_THREAD_TEST_CASE(kvstore) {
     set_configuration("disable_metrics", true);
 
-    auto dir = fmt::format("kvstore_test_{}", random_generators::get_int(4000));
+    auto dir = ssx::sformat(
+      "kvstore_test_{}", random_generators::get_int(4000));
 
     auto conf = get_conf(dir);
 

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -68,7 +68,7 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
     ntps.reserve(4);
     for (size_t i = 0; i < 4; ++i) {
         ntps.push_back(
-          config_from_ntp(model::ntp(fmt::format("ns{}", i), "topic-1", i)));
+          config_from_ntp(model::ntp(ssx::sformat("ns{}", i), "topic-1", i)));
         directories::initialize(ntps[i].work_directory()).get();
     }
     auto seg = m.make_log_segment(

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -761,7 +761,7 @@ void append_single_record_batch(
     for (int i = 0; i < cnt; ++i) {
         ss::sstring key_str;
         if (rand_key) {
-            key_str = fmt::format(
+            key_str = ssx::sformat(
               "key_{}", random_generators::get_int<uint64_t>());
         } else {
             key_str = "key";
@@ -771,7 +771,7 @@ void append_single_record_batch(
         if (val_size > 0) {
             val_bytes = random_generators::get_bytes(val_size);
         } else {
-            ss::sstring v = fmt::format("v-{}", i);
+            ss::sstring v = ssx::sformat("v-{}", i);
             val_bytes = bytes(v.c_str());
         }
         iobuf value = bytes_to_iobuf(val_bytes);
@@ -1067,7 +1067,7 @@ FIXTURE_TEST(check_segment_size_jitter, storage_test_fixture) {
     auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get0(); });
     std::vector<storage::log> logs;
     for (int i = 0; i < 5; ++i) {
-        auto ntp = model::ntp("default", fmt::format("test-{}", i), 0);
+        auto ntp = model::ntp("default", ssx::sformat("test-{}", i), 0);
         storage::ntp_config ntp_cfg(ntp, mgr.config().base_dir);
         auto log = mgr.manage(std::move(ntp_cfg)).get0();
         auto result = append_exactly(log, 1000, 100).get0();

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -15,6 +15,7 @@
 #include "model/record_batch_reader.h"
 #include "random/generators.h"
 #include "seastarx.h"
+#include "ssx/sformat.h"
 #include "storage/api.h"
 #include "storage/disk_log_impl.h"
 #include "storage/tests/utils/random_batch.h"
@@ -32,8 +33,8 @@
 namespace storage {
 
 inline static ss::sstring random_dir() {
-    return ss::sstring(
-      fmt::format("test.dir_{}", random_generators::gen_alphanum_string(7)));
+    return ssx::sformat(
+      "test.dir_{}", random_generators::gen_alphanum_string(7));
 }
 
 inline static log_config log_builder_config() {

--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -52,7 +52,7 @@ void memory(bool ignore) {
 }
 
 ss::future<> systemd_notify_ready() {
-    ss::sstring msg = fmt::format(
+    ss::sstring msg = ssx::sformat(
       "READY=1\nSTATUS=redpanda is ready! - {}", redpanda_version());
     return systemd_raw_message(std::move(msg));
 }

--- a/src/v/syschecks/syschecks.h
+++ b/src/v/syschecks/syschecks.h
@@ -12,11 +12,10 @@
 #pragma once
 
 #include "seastarx.h"
+#include "ssx/sformat.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/util/log.hh>
-
-#include <fmt/format.h>
 
 #include <cpuid.h>
 #include <cstdint>
@@ -53,8 +52,8 @@ ss::future<> systemd_notify_ready();
 
 template<typename... Args>
 ss::future<> systemd_message(const char* fmt, Args&&... args) {
-    ss::sstring s = fmt::format(
-      "STATUS={}\n", fmt::format(fmt, std::forward<Args>(args)...));
+    ss::sstring s = ssx::sformat(
+      "STATUS={}\n", ssx::sformat(fmt, std::forward<Args>(args)...));
     return systemd_raw_message(std::move(s));
 }
 

--- a/src/v/utils/file_sanitizer.h
+++ b/src/v/utils/file_sanitizer.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "ssx/sformat.h"
 #include "vassert.h"
 
 #include <seastar/core/file.hh>
@@ -18,7 +19,6 @@
 #include <seastar/util/log.hh>
 
 #include <boost/intrusive/list.hpp>
-#include <fmt/format.h>
 
 #include <optional>
 #include <ostream>
@@ -79,7 +79,7 @@ public:
       const ss::io_priority_class& pc) final {
         assert_file_not_closed();
         return with_op(
-          fmt::format(
+          ssx::sformat(
             "ss::future<size_t>::write_dma(pos:{}, *void, len:{})", pos, len),
           get_file_impl(_file)->write_dma(pos, buffer, len, pc));
     }
@@ -90,7 +90,7 @@ public:
       const ss::io_priority_class& pc) final {
         assert_file_not_closed();
         return with_op(
-          fmt::format(
+          ssx::sformat(
             "ss::future<size_t>::write_dma(pos:{}, vector<iovec>:{})",
             pos,
             iov.size()),
@@ -104,7 +104,7 @@ public:
       const ss::io_priority_class& pc) final {
         assert_file_not_closed();
         return with_op(
-          fmt::format(
+          ssx::sformat(
             "ss::future<size_t> read_dma(pos:{}, void* buffer, len:{})",
             pos,
             len),
@@ -117,7 +117,7 @@ public:
       const ss::io_priority_class& pc) final {
         assert_file_not_closed();
         return with_op(
-          fmt::format(
+          ssx::sformat(
             "ss::future<size_t> read_dma(pos{}, std::vector<iovec>:{} , "
             "const ss::io_priority_class& pc)",
             pos,
@@ -132,27 +132,28 @@ public:
             output_pending_ops();
         }
         return with_op(
-          fmt::format("ss::future<> flush(void)"),
+          ssx::sformat("ss::future<> flush(void)"),
           get_file_impl(_file)->flush());
     }
 
     ss::future<struct stat> stat() final {
         assert_file_not_closed();
         return with_op(
-          fmt::format("ss::future<> stat(void)"), get_file_impl(_file)->stat());
+          ssx::sformat("ss::future<> stat(void)"),
+          get_file_impl(_file)->stat());
     }
 
     ss::future<> truncate(uint64_t length) final {
         assert_file_not_closed();
         return with_op(
-          fmt::format("ss::future<> truncate({})", length),
+          ssx::sformat("ss::future<> truncate({})", length),
           get_file_impl(_file)->truncate(length));
     }
 
     ss::future<> discard(uint64_t offset, uint64_t length) final {
         assert_file_not_closed();
         return with_op(
-          fmt::format(
+          ssx::sformat(
             "ss::future<> discard(offset:{}, length:{})", offset, length),
           get_file_impl(_file)->discard(offset, length));
     }
@@ -160,7 +161,7 @@ public:
     ss::future<> allocate(uint64_t position, uint64_t length) final {
         assert_file_not_closed();
         return with_op(
-          fmt::format(
+          ssx::sformat(
             "ss::future<> allocate(position:{}, length:{})", position, length),
           get_file_impl(_file)->allocate(position, length));
     }
@@ -168,7 +169,7 @@ public:
     ss::future<uint64_t> size() final {
         assert_file_not_closed();
         return with_op(
-          fmt::format("ss::future<uint64_t> size(void)"),
+          ssx::sformat("ss::future<uint64_t> size(void)"),
           get_file_impl(_file)->size());
     }
 
@@ -202,7 +203,7 @@ public:
       const ss::io_priority_class& pc) final {
         assert_file_not_closed();
         return with_op(
-          fmt::format(
+          ssx::sformat(
             "ss::future<ss::temporary_buffer<uint8_t>> "
             "dma_read_bulk(offset:{}, range_size:{}",
             offset,


### PR DESCRIPTION
## Cover letter

Use `ssx::sformat` in the places where it's returned directly to an `ss::sstring`.

Followup to: https://github.com/vectorizedio/redpanda/pull/735

We should probably find a useful benchmark - allocations move from 3 to 1 in the common case, but the args are parsed twice.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/6f7ab9af30355ac730c19432497eff961bc4e91f..ea48eb42f715b0f4eabc796bb52dd0b9b530c07a)
* Rebase

## Release notes

None