### PR TITLE
operator/tls: add separate root cert for admin api

### DIFF
--- a/src/go/k8s/config/samples/redpanda_v1alpha1_with_tls.yaml
+++ b/src/go/k8s/config/samples/redpanda_v1alpha1_with_tls.yaml
@@ -23,7 +23,7 @@ spec:
       port: 9092
     admin:
       port: 9644
-    TLS:
+    tls:
       kafkaApi:
         enabled: true
     developerMode: true

--- a/src/go/k8s/pkg/resources/certmanager/admin_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/admin_api.go
@@ -28,7 +28,7 @@ func (r *PkiReconciler) AdminAPINodeCert() types.NamespacedName {
 }
 
 func (r *PkiReconciler) prepareAdminAPI(
-	selfSignedIssuerRef *cmmeta.ObjectReference,
+	issuerRef *cmmeta.ObjectReference,
 ) []resources.Resource {
 	toApply := []resources.Resource{}
 
@@ -42,14 +42,14 @@ func (r *PkiReconciler) prepareAdminAPI(
 		dnsName = externConn.Subdomain
 	}
 
-	nodeCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, selfSignedIssuerRef, dnsName, cn, false, r.logger)
+	nodeCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, issuerRef, dnsName, cn, false, r.logger)
 	toApply = append(toApply, nodeCert)
 
 	if r.pandaCluster.Spec.Configuration.TLS.AdminAPI.RequireClientAuth {
 		// Certificate for calling the Admin API on any broker
 		cn := NewCommonName(r.pandaCluster.Name, AdminAPIClientCert)
-		certsKey := types.NamespacedName{Name: string(cn), Namespace: r.pandaCluster.Namespace}
-		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, selfSignedIssuerRef, cn, false, r.logger)
+		clientCertsKey := types.NamespacedName{Name: string(cn), Namespace: r.pandaCluster.Namespace}
+		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, clientCertsKey, issuerRef, cn, false, r.logger)
 
 		toApply = append(toApply, adminClientCert)
 	}

--- a/src/go/k8s/pkg/resources/certmanager/admin_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/admin_api.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	adminAPI = "admin"
 	// AdminAPIClientCert cert name - client certificate for Admin API
 	AdminAPIClientCert = "admin-api-client"
 	// AdminAPINodeCert cert name - node certificate for Admin API

--- a/src/go/k8s/pkg/resources/certmanager/admin_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/admin_api.go
@@ -15,6 +15,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	// AdminAPIClientCert cert name - client certificate for Admin API
+	AdminAPIClientCert = "admin-api-client"
+	// AdminAPINodeCert cert name - node certificate for Admin API
+	AdminAPINodeCert = "admin-api-node"
+)
+
 // AdminAPINodeCert returns the namespaced name for the Admin API certificate used by node
 func (r *PkiReconciler) AdminAPINodeCert() types.NamespacedName {
 	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + AdminAPINodeCert, Namespace: r.pandaCluster.Namespace}

