### PR TITLE
task: add cert generation for localhost dev

### DIFF
--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -40,3 +40,93 @@ tasks:
       fi
       sudo systemctl start podman.socket
       sudo curl -H "Content-Type: application/json" --unix-socket /var/run/docker.sock http://localhost/_ping | grep OK
+
+  generate-certs:
+    desc: use openssl to generate dev certs
+    cmds:
+    - |
+      TMPDIR="$HOME/redpanda-certs"
+      rm -rf $TMPDIR || true
+      mkdir -p $TMPDIR/certs
+      echo "Generating Certs in $TMPDIR"
+      cd $TMPDIR
+      cat > ca.cnf <<EOF
+      # OpenSSL CA configuration file
+      [ ca ]
+      default_ca = CA_default
+      [ CA_default ]
+      default_days = 365
+      database = index.txt
+      serial = serial.txt
+      default_md = sha256
+      copy_extensions = copy
+      unique_subject = no
+      # Used to create the CA certificate.
+      [ req ]
+      prompt=no
+      distinguished_name = distinguished_name
+      x509_extensions = extensions
+      [ distinguished_name ]
+      organizationName = Vectorized
+      commonName = Vectorized CA
+      [ extensions ]
+      keyUsage = critical,digitalSignature,nonRepudiation,keyEncipherment,keyCertSign
+      basicConstraints = critical,CA:true,pathlen:1
+      # Common policy for nodes and users.
+      [ signing_policy ]
+      organizationName = supplied
+      commonName = optional
+      # Used to sign node certificates.
+      [ signing_node_req ]
+      keyUsage = critical,digitalSignature,keyEncipherment
+      extendedKeyUsage = serverAuth,clientAuth
+      # Used to sign client certificates.
+      [ signing_client_req ]
+      keyUsage = critical,digitalSignature,keyEncipherment
+      extendedKeyUsage = clientAuth
+      EOF
+      openssl genrsa -out $TMPDIR/ca.key 2048
+      chmod 400 $TMPDIR/ca.key
+      openssl req -new -x509 -config ca.cnf -key $TMPDIR/ca.key -out certs/ca.key -days 365 -batch
+      openssl req \
+            -new \
+            -x509 \
+            -config ca.cnf \
+            -key $TMPDIR/ca.key \
+            -out certs/ca.crt \
+            -days 365 \
+            -batch
+      rm -f index.txt serial.txt
+      touch index.txt
+      echo '01' > serial.txt
+      cat > node.cnf <<EOF
+      # OpenSSL node configuration file
+      [ req ]
+      prompt=no
+      distinguished_name = distinguished_name
+      req_extensions = extensions
+      [ distinguished_name ]
+      organizationName = Vectorized
+      [ extensions ]
+      subjectAltName = critical,DNS:localhost,IP:127.0.0.1,IP:0.0.0.0
+      EOF
+      #DNS:<node-domain>,
+      openssl genrsa -out certs/node.key 2048
+      chmod 400 certs/node.key
+      openssl req \
+            -new \
+            -config node.cnf \
+            -key certs/node.key \
+            -out node.csr \
+            -batch
+      openssl ca \
+            -config ca.cnf \
+            -keyfile $TMPDIR/ca.key \
+            -cert certs/ca.crt \
+            -policy signing_policy \
+            -extensions signing_node_req \
+            -out certs/node.crt \
+            -outdir certs/ \
+            -in node.csr \
+            -batch
+      openssl x509 -in certs/node.crt -text | grep "X509v3 Subject Alternative Name" -A 1


### PR DESCRIPTION
## Cover letter

Add `task dev:generate-certs` that work for localhost RPK

```
# organization and cluster_id help Vectorized identify your system.                                                                                                                                                 
organization: ""                                                                                                                                                                                                    
cluster_id: ""                                                                                                                                                                                                      
                                                                                                                                                                                                                    
license_key: ""                                                                                                                                                                                                     
                                                                                                                                                                                                                    
redpanda:                                                                                                                                                                                                           
  # Data directory where all the files will be stored.                                                                                                                                                              
  # This directory MUST resides on xfs partion.                                                                                                                                                                     
  data_directory: "/home/agallego/redpanda-data"                                                                                                                                                                    
                                                                                                                                                                                                                    
  # Node ID - must be unique for each node                                                                                                                                                                          
  node_id: 1                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  # The initial cluster nodes addresses                                                                                                                                                                             
  seed_servers: []                                                                                                                                                                                                  
                                                                                                                                                                                                                    
  # Redpanda server                                                                                                                                                                                                 
  rpc_server:                                                                                                                                                                                                       
    address: "0.0.0.0"                                                                                                                                                                                              
    port: 33145                                                                                                                                                                                                     
                                                                                                                                                                                                                    
  # Kafka transport                                                                                                                                                                                                 
  kafka_api:                                                                                                                                                                                                        
  - address: "0.0.0.0"                                                                                                                                                                                              
    name: outside                                                                                                                                                                                                   
    port: 9092                                                                                                                                                                                                      
                                                                                                                                                                                                                    
  admin:                                                                                                                                                                                                            
    address: "0.0.0.0"                                                                                                                                                                                              
    port: 9644                                                                                                                                                                                                      
                                                                                                                                                                                                                    
  auto_create_topics_enabled: true                                                                                                                                                                                  
                                                                                                                                                                                                                    
  # Skips most of the checks performed at startup (i.e. memory, xfs)                                                                                                                                                
  # not recomended for production use                                                                                                                                                                               
  developer_mode: true                                                                                                                                                                                              
                                                                                                                                                                                                                    
  kafka_api_tls:                                                                                                                                                                                                    
  -  name: outside                                                                                                                                                                                                  
     enabled: true                                                                                                                                                                                                  
     cert_file: /home/agallego/redpanda-certs/certs/node.crt                                                                                                                                                        
     key_file: /home/agallego/redpanda-certs/certs/node.key                                                                                                                                                         
     truststore_file: /home/agallego/redpanda-certs/certs/ca.crt                                                                                                                                                    
     require_client_auth: false                                                                                                                                                                                     
                                                                                                                                                                                                                    
                                                                                                                                                                                                                    
rpk:                                                                                                                                                                                                                
  tls:                                                                                                                                                                                                              
    cert_file: /home/agallego/redpanda-certs/certs/node.crt                                                                                                                                                         
    key_file: /home/agallego/redpanda-certs/certs/node.key                                                                                                                                                          
    truststore_file: /home/agallego/redpanda-certs/certs/ca.crt                                                                                                                                                     
                                                                                                                                                                                                                    
  # Enables sending environment and resource usage data to Vectorized.                                                                                                                                              
  enable_usage_stats: true                                                                                                                                                                                          
                                                                                                                                                                                                                    
  # Available tuners                                                                                                                                                                                                
  tune_network: false                                                                                                                                                                                               
  tune_disk_scheduler: false                                                                                                                                                                                        
  tune_disk_nomerges: false                                                                                                                                                                                         
  tune_disk_irq: false                                                                                                                                                                                              
  tune_fstrim: false                                                                                                                                                                                                
  tune_cpu: false                                                                                                                                                                                                   
  tune_aio_events: false                                                                                                                                                                                            
  tune_clocksource: false                                                                                                                                                                                           
  tune_swappiness: false                                                                                                                                                                                            
  enable_memory_locking: false                                                                                                                                                                                      
  tune_coredump: false                                                                                                                                                                                              
  coredump_dir: "/var/lib/redpanda/coredump"
```


With the above config, i was able to test tls with RPK 