### PR TITLE
security: add user management into controller

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -51,6 +51,7 @@ v_cc_library(
     persisted_stm.cc
     tm_stm.cc
     rm_stm.cc
+    security_manager.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -52,6 +52,7 @@ v_cc_library(
     tm_stm.cc
     rm_stm.cc
     security_manager.cc
+    security_frontend.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -69,6 +69,7 @@ static constexpr int8_t move_partition_replicas_cmd_type = 2;
 static constexpr int8_t finish_moving_partition_replicas_cmd_type = 3;
 static constexpr int8_t update_topic_properties_cmd_type = 4;
 static constexpr int8_t create_user_cmd_type = 5;
+static constexpr int8_t delete_user_cmd_type = 6;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -104,6 +105,12 @@ using create_user_cmd = controller_command<
   security::credential_user,
   security::scram_credential,
   create_user_cmd_type,
+  user_batch_type()>;
+
+using delete_user_cmd = controller_command<
+  security::credential_user,
+  int8_t, // unused
+  delete_user_cmd_type,
   user_batch_type()>;
 
 // typelist utils

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -70,6 +70,7 @@ static constexpr int8_t finish_moving_partition_replicas_cmd_type = 3;
 static constexpr int8_t update_topic_properties_cmd_type = 4;
 static constexpr int8_t create_user_cmd_type = 5;
 static constexpr int8_t delete_user_cmd_type = 6;
+static constexpr int8_t update_user_cmd_type = 7;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -111,6 +112,12 @@ using delete_user_cmd = controller_command<
   security::credential_user,
   int8_t, // unused
   delete_user_cmd_type,
+  user_batch_type()>;
+
+using update_user_cmd = controller_command<
+  security::credential_user,
+  security::scram_credential,
+  update_user_cmd_type,
   user_batch_type()>;
 
 // typelist utils

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -17,6 +17,8 @@
 #include "model/record.h"
 #include "reflection/adl.h"
 #include "reflection/async_adl.h"
+#include "security/credential_store.h"
+#include "security/scram_credential.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/do_with.hh>
@@ -30,6 +32,9 @@ namespace cluster {
 // filter the batches out
 static constexpr model::record_batch_type topic_batch_type
   = model::record_batch_type(6);
+
+static constexpr model::record_batch_type user_batch_type
+  = model::record_batch_type(12);
 
 using command_type = named_type<int8_t, struct command_type_tag>;
 // Controller state updates are represented in terms of commands. Each
@@ -63,6 +68,7 @@ static constexpr int8_t delete_topic_cmd_type = 1;
 static constexpr int8_t move_partition_replicas_cmd_type = 2;
 static constexpr int8_t finish_moving_partition_replicas_cmd_type = 3;
 static constexpr int8_t update_topic_properties_cmd_type = 4;
+static constexpr int8_t create_user_cmd_type = 5;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -93,6 +99,12 @@ using update_topic_properties_cmd = controller_command<
   incremental_topic_updates,
   update_topic_properties_cmd_type,
   topic_batch_type()>;
+
+using create_user_cmd = controller_command<
+  security::credential_user,
+  security::scram_credential,
+  create_user_cmd_type,
+  user_batch_type()>;
 
 // typelist utils
 // clang-format off

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -42,7 +42,8 @@ controller::controller(
   , _partition_manager(pm)
   , _shard_table(st)
   , _storage(storage)
-  , _tp_updates_dispatcher(_partition_allocator, _tp_state) {}
+  , _tp_updates_dispatcher(_partition_allocator, _tp_state)
+  , _security_manager(_credentials) {}
 
 ss::future<> controller::wire_up() {
     return _as.start()
@@ -84,7 +85,8 @@ ss::future<> controller::start() {
             std::ref(clusterlog),
             _raft0.get(),
             raft::persistent_last_applied::yes,
-            std::ref(_tp_updates_dispatcher));
+            std::ref(_tp_updates_dispatcher),
+            std::ref(_security_manager));
       })
       .then([this] {
           return _tp_frontend.start(

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -19,6 +19,7 @@
 #include "cluster/partition_leaders_table.h"
 #include "cluster/partition_manager.h"
 #include "cluster/raft0_utils.h"
+#include "cluster/security_frontend.h"
 #include "cluster/shard_table.h"
 #include "cluster/topic_table.h"
 #include "cluster/topics_frontend.h"
@@ -89,6 +90,9 @@ ss::future<> controller::start() {
             std::ref(_security_manager));
       })
       .then([this] {
+          return _security_frontend.start(std::ref(_stm), std::ref(_as));
+      })
+      .then([this] {
           return _tp_frontend.start(
             _raft0->self().id(),
             std::ref(_stm),
@@ -143,6 +147,7 @@ ss::future<> controller::stop() {
     return f.then([this] {
         return _backend.stop()
           .then([this] { return _tp_frontend.stop(); })
+          .then([this] { return _security_frontend.stop(); })
           .then([this] { return _stm.stop(); })
           .then([this] { return _credentials.stop(); })
           .then([this] { return _tp_state.stop(); })

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -50,6 +50,7 @@ ss::future<> controller::wire_up() {
       .then([this] { return _partition_leaders.start(); })
       .then(
         [this] { return _partition_allocator.start_single(raft::group_id(0)); })
+      .then([this] { return _credentials.start(); })
       .then([this] { return _tp_state.start(); });
 }
 
@@ -141,6 +142,7 @@ ss::future<> controller::stop() {
         return _backend.stop()
           .then([this] { return _tp_frontend.stop(); })
           .then([this] { return _stm.stop(); })
+          .then([this] { return _credentials.stop(); })
           .then([this] { return _tp_state.stop(); })
           .then([this] { return _members_manager.stop(); })
           .then([this] { return _partition_allocator.stop(); })

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -14,6 +14,7 @@
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
 #include "cluster/topic_updates_dispatcher.h"
+#include "security/credential_store.h"
 #include "rpc/connection_cache.h"
 #include "storage/fwd.h"
 
@@ -43,6 +44,10 @@ public:
         return _partition_leaders;
     }
 
+    ss::sharded<security::credential_store>& get_credential_store() {
+        return _credentials;
+    }
+
     ss::future<> wire_up();
 
     ss::future<> start();
@@ -67,6 +72,7 @@ private:
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<storage::api>& _storage;
     topic_updates_dispatcher _tp_updates_dispatcher;
+    ss::sharded<security::credential_store> _credentials;
     consensus_ptr _raft0;
 };
 

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -14,8 +14,8 @@
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
 #include "cluster/topic_updates_dispatcher.h"
-#include "security/credential_store.h"
 #include "rpc/connection_cache.h"
+#include "security/credential_store.h"
 #include "storage/fwd.h"
 
 #include <seastar/core/abort_source.hh>
@@ -48,6 +48,10 @@ public:
         return _credentials;
     }
 
+    ss::sharded<security_frontend>& get_security_frontend() {
+        return _security_frontend;
+    }
+
     ss::future<> wire_up();
 
     ss::future<> start();
@@ -74,6 +78,7 @@ private:
     topic_updates_dispatcher _tp_updates_dispatcher;
     ss::sharded<security::credential_store> _credentials;
     security_manager _security_manager;
+    ss::sharded<security_frontend> _security_frontend;
     consensus_ptr _raft0;
 };
 

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -73,6 +73,7 @@ private:
     ss::sharded<storage::api>& _storage;
     topic_updates_dispatcher _tp_updates_dispatcher;
     ss::sharded<security::credential_store> _credentials;
+    security_manager _security_manager;
     consensus_ptr _raft0;
 };
 

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -11,13 +11,15 @@
 
 #pragma once
 
+#include "cluster/security_manager.h"
 #include "cluster/topic_updates_dispatcher.h"
 #include "raft/mux_state_machine.h"
 
 namespace cluster {
 
 // single instance
-using controller_stm = raft::mux_state_machine<topic_updates_dispatcher>;
+using controller_stm
+  = raft::mux_state_machine<topic_updates_dispatcher, security_manager>;
 
 static constexpr ss::shard_id controller_stm_shard = 0;
 

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -36,6 +36,7 @@ enum class errc {
     partition_already_exists,
     waiting_for_recovery,
     update_in_progress,
+    user_exists,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -90,6 +91,8 @@ struct errc_category final : public std::error_category {
             return "Waiting for partition to recover";
         case errc::update_in_progress:
             return "Partition configuration update in progress";
+        case errc::user_exists:
+            return "User already exists";
         default:
             return "cluster::errc::unknown";
         }

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -37,6 +37,7 @@ enum class errc {
     waiting_for_recovery,
     update_in_progress,
     user_exists,
+    user_does_not_exist,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -93,6 +94,8 @@ struct errc_category final : public std::error_category {
             return "Partition configuration update in progress";
         case errc::user_exists:
             return "User already exists";
+        case errc::user_does_not_exist:
+            return "User does not exist";
         default:
             return "cluster::errc::unknown";
         }

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -28,5 +28,6 @@ class members_manager;
 class members_table;
 class metadata_cache;
 class metadata_dissemination_service;
+class security_frontend;
 
 } // namespace cluster

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -54,6 +54,14 @@ ss::future<std::error_code> security_frontend::delete_user(
     return replicate_and_wait(std::move(cmd), tout);
 }
 
+ss::future<std::error_code> security_frontend::update_user(
+  security::credential_user username,
+  security::scram_credential credential,
+  model::timeout_clock::time_point tout) {
+    update_user_cmd cmd(std::move(username), std::move(credential));
+    return replicate_and_wait(std::move(cmd), tout);
+}
+
 template<typename Cmd>
 ss::future<std::error_code> security_frontend::replicate_and_wait(
   Cmd&& cmd, model::timeout_clock::time_point timeout) {

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -48,6 +48,12 @@ ss::future<std::error_code> security_frontend::create_user(
     return replicate_and_wait(std::move(cmd), tout);
 }
 
+ss::future<std::error_code> security_frontend::delete_user(
+  security::credential_user username, model::timeout_clock::time_point tout) {
+    delete_user_cmd cmd(std::move(username), 0 /* unused */);
+    return replicate_and_wait(std::move(cmd), tout);
+}
+
 template<typename Cmd>
 ss::future<std::error_code> security_frontend::replicate_and_wait(
   Cmd&& cmd, model::timeout_clock::time_point timeout) {

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/security_frontend.h"
+
+#include "cluster/cluster_utils.h"
+#include "cluster/commands.h"
+#include "cluster/controller_stm.h"
+#include "cluster/errc.h"
+#include "cluster/logger.h"
+#include "cluster/partition_allocator.h"
+#include "cluster/partition_leaders_table.h"
+#include "cluster/types.h"
+#include "model/errc.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/validation.h"
+#include "raft/errc.h"
+#include "raft/types.h"
+#include "random/generators.h"
+#include "rpc/errc.h"
+#include "rpc/types.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <regex>
+
+namespace cluster {
+
+security_frontend::security_frontend(
+  ss::sharded<controller_stm>& s, ss::sharded<ss::abort_source>& as)
+  : _stm(s)
+  , _as(as) {}
+
+ss::future<std::error_code> security_frontend::create_user(
+  security::credential_user username,
+  security::scram_credential credential,
+  model::timeout_clock::time_point tout) {
+    create_user_cmd cmd(std::move(username), std::move(credential));
+    return replicate_and_wait(std::move(cmd), tout);
+}
+
+template<typename Cmd>
+ss::future<std::error_code> security_frontend::replicate_and_wait(
+  Cmd&& cmd, model::timeout_clock::time_point timeout) {
+    return _stm.invoke_on(
+      controller_stm_shard,
+      [cmd = std::forward<Cmd>(cmd), &as = _as, timeout](
+        controller_stm& stm) mutable {
+          return serialize_cmd(std::forward<Cmd>(cmd))
+            .then([&stm, timeout, &as](model::record_batch b) {
+                return stm.replicate_and_wait(
+                  std::move(b), timeout, as.local());
+            });
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -36,6 +36,11 @@ public:
     ss::future<std::error_code>
       delete_user(security::credential_user, model::timeout_clock::time_point);
 
+    ss::future<std::error_code> update_user(
+      security::credential_user,
+      security::scram_credential,
+      model::timeout_clock::time_point);
+
     template<typename Cmd>
     ss::future<std::error_code>
     replicate_and_wait(Cmd&&, model::timeout_clock::time_point);

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -33,6 +33,9 @@ public:
       security::scram_credential,
       model::timeout_clock::time_point);
 
+    ss::future<std::error_code>
+      delete_user(security::credential_user, model::timeout_clock::time_point);
+
     template<typename Cmd>
     ss::future<std::error_code>
     replicate_and_wait(Cmd&&, model::timeout_clock::time_point);

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/controller_stm.h"
+#include "cluster/fwd.h"
+#include "model/timeout_clock.h"
+#include "security/scram_credential.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/sharded.hh>
+
+#include <system_error>
+
+namespace cluster {
+
+class security_frontend final {
+public:
+    security_frontend(
+      ss::sharded<controller_stm>&, ss::sharded<ss::abort_source>&);
+
+    ss::future<std::error_code> create_user(
+      security::credential_user,
+      security::scram_credential,
+      model::timeout_clock::time_point);
+
+    template<typename Cmd>
+    ss::future<std::error_code>
+    replicate_and_wait(Cmd&&, model::timeout_clock::time_point);
+
+private:
+    ss::sharded<controller_stm>& _stm;
+    ss::sharded<ss::abort_source>& _as;
+};
+
+} // namespace cluster

--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -36,8 +36,24 @@ security_manager::apply_update(model::record_batch batch) {
           },
           [this](delete_user_cmd cmd) {
               return dispatch_updates_to_cores(std::move(cmd));
+          },
+          [this](update_user_cmd cmd) {
+              return dispatch_updates_to_cores(std::move(cmd));
           });
     });
+}
+
+/*
+ * handle: update user command
+ */
+static std::error_code
+do_apply(update_user_cmd cmd, security::credential_store& store) {
+    auto removed = store.remove(cmd.key);
+    if (!removed) {
+        return errc::user_does_not_exist;
+    }
+    store.put(cmd.key, std::move(cmd.value));
+    return errc::success;
 }
 
 /*

--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/security_manager.h"
+
+#include "cluster/commands.h"
+#include "model/metadata.h"
+#include "raft/types.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <iterator>
+#include <system_error>
+#include <vector>
+
+namespace cluster {
+
+security_manager::security_manager(
+  ss::sharded<security::credential_store>& credentials)
+  : _credentials(credentials) {}
+
+ss::future<std::error_code>
+security_manager::apply_update(model::record_batch batch) {
+    return deserialize(std::move(batch), commands).then([this](auto cmd) {
+        return ss::visit(std::move(cmd), [this](create_user_cmd cmd) {
+            return dispatch_updates_to_cores(std::move(cmd));
+        });
+    });
+}
+
+/*
+ * handle: create user command
+ */
+static std::error_code
+do_apply(create_user_cmd cmd, security::credential_store& store) {
+    if (store.contains(cmd.key)) {
+        return errc::user_exists;
+    }
+    store.put(cmd.key, std::move(cmd.value));
+    return errc::success;
+}
+
+template<typename Cmd>
+static ss::future<std::error_code> do_apply(
+  ss::shard_id shard, Cmd cmd, ss::sharded<security::credential_store>& store) {
+    return store.invoke_on(
+      shard,
+      [cmd = std::move(cmd)](security::credential_store& local_store) mutable {
+          return do_apply(std::move(cmd), local_store);
+      });
+}
+
+template<typename Cmd>
+ss::future<std::error_code>
+security_manager::dispatch_updates_to_cores(Cmd cmd) {
+    using ret_t = std::vector<std::error_code>;
+    return ss::do_with(
+      ret_t{}, [this, cmd = std::move(cmd)](ret_t& ret) mutable {
+          ret.reserve(ss::smp::count);
+          return ss::parallel_for_each(
+                   boost::irange(0, (int)ss::smp::count),
+                   [this, &ret, cmd = std::move(cmd)](int shard) mutable {
+                       return do_apply(shard, cmd, _credentials)
+                         .then([&ret](std::error_code r) { ret.push_back(r); });
+                   })
+            .then([&ret] { return std::move(ret); })
+            .then([](std::vector<std::error_code> results) mutable {
+                auto ret = results.front();
+                for (auto& r : results) {
+                    vassert(
+                      ret == r,
+                      "State inconsistency across shards detected, "
+                      "expected "
+                      "result: {}, have: {}",
+                      ret,
+                      r);
+                }
+                return ret;
+            });
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/commands.h"
+#include "security/credential_store.h"
+#include "model/record.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace cluster {
+
+class security_manager final {
+public:
+    explicit security_manager(ss::sharded<security::credential_store>&);
+
+    static constexpr auto commands = make_commands_list<create_user_cmd>();
+
+    ss::future<std::error_code> apply_update(model::record_batch);
+
+    bool is_batch_applicable(const model::record_batch& batch) const {
+        return batch.header().type == user_batch_type;
+    }
+
+private:
+    template<typename Cmd>
+    ss::future<std::error_code> dispatch_updates_to_cores(Cmd);
+
+    ss::sharded<security::credential_store>& _credentials;
+};
+
+} // namespace cluster

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -23,7 +23,7 @@ public:
     explicit security_manager(ss::sharded<security::credential_store>&);
 
     static constexpr auto commands
-      = make_commands_list<create_user_cmd, delete_user_cmd>();
+      = make_commands_list<create_user_cmd, delete_user_cmd, update_user_cmd>();
 
     ss::future<std::error_code> apply_update(model::record_batch);
 

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -11,8 +11,8 @@
 
 #pragma once
 #include "cluster/commands.h"
-#include "security/credential_store.h"
 #include "model/record.h"
+#include "security/credential_store.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -22,7 +22,8 @@ class security_manager final {
 public:
     explicit security_manager(ss::sharded<security::credential_store>&);
 
-    static constexpr auto commands = make_commands_list<create_user_cmd>();
+    static constexpr auto commands
+      = make_commands_list<create_user_cmd, delete_user_cmd>();
 
     ss::future<std::error_code> apply_update(model::record_batch);
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -533,18 +533,6 @@ configuration::configuration()
       "Enable SASL authentication for Kafka connections.",
       required::no,
       false)
-  , static_scram_user(
-      *this,
-      "static_scram_user",
-      "A SASL SCRAM user for testing",
-      required::no,
-      "")
-  , static_scram_pass(
-      *this,
-      "static_scram_pass",
-      "A SASL SCRAM password for testing",
-      required::no,
-      "")
   , controller_backend_housekeeping_interval_ms(
       *this,
       "controller_backend_housekeeping_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -135,8 +135,6 @@ struct configuration final : public config_store {
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;
     property<bool> enable_sasl;
-    property<ss::sstring> static_scram_user;
-    property<ss::sstring> static_scram_pass;
     property<std::chrono::milliseconds>
       controller_backend_housekeeping_interval_ms;
 

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -17,7 +17,7 @@ namespace model {
 
 using record_batch_type = named_type<int8_t, struct model_record_batch_type>;
 
-constexpr std::array<record_batch_type, 12> well_known_record_batch_types{
+constexpr std::array<record_batch_type, 13> well_known_record_batch_types{
   record_batch_type(),   // unknown - used for debugging
   record_batch_type(1),  // raft::data
   record_batch_type(2),  // raft::configuration
@@ -30,5 +30,6 @@ constexpr std::array<record_batch_type, 12> well_known_record_batch_types{
   record_batch_type(9),  // tx_prepare_batch_type
   record_batch_type(10), // tx_fence_batch_type
   record_batch_type(11), // tm_update_batch_type
+  record_batch_type(12), // controller user management command batch type
 };
 } // namespace model

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -26,6 +26,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/partition.json.h
 )
 
+seastar_generate_swagger(
+  TARGET security_swagger
+  VAR security_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/security.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/security.json.h
+)
+
 v_cc_library(
   NAME application
   SRCS application.cc
@@ -44,7 +51,8 @@ add_executable(redpanda
   )
 target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
-add_dependencies(v_application config_swagger raft_swagger kafka_swagger partition_swagger)
+add_dependencies(v_application config_swagger raft_swagger kafka_swagger
+    partition_swagger security_swagger)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
   include(CheckIPOSupported)

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -1,0 +1,11 @@
+"/v1/security/users": {
+    "post": {
+        "summary": "Create a user",
+        "operationId": "create_user",
+        "responses": {
+            "200": {
+                "description": "Create user"
+            }
+        }
+    }
+}

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -8,4 +8,23 @@
             }
         }
     }
+},
+"/v1/security/users/{user}": {
+    "delete": {
+        "summary": "Delete a user",
+        "operationId": "delete_user",
+        "parameters": [
+            {
+                "name": "user",
+                "in": "path",
+                "required": true,
+                "type": "string"
+            }
+        ],
+        "responses": {
+            "200": {
+                "description": "Delete user"
+            }
+        }
+    }
 }

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -26,5 +26,22 @@
                 "description": "Delete user"
             }
         }
+    },
+    "put": {
+        "summary": "Update a user",
+        "operationId": "update_user",
+        "parameters": [
+            {
+                "name": "user",
+                "in": "path",
+                "required": true,
+                "type": "string"
+            }
+        ],
+        "responses": {
+            "200": {
+                "description": "Update user"
+            }
+        }
     }
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -467,9 +467,6 @@ void application::wire_up_redpanda_services() {
       std::ref(controller->get_partition_leaders()))
       .get();
 
-    syschecks::systemd_message("Creating kafka credential store").get();
-    construct_service(credentials).get();
-
     syschecks::systemd_message("Creating kafka authorizer").get();
     construct_service(authorizer).get();
 
@@ -729,7 +726,7 @@ void application::start_redpanda() {
             coordinator_ntp_mapper,
             fetch_session_cache,
             std::ref(id_allocator_frontend),
-            credentials,
+            controller->get_credential_store(),
             authorizer);
           s.set_protocol(std::move(proto));
       })

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -473,25 +473,6 @@ void application::wire_up_redpanda_services() {
     syschecks::systemd_message("Creating kafka authorizer").get();
     construct_service(authorizer).get();
 
-    /*
-     * Add in the static scram credential for testing.
-     * - sasl and developer mode needs to be enabled
-     */
-    if (
-      unlikely(config::shard_local_cfg().enable_admin_api())
-      && config::shard_local_cfg().developer_mode()
-      && !config::shard_local_cfg().static_scram_user().empty()
-      && !config::shard_local_cfg().static_scram_pass().empty()) {
-        credentials
-          .invoke_on_all([](security::credential_store& store) {
-              store.put(
-                config::shard_local_cfg().static_scram_user(),
-                security::scram_sha256::make_credentials(
-                  config::shard_local_cfg().static_scram_pass(), 4096));
-          })
-          .get();
-    }
-
     syschecks::systemd_message("Creating metadata dissemination service").get();
     construct_service(
       md_dissemination_service,

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -912,6 +912,25 @@ void application::admin_register_security_routes(ss::http_server& server) {
                   ss::json::json_return_type(ss::json::json_void()));
             });
       });
+
+    ss::httpd::security_json::delete_user.set(
+      server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
+          auto user = security::credential_user(
+            model::topic(req->param["user"]));
+
+          return controller->get_security_frontend()
+            .local()
+            .delete_user(user, model::timeout_clock::now() + 5s)
+            .then([this](std::error_code err) {
+                vlog(_log.debug, "Deleting user {}:{}", err, err.message());
+                if (err) {
+                    throw ss::httpd::bad_request_exception(
+                      fmt::format("Deleting user: {}", err.message()));
+                }
+                return ss::make_ready_future<ss::json::json_return_type>(
+                  ss::json::json_return_type(ss::json::json_void()));
+            });
+      });
 }
 
 void application::admin_register_kafka_routes(ss::http_server& server) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -17,6 +17,7 @@
 #include "cluster/metadata_dissemination_handler.h"
 #include "cluster/metadata_dissemination_service.h"
 #include "cluster/partition_manager.h"
