### PR TITLE
Returning log start offset in fetch response

### DIFF
--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -489,6 +489,8 @@ public:
                     : _partition->high_watermark();
     }
 
+    model::offset start_offset() const { return _partition->start_offset(); }
+
     model::offset last_stable_offset() const {
         return _log ? _log->offsets().dirty_offset
                     : _partition->last_stable_offset();
@@ -513,18 +515,24 @@ struct read_result {
       : error(e) {}
 
     read_result(
-      model::record_batch_reader rdr, model::offset hw, model::offset lso)
+      model::record_batch_reader rdr,
+      model::offset start_offset,
+      model::offset hw,
+      model::offset lso)
       : reader(std::move(rdr))
+      , start_offset(start_offset)
       , high_watermark(hw)
       , last_stable_offset(lso)
       , error(error_code::none) {}
 
-    read_result(model::offset hw, model::offset lso)
-      : high_watermark(hw)
+    read_result(model::offset start_offset, model::offset hw, model::offset lso)
+      : start_offset(start_offset)
+      , high_watermark(hw)
       , last_stable_offset(lso)
       , error(error_code::none) {}
 
     std::optional<model::record_batch_reader> reader;
+    model::offset start_offset;
     model::offset high_watermark;
     model::offset last_stable_offset;
     error_code error;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -369,9 +369,10 @@ static ss::future<read_result> read_from_partition(
   std::optional<model::timeout_clock::time_point> deadline) {
     auto hw = pw.high_watermark();
     auto lso = pw.last_stable_offset();
+    auto start_o = pw.start_offset();
     // if we have no data read, return fast
     if (hw < config.start_offset) {
-        return ss::make_ready_future<read_result>(hw, lso);
+        return ss::make_ready_future<read_result>(start_o, hw, lso);
     }
 
     storage::log_reader_config reader_config(
@@ -386,7 +387,8 @@ static ss::future<read_result> read_from_partition(
 
     reader_config.strict_max_bytes = config.strict_max_bytes;
     return pw.make_reader(reader_config)
-      .then([hw, lso, foreign_read, deadline](model::record_batch_reader rdr) {
+      .then([start_o, hw, lso, foreign_read, deadline](
+              model::record_batch_reader rdr) {
           return model::transform_reader_to_memory(
                    std::move(rdr),
                    deadline.value_or(model::no_timeout),
@@ -401,8 +403,8 @@ static ss::future<read_result> read_from_partition(
                 }
                 return model::make_memory_record_batch_reader(std::move(data));
             })
-            .then([hw, lso](model::record_batch_reader rdr) {
-                return read_result(std::move(rdr), hw, lso);
+            .then([start_o, hw, lso](model::record_batch_reader rdr) {
+                return read_result(std::move(rdr), start_o, hw, lso);
             });
       });
 }
@@ -473,6 +475,7 @@ static ss::future<> do_fill_fetch_responses(
         if (!res.reader) {
             resp_it.set(
               make_partition_response_error(res.partition, res.error));
+            resp_it->partition_response->log_start_offset = res.start_offset;
             resp_it->partition_response->high_watermark = res.high_watermark;
             resp_it->partition_response->last_stable_offset
               = res.last_stable_offset;
@@ -481,7 +484,8 @@ static ss::future<> do_fill_fetch_responses(
         return std::move(*res.reader)
           .consume(kafka_batch_serializer(), model::no_timeout)
           .then(
-            [hw = res.high_watermark,
+            [so = res.start_offset,
+             hw = res.high_watermark,
              lso = res.last_stable_offset,
              pid = res.partition,
              resp_it = resp_it](kafka_batch_serializer::result res) mutable {
@@ -491,11 +495,13 @@ static ss::future<> do_fill_fetch_responses(
                   .record_set = batch_reader(std::move(res.data)),
                 };
                 resp_it.set(std::move(resp));
+                resp_it->partition_response->log_start_offset = so;
                 resp_it->partition_response->high_watermark = hw;
                 resp_it->partition_response->last_stable_offset = lso;
             })
           .handle_exception(
-            [hw = res.high_watermark,
+            [so = res.start_offset,
+             hw = res.high_watermark,
              lso = res.last_stable_offset,
              pid = res.partition,
              resp_it = resp_it](const std::exception_ptr&) mutable {
@@ -507,6 +513,7 @@ static ss::future<> do_fill_fetch_responses(
                  */
                 resp_it.set(make_partition_response_error(
                   pid, error_code::unknown_server_error));
+                resp_it->partition_response->log_start_offset = so;
                 resp_it->partition_response->high_watermark = hw;
                 resp_it->partition_response->last_stable_offset = lso;
             });


### PR DESCRIPTION
Fetch response contains `start_offset` field for each partition.
Fixed setting start offset in fetch response. Some of the clients f.e.
librdkafka uses start offset to present statistics.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Release notes
This fixes `librdkafka` consumer statistics output.