### PR TITLE
rpk/topic/create: Rename --config to --cfg to fix conflict

### DIFF
--- a/docs/www/rpk-commands.md
+++ b/docs/www/rpk-commands.md
@@ -100,7 +100,10 @@ Flags:
 Interact with the Redpanda API.
 
 ```
-Global flags: --brokers strings   Comma-separated list of broker ip:port pair
+Global flags:
+
+      --brokers strings   Comma-separated list of broker ip:port pair
+      --config  string    Redpanda config file, if not set the file will be searched for in the default location (default "/etc/redpanda/redpanda.yaml")
 ```
 
 ### create
@@ -112,9 +115,11 @@ Usage:
   rpk topic create <topic name> [flags]
 
 Flags:
-      --compact            Enable topic compaction
-  -p, --partitions int32   Number of partitions (default 1)
-  -r, --replicas int16     Number of replicas (default 1)
+      --compact                    Enable topic compaction
+  -h, --help                       help for create
+  -p, --partitions int32           Number of partitions (default 1)
+  -r, --replicas int16             Replication factor. If it's negative or is left unspecified, it will use the cluster's default topic replication factor. (default -1)
+  -c, --topic-config stringArray   Config entries in the format <key>:<value>. May be used multiple times to add more entries.
 ```
 
 ### delete

--- a/src/go/rpk/pkg/cli/cmd/topic/create.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/create.go
@@ -23,10 +23,10 @@ func NewCreateCommand(
 	admin func() (sarama.ClusterAdmin, error),
 ) *cobra.Command {
 	var (
-		partitions int32
-		replicas   int16
-		compact    bool
-		config     []string
+		partitions  int32
+		replicas    int16
+		compact     bool
+		topicConfig []string
 	)
 	cmd := &cobra.Command{
 		Use:   "create <topic name>",
@@ -35,7 +35,7 @@ func NewCreateCommand(
 		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configEntries, err := parseKVs(config)
+			configEntries, err := parseKVs(topicConfig)
 			if err != nil {
 				return err
 			}
@@ -87,8 +87,8 @@ rpk topic describe '%s'
 		},
 	}
 	cmd.Flags().StringArrayVarP(
-		&config,
-		"config",
+		&topicConfig,
+		"topic-config",
 		"c",
 		[]string{},
 		"Config entries in the format <key>:<value>. May be used multiple times"+

--- a/src/go/rpk/pkg/cli/cmd/topic_test.go
+++ b/src/go/rpk/pkg/cli/cmd/topic_test.go
@@ -66,13 +66,13 @@ func TestTopicCmd(t *testing.T) {
 		{
 			name:           "create should allow passing arbitrary topic config",
 			cmd:            topic.NewCreateCommand,
-			args:           []string{"San Francisco", "-c", "custom.config:value", "--config", "another.config:anothervalue"},
+			args:           []string{"San Francisco", "--topic-config", "custom.config:value", "--topic-config", "another.config:anothervalue"},
 			expectedOutput: "Created topic 'San Francisco'.\\nYou may check its config with\\n\\nrpk topic describe 'San Francisco'\\n\"\n",
 		},
 		{
 			name:           "create should allow passing comma-separated config values",
 			cmd:            topic.NewCreateCommand,
-			args:           []string{"San Francisco", "-c", "custom.config:value", "--config", "cleanup.policy:cleanup,compact"},
+			args:           []string{"San Francisco", "-c", "custom.config:value", "-c", "cleanup.policy:cleanup,compact"},
 			expectedOutput: "Created topic 'San Francisco'.\\nYou may check its config with\\n\\nrpk topic describe 'San Francisco'\\n\"\n",
 		},
 		{


### PR DESCRIPTION
`rpk topic` has a global --config flag which, like in the rest of commands, points the command to the desired config file path. However, `rpk topic create` declared another flag named --config, but for passing custom k:v pairs to be sent as the new topic's configuration. Rename the latter to --cfg to fix the conflict between the two.

Fix #1003

Release note: Rename `rpk topic create`'s --config flag to --cfg to prevent it from clashing with the global --config flag.
