### PR TITLE
kafka: implement kafka acl creation and description apis

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -36,6 +36,9 @@ static constexpr model::record_batch_type topic_batch_type
 static constexpr model::record_batch_type user_batch_type
   = model::record_batch_type(12);
 
+static constexpr model::record_batch_type acl_batch_type
+  = model::record_batch_type(13);
+
 using command_type = named_type<int8_t, struct command_type_tag>;
 // Controller state updates are represented in terms of commands. Each
 // command represent different type of action that is going to be executed
@@ -71,6 +74,7 @@ static constexpr int8_t update_topic_properties_cmd_type = 4;
 static constexpr int8_t create_user_cmd_type = 5;
 static constexpr int8_t delete_user_cmd_type = 6;
 static constexpr int8_t update_user_cmd_type = 7;
+static constexpr int8_t create_acls_cmd_type = 8;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -119,6 +123,12 @@ using update_user_cmd = controller_command<
   security::scram_credential,
   update_user_cmd_type,
   user_batch_type()>;
+
+using create_acls_cmd = controller_command<
+  create_acls_cmd_data,
+  int8_t, // unused
+  create_acls_cmd_type,
+  acl_batch_type()>;
 
 // typelist utils
 // clang-format off

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -44,7 +44,7 @@ controller::controller(
   , _shard_table(st)
   , _storage(storage)
   , _tp_updates_dispatcher(_partition_allocator, _tp_state)
-  , _security_manager(_credentials) {}
+  , _security_manager(_credentials, _authorizer) {}
 
 ss::future<> controller::wire_up() {
     return _as.start()

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -91,7 +91,12 @@ ss::future<> controller::start() {
             std::ref(_security_manager));
       })
       .then([this] {
-          return _security_frontend.start(std::ref(_stm), std::ref(_as));
+          return _security_frontend.start(
+            _raft0->self().id(),
+            std::ref(_stm),
+            std::ref(_connections),
+            std::ref(_partition_leaders),
+            std::ref(_as));
       })
       .then([this] {
           return _tp_frontend.start(

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -53,6 +53,7 @@ ss::future<> controller::wire_up() {
       .then(
         [this] { return _partition_allocator.start_single(raft::group_id(0)); })
       .then([this] { return _credentials.start(); })
+      .then([this] { return _authorizer.start(); })
       .then([this] { return _tp_state.start(); });
 }
 
@@ -149,6 +150,7 @@ ss::future<> controller::stop() {
           .then([this] { return _tp_frontend.stop(); })
           .then([this] { return _security_frontend.stop(); })
           .then([this] { return _stm.stop(); })
+          .then([this] { return _authorizer.stop(); })
           .then([this] { return _credentials.stop(); })
           .then([this] { return _tp_state.stop(); })
           .then([this] { return _members_manager.stop(); })

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -15,6 +15,7 @@
 #include "cluster/fwd.h"
 #include "cluster/topic_updates_dispatcher.h"
 #include "rpc/connection_cache.h"
+#include "security/authorizer.h"
 #include "security/credential_store.h"
 #include "storage/fwd.h"
 
@@ -52,6 +53,8 @@ public:
         return _security_frontend;
     }
 
+    ss::sharded<security::authorizer>& get_authorizer() { return _authorizer; }
+
     ss::future<> wire_up();
 
     ss::future<> start();
@@ -79,6 +82,7 @@ private:
     ss::sharded<security::credential_store> _credentials;
     security_manager _security_manager;
     ss::sharded<security_frontend> _security_frontend;
+    ss::sharded<security::authorizer> _authorizer;
     consensus_ptr _raft0;
 };
 

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -29,6 +29,11 @@
             "name": "update_topic_properties",
             "input_type": "update_topic_properties_request",
             "output_type": "update_topic_properties_reply"
+        },
+        {
+            "name": "create_acls",
+            "input_type": "create_acls_request",
+            "output_type": "create_acls_reply"
         }
     ]
 }

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -35,6 +35,41 @@
 
 namespace cluster {
 
+// TODO: possibly generalize with other error mapping routines in cluster::*
+// on the other hand, these mappings may be partially specialized for each case
+// (e.g. topic-creation, or error-creation).
+static inline cluster::errc map_errc(std::error_code ec) {
+    if (ec == errc::success) {
+        return errc::success;
+    }
+
+    if (ec.category() == raft::error_category()) {
+        switch (static_cast<raft::errc>(ec.value())) {
+        case raft::errc::timeout:
+            return errc::timeout;
+        case raft::errc::not_leader:
+            return errc::not_leader_controller;
+        default:
+            return errc::replication_error;
+        }
+    }
+
+    if (ec.category() == rpc::error_category()) {
+        switch (static_cast<rpc::errc>(ec.value())) {
+        case rpc::errc::client_request_timeout:
+            return errc::timeout;
+        default:
+            return errc::replication_error;
+        }
+    }
+
+    if (ec.category() == cluster::error_category()) {
+        return static_cast<errc>(ec.value());
+    }
+
+    return errc::replication_error;
+}
+
 security_frontend::security_frontend(
   ss::sharded<controller_stm>& s, ss::sharded<ss::abort_source>& as)
   : _stm(s)
@@ -60,6 +95,32 @@ ss::future<std::error_code> security_frontend::update_user(
   model::timeout_clock::time_point tout) {
     update_user_cmd cmd(std::move(username), std::move(credential));
     return replicate_and_wait(std::move(cmd), tout);
+}
+
+ss::future<std::vector<errc>> security_frontend::create_acls(
+  std::vector<security::acl_binding> bindings,
+  model::timeout_clock::time_point timeout) {
+    if (unlikely(bindings.empty())) {
+        co_return std::vector<errc>{};
+    }
+
+    const auto num_bindings = bindings.size();
+    create_acls_cmd_data data;
+    data.bindings = std::move(bindings);
+    create_acls_cmd cmd(std::move(data), 0 /* unused */);
+
+    errc err;
+    try {
+        auto ec = co_await replicate_and_wait(std::move(cmd), timeout);
+        err = map_errc(ec);
+    } catch (const std::exception& e) {
+        vlog(clusterlog.warn, "Unable to create ACLs: {}", e);
+        err = errc::replication_error;
+    }
+
+    std::vector<errc> result;
+    result.assign(num_bindings, err);
+    co_return result;
 }
 
 template<typename Cmd>

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -71,8 +71,15 @@ static inline cluster::errc map_errc(std::error_code ec) {
 }
 
 security_frontend::security_frontend(
-  ss::sharded<controller_stm>& s, ss::sharded<ss::abort_source>& as)
-  : _stm(s)
+  model::node_id self,
+  ss::sharded<controller_stm>& s,
+  ss::sharded<rpc::connection_cache>& connections,
+  ss::sharded<partition_leaders_table>& leaders,
+  ss::sharded<ss::abort_source>& as)
+  : _self(self)
+  , _stm(s)
+  , _connections(connections)
+  , _leaders(leaders)
   , _as(as) {}
 
 ss::future<std::error_code> security_frontend::create_user(
@@ -99,11 +106,59 @@ ss::future<std::error_code> security_frontend::update_user(
 
 ss::future<std::vector<errc>> security_frontend::create_acls(
   std::vector<security::acl_binding> bindings,
-  model::timeout_clock::time_point timeout) {
+  model::timeout_clock::duration timeout) {
     if (unlikely(bindings.empty())) {
         co_return std::vector<errc>{};
     }
 
+    auto leader = _leaders.local().get_leader(model::controller_ntp);
+
+    if (!leader) {
+        std::vector<errc> res;
+        res.assign(bindings.size(), errc::no_leader_controller);
+        co_return res;
+    }
+
+    if (leader == _self) {
+        co_return co_await do_create_acls(std::move(bindings), timeout);
+    }
+
+    co_return co_await dispatch_create_acls_to_leader(
+      leader.value(), std::move(bindings), timeout);
+}
+
+ss::future<std::vector<errc>> security_frontend::dispatch_create_acls_to_leader(
+  model::node_id leader,
+  std::vector<security::acl_binding> bindings,
+  model::timeout_clock::duration timeout) {
+    auto num_bindings = bindings.size();
+    return _connections.local()
+      .with_node_client<cluster::controller_client_protocol>(
+        _self,
+        ss::this_shard_id(),
+        leader,
+        timeout,
+        [bindings = std::move(bindings),
+         timeout](controller_client_protocol cp) mutable {
+            create_acls_cmd_data data{.bindings = std::move(bindings)};
+            return cp.create_acls(
+              create_acls_request{std::move(data), timeout},
+              rpc::client_opts(model::timeout_clock::now() + timeout));
+        })
+      .then(&rpc::get_ctx_data<create_acls_reply>)
+      .then([num_bindings](result<create_acls_reply> r) {
+          if (r.has_error()) {
+              std::vector<errc> res;
+              res.assign(num_bindings, map_errc(r.error()));
+              return res;
+          }
+          return std::move(r.value().results);
+      });
+}
+
+ss::future<std::vector<errc>> security_frontend::do_create_acls(
+  std::vector<security::acl_binding> bindings,
+  model::timeout_clock::duration timeout) {
     const auto num_bindings = bindings.size();
     create_acls_cmd_data data;
     data.bindings = std::move(bindings);
@@ -111,7 +166,8 @@ ss::future<std::vector<errc>> security_frontend::create_acls(
 
     errc err;
     try {
-        auto ec = co_await replicate_and_wait(std::move(cmd), timeout);
+        auto ec = co_await replicate_and_wait(
+          std::move(cmd), model::timeout_clock::now() + timeout);
         err = map_errc(ec);
     } catch (const std::exception& e) {
         vlog(clusterlog.warn, "Unable to create ACLs: {}", e);

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -41,6 +41,9 @@ public:
       security::scram_credential,
       model::timeout_clock::time_point);
 
+    ss::future<std::vector<errc>> create_acls(
+      std::vector<security::acl_binding>, model::timeout_clock::time_point);
+
     template<typename Cmd>
     ss::future<std::error_code>
     replicate_and_wait(Cmd&&, model::timeout_clock::time_point);

--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -41,8 +41,20 @@ security_manager::apply_update(model::record_batch batch) {
           },
           [this](update_user_cmd cmd) {
               return dispatch_updates_to_cores(std::move(cmd), _credentials);
+          },
+          [this](create_acls_cmd cmd) {
+              return dispatch_updates_to_cores(std::move(cmd), _authorizer);
           });
     });
+}
+
+/*
+ * handle: update user command
+ */
+static std::error_code
+do_apply(create_acls_cmd cmd, security::authorizer& authorizer) {
+    authorizer.add_bindings(cmd.key.bindings);
+    return errc::success;
 }
 
 /*

--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -23,8 +23,10 @@
 namespace cluster {
 
 security_manager::security_manager(
-  ss::sharded<security::credential_store>& credentials)
-  : _credentials(credentials) {}
+  ss::sharded<security::credential_store>& credentials,
+  ss::sharded<security::authorizer>& authorizer)
+  : _credentials(credentials)
+  , _authorizer(authorizer) {}
 
 ss::future<std::error_code>
 security_manager::apply_update(model::record_batch batch) {

--- a/src/v/cluster/security_manager.cc
+++ b/src/v/cluster/security_manager.cc
@@ -34,13 +34,13 @@ security_manager::apply_update(model::record_batch batch) {
         return ss::visit(
           std::move(cmd),
           [this](create_user_cmd cmd) {
-              return dispatch_updates_to_cores(std::move(cmd));
+              return dispatch_updates_to_cores(std::move(cmd), _credentials);
           },
           [this](delete_user_cmd cmd) {
-              return dispatch_updates_to_cores(std::move(cmd));
+              return dispatch_updates_to_cores(std::move(cmd), _credentials);
           },
           [this](update_user_cmd cmd) {
-              return dispatch_updates_to_cores(std::move(cmd));
+              return dispatch_updates_to_cores(std::move(cmd), _credentials);
           });
     });
 }
@@ -79,27 +79,26 @@ do_apply(create_user_cmd cmd, security::credential_store& store) {
     return errc::success;
 }
 
-template<typename Cmd>
-static ss::future<std::error_code> do_apply(
-  ss::shard_id shard, Cmd cmd, ss::sharded<security::credential_store>& store) {
-    return store.invoke_on(
-      shard,
-      [cmd = std::move(cmd)](security::credential_store& local_store) mutable {
-          return do_apply(std::move(cmd), local_store);
+template<typename Cmd, typename Service>
+static ss::future<std::error_code>
+do_apply(ss::shard_id shard, Cmd cmd, ss::sharded<Service>& service) {
+    return service.invoke_on(
+      shard, [cmd = std::move(cmd)](auto& local_service) mutable {
+          return do_apply(std::move(cmd), local_service);
       });
 }
 
-template<typename Cmd>
-ss::future<std::error_code>
-security_manager::dispatch_updates_to_cores(Cmd cmd) {
+template<typename Cmd, typename Service>
+ss::future<std::error_code> security_manager::dispatch_updates_to_cores(
+  Cmd cmd, ss::sharded<Service>& service) {
     using ret_t = std::vector<std::error_code>;
     return ss::do_with(
-      ret_t{}, [this, cmd = std::move(cmd)](ret_t& ret) mutable {
+      ret_t{}, [cmd = std::move(cmd), &service](ret_t& ret) mutable {
           ret.reserve(ss::smp::count);
           return ss::parallel_for_each(
                    boost::irange(0, (int)ss::smp::count),
-                   [this, &ret, cmd = std::move(cmd)](int shard) mutable {
-                       return do_apply(shard, cmd, _credentials)
+                   [&ret, cmd = std::move(cmd), &service](int shard) mutable {
+                       return do_apply(shard, cmd, service)
                          .then([&ret](std::error_code r) { ret.push_back(r); });
                    })
             .then([&ret] { return std::move(ret); })

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -35,8 +35,8 @@ public:
     }
 
 private:
-    template<typename Cmd>
-    ss::future<std::error_code> dispatch_updates_to_cores(Cmd);
+    template<typename Cmd, typename T>
+    ss::future<std::error_code> dispatch_updates_to_cores(Cmd, ss::sharded<T>&);
 
     ss::sharded<security::credential_store>& _credentials;
     ss::sharded<security::authorizer>& _authorizer;

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -25,13 +25,17 @@ public:
       ss::sharded<security::credential_store>&,
       ss::sharded<security::authorizer>&);
 
-    static constexpr auto commands
-      = make_commands_list<create_user_cmd, delete_user_cmd, update_user_cmd>();
+    static constexpr auto commands = make_commands_list<
+      create_user_cmd,
+      delete_user_cmd,
+      update_user_cmd,
+      create_acls_cmd>();
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
     bool is_batch_applicable(const model::record_batch& batch) const {
-        return batch.header().type == user_batch_type;
+        return batch.header().type == user_batch_type
+               || batch.header().type == acl_batch_type;
     }
 
 private:

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "cluster/commands.h"
 #include "model/record.h"
+#include "security/authorizer.h"
 #include "security/credential_store.h"
 
 #include <seastar/core/sharded.hh>
@@ -20,7 +21,9 @@ namespace cluster {
 
 class security_manager final {
 public:
-    explicit security_manager(ss::sharded<security::credential_store>&);
+    explicit security_manager(
+      ss::sharded<security::credential_store>&,
+      ss::sharded<security::authorizer>&);
 
     static constexpr auto commands
       = make_commands_list<create_user_cmd, delete_user_cmd, update_user_cmd>();
@@ -36,6 +39,7 @@ private:
     ss::future<std::error_code> dispatch_updates_to_cores(Cmd);
 
     ss::sharded<security::credential_store>& _credentials;
+    ss::sharded<security::authorizer>& _authorizer;
 };
 
 } // namespace cluster

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/members_manager.h"
 #include "cluster/metadata_cache.h"
+#include "cluster/security_frontend.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
@@ -26,11 +27,13 @@ service::service(
   ss::smp_service_group ssg,
   ss::sharded<topics_frontend>& tf,
   ss::sharded<members_manager>& mm,
-  ss::sharded<metadata_cache>& cache)
+  ss::sharded<metadata_cache>& cache,
+  ss::sharded<security_frontend>& sf)
   : controller_service(sg, ssg)
   , _topics_frontend(tf)
   , _members_manager(mm)
-  , _md_cache(cache) {}
+  , _md_cache(cache)
+  , _security_frontend(sf) {}
 
 ss::future<join_reply>
 service::join(join_request&& req, rpc::streaming_context&) {
@@ -148,4 +151,19 @@ service::do_update_topic_properties(update_topic_properties_request&& req) {
 
     co_return update_topic_properties_reply{.results = std::move(res)};
 }
+
+ss::future<create_acls_reply>
+service::create_acls(create_acls_request&& request, rpc::streaming_context&) {
+    return ss::with_scheduling_group(
+             get_scheduling_group(),
+             [this, r = std::move(request)]() mutable {
+                 return _security_frontend.local().create_acls(
+                   std::move(r.data.bindings),
+                   model::timeout_clock::now() + r.timeout);
+             })
+      .then([](std::vector<errc> results) {
+          return create_acls_reply{.results = std::move(results)};
+      });
+}
+
 } // namespace cluster

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -158,8 +158,7 @@ service::create_acls(create_acls_request&& request, rpc::streaming_context&) {
              get_scheduling_group(),
              [this, r = std::move(request)]() mutable {
                  return _security_frontend.local().create_acls(
-                   std::move(r.data.bindings),
-                   model::timeout_clock::now() + r.timeout);
+                   std::move(r.data.bindings), r.timeout);
              })
       .then([](std::vector<errc> results) {
           return create_acls_reply{.results = std::move(results)};

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -29,7 +29,8 @@ public:
       ss::smp_service_group,
       ss::sharded<topics_frontend>&,
       ss::sharded<members_manager>&,
-      ss::sharded<metadata_cache>&);
+      ss::sharded<metadata_cache>&,
+      ss::sharded<security_frontend>&);
 
     virtual ss::future<join_reply>
     join(join_request&&, rpc::streaming_context&) override;
@@ -46,6 +47,9 @@ public:
     ss::future<update_topic_properties_reply> update_topic_properties(
       update_topic_properties_request&&, rpc::streaming_context&) final;
 
+    ss::future<create_acls_reply>
+    create_acls(create_acls_request&&, rpc::streaming_context&) final;
+
 private:
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
@@ -60,5 +64,6 @@ private:
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<metadata_cache>& _md_cache;
+    ss::sharded<security_frontend>& _security_frontend;
 };
 } // namespace cluster

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -19,6 +19,7 @@
 #include "model/record_batch_types.h"
 #include "model/timeout_clock.h"
 #include "raft/types.h"
+#include "security/acl.h"
 #include "storage/ntp_config.h"
 #include "tristate.h"
 #include "utils/to_string.h"
@@ -312,6 +313,11 @@ private:
     ss::sstring _msg;
 };
 
+struct create_acls_cmd_data {
+    static constexpr int8_t current_version = 1;
+    std::vector<security::acl_binding> bindings;
+};
+
 } // namespace cluster
 namespace std {
 template<>
@@ -383,6 +389,12 @@ template<>
 struct adl<cluster::topic_properties_update> {
     void to(iobuf&, cluster::topic_properties_update&&);
     cluster::topic_properties_update from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::create_acls_cmd_data> {
+    void to(iobuf&, cluster::create_acls_cmd_data&&);
+    cluster::create_acls_cmd_data from(iobuf_parser&);
 };
 
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -318,6 +318,15 @@ struct create_acls_cmd_data {
     std::vector<security::acl_binding> bindings;
 };
 
+struct create_acls_request {
+    create_acls_cmd_data data;
+    model::timeout_clock::duration timeout;
+};
+
+struct create_acls_reply {
+    std::vector<errc> results;
+};
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/kafka/protocol/tests/CMakeLists.txt
+++ b/src/v/kafka/protocol/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ rp_test(
     test_kafka_protocol
   SOURCES
     batch_reader_test.cc
+    security_test.cc
   DEFINITIONS
     BOOST_TEST_DYN_LINK
   LIBRARIES

--- a/src/v/kafka/protocol/tests/security_test.cc
+++ b/src/v/kafka/protocol/tests/security_test.cc
@@ -1,0 +1,130 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "security/acl.h"
+#define BOOST_TEST_MODULE example
+#include "kafka/server/handlers/details/security.h"
+#include "random/generators.h"
+#include "security/authorizer.h"
+#include "utils/base64.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <absl/container/flat_hash_set.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fmt/ostream.h>
+
+namespace kafka {
+
+BOOST_AUTO_TEST_CASE(to_acl_principal) {
+    BOOST_REQUIRE_THROW(
+      details::to_acl_principal(""), details::acl_conversion_error);
+    BOOST_REQUIRE_THROW(
+      details::to_acl_principal("XXX"), details::acl_conversion_error);
+    BOOST_REQUIRE_THROW(
+      details::to_acl_principal("User:"), details::acl_conversion_error);
+
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_principal("User:*"), security::acl_wildcard_user);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_principal("User:*").type(),
+      security::principal_type::user);
+    BOOST_REQUIRE_EQUAL(details::to_acl_principal("User:*").name(), "*");
+
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_principal("User:Fred").type(),
+      security::principal_type::user);
+    BOOST_REQUIRE_EQUAL(details::to_acl_principal("User:Fred").name(), "Fred");
+}
+
+BOOST_AUTO_TEST_CASE(to_acl_host) {
+    BOOST_REQUIRE_THROW(
+      details::to_acl_host("a.b.c.d"), details::acl_conversion_error);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_host("*"), security::acl_host::wildcard_host());
+    BOOST_REQUIRE(details::to_acl_host("1.2.3.4").address());
+}
+
+BOOST_AUTO_TEST_CASE(to_resource_type) {
+    BOOST_REQUIRE_THROW(
+      details::to_resource_type(0), details::acl_conversion_error);
+    BOOST_REQUIRE_THROW(
+      details::to_resource_type(1), details::acl_conversion_error);
+    BOOST_REQUIRE_EQUAL(
+      details::to_resource_type(2), security::resource_type::topic);
+    BOOST_REQUIRE_EQUAL(
+      details::to_resource_type(3), security::resource_type::group);
+    BOOST_REQUIRE_EQUAL(
+      details::to_resource_type(4), security::resource_type::cluster);
+    BOOST_REQUIRE_EQUAL(
+      details::to_resource_type(5), security::resource_type::transactional_id);
+    BOOST_REQUIRE_THROW(
+      details::to_resource_type(6), details::acl_conversion_error);
+}
+
+BOOST_AUTO_TEST_CASE(to_pattern_type) {
+    BOOST_REQUIRE_THROW(
+      details::to_pattern_type(0), details::acl_conversion_error);
+    BOOST_REQUIRE_THROW(
+      details::to_pattern_type(1), details::acl_conversion_error);
+    BOOST_REQUIRE_THROW(
+      details::to_pattern_type(2), details::acl_conversion_error);
+    BOOST_REQUIRE_EQUAL(
+      details::to_pattern_type(3), security::pattern_type::literal);
+    BOOST_REQUIRE_EQUAL(
+      details::to_pattern_type(4), security::pattern_type::prefixed);
+    BOOST_REQUIRE_THROW(
+      details::to_pattern_type(5), details::acl_conversion_error);
+}
+
+BOOST_AUTO_TEST_CASE(to_acl_operation) {
+    BOOST_REQUIRE_THROW(
+      details::to_acl_operation(0), details::acl_conversion_error);
+    BOOST_REQUIRE_THROW(
+      details::to_acl_operation(1), details::acl_conversion_error);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(2), security::acl_operation::all);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(3), security::acl_operation::read);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(4), security::acl_operation::write);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(5), security::acl_operation::create);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(6), security::acl_operation::remove);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(7), security::acl_operation::alter);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(8), security::acl_operation::describe);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(9), security::acl_operation::cluster_action);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(10), security::acl_operation::describe_configs);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(11), security::acl_operation::alter_configs);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_operation(12), security::acl_operation::idempotent_write);
+    BOOST_REQUIRE_THROW(
+      details::to_acl_operation(13), details::acl_conversion_error);
+}
+
+BOOST_AUTO_TEST_CASE(to_acl_permission) {
+    BOOST_REQUIRE_THROW(
+      details::to_acl_permission(0), details::acl_conversion_error);
+    BOOST_REQUIRE_THROW(
+      details::to_acl_permission(1), details::acl_conversion_error);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_permission(2), security::acl_permission::deny);
+    BOOST_REQUIRE_EQUAL(
+      details::to_acl_permission(3), security::acl_permission::allow);
+    BOOST_REQUIRE_THROW(
+      details::to_acl_permission(4), details::acl_conversion_error);
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/create_acls.cc
+++ b/src/v/kafka/server/handlers/create_acls.cc
@@ -11,14 +11,23 @@
 #include "kafka/server/handlers/create_acls.h"
 
 #include "kafka/protocol/errors.h"
+#include "kafka/server/errors.h"
+#include "kafka/server/handlers/details/security.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
 #include "model/fundamental.h"
+#include "security/acl.h"
 
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/log.hh>
 
 #include <fmt/ostream.h>
+
+#include <variant>
+
+using namespace std::chrono_literals;
 
 namespace kafka {
 
@@ -35,17 +44,70 @@ ss::future<response_ptr> create_acls_handler::handle(
         result.error_code = error_code::cluster_authorization_failed;
         create_acls_response resp;
         resp.data.results.assign(request.data.creations.size(), result);
-        return ctx.respond(std::move(resp));
+        co_return co_await ctx.respond(std::move(resp));
     }
 
+    // <bindings index> | error
+    std::vector<std::variant<size_t, creatable_acl_result>> result_index;
+    result_index.reserve(request.data.creations.size());
+
+    // bindings to create. optimized for common case
+    std::vector<security::acl_binding> bindings;
+    bindings.reserve(request.data.creations.size());
+
+    for (const auto& acl : request.data.creations) {
+        try {
+            auto binding = details::to_acl_binding(acl);
+            result_index.emplace_back(bindings.size());
+            bindings.push_back(std::move(binding));
+
+        } catch (const details::acl_conversion_error& e) {
+            result_index.emplace_back(creatable_acl_result{
+              .error_code = error_code::invalid_request,
+              .error_message = e.what(),
+            });
+        }
+    }
+
+    const auto num_bindings = bindings.size();
+
+    auto results = co_await ctx.security_frontend().create_acls(
+      std::move(bindings), 5s);
+
+    // kafka: put things back in the same order :(
     create_acls_response response;
+    response.data.results.reserve(result_index.size());
 
-    // HACK: report success
-    response.data.results.assign(
-      request.data.creations.size(),
-      creatable_acl_result{.error_code = error_code::none});
+    // this is an important step because the loop below that constructs the
+    // response unconditionally indexes into the result set.
+    if (unlikely(results.size() != num_bindings)) {
+        vlog(
+          klog.error,
+          "Unexpected result size creating ACLs: {} (expected {})",
+          results.size(),
+          num_bindings);
 
-    return ctx.respond(std::move(response));
+        response.data.results.assign(
+          result_index.size(),
+          creatable_acl_result{.error_code = error_code::unknown_server_error});
+
+        co_return co_await ctx.respond(std::move(response));
+    }
+
+    for (auto& result : result_index) {
+        ss::visit(
+          result,
+          [&response, &results](size_t i) {
+              auto ec = map_topic_error_code(results[i]);
+              response.data.results.push_back(
+                creatable_acl_result{.error_code = ec});
+          },
+          [&response](creatable_acl_result r) {
+              response.data.results.push_back(std::move(r));
+          });
+    }
+
+    co_return co_await ctx.respond(std::move(response));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/describe_acls.cc
+++ b/src/v/kafka/server/handlers/describe_acls.cc
@@ -11,16 +11,59 @@
 #include "kafka/server/handlers/describe_acls.h"
 
 #include "kafka/protocol/errors.h"
+#include "kafka/server/handlers/details/security.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
 #include "model/fundamental.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/log.hh>
 
 #include <fmt/ostream.h>
 
 namespace kafka {
+
+static void fill_response(
+  request_context& ctx,
+  security::acl_binding_filter& filter,
+  describe_acls_response_data& response) {
+    /*
+     * collapse common acls by pattern
+     */
+    absl::flat_hash_map<
+      security::resource_pattern,
+      std::vector<security::acl_entry>>
+      entries;
+
+    auto bindings = ctx.authorizer().acls(filter);
+
+    for (const auto& binding : bindings) {
+        entries[binding.pattern()].push_back(binding.entry());
+    }
+
+    for (const auto& entry : entries) {
+        describe_acls_resource resource;
+
+        // resource pattern
+        resource.type = details::to_kafka_resource_type(entry.first.resource());
+        resource.name = entry.first.name();
+        resource.pattern_type = details::to_kafka_pattern_type(
+          entry.first.pattern());
+
+        // acl entries
+        for (auto& acl : entry.second) {
+            acl_description desc{
+              .principal = details::to_kafka_principal(acl.principal()),
+              .host = details::to_kafka_host(acl.host()),
+              .operation = details::to_kafka_operation(acl.operation()),
+              .permission_type = details::to_kafka_permission(acl.permission()),
+            };
+            resource.acls.push_back(std::move(desc));
+        }
+        response.resources.push_back(std::move(resource));
+    }
+}
 
 template<>
 ss::future<response_ptr> describe_acls_handler::handle(
@@ -33,19 +76,25 @@ ss::future<response_ptr> describe_acls_handler::handle(
           security::acl_operation::describe, security::default_cluster_name)) {
         describe_acls_response resp;
         resp.data.error_code = error_code::cluster_authorization_failed;
-        return ctx.respond(std::move(resp));
+        co_return co_await ctx.respond(std::move(resp));
     }
 
