### PR TITLE
Enabled different TLS configuration for each Kafka endpoint

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -131,8 +131,8 @@ configuration::configuration()
       "kafka_api_tls",
       "TLS configuration for Kafka API endpoint",
       required::no,
-      tls_config(),
-      tls_config::validate)
+      {},
+      endpoint_tls_config::validate_many)
   , use_scheduling_groups(
       *this,
       "use_scheduling_groups",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "config/config_store.h"
 #include "config/data_directory_path.h"
+#include "config/endpoint_tls_config.h"
 #include "config/seed_server.h"
 #include "config/tls_config.h"
 #include "model/compression.h"
@@ -552,5 +553,32 @@ struct convert<model::timestamp_type> {
         return true;
     }
 };
+template<>
+struct convert<config::endpoint_tls_config> {
+    using type = config::endpoint_tls_config;
+    static Node encode(const type& rhs) {
+        Node node;
+        node["name"] = rhs.name;
+        node["config"] = rhs.config;
+        return node;
+    }
 
-}; // namespace YAML
+    static bool decode(const Node& node, type& rhs) {
+        ss::sstring name;
+        if (node["name"]) {
+            name = node["name"].as<ss::sstring>();
+        }
+        config::tls_config tls_cfg;
+        auto res = convert<config::tls_config>{}.decode(node, tls_cfg);
+        if (!res) {
+            return res;
+        }
+        rhs = config::endpoint_tls_config{
+          .name = name,
+          .config = tls_cfg,
+        };
+
+        return true;
+    }
+};
+} // namespace YAML

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -64,7 +64,7 @@ struct configuration final : public config_store {
     property<int16_t> max_version;
     // Kafka
     one_or_many_property<model::broker_endpoint> kafka_api;
-    property<tls_config> kafka_api_tls;
+    one_or_many_property<endpoint_tls_config> kafka_api_tls;
     property<bool> use_scheduling_groups;
     property<unresolved_address> admin;
     property<tls_config> admin_api_tls;

--- a/src/v/config/endpoint_tls_config.h
+++ b/src/v/config/endpoint_tls_config.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/tls_config.h"
+#include "seastarx.h"
+
+namespace config {
+struct endpoint_tls_config {
+    ss::sstring name;
+    tls_config config;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const endpoint_tls_config& cfg) {
+        fmt::print(o, "{{name: {}, tls_config: {}}}", cfg.name, cfg.config);
+        return o;
+    }
+
+    static std::optional<ss::sstring> validate(const endpoint_tls_config& ec) {
+        return tls_config::validate(ec.config);
+    }
+    static std::optional<ss::sstring>
+    validate_many(const std::vector<endpoint_tls_config>& v) {
+        for (auto& ec : v) {
+            auto err = tls_config::validate(ec.config);
+            if (err) {
+                return err;
+            }
+        }
+        return std::nullopt;
+    }
+};
+} // namespace config

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -86,4 +86,27 @@ void rjson_serialize(
     w.EndObject();
 }
 
+void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const config::endpoint_tls_config& v) {
+    w.StartObject();
+
+    w.Key("name");
+    w.String(v.name.c_str());
+
+    w.Key("config");
+    rjson_serialize(w, v.config);
+
+    w.EndObject();
+}
+
+void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const std::vector<config::endpoint_tls_config>& v) {
+    w.StartArray();
+    for (const auto& e : v) {
+        rjson_serialize(w, e);
+    }
+    w.EndArray();
+}
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "config/data_directory_path.h"
+#include "config/endpoint_tls_config.h"
 #include "config/seed_server.h"
 #include "config/tests/custom_aggregate.h"
 #include "config/tls_config.h"
@@ -44,5 +45,13 @@ void rjson_serialize(
 
 void rjson_serialize(
   rapidjson::Writer<rapidjson::StringBuffer>& w, const custom_aggregate& v);
+
+void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const config::endpoint_tls_config& v);
+
+void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const std::vector<config::endpoint_tls_config>& v);
 
 } // namespace json

