### PR TITLE
release: fix conditional for 'dev' k8s releases

### DIFF
--- a/.github/workflows/k8s-build-and-test.yml
+++ b/.github/workflows/k8s-build-and-test.yml
@@ -93,18 +93,18 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    if: github.ref == 'refs/heads/dev' && github.repository == 'vectorizedio/redpanda'
+
     steps:
 
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Get tag name (if any)
-      run: echo "TAG_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
     - name: Build and tag dev images
       working-directory: src/go/k8s/
-      if: github.ref == 'dev' && github.repository == 'vectorizedio/redpanda'
       shell: bash
+      env:
+        TAG_NAME: "dev"
       run: |
         make docker-build
         make docker-build-configurator
@@ -112,13 +112,13 @@ jobs:
 
     - name: Login to dockerhub
       uses: docker/login-action@v1
-      if: startsWith(github.ref, 'refs/tags/v')
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Push dev images
       working-directory: src/go/k8s/
-      if: github.ref == 'dev' && github.repository == 'vectorizedio/redpanda'
       shell: bash
+      env:
+        TAG_NAME: "dev"
       run: make docker-push-dev


### PR DESCRIPTION
Fix the `if` conditional that skips the k8s GHA release workflow job (push operator to duckerhub) on all builds except those in `dev` branch.