### PR TITLE
redpanda: Fix kafka server and rpc server intiialization

### DIFF
--- a/src/v/rpc/server.cc
+++ b/src/v/rpc/server.cc
@@ -29,6 +29,9 @@ server::server(server_configuration c)
   : cfg(std::move(c))
   , _memory(cfg.max_service_memory_per_core) {}
 
+server::server(ss::sharded<server_configuration>* s)
+  : server(s->local()) {}
+
 server::~server() = default;
 
 void server::start() {

--- a/src/v/rpc/server.h
+++ b/src/v/rpc/server.h
@@ -65,6 +65,7 @@ public:
     };
 
     explicit server(server_configuration);
+    explicit server(ss::sharded<server_configuration>* s);
     server(server&&) noexcept = default;
     server& operator=(server&&) noexcept = delete;
     server(const server&) = delete;


### PR DESCRIPTION
The problem: we introduced multi-listeners and per-listener credentials
to redpanda. To do that 'server_endpoint' class was introduced. The
instances of this class contains shared_ptr<server_credentials> field.
This field was initialized in main and passed to the shards. The
server_endpont was copied and this triggered assertion in shared_ptr
since it was created on different shard.

This PR adds c-tor to rpc::server that accepts ss::sharded<configuration>
and uses local() to obtain its shard-local copy of the config. Also, it
initializes rpc::configuration for both kafka and rpc servers as a
sharded<rpc::configuration> so the actual initialization and allocation
of the server_credentials is shifted to the shard.

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes issues: [#NNN, #NNN, ...]

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
