### PR TITLE
operator: update configmap when CR changes

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -76,8 +76,16 @@ func (r *ConfigMapResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to construct object: %w", err)
 	}
-	_, err = CreateIfNotExists(ctx, r, obj, r.logger)
-	return err
+	created, err := CreateIfNotExists(ctx, r, obj, r.logger)
+	if err != nil || created {
+		return err
+	}
+	var cm corev1.ConfigMap
+	err = r.Get(ctx, r.Key(), &cm)
+	if err != nil {
+		return fmt.Errorf("error while fetching ConfigMap resource: %w", err)
+	}
+	return Update(ctx, &cm, obj, r.Client, r.logger)
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -85,12 +85,12 @@ func Update(
 	}
 	if !patchResult.IsEmpty() {
 		// need to set current version first otherwise the request would get rejected
-		logger.Info(fmt.Sprintf("StatefulSet changed, updating %s. Diff: %v", modified.GetName(), string(patchResult.Patch)))
+		logger.Info(fmt.Sprintf("Resource changed, updating %s. Diff: %v", modified.GetName(), string(patchResult.Patch)))
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(modified); err != nil {
 			return err
 		}
 		if err := c.Update(ctx, modified); err != nil {
-			return fmt.Errorf("failed to update StatefulSet: %w", err)
+			return fmt.Errorf("failed to update resource: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Cover letter

This supports patching configmap when some value in the configuration changes. This is important to allow updating running cluster after it was deployed.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
ConfigMap is updated after CustomResource changes.