### PR TITLE
operator: more memory as default for operator

### DIFF
--- a/src/go/k8s/config/manager/manager.yaml
+++ b/src/go/k8s/config/manager/manager.yaml
@@ -48,8 +48,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 128Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 100Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
## Cover letter

30 and 20MB is probably too less for most deployments.

Fixes issues: [#NNN, #NNN, ...]

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
Operator has is now started with a default of 128MB of memory.