### PR TITLE
rpk/config: add extended archival configuration

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -862,6 +862,9 @@ rpk:
 				interval := 20000
 				conns := 4
 				endpoint := "http"
+				tls := true
+				port := 100
+				trustfile := "trust"
 				c.Redpanda.ArchivalStorageEnabled = &enabled
 				c.Redpanda.ArchivalStorageS3AccessKey = &access
 				c.Redpanda.ArchivalStorageS3Bucket = &bucket
@@ -870,6 +873,9 @@ rpk:
 				c.Redpanda.ArchivalStorageReconciliationIntervalMs = &interval
 				c.Redpanda.ArchivalStorageMaxConnections = &conns
 				c.Redpanda.ArchivalStorageApiEndpoint = &endpoint
+				c.Redpanda.ArchivalStorageDisableTls = &tls
+				c.Redpanda.ArchivalStorageApiEndpointPort = &port
+				c.Redpanda.ArchivalStorageTrustFile = &trustfile
 				return c
 			},
 			wantErr: false,
@@ -879,6 +885,8 @@ redpanda:
     address: 0.0.0.0
     port: 9644
   archival_storage_api_endpoint: http
+  archival_storage_api_endpoint_port: 100
+  archival_storage_disable_tls: true
   archival_storage_enabled: true
   archival_storage_max_connections: 4
   archival_storage_reconciliation_interval_ms: 20000
@@ -886,6 +894,7 @@ redpanda:
   archival_storage_s3_bucket: bucket
   archival_storage_s3_region: region
   archival_storage_s3_secret_key: secret
+  archival_storage_trust_file: trust
   data_directory: /var/lib/redpanda/data
   developer_mode: false
   kafka_api:

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -42,6 +42,9 @@ type RedpandaConfig struct {
 	ArchivalStorageS3Bucket                 *string                `yaml:"archival_storage_s3_bucket,omitempty" mapstructure:"archival_storage_s3_bucket,omitempty" json:"archivalStorageS3Bucket,omitempty"`
 	ArchivalStorageReconciliationIntervalMs *int                   `yaml:"archival_storage_reconciliation_interval_ms,omitempty" mapstructure:"archival_storage_reconciliation_interval_ms,omitempty" json:"archivalStorageReconciliationIntervalMs,omitempty"`
 	ArchivalStorageMaxConnections           *int                   `yaml:"archival_storage_max_connections,omitempty" mapstructure:"archival_storage_max_connections,omitempty" json:"archivalStorageMaxConnections,omitempty"`
+	ArchivalStorageDisableTls               *bool                  `yaml:"archival_storage_disable_tls,omitempty" mapstructure:"archival_storage_disable_tls,omitempty" json:"archivalStorageDisableTls,omitempty"`
+	ArchivalStorageApiEndpointPort          *int                   `yaml:"archival_storage_api_endpoint_port,omitempty" mapstructure:"archival_storage_api_endpoint_port,omitempty" json:"archivalStorageApiEndpointPort,omitempty"`
+	ArchivalStorageTrustFile                *string                `yaml:"archival_storage_trust_file,omitempty" mapstructure:"archival_storage_trust_file,omitempty" json:"archivalStorageTrustFile,omitempty"`
 	Other                                   map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 


### PR DESCRIPTION
## Cover letter

Today's #963 extended the archival properties to include:

```
archival_storage_disable_tls 
archival_storage_api_endpont_port
archival_storage_trust_file
```
Adding them to rpk config so they can be used by the operator in #943
