### PR TITLE
operator/tls: populate Kafka TLS list

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -342,7 +342,6 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 								// sometimes a little bit of memory is consumed by other processes than seastar
 								"--reserve-memory " + redpandav1alpha1.ReserveMemoryString,
 								r.portsConfiguration(),
-								"--",
 								"--default-log-level=debug",
 							},
 							Env: []corev1.EnvVar{

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -11,7 +11,6 @@ package resources
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"reflect"
@@ -166,6 +165,7 @@ func (r *StatefulSetResource) ensureRedpandaGroupsReady(
 	return r.queryRedpandaForTopicMembers(ctx, addresses, r.logger)
 }
 
+//nolint:unparam // ctx; will re-include the TLS call in future.
 // Used as a temporary indicator that Redpanda is ready until a health
 // endpoint is introduced or logic is added here that goes through all topics
 // metadata.
@@ -179,20 +179,6 @@ func (r *StatefulSetResource) queryRedpandaForTopicMembers(
 	conf.ClientID = "operator"
 	conf.Admin.Timeout = time.Second
 
-	tlsConfig := tls.Config{MinVersion: tls.VersionTLS12} // TLS12 is min version allowed by gosec.
-	if r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.Enabled {
-		// For simplicity, we skip broker verification until per-listener
-		// TLS is available in Redpanda. This client calls the internal listener.
-		tlsConfig.InsecureSkipVerify = true
-
-		if err := r.populateTLSConfigCert(ctx, &tlsConfig); err != nil {
-			return err
-		}
-
-		conf.Net.TLS.Enable = true
-		conf.Net.TLS.Config = &tlsConfig
-	}
-
 	consumer, err := sarama.NewConsumer(addresses, conf)
 	if err != nil {
 		logger.Error(err, "Error while creating consumer")
@@ -200,31 +186,6 @@ func (r *StatefulSetResource) queryRedpandaForTopicMembers(
 	}
 
 	return consumer.Close()
-}
-
-// Populates crypto/TLS configuration for certificate used by the operator
-// during its client authentication.
-func (r *StatefulSetResource) populateTLSConfigCert(
-	ctx context.Context, tlsConfig *tls.Config,
-) error {
-	if !r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.RequireClientAuth {
-		return nil
-	}
-
-	var certSecret corev1.Secret
-	err := r.Get(ctx, r.internalClientCertSecretKey, &certSecret)
-	if err != nil {
-		return err
-	}
-
-	cert, err := tls.X509KeyPair(certSecret.Data[corev1.TLSCertKey], certSecret.Data[corev1.TLSPrivateKeyKey])
-	if err != nil {
-		return err
-	}
-
-	tlsConfig.Certificates = []tls.Certificate{cert}
-
-	return nil
 }
 
 func (r *StatefulSetResource) podImageIdenticalToClusterImage(

--- a/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
@@ -32,7 +32,6 @@ spec:
             - --smp 1
             - --reserve-memory 1M
             - --advertise-rpc-addr=$(POD_NAME).external-connectivity.$(POD_NAMESPACE).svc.cluster.local.:33145
-            - --
             - --default-log-level=debug
 status:
   readyReplicas: 3

--- a/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
@@ -32,7 +32,6 @@ spec:
             - --smp 1
             - --reserve-memory 1M
             - --advertise-rpc-addr=$(POD_NAME).cluster-sample.$(POD_NAMESPACE).svc.cluster.local.:33145
-            - --
             - --default-log-level=debug
 status:
   readyReplicas: 1

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.2.2"
+  version: "v21.4.5"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.2.2"
+  version: "v21.4.5"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: update-image-cluster
 spec:
   image: "vectorized/redpanda"
-  version: "v21.2.2"
+  version: "v21.4.5"
   replicas: 2
   resources:
     requests:


### PR DESCRIPTION
## Cover letter

Passing TLS to redpanda config. We only support one TLS config in the cluster CR at the moment.