### PR TITLE
operator: all errors should retry reconciliation

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -126,6 +126,7 @@ func (r *ClusterReconciler) Reconcile(
 
 		if err != nil {
 			log.Error(err, "Failed to reconcile resource")
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -118,7 +118,7 @@ func (r *ClusterReconciler) Reconcile(
 	for _, res := range toApply {
 		err := res.Ensure(ctx)
 
-		var e *resources.NeedToReconcileError
+		var e *resources.RequeueAfterError
 		if errors.As(err, &e) {
 			log.Info(e.Error())
 			return ctrl.Result{RequeueAfter: e.RequeueAfter}, nil

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -125,18 +125,17 @@ func (r *StatefulSetResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if created {
+		r.LastObservedState = obj.(*appsv1.StatefulSet)
+		return nil
+	}
 
 	err = r.Get(ctx, r.Key(), &sts)
 	if err != nil {
 		return fmt.Errorf("error while fetching StatefulSet resource: %w", err)
 	}
-
 	r.LastObservedState = &sts
 
-	if created {
-		// we don't need to update since we've just created the resource
-		return nil
-	}
 	partitioned, err := r.shouldUsePartitionedUpdate(&sts)
 	if err != nil {
 		return err

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -127,7 +127,7 @@ func (r *StatefulSetResource) partitionUpdateImage(
 		// Before continuing to update the ith Pod, verify that the previously updated
 		// Pod (if any) has rejoined its groups after restarting, i.e., is ready for I/O.
 		if err := r.ensureRedpandaGroupsReady(ctx, sts, replicas, ordinal+1); err != nil {
-			return &NeedToReconcileError{RequeueAfter: requeueDuration,
+			return &RequeueAfterError{RequeueAfter: requeueDuration,
 				Msg: fmt.Sprintf("redpanda on pod (ordinal: %d) not ready", ordinal)}
 		}
 
@@ -136,13 +136,13 @@ func (r *StatefulSetResource) partitionUpdateImage(
 		}
 
 		// Restarting the Pod takes enough time to warrant a requeue.
-		return &NeedToReconcileError{RequeueAfter: requeueDuration,
+		return &RequeueAfterError{RequeueAfter: requeueDuration,
 			Msg: fmt.Sprintf("wait for pod (ordinal: %d) to restart", ordinal)}
 	}
 
 	// Ensure 0th Pod is ready for I/O before completing the upgrade.
 	if err := r.ensureRedpandaGroupsReady(ctx, sts, replicas, 0); err != nil {
-		return &NeedToReconcileError{RequeueAfter: requeueDuration,
+		return &RequeueAfterError{RequeueAfter: requeueDuration,
 			Msg: fmt.Sprintf("redpanda on pod (ordinal: %d) not ready", 0)}
 	}
 
@@ -321,14 +321,14 @@ func podIsReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// NeedToReconcileError error carrying the time after which to requeue.
-type NeedToReconcileError struct {
+// RequeueAfterError error carrying the time after which to requeue.
+type RequeueAfterError struct {
 	RequeueAfter time.Duration
 	Msg          string
 }
 
-func (e *NeedToReconcileError) Error() string {
-	return fmt.Sprintf("NeedToReconcileError %s", e.Msg)
+func (e *RequeueAfterError) Error() string {
+	return fmt.Sprintf("RequeueAfterError %s", e.Msg)
 }
 
 var errContainerHasWrongImage = errors.New("container has wrong image")


### PR DESCRIPTION
## Cover letter

Currently errors were not retrying reconciliation https://github.com/vectorizedio/redpanda/compare/dev...alenkacz:av/reconcile-error#diff-208e6df471016ebc997b72c36741150b86b9023d2d8d698bbcb3a8e56f0f84d2L128 and that was wrong and was producing errors in logs. All errors in our resources currently are fatal and should retry reconciliation (with no requeueafter - using default).

Not doing this was e.g. producing errors because we're doing GET after CREATE here https://github.com/vectorizedio/redpanda/compare/dev...alenkacz:av/reconcile-error#diff-11cd0daf9c52813e733b2526ffd440b85ff6e9a8f6a11d8454c02cbd129bcb60R133

This is not possible because we're using cached client and that cache is populated from watch, not from our create call so GET after CREATE will fail in most cases.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
Retry reconciliation after error happened in resource management.