### PR TITLE
pandaproxy: Consumer group validation, fixes, and tests

### DIFF
--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -30,6 +30,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <absl/container/node_hash_map.h>
 
 namespace kafka::client {
 
@@ -66,7 +67,7 @@ public:
     /// \brief Connect to all brokers.
     ss::future<> connect();
     /// \brief Disconnect from all brokers.
-    ss::future<> stop();
+    ss::future<> stop() noexcept;
 
     /// \brief Invoke func, on failure, mitigate error and retry.
     template<typename Func>
@@ -176,10 +177,12 @@ private:
     /// \brief Batching producer.
     producer _producer;
     /// \brief Consumers
-    absl::flat_hash_set<
-      shared_consumer_t,
-      detail::consumer_hash,
-      detail::consumer_eq>
+    absl::node_hash_map<
+      kafka::group_id,
+      absl::flat_hash_set<
+        shared_consumer_t,
+        detail::consumer_hash,
+        detail::consumer_eq>>
       _consumers;
     /// \brief Wait for retries.
     ss::gate _gate;

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -236,8 +236,15 @@ create_consumer(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 remove_consumer(server::request_t rq, server::reply_t rp) {
-    auto group_id = kafka::group_id(rq.req->param["group_name"]);
-    auto member_id = kafka::member_id(rq.req->param["instance"]);
+    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    parse::accept_header(
+      *rq.req,
+      {json::serialization_format::json_v2, json::serialization_format::none});
+
+    auto group_id = parse::request_param<kafka::group_id>(
+      *rq.req, "group_name");
+    auto member_id = parse::request_param<kafka::member_id>(
+      *rq.req, "instance");
 
     co_await rq.ctx.client.remove_consumer(group_id, member_id);
     rp.rep->set_status(ss::httpd::reply::status_type::no_content);

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -246,15 +246,23 @@ remove_consumer(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 subscribe_consumer(server::request_t rq, server::reply_t rp) {
+    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    auto res_fmt = parse::accept_header(
+      *rq.req,
+      {json::serialization_format::json_v2, json::serialization_format::none});
+
+    auto group_id = parse::request_param<kafka::group_id>(
+      *rq.req, "group_name");
+    auto member_id = parse::request_param<kafka::member_id>(
+      *rq.req, "instance");
+
     auto req_data = ppj::rjson_parse(
       rq.req->content.data(), ppj::subscribe_consumer_request_handler());
-    auto group_id = kafka::group_id(rq.req->param["group_name"]);
-    auto member_id = kafka::member_id(rq.req->param["instance"]);
 
     return rq.ctx.client
       .subscribe_consumer(group_id, member_id, std::move(req_data.topics))
-      .then([rp{std::move(rp)}]() mutable {
-          // nothing to do!
+      .then([res_fmt, rp{std::move(rp)}]() mutable {
+          rp.mime_type = res_fmt;
           return std::move(rp);
       });
 }

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -259,7 +259,9 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
         auto res = http_request(
           client,
           fmt::format("/consumers/{}/instances/{}", group_id(), member_id()),
-          boost::beast::http::verb::delete_);
+          boost::beast::http::verb::delete_,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::json_v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::no_content);
     }
@@ -269,7 +271,9 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
         auto res = http_request(
           client,
           fmt::format("/consumers/{}/instances/{}", group_id(), member_id()),
-          boost::beast::http::verb::delete_);
+          boost::beast::http::verb::delete_,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::json_v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::not_found);
     }

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -131,7 +131,10 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           client,
           fmt::format(
             "/consumers/{}/instances/{}/subscription", group_id(), member_id()),
-          std::move(req_body_buf));
+          std::move(req_body_buf),
+          boost::beast::http::verb::post,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::json_v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -80,7 +80,10 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
         auto res = http_request(
           client,
           fmt::format("/consumers/{}", group_id()),
-          std::move(req_body_buf));
+          std::move(req_body_buf),
+          boost::beast::http::verb::post,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::json_v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -98,7 +101,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
             member_id()));
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
-          "application/vnd.kafka.binary.v2+json");
+          to_header_value(ppj::serialization_format::json_v2));
     }
     info("Member id: {}", member_id);
 

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -22,3 +22,4 @@ quick:
   - tests/partition_movement_test.py::PartitionMovementTest.test_cycle_simple
   - tests/wasm_identity_test.py
   - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group