+#include "cluster/security_frontend.h"
 #include "cluster/service.h"
 #include "cluster/topics_frontend.h"
 #include "config/configuration.h"
@@ -36,9 +37,11 @@
 #include "redpanda/admin/api-doc/kafka.json.h"
 #include "redpanda/admin/api-doc/partition.json.h"
 #include "redpanda/admin/api-doc/raft.json.h"
+#include "redpanda/admin/api-doc/security.json.h"
 #include "resource_mgmt/io_priority.h"
 #include "rpc/simple_protocol.h"
 #include "security/scram_algorithm.h"
+#include "security/scram_authenticator.h"
 #include "storage/chunk_cache.h"
 #include "storage/directories.h"
 #include "syschecks/syschecks.h"
@@ -59,6 +62,7 @@
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 #include <sys/utsname.h>
@@ -321,6 +325,8 @@ void application::configure_admin_server() {
               rb->register_api_file(server._routes, "kafka");
               rb->register_function(server._routes, insert_comma);
               rb->register_api_file(server._routes, "partition");
+              rb->register_function(server._routes, insert_comma);
+              rb->register_api_file(server._routes, "security");
               ss::httpd::config_json::get_config.set(
                 server._routes, []([[maybe_unused]] ss::const_req req) {
                     rapidjson::StringBuffer buf;
@@ -330,6 +336,7 @@ void application::configure_admin_server() {
                 });
               admin_register_raft_routes(server);
               admin_register_kafka_routes(server);
+              admin_register_security_routes(server);
           })
           .get();
     }
