### PR TITLE
kafka: excludes idempotent producers from api_version

### DIFF
--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -49,7 +49,6 @@ using request_types = make_request_types<
   sasl_handshake_handler,
   sasl_authenticate_handler,
   incremental_alter_configs_handler,
-  init_producer_id_handler,
   delete_groups_handler,
   describe_acls_handler,
   describe_log_dirs_handler>;


### PR DESCRIPTION
The feature isn't ready yet, updating api_version to send correct error code to kafka clients