### PR TITLE
Admin API - multiple listeners and health check

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -9,6 +9,7 @@
 
 #include "config/configuration.h"
 
+#include "model/metadata.h"
 #include "units.h"
 
 namespace config {
@@ -144,14 +145,14 @@ configuration::configuration()
       "admin",
       "Address and port of admin server",
       required::no,
-      unresolved_address("127.0.0.1", 9644))
+      {model::broker_endpoint(unresolved_address("127.0.0.1", 9644))})
   , admin_api_tls(
       *this,
       "admin_api_tls",
       "TLS configuration for admin HTTP server",
       required::no,
-      tls_config(),
-      tls_config::validate)
+      {},
+      endpoint_tls_config::validate_many)
   , enable_admin_api(
       *this, "enable_admin_api", "Enable the admin API", required::no, true)
   , admin_api_doc_dir(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -13,6 +13,7 @@
 #include "config/config_store.h"
 #include "config/data_directory_path.h"
 #include "config/endpoint_tls_config.h"
+#include "config/property.h"
 #include "config/seed_server.h"
 #include "config/tls_config.h"
 #include "model/compression.h"
@@ -66,8 +67,8 @@ struct configuration final : public config_store {
     one_or_many_property<model::broker_endpoint> kafka_api;
     one_or_many_property<endpoint_tls_config> kafka_api_tls;
     property<bool> use_scheduling_groups;
-    property<unresolved_address> admin;
-    property<tls_config> admin_api_tls;
+    one_or_many_property<model::broker_endpoint> admin;
+    one_or_many_property<endpoint_tls_config> admin_api_tls;
     property<bool> enable_admin_api;
     property<ss::sstring> admin_api_doc_dir;
     property<int16_t> default_num_windows;

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -33,6 +33,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/security.json.h
 )
 
+seastar_generate_swagger(
+  TARGET status_swagger
+  VAR status_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/status.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/status.json.h
+)
+
 v_cc_library(
   NAME application
   SRCS 
@@ -54,7 +61,7 @@ add_executable(redpanda
 target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_dependencies(v_application config_swagger raft_swagger kafka_swagger
-    partition_swagger security_swagger)
+    partition_swagger security_swagger status_swagger)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
   include(CheckIPOSupported)

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -35,7 +35,9 @@ seastar_generate_swagger(
 
 v_cc_library(
   NAME application
-  SRCS application.cc
+  SRCS 
+    admin_server.cc
+    application.cc
   DEPS
     Seastar::seastar
     v::cluster

--- a/src/v/redpanda/admin/api-doc/status.json
+++ b/src/v/redpanda/admin/api-doc/status.json
@@ -1,0 +1,14 @@
+"/v1/status/ready": {
+    "get": {
+      "summary": "redpanda healthcheck",
+      "operationId": "ready",
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "Redpanda is up and running"
+        }
+      }
+    }
+  }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1,0 +1,500 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "redpanda/admin_server.h"
+
+#include "cluster/cluster_utils.h"
+#include "cluster/controller.h"
+#include "cluster/fwd.h"
+#include "cluster/partition_manager.h"
+#include "cluster/security_frontend.h"
+#include "cluster/shard_table.h"
+#include "cluster/topics_frontend.h"
+#include "config/configuration.h"
+#include "config/endpoint_tls_config.h"
+#include "raft/types.h"
+#include "redpanda/admin/api-doc/config.json.h"
+#include "redpanda/admin/api-doc/kafka.json.h"
+#include "redpanda/admin/api-doc/partition.json.h"
+#include "redpanda/admin/api-doc/raft.json.h"
+#include "redpanda/admin/api-doc/security.json.h"
+#include "rpc/dns.h"
+#include "security/scram_algorithm.h"
+#include "security/scram_authenticator.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/prometheus.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/with_scheduling_group.hh>
+#include <seastar/http/api_docs.hh>
+#include <seastar/http/exception.hh>
+#include <seastar/http/httpd.hh>
+#include <seastar/http/json_path.hh>
+
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+using namespace std::chrono_literals;
+
+static ss::logger logger{"admin_api_server"};
+
+admin_server::admin_server(
+  admin_server_cfg cfg,
+  ss::sharded<cluster::partition_manager>& pm,
+  cluster::controller* controller,
+  ss::sharded<cluster::shard_table>& st)
+  : _server("admin")
+  , _cfg(std::move(cfg))
+  , _partition_manager(pm)
+  , _controller(controller)
+  , _shard_table(st) {}
+
+ss::future<> admin_server::start() {
+    configure_metrics_route();
+    configure_dashboard();
+    configure_admin_routes();
+
+    co_await configure_listeners();
+
+    vlog(
+      logger.info, "Started HTTP admin service listening at {}", _cfg.endpoint);
+}
+
+ss::future<> admin_server::stop() { return _server.stop(); }
+
+void admin_server::configure_admin_routes() {
+    auto rb = ss::make_shared<ss::api_registry_builder20>(
+      _cfg.admin_api_docs_dir, "/v1");
+
+    auto insert_comma = [](ss::output_stream<char>& os) {
+        return os.write(",\n");
+    };
+    rb->set_api_doc(_server._routes);
+    rb->register_api_file(_server._routes, "header");
+    rb->register_api_file(_server._routes, "config");
+    rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "raft");
+    rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "kafka");
+    rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "partition");
+    rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "security");
+    ss::httpd::config_json::get_config.set(
+      _server._routes, []([[maybe_unused]] ss::const_req req) {
+          rapidjson::StringBuffer buf;
+          rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+          config::shard_local_cfg().to_json(writer);
+          return ss::json::json_return_type(buf.GetString());
+      });
+    register_raft_routes();
+    register_kafka_routes();
+    register_security_routes();
+}
+
+void admin_server::configure_dashboard() {
+    if (_cfg.dashboard_dir) {
+        _dashboard_handler = std::make_unique<dashboard_handler>(
+          *_cfg.dashboard_dir);
+        _server._routes.add(
+          ss::httpd::operation_type::GET,
+          ss::httpd::url("/dashboard").remainder("path"),
+          _dashboard_handler.get());
+    }
+}
+
+void admin_server::configure_metrics_route() {
+    ss::prometheus::config metrics_conf;
+    metrics_conf.metric_help = "redpanda metrics";
+    metrics_conf.prefix = "vectorized";
+    ss::prometheus::add_prometheus_routes(_server, metrics_conf).get();
+}
+
+ss::future<> admin_server::configure_listeners() {
+    ss::shared_ptr<ss::tls::server_credentials> cred;
+
+    auto builder = co_await _cfg.tls.get_credentials_builder();
+    if (builder) {
+        cred = co_await builder->build_reloadable_server_credentials(
+          [](
+            const std::unordered_set<ss::sstring>& updated,
+            const std::exception_ptr& eptr) {
+              cluster::log_certificate_reload_event(
+                logger, "API TLS", updated, eptr);
+          });
+    }
+
+    auto resolved = co_await rpc::resolve_dns(_cfg.endpoint);
+    co_await ss::with_scheduling_group(_cfg.sg, [this, cred, resolved] {
+        return _server.listen(resolved, cred);
+    });
+}
+
+void admin_server::register_raft_routes() {
+    ss::httpd::raft_json::raft_transfer_leadership.set(
+      _server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
+          raft::group_id group_id;
+          try {
+              group_id = raft::group_id(std::stoll(req->param["group_id"]));
+          } catch (...) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Raft group id must be an integer: {}",
+                req->param["group_id"]));
+          }
+
+          if (group_id() < 0) {
+              throw ss::httpd::bad_param_exception(
+                fmt::format("Invalid raft group id {}", group_id));
+          }
+
+          if (!_shard_table.local().contains(group_id)) {
+              throw ss::httpd::not_found_exception(
+                fmt::format("Raft group {} not found", group_id));
+          }
+
+          std::optional<model::node_id> target;
+          if (auto node = req->get_query_param("target"); !node.empty()) {
+              try {
+                  target = model::node_id(std::stoi(node));
+              } catch (...) {
+                  throw ss::httpd::bad_param_exception(
+                    fmt::format("Target node id must be an integer: {}", node));
+              }
+              if (*target < 0) {
+                  throw ss::httpd::bad_param_exception(
+                    fmt::format("Invalid target node id {}", *target));
+              }
+          }
+
+          vlog(
+            logger.info,
+            "Leadership transfer request for raft group {} to node {}",
+            group_id,
+            target);
+
+          auto shard = _shard_table.local().shard_for(group_id);
+
+          return _partition_manager.invoke_on(
+            shard, [group_id, target](cluster::partition_manager& pm) mutable {
+                auto consensus = pm.consensus_for(group_id);
+                if (!consensus) {
+                    throw ss::httpd::not_found_exception();
+                }
+                return consensus->transfer_leadership(target).then(
+                  [](std::error_code err) {
+                      if (err) {
+                          throw ss::httpd::server_error_exception(fmt::format(
+                            "Leadership transfer failed: {}", err.message()));
+                      }
+                      return ss::json::json_return_type(ss::json::json_void());
+                  });
+            });
+      });
+}
+
+/*
+ * Parse integer pairs from: ?target={\d,\d}* where each pair represent a
+ * node-id and a shard-id, repsectively.
+ */
+static std::vector<model::broker_shard>
+parse_target_broker_shards(const ss::sstring& param) {
+    std::vector<ss::sstring> parts;
+    boost::split(parts, param, boost::is_any_of(","));
+
+    if (parts.size() % 2 != 0) {
+        throw ss::httpd::bad_param_exception(
+          fmt::format("Invalid target parameter format: {}", param));
+    }
+
+    std::vector<model::broker_shard> replicas;
+
+    for (auto i = 0u; i < parts.size(); i += 2) {
+        auto node = std::stoi(parts[i]);
+        auto shard = std::stoi(parts[i + 1]);
+
+        if (node < 0 || shard < 0) {
+            throw ss::httpd::bad_param_exception(
+              fmt::format("Invalid target {}:{}", node, shard));
+        }
+
+        replicas.push_back(model::broker_shard{
+          .node_id = model::node_id(node),
+          .shard = static_cast<uint32_t>(shard),
+        });
+    }
+
+    return replicas;
+}
+
+// TODO: factor out generic serialization from seastar http exceptions
+static security::scram_credential
+parse_scram_credential(const rapidjson::Document& doc) {
+    if (!doc.IsObject()) {
+        throw ss::httpd::bad_request_exception(fmt::format("Not an object"));
+    }
+
+    if (!doc.HasMember("algorithm") || !doc["algorithm"].IsString()) {
+        throw ss::httpd::bad_request_exception(
+          fmt::format("String algo missing"));
+    }
+    const auto algorithm = std::string_view(
+      doc["algorithm"].GetString(), doc["algorithm"].GetStringLength());
+
+    if (!doc.HasMember("password") || !doc["password"].IsString()) {
+        throw ss::httpd::bad_request_exception(
+          fmt::format("String password smissing"));
+    }
+    const auto password = doc["password"].GetString();
+
+    security::scram_credential credential;
+
+    if (algorithm == security::scram_sha256_authenticator::name) {
+        credential = security::scram_sha256::make_credentials(
+          password, security::scram_sha256::min_iterations);
+
+    } else if (algorithm == security::scram_sha512_authenticator::name) {
+        credential = security::scram_sha512::make_credentials(
+          password, security::scram_sha512::min_iterations);
+
+    } else {
+        throw ss::httpd::bad_request_exception(
+          fmt::format("Unknown scram algorithm: {}", algorithm));
+    }
+
+    return credential;
+}
+
+void admin_server::register_security_routes() {
+    ss::httpd::security_json::create_user.set(
+      _server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
+          rapidjson::Document doc;
+          doc.Parse(req->content.data());
+
+          auto credential = parse_scram_credential(doc);
+
+          if (!doc.HasMember("username") || !doc["username"].IsString()) {
+              throw ss::httpd::bad_request_exception(
+                fmt::format("String username missing"));
+          }
+
+          auto username = security::credential_user(
+            doc["username"].GetString());
+
+          return _controller->get_security_frontend()
+            .local()
+            .create_user(username, credential, model::timeout_clock::now() + 5s)
+            .then([](std::error_code err) {
+                vlog(logger.debug, "Creating user {}:{}", err, err.message());
+                if (err) {
+                    throw ss::httpd::bad_request_exception(
+                      fmt::format("Creating user: {}", err.message()));
+                }
+                return ss::make_ready_future<ss::json::json_return_type>(
+                  ss::json::json_return_type(ss::json::json_void()));
+            });
+      });
+
+    ss::httpd::security_json::delete_user.set(
+      _server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
+          auto user = security::credential_user(
+            model::topic(req->param["user"]));
+
+          return _controller->get_security_frontend()
+            .local()
+            .delete_user(user, model::timeout_clock::now() + 5s)
+            .then([](std::error_code err) {
+                vlog(logger.debug, "Deleting user {}:{}", err, err.message());
+                if (err) {
+                    throw ss::httpd::bad_request_exception(
+                      fmt::format("Deleting user: {}", err.message()));
+                }
+                return ss::make_ready_future<ss::json::json_return_type>(
+                  ss::json::json_return_type(ss::json::json_void()));
+            });
+      });
+
+    ss::httpd::security_json::update_user.set(
+      _server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
+          auto user = security::credential_user(
+            model::topic(req->param["user"]));
+
+          rapidjson::Document doc;
+          doc.Parse(req->content.data());
+
+          auto credential = parse_scram_credential(doc);
+
+          return _controller->get_security_frontend()
+            .local()
+            .update_user(user, credential, model::timeout_clock::now() + 5s)
+            .then([](std::error_code err) {
+                vlog(logger.debug, "Updating user {}:{}", err, err.message());
+                if (err) {
+                    throw ss::httpd::bad_request_exception(
+                      fmt::format("Updating user: {}", err.message()));
+                }
+                return ss::make_ready_future<ss::json::json_return_type>(
+                  ss::json::json_return_type(ss::json::json_void()));
+            });
+      });
+
+    ss::httpd::security_json::list_users.set(
+      _server._routes, [this](std::unique_ptr<ss::httpd::request>) {
+          std::vector<ss::sstring> users;
+          for (const auto& [user, _] :
+               _controller->get_credential_store().local()) {
+              users.push_back(user());
+          }
+          return ss::make_ready_future<ss::json::json_return_type>(
+            std::move(users));
+      });
+}
+
+void admin_server::register_kafka_routes() {
+    ss::httpd::kafka_json::kafka_transfer_leadership.set(
+      _server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
+          auto topic = model::topic(req->param["topic"]);
+
+          model::partition_id partition;
+          try {
+              partition = model::partition_id(
+                std::stoll(req->param["partition"]));
+          } catch (...) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Partition id must be an integer: {}",
+                req->param["partition"]));
+          }
+
+          if (partition() < 0) {
+              throw ss::httpd::bad_param_exception(
+                fmt::format("Invalid partition id {}", partition));
+          }
+
+          std::optional<model::node_id> target;
+          if (auto node = req->get_query_param("target"); !node.empty()) {
+              try {
+                  target = model::node_id(std::stoi(node));
+              } catch (...) {
+                  throw ss::httpd::bad_param_exception(
+                    fmt::format("Target node id must be an integer: {}", node));
+              }
+              if (*target < 0) {
+                  throw ss::httpd::bad_param_exception(
+                    fmt::format("Invalid target node id {}", *target));
+              }
+          }
+
+          vlog(
+            logger.info,
+            "Leadership transfer request for leader of topic-partition {}:{} "
+            "to node {}",
+            topic,
+            partition,
+            target);
+
+          model::ntp ntp(model::kafka_namespace, topic, partition);
+
+          auto shard = _shard_table.local().shard_for(ntp);
+          if (!shard) {
+              throw ss::httpd::not_found_exception(fmt::format(
+                "Topic partition {}:{} not found", topic, partition));
+          }
+
+          return _partition_manager.invoke_on(
+            *shard,
+            [ntp = std::move(ntp),
+             target](cluster::partition_manager& pm) mutable {
+                auto partition = pm.get(ntp);
+                if (!partition) {
+                    throw ss::httpd::not_found_exception();
+                }
+                return partition->transfer_leadership(target).then(
+                  [](std::error_code err) {
+                      if (err) {
+                          throw ss::httpd::server_error_exception(fmt::format(
+                            "Leadership transfer failed: {}", err.message()));
+                      }
+                      return ss::json::json_return_type(ss::json::json_void());
+                  });
+            });
+      });
+
+    ss::httpd::partition_json::kafka_move_partition.set(
+      _server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
+          auto topic = model::topic(req->param["topic"]);
+
+          model::partition_id partition;
+          try {
+              partition = model::partition_id(
+                std::stoll(req->param["partition"]));
+          } catch (...) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Partition id must be an integer: {}",
+                req->param["partition"]));
+          }
+
+          if (partition() < 0) {
+              throw ss::httpd::bad_param_exception(
+                fmt::format("Invalid partition id {}", partition));
+          }
+
+          std::optional<std::vector<model::broker_shard>> replicas;
+          if (auto node = req->get_query_param("target"); !node.empty()) {
+              try {
+                  replicas = parse_target_broker_shards(node);
+              } catch (...) {
+                  throw ss::httpd::bad_param_exception(fmt::format(
+                    "Invalid target format {}: {}",
+                    node,
+                    std::current_exception()));
+              }
+          }
+
+          // this can be removed when we have more sophisticated machinary in
+          // redpanda itself for automatically selecting target node/shard.
+          if (!replicas || replicas->empty()) {
+              throw ss::httpd::bad_request_exception(
+                "Partition movement requires target replica set");
+          }
+
+          model::ntp ntp(model::kafka_namespace, topic, partition);
+
+          vlog(
+            logger.debug,
+            "Request to change ntp {} replica set to {}",
+            ntp,
+            replicas);
+
+          return _controller->get_topics_frontend()
+            .local()
+            .move_partition_replicas(
+              ntp, *replicas, model::timeout_clock::now() + 5s)
+            .then([ntp, replicas](std::error_code err) {
+                vlog(
+                  logger.debug,
+                  "Result changing ntp {} replica set to {}: {}:{}",
+                  ntp,
+                  replicas,
+                  err,
+                  err.message());
+                if (err) {
+                    throw ss::httpd::bad_request_exception(
+                      fmt::format("Error moving partition: {}", err.message()));
+                }
+                return ss::make_ready_future<ss::json::json_return_type>(
+                  ss::json::json_return_type(ss::json::json_void()));
+            });
+      });
+}

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -12,10 +12,8 @@
 #pragma once
 #include "cluster/fwd.h"
 #include "config/endpoint_tls_config.h"
