### PR TITLE
Enable Pandaproxy by default

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -46,6 +46,9 @@ redpanda:
   # not recomended for production use
   developer_mode: true
 
+# Enable Pandaproxy
+pandaproxy:
+
 rpk:
   # TLS configuration.
   tls:

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -221,7 +221,15 @@ void application::hydrate_config(const po::variables_map& cfg) {
     }
     if (config["pandaproxy"]) {
         _proxy_config.emplace(config["pandaproxy"]);
-        _proxy_client_config.emplace(config["pandaproxy_client"]);
+        if (config["pandaproxy_client"]) {
+            _proxy_client_config.emplace(config["pandaproxy_client"]);
+        } else {
+            _proxy_client_config.emplace();
+            const auto& kafka_api = config::shard_local_cfg().kafka_api.value();
+            vassert(!kafka_api.empty(), "There are no kafka_api listeners");
+            _proxy_client_config->brokers.set_value(
+              std::vector<unresolved_address>{kafka_api[0].address});
+        }
         _proxy_config->for_each(config_printer("pandaproxy"));
         _proxy_client_config->for_each(config_printer("pandaproxy_client"));
     }


### PR DESCRIPTION
## Cover letter

Enable Pandaproxy by default

If no `pandaproxy_client` configuration is provided:
* Use `kafka::client::configuration` defaults
* Override brokers to the first `kafka_api` configuration

If there is additional configuration such as TLS, then `pandaproxy_client.brokers` will need to be specified.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/ae52730c361d2378175491c93174644ef00718db..de114418c009c23ed7f6889bb240e3d258d1019a)
* Rebase to fix gcc build failures

## Release notes

Release note: Pandaproxy is enabled by default
