### PR TITLE
rpk: add multiple admin listeners

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -163,7 +163,7 @@ func (r *ConfigMapResource) createConfiguration(
 		Port:    clusterCRPortOrRPKDefault(c.RPCServer.Port, cr.RPCServer.Port),
 	}
 
-	cr.AdminApi.Port = clusterCRPortOrRPKDefault(c.AdminAPI.Port, cr.AdminApi.Port)
+	cr.AdminApi[0].Port = clusterCRPortOrRPKDefault(c.AdminAPI.Port, cr.AdminApi[0].Port)
 	cr.DeveloperMode = c.DeveloperMode
 	cr.Directory = dataDirectory
 	if r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.Enabled {
@@ -188,15 +188,16 @@ func (r *ConfigMapResource) createConfiguration(
 		}
 	}
 	if r.pandaCluster.Spec.Configuration.TLS.AdminAPI.Enabled {
-		cr.AdminApiTLS = config.ServerTLS{
+		adminTLS := config.ServerTLS{
 			KeyFile:           fmt.Sprintf("%s/%s", tlsAdminDir, corev1.TLSPrivateKeyKey),
 			CertFile:          fmt.Sprintf("%s/%s", tlsAdminDir, corev1.TLSCertKey),
 			Enabled:           true,
 			RequireClientAuth: r.pandaCluster.Spec.Configuration.TLS.AdminAPI.RequireClientAuth,
 		}
 		if r.pandaCluster.Spec.Configuration.TLS.AdminAPI.RequireClientAuth {
-			cr.AdminApiTLS.TruststoreFile = fmt.Sprintf("%s/%s", tlsAdminDir, cmetav1.TLSCAKey)
+			adminTLS.TruststoreFile = fmt.Sprintf("%s/%s", tlsAdminDir, cmetav1.TLSCAKey)
 		}
+		cr.AdminApiTLS = append(cr.AdminApiTLS, adminTLS)
 	}
 
 	if r.pandaCluster.Spec.CloudStorage.Enabled {

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.4.5"
+  version: "v21.4.8"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.4.5"
+  version: "v21.4.8"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: update-image-cluster
 spec:
   image: "vectorized/redpanda"
-  version: "v21.4.5"
+  version: "v21.4.8"
   replicas: 2
   resources:
     requests:

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -219,7 +219,7 @@ func CreateNode(
 	}
 	metPort, err := nat.NewPort(
 		"tcp",
-		strconv.Itoa(config.Default().Redpanda.AdminApi.Port),
+		strconv.Itoa(config.DefaultAdminPort),
 	)
 	if err != nil {
 		return nil, err

--- a/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
@@ -86,7 +86,7 @@ especify an arbitrary config file.`,
 A comma-delimited list of the addresses (<host:port>) of all the redpanda nodes
 in a cluster. The port must be the one configured for the nodes' admin API
 (%d by default)`,
-			config.Default().Redpanda.AdminApi.Port,
+			config.DefaultAdminPort,
 		))
 	command.Flags().StringVar(
 		&seedAddr,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -125,7 +125,12 @@ func bootstrap(mgr config.Manager) *cobra.Command {
 				},
 			}}
 