@@ -836,6 +843,75 @@ parse_target_broker_shards(const ss::sstring& param) {
     }
 
     return replicas;
+}
+
+// TODO: factor out generic serialization from seastar http exceptions
+static security::scram_credential
+parse_scram_credential(const rapidjson::Document& doc) {
+    if (!doc.IsObject()) {
+        throw ss::httpd::bad_request_exception(fmt::format("Not an object"));
+    }
+
+    if (!doc.HasMember("algorithm") || !doc["algorithm"].IsString()) {
+        throw ss::httpd::bad_request_exception(
+          fmt::format("String algo missing"));
+    }
+    const auto algorithm = std::string_view(
+      doc["algorithm"].GetString(), doc["algorithm"].GetStringLength());
+
+    if (!doc.HasMember("password") || !doc["password"].IsString()) {
+        throw ss::httpd::bad_request_exception(
+          fmt::format("String password smissing"));
+    }
+    const auto password = doc["password"].GetString();
+
+    security::scram_credential credential;
+
+    if (algorithm == security::scram_sha256_authenticator::name) {
+        credential = security::scram_sha256::make_credentials(
+          password, security::scram_sha256::min_iterations);
+
+    } else if (algorithm == security::scram_sha512_authenticator::name) {
+        credential = security::scram_sha512::make_credentials(
+          password, security::scram_sha512::min_iterations);
+
+    } else {
+        throw ss::httpd::bad_request_exception(
+          fmt::format("Unknown scram algorithm: {}", algorithm));
+    }
+
+    return credential;
+}
+
+void application::admin_register_security_routes(ss::http_server& server) {
+    ss::httpd::security_json::create_user.set(
+      server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
+          rapidjson::Document doc;
+          doc.Parse(req->content.data());
+
+          auto credential = parse_scram_credential(doc);
+
+          if (!doc.HasMember("username") || !doc["username"].IsString()) {
+              throw ss::httpd::bad_request_exception(
+                fmt::format("String username missing"));
+          }
+
+          auto username = security::credential_user(
+            doc["username"].GetString());
+
+          return controller->get_security_frontend()
+            .local()
+            .create_user(username, credential, model::timeout_clock::now() + 5s)
+            .then([this](std::error_code err) {
+                vlog(_log.debug, "Creating user {}:{}", err, err.message());
+                if (err) {
+                    throw ss::httpd::bad_request_exception(
+                      fmt::format("Creating user: {}", err.message()));
+                }
+                return ss::make_ready_future<ss::json::json_return_type>(
+                  ss::json::json_return_type(ss::json::json_void()));
+            });
+      });
 }
 
 void application::admin_register_kafka_routes(ss::http_server& server) {

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -92,6 +92,7 @@ private:
 
     void admin_register_raft_routes(ss::http_server& server);
     void admin_register_kafka_routes(ss::http_server& server);
+    void admin_register_security_routes(ss::http_server& server);
 
     bool coproc_enabled() {
         const auto& cfg = config::shard_local_cfg();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -77,7 +77,6 @@ public:
     smp_groups smp_service_groups;
     ss::sharded<kafka::quota_manager> quota_mgr;
     ss::sharded<cluster::id_allocator_frontend> id_allocator_frontend;
-    ss::sharded<security::credential_store> credentials;
     ss::sharded<archival::scheduler_service> archival_scheduler;
     ss::sharded<security::authorizer> authorizer;
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -83,7 +83,7 @@ public:
           app.coordinator_ntp_mapper,
           app.fetch_session_cache,
           app.id_allocator_frontend,
-          app.credentials,
+          app.controller->get_credential_store(),
           app.authorizer);
     }
 

