### PR TITLE
Pandaproxy multi listeners

### DIFF
--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -47,12 +47,15 @@ void rjson_serialize(
     w.Key("enabled");
     w.Bool(v.is_enabled());
 
-    w.Key("client_auth");
+    w.Key("require_client_auth");
     w.Bool(v.get_require_client_auth());
 
     if (v.get_key_cert_files()) {
-        w.Key("key_cert");
-        rjson_serialize(w, *(v.get_key_cert_files()));
+        w.Key("key_file");
+        w.String(v.get_key_cert_files()->key_file.c_str());
+
+        w.Key("cert_file");
+        w.String(v.get_key_cert_files()->cert_file.c_str());
     }
 
     if (v.get_truststore_file()) {
@@ -93,9 +96,24 @@ void rjson_serialize(
 
     w.Key("name");
     w.String(v.name.c_str());
+    w.Key("enabled");
+    w.Bool(v.config.is_enabled());
 
-    w.Key("config");
-    rjson_serialize(w, v.config);
+    w.Key("require_client_auth");
+    w.Bool(v.config.get_require_client_auth());
+
+    if (v.config.get_key_cert_files()) {
+        w.Key("key_file");
+        w.String(v.config.get_key_cert_files()->key_file.c_str());
+
+        w.Key("cert_file");
+        w.String(v.config.get_key_cert_files()->cert_file.c_str());
+    }
+
+    if (v.config.get_truststore_file()) {
+        w.Key("truststore_file");
+        w.String((*(v.config.get_truststore_file())).c_str());
+    }
 
     w.EndObject();
 }

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -98,7 +98,7 @@ void rjson_serialize(
     w.StartObject();
     w.Key("name");
     w.String(ep.name);
-    w.Key("host");
+    w.Key("address");
     w.String(ep.address.host());
     w.Key("port");
     w.Uint(ep.address.port());

--- a/src/v/pandaproxy/configuration.cc
+++ b/src/v/pandaproxy/configuration.cc
@@ -10,6 +10,8 @@
 #include "configuration.h"
 
 #include "config/configuration.h"
+#include "config/endpoint_tls_config.h"
+#include "model/metadata.h"
 #include "units.h"
 
 namespace pandaproxy {
@@ -26,20 +28,20 @@ configuration::configuration()
     "pandaproxy_api",
     "Rest API listen address and port",
     config::required::no,
-    unresolved_address("0.0.0.0", 8082))
+    {model::broker_endpoint(unresolved_address("0.0.0.0", 8082))})
   , pandaproxy_api_tls(
       *this,
       "pandaproxy_api_tls",
       "TLS configuration for Pandaproxy api",
       config::required::no,
-      config::tls_config(),
-      config::tls_config::validate)
+      {},
+      config::endpoint_tls_config::validate_many)
   , advertised_pandaproxy_api(
       *this,
       "advertised_pandaproxy_api",
       "Rest API address and port to publish to client",
       config::required::no,
-      pandaproxy_api)
+      {})
   , api_doc_dir(
       *this,
       "api_doc_dir",

--- a/src/v/pandaproxy/configuration.h
+++ b/src/v/pandaproxy/configuration.h
@@ -11,7 +11,9 @@
 
 #pragma once
 #include "config/config_store.h"
+#include "config/property.h"
 #include "config/tls_config.h"
+#include "model/metadata.h"
 
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/ip.hh>
@@ -24,9 +26,11 @@ namespace pandaproxy {
 /// All application modules depend on configuration. The configuration module
 /// can not depend on any other module to prevent cyclic dependencies.
 struct configuration final : public config::config_store {
-    config::property<unresolved_address> pandaproxy_api;
-    config::property<config::tls_config> pandaproxy_api_tls;
-    config::property<unresolved_address> advertised_pandaproxy_api;
+    config::one_or_many_property<model::broker_endpoint> pandaproxy_api;
+    config::one_or_many_property<config::endpoint_tls_config>
+      pandaproxy_api_tls;
+    config::one_or_many_property<model::broker_endpoint>
+      advertised_pandaproxy_api;
     config::property<ss::sstring> api_doc_dir;
 
     configuration();

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -79,9 +79,9 @@ std::vector<server::route_t> get_proxy_routes() {
     return routes;
 }
 
-static server::context_t
+static context_t
 make_context(const configuration& cfg, kafka::client::client& client) {
-    return server::context_t{
+    return context_t{
       .mem_sem{ss::memory::stats().free_memory()},
       .as{},
       .client{client},

--- a/src/v/pandaproxy/proxy.h
+++ b/src/v/pandaproxy/proxy.h
@@ -36,7 +36,7 @@ public:
 private:
     configuration _config;
     kafka::client::client _client;
-    server::context_t _ctx;
+    context_t _ctx;
     server _server;
 };
 

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -37,7 +37,13 @@ namespace pandaproxy {
 /// e.g., logging, serialisation, metrics, rate-limiting.
 class server {
 public:
-    using context_t = pandaproxy::context_t;
+    struct context_t {
+        std::vector<unresolved_address> advertised_listeners;
+        ss::semaphore mem_sem;
+        ss::abort_source as;
+        kafka::client::client& client;
+        const configuration& config;
+    };
 
     struct request_t {
         std::unique_ptr<ss::httpd::request> req;
@@ -70,7 +76,7 @@ public:
     server(
       const ss::sstring& server_name,
       ss::api_registry_builder20&& api20,
-      context_t ctx);
+      pandaproxy::context_t ctx);
 
     void route(route_t route);
     void route(std::vector<route_t>&& routes);

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -54,15 +54,10 @@ auto get_consumer_offsets(
 
 FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
     using namespace std::chrono_literals;
-
     info("Waiting for leadership");
     wait_for_controller_leadership().get();
-
     info("Connecting client");
     auto client = make_client();
-
-    auto advertised_address{unresolved_address{"proxy.example.com", 8080}};
-    set_config("advertised_pandaproxy_api", advertised_address);
 
     kafka::group_id group_id{"test_group"};
     kafka::member_id member_id{kafka::no_member};
@@ -95,8 +90,8 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           res_data.base_uri,
           fmt::format(
             "http://{}:{}/consumers/{}/instances/{}",
-            advertised_address.host(),
-            advertised_address.port(),
+            "127.0.0.1",
+            "8082",
             group_id(),
             member_id()));
         BOOST_REQUIRE_EQUAL(

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -150,8 +150,9 @@ public:
 
     YAML::Node proxy_config(uint16_t proxy_port = 8082) {
         pandaproxy::configuration cfg;
-        cfg.pandaproxy_api.set_value(
-          unresolved_address("127.0.0.1", proxy_port));
+        cfg.get("pandaproxy_api")
+          .set_value(std::vector<model::broker_endpoint>{model::broker_endpoint(
+            unresolved_address("127.0.0.1", proxy_port))});
         return to_yaml(cfg);
     }
 


### PR DESCRIPTION
## Cover letter
Added support for multiple listeners in Panda Proxy. Multiple listeners can be configured in similar way as it is in redpanda. 

Example configuration:
```yaml
  pandaproxy_api: 
  - name: secured
    address: 127.0.0.1
    port: 443
  - name: plain
    address: 127.0.0.1
    port: 9090
  pandaproxy_api_tls:
  - name: secured
    cert_file: cluster/secrets/n1/cert.pem
    enabled: true
    key_file: cluster/secrets/n1/key.pem
    require_client_auth: true
    truststore_file: cluster/secrets/ca_cert.pem
  advertised_pandaproxy_api:
  - name: secured
    address: secured.panda.proxy.com
    port: 1234
```

## Release notes
- multi listeners support in panda proxy