--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -18,6 +18,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/net/ip.hh>
 #include <seastar/net/tls.hh>
 
 #include <optional>

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -35,6 +35,7 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>
+#include <seastar/net/tls.hh>
 #include <seastar/util/defer.hh>
 
 #include <boost/algorithm/string.hpp>
@@ -271,22 +272,25 @@ int main(int args, char** argv, char** env) {
             auto ccd = ss::defer(
               [&connection_cache] { connection_cache.stop().get(); });
             rpc::server_configuration scfg("kvelldb_rpc");
-            scfg.addrs.emplace_back(ss::socket_address(
-              ss::net::inet_address(cfg["ip"].as<ss::sstring>()),
-              cfg["port"].as<uint16_t>()));
             scfg.max_service_memory_per_core
               = ss::memory::stats().total_memory() * .7;
             auto key = cfg["key"].as<ss::sstring>();
             auto cert = cfg["cert"].as<ss::sstring>();
+            ss::shared_ptr<ss::tls::server_credentials> credentials;
             if (key != "" && cert != "") {
                 auto builder = ss::tls::credentials_builder();
                 builder.set_dh_level(ss::tls::dh_params::level::MEDIUM);
                 builder
                   .set_x509_key_file(cert, key, ss::tls::x509_crt_format::PEM)
                   .get();
-                scfg.credentials
+                credentials
                   = builder.build_reloadable_server_credentials().get0();
             }
+            scfg.addrs.emplace_back(
+              ss::socket_address(
+                ss::net::inet_address(cfg["ip"].as<ss::sstring>()),
+                cfg["port"].as<uint16_t>()),
+              credentials);
             auto self_id = cfg["node-id"].as<int32_t>();
             if (cfg.find("peers") != cfg.end()) {
                 initialize_connection_cache_in_thread(

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -151,7 +151,6 @@ struct raft_node {
         rpc::server_configuration scfg("raft_test_rpc");
         scfg.addrs.emplace_back(rpc::resolve_dns(broker.rpc_address()).get());
         scfg.max_service_memory_per_core = 1024 * 1024 * 1024;
-        scfg.credentials = nullptr;
         scfg.disable_metrics = rpc::metrics_disabled::yes;
         server.start(std::move(scfg)).get0();
         raft_manager.start().get0();

--- a/src/v/rpc/server.cc
+++ b/src/v/rpc/server.cc
@@ -28,8 +28,7 @@ namespace rpc {
 
 server::server(server_configuration c)
   : cfg(std::move(c))
-  , _memory(cfg.max_service_memory_per_core)
-  , _creds(cfg.credentials) {}
+  , _memory(cfg.max_service_memory_per_core) {}
 
 server::~server() = default;
 
@@ -46,11 +45,11 @@ void server::start() {
             lo.reuse_address = true;
             lo.lba = cfg.load_balancing_algo;
 
-            if (!_creds) {
+            if (!endpoint.credentials) {
                 ss = ss::engine().listen(endpoint.addr, lo);
             } else {
                 ss = ss::tls::listen(
-                  _creds, ss::engine().listen(endpoint.addr, lo));
+                  endpoint.credentials, ss::engine().listen(endpoint.addr, lo));
             }
         } catch (...) {
             throw std::runtime_error(fmt::format(

--- a/src/v/rpc/server.h
+++ b/src/v/rpc/server.h
@@ -103,7 +103,6 @@ private:
     hdr_hist _hist;
     server_probe _probe;
     ss::metrics::metric_groups _metrics;
-    ss::shared_ptr<ss::tls::server_credentials> _creds;
 };
 
 } // namespace rpc

--- a/src/v/rpc/test/rpc_integration_fixture.h
+++ b/src/v/rpc/test/rpc_integration_fixture.h
@@ -155,14 +155,14 @@ public:
       std::optional<ss::tls::credentials_builder> credentials = std::nullopt,
       ss::tls::reload_callback&& cb = {}) override {
         rpc::server_configuration scfg("unit_test_rpc");
-        scfg.addrs.emplace_back(_listen_address);
+        scfg.addrs.emplace_back(
+          _listen_address,
+          credentials
+            ? credentials->build_reloadable_server_credentials(std::move(cb))
+                .get0()
+            : nullptr);
         scfg.max_service_memory_per_core = static_cast<int64_t>(
           ss::memory::stats().total_memory() / 10);
-        scfg.credentials
-          = credentials
-              ? credentials->build_reloadable_server_credentials(std::move(cb))
-                  .get0()
-              : nullptr;
         _server = std::make_unique<rpc::server>(std::move(scfg));
         _proto = std::make_unique<rpc::simple_protocol>();
     }
@@ -201,14 +201,14 @@ public:
       std::optional<ss::tls::credentials_builder> credentials = std::nullopt,
       ss::tls::reload_callback&& cb = {}) override {
         rpc::server_configuration scfg("unit_test_rpc_sharded");
-        scfg.addrs.emplace_back(_listen_address);
+        scfg.addrs.emplace_back(
+          _listen_address,
+          credentials
+            ? credentials->build_reloadable_server_credentials(std::move(cb))
+                .get0()
+            : nullptr);
         scfg.max_service_memory_per_core = static_cast<int64_t>(
           ss::memory::stats().total_memory() / 10);
-        scfg.credentials
-          = credentials
-              ? credentials->build_reloadable_server_credentials(std::move(cb))
-                  .get0()
-              : nullptr;
         _server.start(std::move(scfg)).get();
     }
 

--- a/src/v/rpc/types.cc
+++ b/src/v/rpc/types.cc
@@ -55,13 +55,22 @@ std::ostream& operator<<(std::ostream& o, const server_configuration& c) {
         o << a;
     }
     o << ", max_service_memory_per_core: " << c.max_service_memory_per_core
-      << ", has_tls_credentials: " << (c.credentials ? "yes" : "no")
       << ", metrics_enabled:" << !c.disable_metrics;
     return o << "}";
 }
 
 std::ostream& operator<<(std::ostream& os, const server_endpoint& ep) {
-    fmt::print(os, "{{{}:{}}}", ep.name, ep.addr);
+    /**
+     * We use simmillar syntax to kafka to indicate if endpoint is secured f.e.:
+     *
+     * SECURED://127.0.0.1:9092
+     */
+    fmt::print(
+      os,
+      "{{{}://{}:{}}}",
+      ep.name,
+      ep.addr,
+      ep.credentials ? "SECURED" : "PLAINTEXT");
     return os;
 }
 

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -180,10 +180,24 @@ using metrics_disabled = ss::bool_class<struct metrics_disabled_tag>;
 struct server_endpoint {
     ss::sstring name;
     ss::socket_address addr;
+    ss::shared_ptr<ss::tls::server_credentials> credentials;
 
     server_endpoint(ss::sstring name, ss::socket_address addr)
       : name(std::move(name))
       , addr(addr) {}
+
+    server_endpoint(
+      ss::sstring name,
+      ss::socket_address addr,
+      ss::shared_ptr<ss::tls::server_credentials> creds)
+      : name(std::move(name))
+      , addr(addr)
+      , credentials(std::move(creds)) {}
+
+    server_endpoint(
+      ss::socket_address addr,
+      ss::shared_ptr<ss::tls::server_credentials> creds)
+      : server_endpoint("", addr, std::move(creds)) {}
 
     explicit server_endpoint(ss::socket_address addr)
       : server_endpoint("", addr) {}
@@ -192,7 +206,6 @@ struct server_endpoint {
 struct server_configuration {
     std::vector<server_endpoint> addrs;
     int64_t max_service_memory_per_core;
-    ss::shared_ptr<ss::tls::server_credentials> credentials;
     metrics_disabled disable_metrics = metrics_disabled::no;
     ss::sstring name;
     // we use the same default as seastar for load balancing algorithm


### PR DESCRIPTION
## Cover letter

Added user an ability to configure different security policy for each Kafka API server named listener. 

Fixes issues: #816

## Release notes

- Support for different security policies on different Kafka listeners
