### PR TITLE
operator: set kind to have better logs

### DIFF
--- a/src/go/k8s/pkg/resources/cluster_role.go
+++ b/src/go/k8s/pkg/resources/cluster_role.go
@@ -68,6 +68,10 @@ func (r *ClusterRoleResource) obj() k8sclient.Object {
 			Name:      r.Key().Name,
 			Namespace: "",
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
 		Rules: []v1.PolicyRule{
 			{
 				Verbs:     []string{"get"},

--- a/src/go/k8s/pkg/resources/cluster_role_binding.go
+++ b/src/go/k8s/pkg/resources/cluster_role_binding.go
@@ -114,6 +114,10 @@ func (r *ClusterRoleBindingResource) Obj() (k8sclient.Object, error) {
 			Name:      r.Key().Name,
 			Namespace: "",
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
 		Subjects: []v1.Subject{
 			{
 				Kind:      "ServiceAccount",

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -108,6 +108,10 @@ func (r *ConfigMapResource) obj(ctx context.Context) (k8sclient.Object, error) {
 			Name:      r.Key().Name,
 			Labels:    labels.ForCluster(r.pandaCluster),
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
 		Data: map[string]string{
 			"redpanda.yaml": string(cfgBytes),
 		},

--- a/src/go/k8s/pkg/resources/headless_service.go
+++ b/src/go/k8s/pkg/resources/headless_service.go
@@ -80,6 +80,10 @@ func (r *HeadlessServiceResource) obj() (k8sclient.Object, error) {
 			Labels:      objLabels,
 			Annotations: r.getAnnotation(),
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
 		Spec: corev1.ServiceSpec{
 			Type:      corev1.ServiceTypeClusterIP,
 			ClusterIP: corev1.ClusterIPNone,

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -75,6 +75,10 @@ func (r *NodePortServiceResource) obj() (k8sclient.Object, error) {
 			Name:      r.Key().Name,
 			Labels:    objLabels,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
 		Spec: corev1.ServiceSpec{
 			// The service type node port assigned port to each node in the cluster.
 			// This gives a way for operator to assign unused port to the redpanda cluster.

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -42,6 +42,10 @@ type Reconciler interface {
 func CreateIfNotExists(
 	ctx context.Context, c client.Client, obj client.Object, l logr.Logger,
 ) (bool, error) {
+	// we need to store the GVK before it enters client methods because client
+	// wipes GVK. That's a bug in apimachinery, but I don't think it will be
+	// fixed any time soon.
+	gvk := obj.GetObjectKind().GroupVersionKind()
 	if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(obj); err != nil {
 		return false, fmt.Errorf("unable to add last applied annotation to %s: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
 	}
@@ -50,7 +54,7 @@ func CreateIfNotExists(
 		return false, fmt.Errorf("unable to create %s resource: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
 	}
 	if err == nil {
-		l.Info(fmt.Sprintf("%s %s did not exist, was created", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName()))
+		l.Info(fmt.Sprintf("%s %s did not exist, was created", gvk.Kind, obj.GetName()))
 		return true, nil
 	}
 	return false, nil

--- a/src/go/k8s/pkg/resources/service_account.go
+++ b/src/go/k8s/pkg/resources/service_account.go
@@ -71,6 +71,10 @@ func (s *ServiceAccountResource) obj() (k8sclient.Object, error) {
 			Name:      s.Key().Name,
 			Namespace: s.Key().Namespace,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: "v1",
+		},
 	}
 
 	err := controllerutil.SetControllerReference(s.pandaCluster, sa, s.scheme)

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -216,6 +216,10 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 			Name:      r.Key().Name,
 			Labels:    clusterLabels,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: "apps/v1",
+		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:            r.pandaCluster.Spec.Replicas,
 			PodManagementPolicy: appsv1.ParallelPodManagement,


### PR DESCRIPTION
## Cover letter

This improves our debugging because now we get
```
StatefulSet one-node-cluster did not exist, was created
```
instead of 
```
one-node-cluster did not exist, was created
```

Fixes #862 

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
Improved operator logging to see types of resources created.