### PR TITLE
Serde v2 (versioning for serialization/deserialization)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 *.app
-/build
+/*build*
 /dbuild
 bin
 _e2e_artifacts/

--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -26,6 +26,7 @@ add_subdirectory(http)
 add_subdirectory(s3)
 add_subdirectory(archival)
 add_subdirectory(security)
+add_subdirectory(serde)
 
 option(ENABLE_GIT_VERSION "Build with Git metadata" OFF)
 if(${ENABLE_GIT_VERSION})

--- a/src/v/serde/CMakeLists.txt
+++ b/src/v/serde/CMakeLists.txt
@@ -1,0 +1,11 @@
+v_cc_library(
+  NAME serde
+  DEPS
+    Seastar::seastar
+    v::bytes
+    v::rphashing
+    v::utils
+    v::reflection
+    absl::flat_hash_map
+    v::compression
+  )

--- a/src/v/serde/CMakeLists.txt
+++ b/src/v/serde/CMakeLists.txt
@@ -9,3 +9,4 @@ v_cc_library(
     absl::flat_hash_map
     v::compression
   )
+add_subdirectory(test)

--- a/src/v/serde/envelope.h
+++ b/src/v/serde/envelope.h
@@ -1,0 +1,74 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include <cinttypes>
+#include <type_traits>
+
+namespace serde {
+
+using version_t = uint8_t;
+
+template<version_t V>
+struct version {
+    static constexpr auto const v = V;
+};
+
+template<version_t V>
+struct compat_version {
+    static constexpr auto const v = V;
+};
+
+/**
+ * \brief provides versioning (version + compat version)
+ *        for serializable aggregate types.
+ *
+ * \tparam Version         the current type version
+ *                         (change for every incompatible update)
+ * \tparam CompatVersion   the minimum required version able to parse the type
+ */
+template<
+  typename T,
+  typename Version,
+  typename CompatVersion = compat_version<Version::v>>
+struct envelope {
+    using value_t = T;
+    static constexpr auto redpanda_serde_version = Version::v;
+    static constexpr auto redpanda_serde_compat_version = CompatVersion::v;
+};
+
+namespace detail {
+
+template<typename T, typename = void>
+struct has_compat_attribute : std::false_type {};
+
+template<typename T>
+struct has_compat_attribute<
+  T,
+  std::void_t<decltype(std::declval<T>().redpanda_serde_compat_version)>>
+  : std::true_type {};
+
+template<typename T, typename = void>
+struct has_version_attribute : std::false_type {};
+
+template<typename T>
+struct has_version_attribute<
+  T,
+  std::void_t<decltype(std::declval<T>().redpanda_serde_compat_version)>>
+  : std::true_type {};
+
+} // namespace detail
+
+template<typename T>
+inline constexpr auto const is_envelope_v = std::conjunction_v<
+  detail::has_compat_attribute<T>,
+  detail::has_version_attribute<T>>;
+
+} // namespace serde

