### PR TITLE
archival: Fix graceful shuttdown problem

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -343,7 +343,7 @@ void segment_matcher<Fixture>::verify_segment(
     auto tmp = stream.read_exactly(size).get0();
     ss::sstring actual = {tmp.get(), tmp.size()};
     vlog(
-      fixt_log.error,
+      fixt_log.info,
       "expected {} bytes, got {}",
       expected.size(),
       actual.size());


### PR DESCRIPTION
## Cover letter

Fix CI issue caused by archival test.

## Release notes

Handle gate_closed_exception in upload loop, also handle proper
exception type (sleep_abroted instead of abort_requeste_exception)
in reconciliation loop.

Minor change in fixture (change log.error to log.info).
