### PR TITLE
Implemented controller  API

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -53,6 +53,7 @@ v_cc_library(
     rm_stm.cc
     security_manager.cc
     security_frontend.cc
+    controller_api.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -55,6 +55,8 @@ public:
 
     ss::sharded<security::authorizer>& get_authorizer() { return _authorizer; }
 
+    ss::sharded<controller_api>& get_api() { return _api; }
+
     ss::future<> wire_up();
 
     ss::future<> start();
@@ -74,6 +76,7 @@ private:
     ss::sharded<controller_backend> _backend;      // instance per core
     ss::sharded<controller_stm> _stm;              // single instance
     ss::sharded<controller_service> _service;      // instance per core
+    ss::sharded<controller_api> _api;              // instance per core
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_manager>& _partition_manager;
     ss::sharded<shard_table>& _shard_table;

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -39,6 +39,11 @@
             "name": "delete_acls",
             "input_type": "delete_acls_request",
             "output_type": "delete_acls_reply"
+        },
+        {
+            "name": "get_reconciliation_state",
+            "input_type": "reconciliation_state_request",
+            "output_type": "reconciliation_state_reply"
         }
     ]
 }

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -34,11 +34,13 @@ controller_api::controller_api(
   ss::sharded<controller_backend>& backend,
   ss::sharded<topic_table>& topics,
   ss::sharded<shard_table>& shard_table,
+  ss::sharded<rpc::connection_cache>& cache,
   ss::sharded<ss::abort_source>& as)
   : _self(self)
   , _backend(backend)
   , _topics(topics)
   , _shard_table(shard_table)
+  , _connections(cache)
   , _as(as) {}
 
 ss::future<std::vector<ntp_reconciliation_state>>
