### PR TITLE
hashing: add murmur2 needed for the kafka client

### DIFF
--- a/src/v/hashing/murmur.cc
+++ b/src/v/hashing/murmur.cc
@@ -378,3 +378,55 @@ void murmurhash3_x64_128(
     ((uint64_t*)out)[0] = h1;
     ((uint64_t*)out)[1] = h2;
 }
+
+// https://github.com/aappleby/smhasher/blob/master/src/MurmurHash2.cpp#L37-L86
+// murmur2 is under the public domain and we copied it from the murmur2 original
+uint32_t murmur2(const void* key, std::size_t len, uint32_t seed) {
+    // 'm' and 'r' are mixing constants generated offline.
+    // They're not really 'magic', they just happen to work well.
+    const uint32_t m = 0x5bd1e995;
+    const int r = 24;
+
+    // Initialize the hash to a 'random' value
+
+    uint32_t h = seed ^ len;
+
+    // Mix 4 bytes at a time into the hash
+
+    const unsigned char* data = (const unsigned char*)key;
+
+    while (len >= 4) {
+        uint32_t k = *(uint32_t*)data;
+
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+
+        h *= m;
+        h ^= k;
+
+        data += 4;
+        len -= 4;
+    }
+
+    // Handle the last few bytes of the input array
+
+    switch (len) {
+    case 3:
+        h ^= data[2] << 16;
+    case 2:
+        h ^= data[1] << 8;
+    case 1:
+        h ^= data[0];
+        h *= m;
+    };
+
+    // Do a few final mixes of the hash to ensure the last few
+    // bytes are well-incorporated.
+
+    h ^= h >> 13;
+    h *= m;
+    h ^= h >> 15;
+
+    return h;
+}

--- a/src/v/hashing/murmur.h
+++ b/src/v/hashing/murmur.h
@@ -34,3 +34,11 @@ void murmurhash3_x64_128(
   std::size_t len,
   void* out,
   uint32_t seed = kDefaultHashingSeed);
+
+uint32_t murmur2(
+  const void* key,
+  std::size_t len,
+  // Default Seed is the Kafka partition hashing seed. Since this is the main
+  // intention for this hashing function, we make this the default value
+  // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L441
+  uint32_t seed = 0x9747b28c);


### PR DESCRIPTION
## Cover letter

Kafka's default key hasher is murmur2(key) % partitions.
We need the default murmur2 impl w/ the kafka seed in order
to have the exact same behavior as users have come to expect
w/ a kafka client


## Release notes

Add murmur2 hasing for kafka::client compatibility