-    // we do not current implement acls, so we do not have any resources. so
-    // instead of returning an error, we'll return success and an empty set.
     describe_acls_response_data data;
-    data.error_code = error_code::none;
+
+    try {
+        auto filter = details::to_acl_binding_filter(request.data);
+        fill_response(ctx, filter, data);
+    } catch (const details::acl_conversion_error& e) {
+        vlog(klog.debug, "Error describing ACLs: {}", e.what());
+        data.error_code = error_code::invalid_request;
+        data.error_message = e.what();
+    }
 
     describe_acls_response response{
       .data = std::move(data),
     };
 
-    return ctx.respond(std::move(response));
+    co_return co_await ctx.respond(std::move(response));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/details/security.h
+++ b/src/v/kafka/server/handlers/details/security.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/protocol/schemata/create_acls_request.h"
+#include "security/acl.h"
+
+namespace kafka::details {
+
+/*
+ * Conversions throw acl_conversion_error and the exception message via (what())
+ * is generally what should be returned as the error message in kafka responses.
+ *
+ * Using an exception here eliminates the need to write c/go-style error
+ * handling for the large number of fields that need to be converted.
+ */
+struct acl_conversion_error : std::exception {
+    explicit acl_conversion_error(ss::sstring msg)
+      : msg{std::move(msg)} {}
+    const char* what() const noexcept final { return msg.c_str(); }
+    ss::sstring msg;
+};
+
+inline security::acl_principal to_acl_principal(const ss::sstring& principal) {
+    std::string_view view(principal);
+    if (unlikely(!view.starts_with("User:"))) {
+        throw acl_conversion_error(
+          fmt::format("Invalid principal name: {{{}}}", principal));
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    auto user = principal.substr(5);
+    if (unlikely(user.empty())) {
+        throw acl_conversion_error(
+          fmt::format("Principal name cannot be empty"));
+    }
+    if (user == "*") {
+        return security::acl_wildcard_user;
+    }
+    return security::acl_principal(
+      security::principal_type::user, std::move(user));
+}
+
+inline security::acl_host to_acl_host(const ss::sstring& host) {
+    if (host == "*") {
+        return security::acl_host::wildcard_host();
+    }
+    try {
+        return security::acl_host(host);
+    } catch (const std::invalid_argument& e) {
+        throw acl_conversion_error(
+          fmt::format("Invalid host {}: {}", host, e.what()));
+    }
+}
+
+inline security::resource_type to_resource_type(int8_t type) {
+    switch (type) {
+    case 2:
+        return security::resource_type::topic;
+    case 3:
+        return security::resource_type::group;
+    case 4:
+        return security::resource_type::cluster;
+    case 5: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        return security::resource_type::transactional_id;
+    default:
+        throw acl_conversion_error(
+          fmt::format("Invalid resource type: {}", type));
+    }
+}
+
+inline security::pattern_type to_pattern_type(int8_t type) {
+    switch (type) {
+    case 3:
+        return security::pattern_type::literal;
+    case 4:
+        return security::pattern_type::prefixed;
+    default:
+        throw acl_conversion_error(
+          fmt::format("Invalid resource pattern type: {}", type));
+    }
+}
+
+inline security::acl_operation to_acl_operation(int8_t op) {
+    switch (op) {
+    case 2:
+        return security::acl_operation::all;
+    case 3:
+        return security::acl_operation::read;
+    case 4:
+        return security::acl_operation::write;
+    case 5: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        return security::acl_operation::create;
+    case 6: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        return security::acl_operation::remove;
+    case 7: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        return security::acl_operation::alter;
+    case 8: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        return security::acl_operation::describe;
+    case 9: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        return security::acl_operation::cluster_action;
+    case 10: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        return security::acl_operation::describe_configs;
+    case 11: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        return security::acl_operation::alter_configs;
+    case 12: // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        return security::acl_operation::idempotent_write;
+    default:
+        throw acl_conversion_error(fmt::format("Invalid operation: {}", op));
+    }
+}
+
+inline security::acl_permission to_acl_permission(int8_t perm) {
+    switch (perm) {
+    case 2:
+        return security::acl_permission::deny;
+    case 3:
+        return security::acl_permission::allow;
+    default:
+        throw acl_conversion_error(fmt::format("Invalid permission: {}", perm));
+    }
+}
+
+/*
+ * convert kafka acl message into redpanda internal acl representation
+ */
+inline security::acl_binding to_acl_binding(const creatable_acl& acl) {
+    if (acl.resource_name.empty()) {
+        throw acl_conversion_error("Empty resource name");
+    }
+
+    security::resource_pattern pattern(
+      to_resource_type(acl.resource_type),
+      acl.resource_name,
+      to_pattern_type(acl.resource_pattern_type));
+
+    if (
+      pattern.resource() == security::resource_type::cluster
+      && pattern.name() != security::default_cluster_name) {
+        throw acl_conversion_error(
+          fmt::format("Invalid cluster name: {}", pattern.name()));
+    }
+
+    security::acl_entry entry(
+      to_acl_principal(acl.principal),
+      to_acl_host(acl.host),
+      to_acl_operation(acl.operation),
+      to_acl_permission(acl.permission_type));
+
+    return security::acl_binding(std::move(pattern), std::move(entry));
+}
+
+} // namespace kafka::details

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -44,7 +44,8 @@ protocol::protocol(
   ss::sharded<fetch_session_cache>& session_cache,
   ss::sharded<cluster::id_allocator_frontend>& id_allocator_frontend,
   ss::sharded<security::credential_store>& credentials,
-  ss::sharded<security::authorizer>& authorizer) noexcept
+  ss::sharded<security::authorizer>& authorizer,
+  ss::sharded<cluster::security_frontend>& sec_fe) noexcept
   : _smp_group(smp)
   , _topics_frontend(tf)
   , _metadata_cache(meta)
