### PR TITLE
ci: address transient network errors

### DIFF
--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -10,7 +10,7 @@ tasks:
     desc: install docker-compose
     cmds:
     - mkdir -p '{{.BUILD_ROOT}}/bin/'
-    - curl -L "https://github.com/docker/compose/releases/download/1.28.5/docker-compose-$(uname -s)-$(uname -m)" -o '{{.BUILD_ROOT}}/bin/docker-compose'
+    - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 "https://github.com/docker/compose/releases/download/1.28.5/docker-compose-$(uname -s)-$(uname -m)" -o '{{.BUILD_ROOT}}/bin/docker-compose'
     - chmod +x '{{.BUILD_ROOT}}/bin/docker-compose'
     status:
     - test -f '{{.BUILD_ROOT}}/bin/docker-compose'
@@ -23,8 +23,8 @@ tasks:
       JAVA_DIR: '{{.BUILD_ROOT}}/java'
     cmds:
     - mkdir -p '{{.JAVA_DIR}}'
-    - curl -L '{{.JDK_URL}}' | tar --strip-components=1 -C '{{.JAVA_DIR}}' -xz
-    - curl -L '{{.MAVEN_URL}}' | tar --strip-components=1 -C '{{.JAVA_DIR}}' -xz
+    - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.JDK_URL}}' | tar --strip-components=1 -C '{{.JAVA_DIR}}' -xz
+    - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.MAVEN_URL}}' | tar --strip-components=1 -C '{{.JAVA_DIR}}' -xz
       # delete this (empty) folder; leaving it generates an error
     - rm -r '{{.JAVA_DIR}}/lib/ext'
     status:

--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -105,10 +105,21 @@ tasks:
     desc: build image used in integration tests
     cmds:
     - |
-      docker build \
-        --tag vectorized/redpanda-test-node \
-        --file '{{.SRC_DIR}}/tests/docker/Dockerfile' \
-        '{{.SRC_DIR}}/tests/'
+      if [ '{{.CI}}' == '1' ]; then
+        chmod 644 '{{.SRC_DIR}}/tests/docker/ssh/'* '{{.SRC_DIR}}/tests/setup.py'
+        chmod 755 '{{.SRC_DIR}}/tests/docker/ssh'
+        docker pull docker.io/vectorized/redpanda-test-node:cache || true
+        docker build \
+          --tag vectorized/redpanda-test-node \
+          --file '{{.SRC_DIR}}/tests/docker/Dockerfile' \
+          --cache-from docker.io/vectorized/redpanda-test-node:cache \
+          '{{.SRC_DIR}}/tests/'
+      else
+        docker build \
+          --tag vectorized/redpanda-test-node \
+          --file '{{.SRC_DIR}}/tests/docker/Dockerfile' \
+          '{{.SRC_DIR}}/tests/'
+      fi
 
   start-compose-cluster:
     desc: deploy a cluster using docker-compose


### PR DESCRIPTION
   * bring back caching of docker image used in integration tests
   * pass "retry" set of flags to curl to address network transient errors