### PR TITLE
redpanda: add configuration option to register superusers

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -606,6 +606,8 @@ configuration::configuration()
       "during TLS handshake",
       required::no,
       std::nullopt)
+  , superusers(
+      *this, "superusers", "List of superuser usernames", required::no, {})
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -151,6 +151,7 @@ struct configuration final : public config_store {
     property<bool> cloud_storage_disable_tls;
     property<int16_t> cloud_storage_api_endpoint_port;
     property<std::optional<ss::sstring>> cloud_storage_trust_file;
+    one_or_many_property<ss::sstring> superusers;
 
     configuration();
 

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -113,6 +113,9 @@ public:
     }
 
     void add_superuser(acl_principal principal) {
+        if (unlikely(seclog.is_shard_zero())) {
+            vlog(seclog.debug, "Adding superuser: {}", principal);
+        }
         _superusers.emplace(std::move(principal));
     }
 


### PR DESCRIPTION
Configuration option `superusers:` specifies superusers.

```
superusers: jerry
```
or
```
superusers:
    - jerry
    - garcia
```