### PR TITLE
task: Allow tests to be excluded on CI

### DIFF
--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -79,7 +79,7 @@ tasks:
     deps:
     - set-aio-max
     cmds:
-    - ctest {{if eq .CI "1"}}"--output-on-failure"{{end}} {{.CTEST_ARGS}}
+    - ctest {{if eq .CI "1"}}"--output-on-failure" -LE "disable_on_ci"{{end}} {{.CTEST_ARGS}}
 
   build-java-test-programs:
     desc: build java programs used in integrations tests


### PR DESCRIPTION
## Cover letter

* Allow tests to be excluded on CI by adding the label `disable_on_ci`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/33cdb8d83e948437f3d855c81486168923cf7f6f..ba362a59429f2076769091f8a787dbbbca7c67d1)
* Rebased
* Dropped the commit for disabling `pandaproxy_fixture_test` due to #1056 