@@ -142,5 +144,122 @@ controller_api::get_reconciliation_state(model::ntp ntp) {
     // cluster & metadata state are inconsistent
     co_return ntp_reconciliation_state(
       std::move(ntp), {}, reconciliation_status::in_progress);
+}
+
+ss::future<result<std::vector<ntp_reconciliation_state>>>
+controller_api::get_reconciliation_state(
+  model::node_id target_id,
+  std::vector<model::ntp> ntps,
+  model::timeout_clock::time_point timeout) {
+    using ret_t = result<std::vector<ntp_reconciliation_state>>;
+    if (target_id == _self) {
+        return get_reconciliation_state(std::move(ntps))
+          .then([](std::vector<ntp_reconciliation_state> ret) {
+              return ret_t(std::move(ret));
+          });
+    }
+
+    vlog(
+      clusterlog.trace,
+      "dispatching get ntps: {} reconciliation state request to {}",
+      ntps,
+      target_id);
+    return _connections.local()
+      .with_node_client<controller_client_protocol>(
+        _self,
+        ss::this_shard_id(),
+        target_id,
+        timeout,
+        [timeout,
+         ntps = std::move(ntps)](controller_client_protocol client) mutable {
+            reconciliation_state_request req{.ntps = std::move(ntps)};
+            return client.get_reconciliation_state(
+              std::move(req), rpc::client_opts(timeout));
+        })
+      .then(&rpc::get_ctx_data<reconciliation_state_reply>)
+      .then([](result<reconciliation_state_reply> reply) {
+          if (reply) {
+              return ret_t(std::move(reply.value().results));
+          }
+          return ret_t(reply.error());
+      });
+}
+
+ss::future<result<ntp_reconciliation_state>>
+controller_api::get_reconciliation_state(
+  model::node_id id, model::ntp ntp, model::timeout_clock::time_point timeout) {
+    using ret_t = result<ntp_reconciliation_state>;
+    return get_reconciliation_state(
+             id, std::vector<model::ntp>{std::move(ntp)}, timeout)
+      .then([](result<std::vector<ntp_reconciliation_state>> result) {
+          if (result.has_error()) {
+              return ret_t(result.error());
+          }
+          vassert(result.value().size() == 1, "result MUST contain single ntp");
+
+          return ret_t(result.value().front());
+      });
+}
+
+// high level APIs
+ss::future<std::error_code> controller_api::wait_for_topic(
+  model::topic_namespace_view tp_ns, model::timeout_clock::time_point timeout) {
+    auto metadata = _topics.local().get_topic_metadata(tp_ns);
+    if (!metadata) {
+        vlog(clusterlog.trace, "topic {} does not exists", tp_ns);
+        co_return make_error_code(errc::topic_not_exists);
+    }
+
+    absl::node_hash_map<model::node_id, std::vector<model::ntp>> requests;
+    // collect ntps per node
+    for (const auto& p_md : metadata->partitions) {
+        for (const auto& bs : p_md.replicas) {
+            requests[bs.node_id].emplace_back(tp_ns.ns, tp_ns.tp, p_md.id);
+        }
+    }
+    bool ready = false;
+    while (!ready) {
+        if (model::timeout_clock::now() > timeout) {
+            co_return make_error_code(errc::timeout);
+        }
+        auto res = co_await are_ntps_ready(requests, timeout);
+        ready = !res.has_error() && res.value();
+        if (!ready) {
+            co_await ss::sleep_abortable(
+              std::chrono::milliseconds(100), _as.local());
+        }
+    }
+
+    co_return errc::success;
+}
+
+ss::future<result<bool>> controller_api::are_ntps_ready(
+  absl::node_hash_map<model::node_id, std::vector<model::ntp>> requests,
+  model::timeout_clock::time_point timeout) {
+    std::vector<ss::future<result<bool>>> replies;
+    replies.reserve(requests.size());
+
+    for (auto& [id, ntps] : requests) {
+        auto f = get_reconciliation_state(id, std::move(ntps), timeout)
+                   .then([](result<std::vector<ntp_reconciliation_state>> res) {
+                       if (!res) {
+                           return result<bool>(res.error());
+                       }
+                       return result<bool>(std::all_of(
+                         res.value().begin(),
+                         res.value().end(),
+                         [](const ntp_reconciliation_state& state) {
+                             return state.status()
+                                    == reconciliation_status::done;
+                         }));
+                   });
+        replies.push_back(std::move(f));
+    }
+
+    auto r = co_await ss::when_all_succeed(replies.begin(), replies.end());
+
+    co_return std::all_of(r.begin(), r.end(), [](result<bool> is_ready_result) {
+        return !is_ready_result.has_error() && is_ready_result.value();
+    });
 }
 } // namespace cluster

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/controller_api.h"
+
+#include "cluster/controller_backend.h"
+#include "cluster/controller_service.h"
+#include "cluster/errc.h"
+#include "cluster/logger.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
+#include "cluster/topic_table.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timeout_clock.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+
+#include <absl/container/node_hash_map.h>
+
+namespace cluster {
+
+controller_api::controller_api(
+  model::node_id self,
+  ss::sharded<controller_backend>& backend,
+  ss::sharded<topic_table>& topics,
+  ss::sharded<shard_table>& shard_table,
+  ss::sharded<ss::abort_source>& as)
+  : _self(self)
+  , _backend(backend)
+  , _topics(topics)
+  , _shard_table(shard_table)
+  , _as(as) {}
+
+ss::future<std::vector<ntp_reconciliation_state>>
+controller_api::get_reconciliation_state(std::vector<model::ntp> ntps) {
+    return ssx::async_transform(ntps, [this](const model::ntp& ntp) {
+        return get_reconciliation_state(ntp);
+    });
+}
+
+bool has_node_local_replicas(
+  model::node_id self, const partition_assignment& assignment) {
+    return std::any_of(
+      assignment.replicas.cbegin(),
+      assignment.replicas.cend(),
+      [self](const model::broker_shard& p_as) { return p_as.node_id == self; });
+}
+
+ss::future<result<std::vector<ntp_reconciliation_state>>>
+controller_api::get_reconciliation_state(model::topic_namespace_view tp_ns) {
+    using ret_t = result<std::vector<ntp_reconciliation_state>>;
+    auto metadata = _topics.local().get_topic_metadata(tp_ns);
+    if (!metadata) {
+        co_return ret_t(errc::topic_not_exists);
+    }
+    std::vector<model::ntp> ntps;
+    ntps.reserve(metadata->partitions.size());
+
+    std::transform(
+      metadata->partitions.cbegin(),
+      metadata->partitions.cend(),
+      std::back_inserter(ntps),
+      [tp_ns](const model::partition_metadata& p_md) {
+          return model::ntp(tp_ns.ns, tp_ns.tp, p_md.id);
+      });
+
+    co_return co_await get_reconciliation_state(std::move(ntps));
+}
+
+ss::future<std::vector<topic_table_delta>>
+controller_api::get_remote_core_deltas(model::ntp ntp, ss::shard_id shard) {
+    return _backend.invoke_on(
+      shard, [ntp = std::move(ntp)](controller_backend& backend) {
+          return backend.list_ntp_deltas(ntp);
+      });
+}
+
+ss::future<ntp_reconciliation_state>
+controller_api::get_reconciliation_state(model::ntp ntp) {
+    if (_as.local().abort_requested()) {
+        co_return ntp_reconciliation_state(std::move(ntp), errc::shutting_down);
+    }
+    vlog(clusterlog.trace, "getting reconciliation state for {}", ntp);
+    auto target_assignment = _topics.local().get_partition_assignment(ntp);
+
+    // partition not found, return error
+    if (!target_assignment) {
+        co_return ntp_reconciliation_state(
+          std::move(ntp), errc::partition_not_exists);
+    }
+    // query controller backends for in progress operations
+    std::vector<backend_operation> ops;
+    const auto shards = boost::irange<ss::shard_id>(0, ss::smp::count);
+    for (auto shard : shards) {
+        auto local_deltas = co_await get_remote_core_deltas(
+          std::move(ntp), shard);
+
+        std::transform(
+          local_deltas.begin(),
+          local_deltas.end(),
+          std::back_inserter(ops),
+          [shard](topic_table_delta& delta) {
+              return backend_operation{
+                .source_shard = shard,
+                .p_as = std::move(delta.new_assignment),
+                .type = delta.type,
+              };
+          });
+    }
+
+    // having any deltas is sufficient to state that reconciliation is still
+    // in progress
+    if (!ops.empty()) {
+        co_return ntp_reconciliation_state(
+          std::move(ntp), std::move(ops), reconciliation_status::in_progress);
+    }
+
+    // deltas are empty, make sure that local node partitions are in align with
+    // expected cluster state
+
+    auto has_local_replicas = has_node_local_replicas(
+      _self, *target_assignment);
+
+    auto shard = _shard_table.local().shard_for(ntp);
+
+    // shard not found for ntp and it is expected to have no local replicas
+    if ((!shard && !has_local_replicas) || (shard && has_local_replicas)) {
+        co_return ntp_reconciliation_state(
+          std::move(ntp), {}, reconciliation_status::done);
+    }
+
+    // cluster & metadata state are inconsistent
+    co_return ntp_reconciliation_state(
+      std::move(ntp), {}, reconciliation_status::in_progress);
+}
+} // namespace cluster

