### PR TITLE
rpk/config: Create the dir path if it doesn't exist.

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1763,7 +1763,7 @@ func TestReadOrGenerate(t *testing.T) {
 				err := tt.setup(fs)
 				require.NoError(t, err)
 			}
-			_, err := readOrGenerate(InitViper(fs), tt.configFile)
+			_, err := readOrGenerate(fs, InitViper(fs), tt.configFile)
 			if tt.expectError {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
Fix #684

Release note: rpk config commands now try to create any dir in the path given for `--config` if they don't exist.