--- a/src/v/serde/envelope_for_each_field.h
+++ b/src/v/serde/envelope_for_each_field.h
@@ -1,0 +1,191 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "reflection/arity.h"
+#include "serde/envelope.h"
+
+#include <tuple>
+
+namespace serde {
+
+template<typename T>
+inline auto envelope_to_tuple(T& t) {
+    constexpr auto const a = reflection::arity<T>() - 1;
+    if constexpr (a == 0) {
+        return std::tie();
+    } else if constexpr (a == 1) {
+        auto& [p1] = t;
+        return std::tie(p1);
+    } else if constexpr (a == 2) {
+        auto& [p1, p2] = t;
+        return std::tie(p1, p2);
+    } else if constexpr (a == 3) {
+        auto& [p1, p2, p3] = t;
+        return std::tie(p1, p2, p3);
+    } else if constexpr (a == 4) {
+        auto& [p1, p2, p3, p4] = t;
+        return std::tie(p1, p2, p3, p4);
+    } else if constexpr (a == 5) {
+        auto& [p1, p2, p3, p4, p5] = t;
+        return std::tie(p1, p2, p3, p4, p5);
+    } else if constexpr (a == 6) {
+        auto& [p1, p2, p3, p4, p5, p6] = t;
+        return std::tie(p1, p2, p3, p4, p5, p6);
+    } else if constexpr (a == 7) {
+        auto& [p1, p2, p3, p4, p5, p6, p7] = t;
+        return std::tie(p1, p2, p3, p4, p5, p6, p7);
+    } else if constexpr (a == 8) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8] = t;
+        return std::tie(p1, p2, p3, p4, p5, p6, p7, p8);
+    } else if constexpr (a == 9) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9] = t;
+        return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    } else if constexpr (a == 10) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10] = t;
+        return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
+    } else if constexpr (a == 11) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11] = t;
+        return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);
+    } else if constexpr (a == 12) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12] = t;
+        return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);
+    } else if constexpr (a == 13) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13] = t;
+        return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);
+    } else if constexpr (a == 14) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14] = t;
+        return std::tie(
+          p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);
+    } else if constexpr (a == 15) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15]
+          = t;
+        return std::tie(
+          p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);
+    } else if constexpr (a == 16) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16]
+          = t;
+        return std::tie(
+          p1,
+          p2,
+          p3,
+          p4,
+          p5,
+          p6,
+          p7,
+          p8,
+          p9,
+          p10,
+          p11,
+          p12,
+          p13,
+          p14,
+          p15,
+          p16);
+    } else if constexpr (a == 17) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17]
+          = t;
+        return std::tie(
+          p1,
+          p2,
+          p3,
+          p4,
+          p5,
+          p6,
+          p7,
+          p8,
+          p9,
+          p10,
+          p11,
+          p12,
+          p13,
+          p14,
+          p15,
+          p16,
+          p17);
+    } else if constexpr (a == 18) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18]
+          = t;
+        return std::tie(
+          p1,
+          p2,
+          p3,
+          p4,
+          p5,
+          p6,
+          p7,
+          p8,
+          p9,
+          p10,
+          p11,
+          p12,
+          p13,
+          p14,
+          p15,
+          p16,
+          p17,
+          p18);
+    } else if constexpr (a == 19) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19]
+          = t;
+        return std::tie(
+          p1,
+          p2,
+          p3,
+          p4,
+          p5,
+          p6,
+          p7,
+          p8,
+          p9,
+          p10,
+          p11,
+          p12,
+          p13,
+          p14,
+          p15,
+          p16,
+          p17,
+          p18,
+          p19);
+    } else if constexpr (a == 20) {
+        auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20]
+          = t;
+        return std::tie(
+          p1,
+          p2,
+          p3,
+          p4,
+          p5,
+          p6,
+          p7,
+          p8,
+          p9,
+          p10,
+          p11,
+          p12,
+          p13,
+          p14,
+          p15,
+          p16,
+          p17,
+          p18,
+          p19,
+          p20);
+    }
+}
+
+template<typename T, typename Fn>
+inline void envelope_for_each_field(T& t, Fn&& fn) {
+    static_assert(is_envelope_v<std::decay_t<T>>);
+    std::apply([&](auto&&... args) { (fn(args), ...); }, envelope_to_tuple(t));
+}
+
+} // namespace serde