-			conf.Redpanda.AdminApi.Address = ownIp.String()
+			conf.Redpanda.AdminApi = []config.NamedSocketAddress{{
+				SocketAddress: config.SocketAddress{
+					Address: ownIp.String(),
+					Port:    config.DefaultAdminPort,
+				},
+			}}
 			conf.Redpanda.SeedServers = []config.SeedServer{}
 			seeds := []config.SeedServer{}
 			for _, ip := range ips {

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -248,7 +248,7 @@ func TestBootstrap(t *testing.T) {
 
 			require.Equal(t, tt.self, conf.Redpanda.RPCServer.Address)
 			require.Equal(t, tt.self, conf.Redpanda.KafkaApi[0].Address)
-			require.Equal(t, tt.self, conf.Redpanda.AdminApi.Address)
+			require.Equal(t, tt.self, conf.Redpanda.AdminApi[0].Address)
 			if len(tt.ips) == 1 {
 				require.Equal(
 					t,

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -28,6 +28,7 @@ const (
 	ModeProd = "prod"
 
 	DefaultKafkaPort = 9092
+	DefaultAdminPort = 9644
 )
 
 func InitViper(fs afero.Fs) *viper.Viper {
@@ -85,6 +86,11 @@ func defaultMap() map[string]interface{} {
 		"port":    9092,
 	}
 	var defaultListeners []interface{} = []interface{}{defaultListener}
+	var defaultAdminListener interface{} = map[string]interface{}{
+		"address": "0.0.0.0",
+		"port":    9644,
+	}
+	var defaultAdminListeners []interface{} = []interface{}{defaultAdminListener}
 	return map[string]interface{}{
 		"config_file": "/etc/redpanda/redpanda.yaml",
 		"pandaproxy":  Pandaproxy{},
@@ -94,11 +100,8 @@ func defaultMap() map[string]interface{} {
 				"address": "0.0.0.0",
 				"port":    33145,
 			},
-			"kafka_api": defaultListeners,
-			"admin": map[string]interface{}{
-				"address": "0.0.0.0",
-				"port":    9644,
-			},
+			"kafka_api":      defaultListeners,
+			"admin":          defaultAdminListeners,
 			"node_id":        0,
 			"seed_servers":   []interface{}{},
 			"developer_mode": true,

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -211,7 +211,12 @@ func TestDefault(t *testing.T) {
 					9092,
 				},
 			}},
-			AdminApi:      SocketAddress{"0.0.0.0", 9644},
+			AdminApi: []NamedSocketAddress{{
+				SocketAddress: SocketAddress{
+					"0.0.0.0",
+					9644,
+				},
+			}},
 			Id:            0,
 			SeedServers:   []SeedServer{},
 			DeveloperMode: true,
@@ -289,7 +294,7 @@ func TestWrite(t *testing.T) {
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -335,7 +340,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -388,7 +393,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   advertised_rpc_api:
     address: 174.32.64.2
@@ -446,7 +451,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   advertised_kafka_api:
   - address: 174.32.64.2
@@ -499,7 +504,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -553,7 +558,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -597,7 +602,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   admin_api_doc_dir: /usr/share/redpanda/admin-api-doc
   data_directory: /var/lib/redpanda/data
@@ -628,7 +633,7 @@ unrecognized_top_field:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   admin_api_doc_dir: /usr/share/redpanda/admin-api-doc
   data_directory: /var/lib/redpanda/data
@@ -677,7 +682,7 @@ unrecognized_top_field:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   admin_api_doc_dir: /usr/share/redpanda/admin-api-doc
   auto_create_topics_enabled: true
@@ -703,7 +708,7 @@ redpanda:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   admin_api_doc_dir: /usr/share/redpanda/admin-api-doc
   auto_create_topics_enabled: true
@@ -759,7 +764,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -809,13 +814,13 @@ rpk:
 			name: "shall write config with admin tls configuration",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.Redpanda.AdminApiTLS = ServerTLS{
+				c.Redpanda.AdminApiTLS = []ServerTLS{{
 					KeyFile:           "/etc/certs/admin/cert.key",
 					TruststoreFile:    "/etc/certs/admin/ca.crt",
 					CertFile:          "/etc/certs/admin/cert.crt",
 					Enabled:           true,
 					RequireClientAuth: true,
-				}
+				}}
 				return c
 			},
 			wantErr: false,
@@ -823,10 +828,10 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   admin_api_tls:
-    cert_file: /etc/certs/admin/cert.crt
+  - cert_file: /etc/certs/admin/cert.crt
     enabled: true
     key_file: /etc/certs/admin/cert.key
     require_client_auth: true
@@ -880,7 +885,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -971,7 +976,7 @@ pandaproxy:
     truststore_file: /etc/certs/ca.crt
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -1035,7 +1040,7 @@ pandaproxy:
     port: 1234
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -1109,7 +1114,7 @@ pandaproxy_client:
     port: 1234
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -1160,7 +1165,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -1212,7 +1217,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -1284,7 +1289,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   cloud_storage_access_key: access
   cloud_storage_api_endpoint: http
@@ -1348,7 +1353,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -1403,7 +1408,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   data_directory: /var/lib/redpanda/data
   developer_mode: false
@@ -1451,7 +1456,7 @@ rpk:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   admin_api_doc_dir: /usr/share/redpanda/admin-api-doc
   auto_create_topics_enabled: true
@@ -1475,7 +1480,7 @@ redpanda:
 pandaproxy: {}
 redpanda:
   admin:
-    address: 0.0.0.0
+  - address: 0.0.0.0
     port: 9644
   admin_api_doc_dir: /usr/share/redpanda/admin-api-doc
   advertised_kafka_api:
@@ -1825,7 +1830,7 @@ func TestReadAsJSON(t *testing.T) {
 				return mgr.Write(conf)
 			},
 			path:     Default().ConfigFile,
-			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","pandaproxy":{},"redpanda":{"admin":{"address":"0.0.0.0","port":9644},"data_directory":"/var/lib/redpanda/data","developer_mode":true,"kafka_api":[{"address":"0.0.0.0","name":"internal","port":9092}],"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_disk_write_cache":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
+			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","pandaproxy":{},"redpanda":{"admin":[{"address":"0.0.0.0","port":9644}],"data_directory":"/var/lib/redpanda/data","developer_mode":true,"kafka_api":[{"address":"0.0.0.0","name":"internal","port":9092}],"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_disk_write_cache":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
 		},
 		{
 			name:           "it should fail if the the config isn't found",
@@ -1855,7 +1860,17 @@ func TestReadFlat(t *testing.T) {
 	expected := map[string]string{
 		"config_file":                                  "/etc/redpanda/redpanda.yaml",
 		"pandaproxy":                                   "",
-		"redpanda.admin":                               "0.0.0.0:9644",
+		"redpanda.admin.0":                             "internal://192.168.92.34:9644",
+		"redpanda.admin.1":                             "127.0.0.1:9645",
+		"redpanda.admin_api_tls.0.cert_file":           "some/cert/file.crt",
+		"redpanda.admin_api_tls.0.key_file":            "/some/key/file.pem",
+		"redpanda.admin_api_tls.0.name":                "internal",
+		"redpanda.admin_api_tls.1.cert_file":           "some/other/cert.crt",
+		"redpanda.admin_api_tls.1.enabled":             "true",
+		"redpanda.admin_api_tls.1.key_file":            "/some/other/file.pem",
+		"redpanda.admin_api_tls.1.name":                "external",
+		"redpanda.admin_api_tls.1.truststore_file":     "/some/other/truststore.pem",
+		"redpanda.admin_api_tls.1.require_client_auth": "true",
 		"redpanda.advertised_kafka_api.0":              "internal://127.0.0.1:9092",
 		"redpanda.advertised_kafka_api.1":              "127.0.0.1:9093",
 		"redpanda.data_directory":                      "/var/lib/redpanda/data",
@@ -1929,6 +1944,32 @@ func TestReadFlat(t *testing.T) {
 	}}
 
 	conf.Redpanda.KafkaApiTLS = []ServerTLS{{
+		Name:     "internal",
+		KeyFile:  "/some/key/file.pem",
+		CertFile: "some/cert/file.crt",
+	}, {
+		Name:              "external",
+		KeyFile:           "/some/other/file.pem",
+		CertFile:          "some/other/cert.crt",
+		TruststoreFile:    "/some/other/truststore.pem",
+		Enabled:           true,
+		RequireClientAuth: true,
+	}}
+
+	conf.Redpanda.AdminApi = []NamedSocketAddress{{
+		SocketAddress: SocketAddress{
+			Address: "192.168.92.34",
+			Port:    9644,
+		},
+		Name: "internal",
+	}, {
+		SocketAddress: SocketAddress{
+			Address: "127.0.0.1",
+			Port:    9645,
+		},
+	}}
+
+	conf.Redpanda.AdminApiTLS = []ServerTLS{{
 		Name:     "internal",
 		KeyFile:  "/some/key/file.pem",
 		CertFile: "some/cert/file.crt",

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -147,7 +147,6 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 	flatMap := map[string]string{}
 	compactAddrFields := []string{
 		"redpanda.rpc_server",
-		"redpanda.admin",
 	}
 	for _, k := range keys {
 		if k == "redpanda.seed_servers" {
@@ -166,7 +165,7 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 			}
 			continue
 		}
-		if k == "redpanda.advertised_kafka_api" || k == "redpanda.kafka_api" {
+		if k == "redpanda.advertised_kafka_api" || k == "redpanda.kafka_api" || k == "redpanda.admin" {
 			addrs := []NamedSocketAddress{}
 			err := unmarshalKey(m.v, k, &addrs)
 			if err != nil {
@@ -186,7 +185,7 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 			}
 			continue
 		}
-		if k == "redpanda.kafka_api_tls" {
+		if k == "redpanda.kafka_api_tls" || k == "redpanda.admin_api_tls" {
 			tlss := []map[string]interface{}{}
 			err := unmarshalKey(m.v, k, &tlss)
 			if err != nil {

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -31,8 +31,8 @@ type RedpandaConfig struct {
 	KafkaApi                             []NamedSocketAddress   `yaml:"kafka_api" mapstructure:"kafka_api" json:"kafkaApi"`
 	AdvertisedKafkaApi                   []NamedSocketAddress   `yaml:"advertised_kafka_api,omitempty" mapstructure:"advertised_kafka_api,omitempty" json:"advertisedKafkaApi,omitempty"`
 	KafkaApiTLS                          []ServerTLS            `yaml:"kafka_api_tls,omitempty" mapstructure:"kafka_api_tls,omitempty" json:"kafkaApiTls"`
-	AdminApi                             SocketAddress          `yaml:"admin" mapstructure:"admin" json:"admin"`
-	AdminApiTLS                          ServerTLS              `yaml:"admin_api_tls,omitempty" mapstructure:"admin_api_tls,omitempty" json:"adminApiTls"`
+	AdminApi                             []NamedSocketAddress   `yaml:"admin" mapstructure:"admin" json:"admin"`
+	AdminApiTLS                          []ServerTLS            `yaml:"admin_api_tls,omitempty" mapstructure:"admin_api_tls,omitempty" json:"adminApiTls"`
 	Id                                   int                    `yaml:"node_id" mapstructure:"node_id" json:"id"`
 	SeedServers                          []SeedServer           `yaml:"seed_servers" mapstructure:"seed_servers" json:"seedServers"`
 	DeveloperMode                        bool                   `yaml:"developer_mode" mapstructure:"developer_mode" json:"developerMode"`


### PR DESCRIPTION
## Cover letter

Change from single admin listener (and TLS) to list of named admin listeners (and TLS).

Note: tests are failing because the "latest" redpanda image doesn't include multiple admin listeners in the rpk schema (this change adds that).