-#include "config/tls_config.h"
 #include "model/metadata.h"
 #include "seastarx.h"
-#include "utils/unresolved_address.h"
 
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/sstring.hh>
@@ -24,8 +22,8 @@
 #include <seastar/util/log.hh>
 
 struct admin_server_cfg {
-    unresolved_address endpoint;
-    config::tls_config tls;
+    std::vector<model::broker_endpoint> endpoints;
+    std::vector<config::endpoint_tls_config> endpoints_tls;
     std::optional<ss::sstring> dashboard_dir;
     ss::sstring admin_api_docs_dir;
     bool enable_admin_api;

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/fwd.h"
+#include "config/endpoint_tls_config.h"
+#include "config/tls_config.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+#include "utils/unresolved_address.h"
+
+#include <seastar/core/scheduling.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/http/file_handler.hh>
+#include <seastar/http/httpd.hh>
+#include <seastar/util/log.hh>
+
+struct admin_server_cfg {
+    unresolved_address endpoint;
+    config::tls_config tls;
+    std::optional<ss::sstring> dashboard_dir;
+    ss::sstring admin_api_docs_dir;
+    bool enable_admin_api;
+    ss::scheduling_group sg;
+};
+
+class admin_server {
+public:
+    explicit admin_server(
+      admin_server_cfg,
+      ss::sharded<cluster::partition_manager>&,
+      cluster::controller*,
+      ss::sharded<cluster::shard_table>&);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+private:
+    /**
+     * Prepend a / to the path component. This handles the case where path is an
+     * empty string (e.g. url/) or when the path omits the root file path
+     * directory (e.g. url/index.html vs url//index.html). The directory handler
+     * in seastar is opininated and not very forgiving here so we help it a bit.
+     */
+    class dashboard_handler final : public ss::httpd::directory_handler {
+    public:
+        explicit dashboard_handler(const ss::sstring& dashboard_dir)
+          : directory_handler(dashboard_dir) {}
+
+        ss::future<std::unique_ptr<ss::httpd::reply>> handle(
+          const ss::sstring& path,
+          std::unique_ptr<ss::httpd::request> req,
+          std::unique_ptr<ss::httpd::reply> rep) override {
+            req->param.set("path", "/" + req->param.at("path"));
+            return directory_handler::handle(
+              path, std::move(req), std::move(rep));
+        }
+    };
+    ss::future<> configure_listeners();
+    void configure_dashboard();
+    void configure_metrics_route();
+    void configure_admin_routes();
+    void register_raft_routes();
+    void register_kafka_routes();
+    void register_security_routes();
+
+    ss::http_server _server;
+    admin_server_cfg _cfg;
+    ss::sharded<cluster::partition_manager>& _partition_manager;
+    cluster::controller* _controller;
+    ss::sharded<cluster::shard_table>& _shard_table;
+    std::unique_ptr<dashboard_handler> _dashboard_handler;
+};

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -69,6 +69,7 @@ private:
     void register_raft_routes();
     void register_kafka_routes();
     void register_security_routes();
+    void register_status_routes();
 
     ss::http_server _server;
     admin_server_cfg _cfg;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -235,8 +235,8 @@ void application::check_environment() {
 static admin_server_cfg
 admin_server_cfg_from_global_cfg(scheduling_groups& sgs) {
     return admin_server_cfg{
-      .endpoint = config::shard_local_cfg().admin(),
-      .tls = config::shard_local_cfg().admin_api_tls(),
+      .endpoints = config::shard_local_cfg().admin(),
+      .endpoints_tls = config::shard_local_cfg().admin_api_tls(),
       .dashboard_dir = config::shard_local_cfg().dashboard_dir(),
       .admin_api_docs_dir = config::shard_local_cfg().admin_api_doc_dir(),
       .enable_admin_api = config::shard_local_cfg().enable_admin_api(),

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -34,15 +34,9 @@
 #include "pandaproxy/proxy.h"
 #include "platform/stop_signal.h"
 #include "raft/service.h"
-#include "redpanda/admin/api-doc/config.json.h"
-#include "redpanda/admin/api-doc/kafka.json.h"
-#include "redpanda/admin/api-doc/partition.json.h"
-#include "redpanda/admin/api-doc/raft.json.h"
-#include "redpanda/admin/api-doc/security.json.h"
+#include "redpanda/admin_server.h"
 #include "resource_mgmt/io_priority.h"
 #include "rpc/simple_protocol.h"
-#include "security/scram_algorithm.h"
-#include "security/scram_authenticator.h"
 #include "storage/chunk_cache.h"
 #include "storage/directories.h"
 #include "syschecks/syschecks.h"
@@ -55,18 +49,10 @@
 #include <seastar/core/prometheus.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/thread.hh>
-#include <seastar/http/api_docs.hh>
-#include <seastar/http/exception.hh>
-#include <seastar/http/file_handler.hh>
 #include <seastar/json/json_elements.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/util/defer.hh>
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 #include <sys/utsname.h>
 
 #include <chrono>
@@ -108,8 +94,8 @@ int application::run(int ac, char** av) {
                 initialize();
                 check_environment();
                 setup_metrics();
-                configure_admin_server();
                 wire_up_services();
+                configure_admin_server();
                 start();
                 app_signal.wait().get();
                 vlog(_log.info, "Stopping...");
@@ -246,25 +232,17 @@ void application::check_environment() {
     }
 }
 
-/**
- * Prepend a / to the path component. This handles the case where path is an
- * empty string (e.g. url/) or when the path omits the root file path directory
- * (e.g. url/index.html vs url//index.html). The directory handler in seastar is
- * opininated and not very forgiving here so we help it a bit.
- */
-class dashboard_handler final : public ss::httpd::directory_handler {
-public:
-    dashboard_handler()
-      : directory_handler(*config::shard_local_cfg().dashboard_dir()) {}
-
-    ss::future<std::unique_ptr<ss::httpd::reply>> handle(
-      const ss::sstring& path,
-      std::unique_ptr<ss::httpd::request> req,
-      std::unique_ptr<ss::httpd::reply> rep) override {
-        req->param.set("path", "/" + req->param.at("path"));
-        return directory_handler::handle(path, std::move(req), std::move(rep));
-    }
-};
+static admin_server_cfg
+admin_server_cfg_from_global_cfg(scheduling_groups& sgs) {
+    return admin_server_cfg{
+      .endpoint = config::shard_local_cfg().admin(),
+      .tls = config::shard_local_cfg().admin_api_tls(),
+      .dashboard_dir = config::shard_local_cfg().dashboard_dir(),
+      .admin_api_docs_dir = config::shard_local_cfg().admin_api_doc_dir(),
+      .enable_admin_api = config::shard_local_cfg().enable_admin_api(),
+      .sg = sgs.admin_sg(),
+    };
+}
 
 void application::configure_admin_server() {
     auto& conf = config::shard_local_cfg();
@@ -272,99 +250,13 @@ void application::configure_admin_server() {
         return;
     }
     syschecks::systemd_message("constructing http server").get();
-    construct_service(_admin, ss::sstring("admin")).get();
-    // configure admin API TLS
-    if (conf.admin_api_tls().is_enabled()) {
-        _admin
-          .invoke_on_all([this](ss::http_server& server) {
-              return config::shard_local_cfg()
-                .admin_api_tls()
-                .get_credentials_builder()
-                .then([this, &server](
-                        std::optional<ss::tls::credentials_builder> builder) {
-                    if (!builder) {
-                        return ss::now();
-                    }
-
-                    return builder
-                      ->build_reloadable_server_credentials(
-                        [this](
-                          const std::unordered_set<ss::sstring>& updated,
-                          const std::exception_ptr& eptr) {
-                            cluster::log_certificate_reload_event(
-                              _log, "API TLS", updated, eptr);
-                        })
-                      .then([&server](auto cred) {
-                          server.set_tls_credentials(std::move(cred));
-                      });
-                });
-          })
-          .get0();
-    }
-    if (conf.dashboard_dir()) {
-        _admin
-          .invoke_on_all([](ss::http_server& server) {
-              server._routes.add(
-                ss::httpd::operation_type::GET,
-                ss::httpd::url("/dashboard").remainder("path"),
-                new dashboard_handler());
-          })
-          .get0();
-    }
-    ss::prometheus::config metrics_conf;
-    metrics_conf.metric_help = "redpanda metrics";
-    metrics_conf.prefix = "vectorized";
-    ss::prometheus::add_prometheus_routes(_admin, metrics_conf).get();
-    if (conf.enable_admin_api()) {
-        syschecks::systemd_message(
-          "enabling admin HTTP api: {}", config::shard_local_cfg().admin())
-          .get();
-        auto rb = ss::make_shared<ss::api_registry_builder20>(
-          conf.admin_api_doc_dir(), "/v1");
-        _admin
-          .invoke_on_all([this, rb](ss::http_server& server) {
-              auto insert_comma = [](ss::output_stream<char>& os) {
-                  return os.write(",\n");
-              };
-              rb->set_api_doc(server._routes);
-              rb->register_api_file(server._routes, "header");
-              rb->register_api_file(server._routes, "config");
-              rb->register_function(server._routes, insert_comma);
-              rb->register_api_file(server._routes, "raft");
-              rb->register_function(server._routes, insert_comma);
-              rb->register_api_file(server._routes, "kafka");
-              rb->register_function(server._routes, insert_comma);
-              rb->register_api_file(server._routes, "partition");
-              rb->register_function(server._routes, insert_comma);
-              rb->register_api_file(server._routes, "security");
-              ss::httpd::config_json::get_config.set(
-                server._routes, []([[maybe_unused]] ss::const_req req) {
-                    rapidjson::StringBuffer buf;
-                    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-                    config::shard_local_cfg().to_json(writer);
-                    return ss::json::json_return_type(buf.GetString());
-                });
-              admin_register_raft_routes(server);
-              admin_register_kafka_routes(server);
-              admin_register_security_routes(server);
-          })
-          .get();
-    }
-
-    with_scheduling_group(_scheduling_groups.admin_sg(), [this] {
-        return rpc::resolve_dns(config::shard_local_cfg().admin())
-          .then([this](ss::socket_address addr) mutable {
-              return _admin
-                .invoke_on_all<ss::future<> (ss::http_server::*)(
-                  ss::socket_address)>(&ss::http_server::listen, addr)
-                .handle_exception([this](auto ep) {
-                    _log.error("Exception on http admin server: {}", ep);
-                    return ss::make_exception_future<>(ep);
-                });
-          });
-    }).get();
-
-    vlog(_log.info, "Started HTTP admin service listening at {}", conf.admin());
+    construct_service(
+      _admin,
+      admin_server_cfg_from_global_cfg(_scheduling_groups),
+      std::ref(partition_manager),
+      controller.get(),
+      std::ref(shard_table))
+      .get();
 }
 
 static storage::kvstore_config kvstore_config_from_global_config() {
@@ -795,360 +687,7 @@ void application::start_redpanda() {
         _wasm_event_listener->start().get();
         pacemaker.invoke_on_all(&coproc::pacemaker::start).get();
     }
-}
-
-void application::admin_register_raft_routes(ss::http_server& server) {
-    ss::httpd::raft_json::raft_transfer_leadership.set(
-      server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
-          raft::group_id group_id;
-          try {
-              group_id = raft::group_id(std::stoll(req->param["group_id"]));
-          } catch (...) {
-              throw ss::httpd::bad_param_exception(fmt::format(
-                "Raft group id must be an integer: {}",
-                req->param["group_id"]));
-          }
-
-          if (group_id() < 0) {
-              throw ss::httpd::bad_param_exception(
-                fmt::format("Invalid raft group id {}", group_id));
-          }
-
-          if (!shard_table.local().contains(group_id)) {
-              throw ss::httpd::not_found_exception(
-                fmt::format("Raft group {} not found", group_id));
-          }
-
-          std::optional<model::node_id> target;
-          if (auto node = req->get_query_param("target"); !node.empty()) {
-              try {
-                  target = model::node_id(std::stoi(node));
-              } catch (...) {
-                  throw ss::httpd::bad_param_exception(
-                    fmt::format("Target node id must be an integer: {}", node));
-              }
-              if (*target < 0) {
-                  throw ss::httpd::bad_param_exception(
-                    fmt::format("Invalid target node id {}", *target));
-              }
-          }
-
-          vlog(
-            _log.info,
-            "Leadership transfer request for raft group {} to node {}",
-            group_id,
-            target);
-
-          auto shard = shard_table.local().shard_for(group_id);
-
-          return partition_manager.invoke_on(
-            shard, [group_id, target](cluster::partition_manager& pm) mutable {
-                auto consensus = pm.consensus_for(group_id);
-                if (!consensus) {
-                    throw ss::httpd::not_found_exception();
-                }
-                return consensus->transfer_leadership(target).then(
-                  [](std::error_code err) {
-                      if (err) {
-                          throw ss::httpd::server_error_exception(fmt::format(
-                            "Leadership transfer failed: {}", err.message()));
-                      }
-                      return ss::json::json_return_type(ss::json::json_void());
-                  });
-            });
-      });
-}
-
-/*
- * Parse integer pairs from: ?target={\d,\d}* where each pair represent a
- * node-id and a shard-id, repsectively.
- */
-static std::vector<model::broker_shard>
-parse_target_broker_shards(const ss::sstring& param) {
-    std::vector<ss::sstring> parts;
-    boost::split(parts, param, boost::is_any_of(","));
-
-    if (parts.size() % 2 != 0) {
-        throw ss::httpd::bad_param_exception(
-          fmt::format("Invalid target parameter format: {}", param));
+    if (config::shard_local_cfg().enable_admin_api()) {
+        _admin.invoke_on_all(&admin_server::start).get0();
     }
-
-    std::vector<model::broker_shard> replicas;
-
-    for (auto i = 0u; i < parts.size(); i += 2) {
-        auto node = std::stoi(parts[i]);
-        auto shard = std::stoi(parts[i + 1]);
-
-        if (node < 0 || shard < 0) {
-            throw ss::httpd::bad_param_exception(
-              fmt::format("Invalid target {}:{}", node, shard));
-        }
-
-        replicas.push_back(model::broker_shard{
-          .node_id = model::node_id(node),
-          .shard = static_cast<uint32_t>(shard),
-        });
-    }
-
-    return replicas;
-}
-
-// TODO: factor out generic serialization from seastar http exceptions
-static security::scram_credential
-parse_scram_credential(const rapidjson::Document& doc) {
-    if (!doc.IsObject()) {
-        throw ss::httpd::bad_request_exception(fmt::format("Not an object"));
-    }
-
-    if (!doc.HasMember("algorithm") || !doc["algorithm"].IsString()) {
-        throw ss::httpd::bad_request_exception(
-          fmt::format("String algo missing"));
-    }
-    const auto algorithm = std::string_view(
-      doc["algorithm"].GetString(), doc["algorithm"].GetStringLength());
-
-    if (!doc.HasMember("password") || !doc["password"].IsString()) {
-        throw ss::httpd::bad_request_exception(
-          fmt::format("String password smissing"));
-    }
-    const auto password = doc["password"].GetString();
-
-    security::scram_credential credential;
-
-    if (algorithm == security::scram_sha256_authenticator::name) {
-        credential = security::scram_sha256::make_credentials(
-          password, security::scram_sha256::min_iterations);
-
-    } else if (algorithm == security::scram_sha512_authenticator::name) {
-        credential = security::scram_sha512::make_credentials(
-          password, security::scram_sha512::min_iterations);
-
-    } else {
-        throw ss::httpd::bad_request_exception(
-          fmt::format("Unknown scram algorithm: {}", algorithm));
-    }
-
-    return credential;
-}
-
-void application::admin_register_security_routes(ss::http_server& server) {
-    ss::httpd::security_json::create_user.set(
-      server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
-          rapidjson::Document doc;
-          doc.Parse(req->content.data());
-
-          auto credential = parse_scram_credential(doc);
-
-          if (!doc.HasMember("username") || !doc["username"].IsString()) {
-              throw ss::httpd::bad_request_exception(
-                fmt::format("String username missing"));
-          }
-
-          auto username = security::credential_user(
-            doc["username"].GetString());
-
-          return controller->get_security_frontend()
-            .local()
-            .create_user(username, credential, model::timeout_clock::now() + 5s)
-            .then([this](std::error_code err) {
-                vlog(_log.debug, "Creating user {}:{}", err, err.message());
-                if (err) {
-                    throw ss::httpd::bad_request_exception(
-                      fmt::format("Creating user: {}", err.message()));
-                }
-                return ss::make_ready_future<ss::json::json_return_type>(
-                  ss::json::json_return_type(ss::json::json_void()));
-            });
-      });
-
-    ss::httpd::security_json::delete_user.set(
-      server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
-          auto user = security::credential_user(
-            model::topic(req->param["user"]));
-
-          return controller->get_security_frontend()
-            .local()
-            .delete_user(user, model::timeout_clock::now() + 5s)
-            .then([this](std::error_code err) {
-                vlog(_log.debug, "Deleting user {}:{}", err, err.message());
-                if (err) {
-                    throw ss::httpd::bad_request_exception(
-                      fmt::format("Deleting user: {}", err.message()));
-                }
-                return ss::make_ready_future<ss::json::json_return_type>(
-                  ss::json::json_return_type(ss::json::json_void()));
-            });
-      });
-
-    ss::httpd::security_json::update_user.set(
-      server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
-          auto user = security::credential_user(
-            model::topic(req->param["user"]));
-
-          rapidjson::Document doc;
-          doc.Parse(req->content.data());
-
-          auto credential = parse_scram_credential(doc);
-
-          return controller->get_security_frontend()
-            .local()
-            .update_user(user, credential, model::timeout_clock::now() + 5s)
-            .then([this](std::error_code err) {
-                vlog(_log.debug, "Updating user {}:{}", err, err.message());
-                if (err) {
-                    throw ss::httpd::bad_request_exception(
-                      fmt::format("Updating user: {}", err.message()));
-                }
-                return ss::make_ready_future<ss::json::json_return_type>(
-                  ss::json::json_return_type(ss::json::json_void()));
-            });
-      });
-
-    ss::httpd::security_json::list_users.set(
-      server._routes, [this](std::unique_ptr<ss::httpd::request>) {
-          std::vector<ss::sstring> users;
-          for (const auto& [user, _] :
-               controller->get_credential_store().local()) {
-              users.push_back(user());
-          }
-          return ss::make_ready_future<ss::json::json_return_type>(
-            std::move(users));
-      });
-}
-
-void application::admin_register_kafka_routes(ss::http_server& server) {
-    ss::httpd::kafka_json::kafka_transfer_leadership.set(
-      server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
-          auto topic = model::topic(req->param["topic"]);
-
-          model::partition_id partition;
-          try {
-              partition = model::partition_id(
-                std::stoll(req->param["partition"]));
-          } catch (...) {
-              throw ss::httpd::bad_param_exception(fmt::format(
-                "Partition id must be an integer: {}",
-                req->param["partition"]));
-          }
-
-          if (partition() < 0) {
-              throw ss::httpd::bad_param_exception(
-                fmt::format("Invalid partition id {}", partition));
-          }
-
-          std::optional<model::node_id> target;
-          if (auto node = req->get_query_param("target"); !node.empty()) {
-              try {
-                  target = model::node_id(std::stoi(node));
-              } catch (...) {
-                  throw ss::httpd::bad_param_exception(
-                    fmt::format("Target node id must be an integer: {}", node));
-              }
-              if (*target < 0) {
-                  throw ss::httpd::bad_param_exception(
-                    fmt::format("Invalid target node id {}", *target));
-              }
-          }
-
-          vlog(
-            _log.info,
-            "Leadership transfer request for leader of topic-partition {}:{} "
-            "to node {}",
-            topic,
-            partition,
-            target);
-
-          model::ntp ntp(model::kafka_namespace, topic, partition);
-
-          auto shard = shard_table.local().shard_for(ntp);
-          if (!shard) {
-              throw ss::httpd::not_found_exception(fmt::format(
-                "Topic partition {}:{} not found", topic, partition));
-          }
-
-          return partition_manager.invoke_on(
-            *shard,
-            [ntp = std::move(ntp),
-             target](cluster::partition_manager& pm) mutable {
-                auto partition = pm.get(ntp);
-                if (!partition) {
-                    throw ss::httpd::not_found_exception();
-                }
-                return partition->transfer_leadership(target).then(
-                  [](std::error_code err) {
-                      if (err) {
-                          throw ss::httpd::server_error_exception(fmt::format(
-                            "Leadership transfer failed: {}", err.message()));
-                      }
-                      return ss::json::json_return_type(ss::json::json_void());
-                  });
-            });
-      });
-
-    ss::httpd::partition_json::kafka_move_partition.set(
-      server._routes, [this](std::unique_ptr<ss::httpd::request> req) {
-          auto topic = model::topic(req->param["topic"]);
-
-          model::partition_id partition;
-          try {
-              partition = model::partition_id(
-                std::stoll(req->param["partition"]));
-          } catch (...) {
-              throw ss::httpd::bad_param_exception(fmt::format(
-                "Partition id must be an integer: {}",
-                req->param["partition"]));
-          }
-
-          if (partition() < 0) {
-              throw ss::httpd::bad_param_exception(
-                fmt::format("Invalid partition id {}", partition));
-          }
-
-          std::optional<std::vector<model::broker_shard>> replicas;
-          if (auto node = req->get_query_param("target"); !node.empty()) {
-              try {
-                  replicas = parse_target_broker_shards(node);
-              } catch (...) {
-                  throw ss::httpd::bad_param_exception(fmt::format(
-                    "Invalid target format {}: {}",
-                    node,
-                    std::current_exception()));
-              }
-          }
-
-          // this can be removed when we have more sophisticated machinary in
-          // redpanda itself for automatically selecting target node/shard.
-          if (!replicas || replicas->empty()) {
-              throw ss::httpd::bad_request_exception(
-                "Partition movement requires target replica set");
-          }
-
-          model::ntp ntp(model::kafka_namespace, topic, partition);
-
-          vlog(
-            _log.debug,
-            "Request to change ntp {} replica set to {}",
-            ntp,
-            replicas);
-
-          return controller->get_topics_frontend()
-            .local()
-            .move_partition_replicas(
-              ntp, *replicas, model::timeout_clock::now() + 5s)
-            .then([this, ntp, replicas](std::error_code err) {
-                vlog(
-                  _log.debug,
-                  "Result changing ntp {} replica set to {}: {}:{}",
-                  ntp,
-                  replicas,
-                  err,
-                  err.message());
-                if (err) {
-                    throw ss::httpd::bad_request_exception(
-                      fmt::format("Error moving partition: {}", err.message()));
-                }
-                return ss::make_ready_future<ss::json::json_return_type>(
-                  ss::json::json_return_type(ss::json::json_void()));
-            });
-      });
 }

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -19,6 +19,7 @@
 #include "pandaproxy/configuration.h"
 #include "pandaproxy/fwd.h"
 #include "raft/group_manager.h"
