### PR TITLE
kafka/client: Improve gate handling

### DIFF
--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -30,7 +30,7 @@ struct gated_mutex {
 
     template<typename Func>
     auto with(Func&& func) noexcept {
-        return ss::with_gate(
+        return ss::try_with_gate(
           _gate, [this, func{std::forward<Func>(func)}]() mutable {
               return _mutex.with(
                 [this, func{std::forward<Func>(func)}]() mutable {

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -71,7 +71,7 @@ public:
     /// \brief Invoke func, on failure, mitigate error and retry.
     template<typename Func>
     std::invoke_result_t<Func> gated_retry_with_mitigation(Func func) {
-        return ss::with_gate(_gate, [this, func{std::move(func)}]() {
+        return ss::try_with_gate(_gate, [this, func{std::move(func)}]() {
             return retry_with_mitigation(
               _config.retries(),
               _config.retry_base_backoff(),

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -91,7 +91,7 @@ private:
     req_res(RequestFactory req) {
         using api_t = typename std::invoke_result_t<RequestFactory>::api_type;
         using response_t = typename api_t::response_type;
-        return ss::with_gate(_gate, [this, req{std::move(req)}]() {
+        return ss::try_with_gate(_gate, [this, req{std::move(req)}]() {
             auto r = req();
             kclog.debug("Consumer: {}: {} req: {}", *this, api_t::name, r);
             return _coordinator->dispatch(std::move(r))

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -79,7 +79,7 @@ struct handler_adaptor : ss::httpd::handler_base {
       const ss::sstring&,
       std::unique_ptr<ss::request> req,
       std::unique_ptr<ss::reply> rep) final {
-        return ss::with_gate(
+        return ss::try_with_gate(
           _pending_requests,
           [this,
            req{std::move(req)},


### PR DESCRIPTION
## Cover letter

Replace use of `with_gate` by  `try_with_gate`.

This was always a mistake in `kafka/client` and `pandaproxy`as the rest of the code was written based on the semantics of the former (an `exception_future` instead of an exception)

Handle `gate_closed_exception` in heartbeat timer to fix an `Exceptional future ignored` error in `pandaproxy_fixture_test`.

## Release notes

Release note: none
