### PR TITLE
helm: Add helm-docs paramter for app version

### DIFF
--- a/src/go/k8s/helm-chart/charts/redpanda-operator/README.md.gotmpl
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/README.md.gotmpl
@@ -19,7 +19,7 @@ resources. To verify that cert manager is ready please follow
 1. Install Redpanda operator CRDs:
 
 ```sh
-kubectl apply -k 'https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=v21.3.4'
+kubectl apply -k 'https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref={{ template "chart.appVersion" . }}'
 ```
 
 > The CRDs are decoupled from helm chart, so that helm release can be


### PR DESCRIPTION
## Cover letter

In the helm-docs defines templates like app version that can be injected during
README generation.

REF:
> chart.appVersion	The appVersion field from the chart's Chart.yaml file
https://github.com/norwoodj/helm-docs/blame/master/README.md#L156