--- a/src/go/k8s/pkg/resources/certmanager/kafka_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/kafka_api.go
@@ -1,0 +1,141 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package certmanager
+
+import (
+	"context"
+
+	cmmetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// OperatorClientCert cert name - used by kubernetes operator to call KafkaAPI
+	OperatorClientCert = "operator-client"
+	// UserClientCert cert name - used by redpanda clients using KafkaAPI
+	UserClientCert = "user-client"
+	// AdminClientCert cert name - used by redpanda clients using KafkaAPI
+	AdminClientCert = "admin-client"
+	// RedpandaNodeCert cert name - node certificate
+	RedpandaNodeCert = "redpanda"
+)
+
+// OperatorClientCert returns the namespaced name for the client certificate
+// used by the Kubernetes operator
+func (r *PkiReconciler) OperatorClientCert() types.NamespacedName {
+	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + OperatorClientCert, Namespace: r.pandaCluster.Namespace}
+}
+
+// AdminCert returns the namespaced name for the certificate used by an administrator to query the Kafka API
+func (r *PkiReconciler) AdminCert() types.NamespacedName {
+	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + OperatorClientCert, Namespace: r.pandaCluster.Namespace}
+}
+
+// NodeCert returns the namespaced name for Redpanda's node certificate
+func (r *PkiReconciler) NodeCert() types.NamespacedName {
+	if r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.NodeSecretRef != nil {
+		return types.NamespacedName{
+			Name:      r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.NodeSecretRef.Name,
+			Namespace: r.pandaCluster.Namespace,
+		}
+	}
+	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + RedpandaNodeCert, Namespace: r.pandaCluster.Namespace}
+}
+
+func (r *PkiReconciler) prepareKafkaAPI(
+	ctx context.Context, selfSignedIssuerRef *cmmetav1.ObjectReference,
+) ([]resources.Resource, error) {
+	toApply := []resources.Resource{}
+
+	externalIssuerRef := r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.IssuerRef
+	nodeSecretRef := r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.NodeSecretRef
+
+	if nodeSecretRef == nil {
+		// Redpanda cluster certificate for Kafka API - to be provided to each broker
+		cn := NewCommonName(r.pandaCluster.Name, RedpandaNodeCert)
+		certsKey := types.NamespacedName{Name: string(cn), Namespace: r.pandaCluster.Namespace}
+		nodeIssuerRef := selfSignedIssuerRef
+		if externalIssuerRef != nil {
+			// if external issuer is provided, we will use it to generate node certificates
+			nodeIssuerRef = externalIssuerRef
+		}
+
+		dnsName := r.internalFQDN
+		externConn := r.pandaCluster.Spec.ExternalConnectivity
+		if externConn.Enabled && externConn.Subdomain != "" {
+			dnsName = externConn.Subdomain
+		}
+
+		redpandaCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, nodeIssuerRef, dnsName, cn, false, r.logger)
+
+		toApply = append(toApply, redpandaCert)
+	}
+
+	if nodeSecretRef != nil && nodeSecretRef.Namespace != r.pandaCluster.Namespace {
+		if err := r.copyNodeSecretToLocalNamespace(ctx, nodeSecretRef); err != nil {
+			return nil, err
+		}
+	}
+
+	if r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.RequireClientAuth {
+		// Certificate for external clients to call the Kafka API on any broker in this Redpanda cluster
+		userClientCn := NewCommonName(r.pandaCluster.Name, UserClientCert)
+		userClientKey := types.NamespacedName{Name: string(userClientCn), Namespace: r.pandaCluster.Namespace}
+		externalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, userClientKey, selfSignedIssuerRef, userClientCn, false, r.logger)
+
+		// Certificate for operator to call the Kafka API on any broker in this Redpanda cluster
+		operatorClientCn := NewCommonName(r.pandaCluster.Name, OperatorClientCert)
+		operatorClientKey := types.NamespacedName{Name: string(operatorClientCn), Namespace: r.pandaCluster.Namespace}
+		internalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, operatorClientKey, selfSignedIssuerRef, operatorClientCn, false, r.logger)
+
+		// Certificate for admin to call the Kafka API on any broker in this Redpanda cluster
+		adminClientCn := NewCommonName(r.pandaCluster.Name, AdminClientCert)
+		adminClientKey := types.NamespacedName{Name: string(adminClientCn), Namespace: r.pandaCluster.Namespace}
+		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, adminClientKey, selfSignedIssuerRef, adminClientCn, false, r.logger)
+
+		toApply = append(toApply, externalClientCert, internalClientCert, adminClientCert)
+	}
+
+	return toApply, nil
+}
+
+// Creates copy of secret in Redpanda cluster's namespace
+func (r *PkiReconciler) copyNodeSecretToLocalNamespace(
+	ctx context.Context, secretRef *corev1.ObjectReference,
+) error {
+	var secret corev1.Secret
+	err := r.Get(ctx, types.NamespacedName{Name: secretRef.Name, Namespace: secretRef.Namespace}, &secret)
+	if err != nil {
+		return err
+	}
+
+	tlsKey := secret.Data[corev1.TLSPrivateKeyKey]
+	tlsCrt := secret.Data[corev1.TLSCertKey]
+	caCrt := secret.Data[cmmetav1.TLSCAKey]
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.NodeCert().Name,
+			Namespace: r.NodeCert().Namespace,
+			Labels:    secret.Labels,
+		},
+		Type: secret.Type,
+		Data: map[string][]byte{
+			cmmetav1.TLSCAKey:       caCrt,
+			corev1.TLSCertKey:       tlsCrt,
+			corev1.TLSPrivateKeyKey: tlsKey,
+		},
+	}
+	_, err = resources.CreateIfNotExists(ctx, r, caSecret, r.logger)
+	return err
+}

--- a/src/go/k8s/pkg/resources/certmanager/kafka_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/kafka_api.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	kafkaAPI = "kafka"
 	// OperatorClientCert cert name - used by kubernetes operator to call KafkaAPI
 	OperatorClientCert = "operator-client"
 	// UserClientCert cert name - used by redpanda clients using KafkaAPI