--- a/src/v/cluster/controller_api.h
+++ b/src/v/cluster/controller_api.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "cluster/fwd.h"
+#include "cluster/shard_table.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timeout_clock.h"
+#include "outcome.h"
+#include "rpc/connection_cache.h"
+#include "seastarx.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/sharded.hh>
+
+#include <system_error>
+
+namespace cluster {
+/**
+ * An entry point to read controller/cluster state
+ */
+class controller_api {
+public:
+    controller_api(
+      model::node_id,
+      ss::sharded<controller_backend>&,
+      ss::sharded<topic_table>&,
+      ss::sharded<shard_table>&,
+      ss::sharded<ss::abort_source>&);
+
+    ss::future<result<std::vector<ntp_reconciliation_state>>>
+      get_reconciliation_state(model::topic_namespace_view);
+
+    ss::future<std::vector<ntp_reconciliation_state>>
+      get_reconciliation_state(std::vector<model::ntp>);
+
+    ss::future<ntp_reconciliation_state> get_reconciliation_state(model::ntp);
+
+private:
+    ss::future<result<bool>> are_ntps_ready(
+      absl::flat_hash_map<model::node_id, std::vector<model::ntp>>,
+      model::timeout_clock::time_point);
+
+    ss::future<std::vector<topic_table_delta>>
+      get_remote_core_deltas(model::ntp, ss::shard_id);
+
+    model::node_id _self;
+    ss::sharded<controller_backend>& _backend;
+    ss::sharded<topic_table>& _topics;
+    ss::sharded<shard_table>& _shard_table;
+    ss::sharded<ss::abort_source>& _as;
+};
+} // namespace cluster

--- a/src/v/cluster/controller_api.h
+++ b/src/v/cluster/controller_api.h
@@ -35,6 +35,7 @@ public:
       ss::sharded<controller_backend>&,
       ss::sharded<topic_table>&,
       ss::sharded<shard_table>&,
