### PR TITLE
operator: Remove unnecessary labels from Cluster custom resource

### DIFF
--- a/src/go/k8s/config/samples/redpanda_v1alpha1_with_tls.yaml
+++ b/src/go/k8s/config/samples/redpanda_v1alpha1_with_tls.yaml
@@ -2,9 +2,6 @@ apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
   name: cluster-sample-tls
-  labels:
-    app.kubernetes.io/name: "redpanda"
-    app.kubernetes.io/instance: "cluster-sample-tls"
 spec:
   image: "vectorized/redpanda"
   version: "latest"


### PR DESCRIPTION
## Cover letter

End user do not need to set the common labels. They are managed by
operator in labels package.

REF: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
