### PR TITLE
rpk/config: make pandaproxy fields lists, fix brokers field

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -872,20 +872,30 @@ rpk:
 			conf: func() *Config {
 				c := getValidConfig()
 				c.Pandaproxy = &Pandaproxy{
-					PandaproxyAPI: &SocketAddress{
-						Address: "1.2.3.4",
-						Port:    1234,
+					PandaproxyAPI: []NamedSocketAddress{
+						{
+							Name: "first",
+							SocketAddress: SocketAddress{
+								Address: "1.2.3.4",
+								Port:    1234,
+							},
+						},
 					},
-					PandaproxyAPITLS: &ServerTLS{
+					PandaproxyAPITLS: []ServerTLS{{
 						KeyFile:           "/etc/certs/cert.key",
 						TruststoreFile:    "/etc/certs/ca.crt",
 						CertFile:          "/etc/certs/cert.crt",
 						Enabled:           true,
 						RequireClientAuth: true,
-					},
-					AdvertisedPandaproxyAPI: &SocketAddress{
-						Address: "2.3.4.1",
-						Port:    2341,
+					}},
+					AdvertisedPandaproxyAPI: []NamedSocketAddress{
+						{
+							Name: "advertised",
+							SocketAddress: SocketAddress{
+								Address: "2.3.4.1",
+								Port:    2341,
+							},
+						},
 					},
 				}
 				return c
@@ -894,13 +904,15 @@ rpk:
 			expected: `config_file: /etc/redpanda/redpanda.yaml
 pandaproxy:
   advertised_pandaproxy_api:
-    address: 2.3.4.1
+  - address: 2.3.4.1
+    name: advertised
     port: 2341
   pandaproxy_api:
-    address: 1.2.3.4
+  - address: 1.2.3.4
+    name: first
     port: 1234
   pandaproxy_api_tls:
-    cert_file: /etc/certs/cert.crt
+  - cert_file: /etc/certs/cert.crt
     enabled: true
     key_file: /etc/certs/cert.key
     require_client_auth: true
@@ -950,9 +962,14 @@ rpk:
 			conf: func() *Config {
 				c := getValidConfig()
 				c.Pandaproxy = &Pandaproxy{
-					PandaproxyAPI: &SocketAddress{
-						Address: "1.2.3.4",
-						Port:    1234,
+					PandaproxyAPI: []NamedSocketAddress{
+						{
+							Name: "first",
+							SocketAddress: SocketAddress{
+								Address: "1.2.3.4",
+								Port:    1234,
+							},
+						},
 					},
 				}
 				return c
@@ -961,7 +978,8 @@ rpk:
 			expected: `config_file: /etc/redpanda/redpanda.yaml
 pandaproxy:
   pandaproxy_api:
-    address: 1.2.3.4
+  - address: 1.2.3.4
+    name: first
     port: 1234
 redpanda:
   admin:

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1026,7 +1026,7 @@ rpk:
 			conf: func() *Config {
 				c := getValidConfig()
 				c.PandaproxyClient = &PandaproxyClient{
-					Broker: []SocketAddress{
+					Brokers: []SocketAddress{
 						{
 							Address: "1.2.3.4",
 							Port:    1234,
@@ -1046,15 +1046,15 @@ rpk:
 			expected: `config_file: /etc/redpanda/redpanda.yaml
 pandaproxy: {}
 pandaproxy_client:
-  broker:
-  - address: 1.2.3.4
-    port: 1234
   broker_tls:
     cert_file: /etc/certs/cert.crt
     enabled: true
     key_file: /etc/certs/cert.key
     require_client_auth: true
     truststore_file: /etc/certs/ca.crt
+  brokers:
+  - address: 1.2.3.4
+    port: 1234
 redpanda:
   admin:
     address: 0.0.0.0

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -60,7 +60,7 @@ type Pandaproxy struct {
 }
 
 type PandaproxyClient struct {
-	Broker    []SocketAddress `yaml:"broker,omitempty" mapstructure:"broker,omitempty" json:"broker,omitempty"`
+	Brokers   []SocketAddress `yaml:"brokers,omitempty" mapstructure:"brokers,omitempty" json:"brokers,omitempty"`
 	BrokerTLS ServerTLS       `yaml:"broker_tls,omitempty" mapstructure:"broker_tls,omitempty" json:"brokerTls,omitempty"`
 }
 

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -54,9 +54,9 @@ type RedpandaConfig struct {
 }
 
 type Pandaproxy struct {
-	PandaproxyAPI           *SocketAddress `yaml:"pandaproxy_api,omitempty" mapstructure:"pandaproxy_api,omitempty" json:"pandaproxyApi,omitempty"`
-	PandaproxyAPITLS        *ServerTLS     `yaml:"pandaproxy_api_tls,omitempty" mapstructure:"pandaproxy_api_tls,omitempty" json:"pandaproxyApiTls,omitempty"`
-	AdvertisedPandaproxyAPI *SocketAddress `yaml:"advertised_pandaproxy_api,omitempty" mapstructure:"advertised_pandaproxy_api,omitempty" json:"advertisedPandaproxyApi,omitempty"`
+	PandaproxyAPI           []NamedSocketAddress `yaml:"pandaproxy_api,omitempty" mapstructure:"pandaproxy_api,omitempty" json:"pandaproxyApi,omitempty"`
+	PandaproxyAPITLS        []ServerTLS          `yaml:"pandaproxy_api_tls,omitempty" mapstructure:"pandaproxy_api_tls,omitempty" json:"pandaproxyApiTls,omitempty"`
+	AdvertisedPandaproxyAPI []NamedSocketAddress `yaml:"advertised_pandaproxy_api,omitempty" mapstructure:"advertised_pandaproxy_api,omitempty" json:"advertisedPandaproxyApi,omitempty"`
 }
 
 type PandaproxyClient struct {


### PR DESCRIPTION
## Cover letter

1. Make pandaproxy fields lists to match latest redpanda configuration
2. Fix brokers field (currently being `broker` instead of the correct one,`brokers` (https://github.com/vectorizedio/redpanda/blob/dev/src/v/kafka/client/configuration.h#L29)