### PR TITLE
WIP: Improve ctest

### DIFF
--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ rp_test(
     segment_size_jitter_test.cc
     log_segment_reader_test.cc
     log_manager_test.cc
-    offset_assignment_test
+    offset_assignment_test.cc
     storage_e2e_test.cc
     log_truncate_test.cc
     offset_index_utils_tests.cc

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ rp_test(
     directory_walker_test.cc
     outcome_utils_test.cc
     base64_test.cc
-    timed_mutex_test
+    timed_mutex_test.cc
   LIBRARIES v::seastar_testing_main v::utils v::bytes
   ARGS "-- -c 1"
   LABELS utils


### PR DESCRIPTION
## Cover letter

Combining many tests into the same binary makes it much harder to find the actual failure in the log.

Run each test individually in CTest by registering each test with CTest rather than the combined test binary.

Some of this is based on https://eb2.co/blog/2015/06/driving-boost.test-with-cmake/

This is a bit fragile:
* There are many test definition functions
  * `BOOST_AUTO_TEST_CASE`
  * `BOOST_DATA_TEST_CASE`
  * `SEASTAR_TEST_CASE`
  * `SEASTAR_THEAD_TEST_CASE`
  * `FIXTURE_TEST`
* `BOOST_AUTO_TEST_CASE_TEMPLATE` doesn't work, because each type is registered separately (could add a `*` )
* Some tests don't seem to be registered properly

There are about 70 failures of ~671 tests, and some tests might not be included due to missing a regex.

At least some of those failures are due to the test not being registered with the internal boost runner, e.g., `bin/model_thread_rpunit` doesn't have `SEASTAR_THREAD_TEST_CASE(set_max_timestamp)`


An alternative approach is to query the test binary for its tests with `--list_content`, but that doesn't explain why some tests aren't registered. This could be done in the python test runner, which might be easier than in cmake.