### PR TITLE
operator: add SASL bool to cluster CR, pass to redpanda

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -52,6 +52,8 @@ type ClusterSpec struct {
 	CloudStorage CloudStorageConfig `json:"cloudStorage,omitempty"`
 	// List of superusers
 	Superusers []Superuser `json:"superUsers,omitempty"`
+	// SASL enablement flag
+	EnableSASL bool `json:"enableSasl,omitempty"`
 }
 
 // Superuser has full access to the Redpanda cluster

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -225,6 +225,9 @@ spec:
                         type: object
                     type: object
                 type: object
+              enableSasl:
+                description: SASL enablement flag
+                type: boolean
               externalConnectivity:
                 description: ExternalConnectivity enables user to expose Redpanda
                   nodes outside of a Kubernetes cluster. For more information please

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -195,6 +195,10 @@ func (r *ConfigMapResource) createConfiguration(
 		cr.Superusers = append(cr.Superusers, user.Username)
 	}
 
+	if r.pandaCluster.Spec.EnableSASL {
+		cr.EnableSASL = pointer.BoolPtr(true)
+	}
+
 	replicas := *r.pandaCluster.Spec.Replicas
 	for i := int32(0); i < replicas; i++ {
 		cr.SeedServers = append(cr.SeedServers, config.SeedServer{


### PR DESCRIPTION
## Cover letter

Exposes `EnableSASL` to cluster's CR and passes it to redpanda's config

## Release notes

Exposes `EnableSASL` to cluster's CR