### PR TITLE
3rdparty: Update seastar to 58274b

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -112,7 +112,7 @@ ExternalProject_Add(boost
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/vectorizedio/seastar.git
-  GIT_TAG 7b9dbca45617dd04e47b7dec9aa53bcbe900ed23
+  GIT_TAG 58274bbd7e286b178cf954a1293f48bee79aafb8
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS


### PR DESCRIPTION
## Cover letter

Allows building with g++-10.2.1

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: Fix a build error with g++-10.2.1-11.0.0
