### PR TITLE
operator/rpk: set default log_segment_size in operator

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -37,6 +37,9 @@ const (
 	tlsDirCA = "/etc/tls/certs/ca"
 
 	tlsAdminDir = "/etc/tls/certs/admin"
+
+	oneMB          = 1024 * 1024
+	logSegmentSize = 512 * oneMB
 )
 
 var errKeyDoesNotExistInSecretData = errors.New("cannot find key in secret data")
@@ -224,6 +227,9 @@ func (r *ConfigMapResource) createConfiguration(
 	if partitions != 0 {
 		cr.GroupTopicPartitions = &partitions
 	}
+
+	segmentSize := logSegmentSize
+	cr.LogSegmentSize = &segmentSize
 
 	replicas := *r.pandaCluster.Spec.Replicas
 	for i := int32(0); i < replicas; i++ {

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -868,6 +868,58 @@ rpk:
 `,
 		},
 		{
+			name: "shall write config with log_segment_size configuration",
+			conf: func() *Config {
+				c := getValidConfig()
+				size := 536870912
+				c.Redpanda.LogSegmentSize = &size
+				return c
+			},
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+pandaproxy: {}
+redpanda:
+  admin:
+    address: 0.0.0.0
+    port: 9644
+  data_directory: /var/lib/redpanda/data
+  developer_mode: false
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  log_segment_size: 536870912
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers:
+  - host:
+      address: 127.0.0.1
+      port: 33145
+  - host:
+      address: 127.0.0.1
+      port: 33146
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_disk_write_cache: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
+`,
+		},
+		{
 			name: "shall write config with full pandaproxy configuration",
 			conf: func() *Config {
 				c := getValidConfig()

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -50,6 +50,7 @@ type RedpandaConfig struct {
 	Superusers                           []string               `yaml:"superusers,omitempty" mapstructure:"superusers,omitempty" json:"superusers,omitempty"`
 	EnableSASL                           *bool                  `yaml:"enable_sasl,omitempty" mapstructure:"enable_sasl,omitempty" json:"enableSasl,omitempty"`
 	GroupTopicPartitions                 *int                   `yaml:"group_topic_partitions,omitempty" mapstructure:"group_topic_partitions,omitempty" json:"groupTopicPartitions,omitempty"`
+	LogSegmentSize                       *int                   `yaml:"log_segment_size,omitempty" mapstructure:"log_segment_size,omitempty" json:"log_segment_size,omitempty"`
 	Other                                map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 


### PR DESCRIPTION
## Cover letter

1. Add `log_segment_size` under rpk's schema
2. Set a default value (512MB) for `log_segment_size` in the operator

## Release notes

When using the operator, the default `log_segment_size` value is 512MB