+#include "redpanda/admin_server.h"
 #include "resource_mgmt/cpu_scheduling.h"
 #include "resource_mgmt/memory_groups.h"
 #include "resource_mgmt/smp_groups.h"
@@ -30,7 +31,6 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/sharded.hh>
-#include <seastar/http/httpd.hh>
 #include <seastar/util/defer.hh>
 
 namespace po = boost::program_options; // NOLINT
@@ -88,10 +88,6 @@ private:
     void validate_arguments(const po::variables_map&);
     void hydrate_config(const po::variables_map&);
 
-    void admin_register_raft_routes(ss::http_server& server);
-    void admin_register_kafka_routes(ss::http_server& server);
-    void admin_register_security_routes(ss::http_server& server);
-
     bool coproc_enabled() {
         const auto& cfg = config::shard_local_cfg();
         return cfg.developer_mode() && cfg.enable_coproc();
@@ -123,7 +119,7 @@ private:
     ss::sharded<rpc::connection_cache> _raft_connection_cache;
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<rpc::server> _rpc;
-    ss::sharded<ss::http_server> _admin;
+    ss::sharded<admin_server> _admin;
     ss::sharded<rpc::server> _kafka_server;
     ss::sharded<pandaproxy::proxy> _proxy;
     ss::metrics::metric_groups _metrics;


### PR DESCRIPTION
## Cover letter

Added following improvements to redpanda admin API:

- full support for multiple listeners
- health check endpoint at `v1/status/ready`
- factored out admin server to separate class

Example config:

```yaml

admin: 
- name: first
  address: 127.0.0.1
  port: 8080
- name: second
  address: 127.0.0.1
  port: 9090
admin_api_tls:
- name: first
  cert_file: /home/mmaslanka/dev/redpanda/vbuild/cluster/secrets/n1/cert.pem
  enabled: true
  key_file: /home/mmaslanka/dev/redpanda/vbuild/cluster/secrets/n1/key.pem
  require_client_auth: true
  truststore_file: /home/mmaslanka/dev/redpanda/vbuild/cluster/secrets/ca_cert.pem
```

## Release notes

- added ability to configure multiple listeners for admin API http server
- Added health check endpoint

