### PR TITLE
operator/admin: create internal and external admin listeners

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -230,5 +230,19 @@ func (r *Cluster) checkCollidingPorts() field.ErrorList {
 				"admin port collide with external Kafka API that is not visible in the Cluster CR"))
 	}
 
+	if r.Spec.ExternalConnectivity.Enabled && r.Spec.Configuration.AdminAPI.Port+1 == r.Spec.Configuration.RPCServer.Port {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec").Child("configuration", "rpcServer", "port"),
+				r.Spec.Configuration.RPCServer.Port,
+				"rpc port collides with external Admin API port that is not visible in the Cluster CR"))
+	}
+
+	if r.Spec.ExternalConnectivity.Enabled && r.Spec.Configuration.AdminAPI.Port+1 == r.Spec.Configuration.KafkaAPI.Port {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec").Child("configuration", "kafka", "port"),
+				r.Spec.Configuration.KafkaAPI.Port,
+				"kafka port collides with external Admin API port that is not visible in the Cluster CR"))
+	}
+
 	return allErrs
 }

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -175,6 +175,28 @@ func TestValidateUpdate_NoError(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("collision in the port when external connectivity is enabled", func(t *testing.T) {
+		updatePort := redpandaCluster.DeepCopy()
+		updatePort.Spec.ExternalConnectivity.Enabled = true
+		updatePort.Spec.Configuration.KafkaAPI.Port = 200
+		updatePort.Spec.Configuration.AdminAPI.Port = 300
+		updatePort.Spec.Configuration.RPCServer.Port = 301
+
+		err := updatePort.ValidateUpdate(redpandaCluster)
+		assert.Error(t, err)
+	})
+
+	t.Run("collision in the port when external connectivity is enabled", func(t *testing.T) {
+		updatePort := redpandaCluster.DeepCopy()
+		updatePort.Spec.ExternalConnectivity.Enabled = true
+		updatePort.Spec.Configuration.KafkaAPI.Port = 201
+		updatePort.Spec.Configuration.AdminAPI.Port = 200
+		updatePort.Spec.Configuration.RPCServer.Port = 300
+
+		err := updatePort.ValidateUpdate(redpandaCluster)
+		assert.Error(t, err)
+	})
+
 	t.Run("requireclientauth true and tls enabled", func(t *testing.T) {
 		tls := redpandaCluster.DeepCopy()
 		tls.Spec.Configuration.TLS.KafkaAPI.RequireClientAuth = true
@@ -244,6 +266,28 @@ func TestCreation(t *testing.T) {
 		newPort.Spec.Configuration.KafkaAPI.Port = 200
 		newPort.Spec.Configuration.AdminAPI.Port = 300
 		newPort.Spec.Configuration.RPCServer.Port = 201
+
+		err := newPort.ValidateCreate()
+		assert.Error(t, err)
+	})
+
+	t.Run("collision in the port when external connectivity is enabled", func(t *testing.T) {
+		newPort := redpandaCluster.DeepCopy()
+		newPort.Spec.ExternalConnectivity.Enabled = true
+		newPort.Spec.Configuration.KafkaAPI.Port = 200
+		newPort.Spec.Configuration.AdminAPI.Port = 300
+		newPort.Spec.Configuration.RPCServer.Port = 301
+
+		err := newPort.ValidateCreate()
+		assert.Error(t, err)
+	})
+
+	t.Run("collision in the port when external connectivity is enabled", func(t *testing.T) {
+		newPort := redpandaCluster.DeepCopy()
+		newPort.Spec.ExternalConnectivity.Enabled = true
+		newPort.Spec.Configuration.KafkaAPI.Port = 201
+		newPort.Spec.Configuration.AdminAPI.Port = 200
+		newPort.Spec.Configuration.RPCServer.Port = 300
 
 		err := newPort.ValidateCreate()
 		assert.Error(t, err)

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -95,6 +95,7 @@ func TestValidateUpdate(t *testing.T) {
 	}
 }
 
+// nolint:funlen // consider splitting tests
 func TestValidateUpdate_NoError(t *testing.T) {
 	var replicas2 int32 = 2
 
@@ -207,6 +208,7 @@ func TestValidateUpdate_NoError(t *testing.T) {
 	})
 }
 
+// nolint:funlen // consider splitting tests
 func TestCreation(t *testing.T) {
 	redpandaCluster := &v1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -94,7 +94,7 @@ func (r *ClusterReconciler) Reconcile(
 	}
 	nodeports := []resources.NamedServicePort{
 		{Name: resources.AdminPortName, Port: redpandaCluster.Spec.Configuration.AdminAPI.Port + 1},
-		{Name: resources.KafkaPortName, Port: redpandaCluster.Spec.Configuration.KafkaAPI.Port},
+		{Name: resources.KafkaPortName, Port: redpandaCluster.Spec.Configuration.KafkaAPI.Port + 1},
 	}
 	headlessSvc := resources.NewHeadlessService(r.Client, &redpandaCluster, r.Scheme, headlessPorts, log)
 	nodeportSvc := resources.NewNodePortService(r.Client, &redpandaCluster, r.Scheme, nodeports, log)

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -88,12 +88,16 @@ func (r *ClusterReconciler) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("unable to retrieve Cluster resource: %w", err)
 	}
 
-	ports := []resources.NamedServicePort{
+	headlessPorts := []resources.NamedServicePort{
 		{Name: resources.AdminPortName, Port: redpandaCluster.Spec.Configuration.AdminAPI.Port},
 		{Name: resources.KafkaPortName, Port: redpandaCluster.Spec.Configuration.KafkaAPI.Port},
 	}
-	headlessSvc := resources.NewHeadlessService(r.Client, &redpandaCluster, r.Scheme, ports, log)
-	nodeportSvc := resources.NewNodePortService(r.Client, &redpandaCluster, r.Scheme, ports, log)
+	nodeports := []resources.NamedServicePort{
+		{Name: resources.AdminPortName, Port: redpandaCluster.Spec.Configuration.AdminAPI.Port + 1},
+		{Name: resources.KafkaPortName, Port: redpandaCluster.Spec.Configuration.KafkaAPI.Port},
+	}
+	headlessSvc := resources.NewHeadlessService(r.Client, &redpandaCluster, r.Scheme, headlessPorts, log)
+	nodeportSvc := resources.NewNodePortService(r.Client, &redpandaCluster, r.Scheme, nodeports, log)
 
 	pki := certmanager.NewPki(r.Client, &redpandaCluster, headlessSvc.HeadlessServiceFQDN(), r.Scheme, log)
 	sa := resources.NewServiceAccount(r.Client, &redpandaCluster, r.Scheme, log)

--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -146,7 +146,7 @@ var _ = Describe("RedPandaCluster controller", func() {
 				return err == nil &&
 					svc.Spec.Type == corev1.ServiceTypeNodePort &&
 					findPort(svc.Spec.Ports, res.KafkaPortName) == kafkaPort+1 &&
-					findPort(svc.Spec.Ports, res.AdminPortName) == adminPort &&
+					findPort(svc.Spec.Ports, res.AdminPortName) == adminPort+1 &&
 					validOwner(redpandaCluster, svc.OwnerReferences)
 			}, timeout, interval).Should(BeTrue())
 

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -40,6 +40,9 @@ const (
 
 	oneMB          = 1024 * 1024
 	logSegmentSize = 512 * oneMB
+
+	internal = "Internal"
+	external = "External"
 )
 
 var errKeyDoesNotExistInSecretData = errors.New("cannot find key in secret data")
@@ -164,6 +167,18 @@ func (r *ConfigMapResource) createConfiguration(
 	}
 
 	cr.AdminApi[0].Port = clusterCRPortOrRPKDefault(c.AdminAPI.Port, cr.AdminApi[0].Port)
+	cr.AdminApi[0].Name = internal
+	if r.pandaCluster.Spec.ExternalConnectivity.Enabled {
+		externalAdminAPI := config.NamedSocketAddress{
+			SocketAddress: config.SocketAddress{
+				Address: cr.AdminApi[0].Address,
+				Port:    cr.AdminApi[0].Port + 1,
+			},
+			Name: external,
+		}
+		cr.AdminApi = append(cr.AdminApi, externalAdminAPI)
+	}
+
 	cr.DeveloperMode = c.DeveloperMode
 	cr.Directory = dataDirectory
 	if r.pandaCluster.Spec.Configuration.TLS.KafkaAPI.Enabled {
@@ -188,7 +203,12 @@ func (r *ConfigMapResource) createConfiguration(
 		}
 	}
 	if r.pandaCluster.Spec.Configuration.TLS.AdminAPI.Enabled {
+		name := internal
+		if r.pandaCluster.Spec.ExternalConnectivity.Enabled {
+			name = external
+		}
 		adminTLS := config.ServerTLS{
+			Name:              name,
 			KeyFile:           fmt.Sprintf("%s/%s", tlsAdminDir, corev1.TLSPrivateKeyKey),
 			CertFile:          fmt.Sprintf("%s/%s", tlsAdminDir, corev1.TLSCertKey),
 			Enabled:           true,

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -73,9 +73,6 @@ func (r *NodePortServiceResource) Ensure(ctx context.Context) error {
 func (r *NodePortServiceResource) obj() (k8sclient.Object, error) {
 	ports := make([]corev1.ServicePort, 0, len(r.svcPorts))
 	for _, svcPort := range r.svcPorts {
-		if svcPort.Name == "kafka" {
-			svcPort.Port++
-		}
 		ports = append(ports, corev1.ServicePort{
 			Name:       svcPort.Name,
 			Protocol:   corev1.ProtocolTCP,

--- a/src/go/k8s/tests/e2e/admin-api/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cluster
+status:
+  readyReplicas: 1

--- a/src/go/k8s/tests/e2e/admin-api/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/admin-api/00-redpanda-cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster
+spec:
+  image: "vectorized/redpanda"
+  version: "latest"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+      port: 9092
+    admin:
+      port: 9644
+    developerMode: true

--- a/src/go/k8s/tests/e2e/admin-api/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api/01-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: call-admin-api
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/admin-api/01-call-adminapi.yaml
+++ b/src/go/k8s/tests/e2e/admin-api/01-call-adminapi.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: call-admin-api
+spec:
+  template:
+    spec:
+      containers:
+        - name: curl
+          image: curlimages/curl:latest
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/sh
+            - -c
+            - -ex
+          args:
+            - curl http://cluster-0.cluster.$POD_NAMESPACE.svc.cluster.local:9644/metrics -v
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1


### PR DESCRIPTION
## Cover letter

This change ensures the operator creates an internal and an external Admin API listener (if external connectivity is enabled). In that case, the internal one has no TLS, whereas the external one has TLS enabled (if TLS is broadly enabled). If there is no external connectivity, the TLS configuration is applied on the internal listener (as with the Kafka API).

Notes
once #1114 is merged, the same restructuring can happen with the Admin API. The current PR follows the existing approach of not exposing internal/external options in the Cluster CRD.

## Release notes

Admin API has internal and external listener (if external connectivity is enabled). TLS can be enabled for the external one.