### PR TITLE
Ducktape: Disable testing pandaproxy consumer_groups

### DIFF
--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -21,3 +21,4 @@ quick:
   - tests/compaction_recovery_test.py
   - tests/partition_movement_test.py::PartitionMovementTest.test_cycle_simple
   - tests/wasm_identity_test.py
+  - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group


### PR DESCRIPTION
## Cover letter

Temporarily disable these tests to fix CI

Signed-off-by: Ben Pope <ben@vectorized.io>

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/9532a6f57be3bcce386235363b611f932284e322..bc757bb9d11883320b69ac9e69c773d810d38592)
* Rebase to fix gcc build failures

## Release notes

Release note: none