+  - tests/pandaproxy_test.py::PandaProxyTest.test_subscribe_consumer_validation

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -40,6 +40,11 @@ HTTP_PRODUCE_TOPIC_HEADERS = {
     "Content-Type": "application/vnd.kafka.binary.v2+json"
 }
 
+HTTP_CREATE_CONSUMER_HEADERS = {
+    "Accept": "application/vnd.kafka.v2+json",
+    "Content-Type": "application/vnd.kafka.v2+json"
+}
+
 
 class Consumer:
     def __init__(self, res):
@@ -112,16 +117,17 @@ class PandaProxyTest(RedpandaTest):
             f"{self._base_uri()}/topics/{topic}/partitions/{partition}/records?offset={offset}&max_bytes={max_bytes}&timeout={timeout_ms}",
             headers=headers)
 
-    def _create_consumer(self, group_id):
-        res = requests.post(
-            f"{self._base_uri()}/consumers/{group_id}", '''
+    def _create_consumer(self, group_id, headers=HTTP_CREATE_CONSUMER_HEADERS):
+        res = requests.post(f"{self._base_uri()}/consumers/{group_id}",
+                            '''
             {
                 "format": "binary",
                 "auto.offset.reset": "earliest",
                 "auto.commit.enable": "false",
                 "fetch.min.bytes": "1",
                 "consumer.request.timeout.ms": "10000"
-            }''')
+            }''',
+                            headers=headers)
         return res
 
     @cluster(num_nodes=3)

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -50,6 +50,11 @@ HTTP_SUBSCRIBE_CONSUMER_HEADERS = {
     "Content-Type": "application/vnd.kafka.v2+json"
 }
 
+HTTP_REMOVE_CONSUMER_HEADERS = {
+    "Accept": "application/vnd.kafka.v2+json",
+    "Content-Type": "application/vnd.kafka.v2+json"
+}
+
 
 class Consumer:
     def __init__(self, res):
@@ -62,8 +67,8 @@ class Consumer:
                             headers=headers)
         return res
 
-    def remove(self):
-        res = requests.delete(self.base_uri)
+    def remove(self, headers=HTTP_REMOVE_CONSUMER_HEADERS):
+        res = requests.delete(self.base_uri, headers=headers)
         return res
 
 

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -450,6 +450,75 @@ class PandaProxyTest(RedpandaTest):
         assert cc_res.status_code == requests.codes.not_found
 
     @cluster(num_nodes=3)