+      ss::sharded<rpc::connection_cache>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<result<std::vector<ntp_reconciliation_state>>>
@@ -45,9 +46,25 @@ public:
 
     ss::future<ntp_reconciliation_state> get_reconciliation_state(model::ntp);
 
+    /**
+     * API to access both remote and local state
+     */
+    ss::future<result<std::vector<ntp_reconciliation_state>>>
+      get_reconciliation_state(
+        model::node_id,
+        std::vector<model::ntp>,
+        model::timeout_clock::time_point);
+
+    ss::future<result<ntp_reconciliation_state>> get_reconciliation_state(
+      model::node_id, model::ntp, model::timeout_clock::time_point);
+
+    // high level APIs
+    ss::future<std::error_code> wait_for_topic(
+      model::topic_namespace_view, model::timeout_clock::time_point);
+
 private:
     ss::future<result<bool>> are_ntps_ready(
-      absl::flat_hash_map<model::node_id, std::vector<model::ntp>>,
+      absl::node_hash_map<model::node_id, std::vector<model::ntp>>,
       model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_table_delta>>
@@ -57,6 +74,7 @@ private:
     ss::sharded<controller_backend>& _backend;
     ss::sharded<topic_table>& _topics;
     ss::sharded<shard_table>& _shard_table;
+    ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<ss::abort_source>& _as;
 };
 } // namespace cluster

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -841,4 +841,13 @@ controller_backend::delete_partition(model::ntp ntp, model::revision_id rev) {
       .then([] { return make_error_code(errc::success); });
 }
 
+std::vector<topic_table::delta>
+controller_backend::list_ntp_deltas(const model::ntp& ntp) const {
+    if (auto it = _topic_deltas.find(ntp); it != _topic_deltas.end()) {
+        return it->second;
+    }
+
+    return {};
+}
+
 } // namespace cluster

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -43,6 +43,8 @@ public:
     ss::future<> stop();
     ss::future<> start();
 
+    std::vector<topic_table::delta> list_ntp_deltas(const model::ntp&) const;
+
 private:
     using deltas_t = std::vector<topic_table::delta>;
     using underlying_t = absl::flat_hash_map<model::ntp, deltas_t>;

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -14,7 +14,7 @@
 
 namespace cluster {
 
-enum class errc {
+enum class errc : int16_t {
     success = 0, // must be 0
     notification_wait_timeout,
     topic_invalid_partitions,

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -29,5 +29,6 @@ class members_table;
 class metadata_cache;
 class metadata_dissemination_service;
 class security_frontend;
+class controller_api;
 
 } // namespace cluster

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "cluster/controller_service.h"
 #include "cluster/types.h"
+#include "rpc/types.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -30,7 +31,8 @@ public:
       ss::sharded<topics_frontend>&,
       ss::sharded<members_manager>&,
       ss::sharded<metadata_cache>&,
-      ss::sharded<security_frontend>&);
+      ss::sharded<security_frontend>&,
+      ss::sharded<controller_api>&);
 
     virtual ss::future<join_reply>
     join(join_request&&, rpc::streaming_context&) override;
@@ -46,6 +48,8 @@ public:
 
     ss::future<update_topic_properties_reply> update_topic_properties(
       update_topic_properties_request&&, rpc::streaming_context&) final;
+    ss::future<reconciliation_state_reply> get_reconciliation_state(
+      reconciliation_state_request&&, rpc::streaming_context&) final;
 
     ss::future<create_acls_reply>
     create_acls(create_acls_request&&, rpc::streaming_context&) final;
@@ -64,9 +68,13 @@ private:
     ss::future<update_topic_properties_reply>
     do_update_topic_properties(update_topic_properties_request&&);
 
+    ss::future<reconciliation_state_reply>
+      do_get_reconciliation_state(reconciliation_state_request);
+
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<metadata_cache>& _md_cache;
     ss::sharded<security_frontend>& _security_frontend;
+    ss::sharded<controller_api>& _api;
 };
 } // namespace cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(srcs
     idempotency_tests.cc
     tm_stm_tests.cc
     rm_stm_tests.cc
