### PR TITLE
archival: Extend configuration

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -575,6 +575,25 @@ configuration::configuration()
       "Max number of simultaneous uploads to S3",
       required::no,
       20)
+  , archival_storage_disable_tls(
+      *this,
+      "archival_storage_disable_tls",
+      "Disable TLS for all S3 connections",
+      required::no,
+      false)
+  , archival_storage_api_endpoint_port(
+      *this,
+      "archival_storage_api_endpoint_port",
+      "TLS port override",
+      required::no,
+      443)
+  , archival_storage_trust_file(
+      *this,
+      "archival_storage_trust_file",
+      "Path to certificate that should be used to validate server certificate "
+      "during TLS handshake",
+      required::no,
+      std::nullopt)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -141,6 +141,9 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> archival_storage_api_endpoint;
     property<std::chrono::milliseconds> archival_storage_reconciliation_ms;
     property<int16_t> archival_storage_max_connections;
+    property<bool> archival_storage_disable_tls;
+    property<int16_t> archival_storage_api_endpoint_port;
+    property<std::optional<ss::sstring>> archival_storage_trust_file;
 
     configuration();
 


### PR DESCRIPTION
This commit adds three configuration options:
- archival_storage_disable_tls can be used to disable tls
  authentification for archival subsystem (can be used in
  tests)
- archival_storage_api_endpont_port can be used to override
  default port number for TLS (443)
- archival_storage_trust_file allows to implicitly set the
  public CA certificate that should be used to validate server

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes issues: [#NNN, #NNN, ...]

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
