### PR TITLE
operator/test: remove redundant kindNodeCache:true

### DIFF
--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -1,7 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startKIND: true
-kindNodeCache: true
 kindContainers:
   - vectorized/redpanda-operator:latest
   - vectorized/configurator:latest

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -1,7 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startKIND: true
-kindNodeCache: true
 kindContainers:
   - vectorized/redpanda-operator:latest
   - vectorized/configurator:latest


### PR DESCRIPTION
## Cover letter

`kindNodeCache` in kuttl tests was accidentally defined twice, as true and false. We wanted to keep it false.

(Look at the whole file not just the diff).