--- a/src/v/serde/logger.h
+++ b/src/v/serde/logger.h
@@ -1,0 +1,21 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/print.hh>
+#include <seastar/util/log.hh>
+
+namespace serde {
+
+inline ss::logger serde_log{"serde"};
+
+} // namespace serde

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -1,0 +1,315 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "bytes/iobuf_parser.h"
+#include "reflection/type_traits.h"
+#include "serde/envelope_for_each_field.h"
+#include "serde/logger.h"
+#include "serde/serde_exception.h"
+#include "serde/type_str.h"
+#include "ssx/future-util.h"
+#include "ssx/sformat.h"
+#include "utils/named_type.h"
+#include "vlog.h"
+
+#include <iosfwd>
+#include <numeric>
+#include <string>
+#include <string_view>
+
+namespace serde {
+
+template<typename T, typename = void>
+struct help_has_serde_read : std::false_type {};
+
+template<typename T>
+struct help_has_serde_read<
+  T,
+  std::void_t<decltype(std::declval<T>().serde_read(
+    std::declval<std::add_lvalue_reference_t<iobuf_parser>>(),
+    version_t{0},
+    version_t{0},
+    size_t{0U}))>> : std::true_type {};
+
+template<typename T>
+inline constexpr auto const has_serde_read = help_has_serde_read<T>::value;
+
+template<typename T, typename = void>
+struct help_has_serde_write : std::false_type {};
+
+template<typename T>
+struct help_has_serde_write<
+  T,
+  std::void_t<decltype(std::declval<T>().serde_write(
+    std::declval<std::add_lvalue_reference_t<iobuf>>()))>> : std::true_type {};
+
+template<typename T>
+inline constexpr auto const has_serde_write = help_has_serde_write<T>::value;
+
+template<typename T, typename = void>
+struct help_has_serde_async_read : std::false_type {};
+
+template<typename T>
+struct help_has_serde_async_read<
+  T,
+  std::void_t<decltype(std::declval<T>().serde_async_read(
+    std::declval<std::add_lvalue_reference_t<iobuf_parser>>(),
+    version_t{0},
+    version_t{0},
+    size_t{0U}))>> : std::true_type {};
+
+template<typename T>
+inline constexpr auto const has_serde_async_read
+  = help_has_serde_async_read<T>::value;
+
+template<typename T, typename = void>
+struct help_has_serde_async_write : std::false_type {};
+
+template<typename T>
+struct help_has_serde_async_write<
+  T,
+  std::void_t<decltype(std::declval<T>().serde_async_write(
+    std::declval<std::add_lvalue_reference_t<iobuf>>()))>> : std::true_type {};
+
+template<typename T>
+inline constexpr auto const has_serde_async_write
+  = help_has_serde_async_write<T>::value;
+
+template<typename T>
+inline constexpr auto const is_serde_compatible_v
+  = is_envelope_v<T> || (std::is_scalar_v<T> && !std::is_enum_v<T>)
+    || reflection::is_std_vector_v<
+      T> || reflection::is_named_type_v<T> || reflection::is_ss_bool_v<T> || std::is_same_v<T, std::chrono::milliseconds> || std::is_same_v<T, iobuf> || std::is_same_v<T, ss::sstring> || reflection::is_std_optional_v<T>;
+
+using header_t = std::tuple<version_t, version_t, size_t>;
+
+#if defined(SERDE_TEST)
+using serde_size_t = uint16_t;
+#else
+using serde_size_t = int32_t;
+#endif
+
+template<typename T>
+void write(iobuf&, T);
+
+template<typename T>
+void write(iobuf& out, T t) {
+    using Type = std::decay_t<T>;
+    static_assert(has_serde_write<Type> || is_serde_compatible_v<Type>);
+
+    if constexpr (is_envelope_v<Type>) {
+        write(out, Type::redpanda_serde_version);
+        write(out, Type::redpanda_serde_compat_version);
+
+        auto size_placeholder = out.reserve(sizeof(serde_size_t));
+        auto const size_before = out.size_bytes();
+
+        if constexpr (has_serde_write<Type>) {
+            t.serde_write(out);
+        } else {
+            envelope_for_each_field(
+              t, [&out](auto& f) { write(out, std::move(f)); });
+        }
+
+        auto const written_size = out.size_bytes() - size_before;
+        if (unlikely(written_size > std::numeric_limits<serde_size_t>::max())) {
+            throw serde_exception("envelope too big");
+        }
+        auto const size = ss::cpu_to_le(
+          static_cast<serde_size_t>(written_size));
+        size_placeholder.write(
+          reinterpret_cast<char const*>(&size), sizeof(serde_size_t));
+    } else if constexpr (std::is_same_v<bool, Type>) {
+        write<int8_t>(out, t);
+    } else if constexpr (std::is_scalar_v<Type> && !std::is_enum_v<Type>) {
+        if constexpr (sizeof(Type) == 1) {
+            out.append(reinterpret_cast<char const*>(&t), sizeof(t));
+        } else {
+            auto const le_t = ss::cpu_to_le(t);
+            static_assert(sizeof(le_t) == sizeof(Type));
+            out.append(reinterpret_cast<char const*>(&le_t), sizeof(le_t));
+        }
+    } else if constexpr (reflection::is_std_vector_v<Type>) {
+        if (unlikely(t.size() > std::numeric_limits<serde_size_t>::max())) {
+            throw serde_exception(fmt_with_ctx(
+              ssx::sformat,
+              "serde: vector size {} exceeds serde_size_t",
+              t.size()));
+        }
+        write(out, static_cast<serde_size_t>(t.size()));
+        for (auto const& el : t) {
+            write(out, el);
+        }
+    } else if constexpr (reflection::is_named_type_v<Type>) {
+        return write(out, static_cast<typename Type::type>(t));
+    } else if constexpr (reflection::is_ss_bool_v<Type>) {
+        write(out, static_cast<int8_t>(bool(t)));
+    } else if constexpr (std::is_same_v<Type, std::chrono::milliseconds>) {
+        write<int64_t>(out, t.count());
+    } else if constexpr (std::is_same_v<Type, iobuf>) {
+        write<serde_size_t>(out, t.size_bytes());
+        out.append(t.share(0, t.size_bytes()));
+    } else if constexpr (std::is_same_v<Type, ss::sstring>) {
+        write<serde_size_t>(out, t.size());
+        out.append(t.data(), t.size());
+    } else if constexpr (reflection::is_std_optional_v<Type>) {
+        if (t) {
+            write(out, true);
+            write(out, t.value());
+        } else {
+            write(out, false);
+        }
+    }
+}
+
+template<typename T>
+std::decay_t<T> read(iobuf_parser&);
+
+template<typename T>
+header_t read_header(iobuf_parser& in) {
+    using Type = std::decay_t<T>;
+
+    auto const version = read<version_t>(in);
+    auto const compat_version = read<version_t>(in);
+    auto const size = read<serde_size_t>(in);
+
+    if (unlikely(compat_version > Type::redpanda_serde_version)) {
+        throw serde_exception(fmt_with_ctx(
+          ssx::sformat,
+          "read compat_version={} > {}::version={}",
+          static_cast<int>(compat_version),
+          type_str<T>(),
+          static_cast<int>(Type::redpanda_serde_version)));
+    }
+
+    if (unlikely(in.bytes_left() < size)) {
+        throw serde_exception(fmt_with_ctx(
+          ssx::sformat,
+          "bytes_left={}, size={}",
+          in.bytes_left(),
+          static_cast<int>(size)));
+    }
+
+    return std::make_tuple(version, compat_version, size);
+}
+
+template<typename T>
+std::decay_t<T> read(iobuf_parser& in) {
+    using Type = std::decay_t<T>;
+    static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
+
+    auto t = Type();
+    if constexpr (is_envelope_v<Type>) {
+        [[maybe_unused]] auto const [version, compat_version, size]
+          = read_header<Type>(in);
+        if constexpr (has_serde_read<Type>) {
+            t.serde_read(in, version, compat_version, size);
+        } else {
+            envelope_for_each_field(
+              t, [&](auto& f) { f = read<std::decay_t<decltype(f)>>(in); });
+        }
+    } else if constexpr (std::is_same_v<Type, bool>) {
+        t = read<int8_t>(in) != 0;
+    } else if constexpr (std::is_scalar_v<Type> && !std::is_enum_v<Type>) {
+        if (unlikely(in.bytes_left() < sizeof(Type))) {
+            throw serde_exception{"message too short"};
+        }
+
+        if constexpr (sizeof(Type) == 1) {
+            t = in.consume_type<Type>();
+        } else {
+            t = ss::le_to_cpu(in.consume_type<Type>());
+        }
+    } else if constexpr (reflection::is_std_vector_v<Type>) {
+        using value_type = typename Type::value_type;
+        t.resize(read<serde_size_t>(in));
+        for (auto i = 0U; i < t.size(); ++i) {
+            t[i] = read<value_type>(in);
+        }
+    } else if constexpr (reflection::is_named_type_v<Type>) {
+        t = Type{read<typename Type::type>(in)};
+    } else if constexpr (reflection::is_ss_bool_v<Type>) {
+        t = Type{read<int8_t>(in) != 0};
+    } else if constexpr (std::is_same_v<Type, std::chrono::milliseconds>) {
+        t = std::chrono::milliseconds(read<int64_t>(in));
+    } else if constexpr (std::is_same_v<Type, iobuf>) {
+        return in.share(read<serde_size_t>(in));
+    } else if constexpr (std::is_same_v<Type, ss::sstring>) {
+        return in.read_string(read<serde_size_t>(in));
+    } else if constexpr (reflection::is_std_optional_v<Type>) {
+        return read<bool>(in) ? Type{read<typename Type::value_type>(in)}
+                              : std::nullopt;
+    }
+
+    return t;
+}
+
+template<typename T>
+ss::future<std::decay_t<T>> read_async(iobuf_parser& in) {
+    using Type = std::decay_t<T>;
+    if constexpr (has_serde_async_read<Type>) {
+        auto const h = read_header<Type>(in);
+        return ss::do_with(Type{}, [&in, h](Type& t) {
+            auto const& [version, compat_version, size] = h;
+            return t.serde_async_read(in, version, compat_version, size)
+              .then([&t]() { return std::move(t); });
+        });
+    } else {
+        return ss::make_ready_future<std::decay_t<T>>(read<T>(in));
+    }
+}
+
+template<typename T>
+ss::future<> write_async(iobuf& out, T const& t) {
+    using Type = std::decay_t<T>;
+    if constexpr (is_envelope_v<Type> && has_serde_async_write<Type>) {
+        write(out, Type::redpanda_serde_version);
+        write(out, Type::redpanda_serde_compat_version);
+
+        auto size_placeholder = out.reserve(sizeof(serde_size_t));
+        auto const size_before = out.size_bytes();
+
+        return t.serde_async_write(out).then(
+          [&out,
+           size_before,
+           size_placeholder = std::move(size_placeholder)]() mutable {
+              auto const written_size = out.size_bytes() - size_before;
+              if (unlikely(
+                    written_size > std::numeric_limits<serde_size_t>::max())) {
+                  throw serde_exception{"envelope too big"};
+              }
+              auto const size = ss::cpu_to_le(
+                static_cast<serde_size_t>(written_size));
+              size_placeholder.write(
+                reinterpret_cast<char const*>(&size), sizeof(serde_size_t));
+
+              return ss::make_ready_future<>();
+          });
+    } else {
+        write(out, t);
+        return ss::make_ready_future<>();
+    }
+}
+
+template<typename T>
+iobuf to_iobuf(T&& t) {
+    iobuf b;
+    write(b, std::forward<T>(t));
+    return b;
+}
+
+template<typename T>
+T from_iobuf(iobuf b) {
+    auto in = iobuf_parser{std::move(b)};
+    return read<T>(in);
+}
+
+} // namespace serde

