### PR TITLE
operator/tests: reduce cluster name lengths for tls tests

### DIFF
--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: update-image-cluster
+  name: up-img
 status:
   readyReplicas: 2
 
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  update-image-cluster-selfsigned-issuer
+  name:  up-img-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  update-image-cluster-root-issuer
+  name:  up-img-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name:  update-image-cluster-root-certificate
+  name:  up-img-root-certificate
 status:
   conditions:
     - reason: Ready
@@ -45,7 +45,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name:  update-image-cluster-redpanda
+  name:  up-img-redpanda
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
@@ -1,7 +1,7 @@
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: update-image-cluster
+  name: up-img
 spec:
   image: "vectorized/redpanda"
   version: "v21.2.2"

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: update-image-cluster
+  name: up-img
 status:
   readyReplicas: 2
 
@@ -10,7 +10,7 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: update-image-cluster-0
+  name: up-img-0
 spec:
   containers:
     - name: redpanda
@@ -23,7 +23,7 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: update-image-cluster-1
+  name: up-img-1
 spec:
   containers:
     - name: redpanda

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image.yaml
@@ -1,6 +1,6 @@
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: update-image-cluster
+  name: up-img
 spec:
   version: "latest"

--- a/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: update-image-cluster
+  name: up-img
 status:
   readyReplicas: 2
 
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  update-image-cluster-selfsigned-issuer
+  name:  up-img-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  update-image-cluster-root-issuer
+  name:  up-img-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name:  update-image-cluster-root-certificate
+  name: up-img-root-certificate
 status:
   conditions:
     - reason: Ready
@@ -45,7 +45,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name:  update-image-cluster-redpanda
+  name: up-img-redpanda
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
@@ -1,7 +1,7 @@
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: update-image-cluster
+  name: up-img
 spec:
   image: "vectorized/redpanda"
   version: "v21.2.2"

--- a/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: update-image-cluster
+  name: up-img
 status:
   readyReplicas: 2
 
@@ -10,7 +10,7 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: update-image-cluster-0
+  name: up-img-0
 spec:
   containers:
     - name: redpanda
@@ -23,7 +23,7 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: update-image-cluster-1
+  name: up-img-1
 spec:
   containers:
     - name: redpanda

--- a/src/go/k8s/tests/e2e/update-image-tls/01-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-new-image.yaml
@@ -1,6 +1,6 @@
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: update-image-cluster
+  name: up-img
 spec:
   version: "latest"


### PR DESCRIPTION
## Cover letter

`commonName` depends on the namespace and cluster name. The ns is autogenerated by kuttl and can be long, e.g., 24 bytes. When appended with certificate suffixes it can cross the limit of 64 and lead to error failures.

(There are two points in the code that set the commonName, one of them is handled already through truncation as it doesn't correspond to a DNS name, the other one does and cannot be truncated at that point but could be validated earlier in the code path - see issue below).

This PR is related to but does not fix the `commonName` length issue https://github.com/vectorizedio/redpanda/issues/997