--- a/src/go/k8s/pkg/resources/certmanager/kafka_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/kafka_api.go
@@ -53,7 +53,7 @@ func (r *PkiReconciler) NodeCert() types.NamespacedName {
 }
 
 func (r *PkiReconciler) prepareKafkaAPI(
-	ctx context.Context, selfSignedIssuerRef *cmmetav1.ObjectReference,
+	ctx context.Context, issuerRef *cmmetav1.ObjectReference,
 ) ([]resources.Resource, error) {
 	toApply := []resources.Resource{}
 
@@ -64,7 +64,7 @@ func (r *PkiReconciler) prepareKafkaAPI(
 		// Redpanda cluster certificate for Kafka API - to be provided to each broker
 		cn := NewCommonName(r.pandaCluster.Name, RedpandaNodeCert)
 		certsKey := types.NamespacedName{Name: string(cn), Namespace: r.pandaCluster.Namespace}
-		nodeIssuerRef := selfSignedIssuerRef
+		nodeIssuerRef := issuerRef
 		if externalIssuerRef != nil {
 			// if external issuer is provided, we will use it to generate node certificates
 			nodeIssuerRef = externalIssuerRef
@@ -91,17 +91,17 @@ func (r *PkiReconciler) prepareKafkaAPI(
 		// Certificate for external clients to call the Kafka API on any broker in this Redpanda cluster
 		userClientCn := NewCommonName(r.pandaCluster.Name, UserClientCert)
 		userClientKey := types.NamespacedName{Name: string(userClientCn), Namespace: r.pandaCluster.Namespace}
-		externalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, userClientKey, selfSignedIssuerRef, userClientCn, false, r.logger)
+		externalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, userClientKey, issuerRef, userClientCn, false, r.logger)
 
 		// Certificate for operator to call the Kafka API on any broker in this Redpanda cluster
 		operatorClientCn := NewCommonName(r.pandaCluster.Name, OperatorClientCert)
 		operatorClientKey := types.NamespacedName{Name: string(operatorClientCn), Namespace: r.pandaCluster.Namespace}
-		internalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, operatorClientKey, selfSignedIssuerRef, operatorClientCn, false, r.logger)
+		internalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, operatorClientKey, issuerRef, operatorClientCn, false, r.logger)
 
 		// Certificate for admin to call the Kafka API on any broker in this Redpanda cluster
 		adminClientCn := NewCommonName(r.pandaCluster.Name, AdminClientCert)
 		adminClientKey := types.NamespacedName{Name: string(adminClientCn), Namespace: r.pandaCluster.Namespace}
-		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, adminClientKey, selfSignedIssuerRef, adminClientCn, false, r.logger)
+		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, adminClientKey, issuerRef, adminClientCn, false, r.logger)
 
 		toApply = append(toApply, externalClientCert, internalClientCert, adminClientCert)
 	}

