### PR TITLE
archival: Enable archival storage in production mode

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -632,7 +632,7 @@ ss::future<> application::set_proxy_config(ss::sstring name, std::any val) {
 
 bool application::archival_storage_enabled() {
     const auto& cfg = config::shard_local_cfg();
-    return cfg.developer_mode() && cfg.cloud_storage_enabled();
+    return cfg.cloud_storage_enabled();
 }
 
 ss::future<>


### PR DESCRIPTION
## Cover letter

Currently, archival storage require developer mode to be enabled.
This commit removes this requirement.
