### PR TITLE
Pandaproxy ducktape tests part3

### DIFF
--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -22,6 +22,10 @@ struct reply_error_category final : std::error_category {
     const char* name() const noexcept override { return "pandaproxy"; }
     std::string message(int ev) const override {
         switch (static_cast<reply_error_code>(ev)) {
+        case reply_error_code::not_acceptable:
+            return "HTTP 406 Not Acceptable";
+        case reply_error_code::unsupported_media_type:
+            return "HTTP 415 Unsupported Media Type";
         case reply_error_code::kafka_bad_request:
             return "kafka_bad_request";
         case reply_error_code::kafka_authentication_error:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -25,6 +25,8 @@ namespace pandaproxy {
 // This is the default_error_condition for the proxy; to map other
 // error_codes to this, override its error_category::default_error_condition().
 enum class reply_error_code : uint16_t {
+    not_acceptable = 406,
+    unsupported_media_type = 415,
     kafka_bad_request = 40002,
     kafka_authentication_error = 40101,
     kafka_authorization_error = 40301,

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -113,11 +113,9 @@ get_topics_names(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 get_topics_records(server::request_t rq, server::reply_t rp) {
-    auto fmt = parse_serialization_format(rq.req->get_header("Accept"));
-    if (fmt == ppj::serialization_format::unsupported) {
-        rp.rep = unprocessable_entity("Unsupported serialization format");
-        return ss::make_ready_future<server::reply_t>(std::move(rp));
-    }
+    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    auto res_fmt = parse::accept_header(
+      *rq.req, {json::serialization_format::binary_v2});
 
     auto tp{model::topic_partition{
       parse::request_param<model::topic>(*rq.req, "topic_name"),
@@ -130,15 +128,16 @@ get_topics_records(server::request_t rq, server::reply_t rp) {
     rq.req.reset();
     return rq.ctx.client
       .fetch_partition(std::move(tp), offset, max_bytes, timeout)
-      .then([fmt, rp = std::move(rp)](kafka::fetch_response res) mutable {
+      .then([res_fmt, rp = std::move(rp)](kafka::fetch_response res) mutable {
           rapidjson::StringBuffer str_buf;
           rapidjson::Writer<rapidjson::StringBuffer> w(str_buf);
 
-          ppj::rjson_serialize_fmt(fmt)(w, std::move(res));
+          ppj::rjson_serialize_fmt(res_fmt)(w, std::move(res));
 
           // TODO Ben: Prevent this linearization
           ss::sstring json_rslt = str_buf.GetString();
           rp.rep->write_body("json", json_rslt);
+          rp.mime_type = res_fmt;
           return std::move(rp);
       });
 }

--- a/src/v/pandaproxy/json/types.h
+++ b/src/v/pandaproxy/json/types.h
@@ -12,10 +12,30 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace pandaproxy::json {
 
-enum class serialization_format : uint8_t { none = 0, binary_v2, unsupported };
+enum class serialization_format : uint8_t {
+    none = 0,
+    json_v2,
+    binary_v2,
+    unsupported
+};
+
+inline std::string_view name(serialization_format fmt) {
+    switch (fmt) {
+    case pandaproxy::json::serialization_format::none:
+        return "none";
+    case pandaproxy::json::serialization_format::json_v2:
+        return "application/vnd.kafka.v2+json";
+    case pandaproxy::json::serialization_format::binary_v2:
+        return "application/vnd.kafka.binary.v2+json";
+    case pandaproxy::json::serialization_format::unsupported:
+        return "unsupported";
+    }
+    return "(unknown format)";
+}
 
 template<typename T>
 class rjson_parse_impl;

--- a/src/v/pandaproxy/parsing/error.cc
+++ b/src/v/pandaproxy/parsing/error.cc
@@ -25,6 +25,10 @@ struct error_category final : std::error_category {
             return "empty_param";
         case error_code::invalid_param:
             return "invalid_param";
+        case error_code::not_acceptable:
+            return "not_acceptable";
+        case error_code::unsupported_media_type:
+            return "unsupported_media_type";
         }
         return "(unrecognized error)";
     }
@@ -35,6 +39,10 @@ struct error_category final : std::error_category {
         case error_code::empty_param:
         case error_code::invalid_param:
             return reply_error_code::kafka_bad_request;
+        case error_code::not_acceptable:
+            return reply_error_code::not_acceptable;
+        case error_code::unsupported_media_type:
+            return reply_error_code::unsupported_media_type;
         }
         return {};
     }

--- a/src/v/pandaproxy/parsing/error.h
+++ b/src/v/pandaproxy/parsing/error.h
@@ -20,6 +20,8 @@ enum class error_code : uint16_t {
     // ok = 0
     empty_param = 100,
     invalid_param = 101,
+    not_acceptable = 406,
+    unsupported_media_type = 415,
 };
 
 std::error_code make_error_code(error_code);

--- a/src/v/pandaproxy/parsing/exceptions.h
+++ b/src/v/pandaproxy/parsing/exceptions.h
@@ -17,23 +17,30 @@
 
 #include <stdexcept>
 #include <string>
+#include <system_error>
 
 namespace pandaproxy::parse {
 
 struct exception_base : std::exception {
-    exception_base(error_code err, std::string_view msg)
+    explicit exception_base(std::error_condition err)
+      : std::exception{}
+      , error{err}
+      , msg{err.message()} {}
+    exception_base(std::error_condition err, std::string_view msg)
       : std::exception{}
       , error{err}
       , msg{msg} {}
     const char* what() const noexcept final { return msg.c_str(); }
-    error_code error;
+    std::error_condition error;
     std::string msg;
 };
 
 class error final : public exception_base {
 public:
-    explicit error(error_code ec, std::string_view msg)
-      : exception_base(ec, msg) {}
+    explicit error(error_code ec)
+      : exception_base(make_error_code(ec).default_error_condition()) {}
+    error(error_code ec, std::string_view msg)
+      : exception_base(make_error_code(ec).default_error_condition(), msg) {}
 };
 
 } // namespace pandaproxy::parse

--- a/src/v/pandaproxy/parsing/test/CMakeLists.txt
+++ b/src/v/pandaproxy/parsing/test/CMakeLists.txt
@@ -3,6 +3,7 @@ rp_test(
   BINARY_NAME pandaproxy_parsing_unit
   SOURCES
     from_chars.cc
+    httpd.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::pandaproxy_parsing
   LABELS pandaproxy

--- a/src/v/pandaproxy/parsing/test/httpd.cc
+++ b/src/v/pandaproxy/parsing/test/httpd.cc
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/parsing/httpd.h"
+
+#include "pandaproxy/json/types.h"
+
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <boost/tuple/tuple_io.hpp>
+#include <boost/utility/string_view.hpp>
+
+namespace bdata = boost::unit_test::data;
+namespace pp = pandaproxy;
+namespace ppj = pp::json;
+
+namespace pandaproxy::json {
+std::ostream& operator<<(std::ostream& os, serialization_format fmt) {
+    return os << name(fmt);
+}
+} // namespace pandaproxy::json
+
+using ppjfmt = ppj::serialization_format;
+
+static const std::vector<
+  boost::
+    tuple<std::string_view, std::vector<ppjfmt>, ppj::serialization_format>>
+  success_samples{
+    // Simple cases
+    {"", {ppjfmt::none}, ppjfmt::none},
+    {"*/*", {ppjfmt::none}, ppjfmt::none},
+    {name(ppjfmt::json_v2), {ppjfmt::json_v2}, ppjfmt::json_v2},
+    {name(ppjfmt::binary_v2), {ppjfmt::binary_v2}, ppjfmt::binary_v2},
+    // Prefer first entry
+    {name(ppjfmt::json_v2), {ppjfmt::json_v2, ppjfmt::none}, ppjfmt::json_v2},
+    {"", {ppjfmt::json_v2, ppjfmt::none}, ppjfmt::json_v2},
+    // Unsupported
+    {name(ppjfmt::json_v2),
+     {ppjfmt::binary_v2, ppjfmt::none},
+     ppjfmt::unsupported},
+  };
+
+BOOST_DATA_TEST_CASE(
+  parse_serialization_format_success, bdata::make(success_samples), sample) {
+    BOOST_REQUIRE_EQUAL(
+      pp::parse::detail::parse_serialization_format(
+        boost::get<0>(sample), boost::get<1>(sample)),
+      boost::get<2>(sample));
+}

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "pandaproxy/context.h"
+#include "pandaproxy/json/types.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
@@ -46,7 +47,8 @@ public:
 
     struct reply_t {
         std::unique_ptr<ss::httpd::reply> rep;
-        // will contains other extensions passed to user specific handler.
+        json::serialization_format mime_type;
+        // will contain other extensions passed to user specific handler.
     };
 
     using function_handler

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -154,7 +154,13 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
 })");
         auto body = iobuf();
         body.append(produce_body.data(), produce_body.size());
-        auto res = http_request(client, "/topics/t", std::move(body));
+        auto res = http_request(
+          client,
+          "/topics/t",
+          std::move(body),
+          boost::beast::http::verb::post,
+          ppj::serialization_format::binary_v2,
+          ppj::serialization_format::json_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -124,7 +124,13 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         set_client_config("retries", size_t(5));
         auto body = iobuf();
         body.append(batch_1_body.data(), batch_1_body.size());
-        auto res = http_request(client, "/topics/t", std::move(body));
+        auto res = http_request(
+          client,
+          "/topics/t",
+          std::move(body),
+          boost::beast::http::verb::post,
+          ppj::serialization_format::binary_v2,
+          ppj::serialization_format::json_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -155,7 +161,13 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         set_client_config("retries", size_t(0));
         auto body = iobuf();
         body.append(batch_2_body.data(), batch_2_body.size());
-        auto res = http_request(client, "/topics/t", std::move(body));
+        auto res = http_request(
+          client,
+          "/topics/t",
+          std::move(body),
+          boost::beast::http::verb::post,
+          ppj::serialization_format::binary_v2,
+          ppj::serialization_format::json_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -9,6 +9,7 @@
 
 #include "http/client.h"
 #include "pandaproxy/configuration.h"
+#include "pandaproxy/json/types.h"
 #include "pandaproxy/test/pandaproxy_fixture.h"
 #include "pandaproxy/test/utils.h"
 
@@ -17,7 +18,7 @@
 #include <boost/beast/http/verb.hpp>
 #include <boost/test/tools/old/interface.hpp>
 
-namespace kc = kafka::client;
+namespace ppj = pandaproxy::json;
 
 FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
     using namespace std::chrono_literals;
@@ -64,7 +65,10 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         auto res = http_request(
           client,
           "/topics//partitions/0/"
-          "records?max_bytes=1024&timeout=5000");
+          "records?max_bytes=1024&timeout=5000",
+          boost::beast::http::verb::get,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::bad_request);
@@ -79,7 +83,10 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         auto res = http_request(
           client,
           "/topics//partitions/0/"
-          "records?offset=0&max_bytes=1024&timeout=5000");
+          "records?offset=0&max_bytes=1024&timeout=5000",
+          boost::beast::http::verb::get,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::bad_request);
@@ -94,7 +101,10 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         auto res = http_request(
           client,
           "/topics/t/partitions/0/"
-          "records?offset=0&max_bytes=1024&timeout=5000");
+          "records?offset=0&max_bytes=1024&timeout=5000",
+          boost::beast::http::verb::get,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::not_found);
@@ -128,7 +138,10 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         auto res = http_request(
           client,
           "/topics/t/partitions/0/"
-          "records?offset=0&max_bytes=1024&timeout=5000");
+          "records?offset=0&max_bytes=1024&timeout=5000",
+          boost::beast::http::verb::get,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -155,7 +168,10 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         auto res = http_request(
           client,
           "/topics/t/partitions/0/"
-          "records?offset=4&max_bytes=1024&timeout=5000");
+          "records?offset=4&max_bytes=1024&timeout=5000",
+          boost::beast::http::verb::get,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -169,7 +185,10 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         auto res = http_request(
           client,
           "/topics/t/partitions/0/"
-          "records?offset=2&max_bytes=1024&timeout=5000");
+          "records?offset=2&max_bytes=1024&timeout=5000",
+          boost::beast::http::verb::get,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);

--- a/src/v/pandaproxy/test/list_topics.cc
+++ b/src/v/pandaproxy/test/list_topics.cc
@@ -35,7 +35,7 @@ FIXTURE_TEST(pandaproxy_list_topics, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(res.body, R"([])");
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
-          "application/vnd.kafka.binary.v2+json");
+          to_header_value(serialization_format::json_v2));
     }
 
     info("Adding known topic");

--- a/src/v/pandaproxy/test/produce.cc
+++ b/src/v/pandaproxy/test/produce.cc
@@ -17,7 +17,7 @@
 #include <boost/beast/http/verb.hpp>
 #include <boost/test/tools/old/interface.hpp>
 
-namespace kc = kafka::client;
+namespace ppj = pandaproxy::json;
 
 FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
     using namespace std::chrono_literals;
@@ -53,13 +53,19 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
         set_client_config("retries", size_t(0));
         auto body = iobuf();
         body.append(produce_body.data(), produce_body.size());
-        auto res = http_request(client, "/topics/t", std::move(body));
+        auto res = http_request(
+          client,
+          "/topics/t",
+          std::move(body),
+          boost::beast::http::verb::post,
+          ppj::serialization_format::binary_v2,
+          ppj::serialization_format::json_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
-          "application/vnd.kafka.binary.v2+json");
+          to_header_value(serialization_format::json_v2));
         BOOST_REQUIRE_EQUAL(
           res.body,
           R"({"offsets":[{"partition":0,"error_code":3,"offset":-1}]})");
@@ -76,7 +82,13 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
         set_client_config("retries", size_t(5));
         auto body = iobuf();
         body.append(produce_body.data(), produce_body.size());
-        auto res = http_request(client, "/topics/t", std::move(body));
+        auto res = http_request(
+          client,
+          "/topics/t",
+          std::move(body),
+          boost::beast::http::verb::post,
+          ppj::serialization_format::binary_v2,
+          ppj::serialization_format::json_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -89,7 +101,13 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
         set_client_config("retries", size_t(0));
         auto body = iobuf();
         body.append(produce_body.data(), produce_body.size());
-        auto res = http_request(client, "/topics/t", std::move(body));
+        auto res = http_request(
+          client,
+          "/topics/t",
+          std::move(body),
+          boost::beast::http::verb::post,
+          ppj::serialization_format::binary_v2,
+          ppj::serialization_format::json_v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -12,7 +12,6 @@ quick:
   - tests/
 
   excluded:
-  - tests/pandaproxy_test.py
   - tests/librdkafka_test.py
   - tests/rpk_test.py
   - tests/demo_test.py

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -105,7 +105,7 @@ class PandaProxyTest(RedpandaTest):
         return requests.get(f"{self._base_uri()}/topics", headers=headers)
 
     def _produce_topic(self, topic, data):
-        return requests.post(f"{self._base_uri()}/topics/{topic}", data).json()
+        return requests.post(f"{self._base_uri()}/topics/{topic}", data)
 
     def _fetch_topic(self,
                      topic,
@@ -209,7 +209,9 @@ class PandaProxyTest(RedpandaTest):
         }'''
 
         self.logger.info(f"Producing to non-existant topic: {name}")
-        produce_result = self._produce_topic(name, data)
+        produce_result_raw = self._produce_topic(name, data)
+        assert produce_result_raw.status_code == requests.codes.ok
+        produce_result = produce_result_raw.json()
         for o in produce_result["offsets"]:
             assert o["error_code"] == 3
             assert o["offset"] == -1
@@ -221,7 +223,9 @@ class PandaProxyTest(RedpandaTest):
         self._wait_for_topic(name)
 
         self.logger.info(f"Producing to topic: {name}")
-        produce_result = self._produce_topic(name, data)
+        produce_result_raw = self._produce_topic(name, data)
+        assert produce_result_raw.status_code == requests.codes.ok
+        produce_result = produce_result_raw.json()
         for o in produce_result["offsets"]:
             assert o["offset"] == 1, f'error_code {o["error_code"]}'
 
@@ -314,8 +318,9 @@ class PandaProxyTest(RedpandaTest):
                 {"value": "bXVsdGlicm9rZXI=", "partition": 2}
             ]
         }'''
-        produce_result = self._produce_topic(name, data)
-
+        produce_result_raw = self._produce_topic(name, data)
+        assert produce_result_raw.status_code == requests.codes.ok
+        produce_result = produce_result_raw.json()
         for o in produce_result["offsets"]:
             assert o["offset"] == 1, f'error_code {o["error_code"]}'
 

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -34,6 +34,11 @@ HTTP_FETCH_TOPIC_HEADERS = {
     "Content-Type": "application/vnd.kafka.v2+json"
 }
 
+HTTP_PRODUCE_TOPIC_HEADERS = {
+    "Accept": "application/vnd.kafka.v2+json",
+    "Content-Type": "application/vnd.kafka.binary.v2+json"
+}
+
 
 class Consumer:
     def __init__(self, res):
@@ -104,8 +109,10 @@ class PandaProxyTest(RedpandaTest):
     def _get_topics(self, headers=HTTP_GET_TOPICS_HEADERS):
         return requests.get(f"{self._base_uri()}/topics", headers=headers)
 
-    def _produce_topic(self, topic, data):
-        return requests.post(f"{self._base_uri()}/topics/{topic}", data)
+    def _produce_topic(self, topic, data, headers=HTTP_PRODUCE_TOPIC_HEADERS):
+        return requests.post(f"{self._base_uri()}/topics/{topic}",
+                             data,
+                             headers=headers)
 
     def _fetch_topic(self,
                      topic,

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -29,6 +29,12 @@ HTTP_GET_TOPICS_HEADERS = {
     "Content-Type": "application/vnd.kafka.v2+json"
 }
 
+HTTP_FETCH_TOPIC_HEADERS = {
+    "Accept": "application/vnd.kafka.binary.v2+json",
+    "Content-Type": "application/vnd.kafka.v2+json"
+}
+
+
 class Consumer:
     def __init__(self, res):
         self.instance_id = res["instance_id"]
@@ -106,10 +112,11 @@ class PandaProxyTest(RedpandaTest):
                      partition=0,
                      offset=0,
                      max_bytes=1024,
-                     timeout_ms=1000):
+                     timeout_ms=1000,
+                     headers=HTTP_FETCH_TOPIC_HEADERS):
         return requests.get(
-            f"{self._base_uri()}/topics/{topic}/partitions/{partition}/records?offset={offset}&max_bytes={max_bytes}&timeout={timeout_ms}"
-        )
+            f"{self._base_uri()}/topics/{topic}/partitions/{partition}/records?offset={offset}&max_bytes={max_bytes}&timeout={timeout_ms}",
+            headers=headers)
 
     def _create_consumer(self, group_id):
         res = requests.post(


### PR DESCRIPTION
## Cover letter

General infrastructure for checking `Accept` and `Content-Type` headers
Check Headers for:
* List Topics
* Produce
* Consume

There will be a followup PR for other endpoints.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/71c8770d17c0448cd9ee907a6e5ea15cd2ff91d3..0314191d924617dfa38294804c0acc27cbd2a620)
* Review comments
* `parse_serialization_format` tests

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/0314191d924617dfa38294804c0acc27cbd2a620..e2c2a2fa7dc20f6f44d002823470c0dca9551d55)
* Review comments for ducktape
* Enable pandaproxy ducktape tests in quick suite

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/e2c2a2fa7dc20f6f44d002823470c0dca9551d55..ed17a4f272c5f911d0b7e8f1bdd9eca3dff41869)
* Rebase to get seastar changes

## Release notes

Release note: Pandaproxy: Improved header handling for list-topics, produce, and consume
