### PR TITLE
operator/tests: reduce parallelism

### DIFF
--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -14,4 +14,4 @@ commands:
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_e2e_artifacts
 timeout: 300
-parallel: 3
+parallel: 2


### PR DESCRIPTION
## Cover letter

Based on the comment from @BenPope here https://github.com/vectorizedio/redpanda/issues/1030#issuecomment-812509088

I think over time we'll just need to pay for our hardware if we want fast e2e tests. The free tier machines are just poor (and it's expected since gitbub does not want to pay for it either :D).

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
