### PR TITLE
operator: enforce common name under 64 characters

### DIFF
--- a/src/go/k8s/pkg/resources/certmanager/admin_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/admin_api.go
@@ -10,8 +10,6 @@
 package certmanager
 
 import (
-	"fmt"
-
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,7 +26,8 @@ func (r *PkiReconciler) prepareAdminAPI(
 	toApply := []resources.Resource{}
 
 	// Redpanda cluster certificate for Admin API - to be provided to each broker
-	certsKey := r.certNamespacedName(AdminAPINodeCert)
+	cn := NewCommonName(r.pandaCluster.Name, AdminAPINodeCert)
+	certsKey := types.NamespacedName{Name: string(cn), Namespace: r.pandaCluster.Namespace}
 
 	dnsName := r.internalFQDN
 	externConn := r.pandaCluster.Spec.ExternalConnectivity
@@ -36,13 +35,14 @@ func (r *PkiReconciler) prepareAdminAPI(
 		dnsName = externConn.Subdomain
 	}
 
-	nodeCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, selfSignedIssuerRef, dnsName, false, r.logger)
+	nodeCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, selfSignedIssuerRef, dnsName, cn, false, r.logger)
 	toApply = append(toApply, nodeCert)
 
 	if r.pandaCluster.Spec.Configuration.TLS.AdminAPI.RequireClientAuth {
 		// Certificate for calling the Admin API on any broker
-		certsKey = r.certNamespacedName(AdminAPIClientCert)
-		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, selfSignedIssuerRef, fmt.Sprintf("rp-%s", certsKey.Name), false, r.logger)
+		cn := NewCommonName(r.pandaCluster.Name, AdminAPIClientCert)
+		certsKey := types.NamespacedName{Name: string(cn), Namespace: r.pandaCluster.Namespace}
+		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, selfSignedIssuerRef, cn, false, r.logger)
 
 		toApply = append(toApply, adminClientCert)
 	}

--- a/src/go/k8s/pkg/resources/certmanager/common_name.go
+++ b/src/go/k8s/pkg/resources/certmanager/common_name.go
@@ -1,0 +1,24 @@
+package certmanager
+
+import "fmt"
+
+// cert-manager has limit of 64 bytes on the common name of certificate
+const (
+	nameLimit       = 64
+	separatorLength = 1 // we use - as separator
+)
+
+// CommonName is certificate CN that is shortened to 64 chars
+type CommonName string
+
+// NewCommonName ensures the name does not exceed the limit of 64 bytes. It always
+// shortens the cluster name and keeps the whole suffix.
+// Suffix and name will be separated with -
+func NewCommonName(clusterName, suffix string) CommonName {
+	suffixLength := len(suffix)
+	maxClusterNameLength := nameLimit - suffixLength - separatorLength
+	if len(clusterName) > maxClusterNameLength {
+		clusterName = clusterName[:maxClusterNameLength]
+	}
+	return CommonName(fmt.Sprintf("%s-%s", clusterName, suffix))
+}

--- a/src/go/k8s/pkg/resources/certmanager/common_name_test.go
+++ b/src/go/k8s/pkg/resources/certmanager/common_name_test.go
@@ -1,0 +1,27 @@
+package certmanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources/certmanager"
+)
+
+func TestCommonName(t *testing.T) {
+	tests := []struct {
+		testName           string
+		clusterName        string
+		suffix             string
+		expectedCommonName string
+	}{
+		{"short name and suffix", "cluster", "suffix", "cluster-suffix"},
+		{"long name and suffix", "thisisverylongnamethatishittingthemaximal64characterlimitofnames", "suffix", "thisisverylongnamethatishittingthemaximal64characterlimit-suffix"},
+		{"long name and long suffix", "thisisverylongnamethatishittingthemaximal64characterlimitofnames", "thisisverylongsuffixthathas40chars123456", "thisisverylongnamethati-thisisverylongsuffixthathas40chars123456"},
+	}
+
+	for _, tt := range tests {
+		cn := certmanager.NewCommonName(tt.clusterName, tt.suffix)
+		assert.Equal(t, tt.expectedCommonName, string(cn), fmt.Sprintf("%s: expecting common name to be equal", tt.testName))
+	}
+}

--- a/src/go/k8s/tests/e2e/produce-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/00-assert.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: cluster-tls
+  name: thisisverylongnamethatishittingthemax40c
 status:
   readyReplicas: 1
 
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: cluster-tls-selfsigned-issuer
+  name: thisisverylongnamethatishittingthemax40c-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: cluster-tls-root-issuer
+  name: thisisverylongnamethatishittingthemax40c-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: cluster-tls-root-certificate
+  name: thisisverylongnamethatishittingthemax40c-root-certificate
 status:
   conditions:
     - reason: Ready
@@ -45,7 +45,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: cluster-tls-redpanda
+  name: thisisverylongnamethatishittingthemax40c-redpanda
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/produce-tls/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/00-redpanda-cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: cluster-tls
+  name: thisisverylongnamethatishittingthemax40c
 spec:
   image: "vectorized/redpanda"
   version: "latest"

--- a/src/go/k8s/tests/e2e/produce-tls/02-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/02-create-topic.yaml
@@ -9,7 +9,7 @@ spec:
         - name: tlscert
           secret:
             defaultMode: 420
-            secretName: cluster-tls-redpanda
+            secretName: thisisverylongnamethatishittingthemax40c-redpanda
         - name: rpkconfig
           configMap:
             name: rpk-config
@@ -25,7 +25,7 @@ spec:
             - /bin/bash
             - -c
           args:
-            - rpk topic create test --brokers cluster-tls-0.cluster-tls.$POD_NAMESPACE.svc.cluster.local:9092 -v
+            - rpk topic create test --brokers thisisverylongnamethatishittingthemax40c-0.thisisverylongnamethatishittingthemax40c.$POD_NAMESPACE.svc.cluster.local:9092 -v
           volumeMounts:
             - mountPath: /etc/tls/certs
               name: tlscert

--- a/src/go/k8s/tests/e2e/produce-tls/03-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/03-produce-message.yaml
@@ -9,7 +9,7 @@ spec:
         - name: tlscert
           secret:
             defaultMode: 420
-            secretName: cluster-tls-redpanda
+            secretName: thisisverylongnamethatishittingthemax40c-redpanda
             items: # TODO should we explicitly limit visibility to ca.crt?
             - key: ca.crt
               path: ca.crt
@@ -30,7 +30,7 @@ spec:
           args:
             - >
               echo {"test":"message"} |
-              rpk topic produce test --brokers cluster-tls-0.cluster-tls.$POD_NAMESPACE.svc.cluster.local:9092
+              rpk topic produce test --brokers thisisverylongnamethatishittingthemax40c-0.thisisverylongnamethatishittingthemax40c.$POD_NAMESPACE.svc.cluster.local:9092
               -v -n 1 -k "test-key"
           volumeMounts:
             - mountPath: /etc/tls/certs


### PR DESCRIPTION
## Cover letter

This ensures that the common name never exceeds 64chars length which cert-manager validates against.

When looking into this I found out there are more problems with long names #1011 so I'll submit another patch that will limit the total length of redpanda cluster name to 40 to be on the safe side.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
We enforce that cert-manager common name cannot exceed 64 characters.