--- a/src/go/k8s/pkg/resources/certmanager/pki.go
+++ b/src/go/k8s/pkg/resources/certmanager/pki.go
@@ -17,8 +17,6 @@ import (
 	cmmetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
 	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,22 +24,8 @@ import (
 
 var _ resources.Reconciler = &PkiReconciler{}
 
-const (
-	// RootCert cert name
-	RootCert = "rootcert"
-	// OperatorClientCert cert name - used by kubernetes operator to call KafkaAPI
-	OperatorClientCert = "operator-client"
-	// UserClientCert cert name - used by redpanda clients using KafkaAPI
-	UserClientCert = "user-client"
-	// AdminClientCert cert name - used by redpanda clients using KafkaAPI
-	AdminClientCert = "admin-client"
-	// RedpandaNodeCert cert name - node certificate
-	RedpandaNodeCert = "redpanda"
-	// AdminAPIClientCert cert name - client certificate for Admin API
-	AdminAPIClientCert = "admin-api-client"
-	// AdminAPINodeCert cert name - node certificate for Admin API
-	AdminAPINodeCert = "admin-api-node"
-)
+// RootCert cert name
+const RootCert = "rootcert"
 
 // PkiReconciler is part of the reconciliation of redpanda.vectorized.io CRD.
 // It creates certificates for Redpanda and its clients when TLS is enabled.
@@ -64,85 +48,6 @@ func NewPki(
 	return &PkiReconciler{
 		client, scheme, pandaCluster, fqdn, logger.WithValues("Reconciler", "pki"),
 	}
-}
-
-// NodeCert returns the namespaced name for Redpanda's node certificate
-func (r *PkiReconciler) NodeCert() types.NamespacedName {
-	if r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.NodeSecretRef != nil {
-		return types.NamespacedName{
-			Name:      r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.NodeSecretRef.Name,
-			Namespace: r.pandaCluster.Namespace,
-		}
-	}
-	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + RedpandaNodeCert, Namespace: r.pandaCluster.Namespace}
-}
-
-// OperatorClientCert returns the namespaced name for the client certificate
-// used by the Kubernetes operator
-func (r *PkiReconciler) OperatorClientCert() types.NamespacedName {
-	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + OperatorClientCert, Namespace: r.pandaCluster.Namespace}
-}
-
-// AdminCert returns the namespaced name for the certificate used by an administrator to query the Kafka API
-func (r *PkiReconciler) AdminCert() types.NamespacedName {
-	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + OperatorClientCert, Namespace: r.pandaCluster.Namespace}
-}
-
-func (r *PkiReconciler) prepareKafkaAPI(
-	ctx context.Context, selfSignedIssuerRef *cmmetav1.ObjectReference,
-) ([]resources.Resource, error) {
-	toApply := []resources.Resource{}
-
-	externalIssuerRef := r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.IssuerRef
-	nodeSecretRef := r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.NodeSecretRef
-
-	if nodeSecretRef == nil {
-		// Redpanda cluster certificate for Kafka API - to be provided to each broker
-		cn := NewCommonName(r.pandaCluster.Name, RedpandaNodeCert)
-		certsKey := types.NamespacedName{Name: string(cn), Namespace: r.pandaCluster.Namespace}
-		nodeIssuerRef := selfSignedIssuerRef
-		if externalIssuerRef != nil {
-			// if external issuer is provided, we will use it to generate node certificates
-			nodeIssuerRef = externalIssuerRef
-		}
-
-		dnsName := r.internalFQDN
-		externConn := r.pandaCluster.Spec.ExternalConnectivity
-		if externConn.Enabled && externConn.Subdomain != "" {
-			dnsName = externConn.Subdomain
-		}
-
-		redpandaCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, nodeIssuerRef, dnsName, cn, false, r.logger)
-
-		toApply = append(toApply, redpandaCert)
-	}
-
-	if nodeSecretRef != nil && nodeSecretRef.Namespace != r.pandaCluster.Namespace {
-		if err := r.copyNodeSecretToLocalNamespace(ctx, nodeSecretRef); err != nil {
-			return nil, err
-		}
-	}
-
-	if r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.RequireClientAuth {
-		// Certificate for external clients to call the Kafka API on any broker in this Redpanda cluster
-		userClientCn := NewCommonName(r.pandaCluster.Name, UserClientCert)
-		userClientKey := types.NamespacedName{Name: string(userClientCn), Namespace: r.pandaCluster.Namespace}
-		externalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, userClientKey, selfSignedIssuerRef, userClientCn, false, r.logger)
-
-		// Certificate for operator to call the Kafka API on any broker in this Redpanda cluster
-		operatorClientCn := NewCommonName(r.pandaCluster.Name, OperatorClientCert)
-		operatorClientKey := types.NamespacedName{Name: string(operatorClientCn), Namespace: r.pandaCluster.Namespace}
-		internalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, operatorClientKey, selfSignedIssuerRef, operatorClientCn, false, r.logger)
-
-		// Certificate for admin to call the Kafka API on any broker in this Redpanda cluster
-		adminClientCn := NewCommonName(r.pandaCluster.Name, AdminClientCert)
-		adminClientKey := types.NamespacedName{Name: string(adminClientCn), Namespace: r.pandaCluster.Namespace}
-		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, adminClientKey, selfSignedIssuerRef, adminClientCn, false, r.logger)
-
-		toApply = append(toApply, externalClientCert, internalClientCert, adminClientCert)
-	}
-
-	return toApply, nil
 }
 
 func (r *PkiReconciler) prepareRoot() (
@@ -170,7 +75,6 @@ func (r *PkiReconciler) prepareRoot() (
 		true,
 		r.logger)
 
-	// Kubernetes cluster issuer for Redpanda Operator - key provided in RedpandaCluster CR, else created
 	k8sClusterIssuerKey := r.issuerNamespacedName("root-issuer")
 	k8sClusterIssuer := NewIssuer(r.Client,
 		r.scheme,
@@ -214,37 +118,6 @@ func (r *PkiReconciler) Ensure(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// Creates copy of secret in Redpanda cluster's namespace
-func (r *PkiReconciler) copyNodeSecretToLocalNamespace(
-	ctx context.Context, secretRef *corev1.ObjectReference,
-) error {
-	var secret corev1.Secret
-	err := r.Get(ctx, types.NamespacedName{Name: secretRef.Name, Namespace: secretRef.Namespace}, &secret)
-	if err != nil {
-		return err
-	}
-
-	tlsKey := secret.Data[corev1.TLSPrivateKeyKey]
-	tlsCrt := secret.Data[corev1.TLSCertKey]
-	caCrt := secret.Data[cmmetav1.TLSCAKey]
-
-	caSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.NodeCert().Name,
-			Namespace: r.NodeCert().Namespace,
-			Labels:    secret.Labels,
-		},
-		Type: secret.Type,
-		Data: map[string][]byte{
-			cmmetav1.TLSCAKey:       caCrt,
-			corev1.TLSCertKey:       tlsCrt,
-			corev1.TLSPrivateKeyKey: tlsKey,
-		},
-	}
-	_, err = resources.CreateIfNotExists(ctx, r, caSecret, r.logger)
-	return err
 }
 
 func (r *PkiReconciler) issuerNamespacedName(name string) types.NamespacedName {

--- a/src/go/k8s/pkg/resources/certmanager/pki.go
+++ b/src/go/k8s/pkg/resources/certmanager/pki.go
@@ -56,11 +56,10 @@ func (r *PkiReconciler) prepareRoot() (
 ) {
 	toApply := []resources.Resource{}
 
-	selfSignedKey := r.issuerNamespacedName("selfsigned-issuer")
 	selfSignedIssuer := NewIssuer(r.Client,
 		r.scheme,
 		r.pandaCluster,
-		selfSignedKey,
+		r.issuerNamespacedName("selfsigned-issuer"),
 		"",
 		r.logger)
 
@@ -75,18 +74,17 @@ func (r *PkiReconciler) prepareRoot() (
 		true,
 		r.logger)
 
-	k8sClusterIssuerKey := r.issuerNamespacedName("root-issuer")
-	k8sClusterIssuer := NewIssuer(r.Client,
+	leafIssuer := NewIssuer(r.Client,
 		r.scheme,
 		r.pandaCluster,
-		k8sClusterIssuerKey,
+		r.issuerNamespacedName("root-issuer"),
 		rootCertificate.Key().Name,
 		r.logger)
 
-	selfSignedIssuerRef := k8sClusterIssuer.objRef()
+	leafIssuerRef := leafIssuer.objRef()
 
-	toApply = append(toApply, selfSignedIssuer, rootCertificate, k8sClusterIssuer)
-	return toApply, selfSignedIssuerRef
+	toApply = append(toApply, selfSignedIssuer, rootCertificate, leafIssuer)
+	return toApply, leafIssuerRef
 }
 
 // Ensure will manage PKI for redpanda.vectorized.io custom resource

--- a/src/go/k8s/tests/e2e/admin-api-tls-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls-client-auth/00-assert.yaml
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: cluster-tls-selfsigned-issuer
+  name: cluster-tls-admin-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: cluster-tls-root-issuer
+  name: cluster-tls-admin-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: cluster-tls-root-certificate
+  name: cluster-tls-admin-root-certificate
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/admin-api-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls/00-assert.yaml
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: cluster-tls-selfsigned-issuer
+  name: cluster-tls-admin-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: cluster-tls-root-issuer
+  name: cluster-tls-admin-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: cluster-tls-root-certificate
+  name: cluster-tls-admin-root-certificate
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/create-topic-with-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-with-client-auth/00-assert.yaml
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: cluster-tls-selfsigned-issuer
+  name: cluster-tls-kafka-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: cluster-tls-root-issuer
+  name: cluster-tls-kafka-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: cluster-tls-root-certificate
+  name: cluster-tls-kafka-root-certificate
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/produce-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/00-assert.yaml
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: thisisverylongnamethatishittingthemax40c-selfsigned-issuer
+  name: thisisverylongnamethatishittingthemax40c-kafka-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: thisisverylongnamethatishittingthemax40c-root-issuer
+  name: thisisverylongnamethatishittingthemax40c-kafka-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: thisisverylongnamethatishittingthemax40c-root-certificate
+  name: thisisverylongnamethatishittingthemax40c-kafka-root-certificate
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  up-img-selfsigned-issuer
+  name:  up-img-kafka-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  up-img-root-issuer
+  name:  up-img-kafka-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name:  up-img-root-certificate
+  name:  up-img-kafka-root-certificate
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  up-img-selfsigned-issuer
+  name:  up-img-kafka-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  up-img-root-issuer
+  name:  up-img-kafka-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: up-img-root-certificate
+  name: up-img-kafka-root-certificate
 status:
   conditions:
     - reason: Ready


### PR DESCRIPTION
## Cover letter

The Admin API certificate needs its own root certificate - not shared with other APIs.