+    def test_subscribe_consumer_validation(self):
+        """
+        Acceptable headers:
+        * Accept: "", "*/*", "application/vnd.kafka.v2+json"
+        * Content-Type: "application/vnd.kafka.v2+json"
+        Required Params:
+        * Path:
+          * group
+          * instance
+        """
+        group_id = f"pandaproxy-group-{uuid.uuid4()}"
+
+        self.logger.info("Create 3 topics")
+        topics = self._create_topics(create_topic_names(3), 3, 3)
+
+        self.logger.info("Create a consumer group")
+        cc_res = self._create_consumer(group_id)
+        assert cc_res.status_code == requests.codes.ok
+
+        c0 = Consumer(cc_res.json())
+
+        self.logger.info("Subscribe a consumer with no accept header")
+        sc_res = c0.subscribe(
+            topics,
+            headers={
+                "Content-Type": HTTP_SUBSCRIBE_CONSUMER_HEADERS["Content-Type"]
+            })
+        assert sc_res.status_code == requests.codes.ok
+        assert sc_res.headers[
+            "Content-Type"] == HTTP_SUBSCRIBE_CONSUMER_HEADERS["Accept"]
+
+        self.logger.info("Subscribe a consumer with invalid accept header")
+        sc_res = c0.subscribe(
+            topics,
+            headers={
+                "Content-Type":
+                HTTP_SUBSCRIBE_CONSUMER_HEADERS["Content-Type"],
+                "Accept": "application/vnd.kafka.binary.v2+json"
+            })
+        assert sc_res.status_code == requests.codes.not_acceptable
+        assert sc_res.json()["error_code"] == requests.codes.not_acceptable
+        assert sc_res.headers["Content-Type"] == "application/json"
+
+        self.logger.info("Subscribe a consumer with no content-type header")
+        sc_res = c0.subscribe(
+            topics,
+            headers={"Accept": HTTP_SUBSCRIBE_CONSUMER_HEADERS["Accept"]})
+        assert sc_res.status_code == requests.codes.unsupported_media_type
+        assert sc_res.json(
+        )["error_code"] == requests.codes.unsupported_media_type
+
+        self.logger.info("Subscribe a consumer with invalid group parameter")
+        sc_res = requests.post(
+            f"{self._base_uri()}/consumers/{group_id}-invalid/instances/{c0.instance_id}/subscription",
+            json.dumps({"topics": topics}),
+            headers=HTTP_SUBSCRIBE_CONSUMER_HEADERS)
+        assert sc_res.status_code == requests.codes.not_found
+        assert sc_res.json()["error_code"] == 40403
+
+        self.logger.info(
+            "Subscribe a consumer with invalid instance parameter")
+        sc_res = requests.post(
+            f"{self._base_uri()}/consumers/{group_id}/instances/{c0.instance_id}-invalid/subscription",
+            json.dumps({"topics": topics}),
+            headers=HTTP_SUBSCRIBE_CONSUMER_HEADERS)
+        assert sc_res.status_code == requests.codes.not_found
+        assert sc_res.json()["error_code"] == 40403
+
+    @cluster(num_nodes=3)
     def test_consumer_group(self):
         """
         Create a consumer group and use it

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -45,15 +45,21 @@ HTTP_CREATE_CONSUMER_HEADERS = {
     "Content-Type": "application/vnd.kafka.v2+json"
 }
 
+HTTP_SUBSCRIBE_CONSUMER_HEADERS = {
+    "Accept": "application/vnd.kafka.v2+json",
+    "Content-Type": "application/vnd.kafka.v2+json"
+}
+
 
 class Consumer:
     def __init__(self, res):
         self.instance_id = res["instance_id"]
         self.base_uri = res["base_uri"]
 
-    def subscribe(self, topics):
+    def subscribe(self, topics, headers=HTTP_SUBSCRIBE_CONSUMER_HEADERS):
         res = requests.post(f"{self.base_uri}/subscription",
-                            json.dumps({"topics": topics}))
+                            json.dumps({"topics": topics}),
+                            headers=headers)
         return res
 
     def remove(self):
@@ -399,7 +405,7 @@ class PandaProxyTest(RedpandaTest):
     def test_create_consumer_validation(self):
         """
         Acceptable headers:
-        * Accept: "", "*/*", "application/vnd.kafka.binary.v2+json"
+        * Accept: "", "*/*", "application/vnd.kafka.v2+json"
         * Content-Type: "application/vnd.kafka.v2+json"
         Required Params:
         * Path:


### PR DESCRIPTION
## Cover letter

* kafka/client/consumers: Lookup by `group_id` as well as `member_id`
* pandaproxy/consumers: `create`, `subscribe` and `remove`
  * Improve header and request parameter validation
  * Improve error response codes for failure modes

## Release notes

Release note: Pandaproxy: Improve error handling for consumer groups
