### PR TITLE
Ducktape: Enable page cache for Redpanda service (disable O_DIRECT) 

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -108,6 +108,7 @@ class RedpandaService(Service):
                f" --redpanda-cfg {RedpandaService.CONFIG_FILE}"
                f" --default-log-level {self._log_level}"
                f" --logger-log-level=exception=debug "
+               f" --kernel-page-cache=true "
                f" >> {RedpandaService.STDOUT_STDERR_CAPTURE} 2>&1 &")
 
         self.logger.info(


### PR DESCRIPTION
## Cover letter

See: https://github.com/scylladb/seastar/commit/fbb9fcd15a7e15c24b75f85b003723bea29d85e5

Prevents this error:
```
INFO  2021-03-31 19:30:03,509 [shard 0] cluster - raft0_utils.h:32 - Current node is cluster root
INFO  2021-03-31 19:30:03,519 [shard 0] storage - segment.cc:609 - Creating new segment /var/lib/redpanda/data/redpanda/kvstore/0_0/0-0-v1.log
libc++abi: terminating with uncaught exception of type std::__1::system_error: io_submit: Operation not supported

seastar::throw_system_error_on(bool, char const*) at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/debug/clang/rp_deps_install/include/seastar/core/posix.hh:433
seastar::aio_storage_context::handle_aio_error(seastar::internal::linux_abi::iocb*, int) at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/debug/clang/v_deps_build/seastar-prefix/src/seastar/src/core/reactor_backend.cc:143
seastar::aio_storage_context::submit_work() at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/debug/clang/v_deps_build/seastar-prefix/src/seastar/src/core/reactor_backend.cc:190
seastar::reactor_backend_aio::kernel_submit_work() at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/debug/clang/v_deps_build/seastar-prefix/src/seastar/src/core/reactor_backend.cc:451
seastar::reactor::kernel_submit_work_pollfn::poll() at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/debug/clang/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2360
seastar::reactor::poll_once() at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/debug/clang/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2927
seastar::reactor::run()::$_76::operator()() const at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/debug/clang/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2825
decltype ((std::__1::forward<seastar::reactor::run()::$_76&>({parm#1}))()) std::__1::__invoke<seastar::reactor::run()::$_76&>(seastar::reactor::run()::$_76&) at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/llvm/install/bin/../include/c++/v1/type_traits:3899
bool std::__1::__invoke_void_return_wrapper<bool>::__call<seastar::reactor::run()::$_76&>(seastar::reactor::run()::$_76&) at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/llvm/install/bin/../include/c++/v1/__functional_base:317
std::__1::__function::__alloc_func<seastar::reactor::run()::$_76, std::__1::allocator<seastar::reactor::run()::$_76>, bool ()>::operator()() at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/llvm/install/bin/../include/c++/v1/functional:1557
std::__1::__function::__func<seastar::reactor::run()::$_76, std::__1::allocator<seastar::reactor::run()::$_76>, bool ()>::operator()() at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/llvm/install/bin/../include/c++/v1/functional:1731
std::__1::__function::__value_func<bool ()>::operator()() const at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/llvm/install/bin/../include/c++/v1/functional:1884
std::__1::function<bool ()>::operator()() const at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/llvm/install/bin/../include/c++/v1/functional:2556
seastar::reactor::run() at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/debug/clang/v_deps_build/seastar-prefix/src/seastar/src/core/reactor.cc:2851
seastar::app_template::run_deprecated(int, char**, std::__1::function<void ()>&&) at /home/ben/development/src/github.com/BenPope/redpanda/vbuild/debug/clang/v_deps_build/seastar-pre
```

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: Ducktape: Enable page cache for Redpanda service (disable O_DIRECT) 
