### PR TITLE
Simplify configurator by removing KafkaAPI port

### DIFF
--- a/src/go/k8s/cmd/configurator/main.go
+++ b/src/go/k8s/cmd/configurator/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/afero"
-	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -136,8 +135,6 @@ func main() {
 		log.Fatalf("%s", fmt.Errorf("unable to register advertised kafka API: %w", err))
 	}
 
-	registerKafkaAPI(&c, cfg)
-
 	cfg.Redpanda.Id = int(hostIndex)
 
 	// First Redpanda node need to have cleared seed servers in order
@@ -158,30 +155,6 @@ func main() {
 	}
 
 	log.Printf("Configuration saved to: %s", c.configDestination)
-}
-
-func registerKafkaAPI(c *configuratorConfig, cfg *config.Config) {
-	cfg.Redpanda.KafkaApi = []config.NamedSocketAddress{
-		{
-			SocketAddress: config.SocketAddress{
-				Address: "0.0.0.0",
-				Port:    c.kafkaAPIPort,
-			},
-			Name: "Internal",
-		},
-	}
-
-	if !c.externalConnectivity {
-		return
-	}
-
-	cfg.Redpanda.KafkaApi = append(cfg.Redpanda.KafkaApi, config.NamedSocketAddress{
-		SocketAddress: config.SocketAddress{
-			Address: "0.0.0.0",
-			Port:    resources.CalculateExternalPort(c.kafkaAPIPort),
-		},
-		Name: "External",
-	})
 }
 
 func registerAdvertisedKafkaAPI(

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -123,14 +123,6 @@ func (r *NodePortServiceResource) obj() (k8sclient.Object, error) {
 	return svc, nil
 }
 
-// CalculateExternalPort can calculate external Kafka API port based on the internal Kafka API port
-func CalculateExternalPort(kafkaInternalPort int) int {
-	if kafkaInternalPort < 0 || kafkaInternalPort > 65535 {
-		return 0
-	}
-	return kafkaInternalPort + 1
-}
-
 // Key returns namespace/name object that is used to identify object.
 // For reference please visit types.NamespacedName docs in k8s.io/apimachinery
 func (r *NodePortServiceResource) Key() types.NamespacedName {

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -289,10 +289,6 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 									Value: strconv.Itoa(r.pandaCluster.Spec.Configuration.RPCServer.Port),
 								},
 								{
-									Name:  "KAFKA_API_PORT",
-									Value: strconv.Itoa(r.pandaCluster.Spec.Configuration.KafkaAPI.Port),
-								},
-								{
 									Name: "NODE_NAME",
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{


### PR DESCRIPTION
## Cover letter

This way the configuration is unnecessary complex - we're passing port through env var and then writing config that we could have already written in configmap.

Also this is necessary for multi-listener support - then we would have to pass list of ports through env vars and that would not be nice.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
