### PR TITLE
Rk/feature/change advertised kafka api dns scheme

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -254,15 +254,16 @@ func (r *ClusterReconciler) createExternalNodesList(
 	observedNodesExternalAdmin := make([]string, 0, len(pods))
 	for i := range pods {
 		if len(pandaCluster.Spec.ExternalConnectivity.Subdomain) > 0 {
+			prefixLen := len(pods[i].GenerateName)
 			observedNodesExternal = append(observedNodesExternal,
 				fmt.Sprintf("%s.%s:%d",
-					pods[i].Spec.Hostname,
+					pods[i].Name[prefixLen:],
 					pandaCluster.Spec.ExternalConnectivity.Subdomain,
 					getNodePort(&nodePortSvc, resources.KafkaPortName),
 				))
 			observedNodesExternalAdmin = append(observedNodesExternalAdmin,
 				fmt.Sprintf("%s.%s:%d",
-					pods[i].Spec.Hostname,
+					pods[i].Name[prefixLen:],
 					pandaCluster.Spec.ExternalConnectivity.Subdomain,
 					getNodePort(&nodePortSvc, resources.AdminPortName),
 				))


### PR DESCRIPTION
## Cover letter and Release notes

Change the naming scheme for external connectivity for Redpandas. Now the first part of the DNS will be the number of the broker in cluster.