+    controller_api_tests.cc
     id_allocator_stm_test.cc)
 
 rp_test(

--- a/src/v/cluster/tests/controller_api_tests.cc
+++ b/src/v/cluster/tests/controller_api_tests.cc
@@ -1,0 +1,69 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/controller_api.h"
+#include "cluster/errc.h"
+#include "cluster/tests/cluster_test_fixture.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/timeout_clock.h"
+#include "ssx/future-util.h"
+#include "test_utils/async.h"
+
+#include <seastar/core/loop.hh>
+
+using namespace std::chrono_literals; // NOLINT
+
+FIXTURE_TEST(test_querying_ntp_status, cluster_test_fixture) {
+    auto n1 = create_node_application(model::node_id{0});
+    auto n2 = create_node_application(model::node_id{1});
+    auto n3 = create_node_application(model::node_id{2});
+    model::ntp test_ntp(test_ns, model::topic("tp"), model::partition_id(0));
+    wait_for_all_members(3s).get();
+
+    auto state = n1->controller->get_api()
+                   .local()
+                   .get_reconciliation_state(test_ntp)
+                   .get();
+    /**
+     * No topic yet, error expected
+     */
+    BOOST_REQUIRE_EQUAL(
+      state.error(), make_error_code(cluster::errc::partition_not_exists));
+
+    std::optional<model::node_id> leader_id;
+
+    while (!leader_id) {
+        leader_id = n1->metadata_cache.local().get_controller_leader_id();
+    }
+    auto leader = get_node_application(*leader_id);
+
+    // create topic
+    std::vector<cluster::topic_configuration> topics;
+    topics.emplace_back(test_ntp.ns, test_ntp.tp.topic, 3, 1);
+
+    leader->controller->get_topics_frontend()
+      .local()
+      .create_topics(topics, 1s + model::timeout_clock::now())
+      .get();
+
+    // wait for reconciliation to be finished
+    tests::cooperative_spin_wait_with_timeout(2s, [this, &n2, &test_ntp] {
+        return n2->controller->get_api()
+          .local()
+          .get_reconciliation_state(test_ntp)
+          .then([](result<cluster::ntp_reconciliation_state> r) {
+              if (!r) {
+                  return false;
+              }
+              return r.value().status() == cluster::reconciliation_status::done;
+          });
+    }).get();
+}

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -34,18 +34,6 @@ topic_table::transform_topics(Func&& f) const {
     return ret;
 }
 
-topic_table_delta::topic_table_delta(
-  model::ntp ntp,
-  cluster::partition_assignment new_assignment,
-  model::offset o,
-  op_type tp,
-  std::optional<partition_assignment> previous)
-  : ntp(std::move(ntp))
-  , new_assignment(std::move(new_assignment))
-  , offset(o)
-  , type(tp)
-  , previous_assignment(std::move(previous)) {}
-
 ss::future<std::error_code>
 topic_table::apply(create_topic_cmd cmd, model::offset offset) {
     if (_topics.contains(cmd.key)) {
@@ -358,37 +346,6 @@ topic_table::get_partition_assignment(const model::ntp& ntp) const {
     }
 
     return *p_it;
-}
-
-std::ostream&
-operator<<(std::ostream& o, const topic_table::delta::op_type& tp) {
-    switch (tp) {
-    case topic_table::delta::op_type::add:
-        return o << "addition";
-    case topic_table::delta::op_type::del:
-        return o << "deletion";
-    case topic_table::delta::op_type::update:
-        return o << "update";
-    case topic_table::delta::op_type::update_finished:
-        return o << "update_finished";
-    case topic_table::delta::op_type::update_properties:
-        return o << "update_properties";
-    }
-    __builtin_unreachable();
-}
-
-std::ostream& operator<<(std::ostream& o, const topic_table::delta& d) {
-    fmt::print(
-      o,
-      "{{type: {}, ntp: {}, offset: {}, new_assignment: {}, "
-      "previous_assignment: {}}}",
-      d.type,
-      d.ntp,
-      d.offset,
-      d.new_assignment,
-      d.previous_assignment);
-
-    return o;
 }
 
 } // namespace cluster

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -31,30 +31,6 @@ namespace cluster {
 /// with topic creation or deletion are executed. Topic table is also
 /// responsible for commiting or removing pending allocations
 ///
-// delta propagated to backend
-struct topic_table_delta {
-    enum class op_type { add, del, update, update_finished, update_properties };
-
-    topic_table_delta(
-      model::ntp,
-      partition_assignment,
-      model::offset,
-      op_type,
-      std::optional<partition_assignment> = std::nullopt);
-
-    model::ntp ntp;
-    partition_assignment new_assignment;
-    model::offset offset;
-    op_type type;
-    std::optional<partition_assignment> previous_assignment;
-
-    model::topic_namespace_view tp_ns() const {
-        return model::topic_namespace_view(ntp);
-    }
-
-    friend std::ostream& operator<<(std::ostream&, const topic_table_delta&);
-    friend std::ostream& operator<<(std::ostream&, const op_type&);
-};
 
 class topic_table {
 public:

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/types.h"
 
+#include "cluster/fwd.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "security/acl.h"
@@ -102,6 +103,18 @@ model::topic_metadata topic_configuration_assignment::get_metadata() const {
     return ret;
 }
 
+topic_table_delta::topic_table_delta(
+  model::ntp ntp,
+  cluster::partition_assignment new_assignment,
+  model::offset o,
+  op_type tp,
+  std::optional<partition_assignment> previous)
+  : ntp(std::move(ntp))
+  , new_assignment(std::move(new_assignment))
+  , offset(o)
+  , type(tp)
+  , previous_assignment(std::move(previous)) {}
+
 std::ostream& operator<<(std::ostream& o, const topic_configuration& cfg) {
     fmt::print(
       o,
@@ -154,6 +167,37 @@ std::ostream& operator<<(std::ostream& o, const partition_assignment& p_as) {
       p_as.id,
       p_as.group,
       p_as.replicas);
+    return o;
+}
+
+std::ostream&
+operator<<(std::ostream& o, const topic_table_delta::op_type& tp) {
+    switch (tp) {
+    case topic_table_delta::op_type::add:
+        return o << "addition";
+    case topic_table_delta::op_type::del:
+        return o << "deletion";
+    case topic_table_delta::op_type::update:
+        return o << "update";
+    case topic_table_delta::op_type::update_finished:
+        return o << "update_finished";
+    case topic_table_delta::op_type::update_properties:
+        return o << "update_properties";
+    }
+    __builtin_unreachable();
+}
+
+std::ostream& operator<<(std::ostream& o, const topic_table_delta& d) {
+    fmt::print(
+      o,
+      "{{type: {}, ntp: {}, offset: {}, new_assignment: {}, "
+      "previous_assignment: {}}}",
+      d.type,
+      d.ntp,
+      d.offset,
+      d.new_assignment,
+      d.previous_assignment);
+
     return o;
 }
 } // namespace cluster

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -312,6 +312,30 @@ public:
 private:
     ss::sstring _msg;
 };
+// delta propagated to backend
+struct topic_table_delta {
+    enum class op_type { add, del, update, update_finished, update_properties };
+
+    topic_table_delta(
+      model::ntp,
+      cluster::partition_assignment,
+      model::offset,
+      op_type,
+      std::optional<partition_assignment> = std::nullopt);
+
+    model::ntp ntp;
+    cluster::partition_assignment new_assignment;
+    model::offset offset;
+    op_type type;
+    std::optional<partition_assignment> previous_assignment;
+
+    model::topic_namespace_view tp_ns() const {
+        return model::topic_namespace_view(ntp);
+    }
+
+    friend std::ostream& operator<<(std::ostream&, const topic_table_delta&);
+    friend std::ostream& operator<<(std::ostream&, const op_type&);
+};
 
 struct create_acls_cmd_data {
     static constexpr int8_t current_version = 1;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -419,6 +419,14 @@ private:
     errc _error;
 };
 
+struct reconciliation_state_request {
+    std::vector<model::ntp> ntps;
+};
+
+struct reconciliation_state_reply {
+    std::vector<ntp_reconciliation_state> results;
+};
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -659,7 +659,8 @@ void application::start_redpanda() {
             std::ref(controller->get_topics_frontend()),
             std::ref(controller->get_members_manager()),
             std::ref(metadata_cache),
-            std::ref(controller->get_security_frontend()));
+            std::ref(controller->get_security_frontend()),
+            std::ref(controller->get_api()));
           proto->register_service<cluster::metadata_dissemination_handler>(
             _scheduling_groups.cluster_sg(),
             smp_service_groups.cluster_smp_sg(),


### PR DESCRIPTION
## Cover letter

Implemented `cluster::controller_api` class exposing API allowing accessing state of controller background operations. The `cluster::controller_api` is an entry point for all other system components that requires knowledge about state op topic/partition operations. For example: partitions load balancer, kafka requests handlers. 

Fixes: #788

## Release notes
- Internal API, doesn't change end user experince 