--- a/src/v/security/credential_store.h
+++ b/src/v/security/credential_store.h
@@ -49,6 +49,10 @@ public:
         return std::nullopt;
     }
 
+    bool remove(const credential_user& user) {
+        return _credentials.erase(user) > 0;
+    }
+
     bool contains(const credential_user& name) const {
         return _credentials.contains(name);
     }

--- a/src/v/security/credential_store.h
+++ b/src/v/security/credential_store.h
@@ -49,6 +49,10 @@ public:
         return std::nullopt;
     }
 
+    bool contains(const credential_user& name) const {
+        return _credentials.contains(name);
+    }
+
 private:
     // when a second type is supported update `credential_store_test` to include
     // a mismatched credential type test for get<type>(name).

--- a/src/v/security/credential_store.h
+++ b/src/v/security/credential_store.h
@@ -25,6 +25,8 @@ namespace security {
  * process that often spans multiple network round trips and should remain
  * consistent for the duration of that process.
  */
+using credential_user = named_type<ss::sstring, struct credential_user_type>;
+
 class credential_store {
 public:
     credential_store() noexcept = default;
@@ -35,12 +37,12 @@ public:
     ~credential_store() noexcept = default;
 
     template<typename T>
-    void put(const ss::sstring& name, T&& credential) {
+    void put(const credential_user& name, T&& credential) {
         _credentials.insert_or_assign(name, std::forward<T>(credential));
     }
 
     template<typename T>
-    auto get(const ss::sstring& name) -> std::optional<T> const {
+    auto get(const credential_user& name) -> std::optional<T> const {
         if (auto it = _credentials.find(name); it != _credentials.end()) {
             return std::get<T>(it->second);
         }
@@ -52,7 +54,7 @@ private:
     // a mismatched credential type test for get<type>(name).
     using credential_types = std::variant<scram_credential>;
 
-    absl::node_hash_map<ss::sstring, credential_types> _credentials;
+    absl::node_hash_map<credential_user, credential_types> _credentials;
 };
 
 } // namespace security

--- a/src/v/security/scram_authenticator.cc
+++ b/src/v/security/scram_authenticator.cc
@@ -25,7 +25,8 @@ scram_authenticator<T>::handle_client_first(bytes_view auth_bytes) {
 
     // lookup credentials for this user
     _authid = _client_first->username_normalized();
-    auto credential = _credentials.get<scram_credential>(_authid);
+    auto credential = _credentials.get<scram_credential>(
+      credential_user(_authid));
     if (!credential) {
         return errc::invalid_credentials;
     }

--- a/src/v/security/tests/credential_store_test.cc
+++ b/src/v/security/tests/credential_store_test.cc
@@ -38,26 +38,29 @@ BOOST_AUTO_TEST_CASE(credential_store_test) {
     BOOST_REQUIRE_NE(cred0, cred1);
     BOOST_REQUIRE_NE(cred0_copy, cred1_copy);
 
+    const credential_user copied("copied");
+    const credential_user moved("moved");
+
     // put new credentials
     credential_store store;
-    store.put("copied", cred0);
-    store.put("moved", std::move(cred0_copy));
+    store.put(copied, cred0);
+    store.put(moved, std::move(cred0_copy));
 
-    BOOST_REQUIRE(store.get<scram_credential>("moved"));
-    BOOST_REQUIRE_EQUAL(*store.get<scram_credential>("moved"), cred0);
+    BOOST_REQUIRE(store.get<scram_credential>(moved));
+    BOOST_REQUIRE_EQUAL(*store.get<scram_credential>(moved), cred0);
 
-    BOOST_REQUIRE(store.get<scram_credential>("copied"));
-    BOOST_REQUIRE_EQUAL(*store.get<scram_credential>("copied"), cred0);
+    BOOST_REQUIRE(store.get<scram_credential>(copied));
+    BOOST_REQUIRE_EQUAL(*store.get<scram_credential>(copied), cred0);
 
     // update credentials
-    store.put("copied", cred1);
-    store.put("moved", std::move(cred1_copy));
+    store.put(copied, cred1);
+    store.put(moved, std::move(cred1_copy));
 
-    BOOST_REQUIRE(store.get<scram_credential>("moved"));
-    BOOST_REQUIRE_EQUAL(*store.get<scram_credential>("moved"), cred1);
+    BOOST_REQUIRE(store.get<scram_credential>(moved));
+    BOOST_REQUIRE_EQUAL(*store.get<scram_credential>(moved), cred1);
 
-    BOOST_REQUIRE(store.get<scram_credential>("copied"));
-    BOOST_REQUIRE_EQUAL(*store.get<scram_credential>("copied"), cred1);
+    BOOST_REQUIRE(store.get<scram_credential>(copied));
+    BOOST_REQUIRE_EQUAL(*store.get<scram_credential>(copied), cred1);
 }
 
 } // namespace security


### PR DESCRIPTION
Adds an internal controller-level interface for managing redpanda users (create, delete, update), and adds an http admin interface for externally managing users.

* POST v1/security/users
* DELETE, PUT v1/security/users/<user>