### PR TITLE
rpk/pandaproxy: add pandaproxy fields

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -851,6 +851,215 @@ rpk:
 `,
 		},
 		{
+			name: "shall write config with full pandaproxy configuration",
+			conf: func() *Config {
+				c := getValidConfig()
+				c.Pandaproxy = &Pandaproxy{
+					PandaproxyAPI: SocketAddress{
+						Address: "1.2.3.4",
+						Port:    1234,
+					},
+					PandaproxyAPITLS: ServerTLS{
+						KeyFile:           "/etc/certs/cert.key",
+						TruststoreFile:    "/etc/certs/ca.crt",
+						CertFile:          "/etc/certs/cert.crt",
+						Enabled:           true,
+						RequireClientAuth: true,
+					},
+					AdvertisedPandaproxyAPI: &SocketAddress{
+						Address: "2.3.4.1",
+						Port:    2341,
+					},
+				}
+				return c
+			},
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+pandaproxy:
+  advertised_pandaproxy_api:
+    address: 2.3.4.1
+    port: 2341
+  pandaproxy_api:
+    address: 1.2.3.4
+    port: 1234
+  pandaproxy_api_tls:
+    cert_file: /etc/certs/cert.crt
+    enabled: true
+    key_file: /etc/certs/cert.key
+    require_client_auth: true
+    truststore_file: /etc/certs/ca.crt
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  data_directory: /var/lib/redpanda/data
+  developer_mode: false
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers:
+  - host:
+      address: 127.0.0.1
+      port: 33145
+  - host:
+      address: 127.0.0.1
+      port: 33146
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_disk_write_cache: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
+`,
+		},
+		{
+			name: "shall write config with pandaproxy api only configuration",
+			conf: func() *Config {
+				c := getValidConfig()
+				c.Pandaproxy = &Pandaproxy{
+					PandaproxyAPI: SocketAddress{
+						Address: "1.2.3.4",
+						Port:    1234,
+					},
+				}
+				return c
+			},
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+pandaproxy:
+  pandaproxy_api:
+    address: 1.2.3.4
+    port: 1234
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  data_directory: /var/lib/redpanda/data
+  developer_mode: false
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers:
+  - host:
+      address: 127.0.0.1
+      port: 33145
+  - host:
+      address: 127.0.0.1
+      port: 33146
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_disk_write_cache: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
+`,
+		},
+		{
+			name: "shall write config with pandaproxy client configuration",
+			conf: func() *Config {
+				c := getValidConfig()
+				c.PandaproxyClient = &PandaproxyClient{
+					Broker: []SocketAddress{
+						{
+							Address: "1.2.3.4",
+							Port:    1234,
+						},
+					},
+					BrokerTLS: ServerTLS{
+						KeyFile:           "/etc/certs/cert.key",
+						TruststoreFile:    "/etc/certs/ca.crt",
+						CertFile:          "/etc/certs/cert.crt",
+						Enabled:           true,
+						RequireClientAuth: true,
+					},
+				}
+				return c
+			},
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+pandaproxy_client:
+  broker:
+  - address: 1.2.3.4
+    port: 1234
+  broker_tls:
+    cert_file: /etc/certs/cert.crt
+    enabled: true
+    key_file: /etc/certs/cert.key
+    require_client_auth: true
+    truststore_file: /etc/certs/ca.crt
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  data_directory: /var/lib/redpanda/data
+  developer_mode: false
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers:
+  - host:
+      address: 127.0.0.1
+      port: 33145
+  - host:
+      address: 127.0.0.1
+      port: 33146
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_disk_write_cache: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
+`,
+		},
+		{
 			name: "shall write config with archival configuration",
 			conf: func() *Config {
 				c := getValidConfig()

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -12,14 +12,16 @@ package config
 import "path"
 
 type Config struct {
-	NodeUuid     string                 `yaml:"node_uuid,omitempty" mapstructure:"node_uuid,omitempty" json:"nodeUuid"`
-	Organization string                 `yaml:"organization,omitempty" mapstructure:"organization,omitempty" json:"organization"`
-	LicenseKey   string                 `yaml:"license_key,omitempty" mapstructure:"license_key,omitempty" json:"licenseKey"`
-	ClusterId    string                 `yaml:"cluster_id,omitempty" mapstructure:"cluster_id,omitempty" json:"clusterId"`
-	ConfigFile   string                 `yaml:"config_file" mapstructure:"config_file" json:"configFile"`
-	Redpanda     RedpandaConfig         `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
-	Rpk          RpkConfig              `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
-	Other        map[string]interface{} `yaml:",inline" mapstructure:",remain"`
+	NodeUuid         string                 `yaml:"node_uuid,omitempty" mapstructure:"node_uuid,omitempty" json:"nodeUuid"`
+	Organization     string                 `yaml:"organization,omitempty" mapstructure:"organization,omitempty" json:"organization"`
+	LicenseKey       string                 `yaml:"license_key,omitempty" mapstructure:"license_key,omitempty" json:"licenseKey"`
+	ClusterId        string                 `yaml:"cluster_id,omitempty" mapstructure:"cluster_id,omitempty" json:"clusterId"`
+	ConfigFile       string                 `yaml:"config_file" mapstructure:"config_file" json:"configFile"`
+	Redpanda         RedpandaConfig         `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
+	Rpk              RpkConfig              `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
+	Pandaproxy       *Pandaproxy            `yaml:"pandaproxy,omitempty" mapstructure:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`
+	PandaproxyClient *PandaproxyClient      `yaml:"pandaproxy_client,omitempty" mapstructure:"pandaproxy_client,omitempty" json:"pandaproxyClient,omitempty"`
+	Other            map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 
 type RedpandaConfig struct {
@@ -46,6 +48,17 @@ type RedpandaConfig struct {
 	CloudStorageApiEndpointPort          *int                   `yaml:"cloud_storage_api_endpoint_port,omitempty" mapstructure:"cloud_storage_api_endpoint_port,omitempty" json:"cloudStorageApiEndpointPort,omitempty"`
 	CloudStorageTrustFile                *string                `yaml:"cloud_storage_trust_file,omitempty" mapstructure:"cloud_storage_trust_file,omitempty" json:"cloudStorageTrustFile,omitempty"`
 	Other                                map[string]interface{} `yaml:",inline" mapstructure:",remain"`
+}
+
+type Pandaproxy struct {
+	PandaproxyAPI           SocketAddress  `yaml:"pandaproxy_api,omitempty" mapstructure:"pandaproxy_api,omitempty" json:"pandaproxyApi,omitempty"`
+	PandaproxyAPITLS        ServerTLS      `yaml:"pandaproxy_api_tls,omitempty" mapstructure:"pandaproxy_api_tls,omitempty" json:"pandaproxyApiTls,omitempty"`
+	AdvertisedPandaproxyAPI *SocketAddress `yaml:"advertised_pandaproxy_api,omitempty" mapstructure:"advertised_pandaproxy_api,omitempty" json:"advertisedPandaproxyApi,omitempty"`
+}
+
+type PandaproxyClient struct {
+	Broker    []SocketAddress `yaml:"broker,omitempty" mapstructure:"broker,omitempty" json:"broker,omitempty"`
+	BrokerTLS ServerTLS       `yaml:"broker_tls,omitempty" mapstructure:"broker_tls,omitempty" json:"brokerTls,omitempty"`
 }
 
 type SeedServer struct {


### PR DESCRIPTION
## Cover letter

Add pandaproxy fields (API and client) to rpk config schema. Includes all fields of `pandaproxy` and fields `broker` and `broker_tls` of `pandaproxy_client`.