### PR TITLE
kafka/client Introduce partitioners and named consumers

### DIFF
--- a/src/v/kafka/client/CMakeLists.txt
+++ b/src/v/kafka/client/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
     fetcher.cc
     fetch_session.cc
     producer.cc
+    topic_cache.cc
   DEPS
     v::kafka
     v::ssx

--- a/src/v/kafka/client/CMakeLists.txt
+++ b/src/v/kafka/client/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
     consumer.cc
     fetcher.cc
     fetch_session.cc
+    partitioners.cc
     producer.cc
     topic_cache.cc
   DEPS

--- a/src/v/kafka/client/brokers.cc
+++ b/src/v/kafka/client/brokers.cc
@@ -39,16 +39,6 @@ ss::future<shared_broker_t> brokers::find(model::node_id id) {
     return ss::make_ready_future<shared_broker_t>(*b_it);
 }
 
-ss::future<shared_broker_t> brokers::find(model::topic_partition tp) {
-    auto l_it = _leaders.find(tp);
-    if (l_it == _leaders.end()) {
-        return ss::make_exception_future<shared_broker_t>(partition_error(
-          std::move(tp), error_code::unknown_topic_or_partition));
-    }
-
-    return find(l_it->second);
-}
-
 ss::future<> brokers::erase(model::node_id node_id) {
     if (auto b_it = _brokers.find(node_id); b_it != _brokers.end()) {
         auto broker = *b_it;
@@ -58,34 +48,35 @@ ss::future<> brokers::erase(model::node_id node_id) {
     return ss::now();
 }
 
-ss::future<> brokers::apply(metadata_response&& res) {
-    return ss::do_with(std::move(res), [this](metadata_response& res) {
+ss::future<> brokers::apply(std::vector<metadata_response::broker>&& res) {
+    using new_brokers_t = std::vector<metadata_response::broker>;
+    return ss::do_with(std::move(res), [this](new_brokers_t& new_brokers) {
         auto new_brokers_begin = std::partition(
-          res.brokers.begin(),
-          res.brokers.end(),
+          new_brokers.begin(),
+          new_brokers.end(),
           [this](const metadata_response::broker& broker) {
               return _brokers.count(broker.node_id);
           });
 
         return ssx::parallel_transform(
                  new_brokers_begin,
-                 res.brokers.end(),
+                 new_brokers.end(),
                  [](const metadata_response::broker& b) {
                      return make_broker(
                        b.node_id, unresolved_address(b.host, b.port));
                  })
-          .then([this, &res, new_brokers_begin, topics{std::move(res.topics)}](
+          .then([this, &new_brokers, new_brokers_begin](
                   std::vector<shared_broker_t> broker_endpoints) mutable {
               brokers_t brokers;
               brokers.reserve(
                 broker_endpoints.size()
-                + std::distance(res.brokers.begin(), new_brokers_begin));
+                + std::distance(new_brokers.begin(), new_brokers_begin));
               // Insert new brokers
               for (auto& b : broker_endpoints) {
                   brokers.emplace(std::move(b));
               }
               // Insert existing brokers
-              for (auto it = res.brokers.begin(); it != new_brokers_begin;
+              for (auto it = new_brokers.begin(); it != new_brokers_begin;
                    ++it) {
                   auto b = _brokers.find(it->node_id);
                   if (b != _brokers.end()) {
@@ -93,16 +84,7 @@ ss::future<> brokers::apply(metadata_response&& res) {
                   }
               }
 
-              leaders_t leaders;
-              for (const auto& t : topics) {
-                  for (auto const& p : t.partitions) {
-                      leaders.emplace(
-                        model::topic_partition(t.name, p.index), p.leader);
-                  }
-              }
-
               std::swap(brokers, _brokers);
-              std::swap(leaders, _leaders);
           });
     });
 }

--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "kafka/client/broker.h"
+#include "kafka/protocol/metadata.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
 
@@ -28,8 +29,6 @@ const model::node_id unknown_node_id{-1};
 class brokers {
     using brokers_t
       = absl::flat_hash_set<shared_broker_t, broker_hash, broker_eq>;
-    using leaders_t
-      = absl::flat_hash_map<model::topic_partition, model::node_id>;
 
 public:
     brokers() = default;
@@ -50,14 +49,11 @@ public:
     /// \brief Retrieve the broker for the given node_id.
     ss::future<shared_broker_t> find(model::node_id id);
 
-    /// \brief Retrieve the broker for the given topic_partition.
-    ss::future<shared_broker_t> find(model::topic_partition tp);
-
     /// \brief Remove a broker.
     ss::future<> erase(model::node_id id);
 
     /// \brief Apply the given metadata response.
-    ss::future<> apply(metadata_response&& res);
+    ss::future<> apply(std::vector<metadata_response::broker>&& brokers);
 
     /// \brief Returns true if there are no connected brokers
     ss::future<bool> empty() const;
@@ -67,8 +63,6 @@ private:
     brokers_t _brokers;
     /// \brief Next broker to select with round-robin
     size_t _next_broker{0};
-    /// \brief Leaders map a partition to a model::node_id.
-    leaders_t _leaders;
 };
 
 } // namespace kafka::client

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -19,6 +19,7 @@
 #include "kafka/client/fetcher.h"
 #include "kafka/client/producer.h"
 #include "kafka/client/retry_with_mitigation.h"
+#include "kafka/client/topic_cache.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/types.h"
@@ -166,10 +167,15 @@ private:
     ss::future<shared_consumer_t>
     get_consumer(const group_id& g_id, const member_id& m_id);
 
+    /// \brief Apply metadata update
+    ss::future<> apply(metadata_response res);
+
     /// \brief Client holds a copy of its configuration
     configuration _config;
     /// \brief Seeds are used when no brokers are connected.
     std::vector<unresolved_address> _seeds;
+    /// \brief Cache of topic information.
+    topic_cache _topic_cache;
     /// \brief Broker lookup from topic_partition.
     brokers _brokers;
     /// \brief Update metadata, or wait for an existing one.

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -21,6 +21,7 @@
 #include "kafka/client/retry_with_mitigation.h"
 #include "kafka/client/topic_cache.h"
 #include "kafka/client/transport.h"
+#include "kafka/client/types.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/types.h"
 #include "utils/retry.h"
@@ -102,6 +103,9 @@ public:
 
     ss::future<produce_response::partition> produce_record_batch(
       model::topic_partition tp, model::record_batch&& batch);
+
+    ss::future<produce_response>
+    produce_records(model::topic topic, std::vector<record_essence> batch);
 
     ss::future<fetch_response> fetch_partition(
       model::topic_partition tp,

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -113,7 +113,8 @@ public:
       int32_t max_bytes,
       std::chrono::milliseconds timeout);
 
-    ss::future<member_id> create_consumer(const group_id& g_id);
+    ss::future<member_id>
+    create_consumer(const group_id& g_id, member_id name = kafka::no_member);
 
     ss::future<> remove_consumer(const group_id& g_id, const member_id& m_id);
 

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -425,13 +425,15 @@ ss::future<shared_consumer_t> make_consumer(
   topic_cache& topic_cache,
   brokers& brokers,
   shared_broker_t coordinator,
-  group_id group_id) {
+  group_id group_id,
+  member_id name) {
     auto c = ss::make_lw_shared<consumer>(
       config,
       topic_cache,
       brokers,
       std::move(coordinator),
-      std::move(group_id));
+      std::move(group_id),
+      std::move(name));
     return c->join().then([c]() mutable { return std::move(c); });
 }
 

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -339,7 +339,8 @@ consumer::offset_commit(std::vector<offset_commit_request_topic> topics) {
         for (auto& t : topics) {
             for (auto& p : t.partitions) {
                 auto tp = model::topic_partition{t.name, p.partition_index};
-                auto broker = co_await _brokers.find(tp);
+                auto leader = co_await _topic_cache.leader(tp);
+                auto broker = co_await _brokers.find(leader);
                 p.committed_leader_epoch = _fetch_sessions[broker].epoch();
             }
         }
@@ -377,7 +378,8 @@ consumer::fetch(std::chrono::milliseconds timeout, int32_t max_bytes) {
     for (auto const& [t, ps] : _assignment) {
         for (const auto& p : ps) {
             auto tp = model::topic_partition{t, p};
-            auto broker = co_await _brokers.find(tp);
+            auto leader = co_await _topic_cache.leader(tp);
+            auto broker = co_await _brokers.find(leader);
             auto& session = _fetch_sessions[broker];
 
             auto& req = broker_reqs
@@ -420,11 +422,16 @@ consumer::fetch(std::chrono::milliseconds timeout, int32_t max_bytes) {
 
 ss::future<shared_consumer_t> make_consumer(
   const configuration& config,
+  topic_cache& topic_cache,
   brokers& brokers,
   shared_broker_t coordinator,
   group_id group_id) {
     auto c = ss::make_lw_shared<consumer>(
-      config, brokers, std::move(coordinator), std::move(group_id));
+      config,
+      topic_cache,
+      brokers,
+      std::move(coordinator),
+      std::move(group_id));
     return c->join().then([c]() mutable { return std::move(c); });
 }
 

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -16,6 +16,7 @@
 #include "kafka/client/configuration.h"
 #include "kafka/client/fetch_session.h"
 #include "kafka/client/logger.h"
+#include "kafka/client/topic_cache.h"
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/offset_commit.h"
@@ -40,10 +41,12 @@ class consumer final : public ss::enable_lw_shared_from_this<consumer> {
 public:
     consumer(
       const configuration& config,
+      topic_cache& topic_cache,
       brokers& brokers,
       shared_broker_t coordinator,
       group_id group_id)
       : _config(config)
+      , _topic_cache(topic_cache)
       , _brokers(brokers)
       , _coordinator(std::move(coordinator))
       , _group_id(std::move(group_id))
@@ -104,6 +107,7 @@ private:
     }
 
     const configuration& _config;
+    topic_cache& _topic_cache;
     brokers& _brokers;
     shared_broker_t _coordinator;
     ss::abort_source _as;
@@ -135,6 +139,7 @@ using shared_consumer_t = ss::lw_shared_ptr<consumer>;
 
 ss::future<shared_consumer_t> make_consumer(
   const configuration& config,
+  topic_cache& topic_cache,
   brokers& brokers,
   shared_broker_t coordinator,
   group_id group_id);

--- a/src/v/kafka/client/exceptions.h
+++ b/src/v/kafka/client/exceptions.h
@@ -29,6 +29,13 @@ struct broker_error final : exception_base {
     model::node_id node_id;
 };
 
+struct topic_error final : exception_base {
+    topic_error(model::topic_view tp, error_code e)
+      : exception_base{e, fmt::format("{}, {}", tp, e)}
+      , topic{tp} {}
+    model::topic topic;
+};
+
 struct partition_error final : exception_base {
     partition_error(model::topic_partition tp, error_code e)
       : exception_base{e, fmt::format("{}, {}", tp, e)}

--- a/src/v/kafka/client/partitioners.cc
+++ b/src/v/kafka/client/partitioners.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/client/partitioners.h"
+
+#include "hashing/murmur.h"
+
+#include <functional>
+#include <optional>
+#include <tuple>
+#include <type_traits>
+
+namespace kafka::client {
+
+namespace detail {
+
+class identity_partitioner final : public partitioner_impl {
+public:
+    std::optional<model::partition_id>
+    operator()(const record_essence& rec, size_t) override {
+        return rec.partition_id;
+    }
+};
+
+class murmur2_key_partitioner final : public partitioner_impl {
+public:
+    std::optional<model::partition_id>
+    operator()(const record_essence& rec, size_t partition_count) override {
+        if (!rec.key || rec.key->empty()) {
+            return std::nullopt;
+        }
+        iobuf_const_parser p(*rec.key);
+        auto key = p.read_bytes(p.bytes_left());
+        auto hash = murmur2(key.data(), key.size());
+        return model::partition_id(hash % partition_count);
+    }
+};
+
+class roundrobin_partitioner final : public partitioner_impl {
+public:
+    explicit roundrobin_partitioner(model::partition_id initial)
+      : partitioner_impl{}
+      , _next(initial) {}
+
+    std::optional<model::partition_id>
+    operator()(const record_essence&, size_t partition_count) override {
+        return model::partition_id(_next++ % partition_count);
+    }
+
+private:
+    model::partition_id _next;
+};
+
+// Try each partitioner in the list until one succeeds.
+template<typename... Impls>
+class composed_partitioner final : public partitioner_impl {
+public:
+    explicit composed_partitioner(Impls&&... impls)
+      : _impls{std::forward<Impls>(impls)...} {}
+
+    std::optional<model::partition_id>
+    operator()(const record_essence& rec, size_t partition_count) override {
+        return std::apply(
+          [&rec, partition_count, p_id{std::optional<model::partition_id>{}}](
+            auto&&... partitioner) mutable {
+              return (
+                (p_id = p_id.has_value() ? p_id
+                                         : partitioner(rec, partition_count)),
+                ...);
+          },
+          _impls);
+    }
+
+private:
+    std::tuple<Impls...> _impls;
+};
+
+} // namespace detail
+
+partitioner identity_partitioner() {
+    return partitioner{std::make_unique<detail::identity_partitioner>()};
+}
+
+partitioner murmur2_key_partitioner() {
+    return partitioner{std::make_unique<detail::murmur2_key_partitioner>()};
+}
+
+partitioner roundrobin_partitioner(model::partition_id initial) {
+    return partitioner{
+      std::make_unique<detail::roundrobin_partitioner>(initial)};
+}
+
+partitioner default_partitioner(model::partition_id initial) {
+    return partitioner{std::make_unique<detail::composed_partitioner<
+      detail::identity_partitioner,
+      detail::murmur2_key_partitioner,
+      detail::roundrobin_partitioner>>(
+      detail::identity_partitioner{},
+      detail::murmur2_key_partitioner{},
+      detail::roundrobin_partitioner{initial})};
+}
+
+} // namespace kafka::client

--- a/src/v/kafka/client/partitioners.h
+++ b/src/v/kafka/client/partitioners.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/client/types.h"
+#include "model/fundamental.h"
+
+namespace kafka::client {
+
+class partitioner_impl {
+public:
+    partitioner_impl() = default;
+    partitioner_impl(const partitioner_impl&) = delete;
+    partitioner_impl(partitioner_impl&&) = default;
+    partitioner_impl& operator=(const partitioner_impl&) = delete;
+    partitioner_impl& operator=(partitioner_impl&&) = delete;
+    virtual ~partitioner_impl() = default;
+
+    virtual std::optional<model::partition_id>
+    operator()(const record_essence&, size_t partition_count) = 0;
+};
+
+class partitioner {
+public:
+    partitioner() = default;
+    explicit partitioner(std::unique_ptr<partitioner_impl> impl)
+      : _impl(std::move(impl)) {}
+
+    explicit operator bool() const { return bool(_impl); }
+
+    std::optional<model::partition_id>
+    operator()(const record_essence& rec, size_t partition_count) {
+        return (*_impl)(rec, partition_count);
+    }
+
+private:
+    std::unique_ptr<partitioner_impl> _impl;
+};
+
+/// \brief Returns the partition_id in the record
+partitioner identity_partitioner();
+
+/// \brief Returns the murmur2 hash of the key,
+/// or nullopt if there is no key or the key is empty
+partitioner murmur2_key_partitioner();
+
+/// \brief Returns the partition_id in round-robin fashion, starting from
+/// \ref initial
+partitioner roundrobin_partitioner(model::partition_id initial);
+
+/// \brief Returns the partition_id if one exists in the record, or,
+/// returns the murmer2 hash of the key if there is one, or,
+/// returns partition_id based on round-robin.
+partitioner default_partitioner(model::partition_id initial);
+
+} // namespace kafka::client

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -73,7 +73,8 @@ producer::produce(model::topic_partition tp, model::record_batch&& batch) {
 
 ss::future<produce_response::partition>
 producer::do_send(model::topic_partition tp, model::record_batch&& batch) {
-    return _brokers.find(tp)
+    return _topic_cache.leader(tp)
+      .then([this](model::node_id leader) { return _brokers.find(leader); })
       .then([tp{std::move(tp)},
              batch{std::move(batch)}](shared_broker_t broker) mutable {
           return broker->dispatch(

--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -13,6 +13,7 @@
 
 #include "kafka/client/produce_batcher.h"
 #include "kafka/client/produce_partition.h"
+#include "kafka/client/topic_cache.h"
 #include "model/fundamental.h"
 #include "ssx/future-util.h"
 
@@ -32,11 +33,13 @@ public:
 
     producer(
       const configuration& config,
+      topic_cache& topic_cache,
       brokers& brokers,
       error_handler&& error_handler)
       : _config{config}
       , _partitions{}
       , _error_handler(std::move(error_handler))
+      , _topic_cache(topic_cache)
       , _brokers(brokers) {}
 
     ss::future<produce_response::partition>
@@ -75,6 +78,7 @@ private:
     absl::flat_hash_map<model::topic_partition, shared_produce_partition>
       _partitions;
     error_handler _error_handler;
+    topic_cache& _topic_cache;
     brokers& _brokers;
 };
 

--- a/src/v/kafka/client/test/CMakeLists.txt
+++ b/src/v/kafka/client/test/CMakeLists.txt
@@ -1,8 +1,19 @@
 rp_test(
   UNIT_TEST
+  BINARY_NAME test_kafka_client_unit
+  SOURCES
+    partitioners.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES Boost::unit_test_framework v::kafka_client
+  LABELS kafka
+)
+
+rp_test(
+  UNIT_TEST
   BINARY_NAME test_kafka_client
   SOURCES
     fetch_session.cc
+    partitioners.cc
     produce_batcher.cc
     produce_partition.cc
     retry_with_mitigation.cc

--- a/src/v/kafka/client/test/partitioners.cc
+++ b/src/v/kafka/client/test/partitioners.cc
@@ -1,0 +1,78 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf_parser.h"
+#include "hashing/murmur.h"
+#define BOOST_TEST_MODULE kafka_client_unit
+
+#include "kafka/client/partitioners.h"
+#include "model/fundamental.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+namespace k = kafka;
+namespace kc = k::client;
+
+iobuf make_iobuf(std::string_view sv) {
+    iobuf buf{};
+    buf.append(sv.data(), sv.size());
+    return buf;
+}
+
+model::partition_id murmur2(const iobuf& buf, size_t p_cnt) {
+    iobuf_const_parser parser{buf};
+    auto b = parser.read_bytes(parser.bytes_left());
+    auto hash = murmur2(b.data(), b.size());
+    return model::partition_id{hash % p_cnt};
+}
+
+static const auto no_partition{std::nullopt};
+static const auto no_key{std::nullopt};
+static const auto no_value{std::nullopt};
+static const auto empty_key{iobuf()};
+static const auto empty_value{iobuf()};
+static const auto a_partition{model::partition_id{4}};
+static const auto initial_partition{model::partition_id{5}};
+
+iobuf a_key() { return make_iobuf("the key"); };
+
+static const auto match_partition = kc::record_essence{
+  .partition_id = a_partition, .key = no_key, .value = no_value, .headers{}};
+static const auto match_key = kc::record_essence{
+  .partition_id = no_partition, .key = a_key(), .value = no_value, .headers{}};
+static const auto match_none = kc::record_essence{
+  .partition_id = no_partition, .key = no_key, .value = no_value, .headers{}};
+
+BOOST_AUTO_TEST_CASE(test_identity_partitioner) {
+    auto partitioner{kc::identity_partitioner()};
+    BOOST_REQUIRE(partitioner(match_none, 6) == std::nullopt);
+    BOOST_REQUIRE_EQUAL(*partitioner(match_partition, 6), a_partition);
+}
+
+BOOST_AUTO_TEST_CASE(test_murmur2_key_partitioner) {
+    auto partitioner{kc::murmur2_key_partitioner()};
+    BOOST_REQUIRE(partitioner(match_none, 6) == std::nullopt);
+    BOOST_REQUIRE_EQUAL(*partitioner(match_key, 6), murmur2(a_key(), 6));
+}
+
+BOOST_AUTO_TEST_CASE(test_roundrobin_partitioner) {
+    auto partitioner{kc::roundrobin_partitioner(initial_partition)};
+    BOOST_REQUIRE_EQUAL(*partitioner(match_none, 6), initial_partition);
+    BOOST_REQUIRE_EQUAL(
+      *partitioner(match_none, 6), (initial_partition + 1) % 6);
+}
+
+BOOST_AUTO_TEST_CASE(test_default_partitioner) {
+    auto partitioner{kc::default_partitioner(initial_partition)};
+    BOOST_REQUIRE_EQUAL(*partitioner(match_partition, 6), a_partition);
+    BOOST_REQUIRE_EQUAL(*partitioner(match_key, 6), murmur2(a_key(), 6));
+    BOOST_REQUIRE_EQUAL(*partitioner(match_none, 6), initial_partition);
+}

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -10,7 +10,9 @@
 #include "kafka/client/topic_cache.h"
 
 #include "kafka/client/exceptions.h"
+#include "kafka/client/partitioners.h"
 #include "kafka/protocol/metadata.h"
+#include "random/generators.h"
 
 #include <seastar/core/future.hh>
 
@@ -21,7 +23,13 @@ topic_cache::apply(std::vector<metadata_response::topic>&& topics) {
     topics_t cache;
     cache.reserve(topics.size());
     for (const auto& t : topics) {
-        auto& cache_t = cache.try_emplace(t.name).first->second;
+        const auto initial_partition_id = model::partition_id{
+          random_generators::get_int<model::partition_id::type>(
+            t.partitions.size())};
+        topic_data topic_data{
+          .partitioner_func = default_partitioner(initial_partition_id)};
+        auto& cache_t
+          = cache.emplace(t.name, std::move(topic_data)).first->second;
         cache_t.partitions.reserve(t.partitions.size());
         for (auto const& p : t.partitions) {
             cache_t.partitions.emplace(
@@ -45,6 +53,17 @@ topic_cache::leader(model::topic_partition tp) const {
     }
     return ss::make_exception_future<model::node_id>(
       partition_error(std::move(tp), error_code::unknown_topic_or_partition));
+}
+
+ss::future<model::partition_id>
+topic_cache::partition_for(model::topic_view tv, const record_essence& rec) {
+    if (auto topic_it = _topics.find(tv); topic_it != _topics.end()) {
+        auto& pd = topic_it->second;
+        return ss::make_ready_future<model::partition_id>(
+          *pd.partitioner_func(rec, pd.partitions.size()));
+    }
+    return ss::make_exception_future<model::partition_id>(
+      topic_error(tv, error_code::unknown_topic_or_partition));
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -1,0 +1,40 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/client/topic_cache.h"
+
+#include "kafka/client/exceptions.h"
+#include "kafka/protocol/metadata.h"
+
+#include <seastar/core/future.hh>
+
+namespace kafka::client {
+
+ss::future<>
+topic_cache::apply(std::vector<metadata_response::topic>&& topics) {
+    leaders_t leaders;
+    for (const auto& t : topics) {
+        for (auto const& p : t.partitions) {
+            leaders.emplace(model::topic_partition(t.name, p.index), p.leader);
+        }
+    }
+    std::swap(leaders, _leaders);
+    return ss::now();
+}
+
+ss::future<model::node_id>
+topic_cache::leader(model::topic_partition tp) const {
+    if (auto topic_it = _leaders.find(tp); topic_it != _leaders.end()) {
+        return ss::make_ready_future<model::node_id>(topic_it->second);
+    }
+    return ss::make_exception_future<model::node_id>(
+      partition_error(std::move(tp), error_code::unknown_topic_or_partition));
+}
+
+} // namespace kafka::client

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -24,8 +24,15 @@
 namespace kafka::client {
 
 class topic_cache {
-    using leaders_t
-      = absl::flat_hash_map<model::topic_partition, model::node_id>;
+    struct partition_data {
+        model::node_id leader;
+    };
+
+    struct topic_data {
+        absl::flat_hash_map<model::partition_id, partition_data> partitions;
+    };
+
+    using topics_t = absl::node_hash_map<model::topic, topic_data>;
 
 public:
     topic_cache() = default;
@@ -42,8 +49,8 @@ public:
     ss::future<model::node_id> leader(model::topic_partition tp) const;
 
 private:
-    /// \brief Leaders map a partition to a model::node_id.
-    leaders_t _leaders;
+    /// \brief Cache of topic information.
+    topics_t _topics;
 };
 
 } // namespace kafka::client

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/protocol/metadata.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+#include <absl/container/flat_hash_set.h>
+#include <absl/container/node_hash_set.h>
+
+namespace kafka::client {
+
+class topic_cache {
+    using leaders_t
+      = absl::flat_hash_map<model::topic_partition, model::node_id>;
+
+public:
+    topic_cache() = default;
+    topic_cache(const topic_cache&) = delete;
+    topic_cache(topic_cache&&) = default;
+    topic_cache& operator=(topic_cache const&) = delete;
+    topic_cache& operator=(topic_cache&&) = delete;
+    ~topic_cache() noexcept = default;
+
+    /// \brief Apply the given metadata response.
+    ss::future<> apply(std::vector<metadata_response::topic>&& topics);
+
+    /// \brief Obtain the leader for the given topic-partition
+    ss::future<model::node_id> leader(model::topic_partition tp) const;
+
+private:
+    /// \brief Leaders map a partition to a model::node_id.
+    leaders_t _leaders;
+};
+
+} // namespace kafka::client

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "kafka/client/partitioners.h"
+#include "kafka/client/types.h"
 #include "kafka/protocol/metadata.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -29,6 +31,7 @@ class topic_cache {
     };
 
     struct topic_data {
+        partitioner partitioner_func;
         absl::flat_hash_map<model::partition_id, partition_data> partitions;
     };
 
@@ -47,6 +50,10 @@ public:
 
     /// \brief Obtain the leader for the given topic-partition
     ss::future<model::node_id> leader(model::topic_partition tp) const;
+
+    /// \brief Obtain the partition_id for the given record
+    ss::future<model::partition_id>
+    partition_for(model::topic_view tv, const record_essence& rec);
 
 private:
     /// \brief Cache of topic information.

--- a/src/v/kafka/client/types.h
+++ b/src/v/kafka/client/types.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "model/record.h"
+
+#include <optional>
+
+namespace kafka::client {
+
+struct record_essence {
+    std::optional<model::partition_id> partition_id;
+    std::optional<iobuf> key;
+    std::optional<iobuf> value;
+    std::vector<model::record_header> headers;
+};
+
+} // namespace kafka::client

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -192,13 +192,13 @@ create_consumer(server::request_t rq, server::reply_t rp) {
     auto req_data = ppj::rjson_parse(
       rq.req->content.data(), ppj::create_consumer_request_handler());
 
-    return rq.ctx.client.create_consumer(group_id).then(
-      [group_id, res_fmt, rq{std::move(rq)}, rp{std::move(rp)}](
-        kafka::member_id m_id) mutable {
+    return rq.ctx.client.create_consumer(group_id, req_data.name)
+      .then([group_id, res_fmt, rq{std::move(rq)}, rp{std::move(rp)}](
+              kafka::member_id name) mutable {
           auto adv_addr = rq.ctx.config.advertised_pandaproxy_api();
           json::create_consumer_response res{
-            .instance_id = m_id,
-            .base_uri = make_consumer_uri(rq, m_id, group_id)};
+            .instance_id = name,
+            .base_uri = make_consumer_uri(rq, name, group_id)};
           auto json_rslt = ppj::rjson_serialize(res);
           rp.rep->write_body("json", json_rslt);
           rp.mime_type = res_fmt;
@@ -260,9 +260,9 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
     int32_t max_bytes{
       boost::lexical_cast<int32_t>(rq.req->get_query_param("max_bytes"))};
     auto group_id = kafka::group_id(rq.req->param["group_name"]);
-    auto member_id = kafka::member_id(rq.req->param["instance"]);
+    auto name = kafka::member_id(rq.req->param["instance"]);
 
-    return rq.ctx.client.consumer_fetch(group_id, member_id, timeout, max_bytes)
+    return rq.ctx.client.consumer_fetch(group_id, name, timeout, max_bytes)
       .then([fmt, rp{std::move(rp)}](kafka::fetch_response res) mutable {
           rapidjson::StringBuffer str_buf;
           rapidjson::Writer<rapidjson::StringBuffer> w(str_buf);

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -151,57 +151,18 @@ post_topics_name(server::request_t rq, server::reply_t rp) {
       *rq.req,
       {json::serialization_format::json_v2, json::serialization_format::none});
 
-    auto raw_records = ppj::rjson_parse(
+    auto topic = parse::request_param<model::topic>(*rq.req, "topic_name");
+
+    auto records = ppj::rjson_parse(
       rq.req->content.data(), ppj::produce_request_handler(req_fmt));
 
-    absl::flat_hash_map<model::partition_id, storage::record_batch_builder>
-      partition_builders;
+    auto res = co_await rq.ctx.client.produce_records(
+      topic, std::move(records));
 
-    for (auto& r : raw_records) {
-        auto it = partition_builders
-                    .try_emplace(r.id, raft::data_batch_type, model::offset(0))
-                    .first;
-        it->second.add_raw_kv(
-          std::move(r.key).value_or(iobuf{}),
-          std::move(r.value).value_or(iobuf{}));
-    }
-
-    std::vector<kafka::produce_request::partition> partitions;
-    partitions.reserve(partition_builders.size());
-    for (auto& pb : partition_builders) {
-        partitions.emplace_back(kafka::produce_request::partition{
-          .partition_index = pb.first,
-          .records = kafka::produce_request_record_data(
-            std::move(pb.second).build())});
-    }
-
-    auto topic = parse::request_param<model::topic>(*rq.req, "topic_name");
-    return ssx::parallel_transform(
-             std::move(partitions),
-             [topic,
-              rq{std::move(rq)}](kafka::produce_request::partition p) mutable {
-                 return rq.ctx.client.produce_record_batch(
-                   model::topic_partition(topic, p.partition_index),
-                   std::move(*p.records->adapter.batch));
-             })
-      .then([topic, res_fmt, rp{std::move(rp)}](auto responses) mutable {
-          std::vector<kafka::produce_response::topic> topics;
-          topics.push_back(kafka::produce_response::topic{
-            .name{std::move(topic)}, .partitions{std::move(responses)}});
-
-          auto data = kafka::produce_response_data{
-            .responses{std::move(topics)},
-            .throttle_time_ms{std::chrono::milliseconds{0}}};
-
-          auto res = kafka::produce_response{
-            .data = std::move(data),
-          };
-
-          auto json_rslt = ppj::rjson_serialize(res.data.responses[0]);
-          rp.rep->write_body("json", json_rslt);
-          rp.mime_type = res_fmt;
-          return std::move(rp);
-      });
+    auto json_rslt = ppj::rjson_serialize(res.data.responses[0]);
+    rp.rep->write_body("json", json_rslt);
+    rp.mime_type = res_fmt;
+    co_return rp;
 }
 
 static ss::sstring make_consumer_uri(

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -31,7 +31,7 @@
 namespace pandaproxy::json {
 
 struct create_consumer_request {
-    std::optional<ss::sstring> name;
+    kafka::member_id name{kafka::no_member};
     ss::sstring format{"binary"};
     ss::sstring auto_offset_reset;
     ss::sstring auto_commit_enable;
@@ -75,7 +75,7 @@ public:
         case state::empty:
             return false;
         case state::name:
-            result.name = {str, len};
+            result.name = kafka::member_id{ss::sstring{str, len}};
             break;
         case state::format:
             result.format = {str, len};

--- a/src/v/pandaproxy/json/requests/test/produce.cc
+++ b/src/v/pandaproxy/json/requests/test/produce.cc
@@ -45,12 +45,12 @@ SEASTAR_THREAD_TEST_CASE(test_produce_request) {
     auto parser = iobuf_parser(std::move(*records[0].value));
     auto value = parser.read_string(parser.bytes_left());
     BOOST_TEST(value == "vectorized");
-    BOOST_TEST(records[0].id == model::partition_id(0));
+    BOOST_TEST(records[0].partition_id == model::partition_id(0));
 
     parser = iobuf_parser(std::move(*records[1].value));
     value = parser.read_string(parser.bytes_left());
     BOOST_TEST(value == "pandaproxy");
-    BOOST_TEST(records[1].id == model::partition_id(1));
+    BOOST_TEST(records[1].partition_id == model::partition_id(1));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_produce_request_empty) {

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -64,6 +64,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
     {
         info("Create consumer");
         ss::sstring req_body(R"({
+  "name": "test_consumer",
   "format": "binary",
   "auto.offset.reset": "earliest",
   "auto.commit.enable": "false",
@@ -84,7 +85,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
 
         auto res_data = ppj::rjson_parse(
           res.body.data(), ppj::create_consumer_response_handler());
-        BOOST_REQUIRE(res_data.instance_id != kafka::no_member);
+        BOOST_REQUIRE_EQUAL(res_data.instance_id, "test_consumer");
         member_id = res_data.instance_id;
         BOOST_REQUIRE_EQUAL(
           res_data.base_uri,

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -307,6 +307,22 @@ class PandaProxyTest(RedpandaTest):
         assert kc.consume_one(name, 1, 1)["payload"] == "pandaproxy"
         assert kc.consume_one(name, 2, 1)["payload"] == "multibroker"
 
+        self.logger.info(f"Producing to topic without partition: {name}")
+        produce_result_raw = self._produce_topic(
+            name, '''
+        {
+            "records": [
+                {"value": "dmVjdG9yaXplZA=="},
+                {"value": "cGFuZGFwcm94eQ=="},
+                {"value": "bXVsdGlicm9rZXI="}
+            ]
+        }''')
+
+        assert produce_result_raw.status_code == requests.codes.ok
+        produce_result = produce_result_raw.json()
+        for o in produce_result["offsets"]:
+            assert o["offset"] == 2, f'error_code {o["error_code"]}'
+
     @cluster(num_nodes=3)
     def test_fetch_topic_validation(self):
         """


### PR DESCRIPTION
## Cover letter

### Features

When producing records, both the `partitiion_id` and `key` are now optional.

Partition is chosen using a fallback strategy:
* Use `partition_id` if it's provided, else
* Use `murmur2` of `key` if `key` is provided, else
* Use `round-robin` strategy

Consumers can now have a name provided.

### Refactoring

Extract `topic_cache` from brokers

* Improve memory layout
* Support partitioners

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/38a554193ce54d75a525d7aaceb815dbaf692906..61de18ab20d8508d211ea7cac0678d0e1634e7ce)
* Address review comments.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/61de18ab20d8508d211ea7cac0678d0e1634e7ce..27c832a268ba23bb0e21c6a4d114820dbab360c3)
* Fix missing renamed `default_partitioner`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/27c832a268ba23bb0e21c6a4d114820dbab360c3..24e9533547b282f22b1a2cfc09a48ef0d0ca32a0)
* Rebase over conflict in #1131

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/24e9533547b282f22b1a2cfc09a48ef0d0ca32a0..931e0b19772f27270abbb3e0c1ae98246a5ab58b)
* Fix `fmt` for `topic_error`

## Release notes

Release note: Pandaproxy: Support partitioners and named consumers
