### PR TITLE
rpk/kafka: Add sasl scram mechanism for authentication

### DIFF
--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -701,6 +701,7 @@ github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/scram v1.0.3/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tklauser/go-sysconf v0.1.0
+	github.com/xdg/scram v1.0.3
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -301,7 +301,11 @@ github.com/tklauser/numcpus v0.1.0 h1:BQeAuOQKZtytv8qblsFbi9mhTfXQdFFkyX0vaV6B4t
 github.com/tklauser/numcpus v0.1.0/go.mod h1:i3up9VjARpkV00NkBbexuDd0RAVQz4rV5Gl8miYgd5k=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/scram v1.0.3 h1:nTadYh2Fs4BK2xdldEa2g5bbaZp0/+1nJMMPtPxS/to=
+github.com/xdg/scram v1.0.3/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1320,6 +1320,62 @@ rpk:
 `,
 		},
 		{
+			name: "shall write a valid config file with scram configured",
+			conf: func() *Config {
+				c := getValidConfig()
+				c.Rpk.SCRAM.User = "scram_user"
+				c.Rpk.SCRAM.Password = "scram_password"
+				c.Rpk.SCRAM.Type = "SCRAM-SHA-256"
+				return c
+			},
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+pandaproxy: {}
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  data_directory: /var/lib/redpanda/data
+  developer_mode: false
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers:
+  - host:
+      address: 127.0.0.1
+      port: 33145
+  - host:
+      address: 127.0.0.1
+      port: 33146
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  scram:
+    password: scram_password
+    type: SCRAM-SHA-256
+    user: scram_user
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_disk_write_cache: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
+`,
+		},
+		{
 			name: "should update an existing config with single kafka_api & advertised_kafka_api obj to a list",
 			existingConf: `config_file: /etc/redpanda/redpanda.yaml
 pandaproxy: {}

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -114,6 +114,13 @@ type RpkConfig struct {
 	WellKnownIo              string   `yaml:"well_known_io,omitempty" mapstructure:"well_known_io,omitempty" json:"wellKnownIo"`
 	Overprovisioned          bool     `yaml:"overprovisioned" mapstructure:"overprovisioned" json:"overprovisioned"`
 	SMP                      *int     `yaml:"smp,omitempty" mapstructure:"smp,omitempty" json:"smp,omitempty"`
+	SCRAM                    SCRAM    `yaml:"scram,omitempty" mapstructure:"scram,omitempty" json:"scram,omitempty"`
+}
+
+type SCRAM struct {
+	User     string `yaml:"user,omitempty" mapstructure:"user,omitempty" json:"user,omitempty"`
+	Password string `yaml:"password,omitempty" mapstructure:"password,omitempty" json:"password,omitempty"`
+	Type     string `yaml:"type,omitempty" mapstructure:"type,omitempty" json:"type,omitempty"`
 }
 
 func (conf *Config) PIDFile() string {

--- a/src/go/rpk/pkg/kafka/client_test.go
+++ b/src/go/rpk/pkg/kafka/client_test.go
@@ -1,0 +1,82 @@
+package kafka_test
+
+import (
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
+)
+
+func Test_LoadConfig(t *testing.T) {
+
+	getCfg := func() *config.Config {
+		cfg := config.Default()
+		cfg.Rpk.SCRAM.User = "some_user"
+		cfg.Rpk.SCRAM.Password = "some_password"
+		cfg.Rpk.SCRAM.Type = sarama.SASLTypeSCRAMSHA256
+		return cfg
+	}
+
+	tests := []struct {
+		name  string
+		conf  func() *config.Config
+		check func(*testing.T, *config.Config, *sarama.Config)
+	}{{
+		name: "it should load the SCRAM config",
+		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
+			assert.Equal(t, cfg.Rpk.SCRAM.User, c.Net.SASL.User)
+			assert.Equal(t, cfg.Rpk.SCRAM.Password, c.Net.SASL.Password)
+			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.SCRAM.Type), c.Net.SASL.Mechanism)
+		},
+	}, {
+		name: "it shouldn't load the SCRAM user if it's missing",
+		conf: func() *config.Config {
+			cfg := getCfg()
+			cfg.Rpk.SCRAM.User = ""
+			return cfg
+		},
+		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
+			assert.Equal(t, cfg.Rpk.SCRAM.User, c.Net.SASL.User)
+			assert.NotEqual(t, cfg.Rpk.SCRAM.Password, c.Net.SASL.Password)
+			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.SCRAM.Type), c.Net.SASL.Mechanism)
+		},
+	}, {
+		name: "it shouldn't load the SCRAM password if it's missing",
+		conf: func() *config.Config {
+			cfg := getCfg()
+			cfg.Rpk.SCRAM.Password = ""
+			return cfg
+		},
+		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
+			assert.NotEqual(t, cfg.Rpk.SCRAM.User, c.Net.SASL.User)
+			assert.Equal(t, cfg.Rpk.SCRAM.Password, c.Net.SASL.Password)
+			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.SCRAM.Type), c.Net.SASL.Mechanism)
+		},
+	}, {
+		name: "it shouldn't load the SCRAM type if it's missing",
+		conf: func() *config.Config {
+			cfg := getCfg()
+			cfg.Rpk.SCRAM.Type = ""
+			return cfg
+		},
+		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
+			assert.NotEqual(t, cfg.Rpk.SCRAM.User, c.Net.SASL.User)
+			assert.NotEqual(t, cfg.Rpk.SCRAM.Password, c.Net.SASL.Password)
+			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.SCRAM.Type), c.Net.SASL.Mechanism)
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			conf := getCfg()
+			if tt.conf != nil {
+				conf = tt.conf()
+			}
+			c, err := kafka.LoadConfig(conf)
+			require.NoError(t, err)
+			tt.check(st, conf, c)
+		})
+	}
+}

--- a/src/go/rpk/pkg/kafka/scram_client.go
+++ b/src/go/rpk/pkg/kafka/scram_client.go
@@ -1,0 +1,34 @@
+package kafka
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+
+	"github.com/xdg/scram"
+)
+
+var SHA256 scram.HashGeneratorFcn = sha256.New
+var SHA512 scram.HashGeneratorFcn = sha512.New
+
+type XDGSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+func (x *XDGSCRAMClient) Step(challenge string) (string, error) {
+	return x.ClientConversation.Step(challenge)
+}
+
+func (x *XDGSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}


### PR DESCRIPTION
## Cover letter

Enable scram mechanism based on the rpk configuration.

## Release notes

RPK will now support SCRAM machanism for authentication. 
