### PR TITLE
Handling synonyms in describe configs request handler

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -109,18 +109,18 @@ std::optional<model::node_id> metadata_cache::get_controller_leader_id() {
  * hard coded defaults
  */
 model::compression metadata_cache::get_default_compression() const {
-    return model::compression::producer;
+    return config::shard_local_cfg().log_compression_type();
 }
 model::cleanup_policy_bitflags
 metadata_cache::get_default_cleanup_policy_bitflags() const {
-    return model::cleanup_policy_bitflags::deletion;
+    return config::shard_local_cfg().log_cleanup_policy();
 }
 model::compaction_strategy
 metadata_cache::get_default_compaction_strategy() const {
     return model::compaction_strategy::offset;
 }
 model::timestamp_type metadata_cache::get_default_timestamp_type() const {
-    return model::timestamp_type::create_time;
+    return config::shard_local_cfg().log_message_timestamp_type();
 }
 /**
  * We use configuration directly to access default topic properties, in future

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -287,6 +287,24 @@ configuration::configuration()
       "alter configuration requst",
       required::no,
       5s)
+  , log_cleanup_policy(
+      *this,
+      "log_cleanup_policy",
+      "Default topic cleanup policy",
+      required::no,
+      model::cleanup_policy_bitflags::deletion)
+  , log_message_timestamp_type(
+      *this,
+      "log_message_timestamp_type",
+      "Default topic messages timestamp type",
+      required::no,
+      model::timestamp_type::create_time)
+  , log_compression_type(
+      *this,
+      "log_compression_type",
+      "Default topic compression type",
+      required::no,
+      model::compression::producer)
   , transactional_id_expiration_ms(
       *this,
       "transactional_id_expiration_ms",

--- a/src/v/kafka/protocol/schemata/describe_configs_request.json
+++ b/src/v/kafka/protocol/schemata/describe_configs_request.json
@@ -31,7 +31,7 @@
       { "name": "ConfigurationKeys", "type": "[]string", "versions": "0+", "nullableVersions": "0+",
         "about": "The configuration keys to list, or null to list all configuration keys." }
     ]},
-    { "name": "IncludeSynoyms", "type": "bool", "versions": "1+", "default": "false", "ignorable": false,
+    { "name": "IncludeSynonyms", "type": "bool", "versions": "1+", "default": "false", "ignorable": false,
       "about": "True if we should include all synonyms." }
   ]
 }

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -20,6 +20,7 @@
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/validation.h"
+#include "ssx/sformat.h"
 
 #include <seastar/core/do_with.hh>
 #include <seastar/core/smp.hh>
@@ -41,7 +42,7 @@ static void add_config(
   describe_configs_source source) {
     result.configs.push_back(describe_configs_resource_result{
       .name = ss::sstring(name),
-      .value = fmt::format("{}", value),
+      .value = ssx::sformat("{}", value),
       .config_source = source,
     });
 }
@@ -55,7 +56,7 @@ kafka_endpoint_format(const std::vector<model::broker_endpoint>& endpoints) {
       endpoints.cend(),
       std::back_inserter(uris),
       [](const model::broker_endpoint& ep) {
-          return fmt::format(
+          return ssx::sformat(
             "{}://{}:{}",
             (ep.name.empty() ? "plain" : ep.name),
             ep.address.host(),
@@ -74,7 +75,7 @@ static void report_broker_config(describe_configs_result& result) {
         if (res.ec == std::errc()) {
             if (broker_id != config::shard_local_cfg().node_id()) {
                 result.error_code = error_code::invalid_request;
-                result.error_message = fmt::format(
+                result.error_message = ssx::sformat(
                   "Unexpected broker id {} expected {}",
                   broker_id,
                   config::shard_local_cfg().node_id());
@@ -82,7 +83,7 @@ static void report_broker_config(describe_configs_result& result) {
             }
         } else {
             result.error_code = error_code::invalid_request;
-            result.error_message = fmt::format(
+            result.error_message = ssx::sformat(
               "Broker id must be an integer but received {}",
               result.resource_name);
             return;

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -47,6 +47,75 @@ static void add_config(
     });
 }
 
+template<typename T>
+static ss::sstring describe_as_string(const T& t) {
+    return ssx::sformat("{}", t);
+}
+
+template<typename T, typename Func>
+static void add_topic_config(
+  describe_configs_result& result,
+  std::string_view default_name,
+  const T& default_value,
+  std::string_view override_name,
+  const std::optional<T>& overrides,
+  bool include_synonyms,
+  Func&& describe_f) {
+    describe_configs_source src = overrides
+                                    ? describe_configs_source::topic
+                                    : describe_configs_source::default_config;
+
+    std::vector<describe_configs_synonym> synonyms;
+    if (include_synonyms) {
+        synonyms.reserve(2);
+        if (overrides) {
+            synonyms.push_back(describe_configs_synonym{
+              .name = ss::sstring(override_name),
+              .value = describe_f(*overrides),
+              .source = static_cast<int8_t>(describe_configs_source::topic),
+            });
+        }
+        synonyms.push_back(describe_configs_synonym{
+          .name = ss::sstring(default_name),
+          .value = describe_f(default_value),
+          .source = static_cast<int8_t>(
+            describe_configs_source::default_config),
+        });
+    }
+
+    result.configs.push_back(describe_configs_resource_result{
+      .name = ss::sstring(override_name),
+      .value = describe_f(overrides.value_or(default_value)),
+      .config_source = src,
+      .synonyms = std::move(synonyms),
+    });
+}
+
+template<typename T>
+static void add_topic_config(
+  describe_configs_result& result,
+  std::string_view default_name,
+  const std::optional<T>& default_value,
+  std::string_view override_name,
+  const tristate<T>& overrides,
+  bool include_synonyms) {
+    std::optional<ss::sstring> override_value;
+    if (overrides.is_disabled()) {
+        override_value = "-1";
+    } else if (overrides.has_value()) {
+        override_value = ssx::sformat("{}", overrides.value());
+    }
+
+    add_topic_config(
+      result,
+      default_name,
+      default_value ? ssx::sformat("{}", default_value.value()) : "-1",
+      override_name,
+      override_value,
+      include_synonyms,
+      [](const ss::sstring& s) { return s; });
+}
+
 static ss::sstring
 kafka_endpoint_format(const std::vector<model::broker_endpoint>& endpoints) {
     std::vector<ss::sstring> uris;
@@ -180,7 +249,9 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 result.error_code = error_code::unknown_topic_or_partition;
                 continue;
             }
-
+            /**
+             * Redpanda extensions
+             */
             add_config(
               result,
               "partition_count",
@@ -192,54 +263,65 @@ ss::future<response_ptr> describe_configs_handler::handle(
               "replication_factor",
               topic_config->replication_factor,
               describe_configs_source::topic);
-
-            add_config(
+            /**
+             * Kafka properties
+             */
+            add_topic_config(
               result,
-              topic_property_cleanup_policy,
-              describe_topic_cleanup_policy(
-                topic_config,
-                ctx.metadata_cache().get_default_cleanup_policy_bitflags()),
-              describe_configs_source::topic);
-
-            add_config(
-              result,
+              config::shard_local_cfg().log_compression_type.name(),
+              ctx.metadata_cache().get_default_compression(),
               topic_property_compression,
-              topic_config->properties.compression.value_or(
-                ctx.metadata_cache().get_default_compression()),
-              describe_configs_source::topic);
+              topic_config->properties.compression,
+              request.data.include_synonyms,
+              &describe_as_string<model::compression>);
 
-            add_config(
+            add_topic_config(
               result,
+              config::shard_local_cfg().log_cleanup_policy.name(),
+              ctx.metadata_cache().get_default_cleanup_policy_bitflags(),
+              topic_property_cleanup_policy,
+              topic_config->properties.cleanup_policy_bitflags,
+              request.data.include_synonyms,
+              &describe_as_string<model::cleanup_policy_bitflags>);
+
+            add_topic_config(
+              result,
+              topic_config->properties.is_compacted()
+                ? config::shard_local_cfg().compacted_log_segment_size.name()
+                : config::shard_local_cfg().log_segment_size.name(),
+              topic_config->properties.is_compacted()
+                ? ctx.metadata_cache()
+                    .get_default_compacted_topic_segment_size()
+                : ctx.metadata_cache().get_default_segment_size(),
               topic_property_segment_size,
-              topic_config->properties.segment_size.value_or(
-                topic_config->properties.is_compacted()
-                  ? ctx.metadata_cache()
-                      .get_default_compacted_topic_segment_size()
-                  : ctx.metadata_cache().get_default_segment_size()),
-              describe_configs_source::topic);
+              topic_config->properties.segment_size,
+              request.data.include_synonyms,
+              &describe_as_string<size_t>);
 
-            add_config(
+            add_topic_config(
               result,
+              config::shard_local_cfg().delete_retention_ms.name(),
+              ctx.metadata_cache().get_default_retention_duration(),
               topic_property_retention_duration,
-              describe_retention_duration(
-                topic_config->properties.retention_duration,
-                ctx.metadata_cache().get_default_retention_duration()),
-              describe_configs_source::topic);
+              topic_config->properties.retention_duration,
+              request.data.include_synonyms);
 
-            add_config(
+            add_topic_config(
               result,
+              config::shard_local_cfg().retention_bytes.name(),
+              ctx.metadata_cache().get_default_retention_bytes(),
               topic_property_retention_bytes,
-              describe_retention_bytes(
-                topic_config->properties.retention_bytes,
-                ctx.metadata_cache().get_default_retention_bytes()),
-              describe_configs_source::topic);
+              topic_config->properties.retention_bytes,
+              request.data.include_synonyms);
 
-            add_config(
+            add_topic_config(
               result,
+              config::shard_local_cfg().log_message_timestamp_type.name(),
+              ctx.metadata_cache().get_default_timestamp_type(),
               topic_property_timestamp_type,
-              topic_config->properties.timestamp_type.value_or(
-                ctx.metadata_cache().get_default_timestamp_type()),
-              describe_configs_source::topic);
+              topic_config->properties.timestamp_type,
+              request.data.include_synonyms,
+              &describe_as_string<model::timestamp_type>);
 
             break;
         }

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -327,8 +327,11 @@ static ss::future<produce_response::partition> produce_topic_partition(
      * metadata cache. For append time setting we have to recalculate
      * the CRC.
      */
-    auto timestamp_type = octx.rctx.metadata_cache().get_topic_timestamp_type(
-      model::topic_namespace_view(model::kafka_namespace, topic.name));
+    auto timestamp_type
+      = octx.rctx.metadata_cache()
+          .get_topic_timestamp_type(
+            model::topic_namespace_view(model::kafka_namespace, topic.name))
+          .value_or(octx.rctx.metadata_cache().get_default_timestamp_type());
 
     if (timestamp_type == model::timestamp_type::append_time) {
         batch.set_max_timestamp(

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -184,9 +184,4 @@ ss::future<std::vector<model::node_id>> wait_for_leaders(
   cluster::metadata_cache&,
   std::vector<cluster::topic_result>,
   model::timeout_clock::time_point);
-
-ss::sstring describe_topic_cleanup_policy(
-  const std::optional<cluster::topic_configuration>&,
-  model::cleanup_policy_bitflags);
-
 } // namespace kafka

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -290,6 +290,8 @@ std::ostream& operator<<(std::ostream& os, describe_configs_source s) {
         return os << "{topic}";
     case describe_configs_source::static_broker_config:
         return os << "{static_broker_config}";
+    case describe_configs_source::default_config:
+        return os << "{default_config}";
     }
     return os << "{unknown type}";
 }

--- a/src/v/kafka/server/tests/topic_utils_test.cc
+++ b/src/v/kafka/server/tests/topic_utils_test.cc
@@ -209,30 +209,3 @@ BOOST_AUTO_TEST_CASE(shall_return_errors_for_all_requests) {
     BOOST_REQUIRE_EQUAL(errs.size(), 3);
     BOOST_REQUIRE_EQUAL(std::distance(requests.begin(), valid_range_end), 0);
 };
-
-BOOST_AUTO_TEST_CASE(describe_topics_cleanup_policy_test) {
-    model::cleanup_policy_bitflags def
-      = model::cleanup_policy_bitflags::deletion;
-    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy({}, def), "delete");
-
-    cluster::topic_configuration config(
-      model::ns("ns"), model::topic("topic"), 1, 1);
-
-    config.properties.cleanup_policy_bitflags
-      = model::cleanup_policy_bitflags::none;
-    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config, def), "delete");
-
-    config.properties.cleanup_policy_bitflags
-      = model::cleanup_policy_bitflags::compaction;
-    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config, def), "compact");
-
-    config.properties.cleanup_policy_bitflags
-      = model::cleanup_policy_bitflags::deletion;
-    BOOST_REQUIRE_EQUAL(describe_topic_cleanup_policy(config, def), "delete");
-
-    config.properties.cleanup_policy_bitflags
-      = model::cleanup_policy_bitflags::deletion
-        | model::cleanup_policy_bitflags::compaction;
-    BOOST_REQUIRE_EQUAL(
-      describe_topic_cleanup_policy(config, def), "compact,delete");
-};

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -119,9 +119,9 @@ std::ostream& operator<<(std::ostream& os, config_resource_operation);
 enum class describe_configs_source : int8_t {
     topic = 1,
     static_broker_config = 4,
+    default_config = 5,
     // DYNAMIC_BROKER_CONFIG((byte) 2),
     // DYNAMIC_DEFAULT_BROKER_CONFIG((byte) 3),
-    // DEFAULT_CONFIG((byte) 5),
     // DYNAMIC_BROKER_LOGGER_CONFIG((byte) 6);
 };
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -314,22 +314,28 @@ std::istream& operator>>(std::istream& i, timestamp_type& ts_type) {
 };
 
 std::ostream& operator<<(std::ostream& o, cleanup_policy_bitflags c) {
-    o << "{";
-    auto has_prev = false;
-    if (std::underlying_type_t<cleanup_policy_bitflags>(
-          c & cleanup_policy_bitflags::deletion)) {
-        o << "cleanup_policy_bitflags::deletion";
+    if (c == model::cleanup_policy_bitflags::none) {
+        o << "none";
+        return o;
     }
 
-    if (std::underlying_type_t<cleanup_policy_bitflags>(
-          c & cleanup_policy_bitflags::compaction)) {
-        if (has_prev) {
-            o << " | ";
-        }
-        o << "cleanup_policy_bitflags::compaction";
+    auto compaction = (c & model::cleanup_policy_bitflags::compaction)
+                      == model::cleanup_policy_bitflags::compaction;
+    auto deletion = (c & model::cleanup_policy_bitflags::deletion)
+                    == model::cleanup_policy_bitflags::deletion;
+
+    if (compaction && deletion) {
+        o << "compact,delete";
+        return o;
     }
 
-    return o << "}";
+    if (compaction) {
+        o << "compact";
+    } else if (deletion) {
+        o << "delete";
+    }
+
+    return o;
 }
 
 std::istream& operator>>(std::istream& i, cleanup_policy_bitflags& cp) {


### PR DESCRIPTION
## Cover letter
Added handling of synonyms in `DescribeConfigurationsRequest`. Additionally added missing configuration properties allowing setting default topic configuration properties.

Fixes issues: [#978]

## Release notes
- Handling synonyms in `DescribeConfigurationsRequest`
- All topic configuration properties have configurable defaults

Release note: [1-2 sentences of what this PR changes]