--- a/src/v/serde/serde_exception.h
+++ b/src/v/serde/serde_exception.h
@@ -1,0 +1,26 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include <exception>
+
+namespace serde {
+
+class serde_exception : public std::exception {
+public:
+    explicit serde_exception(ss::sstring s)
+      : _msg(std::move(s)) {}
+
+    const char* what() const noexcept override { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
+
+} // namespace serde

--- a/src/v/serde/test/CMakeLists.txt
+++ b/src/v/serde/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+rp_test(
+  UNIT_TEST
+  BINARY_NAME serde
+  SOURCES serde_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK SERDE_TEST
+  LIBRARIES v::seastar_testing_main v::serde
+  LABELS serde
+)
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME serde
+  SOURCES bench.cc
+  LIBRARIES Seastar::seastar_perf_testing v::serde
+  LABELS serde
+)

--- a/src/v/serde/test/bench.cc
+++ b/src/v/serde/test/bench.cc
@@ -1,0 +1,90 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "serde/serde.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/testing/perf_tests.hh>
+
+struct small_t
+  : public serde::
+      envelope<small_t, serde::version<3>, serde::compat_version<2>> {
+    int8_t a = 1;
+    // char __a_padding;
+    int16_t b = 2;
+    int32_t c = 3;
+    int64_t d = 4;
+};
+static_assert(sizeof(small_t) == 16, "one more byte for padding");
+
+PERF_TEST(small, serialize) {
+    perf_tests::start_measuring_time();
+    auto o = serde::to_iobuf(small_t{});
+    perf_tests::do_not_optimize(o);
+    perf_tests::stop_measuring_time();
+}
+PERF_TEST(small, deserialize) {
+    auto b = serde::to_iobuf(small_t{});
+    perf_tests::start_measuring_time();
+    auto result = serde::from_iobuf<small_t>(std::move(b));
+    perf_tests::do_not_optimize(result);
+    perf_tests::stop_measuring_time();
+}
+
+struct big_t
+  : public serde::envelope<big_t, serde::version<3>, serde::compat_version<2>> {
+    small_t s;
+    iobuf data;
+};
+
+inline big_t gen_big(size_t data_size, size_t chunk_size) {
+    const size_t chunks = data_size / chunk_size;
+    big_t ret{.s = small_t{}};
+    for (size_t i = 0; i < chunks; ++i) {
+        auto c = ss::temporary_buffer<char>(chunk_size);
+        ret.data.append(std::move(c));
+    }
+    return ret;
+}
+
+inline void serialize_big(size_t data_size, size_t chunk_size) {
+    big_t b = gen_big(data_size, chunk_size);
+    auto o = iobuf();
+    perf_tests::start_measuring_time();
+    serde::write(o, std::move(b));
+    perf_tests::do_not_optimize(o);
+    perf_tests::stop_measuring_time();
+}
+
+inline void deserialize_big(size_t data_size, size_t chunk_size) {
+    big_t b = gen_big(data_size, chunk_size);
+    auto o = iobuf();
+    serde::write(o, std::move(b));
+    perf_tests::start_measuring_time();
+    auto result = serde::from_iobuf<big_t>(std::move(o));
+    perf_tests::do_not_optimize(result);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(big_1mb, serialize) {
+    serialize_big(1 << 20 /*1MB*/, 1 << 15 /*32KB*/);
+}
+
+PERF_TEST(big_1mb, deserialize) {
+    return deserialize_big(1 << 20 /*1MB*/, 1 << 15 /*32KB*/);
+}
+
+PERF_TEST(big_10mb, serialize) {
+    serialize_big(10 << 20 /*10MB*/, 1 << 15 /*32KB*/);
+}
+
+PERF_TEST(big_10mb, deserialize) {
+    return deserialize_big(10 << 20 /*10MB*/, 1 << 15 /*32KB*/);
+}

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -1,0 +1,331 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "hashing/crc32c.h"
+#include "serde/envelope.h"
+#include "serde/serde.h"
+
+#include <seastar/core/scheduling.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <limits>
+
+struct test_msg0
+  : serde::envelope<test_msg0, serde::version<1>, serde::compat_version<0>> {
+    char _i, _j;
+};
+
+struct test_msg1
+  : serde::envelope<test_msg1, serde::version<4>, serde::compat_version<0>> {
+    int _a;
+    test_msg0 _m;
+    int _b, _c;
+};
+
+struct test_msg1_new
+  : serde::
+      envelope<test_msg1_new, serde::version<10>, serde::compat_version<5>> {
+    int _a;
+    test_msg0 _m;
+    int _b, _c;
+};
+
+struct not_an_envelope {};
+static_assert(!serde::is_envelope_v<not_an_envelope>);
+static_assert(serde::is_envelope_v<test_msg1>);
+static_assert(test_msg1::redpanda_serde_version == 4);
+static_assert(test_msg1::redpanda_serde_compat_version == 0);
+
+SEASTAR_THREAD_TEST_CASE(reserve_test) {
+    auto b = iobuf();
+    auto p = b.reserve(10);
+
+    auto const a = std::array<char, 3>{'a', 'b', 'c'};
+    p.write(&a[0], a.size());
+
+    auto parser = iobuf_parser{std::move(b)};
+    auto called = 0U;
+    parser.consume(3, [&](const char* data, size_t max) {
+        ++called;
+        BOOST_CHECK(max == 3);
+        BOOST_CHECK(data[0] == a[0]);
+        BOOST_CHECK(data[1] == a[1]);
+        BOOST_CHECK(data[2] == a[2]);
+        return ss::stop_iteration::no;
+    });
+    BOOST_CHECK(called == 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(envelope_too_big_test) {
+    struct big
+      : public serde::
+          envelope<big, serde::version<0>, serde::compat_version<0>> {
+        std::vector<char> data_;
+    };
+
+    auto too_big = std::make_unique<big>();
+    too_big->data_.resize(std::numeric_limits<serde::serde_size_t>::max());
+    auto b = iobuf();
+    BOOST_CHECK_THROW(serde::write(b, *too_big), std::exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(simple_envelope_test) {
+    struct msg
+      : serde::envelope<msg, serde::version<1>, serde::compat_version<0>> {
+        int32_t _i, _j;
+    };
+
+    auto b = iobuf();
+    serde::write(b, msg{._i = 2, ._j = 3});
+
+    auto parser = iobuf_parser{std::move(b)};
+    auto m = serde::read<msg>(parser);
+    BOOST_CHECK(m._i == 2);
+    BOOST_CHECK(m._j == 3);
+}
+
+SEASTAR_THREAD_TEST_CASE(envelope_test) {
+    auto b = iobuf();
+
+    serde::write(
+      b, test_msg1{._a = 55, ._m = {._i = 'i', ._j = 'j'}, ._b = 33, ._c = 44});
+
+    auto parser = iobuf_parser{std::move(b)};
+
+    auto m = test_msg1{};
+    BOOST_CHECK_NO_THROW(m = serde::read<test_msg1>(parser));
+    BOOST_CHECK(m._a == 55);
+    BOOST_CHECK(m._b == 33);
+    BOOST_CHECK(m._c == 44);
+    BOOST_CHECK(m._m._i == 'i');
+    BOOST_CHECK(m._m._j == 'j');
+}
+
+SEASTAR_THREAD_TEST_CASE(envelope_test_version_older_than_compat_version) {
+    auto b = iobuf();
+
+    serde::write(
+      b,
+      test_msg1_new{
+        ._a = 55, ._m = {._i = 'i', ._j = 'j'}, ._b = 33, ._c = 44});
+
+    auto parser = iobuf_parser{std::move(b)};
+
+    auto throws = false;
+    try {
+        serde::read<test_msg1>(parser);
+    } catch (std::exception const& e) {
+        throws = true;
+    }
+
+    BOOST_CHECK(throws);
+}
+
+SEASTAR_THREAD_TEST_CASE(envelope_test_buffer_too_short) {
+    auto b = iobuf();
+
+    serde::write(
+      b,
+      test_msg1_new{
+        ._a = 55, ._m = {._i = 'i', ._j = 'j'}, ._b = 33, ._c = 44});
+
+    b.pop_back(); // introduce length mismatch
+    auto parser = iobuf_parser{std::move(b)};
+
+    auto throws = false;
+    try {
+        serde::read<test_msg1_new>(parser);
+    } catch (std::exception const& e) {
+        throws = true;
+    }
+    BOOST_CHECK(throws);
+}
+
+SEASTAR_THREAD_TEST_CASE(vector_test) {
+    auto b = iobuf();
+
+    serde::write(b, std::vector{1, 2, 3});
+
+    auto parser = iobuf_parser{std::move(b)};
+    auto const m = serde::read<std::vector<int>>(parser);
+    BOOST_CHECK((m == std::vector{1, 2, 3}));
+}
+
+// struct with differing sizes:
+// vector length may take different size (vint)
+// vector data may have different size (_ints.size() * sizeof(int))
+struct inner_differing_sizes
+  : serde::envelope<inner_differing_sizes, serde::version<1>> {
+    std::vector<int32_t> _ints;
+};
+
+struct complex_msg : serde::envelope<complex_msg, serde::version<3>> {
+    std::vector<inner_differing_sizes> _vec;
+    int32_t _x;
+};
+
+static_assert(serde::is_envelope_v<complex_msg>);
+
+SEASTAR_THREAD_TEST_CASE(complex_msg_test) {
+    auto b = iobuf();
+
+    inner_differing_sizes big;
+    big._ints.resize(std::numeric_limits<uint8_t>::max() + 1);
+    std::fill(begin(big._ints), end(big._ints), 4);
+
+    serde::write(
+      b,
+      complex_msg{
+        ._vec = std::
+          vector{inner_differing_sizes{._ints = {1, 2, 3}}, big, inner_differing_sizes{._ints = {1, 2, 3}}, big, inner_differing_sizes{._ints = {1, 2, 3}}, big},
+        ._x = 3});
+
+    auto parser = iobuf_parser{std::move(b)};
+    auto const m = serde::read<complex_msg>(parser);
+    BOOST_CHECK(m._vec.size() == 6);
+    for (auto i = 0U; i < m._vec.size(); ++i) {
+        if (i % 2 == 0) {
+            BOOST_CHECK((m._vec[i]._ints == std::vector{1, 2, 3}));
+        } else {
+            BOOST_CHECK(m._vec[i]._ints == big._ints);
+        }
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(all_types_test) {
+    {
+        using named = named_type<int64_t, struct named_test_tag>;
+        auto b = iobuf();
+        serde::write(b, named{123});
+        auto parser = iobuf_parser{std::move(b)};
+        BOOST_CHECK(serde::read<named>(parser) == named{123});
+    }
+
+    {
+        using ss_bool = ss::bool_class<struct bool_tag>;
+        auto b = iobuf();
+        serde::write(b, ss_bool{true});
+        auto parser = iobuf_parser{std::move(b)};
+        BOOST_CHECK(serde::read<ss_bool>(parser) == ss_bool{true});
+    }
+
+    {
+        auto b = iobuf();
+        serde::write(b, std::chrono::milliseconds{123});
+        auto parser = iobuf_parser{std::move(b)};
+        BOOST_CHECK(
+          serde::read<std::chrono::milliseconds>(parser)
+          == std::chrono::milliseconds{123});
+    }
+
+    {
+        auto b = iobuf();
+        auto buf = iobuf{};
+        buf.append("hello", 5U);
+        serde::write(b, std::move(buf));
+        auto parser = iobuf_parser{std::move(b)};
+        BOOST_CHECK(serde::read<iobuf>(parser).size_bytes() == 5);
+    }
+
+    {
+        auto b = iobuf();
+        serde::write(b, ss::sstring{"123"});
+        auto parser = iobuf_parser{std::move(b)};
+        BOOST_CHECK(serde::read<ss::sstring>(parser) == ss::sstring{"123"});
+    }
+
+    {
+        auto b = iobuf();
+        auto const v = std::vector<int32_t>{1, 2, 3};
+        serde::write(b, v);
+        auto parser = iobuf_parser{std::move(b)};
+        BOOST_CHECK(serde::read<std::vector<int32_t>>(parser) == v);
+    }
+
+    {
+        auto b = iobuf();
+        serde::write(b, std::optional<int32_t>{});
+        auto parser = iobuf_parser{std::move(b)};
+        BOOST_CHECK(!serde::read<std::optional<int32_t>>(parser).has_value());
+    }
+}
+
+struct test_snapshot_header
+  : serde::envelope<
+      test_snapshot_header,
+      serde::version<1>,
+      serde::compat_version<0>> {
+    ss::future<>
+    serde_async_read(iobuf_parser&, serde::version_t, serde::version_t, size_t);
+    ss::future<> serde_async_write(iobuf&) const;
+
+    int32_t header_crc;
+    int32_t metadata_crc;
+    int8_t version;
+    int32_t metadata_size;
+};
+
+static_assert(serde::is_envelope_v<test_snapshot_header>);
+static_assert(serde::has_serde_async_read<test_snapshot_header>);
+static_assert(serde::has_serde_async_write<test_snapshot_header>);
+
+ss::future<> test_snapshot_header::serde_async_read(
+  iobuf_parser& in, serde::version_t, serde::version_t, size_t) {
+    header_crc = serde::read<decltype(header_crc)>(in);
+    metadata_crc = serde::read<decltype(metadata_crc)>(in);
+    version = serde::read<decltype(version)>(in);
+    metadata_size = serde::read<decltype(metadata_size)>(in);
+
+    vassert(metadata_size >= 0, "Invalid metadata size {}", metadata_size);
+
+    crc::crc32c crc;
+    crc.extend(ss::cpu_to_le(metadata_crc));
+    crc.extend(ss::cpu_to_le(version));
+    crc.extend(ss::cpu_to_le(metadata_size));
+
+    if (header_crc != crc.value()) {
+        return ss::make_exception_future<>(std::runtime_error(fmt::format(
+          "Corrupt snapshot. Failed to verify header crc: {} != "
+          "{}: path?",
+          crc.value(),
+          header_crc)));
+    }
+
+    return ss::make_ready_future<>();
+}
+
+ss::future<> test_snapshot_header::serde_async_write(iobuf& out) const {
+    serde::write(out, header_crc);
+    serde::write(out, metadata_crc);
+    serde::write(out, version);
+    serde::write(out, metadata_size);
+    return ss::make_ready_future<>();
+}
+
+SEASTAR_THREAD_TEST_CASE(snapshot_test) {
+    auto b = iobuf();
+    auto write_future = serde::write_async(
+      b,
+      test_snapshot_header{
+        .header_crc = 1, .metadata_crc = 2, .version = 3, .metadata_size = 4});
+    write_future.wait();
+    auto parser = iobuf_parser{std::move(b)};
+    auto read_future = serde::read_async<test_snapshot_header>(parser);
+    read_future.wait();
+    BOOST_CHECK(read_future.failed());
+    try {
+        std::rethrow_exception(read_future.get_exception());
+    } catch (std::exception const& e) {
+        BOOST_CHECK(
+          std::string_view{e.what()}.starts_with("Corrupt snapshot."));
+    }
+}

--- a/src/v/serde/type_str.h
+++ b/src/v/serde/type_str.h
@@ -1,0 +1,48 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include <string_view>
+
+namespace serde {
+
+#if defined(_MSC_VER)
+#define SERDE_SIG __FUNCSIG__
+#elif defined(__clang__) || defined(__GNUC__)
+#define SERDE_SIG __PRETTY_FUNCTION__
+#else
+#error unsupported compiler
+#endif
+
+template<typename T>
+constexpr std::string_view type_str() {
+#if defined(__clang__)
+    constexpr std::string_view prefix
+      = "std::string_view serde::type_str() [T = ";
+    constexpr std::string_view suffix = "]";
+#elif defined(_MSC_VER)
+    constexpr std::string_view prefix
+      = "class std::basic_string_view<char,struct std::char_traits<char> > "
+        "__cdecl serde::type_str<";
+    constexpr std::string_view suffix = ">(void)";
+#else
+    constexpr std::string_view prefix
+      = "constexpr std::string_view serde::type_str() [with T = ";
+    constexpr std::string_view suffix
+      = "; std::string_view = std::basic_string_view<char>]";
+#endif
+
+    auto sig = std::string_view{SERDE_SIG};
+    sig.remove_prefix(prefix.size());
+    sig.remove_suffix(suffix.size());
+    return sig;
+}
+
+} // namespace serde


### PR DESCRIPTION
This introduces a new serde module which provides versioning for aggregate types. The main advantage is a unified serialized header for all types `T` derived from `envelope<T, version<X>, compat_version<Y>>` (`X` being the current version of the data structure `T` and `Y` being the earliest version that's capable of handling serialized data of the data structure at hand). The header is structured as follows: 1 byte version, 1 byte compat version, 4 bytes size. So the "overhead" is 6 bytes. This allows us to distinguish 256 unique versions of the data structure which should be sufficient. Using variable length encoding for the size integer was considered but would either require a second pass over the data structure tree to determine the size of an aggregate type (including all its members) or a `placeholder` in `iobuf` with a variable size (currently it is fixed). The serialization function for each type is customizable. In case the 6 byte header is too inefficient or no versioning is required, it's always possible to implement a handwritten read/write/async_read/async_write function. For aggregate types, this can be done as global function as well as member function.