### PR TITLE
operator/svc: fix order of ports

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -88,9 +88,9 @@ func (r *ClusterReconciler) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("unable to retrieve Cluster resource: %w", err)
 	}
 
-	ports := map[string]int{
-		resources.KafkaPortName: redpandaCluster.Spec.Configuration.KafkaAPI.Port,
-		resources.AdminPortName: redpandaCluster.Spec.Configuration.AdminAPI.Port,
+	ports := []resources.NamedServicePort{
+		{Name: resources.AdminPortName, Port: redpandaCluster.Spec.Configuration.AdminAPI.Port},
+		{Name: resources.KafkaPortName, Port: redpandaCluster.Spec.Configuration.KafkaAPI.Port},
 	}
 	headlessSvc := resources.NewHeadlessService(r.Client, &redpandaCluster, r.Scheme, ports, log)
 	nodeportSvc := resources.NewNodePortService(r.Client, &redpandaCluster, r.Scheme, ports, log)

--- a/src/go/k8s/pkg/resources/headless_service.go
+++ b/src/go/k8s/pkg/resources/headless_service.go
@@ -38,7 +38,7 @@ type HeadlessServiceResource struct {
 	k8sclient.Client
 	scheme       *runtime.Scheme
 	pandaCluster *redpandav1alpha1.Cluster
-	svcPorts     map[string]int
+	svcPorts     []NamedServicePort
 	logger       logr.Logger
 }
 
@@ -47,7 +47,7 @@ func NewHeadlessService(
 	client k8sclient.Client,
 	pandaCluster *redpandav1alpha1.Cluster,
 	scheme *runtime.Scheme,
-	svcPorts map[string]int,
+	svcPorts []NamedServicePort,
 	logger logr.Logger,
 ) *HeadlessServiceResource {
 	return &HeadlessServiceResource{
@@ -76,12 +76,12 @@ func (r *HeadlessServiceResource) Ensure(ctx context.Context) error {
 // obj returns resource managed client.Object
 func (r *HeadlessServiceResource) obj() (k8sclient.Object, error) {
 	ports := make([]corev1.ServicePort, 0, len(r.svcPorts))
-	for name, portNumber := range r.svcPorts {
+	for _, svcPort := range r.svcPorts {
 		ports = append(ports, corev1.ServicePort{
-			Name:       name,
+			Name:       svcPort.Name,
 			Protocol:   corev1.ProtocolTCP,
-			Port:       int32(portNumber),
-			TargetPort: intstr.FromInt(portNumber),
+			Port:       int32(svcPort.Port),
+			TargetPort: intstr.FromInt(svcPort.Port),
 		})
 	}
 

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -33,7 +33,7 @@ type NodePortServiceResource struct {
 	k8sclient.Client
 	scheme       *runtime.Scheme
 	pandaCluster *redpandav1alpha1.Cluster
-	svcPorts     map[string]int
+	svcPorts     []NamedServicePort
 	logger       logr.Logger
 }
 
@@ -42,7 +42,7 @@ func NewNodePortService(
 	client k8sclient.Client,
 	pandaCluster *redpandav1alpha1.Cluster,
 	scheme *runtime.Scheme,
-	svcPorts map[string]int,
+	svcPorts []NamedServicePort,
 	logger logr.Logger,
 ) *NodePortServiceResource {
 	return &NodePortServiceResource{
@@ -72,15 +72,15 @@ func (r *NodePortServiceResource) Ensure(ctx context.Context) error {
 // obj returns resource managed client.Object
 func (r *NodePortServiceResource) obj() (k8sclient.Object, error) {
 	ports := make([]corev1.ServicePort, 0, len(r.svcPorts))
-	for name, portNumber := range r.svcPorts {
-		if name == "kafka" {
-			portNumber++
+	for _, svcPort := range r.svcPorts {
+		if svcPort.Name == "kafka" {
+			svcPort.Port++
 		}
 		ports = append(ports, corev1.ServicePort{
-			Name:       name,
+			Name:       svcPort.Name,
 			Protocol:   corev1.ProtocolTCP,
-			Port:       int32(portNumber),
-			TargetPort: intstr.FromInt(portNumber),
+			Port:       int32(svcPort.Port),
+			TargetPort: intstr.FromInt(svcPort.Port),
 		})
 	}
 

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -30,6 +30,12 @@ const (
 	AdminPortName = "admin"
 )
 
+// NamedServicePort allows to pass name ports, e.g., to service resources
+type NamedServicePort struct {
+	Name string
+	Port int
+}
+
 // Resource decompose the reconciliation loop to specific kubernetes objects
 type Resource interface {
 	Reconciler

--- a/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
@@ -44,14 +44,14 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: kafka
-      port: 9092
-      protocol: TCP
-      targetPort: 9092
     - name: admin
       port: 9644
       protocol: TCP
       targetPort: 9644
+    - name: kafka
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
   type: ClusterIP
 ---
 apiVersion: v1

--- a/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
@@ -44,14 +44,14 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - name: kafka
-      port: 9092
-      protocol: TCP
-      targetPort: 9092
     - name: admin
       port: 9644
       protocol: TCP
       targetPort: 9644
+    - name: kafka
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
   type: ClusterIP
 ---
 apiVersion: redpanda.vectorized.io/v1alpha1


### PR DESCRIPTION
## Cover letter

Fix the order of ports in the resource specs so it remains consistent across runs, instead of being in arbitrary order, which affects test assertions.

---
Tests failing are existing failures (update-image-*).