### PR TITLE
operator: Add group_topic_partitions in configuration

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -174,6 +174,8 @@ type RedpandaConfig struct {
 	AdminAPI      SocketAddress `json:"admin,omitempty"`
 	DeveloperMode bool          `json:"developerMode,omitempty"`
 	TLS           TLSConfig     `json:"tls,omitempty"`
+	// Number of partitions in the internal group membership topic
+	GroupTopicPartitions int `json:"groupTopicPartitions,omitempty"`
 }
 
 // TLSConfig configures TLS for Redpanda APIs

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -124,6 +124,10 @@ spec:
                     type: object
                   developerMode:
                     type: boolean
+                  groupTopicPartitions:
+                    description: Number of partitions in the internal group membership
+                      topic
+                    type: integer
                   kafkaApi:
                     description: SocketAddress provide the way to configure the port
                     properties:

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -209,6 +209,11 @@ func (r *ConfigMapResource) createConfiguration(
 		cr.EnableSASL = pointer.BoolPtr(true)
 	}
 
+	partitions := r.pandaCluster.Spec.Configuration.GroupTopicPartitions
+	if partitions != 0 {
+		cr.GroupTopicPartitions = &partitions
+	}
+
 	replicas := *r.pandaCluster.Spec.Replicas
 	for i := int32(0); i < replicas; i++ {
 		cr.SeedServers = append(cr.SeedServers, config.SeedServer{

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1078,6 +1078,58 @@ rpk:
 `,
 		},
 		{
+			name: "shall write config with group_topic_partitions value",
+			conf: func() *Config {
+				c := getValidConfig()
+				val := 16
+				c.Redpanda.GroupTopicPartitions = &val
+				return c
+			},
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+pandaproxy: {}
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  data_directory: /var/lib/redpanda/data
+  developer_mode: false
+  group_topic_partitions: 16
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers:
+  - host:
+      address: 127.0.0.1
+      port: 33145
+  - host:
+      address: 127.0.0.1
+      port: 33146
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_disk_write_cache: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
+`,
+		},
+		{
 			name: "shall write config with SASL enabled",
 			conf: func() *Config {
 				c := getValidConfig()

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -49,6 +49,7 @@ type RedpandaConfig struct {
 	CloudStorageTrustFile                *string                `yaml:"cloud_storage_trust_file,omitempty" mapstructure:"cloud_storage_trust_file,omitempty" json:"cloudStorageTrustFile,omitempty"`
 	Superusers                           []string               `yaml:"superusers,omitempty" mapstructure:"superusers,omitempty" json:"superusers,omitempty"`
 	EnableSASL                           *bool                  `yaml:"enable_sasl,omitempty" mapstructure:"enable_sasl,omitempty" json:"enableSasl,omitempty"`
+	GroupTopicPartitions                 *int                   `yaml:"group_topic_partitions,omitempty" mapstructure:"group_topic_partitions,omitempty" json:"groupTopicPartitions,omitempty"`
 	Other                                map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 


### PR DESCRIPTION
## Cover letter

Expose `group_topic_partitions` in Cluster CR, and pass value to Redpanda's config.

https://github.com/vectorizedio/redpanda/issues/1095

## Release notes

Exposes `group_topic_partitions` in Cluster CR.