### PR TITLE
Wasm failure mode tests

### DIFF
--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -55,8 +55,7 @@ static wasm::event_action query_action(const iobuf& source_code) {
 }
 
 static ss::future<> remove_copro_state(ss::sharded<pacemaker>& svc) {
-    return svc.invoke_on_all(
-      [](pacemaker& p) { return p.remove_all_sources().discard_result(); });
+    return svc.invoke_on_all([](pacemaker& p) { return p.reset(); });
 }
 
 ss::future<> event_listener::stop() {

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -231,7 +231,7 @@ ss::future<> event_listener::do_ingest() {
 ss::future<ss::stop_iteration>
 event_listener::poll_topic(model::record_batch_reader::data_t& events) {
     auto response = co_await _client.fetch_partition(
-      model::coprocessor_internal_tp, _offset, 64_KiB, 5s);
+      model::coprocessor_internal_tp, _offset, 64_KiB, 100ms);
     if (
       response.error != kafka::error_code::none
       || _abort_source.abort_requested()) {

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -192,6 +192,7 @@ ss::future<> event_listener::do_start() {
         if (has_active) {
             vlog(
               coproclog.info, "Shutting down all coprocessor script_contexts");
+            _active_ids.clear();
             co_await remove_copro_state(_pacemaker);
         }
         co_return;

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -106,12 +106,19 @@ private:
         model::timeout_clock::duration duration;
         storage::snapshot_manager snap;
 
+        static ss::sstring snapshot_filename() {
+            return fmt::format(
+              "{}-{}",
+              storage::snapshot_manager::default_snapshot_filename,
+              ss::this_shard_id());
+        }
+
         offset_flush_fiber_state()
           : duration(
             config::shard_local_cfg().coproc_offset_flush_interval_ms())
           , snap(
               offsets_snapshot_path(),
-              storage::snapshot_manager::default_snapshot_filename,
+              snapshot_filename(),
               ss::default_priority_class()) {}
     };
 

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -21,6 +21,7 @@
 #include "storage/snapshot.h"
 
 #include <seastar/core/sharded.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/socket_defs.hh>
 
@@ -46,6 +47,11 @@ public:
      * Begins the offset tracking fiber
      */
     ss::future<> start();
+
+    /**
+     * Stops and removes running scripts but keeps their state (offsets)
+     */
+    ss::future<> reset();
 
     /**
      * Gracefully stops and deregisters all coproc scripts

--- a/src/v/coproc/script_dispatcher.h
+++ b/src/v/coproc/script_dispatcher.h
@@ -47,7 +47,7 @@ public:
     ss::future<std::error_code> disable_all_coprocessors();
 
     /// Invoke this to query weather the wasm engine is up or not
-    ss::future<bool> heartbeat();
+    ss::future<bool> heartbeat(int8_t connect_attempts = 3);
 
 private:
     /// The following methods are introduced to sidestep an issue detected when

--- a/tests/rptest/test_suite_wasm.yml
+++ b/tests/rptest/test_suite_wasm.yml
@@ -1,0 +1,14 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+wasm:
+  included:
+    - tests/wasm_identity_test.py
+    - tests/wasm_failure_recovery_test.py
+    - tests/wasm_redpanda_failure_recovery_test.py

--- a/tests/rptest/tests/wasm_failure_recovery_test.py
+++ b/tests/rptest/tests/wasm_failure_recovery_test.py
@@ -1,0 +1,114 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from rptest.clients.types import TopicSpec
+from rptest.tests.wasm_identity_test import WasmIdentityTest
+from rptest.wasm.topics_result_set import materialized_at_least_once_compare
+
+
+class WasmFailureRecoveryTest(WasmIdentityTest):
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        super(WasmFailureRecoveryTest, self).__init__(test_context,
+                                                      extra_rp_conf=None,
+                                                      num_records=num_records,
+                                                      record_size=record_size)
+        self._one_traunch_observed = False
+
+    def records_recieved(self, output_recieved):
+        if self._one_traunch_observed is False:
+            self.restart_wasm_engine(random.sample(self.redpanda.nodes, 1)[0])
+            self._one_traunch_observed = True
+
+
+class WasmBasicFailureRecoveryTest(WasmFailureRecoveryTest):
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        super(WasmBasicFailureRecoveryTest,
+              self).__init__(test_context,
+                             num_records=num_records,
+                             record_size=record_size)
+
+    def wasm_test_outputs(self):
+        return [["sole_output_a"]]
+
+    def verify_results(self):
+        return materialized_at_least_once_compare
+
+
+class WasmMultiScriptFailureRecoveryTest(WasmFailureRecoveryTest):
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        super(WasmMultiScriptFailureRecoveryTest,
+              self).__init__(test_context,
+                             num_records=num_records,
+                             record_size=record_size)
+
+    def wasm_test_outputs(self):
+        return [["aaa"], ["bbb"], ["ccc"]]
+
+    def verify_results(self):
+        return materialized_at_least_once_compare
+
+
+class WasmMultiInputTopicFailureRecoveryTest(WasmFailureRecoveryTest):
+    topics = (
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+    )
+
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        super(WasmMultiInputTopicFailureRecoveryTest,
+              self).__init__(test_context,
+                             num_records=num_records,
+                             record_size=record_size)
+
+    def wasm_test_outputs(self):
+        return [["first_topic"], ["second_topic"], ["third_topic"]]
+
+    def verify_results(self):
+        return materialized_at_least_once_compare
+
+
+class WasmMeshFailureRecoveryTest(WasmFailureRecoveryTest):
+    topics = (
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+    )
+
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        super(WasmMeshFailureRecoveryTest,
+              self).__init__(test_context,
+                             num_records=num_records,
+                             record_size=record_size)
+
+    def wasm_xfactor(self):
+        return 3
+
+    def wasm_test_outputs(self):
+        otopic_a = "output_topic_a"
+        otopic_b = "output_topic_b"
+        otopic_c = "output_topic_c"
+        return [[otopic_a, otopic_b, otopic_c], [otopic_a, otopic_b, otopic_c],
+                [otopic_a, otopic_b, otopic_c]]
+
+    def verify_results(self):
+        return materialized_at_least_once_compare

--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -69,9 +69,9 @@ class WasmIdentityTest(WasmTest):
         3. Producers set-up and begin producing onto input topics
         4. When finished, perform assertions in this method
         """
-        input_results, output_results = self._start(self.wasm_test_input(),
-                                                    self.wasm_test_plan(),
-                                                    self.wasm_xfactor())
+        self.start(self.wasm_test_input(), self.wasm_test_plan(),
+                   self.wasm_xfactor())
+        input_results, output_results = self.wait_on_results()
         for script in self.wasm_test_outputs():
             for dest in script:
                 outputs = set([
@@ -235,9 +235,9 @@ class WasmAllInputsToAllOutputsIdentityTest(WasmIdentityTest):
     @cluster(num_nodes=3)
     def verify_materialized_topics_test(self):
         # Cannot compare topics to topics, can only verify # of records
-        input_results, output_results = self._start(self.wasm_test_input(),
-                                                    self.wasm_test_plan(),
-                                                    self.wasm_xfactor())
+        self.start(self.wasm_test_input(), self.wasm_test_plan(),
+                   self.wasm_xfactor())
+        input_results, output_results = self.wait_on_results()
 
         def compare(topic):
             iis = input_results.filter(lambda x: x.topic == topic)

--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -20,8 +20,14 @@ class WasmIdentityTest(WasmTest):
                         replication_factor=3,
                         cleanup_policy=TopicSpec.CLEANUP_DELETE), )
 
-    def __init__(self, test_context, num_records=1024, record_size=1024):
-        super(WasmIdentityTest, self).__init__(test_context, extra_rp_conf={})
+    def __init__(self,
+                 test_context,
+                 extra_rp_conf=None,
+                 num_records=1024,
+                 record_size=1024):
+        super(WasmIdentityTest, self).__init__(test_context,
+                                               extra_rp_conf=extra_rp_conf
+                                               or {})
         self._num_records = num_records
         self._record_size = record_size
         assert len(self.topics) >= 1

--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -60,6 +60,10 @@ class WasmIdentityTest(WasmTest):
             for opts in self.wasm_test_outputs()
         ]
 
+    def verify_results(self):
+        """ How to interpret PASS/FAIL between two sets of returned results"""
+        return materialized_result_set_compare
+
     @cluster(num_nodes=3)
     def verify_materialized_topics_test(self):
         """
@@ -79,8 +83,7 @@ class WasmIdentityTest(WasmTest):
                     for src, _, _ in self.wasm_test_input()
                 ])
                 tresults = output_results.filter(lambda x: x.topic in outputs)
-                if not materialized_result_set_compare(input_results,
-                                                       tresults):
+                if not self.verify_results()(input_results, tresults):
                     raise Exception(
                         f"Set {dest} results weren't as expected: {type(self).__name__}"
                     )

--- a/tests/rptest/tests/wasm_redpanda_failure_recovery_test.py
+++ b/tests/rptest/tests/wasm_redpanda_failure_recovery_test.py
@@ -1,0 +1,84 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from rptest.clients.types import TopicSpec
+from rptest.tests.wasm_identity_test import WasmIdentityTest
+from rptest.wasm.topics_result_set import materialized_at_least_once_compare
+
+
+class WasmRedpandaFailureRecoveryTest(WasmIdentityTest):
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        conf = {'coproc_offset_flush_interval_ms': 1000}
+        super(WasmRedpandaFailureRecoveryTest,
+              self).__init__(test_context,
+                             extra_rp_conf=conf,
+                             num_records=num_records,
+                             record_size=record_size)
+        self._one_traunch_observed = False
+
+    def records_recieved(self, output_recieved):
+        if self._one_traunch_observed is False:
+            self.restart_redpanda(random.sample(self.redpanda.nodes, 1)[0])
+            self._one_traunch_observed = True
+
+
+class WasmRPBasicFailureRecoveryTest(WasmRedpandaFailureRecoveryTest):
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        super(WasmRPBasicFailureRecoveryTest,
+              self).__init__(test_context,
+                             num_records=num_records,
+                             record_size=record_size)
+
+    def wasm_test_outputs(self):
+        return [["sole_output_a"]]
+
+    def verify_results(self):
+        return materialized_at_least_once_compare
+
+
+class WasmRPMultiScriptFailureRecoveryTest(WasmRedpandaFailureRecoveryTest):
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        super(WasmRPMultiScriptFailureRecoveryTest,
+              self).__init__(test_context,
+                             num_records=num_records,
+                             record_size=record_size)
+
+    def wasm_test_outputs(self):
+        return [["aaa"], ["bbb"], ["ccc"]]
+
+    def verify_results(self):
+        return materialized_at_least_once_compare
+
+
+class WasmRPMultiInputTopicFailureRecoveryTest(WasmRedpandaFailureRecoveryTest
+                                               ):
+    topics = (
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+    )
+
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        super(WasmRPMultiInputTopicFailureRecoveryTest,
+              self).__init__(test_context,
+                             num_records=num_records,
+                             record_size=record_size)
+
+    def wasm_test_outputs(self):
+        return [["first_topic"], ["second_topic"], ["third_topic"]]
+
+    def verify_results(self):
+        return materialized_at_least_once_compare

--- a/tests/rptest/wasm/background_task.py
+++ b/tests/rptest/wasm/background_task.py
@@ -50,9 +50,11 @@ class BackgroundTask:
     def start(self):
         self._worker.start()
 
-    def join(self):
+    def stop(self):
         with self._lock:
             self._done = True
+
+    def join(self):
         self._worker.join()
         if self._error is not None:
             raise Exception(self._error)

--- a/tests/rptest/wasm/native_kafka_producer.py
+++ b/tests/rptest/wasm/native_kafka_producer.py
@@ -22,7 +22,7 @@ class NativeKafkaProducer(BackgroundTask):
         self._records_size = records_size
         self._producer = KafkaProducer(bootstrap_servers=brokers,
                                        linger_ms=5,
-                                       acks=1,
+                                       acks='all',
                                        retries=10,
                                        key_serializer=str.encode)
 

--- a/tests/rptest/wasm/native_kafka_producer.py
+++ b/tests/rptest/wasm/native_kafka_producer.py
@@ -33,7 +33,6 @@ class NativeKafkaProducer(BackgroundTask):
         for i in range(0, self._num_records):
             if self.is_finished():
                 break
-            key = str(hash(str(i) + self._topic))
             value = os.urandom(self._records_size)
-            self._producer.send(self._topic, key=key, value=value)
+            self._producer.send(self._topic, key=str(i), value=value)
         self._producer.flush()

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -62,6 +62,9 @@ class WasmTest(RedpandaTest):
                                        num_brokers=num_brokers)
         self._rpk_tool = RpkTool(self.redpanda)
         self._build_tool = WasmBuildTool(self._rpk_tool)
+        self._input_consumer = None
+        self._output_consumer = None
+        self._producers = None
 
     def _build_script(self, script):
         # Build the script itself
@@ -71,7 +74,7 @@ class WasmTest(RedpandaTest):
         self._rpk_tool.wasm_deploy(
             script.get_artifact(self._build_tool.work_dir), "ducktape")
 
-    def _start(self, topic_spec, scripts, xfactor):
+    def start(self, topic_spec, scripts, xfactor):
         def to_output_topic_spec(output_topics):
             """
             Create a list of TopicPartitions for the set of output topics.
@@ -123,25 +126,24 @@ class WasmTest(RedpandaTest):
         self.logger.info(f"Input consumer assigned: {input_tps}")
         self.logger.info(f"Output consumer assigned: {output_tps}")
 
-        producers = []
+        self._producers = []
+
         for tp_spec, num_records, record_size in topic_spec:
             try:
                 producer = NativeKafkaProducer(self.redpanda.brokers(),
                                                tp_spec.name, num_records,
                                                record_size)
                 producer.start()
-                producers.append(producer)
+                self._producers.append(producer)
             except Exception as e:
                 self.logger.error(f"Failed to create NativeKafkaProducer: {e}")
                 raise
 
-        input_consumer = None
-        output_consumer = None
         try:
-            input_consumer = NativeKafkaConsumer(self.redpanda.brokers(),
-                                                 input_tps, total_inputs)
-            output_consumer = NativeKafkaConsumer(self.redpanda.brokers(),
-                                                  output_tps, total_outputs)
+            self._input_consumer = NativeKafkaConsumer(self.redpanda.brokers(),
+                                                       input_tps, total_inputs)
+            self._output_consumer = NativeKafkaConsumer(
+                self.redpanda.brokers(), output_tps, total_outputs)
         except Exception as e:
             self.logger.error(f"Failed to create NativeKafkaConsumer: {e}")
             raise
@@ -149,34 +151,56 @@ class WasmTest(RedpandaTest):
         self.logger.info(
             f"Waiting for {total_inputs} input records and {total_outputs}"
             " result records")
-        input_consumer.start()
-        output_consumer.start()
+        self._input_consumer.start()
+        self._output_consumer.start()
 
+    def wait_on_results(self):
         def all_done():
             # Uncomment to periodically see the amt of data read
-            # self.logger.info("Input: %d" %
-            #                  input_consumer.results.num_records())
-            # self.logger.info("Output: %d" %
-            #                  output_consumer.results.num_records())
-            return input_consumer.is_finished() and \
-                output_consumer.is_finished()
+            self.logger.info("Input: %d" %
+                             self._input_consumer.results.num_records())
+            self.logger.info("Output: %d" %
+                             self._output_consumer.results.num_records())
+            batch_total = self._input_consumer.results.num_records()
+            if batch_total > 0:
+                self.records_recieved(batch_total)
 
+            return self._input_consumer.is_finished()
+
+        [x.join() for x in self._producers]
         timeout, backoff = self.wasm_test_timeout()
         wait_until(all_done, timeout_sec=timeout, backoff_sec=backoff)
         try:
-            input_consumer.join()
-            output_consumer.join()
-            [x.join() for x in producers]
+            self._input_consumer.join()
+            self._output_consumer.join()
         except Exception as e:
             self.logger.error("Exception occured in background thread: {e}")
             raise e
 
-        self.logger.info(
-            f"Consumed {input_consumer.results.num_records()} input"
-            f" records/expected {total_inputs} and"
-            f" {output_consumer.results.num_records()} result records/expected"
-            f" {total_outputs}")
-        return (input_consumer.results, output_consumer.results)
+        input_consumed = self._input_consumer.results.num_records()
+        output_consumed = self._output_consumer.results.num_records()
+        self.logger.info(f"Consumed {input_consumed} input"
+                         f" records and"
+                         f" {output_consumed} result records")
+
+        input_expected = self._input_consumer._num_records
+        output_expected = self._output_consumer._num_records
+        if input_consumed < input_expected:
+            raise Exception(
+                f"Consumed {input_consumed} expected {input_expected} input records"
+            )
+        if output_consumed < output_expected:
+            raise Exception(
+                f"Consumed {output_consumed} expected {output_expected} output records"
+            )
+
+        return (self._input_consumer.results, self._output_consumer.results)
+
+    def records_recieved(self, output_recieved):
+        """
+        Called when a traunch of records has been returned from consumers
+        """
+        pass
 
     def wasm_test_timeout(self):
         """

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import os
+import time
 import uuid
 
 from kafka import TopicPartition
@@ -73,6 +74,24 @@ class WasmTest(RedpandaTest):
         # Deploy coprocessor
         self._rpk_tool.wasm_deploy(
             script.get_artifact(self._build_tool.work_dir), "ducktape")
+
+    def restart_wasm_engine(self, node):
+        self.logger.info(
+            f"Begin manually triggered restart of wasm engine on node {node}")
+        node.account.kill_process("bin/node", clean_shutdown=False)
+        # TODO: This sleep is put here to ensure that redpanda will initiate
+        # a failure recovery mechanism. In the event the wasm engine restarts
+        # too quickly, it will have responded to all heartbeats, and redpanda will
+        # falsely think that the state between the wasm engine and itself are
+        # in-sync when they will not be. Github issue #1140 has been filed to keep
+        # track of this issue.
+        time.sleep(3)
+        self.redpanda.start_wasm_engine(node)
+
+    def restart_redpanda(self, node):
+        self.logger.info(
+            f"Begin manually triggered restart of redpanda on node {node}")
+        self.redpanda.restart_nodes(node)
 
     def start(self, topic_spec, scripts, xfactor):
         def to_output_topic_spec(output_topics):


### PR DESCRIPTION
More wasm tests to verify that the failure recovery mode is working as expected. Tests the scenarios where the wasm engine crashes or the entire node (wasm + redpanda) crashes.

During the development of these tests some bugs were found. In this patch are included some recovery specific fixes for wasm. They are at the beginning of the patch series.  