### PR TITLE
Heartbeats backpressure

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -102,6 +102,12 @@ configuration::configuration()
       "Milliseconds for raft leader heartbeats",
       required::no,
       std::chrono::milliseconds(150))
+  , raft_heartbeat_timeout_ms(
+      *this,
+      "raft_heartbeat_timeout_ms",
+      "raft heartbeat RPC timeout",
+      required::no,
+      3s)
   , seed_servers(
       *this,
       "seed_servers",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -53,6 +53,7 @@ struct configuration final : public config_store {
     property<int32_t> node_id;
     property<int32_t> seed_server_meta_topic_partitions;
     property<std::chrono::milliseconds> raft_heartbeat_interval_ms;
+    property<std::chrono::milliseconds> raft_heartbeat_timeout_ms;
     property<std::vector<seed_server>> seed_servers;
     property<int16_t> min_version;
     property<int16_t> max_version;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2315,7 +2315,7 @@ heartbeats_suppressed consensus::are_heartbeats_suppressed(vnode id) const {
     return _fstats.get(id).suppress_heartbeats;
 }
 
-void consensus::suppress_heartbeats(
+void consensus::update_suppress_heartbeats(
   vnode id, follower_req_seq last_seq, heartbeats_suppressed suppressed) {
     if (auto it = _fstats.find(id); it != _fstats.end()) {
         if (last_seq <= it->second.last_sent_seq) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -202,6 +202,11 @@ consensus::success_reply consensus::update_follower_index(
     follower_index_metadata& idx = it->second;
     const append_entries_reply& reply = r.value();
     vlog(_ctxlog.trace, "Append entries response: {}", reply);
+    if (unlikely(reply.result == append_entries_reply::status::timeout)) {
+        // ignore this response, timed out on the receiver node
+        vlog(_ctxlog.trace, "Append entries request timedout at node {}", node);
+        return success_reply::no;
+    }
     if (unlikely(
           reply.result == append_entries_reply::status::group_unavailable)) {
         // ignore this response since group is not yet bootstrapped at the

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2302,19 +2302,19 @@ void consensus::maybe_update_majority_replicated_index() {
     _consumable_offset_monitor.notify(last_visible_index());
 }
 
-bool consensus::are_heartbeats_suppressed(vnode id) const {
+heartbeats_suppressed consensus::are_heartbeats_suppressed(vnode id) const {
     if (!_fstats.contains(id)) {
-        return true;
+        return heartbeats_suppressed::yes;
     }
 
     return _fstats.get(id).suppress_heartbeats;
 }
 
 void consensus::suppress_heartbeats(
-  vnode id, follower_req_seq last_seq, bool is_suppressed) {
+  vnode id, follower_req_seq last_seq, heartbeats_suppressed suppressed) {
     if (auto it = _fstats.find(id); it != _fstats.end()) {
         if (last_seq <= it->second.last_sent_seq) {
-            it->second.suppress_heartbeats = is_suppressed;
+            it->second.suppress_heartbeats = suppressed;
         }
     }
 }

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -286,6 +286,13 @@ public:
 
     storage::log& log() { return _log; }
 
+    /**
+     * In our raft implementation heartbeats are sent outside of the consensus
+     * lock. In order to prevent reordering and do not flood followers with
+     * heartbeats that they will not be able to respond to we suppress sending
+     * heartbeats when other append entries request or heartbeat request is in
+     * flight.
+     */
     bool are_heartbeats_suppressed(vnode) const;
 
     void suppress_heartbeats(vnode, follower_req_seq, bool);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -295,7 +295,8 @@ public:
      */
     heartbeats_suppressed are_heartbeats_suppressed(vnode) const;
 
-    void suppress_heartbeats(vnode, follower_req_seq, heartbeats_suppressed);
+    void update_suppress_heartbeats(
+      vnode, follower_req_seq, heartbeats_suppressed);
 
 private:
     friend replicate_entries_stm;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -293,9 +293,9 @@ public:
      * heartbeats when other append entries request or heartbeat request is in
      * flight.
      */
-    bool are_heartbeats_suppressed(vnode) const;
+    heartbeats_suppressed are_heartbeats_suppressed(vnode) const;
 
-    void suppress_heartbeats(vnode, follower_req_seq, bool);
+    void suppress_heartbeats(vnode, follower_req_seq, heartbeats_suppressed);
 
 private:
     friend replicate_entries_stm;

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -20,12 +20,13 @@ group_manager::group_manager(
   model::node_id self,
   model::timeout_clock::duration disk_timeout,
   std::chrono::milliseconds heartbeat_interval,
+  std::chrono::milliseconds heartbeat_timeout,
   ss::sharded<rpc::connection_cache>& clients,
   ss::sharded<storage::api>& storage)
   : _self(self)
   , _disk_timeout(disk_timeout)
   , _client(make_rpc_client_protocol(self, clients))
-  , _heartbeats(heartbeat_interval, _client, _self)
+  , _heartbeats(heartbeat_interval, _client, _self, heartbeat_timeout)
   , _storage(storage.local()) {
     setup_metrics();
 }

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -38,6 +38,7 @@ public:
       model::node_id self,
       model::timeout_clock::duration disk_timeout,
       std::chrono::milliseconds heartbeat_interval,
+      std::chrono::milliseconds heartbeat_timeout,
       ss::sharded<rpc::connection_cache>& clients,
       ss::sharded<storage::api>& storage);
 

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -82,7 +82,8 @@ static std::vector<heartbeat_manager::node_heartbeat> requests_for_range(
             }
 
             auto seq_id = ptr->next_follower_sequence(rni);
-            ptr->suppress_heartbeats(rni, seq_id, heartbeats_suppressed::yes);
+            ptr->update_suppress_heartbeats(
+              rni, seq_id, heartbeats_suppressed::yes);
             pending_beats[rni.id()].emplace_back(
               heartbeat_metadata{ptr->meta(), ptr->self(), rni}, seq_id);
         };
@@ -212,7 +213,7 @@ void heartbeat_manager::process_reply(
                 vlog(hbeatlog.error, "cannot find consensus group:{}", g);
                 continue;
             }
-            (*it)->suppress_heartbeats(
+            (*it)->update_suppress_heartbeats(
               req_meta.follower_vnode, req_meta.seq, heartbeats_suppressed::no);
             // propagate error
             (*it)->process_append_entries_reply(
@@ -232,7 +233,7 @@ void heartbeat_manager::process_reply(
             continue;
         }
         auto meta = groups.find(m.group)->second;
-        (*it)->suppress_heartbeats(
+        (*it)->update_suppress_heartbeats(
           meta.follower_vnode, meta.seq, heartbeats_suppressed::no);
         (*it)->process_append_entries_reply(
           n,

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -114,8 +114,12 @@ static std::vector<heartbeat_manager::node_heartbeat> requests_for_range(
 }
 
 heartbeat_manager::heartbeat_manager(
-  duration_type interval, consensus_client_protocol proto, model::node_id self)
+  duration_type interval,
+  consensus_client_protocol proto,
+  model::node_id self,
+  duration_type heartbeat_timeout)
   : _heartbeat_interval(interval)
+  , _heartbeat_timeout(heartbeat_timeout)
   , _client_protocol(std::move(proto))
   , _self(self) {
     _heartbeat_timer.set_callback([this] { dispatch_heartbeats(); });

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -155,7 +155,6 @@ private:
     /// this is optimized for traversal + finding
     consensus_set _consensus_groups;
     consensus_client_protocol _client_protocol;
-    ss::semaphore _dispatch_sem{0};
     model::node_id _self;
 };
 } // namespace raft

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -92,6 +92,7 @@ public:
     struct follower_request_meta {
         follower_req_seq seq;
         model::offset dirty_offset;
+        vnode follower_vnode;
     };
     // Heartbeats from all groups for single node
     struct node_heartbeat {

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -111,7 +111,10 @@ public:
     };
 
     heartbeat_manager(
-      duration_type interval, consensus_client_protocol, model::node_id);
+      duration_type interval,
+      consensus_client_protocol,
+      model::node_id,
+      duration_type);
 
     ss::future<> register_group(ss::lw_shared_ptr<consensus>);
     ss::future<> deregister_group(raft::group_id);
@@ -148,6 +151,7 @@ private:
     mutex _lock;
     clock_type::time_point _hbeat = clock_type::now();
     duration_type _heartbeat_interval;
+    duration_type _heartbeat_timeout;
     timer_type _heartbeat_timer;
     /// \brief used to wait for background ops before shutting down
     ss::gate _bghbeats;

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -101,7 +101,11 @@ public:
             std::move(directory),
             1_GiB,
             storage::debug_sanitize_files::yes))
-      , _hbeats(raft_heartbeat_interval, _consensus_client_protocol, self) {}
+      , _hbeats(
+          raft_heartbeat_interval,
+          _consensus_client_protocol,
+          self,
+          raft_heartbeat_interval * 20) {}
 
     ss::lw_shared_ptr<raft::consensus> consensus_for(raft::group_id) {
         return _consensus;

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -358,10 +358,11 @@ ss::future<> recovery_stm::replicate(
     _ptr->update_node_append_timestamp(_node_id);
 
     auto seq = _ptr->next_follower_sequence(_node_id);
-    _ptr->suppress_heartbeats(_node_id, seq, heartbeats_suppressed::yes);
+    _ptr->update_suppress_heartbeats(_node_id, seq, heartbeats_suppressed::yes);
     return dispatch_append_entries(std::move(r))
       .finally([this, seq] {
-          _ptr->suppress_heartbeats(_node_id, seq, heartbeats_suppressed::no);
+          _ptr->update_suppress_heartbeats(
+            _node_id, seq, heartbeats_suppressed::no);
       })
       .then([this, seq, dirty_offset = lstats.dirty_offset](auto r) {
           if (!r) {

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -358,9 +358,11 @@ ss::future<> recovery_stm::replicate(
     _ptr->update_node_append_timestamp(_node_id);
 
     auto seq = _ptr->next_follower_sequence(_node_id);
-    _ptr->suppress_heartbeats(_node_id, seq, true);
+    _ptr->suppress_heartbeats(_node_id, seq, heartbeats_suppressed::yes);
     return dispatch_append_entries(std::move(r))
-      .finally([this, seq] { _ptr->suppress_heartbeats(_node_id, seq, false); })
+      .finally([this, seq] {
+          _ptr->suppress_heartbeats(_node_id, seq, heartbeats_suppressed::no);
+      })
       .then([this, seq, dirty_offset = lstats.dirty_offset](auto r) {
           if (!r) {
               vlog(

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -94,8 +94,10 @@ replicate_entries_stm::send_append_entries_request(
                      "append_entries_replicate", std::move(reply));
                });
     _dispatch_sem.signal();
-    return f.finally(
-      [this, n] { _ptr->suppress_heartbeats(n, _followers_seq[n], false); });
+    return f.finally([this, n] {
+        _ptr->suppress_heartbeats(
+          n, _followers_seq[n], heartbeats_suppressed::no);
+    });
 }
 
 ss::future<> replicate_entries_stm::dispatch_one(
@@ -185,7 +187,8 @@ replicate_entries_stm::apply(ss::semaphore_units<> u) {
     cfg.for_each_broker_id([this](const vnode& rni) {
         // suppress follower heartbeat, before appending to self log
         if (rni != _ptr->_self) {
-            _ptr->suppress_heartbeats(rni, _followers_seq[rni], true);
+            _ptr->suppress_heartbeats(
+              rni, _followers_seq[rni], heartbeats_suppressed::yes);
         }
     });
     return append_to_self()
@@ -211,7 +214,8 @@ replicate_entries_stm::apply(ss::semaphore_units<> u) {
                       _ctxlog.trace,
                       "Skipping sending append request to {}",
                       rni);
-                    _ptr->suppress_heartbeats(rni, _followers_seq[rni], false);
+                    _ptr->suppress_heartbeats(
+                      rni, _followers_seq[rni], heartbeats_suppressed::no);
                     return;
                 }
                 ++requests_count;

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -95,7 +95,7 @@ replicate_entries_stm::send_append_entries_request(
                });
     _dispatch_sem.signal();
     return f.finally([this, n] {
-        _ptr->suppress_heartbeats(
+        _ptr->update_suppress_heartbeats(
           n, _followers_seq[n], heartbeats_suppressed::no);
     });
 }
@@ -187,7 +187,7 @@ replicate_entries_stm::apply(ss::semaphore_units<> u) {
     cfg.for_each_broker_id([this](const vnode& rni) {
         // suppress follower heartbeat, before appending to self log
         if (rni != _ptr->_self) {
-            _ptr->suppress_heartbeats(
+            _ptr->update_suppress_heartbeats(
               rni, _followers_seq[rni], heartbeats_suppressed::yes);
         }
     });
@@ -214,7 +214,7 @@ replicate_entries_stm::apply(ss::semaphore_units<> u) {
                       _ctxlog.trace,
                       "Skipping sending append request to {}",
                       rni);
-                    _ptr->suppress_heartbeats(
+                    _ptr->update_suppress_heartbeats(
                       rni, _followers_seq[rni], heartbeats_suppressed::no);
                     return;
                 }

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -54,6 +54,7 @@ struct mux_state_machine_fixture {
             _self,
             30s,
             std::chrono::milliseconds(100),
+            std::chrono::milliseconds(2000),
             std::ref(_connections),
             std::ref(_storage))
           .get0();

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -166,7 +166,8 @@ struct raft_node {
                   ss::default_scheduling_group(),
                   ss::default_smp_service_group(),
                   raft_manager,
-                  *this);
+                  *this,
+                  heartbeat_interval);
               s.set_protocol(std::move(proto));
           })
           .get0();

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -174,7 +174,8 @@ struct raft_node {
         hbeats = std::make_unique<raft::heartbeat_manager>(
           heartbeat_interval,
           raft::make_rpc_client_protocol(broker.id(), cache),
-          broker.id());
+          broker.id(),
+          heartbeat_interval * 20);
         hbeats->start().get0();
         hbeats->register_group(consensus).get();
         started = true;

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -94,7 +94,11 @@ public:
             std::move(directory),
             1_GiB,
             storage::debug_sanitize_files::yes))
-      , _hbeats(raft_heartbeat_interval, _consensus_client_protocol, self) {}
+      , _hbeats(
+          raft_heartbeat_interval,
+          _consensus_client_protocol,
+          self,
+          raft_heartbeat_interval * 20) {}
 
     ss::lw_shared_ptr<raft::consensus> consensus_for(raft::group_id) {
         return _consensus;

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -55,7 +55,7 @@ struct protocol_metadata {
 
 // The sequence used to track the order of follower append entries request
 using follower_req_seq = named_type<uint64_t, struct follower_req_seq_tag>;
-
+using heartbeats_suppressed = ss::bool_class<struct enable_suppression_tag>;
 struct follower_index_metadata {
     explicit follower_index_metadata(vnode node)
       : node_id(node) {}
@@ -152,7 +152,7 @@ struct follower_index_metadata {
      * We prevent race conditions accessing suppress_heartbeats flag using the
      * `last_sent_seq` value for version control.
      */
-    bool suppress_heartbeats = false;
+    heartbeats_suppressed suppress_heartbeats = heartbeats_suppressed::no;
 };
 
 struct append_entries_request {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -206,7 +206,12 @@ struct append_entries_request {
 };
 
 struct append_entries_reply {
-    enum class status : uint8_t { success, failure, group_unavailable };
+    enum class status : uint8_t {
+        success,
+        failure,
+        group_unavailable,
+        timeout
+    };
     // node id to validate on receiver
     vnode target_node_id;
     /// \brief callee's node_id; work-around for batched heartbeats

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -436,6 +436,7 @@ void application::wire_up_redpanda_services() {
       model::node_id(config::shard_local_cfg().node_id()),
       config::shard_local_cfg().raft_io_timeout_ms(),
       config::shard_local_cfg().raft_heartbeat_interval_ms(),
+      config::shard_local_cfg().raft_heartbeat_timeout_ms(),
       std::ref(_raft_connection_cache),
       std::ref(storage))
       .get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -702,7 +702,8 @@ void application::start_redpanda() {
             _scheduling_groups.raft_sg(),
             smp_service_groups.raft_smp_sg(),
             partition_manager,
-            shard_table.local());
+            shard_table.local(),
+            config::shard_local_cfg().raft_heartbeat_interval_ms());
           proto->register_service<cluster::service>(
             _scheduling_groups.cluster_sg(),
             smp_service_groups.cluster_smp_sg(),


### PR DESCRIPTION
## Cover letter

Implemented back-pressure propagation in heartbeat manager. Previously we were using RPC client timeout equal to heartbeat interval, when one of the groups which heartbeat request targets is busy with doing f.e. I/O the whole heartbeat request will fail on client while server will still be processing heartbeat request. This may cause heartbeats request to
stack up on the follower causing additional pressure and more request timeouts.

To prevent this from happening implemented mechanism preventing us from sending snapshots to the node that isn't yet finished with processing previous heartbeat request.

## Release notes
Improved performance for loads that saturates the hardware.

