### PR TITLE
task/java: install openjdk and mvn on host

### DIFF
--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -15,6 +15,22 @@ tasks:
     status:
     - test -f '{{.BUILD_ROOT}}/bin/docker-compose'
 
+  install-jdk-and-maven:
+    desc: install openjdk and maven
+    vars:
+      JDK_URL: https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz
+      MAVEN_URL: https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+      JAVA_DIR: '{{.BUILD_ROOT}}/java'
+    cmds:
+    - mkdir -p '{{.JAVA_DIR}}'
+    - curl -L '{{.JDK_URL}}' | tar --strip-components=1 -C '{{.JAVA_DIR}}' -xz
+    - curl -L '{{.MAVEN_URL}}' | tar --strip-components=1 -C '{{.JAVA_DIR}}' -xz
+      # delete this (empty) folder; leaving it generates an error
+    - rm -r '{{.JAVA_DIR}}/lib/ext'
+    status:
+    - test -f '{{.JAVA_DIR}}/bin/java'
+    - test -f '{{.JAVA_DIR}}/bin/mvn'
+
   start-podman-socket-service:
     desc: start podman socket service (requires sudo)
     cmds:

--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -82,8 +82,13 @@ tasks:
     - ctest {{if eq .CI "1"}}"--output-on-failure"{{end}} {{.CTEST_ARGS}}
 
   build-java-test-programs:
+    desc: build java programs used in integrations tests
+    deps:
+    - :dev:install-jdk-and-maven
     cmds:
     - |
+      PATH="{{.BUILD_ROOT}}/java/bin:$PATH"
+      mvn -v
       function build {
         mvn clean package --batch-mode \
           --file {{.SRC_DIR}}/tests/java/$1/ \
@@ -92,14 +97,6 @@ tasks:
       }
       build kafka-verifier
       build compacted-log-verifier
-
-  build-java-test-programs-in-docker:
-    desc: build java programs used in integrations tests
-    cmds:
-    - task: :docker:task
-      vars:
-        DOCKER_IMAGE: docker.io/library/maven:3.6-jdk-11
-        TASK_ARGS: rp:build-java-test-programs
     status:
     - test -f '{{.BUILD_ROOT}}/java/kafka-verifier/kafka-verifier.jar'
     - test -f '{{.BUILD_ROOT}}/java/compacted-log-verifier/kafka-compacted-topics-verifier.jar'
@@ -140,7 +137,7 @@ tasks:
     deps:
     - set-aio-max
     - start-compose-cluster
-    - build-java-test-programs-in-docker
+    - build-java-test-programs
     vars:
       DUCKTAPE_ARGS: '{{default "--exit-first tests/rptest/test_suite_quick.yml" .DUCKTAPE_ARGS}}'
       RP_INSTALL_DIR_DEFAULT: '{{.BUILD_DIR}}'


### PR DESCRIPTION
Do not use docker and install jdk/maven on host instead. Using docker assumes that vtools is a subfolder in `redpanda`, but that assumption breaks when `vtools/` is symlinked from other `redpanda/` repos.