@@ -58,7 +59,8 @@ protocol::protocol(
   , _is_idempotence_enabled(
       config::shard_local_cfg().enable_idempotence.value())
   , _credentials(credentials)
-  , _authorizer(authorizer) {}
+  , _authorizer(authorizer)
+  , _security_frontend(sec_fe) {}
 
 ss::future<> protocol::apply(rpc::server::resources rs) {
     /*

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -38,7 +38,8 @@ public:
       ss::sharded<fetch_session_cache>&,
       ss::sharded<cluster::id_allocator_frontend>&,
       ss::sharded<security::credential_store>&,
-      ss::sharded<security::authorizer>&) noexcept;
+      ss::sharded<security::authorizer>&,
+      ss::sharded<cluster::security_frontend>&) noexcept;
 
     ~protocol() noexcept override = default;
     protocol(const protocol&) = delete;
@@ -79,6 +80,10 @@ public:
 
     security::authorizer& authorizer() { return _authorizer.local(); }
 
+    cluster::security_frontend& security_frontend() {
+        return _security_frontend.local();
+    }
+
 private:
     ss::smp_service_group _smp_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
@@ -93,6 +98,7 @@ private:
     bool _is_idempotence_enabled{false};
     ss::sharded<security::credential_store>& _credentials;
     ss::sharded<security::authorizer>& _authorizer;
+    ss::sharded<cluster::security_frontend>& _security_frontend;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "bytes/iobuf.h"
+#include "cluster/security_frontend.h"
 #include "kafka/protocol/fwd.h"
 #include "kafka/protocol/request_reader.h"
 #include "kafka/server/connection_context.h"
@@ -151,6 +152,10 @@ public:
     template<typename T>
     bool authorized(security::acl_operation operation, const T& name) {
         return _conn->authorized(operation, name);
+    }
+
+    cluster::security_frontend& security_frontend() const {
+        return _conn->server().security_frontend();
     }
 
 private:

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -158,6 +158,8 @@ public:
         return _conn->server().security_frontend();
     }
 
+    security::authorizer& authorizer() { return _conn->server().authorizer(); }
+
 private:
     ss::lw_shared_ptr<connection_context> _conn;
     request_header _header;

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -17,7 +17,7 @@ namespace model {
 
 using record_batch_type = named_type<int8_t, struct model_record_batch_type>;
 
-constexpr std::array<record_batch_type, 13> well_known_record_batch_types{
+constexpr std::array<record_batch_type, 14> well_known_record_batch_types{
   record_batch_type(),   // unknown - used for debugging
   record_batch_type(1),  // raft::data
   record_batch_type(2),  // raft::configuration
@@ -31,5 +31,6 @@ constexpr std::array<record_batch_type, 13> well_known_record_batch_types{
   record_batch_type(10), // tx_fence_batch_type
   record_batch_type(11), // tm_update_batch_type
   record_batch_type(12), // controller user management command batch type
+  record_batch_type(13), // controller acl management command batch type
 };
 } // namespace model

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -476,9 +476,6 @@ void application::wire_up_redpanda_services() {
       std::ref(controller->get_partition_leaders()))
       .get();
 
-    syschecks::systemd_message("Creating kafka authorizer").get();
-    construct_service(authorizer).get();
-
     syschecks::systemd_message("Creating metadata dissemination service").get();
     construct_service(
       md_dissemination_service,
@@ -749,7 +746,7 @@ void application::start_redpanda() {
             fetch_session_cache,
             std::ref(id_allocator_frontend),
             controller->get_credential_store(),
-            authorizer);
+            controller->get_authorizer());
           s.set_protocol(std::move(proto));
       })
       .get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -747,7 +747,8 @@ void application::start_redpanda() {
             fetch_session_cache,
             std::ref(id_allocator_frontend),
             controller->get_credential_store(),
-            controller->get_authorizer());
+            controller->get_authorizer(),
+            controller->get_security_frontend());
           s.set_protocol(std::move(proto));
       })
       .get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -709,7 +709,8 @@ void application::start_redpanda() {
             smp_service_groups.cluster_smp_sg(),
             std::ref(controller->get_topics_frontend()),
             std::ref(controller->get_members_manager()),
-            std::ref(metadata_cache));
+            std::ref(metadata_cache),
+            std::ref(controller->get_security_frontend()));
           proto->register_service<cluster::metadata_dissemination_handler>(
             _scheduling_groups.cluster_sg(),
             smp_service_groups.cluster_smp_sg(),

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -24,7 +24,6 @@
 #include "resource_mgmt/smp_groups.h"
 #include "rpc/server.h"
 #include "seastarx.h"
-#include "security/authorizer.h"
 #include "security/credential_store.h"
 #include "storage/fwd.h"
 
@@ -78,7 +77,6 @@ public:
     ss::sharded<kafka::quota_manager> quota_mgr;
     ss::sharded<cluster::id_allocator_frontend> id_allocator_frontend;
     ss::sharded<archival::scheduler_service> archival_scheduler;
-    ss::sharded<security::authorizer> authorizer;
 
 private:
     using deferred_actions

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -84,7 +84,7 @@ public:
           app.fetch_session_cache,
           app.id_allocator_frontend,
           app.controller->get_credential_store(),
-          app.authorizer);
+          app.controller->get_authorizer());
     }
 
     // creates single node with default configuration

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -84,7 +84,8 @@ public:
           app.fetch_session_cache,
           app.id_allocator_frontend,
           app.controller->get_credential_store(),
-          app.controller->get_authorizer());
+          app.controller->get_authorizer(),
+          app.controller->get_security_frontend());
     }
 
     // creates single node with default configuration

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -35,12 +35,14 @@ inline const acl_cluster_name default_cluster_name("redpanda-cluster");
 
 /*
  * An ACL resource type.
+ *
+ * IMPORTANT: on-write value
  */
-enum class resource_type {
-    topic,
-    group,
-    cluster,
-    transactional_id,
+enum class resource_type : int8_t {
+    topic = 0,
+    group = 1,
+    cluster = 2,
+    transactional_id = 3,
 };
 
 template<typename T>
@@ -60,27 +62,31 @@ inline resource_type get_resource_type() {
 
 /*
  * A pattern rule for matching ACL resource names.
+ *
+ * IMPORTANT: on-write value
  */
-enum class pattern_type {
-    literal,
-    prefixed,
+enum class pattern_type : int8_t {
+    literal = 0,
+    prefixed = 1,
 };
 
 /*
- * an operation on a resource.
+ * An operation on a resource.
+ *
+ * IMPORTANT: on-write value
  */
-enum class acl_operation {
-    all,
-    read,
-    write,
-    create,
-    remove,
-    alter,
-    describe,
-    cluster_action,
-    describe_configs,
-    alter_configs,
-    idempotent_write,
+enum class acl_operation : int8_t {
+    all = 0,
+    read = 1,
+    write = 2,
+    create = 3,
+    remove = 4,
+    alter = 5,
+    describe = 6,
+    cluster_action = 7,
+    describe_configs = 8,
+    alter_configs = 9,
+    idempotent_write = 10,
 };
 
 /*
@@ -136,10 +142,12 @@ inline std::ostream& operator<<(std::ostream& os, acl_operation op) {
 
 /*
  * Grant or deny access.
+ *
+ * IMPORTANT: on-write value
  */
-enum class acl_permission {
-    deny,
-    allow,
+enum class acl_permission : int8_t {
+    deny = 0,
+    allow = 1,
 };
 
 inline std::ostream& operator<<(std::ostream& os, acl_permission perm) {
@@ -157,9 +165,11 @@ inline std::ostream& operator<<(std::ostream& os, acl_permission perm) {
  *
  * Only `User` is currently supported, but when integrating with other identity
  * providers it may be useful to introduce a `Group` type.
+ *
+ * IMPORTANT: on-write value
  */
-enum class principal_type {
-    user,
+enum class principal_type : int8_t {
+    user = 0,
 };
 
 inline std::ostream& operator<<(std::ostream& os, resource_type type) {

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -213,6 +213,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream&, const acl_principal&);
 
+    const ss::sstring& name() const { return _name; }
+    principal_type type() const { return _type; }
     bool wildcard() const { return _name == "*"; }
 
 private:
@@ -296,6 +298,8 @@ public:
     }
 
     friend std::ostream& operator<<(std::ostream&, const acl_host&);
+
+    std::optional<ss::net::inet_address> address() const { return _addr; }
 
 private:
     acl_host() = default;

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -14,6 +14,8 @@
 #include "seastarx.h"
 #include "security/acl.h"
 #include "security/acl_store.h"
+#include "security/logger.h"
+#include "vlog.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
@@ -49,6 +51,13 @@ public:
      * Add ACL bindings to the authorizer.
      */
     void add_bindings(const std::vector<acl_binding>& bindings) {
+        if (unlikely(
+              seclog.is_shard_zero()
+              && seclog.is_enabled(ss::log_level::debug))) {
+            for (const auto& binding : bindings) {
+                vlog(seclog.debug, "Adding ACL binding: {}", binding);
+            }
+        }
         _store.add_bindings(bindings);
     }
 


### PR DESCRIPTION
Adds implementations for ACL creation and ACL describe APIs. ACL data is stored in and managed by the cluster controller and there are new RPC endpoints that allow brokers to forward ACL management calls to the controller leader.