### PR TITLE
Rpk acl

### DIFF
--- a/docs/www/rpk-commands.md
+++ b/docs/www/rpk-commands.md
@@ -116,8 +116,14 @@ Interact with the Redpanda API to work with topics.
 The global flags for the `rpk topic` command are:
 
 ```cmd
-      --brokers strings   Comma-separated list of broker 'ip:port' pairs
-      --config string     Redpanda config file, if not set the file will be searched for in the default locations
+      --brokers strings         Comma-separated list of broker ip:port pairs
+      --config string           Redpanda config file, if not set the file will be searched for in the default locations
+      --user string             SASL user to be used for authentication.
+      --password string         SASL password to be used for authentication.
+      --sasl-mechanism string   The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+      --tls-cert string         The certificate to be used for TLS authentication with the broker.
+      --tls-key string          The certificate key to be used for TLS authentication with the broker.
+      --tls-truststore string   The truststore to be used for TLS communication with the broker.
 ```
 
 ### topic create
@@ -227,6 +233,180 @@ Stop and remove an existing local container cluster's data
 Usage:
   rpk container purge [flags]
 ```
+
+## acl
+
+Manage ACLs
+
+The global flags for `rpk acl` are:
+```cmd
+      --brokers strings         Comma-separated list of broker ip:port pairs
+      --config string           Redpanda config file, if not set the file will be searched for in the default locations
+      --password string         SASL password to be used for authentication.
+      --sasl-mechanism string   The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+      --tls-cert string         The certificate to be used for TLS authentication with the broker.
+      --tls-key string          The certificate key to be used for TLS authentication with the broker.
+      --tls-truststore string   The truststore to be used for TLS communication with the broker.
+      --user string             SASL user to be used for authentication.
+  -v, --verbose                 enable verbose logging (default false)
+```
+
+### acl create
+
+Create ACLs
+
+```cmd
+Usage:
+  rpk acl create [flags]
+
+Flags:
+      --allow-host strings        Host from which access will be granted. Can be passed many times.
+      --allow-principal strings   Principal to which permissions will be granted. Can be passed many times.
+      --deny-host strings         Host from which access will be denied. Can be passed many times.
+      --deny-principal strings    Principal to which permissions will be denied. Can be passed many times.
+      --name-pattern string       The name pattern type to be used when matching the resource names. Supported values: any, match, literal, prefixed. (default "literal")
+      --operation strings         Operation that the principal will be allowed or denied. Can be passed many times. Supported values: any, all, read, write, create, delete, alter, describe, clusteraction, describeconfigs, alterconfigs, idempotentwrite.
+      --resource string           The target resource for the ACL. Supported values: *, cluster, group, topic, transactionalid.
+      --resource-name string      The name of the target resource for the ACL.
+```
+
+### acl delete
+
+Delete ACLs
+
+```cmd
+Usage:
+  rpk acl delete [flags]
+
+Flags:
+      --allow-host strings        Host from which access will be granted. Can be passed many times.
+      --allow-principal strings   Principal to which permissions will be granted. Can be passed many times.
+      --deny-host strings         Host from which access will be denied. Can be passed many times.
+      --deny-principal strings    Principal to which permissions will be denied. Can be passed many times.
+      --name-pattern string       The name pattern type to be used when matching the resource names. Supported values: any, match, literal, prefixed. (default "literal")
+      --operation strings         Operation that the principal will be allowed or denied. Can be passed many times. Supported values: any, all, read, write, create, delete, alter, describe, clusteraction, describeconfigs, alterconfigs, idempotentwrite.
+      --resource string           The target resource for the ACL. Supported values: *, cluster, group, topic, transactionalid.
+      --resource-name string      The name of the target resource for the ACL.
+```
+
+### acl list
+
+List ACLs
+
+```cmd
+Usage:
+  rpk acl list [flags]
+
+Aliases:
+  list, ls
+
+Flags:
+      --host strings           Host to filter by. Can be passed multiple times to filter by many hosts.
+      --name-pattern string    The name pattern type to be used when matching affected resources. Supported values: any, match, literal, prefixed.
+      --operation strings      Operation to filter by. Can be passed multiple times to filter by many operations. Supported values: any, all, read, write, create, delete, alter, describe, clusteraction, describeconfigs, alterconfigs, idempotentwrite.
+      --permission strings     Permission to filter by. Can be passed many times to filter by multiple permission types. Supported values: any, deny, allow.
+      --principal strings      Principal to filter by. Can be passed multiple times to filter by many principals.
+      --resource string        Resource type to filter by. Supported values: *, cluster, group, topic, transactionalid.
+      --resource-name string   The name of the resource of the given type.
+```
+
+### acl user
+
+Manage users
+
+The global flags for `rpk acl user` are:
+
+```cmd
+      --api-url string   The Admin API URL (default "localhost:9644")
+```
+
+#### acl user create
+
+Create users
+
+```cmd
+Usage:
+  rpk acl user create [flags]
+
+Flags:
+      --new-password string   The new user's password
+      --new-username string   The user to be created
+```
+
+#### acl user delete
+
+Delete users
+
+```cmd
+Usage:
+  rpk acl user delete [flags]
+
+Flags:
+      --delete-username string   The user to be deleted
+```
+
+#### acl user list
+
+List users
+
+```cmd
+List users
+
+Usage:
+  rpk acl user list [flags]
+
+Aliases:
+  list, ls
+```
+
+## wasm
+
+Deploy and remove inline WASM engine scripts
+
+The global flags for `rpk wasm` are:
+```cmd
+      --brokers strings         Comma-separated list of broker ip:port pairs
+      --config string           Redpanda config file, if not set the file will be searched for in the default locations
+      --password string         SASL password to be used for authentication.
+      --sasl-mechanism string   The authentication mechanism to use. Supported values: SCRAM-SHA-256, SCRAM-SHA-512.
+      --tls-cert string         The certificate to be used for TLS authentication with the broker.
+      --tls-key string          The certificate key to be used for TLS authentication with the broker.
+      --tls-truststore string   The truststore to be used for TLS communication with the broker.
+      --user string             SASL user to be used for authentication.
+  -v, --verbose                 enable verbose logging (default false)
+```
+
+### wasm generate
+
+Create an npm template project for the inline WASM engine
+
+```cmd
+Usage:
+  rpk wasm generate <project directory> [flags]
+```
+
+
+### wasm deploy
+
+Deploy inline WASM scripts
+
+```cmd
+Usage:
+  rpk wasm deploy <path> [flags]
+
+Flags:
+      --description string   Optional description about what the wasm function does, for reference.
+```
+
+### wasm remove
+
+Remove an inline WASM script
+
+```cmd
+Usage:
+  rpk wasm remove <name> [flags]
+```
+
 
 ## iotune
 

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -14,8 +14,10 @@ github.com/Shopify/sarama v1.28.1-0.20210318150015-41df78df10a9/go.mod h1:RvHIxP
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/avast/retry-go v2.6.0+incompatible h1:FelcMrm7Bxacr1/RM8+/eqkDkmVN7tjlsy51dOzB3LI=
@@ -418,6 +420,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -1,0 +1,174 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/prometheus/common/log"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	vtls "github.com/vectorizedio/redpanda/src/go/rpk/pkg/tls"
+)
+
+const (
+	usersEndpoint = "/v1/security/users"
+	httpPrefix    = "http://"
+	httpsPrefix   = "https://"
+)
+
+type AdminAPI interface {
+	CreateUser(username, password string) error
+	DeleteUser(username string) error
+	ListUsers() ([]string, error)
+}
+
+type adminAPI struct {
+	url    string
+	client *http.Client
+}
+
+type newUser struct {
+	User      string `json:"username"`
+	Password  string `json:"password"`
+	Algorithm string `json:"algorithm"`
+}
+
+func NewAdminAPI(url string, tlsConf *config.TLS) (AdminAPI, error) {
+	var err error
+
+	// Go's http library requires that the URL have a protocol.
+	if !(strings.HasPrefix(url, httpPrefix) ||
+		strings.HasPrefix(url, httpsPrefix)) {
+
+		prefix := httpPrefix
+
+		if tlsConf != nil {
+			// If TLS will be enabled, use HTTPS as the protocol
+			prefix = httpsPrefix
+		}
+
+		url = strings.TrimRight(url, "/")
+		url = fmt.Sprintf("%s%s", prefix, url)
+	}
+
+	var tlsConfig *tls.Config
+	if tlsConf != nil {
+		tlsConfig, err = vtls.BuildTLSConfig(
+			tlsConf.CertFile,
+			tlsConf.KeyFile,
+			tlsConf.TruststoreFile,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	client := &http.Client{Transport: tr}
+	return &adminAPI{url: url, client: client}, nil
+}
+
+func (a *adminAPI) CreateUser(username, password string) error {
+	if username == "" {
+		return errors.New("empty username")
+	}
+	if password == "" {
+		return errors.New("empty password")
+	}
+	u := newUser{
+		User:      username,
+		Password:  password,
+		Algorithm: sarama.SASLTypeSCRAMSHA256,
+	}
+	url := fmt.Sprintf("%s%s", a.url, usersEndpoint)
+	_, err := send(url, http.MethodPost, u, a.client)
+	return err
+}
+
+func (a *adminAPI) DeleteUser(username string) error {
+	if username == "" {
+		return errors.New("empty username")
+	}
+	url := fmt.Sprintf("%s%s/%s", a.url, usersEndpoint, username)
+	_, err := send(url, http.MethodDelete, nil, a.client)
+	return err
+}
+
+func (a *adminAPI) ListUsers() ([]string, error) {
+	url := fmt.Sprintf("%s%s", a.url, usersEndpoint)
+	res, err := send(url, http.MethodGet, nil, a.client)
+	if err != nil {
+		return nil, err
+	}
+	bs, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	usernames := []string{}
+	err = json.Unmarshal(bs, &usernames)
+	return usernames, err
+}
+
+func send(
+	url, method string, body interface{}, client *http.Client,
+) (*http.Response, error) {
+	var bodyBuffer io.Reader
+	if body != nil {
+		bs, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't encode request: %v", err)
+		}
+		bodyBuffer = bytes.NewBuffer(bs)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		method,
+		url,
+		bodyBuffer,
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+
+	if res != nil && res.StatusCode >= 400 {
+		resBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			log.Error(err)
+		}
+		return res, fmt.Errorf(
+			"Request failed with status %d: %s",
+			res.StatusCode,
+			string(resBody),
+		)
+	}
+
+	return res, err
+}

--- a/src/go/rpk/pkg/api/admin/admin_test.go
+++ b/src/go/rpk/pkg/api/admin/admin_test.go
@@ -1,0 +1,79 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateUser(t *testing.T) {
+	username := "Joss"
+	password := "momorocks"
+	algorithm := sarama.SASLTypeSCRAMSHA256
+	body := newUser{
+		User:      username,
+		Password:  password,
+		Algorithm: algorithm,
+	}
+	bs, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, err := ioutil.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Exactly(t, bs, b)
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	defer ts.Close()
+
+	adminClient, err := NewAdminAPI(ts.URL, nil)
+	err = adminClient.CreateUser(username, password)
+	require.NoError(t, err)
+}
+
+func TestDeleteUser(t *testing.T) {
+	username := "Lola"
+
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Exactly(t, "/v1/security/users/Lola", r.URL.Path)
+		}),
+	)
+	defer ts.Close()
+
+	adminClient, err := NewAdminAPI(ts.URL, nil)
+	err = adminClient.DeleteUser(username)
+	require.NoError(t, err)
+}
+
+func TestListUsers(t *testing.T) {
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(
+				`["Joss", "lola", "jeff", "tobias"]`,
+			))
+		}),
+	)
+	defer ts.Close()
+
+	adminClient, err := NewAdminAPI(ts.URL, nil)
+	users, err := adminClient.ListUsers()
+	require.NoError(t, err)
+	require.Exactly(t, []string{"Joss", "lola", "jeff", "tobias"}, users)
+}

--- a/src/go/rpk/pkg/api/admin/mock.go
+++ b/src/go/rpk/pkg/api/admin/mock.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+type MockAdminAPI struct {
+	MockCreateUser func(username, password string) error
+	MockDeleteUser func(username string) error
+	MockListUsers  func() ([]string, error)
+}
+
+func (m *MockAdminAPI) CreateUser(username, password string) error {
+	if m.MockCreateUser != nil {
+		return m.MockCreateUser(username, password)
+	}
+	return nil
+}
+
+func (m *MockAdminAPI) DeleteUser(username string) error {
+	if m.MockDeleteUser != nil {
+		return m.MockDeleteUser(username)
+	}
+	return nil
+}
+
+func (m *MockAdminAPI) ListUsers() ([]string, error) {
+	if m.MockListUsers != nil {
+		return m.MockListUsers()
+	}
+	return []string{}, nil
+}

--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -51,5 +51,6 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 
 	command.AddCommand(acl.NewCreateACLsCommand(adminClosure))
 	command.AddCommand(acl.NewListACLsCommand(adminClosure))
+	command.AddCommand(acl.NewDeleteACLsCommand(adminClosure))
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -52,12 +52,13 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	tlsClosure := common.BuildTLSConfig(&certFile, &keyFile, &truststoreFile)
+	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 
 	command.AddCommand(acl.NewCreateACLsCommand(adminClosure))
 	command.AddCommand(acl.NewListACLsCommand(adminClosure))
 	command.AddCommand(acl.NewDeleteACLsCommand(adminClosure))
+	command.AddCommand(acl.NewUserCommand(tlsClosure))
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -19,11 +19,14 @@ import (
 
 func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
-		brokers    []string
-		configFile string
-		user       string
-		password   string
-		mechanism  string
+		brokers        []string
+		configFile     string
+		user           string
+		password       string
+		mechanism      string
+		certFile       string
+		keyFile        string
+		truststoreFile string
 	)
 	command := &cobra.Command{
 		Use:          "acl",
@@ -37,6 +40,9 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&user,
 		&password,
 		&mechanism,
+		&certFile,
+		&keyFile,
+		&truststoreFile,
 		&brokers,
 	)
 
@@ -47,7 +53,8 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&brokers,
 	)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
-	adminClosure := common.CreateAdmin(brokersClosure, configClosure, kAuthClosure)
+	tlsClosure := common.BuildTLSConfig(&certFile, &keyFile, &truststoreFile)
+	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 
 	command.AddCommand(acl.NewCreateACLsCommand(adminClosure))
 	command.AddCommand(acl.NewListACLsCommand(adminClosure))

--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -50,5 +50,6 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, kAuthClosure)
 
 	command.AddCommand(acl.NewCreateACLsCommand(adminClosure))
+	command.AddCommand(acl.NewListACLsCommand(adminClosure))
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -1,0 +1,54 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cmd
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/acl"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+)
+
+func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
+	var (
+		brokers    []string
+		configFile string
+		user       string
+		password   string
+		mechanism  string
+	)
+	command := &cobra.Command{
+		Use:          "acl",
+		Short:        "Manage ACLs",
+		SilenceUsage: true,
+	}
+
+	common.AddKafkaFlags(
+		command,
+		&configFile,
+		&user,
+		&password,
+		&mechanism,
+		&brokers,
+	)
+
+	configClosure := common.FindConfigFile(mgr, &configFile)
+	brokersClosure := common.DeduceBrokers(
+		common.CreateDockerClient,
+		configClosure,
+		&brokers,
+	)
+	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
+	adminClosure := common.CreateAdmin(brokersClosure, configClosure, kAuthClosure)
+
+	command.AddCommand(acl.NewCreateACLsCommand(adminClosure))
+	return command
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/common.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/common.go
@@ -1,0 +1,128 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	"github.com/hashicorp/go-multierror"
+)
+
+const (
+	resourceFlag       = "resource"
+	resourceNameFlag   = "resource-name"
+	namePatternFlag    = "name-pattern"
+	allowPrincipalFlag = "allow-principal"
+	allowHostFlag      = "allow-host"
+	denyPrincipalFlag  = "deny-principal"
+	denyHostFlag       = "deny-host"
+	operationFlag      = "operation"
+
+	defaultClusterResourceName = "kafka-cluster"
+)
+
+// These need to match the ones in Sarama:
+// https://github.com/Shopify/sarama/blob/41df78df10a9ef3c807cbe1f2814001e330fbdf1/acl_types.go#L172-L176
+func supportedResources() []string {
+	return []string{"any", "cluster", "group", "topic", "transactionalid"}
+}
+
+// These need to match the ones in Sarama:
+// https://github.com/Shopify/sarama/blob/41df78df10a9ef3c807cbe1f2814001e330fbdf1/acl_types.go#L200-L203
+func supportedPatterns() []string {
+	return []string{"any", "match", "literal", "prefixed"}
+}
+
+// These need to match the ones in Sarama:
+// https://github.com/Shopify/sarama/blob/41df78df10a9ef3c807cbe1f2814001e330fbdf1/acl_types.go#L68-L79
+func supportedOperations() []string {
+	return []string{
+		"any",
+		"all",
+		"read",
+		"write",
+		"create",
+		"delete",
+		"alter",
+		"describe",
+		"clusteraction",
+		"describeconfigs",
+		"alterconfigs",
+		"idempotentwrite",
+	}
+}
+
+// These need to match the ones in Sarama:
+// https://github.com/Shopify/sarama/blob/41df78df10a9ef3c807cbe1f2814001e330fbdf1/acl_types.go#L68-L79
+func supportedPermissions() []string {
+	return []string{"any", "deny", "allow"}
+}
+
+func parseOperations(operations []string) ([]sarama.AclOperation, error) {
+	var errs error
+	var ops []sarama.AclOperation
+	for _, operation := range operations {
+		var op sarama.AclOperation
+		err := op.UnmarshalText([]byte(operation))
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+		ops = append(ops, op)
+	}
+	if errs != nil {
+		return nil, errs
+	}
+	return ops, nil
+}
+
+func parsePermissions(
+	permissions []string,
+) ([]sarama.AclPermissionType, error) {
+	var errs error
+	var perms []sarama.AclPermissionType
+	for _, p := range permissions {
+		var perm sarama.AclPermissionType
+		err := perm.UnmarshalText([]byte(p))
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+		perms = append(perms, perm)
+	}
+	if errs != nil {
+		return nil, errs
+	}
+	return perms, nil
+}
+
+func checkSupported(supported []string, val string, flag string) error {
+	if val == "" {
+		return fmt.Errorf(
+			"--%s can't be empty. Supported values: %s.",
+			flag,
+			strings.Join(supported, ", "),
+		)
+	}
+	val = strings.ToLower(val)
+	for _, s := range supported {
+		if val == s {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"invalid %s '%s'. Supported values: %s.",
+		flag,
+		val,
+		strings.Join(supported, ", "),
+	)
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/common_test.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl
+
+import (
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOperations(t *testing.T) {
+	tests := []struct {
+		name           string
+		operations     []string
+		expected       []sarama.AclOperation
+		expectedErrMsg string
+	}{{
+		name:       "it should parse valid operations",
+		operations: supportedOperations(),
+		expected: []sarama.AclOperation{
+			sarama.AclOperationAny,
+			sarama.AclOperationAll,
+			sarama.AclOperationRead,
+			sarama.AclOperationWrite,
+			sarama.AclOperationCreate,
+			sarama.AclOperationDelete,
+			sarama.AclOperationAlter,
+			sarama.AclOperationDescribe,
+			sarama.AclOperationClusterAction,
+			sarama.AclOperationDescribeConfigs,
+			sarama.AclOperationAlterConfigs,
+			sarama.AclOperationIdempotentWrite,
+		},
+	}, {
+		name:           "it should fail if there's an invalid operation",
+		operations:     []string{"write", "describe", "mycatiswalkingonmykeyboard"},
+		expectedErrMsg: "1 error occurred:\n\t* no acl operation with name mycatiswalkingonmykeyboard\n\n",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			res, err := parseOperations(tt.operations)
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.Exactly(st, tt.expected, res)
+		})
+	}
+}
+
+func TestParsePermissions(t *testing.T) {
+	tests := []struct {
+		name           string
+		permissions    []string
+		expected       []sarama.AclPermissionType
+		expectedErrMsg string
+	}{{
+		name:        "it should parse valid permissions",
+		permissions: supportedPermissions(),
+		expected: []sarama.AclPermissionType{
+			sarama.AclPermissionAny,
+			sarama.AclPermissionDeny,
+			sarama.AclPermissionAllow,
+		},
+	}, {
+		name:           "it should fail if there's an invalid permission",
+		permissions:    []string{"allow", "any", "squirrel"},
+		expectedErrMsg: "1 error occurred:\n\t* no acl permission with name squirrel\n\n",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			res, err := parsePermissions(tt.permissions)
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.Exactly(st, tt.expected, res)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/create.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/create.go
@@ -1,0 +1,267 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+)
+
+func NewCreateACLsCommand(
+	admin func() (sarama.ClusterAdmin, error),
+) *cobra.Command {
+	var (
+		resource        string
+		resourceName    string
+		namePattern     string
+		operations      []string
+		allowPrincipals []string
+		allowHosts      []string
+		denyPrincipals  []string
+		denyHosts       []string
+	)
+	command := &cobra.Command{
+		Use:          "create",
+		Short:        "Create ACLs",
+		SilenceUsage: true,
+		Args: func(_ *cobra.Command, _ []string) error {
+			if len(allowPrincipals) == 0 &&
+				len(denyPrincipals) == 0 {
+				return fmt.Errorf(
+					"at least one of --%s or --%s must be set",
+					allowPrincipalFlag,
+					denyPrincipalFlag,
+				)
+			}
+
+			if resource == "cluster" {
+				resourceName = defaultClusterResourceName
+			}
+
+			err := checkSupported(
+				supportedResources(),
+				resource,
+				resourceFlag,
+			)
+			if err != nil {
+				return err
+			}
+
+			return checkSupported(
+				supportedPatterns(),
+				namePattern,
+				namePatternFlag,
+			)
+		},
+		RunE: func(ccmd *cobra.Command, args []string) error {
+			adm, err := admin()
+			if err != nil {
+				return err
+			}
+
+			return executeCreateACLs(
+				adm,
+				resource,
+				resourceName,
+				namePattern,
+				operations,
+				allowPrincipals,
+				allowHosts,
+				denyPrincipals,
+				denyHosts,
+			)
+		},
+	}
+
+	command.Flags().StringVar(
+		&resource,
+		resourceFlag,
+		"",
+		fmt.Sprintf(
+			"The target resource for the ACL. Supported values: %s.",
+			strings.Join(supportedResources(), ", "),
+		),
+	)
+	command.MarkFlagRequired(resourceFlag)
+	command.Flags().StringVar(
+		&resourceName,
+		resourceNameFlag,
+		"",
+		"The name of the target resource for the ACL.",
+	)
+	command.Flags().StringVar(
+		&namePattern,
+		namePatternFlag,
+		"literal",
+		fmt.Sprintf(
+			"The name pattern type to be used when matching the"+
+				" resource names. Supported values: %s.",
+			strings.Join(supportedPatterns(), ", "),
+		),
+	)
+	command.Flags().StringSliceVar(
+		&operations,
+		operationFlag,
+		[]string{},
+		fmt.Sprintf(
+			"Operation that the principal will be allowed or denied. Can be"+
+				" passed many times. Supported values: %s.",
+			strings.Join(supportedOperations(), ", "),
+		),
+	)
+	command.Flags().StringSliceVar(
+		&allowPrincipals,
+		allowPrincipalFlag,
+		[]string{},
+		"Principal to which permissions will be granted. Can be passed many times.",
+	)
+	command.Flags().StringSliceVar(
+		&allowHosts,
+		allowHostFlag,
+		[]string{},
+		"Host from which access will be granted. Can be passed many times.",
+	)
+	command.Flags().StringSliceVar(
+		&denyPrincipals,
+		denyPrincipalFlag,
+		[]string{},
+		"Principal to which permissions will be denied. Can be passed many times.",
+	)
+	command.Flags().StringSliceVar(
+		&denyHosts,
+		denyHostFlag,
+		[]string{},
+		"Host from which access will be denied. Can be passed many times.",
+	)
+	return command
+}
+
+func executeCreateACLs(
+	adm sarama.ClusterAdmin,
+	resource, resourceName, namePattern string,
+	operations, allowPrincipals, allowHosts, denyPrincipals, denyHosts []string,
+) error {
+	var resType sarama.AclResourceType
+	err := resType.UnmarshalText([]byte(resource))
+	if err != nil {
+		return err
+	}
+	var pat sarama.AclResourcePatternType
+	err = pat.UnmarshalText([]byte(namePattern))
+	if err != nil {
+		return err
+	}
+
+	res := sarama.Resource{
+		ResourceType:        resType,
+		ResourceName:        resourceName,
+		ResourcePatternType: pat,
+	}
+
+	acls, err := calculateACLs(
+		operations,
+		allowPrincipals,
+		denyPrincipals,
+		allowHosts,
+		denyHosts,
+	)
+	if err != nil {
+		return err
+	}
+	grp, _ := errgroup.WithContext(context.Background())
+	for _, acl := range acls {
+		a := acl
+		grp.Go(createACL(adm, res, a))
+	}
+
+	return grp.Wait()
+}
+
+// Returns the set of ACLs
+func calculateACLs(
+	operations, allowPrincipals, denyPrincipals, allowHosts, denyHosts []string,
+) ([]*sarama.Acl, error) {
+	var err error
+	acls := []*sarama.Acl{}
+	if len(allowPrincipals) == 0 && len(denyPrincipals) == 0 {
+		return nil, errors.New("empty allow & deny principals list")
+	}
+	if len(allowPrincipals) != 0 && len(allowHosts) == 0 {
+		allowHosts = []string{"*"}
+	}
+	if len(denyPrincipals) != 0 && len(denyHosts) == 0 {
+		denyHosts = []string{"*"}
+	}
+
+	ops := []sarama.AclOperation{sarama.AclOperationAll}
+	if len(operations) != 0 {
+		ops, err = parseOperations(operations)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, op := range ops {
+		for _, ap := range allowPrincipals {
+			for _, ah := range allowHosts {
+				acl := &sarama.Acl{
+					Principal:      ap,
+					Host:           ah,
+					Operation:      op,
+					PermissionType: sarama.AclPermissionAllow,
+				}
+				acls = append(acls, acl)
+			}
+		}
+
+		for _, dp := range denyPrincipals {
+			for _, dh := range denyHosts {
+				acl := &sarama.Acl{
+					Principal:      dp,
+					Host:           dh,
+					Operation:      op,
+					PermissionType: sarama.AclPermissionDeny,
+				}
+				acls = append(acls, acl)
+			}
+		}
+	}
+	return acls, nil
+}
+
+func createACL(
+	adm sarama.ClusterAdmin, res sarama.Resource, acl *sarama.Acl,
+) func() error {
+	return func() error {
+		op, _ := acl.Operation.MarshalText()
+		perm, _ := acl.PermissionType.MarshalText()
+		msg := fmt.Sprintf(
+			"ACL for principal '%s' with host '%s', operation '%s' and"+
+				" permission '%s'",
+			acl.Principal,
+			acl.Host,
+			string(op),
+			string(perm),
+		)
+		err := adm.CreateACL(res, *acl)
+		if err == nil {
+			log.Infof("Created %s", msg)
+			return nil
+		}
+		return errors.Wrap(err, fmt.Sprintf("Couldn't create %s", msg))
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/create_test.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/create_test.go
@@ -1,0 +1,314 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka/mocks"
+)
+
+func TestNewCreateACLsCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		admin          func() (sarama.ClusterAdmin, error)
+		expectedOut    string
+		expectedErrMsg string
+	}{{
+		name: "it should fail if getting the admin fails",
+		args: []string{
+			"--resource", "topic",
+			"--allow-principal", "User:*",
+		},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return nil, errors.New("No admin for you")
+		},
+		expectedErrMsg: "No admin for you",
+	}, {
+		name: "it should fail if allowPrincipals and denyPrincipals are empty",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"name-pattern", "literal",
+		},
+		expectedErrMsg: "at least one of --allow-principal or --deny-principal must be set",
+	}, {
+		name: "it should fail if there is an invalid resource",
+		args: []string{
+			"--resource", "weird-made-up-resource",
+			"--name-pattern", "literal",
+			"--allow-principal", "Group:group-1",
+		},
+		expectedErrMsg: "invalid resource 'weird-made-up-resource'. Supported values: any, cluster, group, topic, transactionalid.",
+	}, {
+		name: "it should fail if there is an invalid operation",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--name-pattern", "any",
+			"--deny-principal", "User:user-1",
+			"--operation", "read",
+			"--operation", "describe",
+			"--operation", "do-cool-stuff",
+		},
+		expectedErrMsg: "1 error occurred:\n\t* no acl operation with name do-cool-stuff\n\n",
+	}, {
+		name: "it should fail CreateAcl fails",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--name-pattern", "any",
+			"--deny-principal", "User:user-1",
+			"--operation", "describe",
+		},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return &mocks.MockAdmin{
+				MockCreateACL: func(_ sarama.Resource, _ sarama.Acl) error {
+					return errors.New("Couldn't create yo' ACLs, yo")
+				},
+			}, nil
+		},
+		expectedErrMsg: "Couldn't create ACL for principal 'User:user-1' with host '*', operation 'Describe' and permission 'Deny': Couldn't create yo' ACLs, yo",
+	}, {
+		name: "it should log the created ACLs",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--name-pattern", "any",
+			"--deny-principal", "User:user-1",
+			"--operation", "describe",
+		},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return &mocks.MockAdmin{
+				MockCreateACL: func(_ sarama.Resource, _ sarama.Acl) error {
+					return nil
+				},
+			}, nil
+		},
+		expectedOut: "Created ACL for principal 'User:user-1' with host '*', operation 'Describe' and permission 'Deny'",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			admin := func() (sarama.ClusterAdmin, error) {
+				return mocks.MockAdmin{}, nil
+			}
+			if tt.admin != nil {
+				admin = tt.admin
+			}
+			var out bytes.Buffer
+			logrus.SetOutput(&out)
+			cmd := NewCreateACLsCommand(admin)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.NoError(st, err)
+			if tt.expectedOut != "" {
+				require.Contains(t, out.String(), tt.expectedOut)
+			}
+		})
+	}
+}
+
+func TestCalculateACLFilters(t *testing.T) {
+	tests := []struct {
+		name            string
+		resource        string
+		resourceName    string
+		namePattern     string
+		operations      []string
+		allowPrincipals []string
+		allowHosts      []string
+		denyPrincipals  []string
+		denyHosts       []string
+		expected        []*sarama.Acl
+		expectedErrMsg  string
+	}{{
+		name:           "it should fail if allowPrincipals and denyPrincipals are empty",
+		expectedErrMsg: "empty allow & deny principals list",
+	}, {
+		name:           "it should fail if there is an invalid operation",
+		resource:       "topic",
+		resourceName:   "test-topic",
+		namePattern:    "any",
+		denyPrincipals: []string{"User:user-1"},
+		operations:     []string{"read", "describe", "do-cool-stuff"},
+		expectedErrMsg: "1 error occurred:\n\t* no acl operation with name do-cool-stuff\n\n",
+	}, {
+		name:           "it should fail if there is an invalid operation",
+		resource:       "topic",
+		resourceName:   "test-topic",
+		namePattern:    "any",
+		denyPrincipals: []string{"User:user-1"},
+		operations:     []string{"read", "describe", "do-cool-stuff"},
+		expectedErrMsg: "1 error occurred:\n\t* no acl operation with name do-cool-stuff\n\n",
+	}, {
+		name:            "it should calculate the ACLs (1)",
+		resource:        "topic",
+		resourceName:    "test-topic",
+		namePattern:     "any",
+		allowPrincipals: []string{"User:user-1"},
+		denyPrincipals:  []string{"User:user-2"},
+		operations:      []string{"read", "describe"},
+		expected: []*sarama.Acl{{
+			Principal:      "User:user-1",
+			Host:           "*",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionAllow,
+		}, {
+			Principal:      "User:user-2",
+			Host:           "*",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionDeny,
+		}, {
+			Principal:      "User:user-1",
+			Host:           "*",
+			Operation:      sarama.AclOperationDescribe,
+			PermissionType: sarama.AclPermissionAllow,
+		}, {
+			Principal:      "User:user-2",
+			Host:           "*",
+			Operation:      sarama.AclOperationDescribe,
+			PermissionType: sarama.AclPermissionDeny,
+		}},
+	}, {
+		name:            "it should calculate the ACLs (2)",
+		resource:        "topic",
+		resourceName:    "test-topic",
+		namePattern:     "any",
+		allowPrincipals: []string{"User:user-1", "User:user-2"},
+		allowHosts:      []string{"172.35.65.152", "192.168.786.90"},
+		operations:      []string{"read"},
+		expected: []*sarama.Acl{{
+			Principal:      "User:user-1",
+			Host:           "172.35.65.152",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionAllow,
+		}, {
+			Principal:      "User:user-1",
+			Host:           "192.168.786.90",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionAllow,
+		}, {
+			Principal:      "User:user-2",
+			Host:           "172.35.65.152",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionAllow,
+		}, {
+			Principal:      "User:user-2",
+			Host:           "192.168.786.90",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionAllow,
+		}},
+	}, {
+		name:            "it should calculate the ACLs (2)",
+		resource:        "topic",
+		resourceName:    "test-topic",
+		namePattern:     "any",
+		allowPrincipals: []string{"User:user-1"},
+		allowHosts:      []string{"172.35.65.152", "192.168.786.90"},
+		// Shouldn't generate any "deny" ACLs since denyPrincipals is empty
+		denyHosts:  []string{"172.35.65.152", "192.168.786.90"},
+		operations: []string{"read"},
+		expected: []*sarama.Acl{{
+			Principal:      "User:user-1",
+			Host:           "172.35.65.152",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionAllow,
+		}, {
+			Principal:      "User:user-1",
+			Host:           "192.168.786.90",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionAllow,
+		}},
+	}, {
+		name:            "it should calculate the ACLs (2)",
+		resource:        "topic",
+		resourceName:    "test-topic",
+		namePattern:     "any",
+		allowPrincipals: []string{"User:user-1"},
+		denyPrincipals:  []string{"User:user-3"},
+		allowHosts:      []string{"172.35.65.152", "192.168.786.90"},
+		// Shouldn't generate any "deny" ACLs since denyPrincipals is empty
+		denyHosts:  []string{"172.35.65.153", "192.168.786.91"},
+		operations: []string{"read"},
+		expected: []*sarama.Acl{{
+			Principal:      "User:user-1",
+			Host:           "172.35.65.152",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionAllow,
+		}, {
+			Principal:      "User:user-1",
+			Host:           "192.168.786.90",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionAllow,
+		}, {
+			Principal:      "User:user-3",
+			Host:           "172.35.65.153",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionDeny,
+		}, {
+			Principal:      "User:user-3",
+			Host:           "192.168.786.91",
+			Operation:      sarama.AclOperationRead,
+			PermissionType: sarama.AclPermissionDeny,
+		}},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			operations := []string{}
+			if tt.operations != nil {
+				operations = tt.operations
+			}
+			allowPrincipals := []string{}
+			if tt.allowPrincipals != nil {
+				allowPrincipals = tt.allowPrincipals
+			}
+
+			denyPrincipals := []string{}
+			if tt.denyPrincipals != nil {
+				denyPrincipals = tt.denyPrincipals
+			}
+			allowHosts := []string{}
+			if tt.allowHosts != nil {
+				allowHosts = tt.allowHosts
+			}
+			denyHosts := []string{}
+			if tt.denyHosts != nil {
+				denyHosts = tt.denyHosts
+			}
+			var out bytes.Buffer
+			logrus.SetOutput(&out)
+			acls, err := calculateACLs(
+				operations,
+				allowPrincipals,
+				denyPrincipals,
+				allowHosts,
+				denyHosts,
+			)
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.NoError(st, err)
+			require.Exactly(st, tt.expected, acls)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/delete.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/delete.go
@@ -1,0 +1,389 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/ui"
+	"golang.org/x/sync/errgroup"
+)
+
+func NewDeleteACLsCommand(
+	admin func() (sarama.ClusterAdmin, error),
+) *cobra.Command {
+	var (
+		resource        string
+		resourceName    string
+		namePattern     string
+		operations      []string
+		allowPrincipals []string
+		allowHosts      []string
+		denyPrincipals  []string
+		denyHosts       []string
+	)
+	command := &cobra.Command{
+		Use:          "delete",
+		Short:        "Delete ACLs",
+		SilenceUsage: true,
+		Args: func(_ *cobra.Command, _ []string) error {
+			if len(allowPrincipals) == 0 &&
+				len(denyPrincipals) == 0 {
+				return fmt.Errorf(
+					"at least one of --%s or --%s must be set",
+					allowPrincipalFlag,
+					denyPrincipalFlag,
+				)
+			}
+			err := checkSupported(
+				supportedResources(),
+				resource,
+				resourceFlag,
+			)
+			if err != nil {
+				return err
+			}
+			if namePattern != "" {
+				err = checkSupported(
+					supportedPatterns(),
+					namePattern,
+					namePatternFlag,
+				)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		RunE: func(ccmd *cobra.Command, args []string) error {
+			adm, err := admin()
+			if err != nil {
+				return err
+			}
+
+			if resource == "cluster" {
+				resourceName = defaultClusterResourceName
+			}
+
+			return executeDeleteACLs(
+				adm,
+				resource,
+				resourceName,
+				namePattern,
+				operations,
+				allowPrincipals,
+				allowHosts,
+				denyPrincipals,
+				denyHosts,
+			)
+		},
+	}
+
+	command.Flags().StringVar(
+		&resource,
+		resourceFlag,
+		"",
+		fmt.Sprintf(
+			"The target resource for the ACLs that will be deleted. Supported"+
+				" values: %s.",
+			strings.Join(supportedResources(), ", "),
+		),
+	)
+	command.MarkFlagRequired(resourceFlag)
+	command.Flags().StringVar(
+		&resourceName,
+		resourceNameFlag,
+		"",
+		"The name of the target resource for the ACL that will be deleted.",
+	)
+	command.Flags().StringVar(
+		&namePattern,
+		namePatternFlag,
+		"literal",
+		fmt.Sprintf(
+			"The name pattern type to be used when matching the"+
+				" resource names. Supported values: %s.",
+			strings.Join(supportedPatterns(), ", "),
+		),
+	)
+	command.Flags().StringSliceVar(
+		&operations,
+		operationFlag,
+		[]string{},
+		fmt.Sprintf(
+			"Operation that the ACLs that will be deleted allow or deny. Can be"+
+				" passed many times. Supported values: %s.",
+			strings.Join(supportedOperations(), ", "),
+		),
+	)
+	command.Flags().StringSliceVar(
+		&allowPrincipals,
+		allowPrincipalFlag,
+		[]string{},
+		"Principal to which the ACLs that will be deleted grant"+
+			" permission. Can be passed many times.",
+	)
+	command.Flags().StringSliceVar(
+		&allowHosts,
+		allowHostFlag,
+		[]string{},
+		"Host from which access will be granted. Can be passed many times.",
+	)
+	command.Flags().StringSliceVar(
+		&denyPrincipals,
+		denyPrincipalFlag,
+		[]string{},
+		"Principal to which that the ACLs that will be deleted deny"+
+			" permission. Can be passed many times.",
+	)
+	command.Flags().StringSliceVar(
+		&denyHosts,
+		denyHostFlag,
+		[]string{},
+		"Host from which access will be denied. Can be passed many times.",
+	)
+	return command
+}
+
+func executeDeleteACLs(
+	adm sarama.ClusterAdmin,
+	resource, resourceName, namePattern string,
+	operations, allowPrincipals, allowHosts, denyPrincipals, denyHosts []string,
+) error {
+	var resType sarama.AclResourceType
+	err := resType.UnmarshalText([]byte(resource))
+	if err != nil {
+		return err
+	}
+	var pat sarama.AclResourcePatternType
+	err = pat.UnmarshalText([]byte(namePattern))
+	if err != nil {
+		return err
+	}
+
+	filters, err := calculateDeleteACLFilters(
+		resource,
+		resourceName,
+		namePattern,
+		operations,
+		allowPrincipals,
+		denyPrincipals,
+		allowHosts,
+		denyHosts,
+	)
+	if err != nil {
+		return err
+	}
+	grp, _ := errgroup.WithContext(context.Background())
+	aclsChan := make(chan []sarama.MatchingAcl, len(filters))
+	for _, filter := range filters {
+		grp.Go(deleteACLs(adm, *filter, aclsChan))
+	}
+
+	err = grp.Wait()
+
+	close(aclsChan)
+
+	acls := []sarama.MatchingAcl{}
+	for matchingACLs := range aclsChan {
+		acls = append(acls, matchingACLs...)
+	}
+
+	printMatchingACLs(acls)
+
+	return err
+}
+
+func deleteACLs(
+	adm sarama.ClusterAdmin,
+	filter sarama.AclFilter,
+	acls chan<- []sarama.MatchingAcl,
+) func() error {
+	return func() error {
+		resType, _ := filter.ResourceType.MarshalText()
+		pat, _ := filter.ResourcePatternTypeFilter.MarshalText()
+		op, _ := filter.Operation.MarshalText()
+		perm, _ := filter.PermissionType.MarshalText()
+		filterInfo := fmt.Sprintf("resource type: '%s',"+
+			" name pattern type '%s', operation '%s', permission '%s'",
+			string(resType),
+			string(pat),
+			string(op),
+			string(perm),
+		)
+		as, err := adm.DeleteACL(filter, false)
+		if err == nil {
+			acls <- as
+			return nil
+		}
+
+		msg := fmt.Sprintf(
+			"couldn't list ACLs with filter %s",
+			filterInfo,
+		)
+		if filter.ResourceName != nil {
+			msg = fmt.Sprintf("%s, resource name %s", msg, *filter.ResourceName)
+		}
+		if filter.Principal != nil {
+			msg = fmt.Sprintf("%s, principal %s", msg, *filter.Principal)
+		}
+
+		if filter.Host != nil {
+			msg = fmt.Sprintf("%s, host %s", msg, *filter.Host)
+		}
+		return errors.Wrap(err, msg)
+	}
+}
+
+// Returns the set of ACL filters for deleting ACLs
+func calculateDeleteACLFilters(
+	resource, resourceName, resourceNamePattern string,
+	operations, allowPrincipals, denyPrincipals, allowHosts, denyHosts []string,
+) ([]*sarama.AclFilter, error) {
+	filters := []*sarama.AclFilter{}
+	allowPrincipalsFilter := []*string{}
+	denyPrincipalsFilter := []*string{}
+	var allowHostsFilter []*string
+	var denyHostsFilter []*string
+	var ops []sarama.AclOperation
+	var err error
+
+	for _, ppal := range allowPrincipals {
+		p := ppal
+		allowPrincipalsFilter = append(allowPrincipalsFilter, &p)
+	}
+
+	for _, ppal := range denyPrincipals {
+		p := ppal
+		denyPrincipalsFilter = append(denyPrincipalsFilter, &p)
+	}
+
+	if len(allowHosts) == 0 {
+		allowHostsFilter = []*string{nil}
+	} else {
+		for _, host := range allowHosts {
+			h := host
+			allowHostsFilter = append(allowHostsFilter, &h)
+		}
+	}
+
+	if len(denyHosts) == 0 {
+		denyHostsFilter = []*string{nil}
+	} else {
+		for _, host := range denyHosts {
+			h := host
+			denyHostsFilter = append(denyHostsFilter, &h)
+		}
+	}
+
+	if len(operations) == 0 {
+		ops = []sarama.AclOperation{sarama.AclOperationAny}
+	} else {
+		ops, err = parseOperations(operations)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var resName *string = nil
+	if resourceName != "" {
+		resName = &resourceName
+	}
+	resType := sarama.AclResourceAny
+	if resource != "" {
+		err = resType.UnmarshalText([]byte(resource))
+		if err != nil {
+			return nil, err
+		}
+	}
+	pat := sarama.AclPatternAny
+	if resourceNamePattern != "" {
+		err = pat.UnmarshalText([]byte(resourceNamePattern))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, op := range ops {
+		for _, ap := range allowPrincipalsFilter {
+			for _, ah := range allowHostsFilter {
+				filter := &sarama.AclFilter{
+					ResourceType:              resType,
+					ResourceName:              resName,
+					ResourcePatternTypeFilter: pat,
+					Principal:                 ap,
+					Host:                      ah,
+					Operation:                 op,
+					PermissionType:            sarama.AclPermissionAllow,
+				}
+				filters = append(filters, filter)
+			}
+		}
+
+		for _, dp := range denyPrincipalsFilter {
+			for _, dh := range denyHostsFilter {
+				filter := &sarama.AclFilter{
+					ResourceType:              resType,
+					ResourceName:              resName,
+					ResourcePatternTypeFilter: pat,
+					Principal:                 dp,
+					Host:                      dh,
+					Operation:                 op,
+					PermissionType:            sarama.AclPermissionDeny,
+				}
+				filters = append(filters, filter)
+			}
+		}
+	}
+	return filters, nil
+}
+
+func printMatchingACLs(matchingACLs []sarama.MatchingAcl) {
+	if len(matchingACLs) == 0 {
+		log.Info("No ACLs matched the given filters, so none were deleted.")
+		return
+	}
+	spacer := []string{""}
+	t := ui.NewRpkTable(log.StandardLogger().Out)
+	t.SetColWidth(80)
+	t.SetAutoWrapText(true)
+	t.SetHeader([]string{"Deleted", "Principal", "Host", "Operation", "Permission Type", "Resource Type", "Resource Name", "Error Message"})
+	t.Append(spacer)
+
+	for _, acl := range matchingACLs {
+		resType, _ := acl.ResourceType.MarshalText()
+		op, _ := acl.Operation.MarshalText()
+		perm, _ := acl.PermissionType.MarshalText()
+		deleted := "yes"
+		errMsg := "None"
+		if acl.ErrMsg != nil {
+			deleted = "no"
+			errMsg = *acl.ErrMsg
+		}
+		t.Append([]string{
+			deleted,
+			acl.Principal,
+			acl.Host,
+			string(op),
+			string(perm),
+			string(resType),
+			acl.ResourceName,
+			errMsg,
+		})
+	}
+	t.Append(spacer)
+	t.Render()
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/delete_test.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/delete_test.go
@@ -1,0 +1,401 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka/mocks"
+)
+
+func TestNewDeleteACLsCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		admin          func() (sarama.ClusterAdmin, error)
+		expectedOut    string
+		expectedErrMsg string
+	}{{
+		name: "it should fail if there is an invalid resource",
+		args: []string{
+			"--resource", "weird-made-up-resource",
+			"--allow-principal", "Group:group-1",
+		},
+		expectedErrMsg: "invalid resource 'weird-made-up-resource'. Supported values: any, cluster, group, topic, transactionalid.",
+	}, {
+		name: "it should fail if there is an invalid operation",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--name-pattern", "any",
+			"--deny-principal", "User:user-1",
+			"--operation", "read,describe,do-cool-stuff",
+		},
+		expectedErrMsg: "1 error occurred:\n\t* no acl operation with name do-cool-stuff\n\n",
+	}, {
+		name: "it should fail if getting the admin fails",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--deny-principal", "User:user-1",
+			"--operation", "describe",
+		},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return nil, errors.New("No admin for you")
+		},
+		expectedErrMsg: "No admin for you",
+	}, {
+		name: "it should fail if DeleteAcl fails",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--deny-principal", "User:user-1",
+			"--operation", "describe",
+		},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return &mocks.MockAdmin{
+				MockDeleteACL: func(_ sarama.AclFilter, _ bool) ([]sarama.MatchingAcl, error) {
+					return nil, errors.New("Couldn't create yo' ACLs, yo")
+				},
+			}, nil
+		},
+		expectedErrMsg: "couldn't list ACLs with filter resource type: 'Topic', name pattern type 'Literal', operation 'Describe', permission 'Deny', resource name test-topic, principal User:user-1: Couldn't create yo' ACLs, yo",
+	}, {
+		name: "it should show the deleted ACLs",
+		// The inputs don't really matter in this test case since the response is mocked.
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--deny-principal", "User:user-1",
+			"--deny-principal", "User:user-2",
+			"--operation", "describe",
+		},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return &mocks.MockAdmin{
+				MockDeleteACL: func(filter sarama.AclFilter, _ bool) ([]sarama.MatchingAcl, error) {
+					ppal1 := "User:user-1"
+					ppal2 := "User:user-2"
+					acl1 := sarama.MatchingAcl{
+						Resource: sarama.Resource{
+							ResourceType:        sarama.AclResourceTopic,
+							ResourceName:        "some-cool-topic",
+							ResourcePatternType: sarama.AclPatternAny,
+						},
+						Acl: sarama.Acl{
+							Principal:      ppal1,
+							Host:           "*",
+							Operation:      sarama.AclOperationRead,
+							PermissionType: sarama.AclPermissionAllow,
+						},
+					}
+					acl2 := sarama.MatchingAcl{
+						Resource: sarama.Resource{
+							ResourceType:        sarama.AclResourceTopic,
+							ResourceName:        "some-cool-topic-2",
+							ResourcePatternType: sarama.AclPatternAny,
+						},
+						Acl: sarama.Acl{
+							Principal:      ppal2,
+							Host:           "127.0.0.1",
+							Operation:      sarama.AclOperationAlter,
+							PermissionType: sarama.AclPermissionDeny,
+						},
+					}
+					if filter.Principal != nil && *filter.Principal == ppal1 {
+						return []sarama.MatchingAcl{acl1}, nil
+					}
+					return []sarama.MatchingAcl{acl2}, nil
+				},
+			}, nil
+		},
+		expectedOut: `  DELETED  PRINCIPAL    HOST       OPERATION  PERMISSION TYPE  RESOURCE TYPE  RESOURCE NAME      ERROR MESSAGE  
+           
+  yes      User:user-2  127.0.0.1  Alter      Deny             Topic          some-cool-topic-2  None           
+  yes      User:user-1  *          Read       Allow            Topic          some-cool-topic    None           
+           
+`,
+	}, {
+		name: "it should show the deleted & failed ACLs",
+		// The inputs don't really matter in this test case since the response is mocked.
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--deny-principal", "User:user-1",
+			"--deny-principal", "User:user-2",
+			"--operation", "describe",
+		},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return &mocks.MockAdmin{
+				MockDeleteACL: func(filter sarama.AclFilter, _ bool) ([]sarama.MatchingAcl, error) {
+					ppal1 := "User:user-1"
+					acl1 := sarama.MatchingAcl{
+						Resource: sarama.Resource{
+							ResourceType:        sarama.AclResourceTopic,
+							ResourceName:        "some-cool-topic",
+							ResourcePatternType: sarama.AclPatternAny,
+						},
+						Acl: sarama.Acl{
+							Principal:      ppal1,
+							Host:           "*",
+							Operation:      sarama.AclOperationRead,
+							PermissionType: sarama.AclPermissionAllow,
+						},
+					}
+					errMsg := "something went wrong!"
+					acl2 := sarama.MatchingAcl{ErrMsg: &errMsg}
+					if filter.Principal != nil && *filter.Principal == ppal1 {
+						return []sarama.MatchingAcl{acl1}, nil
+					}
+					return []sarama.MatchingAcl{acl2}, nil
+				},
+			}, nil
+		},
+		expectedOut: `  DELETED  PRINCIPAL    HOST  OPERATION  PERMISSION TYPE  RESOURCE TYPE  RESOURCE NAME    ERROR MESSAGE          
+           
+  no                          Unknown    Unknown          Unknown                         something went wrong!  
+  yes      User:user-1  *     Read       Allow            Topic          some-cool-topic  None                   
+           
+`,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			admin := func() (sarama.ClusterAdmin, error) {
+				return mocks.MockAdmin{}, nil
+			}
+			if tt.admin != nil {
+				admin = tt.admin
+			}
+			var out bytes.Buffer
+			logrus.SetOutput(&out)
+			cmd := NewDeleteACLsCommand(admin)
+			cmd.SetOut(&out)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.NoError(st, err)
+			if tt.expectedOut != "" {
+				require.Equal(t, tt.expectedOut, out.String())
+			}
+		})
+	}
+}
+
+func TestCalculateDeleteACLFilters(t *testing.T) {
+	tests := []struct {
+		name            string
+		resource        string
+		resourceName    string
+		namePattern     string
+		operations      []string
+		allowPrincipals []string
+		allowHosts      []string
+		denyPrincipals  []string
+		denyHosts       []string
+		expected        func() []*sarama.AclFilter
+		expectedErrMsg  string
+	}{{
+		name:           "it should fail if there is an invalid resource",
+		resource:       "weird-made-up-resource",
+		expectedErrMsg: "no acl resource with name weird-made-up-resource",
+	}, {
+		name:           "it should fail if there is an invalid operation",
+		resource:       "topic",
+		resourceName:   "test-topic",
+		operations:     []string{"read", "write", "do-cool-stuff"},
+		expectedErrMsg: "1 error occurred:\n\t* no acl operation with name do-cool-stuff\n\n",
+	}, {
+		name:            "it should calculate the ACL filters (1)",
+		resource:        "transactionalid",
+		resourceName:    "id-2",
+		operations:      []string{"read", "alter"},
+		allowPrincipals: []string{"User:Bob"},
+		allowHosts:      []string{"168.168.245.3"},
+		expected: func() []*sarama.AclFilter {
+			name := "id-2"
+			host := "168.168.245.3"
+			allowPpal := "User:Bob"
+			return []*sarama.AclFilter{{
+				ResourceType:              sarama.AclResourceTransactionalID,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Principal:                 &allowPpal,
+				Host:                      &host,
+				Operation:                 sarama.AclOperationRead,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTransactionalID,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Principal:                 &allowPpal,
+				Host:                      &host,
+				Operation:                 sarama.AclOperationAlter,
+				PermissionType:            sarama.AclPermissionAllow,
+			}}
+		},
+	}, {
+		name:           "it should calculate the ACL filters (2)",
+		resource:       "topic",
+		resourceName:   "topic-1",
+		namePattern:    "match",
+		operations:     []string{"read", "alter"},
+		denyPrincipals: []string{"User:Bob", "Group:gr-0123"},
+		denyHosts:      []string{"168.168.245.3"},
+		expected: func() []*sarama.AclFilter {
+			name := "topic-1"
+			host := "168.168.245.3"
+			denyPpal1 := "User:Bob"
+			denyPpal2 := "Group:gr-0123"
+			return []*sarama.AclFilter{{
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &denyPpal1,
+				Host:                      &host,
+				Operation:                 sarama.AclOperationRead,
+				PermissionType:            sarama.AclPermissionDeny,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &denyPpal2,
+				Host:                      &host,
+				Operation:                 sarama.AclOperationRead,
+				PermissionType:            sarama.AclPermissionDeny,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &denyPpal1,
+				Host:                      &host,
+				Operation:                 sarama.AclOperationAlter,
+				PermissionType:            sarama.AclPermissionDeny,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &denyPpal2,
+				Host:                      &host,
+				Operation:                 sarama.AclOperationAlter,
+				PermissionType:            sarama.AclPermissionDeny,
+			}}
+		},
+	}, {
+		name:            "it should calculate the ACL filters (3)",
+		resource:        "topic",
+		operations:      []string{"describe"},
+		allowPrincipals: []string{"Group:0", "Group:1"},
+		denyPrincipals:  []string{"User:Bob", "Group:gr-0123"},
+		denyHosts:       []string{"168.168.245.3", "127.0.0.1"},
+		expected: func() []*sarama.AclFilter {
+			allowPpal1, allowPpal2 := "Group:0", "Group:1"
+			denyPpal1, denyPpal2 := "User:Bob", "Group:gr-0123"
+			denyHost1, denyHost2 := "168.168.245.3", "127.0.0.1"
+			return []*sarama.AclFilter{{
+				ResourceType:              sarama.AclResourceTopic,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Principal:                 &allowPpal1,
+				Operation:                 sarama.AclOperationDescribe,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Principal:                 &allowPpal2,
+				Operation:                 sarama.AclOperationDescribe,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Principal:                 &denyPpal1,
+				Host:                      &denyHost1,
+				Operation:                 sarama.AclOperationDescribe,
+				PermissionType:            sarama.AclPermissionDeny,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Principal:                 &denyPpal1,
+				Host:                      &denyHost2,
+				Operation:                 sarama.AclOperationDescribe,
+				PermissionType:            sarama.AclPermissionDeny,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Principal:                 &denyPpal2,
+				Host:                      &denyHost1,
+				Operation:                 sarama.AclOperationDescribe,
+				PermissionType:            sarama.AclPermissionDeny,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Principal:                 &denyPpal2,
+				Host:                      &denyHost2,
+				Operation:                 sarama.AclOperationDescribe,
+				PermissionType:            sarama.AclPermissionDeny,
+			}}
+		},
+	}, {
+		name:       "it should calculate the ACL filters (4)",
+		resource:   "topic",
+		operations: []string{"describe"},
+		denyHosts:  []string{"168.168.245.3", "127.0.0.1"},
+		expected: func() []*sarama.AclFilter {
+			return []*sarama.AclFilter{}
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			operations := []string{}
+			if tt.operations != nil {
+				operations = tt.operations
+			}
+			allowPrincipals := []string{}
+			if tt.allowPrincipals != nil {
+				allowPrincipals = tt.allowPrincipals
+			}
+
+			denyPrincipals := []string{}
+			if tt.denyPrincipals != nil {
+				denyPrincipals = tt.denyPrincipals
+			}
+			allowHosts := []string{}
+			if tt.allowHosts != nil {
+				allowHosts = tt.allowHosts
+			}
+			denyHosts := []string{}
+			if tt.denyHosts != nil {
+				denyHosts = tt.denyHosts
+			}
+			filters, err := calculateDeleteACLFilters(
+				tt.resource,
+				tt.resourceName,
+				tt.namePattern,
+				operations,
+				allowPrincipals,
+				denyPrincipals,
+				allowHosts,
+				denyHosts,
+			)
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.NoError(st, err)
+			require.Exactly(st, tt.expected(), filters)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/list.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/list.go
@@ -1,0 +1,318 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/ui"
+	"golang.org/x/sync/errgroup"
+)
+
+func NewListACLsCommand(
+	admin func() (sarama.ClusterAdmin, error),
+) *cobra.Command {
+	var (
+		resource     string
+		resourceName string
+		namePattern  string
+		operations   []string
+		permissions  []string
+		principals   []string
+		hosts        []string
+	)
+	command := &cobra.Command{
+		Use:          "list",
+		Aliases:      []string{"ls"},
+		Short:        "List ACLs",
+		SilenceUsage: true,
+		RunE: func(ccmd *cobra.Command, args []string) error {
+			adm, err := admin()
+			if err != nil {
+				return err
+			}
+
+			return executeListACLs(
+				adm,
+				resource,
+				resourceName,
+				namePattern,
+				operations,
+				permissions,
+				principals,
+				hosts,
+			)
+		},
+	}
+
+	command.Flags().StringVar(
+		&resource,
+		resourceFlag,
+		"",
+		fmt.Sprintf(
+			"Resource type to filter by. Supported values: %s.",
+			strings.Join(supportedResources(), ", "),
+		),
+	)
+	command.Flags().StringVar(
+		&resourceName,
+		resourceNameFlag,
+		"",
+		"The name of the resource of the given type.",
+	)
+	command.Flags().StringVar(
+		&namePattern,
+		namePatternFlag,
+		"",
+		fmt.Sprintf(
+			"The name pattern type to be used when matching affected"+
+				" resources. Supported values: %s.",
+			strings.Join(supportedPatterns(), ", "),
+		),
+	)
+	command.Flags().StringSliceVar(
+		&operations,
+		operationFlag,
+		[]string{},
+		fmt.Sprintf(
+			"Operation to filter by. Can be passed multiple times to filter by many operations. Supported"+
+				" values: %s.",
+			strings.Join(supportedOperations(), ", "),
+		),
+	)
+	command.Flags().StringSliceVar(
+		&permissions,
+		"permission",
+		[]string{},
+		fmt.Sprintf(
+			"Permission to filter by. Can be"+
+				" passed many times to filter by multiple permission types. Supported values: %s.",
+			strings.Join(supportedPermissions(), ", "),
+		),
+	)
+	command.Flags().StringSliceVar(
+		&principals,
+		"principal",
+		[]string{},
+		"Principal to filter by. Can be passed multiple times to filter by many principals.",
+	)
+	command.Flags().StringSliceVar(
+		&hosts,
+		"host",
+		[]string{},
+		"Host to filter by. Can be passed multiple times to filter by many hosts.",
+	)
+	return command
+}
+
+func executeListACLs(
+	adm sarama.ClusterAdmin,
+	resource, resourceName, namePattern string,
+	operations, permissions, principals, hosts []string,
+) error {
+	filters, err := calculateListACLFilters(
+		resource,
+		resourceName,
+		namePattern,
+		operations,
+		permissions,
+		principals,
+		hosts,
+	)
+	if err != nil {
+		return err
+	}
+
+	grp, _ := errgroup.WithContext(context.Background())
+	aclsChan := make(chan []sarama.ResourceAcls, len(filters))
+	for _, filter := range filters {
+		grp.Go(listACLs(adm, *filter, aclsChan))
+	}
+
+	err = grp.Wait()
+
+	close(aclsChan)
+
+	acls := []sarama.ResourceAcls{}
+	for resACLs := range aclsChan {
+		acls = append(acls, resACLs...)
+	}
+
+	printResourceACLs(acls)
+
+	return err
+}
+
+func listACLs(
+	adm sarama.ClusterAdmin,
+	filter sarama.AclFilter,
+	acls chan<- []sarama.ResourceAcls,
+) func() error {
+	return func() error {
+		resType, _ := filter.ResourceType.MarshalText()
+		pat, _ := filter.ResourcePatternTypeFilter.MarshalText()
+		op, _ := filter.Operation.MarshalText()
+		perm, _ := filter.PermissionType.MarshalText()
+		filterInfo := fmt.Sprintf("resource type: '%s',"+
+			" name pattern type '%s', operation '%s', permission '%s'",
+			string(resType),
+			string(pat),
+			string(op),
+			string(perm),
+		)
+		log.Debugf("Listing ACLs with filter %s", filterInfo)
+		as, err := adm.ListAcls(filter)
+		if err == nil {
+			acls <- as
+			return nil
+		}
+
+		msg := fmt.Sprintf(
+			"couldn't list ACLs with filter %s",
+			filterInfo,
+		)
+		if filter.ResourceName != nil {
+			msg = fmt.Sprintf("%s, resource name %s", msg, *filter.ResourceName)
+		}
+		if filter.Principal != nil {
+			msg = fmt.Sprintf("%s, principal %s", msg, *filter.Principal)
+		}
+
+		if filter.Host != nil {
+			msg = fmt.Sprintf("%s, host %s", msg, *filter.Host)
+		}
+		return errors.Wrap(err, msg)
+	}
+}
+
+// Returns the set of ACL filters
+func calculateListACLFilters(
+	resource, resourceName, resourceNamePattern string,
+	operations, permissions, principals, hosts []string,
+) ([]*sarama.AclFilter, error) {
+	filters := []*sarama.AclFilter{}
+	var principalsFilter []*string
+	var hostsFilter []*string
+	var ops []sarama.AclOperation
+	var perms []sarama.AclPermissionType
+	var err error
+
+	if len(principals) == 0 {
+		principalsFilter = []*string{nil}
+	} else {
+		for _, ppal := range principals {
+			p := ppal
+			principalsFilter = append(principalsFilter, &p)
+		}
+	}
+
+	if len(hosts) == 0 {
+		hostsFilter = []*string{nil}
+	} else {
+		for _, host := range hosts {
+			h := host
+			hostsFilter = append(hostsFilter, &h)
+		}
+	}
+
+	if len(operations) == 0 {
+		ops = []sarama.AclOperation{sarama.AclOperationAny}
+	} else {
+		ops, err = parseOperations(operations)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(permissions) == 0 {
+		perms = []sarama.AclPermissionType{sarama.AclPermissionAny}
+	} else {
+		perms, err = parsePermissions(permissions)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var resName *string = nil
+	if resourceName != "" {
+		resName = &resourceName
+	}
+	resType := sarama.AclResourceAny
+	if resource != "" {
+		err = resType.UnmarshalText([]byte(resource))
+		if err != nil {
+			return nil, err
+		}
+	}
+	pat := sarama.AclPatternAny
+	if resourceNamePattern != "" {
+		err = pat.UnmarshalText([]byte(resourceNamePattern))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, p := range perms {
+		for _, op := range ops {
+			for _, ap := range principalsFilter {
+				for _, ah := range hostsFilter {
+					filter := &sarama.AclFilter{
+						ResourceType:              resType,
+						ResourceName:              resName,
+						ResourcePatternTypeFilter: pat,
+						Principal:                 ap,
+						Host:                      ah,
+						Operation:                 op,
+						PermissionType:            p,
+					}
+					filters = append(filters, filter)
+				}
+			}
+		}
+	}
+	return filters, nil
+}
+
+func printResourceACLs(resACLs []sarama.ResourceAcls) {
+	if len(resACLs) == 0 {
+		log.Info("No ACLs found for the given filters.")
+		return
+	}
+	spacer := []string{""}
+	t := ui.NewRpkTable(log.StandardLogger().Out)
+	t.SetColWidth(80)
+	t.SetAutoWrapText(true)
+	t.SetHeader([]string{"Principal", "Host", "Operation", "Permission Type", "Resource Type", "Resource Name"})
+	t.Append(spacer)
+
+	for _, resACL := range resACLs {
+		resType, _ := resACL.Resource.ResourceType.MarshalText()
+		for _, acl := range resACL.Acls {
+			op, _ := acl.Operation.MarshalText()
+			perm, _ := acl.PermissionType.MarshalText()
+			t.Append([]string{
+				acl.Principal,
+				acl.Host,
+				string(op),
+				string(perm),
+				string(resType),
+				resACL.ResourceName,
+			})
+		}
+	}
+	t.Append(spacer)
+	t.Render()
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/list_test.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/list_test.go
@@ -1,0 +1,386 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka/mocks"
+)
+
+func TestNewListACLsCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		admin          func() (sarama.ClusterAdmin, error)
+		expectedOut    string
+		expectedErrMsg string
+	}{{
+		name: "it should fail if getting the admin fails",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--operation", "describe",
+		},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return nil, errors.New("No admin for you")
+		},
+		expectedErrMsg: "No admin for you",
+	}, {
+		name:           "it should fail if there is an invalid resource",
+		args:           []string{"--resource", "weird-made-up-resource"},
+		expectedErrMsg: "no acl resource with name weird-made-up-resource",
+	}, {
+		name: "it should fail if there is an invalid operation",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--operation", "read",
+			"--operation", "write",
+			"--operation", "do-cool-stuff",
+		},
+		expectedErrMsg: "1 error occurred:\n\t* no acl operation with name do-cool-stuff\n\n",
+	}, {
+		name: "it should fail if there is an invalid permission",
+		args: []string{
+			"--resource", "topic",
+			"--resource-name", "test-topic",
+			"--permission", "allow",
+			"--permission", "whatever",
+		},
+		expectedErrMsg: "1 error occurred:\n\t* no acl permission with name whatever\n\n",
+	}, {
+		name: "it should fail if ListACLs fails",
+		args: []string{
+			"--resource", "cluster",
+			"--operation", "write",
+			"--permission", "deny",
+			"--principal", "Group:group-2",
+			"--host", "168.79.78.24",
+		},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return mocks.MockAdmin{
+				MockListAcls: func(_ sarama.AclFilter) ([]sarama.ResourceAcls, error) {
+					return nil, errors.New("Boom it failed ha")
+				},
+			}, nil
+		},
+		expectedErrMsg: "couldn't list ACLs with filter resource type: 'Cluster', name pattern type 'Any', operation 'Write', permission 'Deny', principal Group:group-2, host 168.79.78.24: Boom it failed ha",
+	}, {
+		name: "it should print the ACLs",
+		// The inputs don't really matter since we're mocking the
+		// result anyway. This case tests that the output is as expected.
+		admin: func() (sarama.ClusterAdmin, error) {
+			return &mocks.MockAdmin{
+				MockListAcls: func(_ sarama.AclFilter) ([]sarama.ResourceAcls, error) {
+					return []sarama.ResourceAcls{{
+						Resource: sarama.Resource{
+							ResourceType:        sarama.AclResourceTopic,
+							ResourceName:        "some-cool-topic",
+							ResourcePatternType: sarama.AclPatternAny,
+						},
+						Acls: []*sarama.Acl{{
+							Principal:      "User:Lola",
+							Host:           "127.0.0.1",
+							Operation:      sarama.AclOperationAll,
+							PermissionType: sarama.AclPermissionAllow,
+						}, {
+							Principal:      "User:Momo",
+							Host:           "162.168.90.124",
+							Operation:      sarama.AclOperationAny,
+							PermissionType: sarama.AclPermissionDeny,
+						}},
+					}}, nil
+				},
+			}, nil
+		},
+		expectedOut: `  PRINCIPAL  HOST            OPERATION  PERMISSION TYPE  RESOURCE TYPE  RESOURCE NAME    
+             
+  User:Lola  127.0.0.1       All        Allow            Topic          some-cool-topic  
+  User:Momo  162.168.90.124  Any        Deny             Topic          some-cool-topic  
+             
+`,
+	}, {
+		name: "it should print the ACLs",
+		// The inputs don't really matter since we're mocking the
+		// result anyway. This case tests that the resulting set of ACLs is
+		// logged as expected.
+		args: []string{"--resource", "topic"},
+		admin: func() (sarama.ClusterAdmin, error) {
+			return &mocks.MockAdmin{
+				MockListAcls: func(_ sarama.AclFilter) ([]sarama.ResourceAcls, error) {
+					return []sarama.ResourceAcls{}, nil
+				},
+			}, nil
+		},
+		expectedOut: "No ACLs found for the given filters.",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			admin := func() (sarama.ClusterAdmin, error) {
+				return mocks.MockAdmin{}, nil
+			}
+			if tt.admin != nil {
+				admin = tt.admin
+			}
+			cmd := NewListACLsCommand(admin)
+			cmd.SetArgs(tt.args)
+			var out bytes.Buffer
+			logrus.SetOutput(&out)
+			err := cmd.Execute()
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.NoError(st, err)
+			if tt.expectedOut != "" {
+				require.Regexp(t, tt.expectedOut, out.String())
+			}
+		})
+	}
+}
+
+func TestCalculateListACLFilters(t *testing.T) {
+	tests := []struct {
+		name           string
+		resource       string
+		resourceName   string
+		namePattern    string
+		operations     []string
+		permissions    []string
+		principals     []string
+		hosts          []string
+		expected       func() []*sarama.AclFilter
+		expectedErrMsg string
+	}{{
+		name:           "it should fail if there is an invalid resource",
+		resource:       "weird-made-up-resource",
+		expectedErrMsg: "no acl resource with name weird-made-up-resource",
+	}, {
+		name:           "it should fail if there is an invalid operation",
+		resource:       "topic",
+		resourceName:   "test-topic",
+		operations:     []string{"read", "write", "do-cool-stuff"},
+		expectedErrMsg: "1 error occurred:\n\t* no acl operation with name do-cool-stuff\n\n",
+	}, {
+		name:           "it should fail if there is an invalid permission",
+		resource:       "topic",
+		resourceName:   "test-topic",
+		permissions:    []string{"allow", "whatever"},
+		expectedErrMsg: "1 error occurred:\n\t* no acl permission with name whatever\n\n",
+	}, {
+		name: "it should calculate the ACL filters (empty imputs)",
+		expected: func() []*sarama.AclFilter {
+			return []*sarama.AclFilter{{
+				ResourceType:              sarama.AclResourceAny,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Operation:                 sarama.AclOperationAny,
+				PermissionType:            sarama.AclPermissionAny,
+			}}
+		},
+	}, {
+		name:         "it should calculate the ACL filters (mixed imputs 1)",
+		resource:     "transactionalid",
+		resourceName: "tx-id-2",
+		operations:   []string{"read", "write"},
+		permissions:  []string{"allow", "deny"},
+		expected: func() []*sarama.AclFilter {
+			name := "tx-id-2"
+			return []*sarama.AclFilter{{
+				ResourceType:              sarama.AclResourceTransactionalID,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Operation:                 sarama.AclOperationRead,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTransactionalID,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Operation:                 sarama.AclOperationWrite,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTransactionalID,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Operation:                 sarama.AclOperationRead,
+				PermissionType:            sarama.AclPermissionDeny,
+			}, {
+				ResourceType:              sarama.AclResourceTransactionalID,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternAny,
+				Operation:                 sarama.AclOperationWrite,
+				PermissionType:            sarama.AclPermissionDeny,
+			}}
+		},
+	}, {
+		name:         "it should calculate the ACL filters (mixed imputs 2)",
+		resource:     "topic",
+		resourceName: "topic-3",
+		namePattern:  "match",
+		principals:   []string{"User:D", "User:B", "User:A"},
+		operations:   []string{"read", "write", "alterconfigs"},
+		permissions:  []string{"allow"},
+		expected: func() []*sarama.AclFilter {
+			name := "topic-3"
+			ppal1 := "User:D"
+			ppal2 := "User:B"
+			ppal3 := "User:A"
+
+			return []*sarama.AclFilter{{
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &ppal1,
+				Operation:                 sarama.AclOperationRead,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &ppal2,
+				Operation:                 sarama.AclOperationRead,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &ppal3,
+				Operation:                 sarama.AclOperationRead,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &ppal1,
+				Operation:                 sarama.AclOperationWrite,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &ppal2,
+				Operation:                 sarama.AclOperationWrite,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &ppal3,
+				Operation:                 sarama.AclOperationWrite,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &ppal1,
+				Operation:                 sarama.AclOperationAlterConfigs,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &ppal2,
+				Operation:                 sarama.AclOperationAlterConfigs,
+				PermissionType:            sarama.AclPermissionAllow,
+			}, {
+				ResourceType:              sarama.AclResourceTopic,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternMatch,
+				Principal:                 &ppal3,
+				Operation:                 sarama.AclOperationAlterConfigs,
+				PermissionType:            sarama.AclPermissionAllow,
+			}}
+		},
+	}, {
+		name:         "it should calculate the ACL filters (mixed imputs 3)",
+		resource:     "group",
+		resourceName: "asdfasdfasldfkjasdf2342134",
+		namePattern:  "literal",
+		operations:   []string{"describe", "delete"},
+		permissions:  []string{"any"},
+		hosts:        []string{"127.0.0.1", "localhost"},
+		expected: func() []*sarama.AclFilter {
+			name := "asdfasdfasldfkjasdf2342134"
+			host1 := "127.0.0.1"
+			host2 := "localhost"
+			return []*sarama.AclFilter{{
+				ResourceType:              sarama.AclResourceGroup,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternLiteral,
+				Host:                      &host1,
+				Operation:                 sarama.AclOperationDescribe,
+				PermissionType:            sarama.AclPermissionAny,
+			}, {
+				ResourceType:              sarama.AclResourceGroup,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternLiteral,
+				Host:                      &host2,
+				Operation:                 sarama.AclOperationDescribe,
+				PermissionType:            sarama.AclPermissionAny,
+			}, {
+				ResourceType:              sarama.AclResourceGroup,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternLiteral,
+				Host:                      &host1,
+				Operation:                 sarama.AclOperationDelete,
+				PermissionType:            sarama.AclPermissionAny,
+			}, {
+				ResourceType:              sarama.AclResourceGroup,
+				ResourceName:              &name,
+				ResourcePatternTypeFilter: sarama.AclPatternLiteral,
+				Host:                      &host2,
+				Operation:                 sarama.AclOperationDelete,
+				PermissionType:            sarama.AclPermissionAny,
+			}}
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			operations := []string{}
+			if tt.operations != nil {
+				operations = tt.operations
+			}
+			permissions := []string{}
+			if tt.permissions != nil {
+				permissions = tt.permissions
+			}
+			principals := []string{}
+			if tt.principals != nil {
+				principals = tt.principals
+			}
+			hosts := []string{}
+			if tt.hosts != nil {
+				hosts = tt.hosts
+			}
+			filters, err := calculateListACLFilters(
+				tt.resource,
+				tt.resourceName,
+				tt.namePattern,
+				operations,
+				permissions,
+				principals,
+				hosts,
+			)
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.NoError(st, err)
+			require.Exactly(st, tt.expected(), filters)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/user.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/user.go
@@ -21,6 +21,8 @@ import (
 const (
 	newUserFlag     = "new-username"
 	newPasswordFlag = "new-password"
+
+	deleteUsernameFlag = "delete-username"
 )
 
 func NewUserCommand(tls func() (*config.TLS, error)) *cobra.Command {
@@ -41,6 +43,7 @@ func NewUserCommand(tls func() (*config.TLS, error)) *cobra.Command {
 	adminApi := buildAdminAPI(&apiUrl, tls)
 
 	command.AddCommand(NewCreateUserCommand(adminApi))
+	command.AddCommand(NewDeleteUserCommand(adminApi))
 	return command
 }
 
@@ -85,6 +88,43 @@ func NewCreateUserCommand(
 		"The new user's password",
 	)
 	command.MarkFlagRequired(newPasswordFlag)
+
+	return command
+}
+
+func NewDeleteUserCommand(
+	adminApi func() (admin.AdminAPI, error),
+) *cobra.Command {
+	var (
+		username string
+	)
+	command := &cobra.Command{
+		Use:          "delete",
+		Short:        "Delete users",
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			adminApi, err := adminApi()
+			if err != nil {
+				return err
+			}
+			err = adminApi.DeleteUser(username)
+			if err != nil {
+				return err
+			}
+
+			log.Infof("Deleted user '%s'", username)
+
+			return nil
+		},
+	}
+
+	command.Flags().StringVar(
+		&username,
+		deleteUsernameFlag,
+		"",
+		"The user to be deleted",
+	)
+	command.MarkFlagRequired(deleteUsernameFlag)
 
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/acl/user.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/user.go
@@ -1,0 +1,102 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+)
+
+const (
+	newUserFlag     = "new-username"
+	newPasswordFlag = "new-password"
+)
+
+func NewUserCommand(tls func() (*config.TLS, error)) *cobra.Command {
+	var apiUrl string
+
+	command := &cobra.Command{
+		Use:          "user",
+		Short:        "Manage users",
+		SilenceUsage: true,
+	}
+	command.PersistentFlags().StringVar(
+		&apiUrl,
+		"api-url",
+		fmt.Sprintf("localhost:%d", config.DefaultAdminPort),
+		"The Admin API URL",
+	)
+
+	adminApi := buildAdminAPI(&apiUrl, tls)
+
+	command.AddCommand(NewCreateUserCommand(adminApi))
+	return command
+}
+
+func NewCreateUserCommand(
+	adminApi func() (admin.AdminAPI, error),
+) *cobra.Command {
+	var (
+		newUser     string
+		newPassword string
+	)
+	command := &cobra.Command{
+		Use:          "create",
+		Short:        "Create users",
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			adminApi, err := adminApi()
+			if err != nil {
+				return err
+			}
+			err = adminApi.CreateUser(newUser, newPassword)
+			if err != nil {
+				return err
+			}
+
+			log.Infof("Created user '%s'", newUser)
+
+			return nil
+		},
+	}
+
+	command.Flags().StringVar(
+		&newUser,
+		newUserFlag,
+		"",
+		"The user to be created",
+	)
+	command.MarkFlagRequired(newUserFlag)
+	command.Flags().StringVar(
+		&newPassword,
+		newPasswordFlag,
+		"",
+		"The new user's password",
+	)
+	command.MarkFlagRequired(newPasswordFlag)
+
+	return command
+}
+
+func buildAdminAPI(
+	apiUrl *string, tls func() (*config.TLS, error),
+) func() (admin.AdminAPI, error) {
+	return func() (admin.AdminAPI, error) {
+		tlsConfig, err := tls()
+		if err != nil {
+			return nil, err
+		}
+		return admin.NewAdminAPI(*apiUrl, tlsConfig)
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/user_test.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/user_test.go
@@ -1,0 +1,106 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package acl_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/acl"
+)
+
+func TestACLUserCommands(t *testing.T) {
+	tests := []struct {
+		name           string
+		command        func(func() (admin.AdminAPI, error)) *cobra.Command
+		mockAdminAPI   func() (admin.AdminAPI, error)
+		args           []string
+		expectedOut    string
+		expectedErrMsg string
+	}{{
+		name:    "create should fail if building the admin API client fails",
+		command: acl.NewCreateUserCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return nil, errors.New("Woops, sorry")
+		},
+		args: []string{
+			"--new-username", "user",
+			"--new-password", "pass",
+		},
+		expectedErrMsg: "Woops, sorry",
+	}, {
+		name:    "create should fail if --new-username isn't passed",
+		command: acl.NewCreateUserCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return nil, nil
+		},
+		args: []string{
+			"--new-password", "pass",
+		},
+		expectedErrMsg: `required flag(s) "new-username" not set`,
+	}, {
+		name:    "create should fail if --new-password isn't passed",
+		command: acl.NewCreateUserCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return nil, nil
+		},
+		args: []string{
+			"--new-username", "user",
+		},
+		expectedErrMsg: `required flag(s) "new-password" not set`,
+	}, {
+		name:    "create should fail if creating the user fails",
+		command: acl.NewCreateUserCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return &admin.MockAdminAPI{
+				MockCreateUser: func(_, _ string) error {
+					return errors.New("user creation request failed")
+				},
+			}, nil
+		},
+		args: []string{
+			"--new-username", "user",
+			"--new-password", "pass",
+		},
+		expectedErrMsg: "user creation request failed",
+	}, {
+		name:    "create should print the created user",
+		command: acl.NewCreateUserCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return &admin.MockAdminAPI{}, nil
+		},
+		args: []string{
+			"--new-username", "user",
+			"--new-password", "pass",
+		},
+		expectedOut: "Created user 'user'",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			var out bytes.Buffer
+			cmd := tt.command(tt.mockAdminAPI)
+			logrus.SetOutput(&out)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			require.NoError(st, err)
+			require.Contains(st, out.String(), tt.expectedOut)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/acl/user_test.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/user_test.go
@@ -127,6 +127,50 @@ func TestACLUserCommands(t *testing.T) {
 			"--delete-username", "user",
 		},
 		expectedOut: "Deleted user 'user'",
+	}, {
+		name:    "list should fail if building the admin API client fails",
+		command: acl.NewListUsersCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return nil, errors.New("Woops, sorry")
+		},
+		expectedErrMsg: "Woops, sorry",
+	}, {
+		name:    "list should fail if listing the users fails",
+		command: acl.NewListUsersCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return &admin.MockAdminAPI{
+				MockListUsers: func() ([]string, error) {
+					return nil, errors.New("user list request failed")
+				},
+			}, nil
+		},
+		expectedErrMsg: "user list request failed",
+	}, {
+		name:    "list should print the users",
+		command: acl.NewListUsersCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return &admin.MockAdminAPI{
+				MockListUsers: func() ([]string, error) {
+					return []string{
+						"Michael",
+						"Jim",
+						"Pam",
+						"Dwight",
+						"Kelly",
+						"Bob Vance, Vance Refrigeration",
+					}, nil
+				},
+			}, nil
+		},
+		expectedOut: `  USERNAME                        
+                                  
+  Michael                         
+  Jim                             
+  Pam                             
+  Dwight                          
+  Kelly                           
+  Bob Vance, Vance Refrigeration  
+`,
 	}}
 
 	for _, tt := range tests {

--- a/src/go/rpk/pkg/cli/cmd/acl/user_test.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/user_test.go
@@ -86,6 +86,47 @@ func TestACLUserCommands(t *testing.T) {
 			"--new-password", "pass",
 		},
 		expectedOut: "Created user 'user'",
+	}, {
+		name:    "delete should fail if building the admin API client fails",
+		command: acl.NewDeleteUserCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return nil, errors.New("Woops, sorry")
+		},
+		args: []string{
+			"--delete-username", "user",
+		},
+		expectedErrMsg: "Woops, sorry",
+	}, {
+		name:    "delete should fail if --delete-username isn't passed",
+		command: acl.NewDeleteUserCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return nil, nil
+		},
+		expectedErrMsg: `required flag(s) "delete-username" not set`,
+	}, {
+		name:    "delete should fail if deleting the user fails",
+		command: acl.NewDeleteUserCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return &admin.MockAdminAPI{
+				MockDeleteUser: func(_ string) error {
+					return errors.New("user deletion request failed")
+				},
+			}, nil
+		},
+		args: []string{
+			"--delete-username", "user",
+		},
+		expectedErrMsg: "user deletion request failed",
+	}, {
+		name:    "create should print the deleted user",
+		command: acl.NewDeleteUserCommand,
+		mockAdminAPI: func() (admin.AdminAPI, error) {
+			return &admin.MockAdminAPI{}, nil
+		},
+		args: []string{
+			"--delete-username", "user",
+		},
+		expectedOut: "Deleted user 'user'",
 	}}
 
 	for _, tt := range tests {

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -62,17 +62,16 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	// actual brokers list to be used.
 	configClosure := common.FindConfigFile(mgr, &configFile)
 	brokersClosure := common.DeduceBrokers(
-		fs,
 		common.CreateDockerClient,
 		configClosure,
 		&brokers,
 	)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
-	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure, kAuthClosure)
+	adminClosure := common.CreateAdmin(brokersClosure, configClosure, kAuthClosure)
 	command.AddCommand(cluster.NewInfoCommand(adminClosure))
 
 	// NewOffsetsCommand takes client and admin factories so we can mock both
-	clientClosure := common.CreateClient(fs, brokersClosure, configClosure)
+	clientClosure := common.CreateClient(brokersClosure, configClosure)
 	adminWrapperClosure := func(client sarama.Client) (sarama.ClusterAdmin, error) {
 		return sarama.NewClusterAdminFromClient(client)
 	}

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -20,29 +20,29 @@ import (
 
 func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
-		brokers    []string
-		configFile string
-		user       string
-		password   string
-		mechanism  string
+		brokers        []string
+		configFile     string
+		user           string
+		password       string
+		mechanism      string
+		certFile       string
+		keyFile        string
+		truststoreFile string
 	)
 	command := &cobra.Command{
 		Use:   "cluster",
 		Short: "Interact with a Redpanda cluster",
 	}
-
-	command.PersistentFlags().StringSliceVar(
-		&brokers,
-		"brokers",
-		[]string{},
-		"Comma-separated list of broker ip:port pairs",
-	)
-	command.PersistentFlags().StringVar(
+	common.AddKafkaFlags(
+		command,
 		&configFile,
-		"config",
-		"",
-		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations",
+		&user,
+		&password,
+		&mechanism,
+		&certFile,
+		&keyFile,
+		&truststoreFile,
+		&brokers,
 	)
 	// The ideal way to pass common (global flags') values would be to
 	// declare PersistentPreRun hooks on each command root (such as rpk
@@ -67,11 +67,12 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&brokers,
 	)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
-	adminClosure := common.CreateAdmin(brokersClosure, configClosure, kAuthClosure)
+	tlsClosure := common.BuildTLSConfig(&certFile, &keyFile, &truststoreFile)
+	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	command.AddCommand(cluster.NewInfoCommand(adminClosure))
 
 	// NewOffsetsCommand takes client and admin factories so we can mock both
-	clientClosure := common.CreateClient(brokersClosure, configClosure)
+	clientClosure := common.CreateClient(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	adminWrapperClosure := func(client sarama.Client) (sarama.ClusterAdmin, error) {
 		return sarama.NewClusterAdminFromClient(client)
 	}

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -22,6 +22,9 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
 		brokers    []string
 		configFile string
+		user       string
+		password   string
+		mechanism  string
 	)
 	command := &cobra.Command{
 		Use:   "cluster",
@@ -64,7 +67,8 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure)
+	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
+	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure, kAuthClosure)
 	command.AddCommand(cluster.NewInfoCommand(adminClosure))
 
 	// NewOffsetsCommand takes client and admin factories so we can mock both

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/burdiyan/kafkautil"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/container/common"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
@@ -85,7 +84,6 @@ func FindConfigFile(
 }
 
 func DeduceBrokers(
-	fs afero.Fs,
 	client func() (common.Client, error),
 	configuration func() (*config.Config, error),
 	brokers *[]string,
@@ -190,7 +188,6 @@ func CreateProducer(
 }
 
 func CreateClient(
-	fs afero.Fs,
 	brokers func() []string,
 	configuration func() (*config.Config, error),
 ) func() (sarama.Client, error) {
@@ -206,7 +203,6 @@ func CreateClient(
 }
 
 func CreateAdmin(
-	fs afero.Fs,
 	brokers func() []string,
 	configuration func() (*config.Config, error),
 	authConfig func() (*config.SCRAM, error),

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -171,7 +171,7 @@ func CreateProducer(
 		if err != nil {
 			return nil, err
 		}
-		cfg, err := kafka.LoadConfig(conf)
+		cfg, err := kafka.LoadConfig(&conf.Rpk.TLS, &conf.Rpk.SCRAM)
 		if err != nil {
 			return nil, err
 		}
@@ -197,7 +197,7 @@ func CreateClient(
 			return nil, err
 		}
 		bs := brokers()
-		client, err := kafka.InitClientWithConf(conf, bs...)
+		client, err := kafka.InitClientWithConf(&conf.Rpk.TLS, &conf.Rpk.SCRAM, bs...)
 		return client, wrapConnErr(err, bs)
 	}
 }
@@ -213,7 +213,7 @@ func CreateAdmin(
 		if err != nil {
 			return nil, err
 		}
-		cfg, err := kafka.LoadConfig(conf)
+		cfg, err := kafka.LoadConfig(&conf.Rpk.TLS, &conf.Rpk.SCRAM)
 		if err != nil {
 			return nil, err
 		}

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -245,6 +245,26 @@ func ContainerBrokers(c common.Client) ([]string, []string) {
 	return addrs, stopped
 }
 
+func AddKafkaFlags(
+	command *cobra.Command, configFile *string, brokers *[]string,
+) *cobra.Command {
+	command.PersistentFlags().StringSliceVar(
+		brokers,
+		"brokers",
+		[]string{},
+		"Comma-separated list of broker ip:port pairs",
+	)
+	command.PersistentFlags().StringVar(
+		configFile,
+		"config",
+		"",
+		"Redpanda config file, if not set the file will be searched for"+
+			" in the default locations",
+	)
+
+	return command
+}
+
 func wrapConnErr(err error, addrs []string) error {
 	if err == nil {
 		return nil

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -135,11 +135,14 @@ func TestDeduceBrokers(t *testing.T) {
 
 func TestAddKafkaFlags(t *testing.T) {
 	var (
-		brokers    []string
-		configFile string
-		user       string
-		password   string
-		mechanism  string
+		brokers        []string
+		configFile     string
+		user           string
+		password       string
+		mechanism      string
+		certFile       string
+		keyFile        string
+		truststoreFile string
 	)
 	command := func() *cobra.Command {
 		parent := &cobra.Command{
@@ -156,7 +159,17 @@ func TestAddKafkaFlags(t *testing.T) {
 		}
 		parent.AddCommand(child)
 
-		common.AddKafkaFlags(parent, &configFile, &user, &password, &mechanism, &brokers)
+		common.AddKafkaFlags(
+			parent,
+			&configFile,
+			&user,
+			&password,
+			&mechanism,
+			&certFile,
+			&keyFile,
+			&truststoreFile,
+			&brokers,
+		)
 		return parent
 	}
 
@@ -167,6 +180,9 @@ func TestAddKafkaFlags(t *testing.T) {
 		"--user", "david",
 		"--password", "verysecrethaha",
 		"--sasl-mechanism", "some-mechanism",
+		"--tls-cert", "cert.pem",
+		"--tls-key", "key.pem",
+		"--tls-truststore", "truststore.pem",
 	})
 
 	err := cmd.Execute()
@@ -177,6 +193,9 @@ func TestAddKafkaFlags(t *testing.T) {
 	require.Exactly(t, "david", user)
 	require.Exactly(t, "verysecrethaha", password)
 	require.Exactly(t, "some-mechanism", mechanism)
+	require.Exactly(t, "cert.pem", certFile)
+	require.Exactly(t, "key.pem", keyFile)
+	require.Exactly(t, "truststore.pem", truststoreFile)
 
 	// The flags should be available for the children commands too
 	cmd = command() // reset it.
@@ -188,6 +207,9 @@ func TestAddKafkaFlags(t *testing.T) {
 		"--user", "juan",
 		"--password", "sosecure",
 		"--sasl-mechanism", "whatevs",
+		"--tls-cert", "cert1.pem",
+		"--tls-key", "key1.pem",
+		"--tls-truststore", "truststore1.pem",
 	})
 
 	err = cmd.Execute()
@@ -198,6 +220,9 @@ func TestAddKafkaFlags(t *testing.T) {
 	require.Exactly(t, "juan", user)
 	require.Exactly(t, "sosecure", password)
 	require.Exactly(t, "whatevs", mechanism)
+	require.Exactly(t, "cert1.pem", certFile)
+	require.Exactly(t, "key1.pem", keyFile)
+	require.Exactly(t, "truststore1.pem", truststoreFile)
 }
 
 func TestKafkaAuthConfig(t *testing.T) {

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/common"
@@ -110,7 +109,6 @@ func TestDeduceBrokers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(st *testing.T) {
-			fs := afero.NewMemMapFs()
 			client := func() (ccommon.Client, error) {
 				return &ccommon.MockClient{}, nil
 			}
@@ -129,7 +127,7 @@ func TestDeduceBrokers(t *testing.T) {
 			if tt.brokers != nil {
 				brokers = &tt.brokers
 			}
-			bs := common.DeduceBrokers(fs, client, config, brokers)()
+			bs := common.DeduceBrokers(client, config, brokers)()
 			require.Exactly(st, tt.expected, bs)
 		})
 	}

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -276,7 +276,7 @@ func getKafkaInfo(
 		conf.Redpanda.KafkaApi[0].Address,
 		conf.Redpanda.KafkaApi[0].Port,
 	)
-	client, err := kafka.InitClientWithConf(&conf, addr)
+	client, err := kafka.InitClientWithConf(&conf.Rpk.TLS, &conf.Rpk.SCRAM, addr)
 	if err != nil {
 		out <- [][]string{}
 		kafkaInfoCh <- kInfo

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -70,6 +70,7 @@ func Execute() {
 	rootCmd.AddCommand(NewTopicCommand(fs, mgr))
 	rootCmd.AddCommand(NewClusterCommand(fs, mgr))
 	rootCmd.AddCommand(NewCloudCommand(fs))
+	rootCmd.AddCommand(NewACLCommand(fs, mgr))
 
 	addPlatformDependentCmds(fs, mgr, rootCmd)
 

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -49,14 +49,13 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	// path, the list of brokers passed through --brokers).
 	configClosure := common.FindConfigFile(mgr, &configFile)
 	brokersClosure := common.DeduceBrokers(
-		fs,
 		common.CreateDockerClient,
 		configClosure,
 		&brokers,
 	)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
-	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure, kAuthClosure)
-	clientClosure := common.CreateClient(fs, brokersClosure, configClosure)
+	adminClosure := common.CreateAdmin(brokersClosure, configClosure, kAuthClosure)
+	clientClosure := common.CreateClient(brokersClosure, configClosure)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure)
 
 	command.AddCommand(topic.NewCreateCommand(adminClosure))

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -21,13 +21,16 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
 		brokers    []string
 		configFile string
+		user       string
+		password   string
+		mechanism  string
 	)
 	command := &cobra.Command{
 		Use:   "topic",
 		Short: "Create, delete, produce to and consume from Redpanda topics.",
 	}
 
-	common.AddKafkaFlags(command, &configFile, &brokers)
+	common.AddKafkaFlags(command, &configFile, &user, &password, &mechanism, &brokers)
 
 	// The ideal way to pass common (global flags') values would be to
 	// declare PersistentPreRun hooks on each command root (such as rpk
@@ -51,7 +54,8 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure)
+	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
+	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure, kAuthClosure)
 	clientClosure := common.CreateClient(fs, brokersClosure, configClosure)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure)
 

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -27,19 +27,7 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		Short: "Create, delete, produce to and consume from Redpanda topics.",
 	}
 
-	command.PersistentFlags().StringSliceVar(
-		&brokers,
-		"brokers",
-		[]string{},
-		"Comma-separated list of broker ip:port pairs",
-	)
-	command.PersistentFlags().StringVar(
-		&configFile,
-		"config",
-		"",
-		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations",
-	)
+	common.AddKafkaFlags(command, &configFile, &brokers)
 
 	// The ideal way to pass common (global flags') values would be to
 	// declare PersistentPreRun hooks on each command root (such as rpk

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -27,6 +27,7 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		Use:   "wasm",
 		Short: "Deploy and remove inline WASM engine scripts",
 	}
+	common.AddKafkaFlags(command, &configFile, &brokers)
 	command.AddCommand(wasm.NewGenerateCommand(fs))
 
 	// configure kafka producer
@@ -40,42 +41,9 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	producerClosure := common.CreateProducer(brokersClosure, configClosure)
 	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure)
 
-	command.AddCommand(
-		addKafkaFlags(
-			wasm.NewDeployCommand(fs, producerClosure, adminClosure),
-			&configFile,
-			&brokers,
-		),
-	)
+	command.AddCommand(wasm.NewDeployCommand(fs, producerClosure, adminClosure))
 
-	command.AddCommand(
-		addKafkaFlags(
-			wasm.NewRemoveCommand(producerClosure, adminClosure),
-			&configFile,
-			&brokers,
-		),
-	)
+	command.AddCommand(wasm.NewRemoveCommand(producerClosure, adminClosure))
 
-	return command
-}
-
-func addKafkaFlags(
-	command *cobra.Command, configFile *string, brokers *[]string,
-) *cobra.Command {
-
-	command.Flags().StringSliceVar(
-		brokers,
-		"brokers",
-		[]string{},
-		"Comma-separated list of broker ip:port pairs",
-	)
-
-	command.Flags().StringVar(
-		configFile,
-		"config",
-		"",
-		"Redpanda config file, if not set the file will be searched for"+
-			" in the default locations",
-	)
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -43,14 +43,13 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	// configure kafka producer
 	configClosure := common.FindConfigFile(mgr, &configFile)
 	brokersClosure := common.DeduceBrokers(
-		fs,
 		common.CreateDockerClient,
 		configClosure,
 		&brokers,
 	)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure)
-	adminClosure := common.CreateAdmin(fs, brokersClosure, configClosure, kAuthClosure)
+	adminClosure := common.CreateAdmin(brokersClosure, configClosure, kAuthClosure)
 
 	command.AddCommand(wasm.NewDeployCommand(fs, producerClosure, adminClosure))
 

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -19,11 +19,14 @@ import (
 
 func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	var (
-		configFile string
-		brokers    []string
-		user       string
-		password   string
-		mechanism  string
+		configFile     string
+		brokers        []string
+		user           string
+		password       string
+		mechanism      string
+		certFile       string
+		keyFile        string
+		truststoreFile string
 	)
 
 	command := &cobra.Command{
@@ -36,6 +39,9 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&user,
 		&password,
 		&mechanism,
+		&certFile,
+		&keyFile,
+		&truststoreFile,
 		&brokers,
 	)
 	command.AddCommand(wasm.NewGenerateCommand(fs))
@@ -47,9 +53,10 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
+	tlsClosure := common.BuildTLSConfig(&certFile, &keyFile, &truststoreFile)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
-	producerClosure := common.CreateProducer(brokersClosure, configClosure)
-	adminClosure := common.CreateAdmin(brokersClosure, configClosure, kAuthClosure)
+	producerClosure := common.CreateProducer(brokersClosure, configClosure, tlsClosure, kAuthClosure)
+	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 
 	command.AddCommand(wasm.NewDeployCommand(fs, producerClosure, adminClosure))
 

--- a/src/go/rpk/pkg/kafka/client_test.go
+++ b/src/go/rpk/pkg/kafka/client_test.go
@@ -80,3 +80,89 @@ func Test_LoadConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigureSASL(t *testing.T) {
+	tests := []struct {
+		name           string
+		scram          *config.SCRAM
+		check          func(*testing.T, *sarama.Config)
+		expectedErrMsg string
+	}{{
+		name: "it should fail if the mechanism is not supported",
+		scram: &config.SCRAM{
+			User:     "admin",
+			Password: "admin123",
+			Type:     "unsupported",
+		},
+		expectedErrMsg: "unrecongnized Salted Challenge Response Authentication Mechanism (SCRAM): 'unsupported'.",
+	}, {
+		name: "it shouldn't enable SASL if user is empty",
+		scram: &config.SCRAM{
+			Password: "admin123",
+			Type:     "SCRAM-SHA-256",
+		},
+		check: func(st *testing.T, cfg *sarama.Config) {
+			require.False(st, cfg.Net.SASL.Enable, "cfg.Net.SASL.Enable")
+			require.Empty(st, cfg.Net.SASL.User, "cfg.Net.SASL.User")
+			require.Empty(st, cfg.Net.SASL.Password, "cfg.Net.SASL.Password")
+			require.Empty(st, cfg.Net.SASL.Mechanism, "cfg.Net.SASL.Mechanism")
+			require.Nil(st, cfg.Net.SASL.SCRAMClientGeneratorFunc, "cfg.Net.SASL.SCRAMClientGeneratorFunc")
+		},
+	}, {
+		name: "it shouldn't enable SASL if password is empty",
+		scram: &config.SCRAM{
+			User: "user1",
+			Type: "SCRAM-SHA-256",
+		},
+		check: func(st *testing.T, cfg *sarama.Config) {
+			require.False(st, cfg.Net.SASL.Enable, "cfg.Net.SASL.Enable")
+			require.Empty(st, cfg.Net.SASL.User, "cfg.Net.SASL.User")
+			require.Empty(st, cfg.Net.SASL.Password, "cfg.Net.SASL.Password")
+			require.Empty(st, cfg.Net.SASL.Mechanism, "cfg.Net.SASL.Mechanism")
+			require.Nil(st, cfg.Net.SASL.SCRAMClientGeneratorFunc, "cfg.Net.SASL.SCRAMClientGeneratorFunc")
+		},
+	}, {
+		name: "it shouldn't enable SASL if mechanism is empty",
+		scram: &config.SCRAM{
+			User:     "user1",
+			Password: "pass",
+		},
+		check: func(st *testing.T, cfg *sarama.Config) {
+			require.False(st, cfg.Net.SASL.Enable, "cfg.Net.SASL.Enable")
+			require.Empty(st, cfg.Net.SASL.User, "cfg.Net.SASL.User")
+			require.Empty(st, cfg.Net.SASL.Password, "cfg.Net.SASL.Password")
+			require.Empty(st, cfg.Net.SASL.Mechanism, "cfg.Net.SASL.Mechanism")
+			require.Nil(st, cfg.Net.SASL.SCRAMClientGeneratorFunc, "cfg.Net.SASL.SCRAMClientGeneratorFunc")
+		},
+	}, {
+		name: "it should set the appropriate mechanism for SCRAM-SHA-256",
+		scram: &config.SCRAM{
+			User:     "user1",
+			Password: "pass",
+			Type:     "SCRAM-SHA-256",
+		},
+		check: func(st *testing.T, cfg *sarama.Config) {
+			require.Equal(st, sarama.SASLTypeSCRAMSHA256, string(cfg.Net.SASL.Mechanism))
+		},
+	}, {
+		name: "it should set the appropriate mechanism for SCRAM-SHA-512",
+		scram: &config.SCRAM{
+			User:     "user1",
+			Password: "pass",
+			Type:     "SCRAM-SHA-512",
+		},
+		check: func(st *testing.T, cfg *sarama.Config) {
+			require.Equal(st, sarama.SASLTypeSCRAMSHA512, string(cfg.Net.SASL.Mechanism))
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			res, err := kafka.ConfigureSASL(kafka.DefaultConfig(), tt.scram)
+			if tt.expectedErrMsg != "" {
+				require.EqualError(st, err, tt.expectedErrMsg)
+				return
+			}
+			tt.check(st, res)
+		})
+	}
+}

--- a/src/go/rpk/pkg/kafka/client_test.go
+++ b/src/go/rpk/pkg/kafka/client_test.go
@@ -74,7 +74,7 @@ func Test_LoadConfig(t *testing.T) {
 			if tt.conf != nil {
 				conf = tt.conf()
 			}
-			c, err := kafka.LoadConfig(conf)
+			c, err := kafka.LoadConfig(&conf.Rpk.TLS, &conf.Rpk.SCRAM)
 			require.NoError(t, err)
 			tt.check(st, conf, c)
 		})

--- a/src/go/rpk/pkg/tls/tls.go
+++ b/src/go/rpk/pkg/tls/tls.go
@@ -1,0 +1,78 @@
+package tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+)
+
+func LoadTLSConfig(
+	truststoreFile, certFile, keyFile string,
+) (*tls.Config, error) {
+	caCertPool, err := LoadRootCACert(truststoreFile)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := LoadCert(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	tlsConf := &tls.Config{RootCAs: caCertPool, Certificates: certs}
+
+	tlsConf.BuildNameToCertificate()
+	return tlsConf, nil
+}
+
+func LoadRootCACert(truststoreFile string) (*x509.CertPool, error) {
+	caCert, err := ioutil.ReadFile(truststoreFile)
+	if err != nil {
+		return nil, err
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+	return caCertPool, nil
+}
+
+func LoadCert(certFile, keyFile string) ([]tls.Certificate, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	return []tls.Certificate{cert}, nil
+}
+
+func BuildTLSConfig(
+	certFile, keyFile, truststoreFile string,
+) (*tls.Config, error) {
+	var tlsConfig *tls.Config
+	var err error
+
+	switch {
+	case certFile == "" &&
+		keyFile == "" &&
+		truststoreFile == "":
+		return nil, nil
+
+	case certFile != "" &&
+		keyFile != "" &&
+		truststoreFile != "":
+
+		tlsConfig, err = LoadTLSConfig(
+			truststoreFile,
+			certFile,
+			keyFile,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+	// Enable TLS (no auth) if only the CA cert file is set for rpk
+	case truststoreFile != "":
+		caCertPool, err := LoadRootCACert(truststoreFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig = &tls.Config{RootCAs: caCertPool}
+	}
+	return tlsConfig, nil
+}


### PR DESCRIPTION
### Add support for ACL & users management to rpk.

- `rpk acl create`
```
$ rpk acl create \
--resource cluster \
--allow-host 168.72.98.52 \
--deny-host 169.78.31.9 \
--deny-principal 'User:david' \
--allow-principal 'User:Alex' \
--allow-principal 'User:Ben' 
Created ACL for principal 'User:david' with host '169.78.31.9', operation 'All' and permission 'Deny'
Created ACL for principal 'User:Alex' with host '168.72.98.52', operation 'All' and permission 'Allow'
Created ACL for principal 'User:Ben' with host '168.72.98.52', operation 'All' and permission 'Allow'
```
- `rpk acl list`
```
$ rpk acl list                            
  PRINCIPAL   HOST          OPERATION  PERMISSION TYPE  RESOURCE TYPE  RESOURCE NAME  
              
  User:david  169.78.31.9   All        Deny             Cluster        kafka-cluster  
  User:Alex   168.72.98.52  All        Allow            Cluster        kafka-cluster  
  User:Ben    168.72.98.52  All        Allow            Cluster        kafka-cluster
```
Or with filters:
```
$ rpk acl list --permission deny --host 169.78.31.9
  PRINCIPAL   HOST         OPERATION  PERMISSION TYPE  RESOURCE TYPE  RESOURCE NAME  
              
  User:david  169.78.31.9  All        Deny             Cluster        kafka-cluster
```
- `rpk acl delete`
```
$ rpk acl delete --deny-principal 'User:david' --resource cluster
  DELETED  PRINCIPAL   HOST         OPERATION  PERMISSION TYPE  RESOURCE TYPE  RESOURCE NAME  ERROR MESSAGE  
           
  yes      User:david  169.78.31.9  All        Deny             Cluster        kafka-cluster  None
```

#### User management:

- `rpk acl user create`
```
$ rpk acl user create --new-username david --new-password password123
Created user 'david'.
```
- `rpk acl user delete`
```
$ rpk acl user delete --delete-username david
Delete user 'david'.
```
- `rpk acl user list`
```
$ rpk acl user list
  USERNAME                        
                                  
  Michael                         
  Jim                             
  Pam                             
  Dwight                          
  Kelly                           
  Bob Vance, Vance Refrigeration  
```
Also adds support for SASL/SCRAM & TLS authentication through flags across all relevant commands.

Ex.

```
$ rpk topic create 'events' -p 10 -r 3 --user david --password password123 --sasl-mechanism SCRAM-SHA-256
```

```
$ rpk acl create \
--resource cluster \
--deny-principal 'User:david' \
--tls-truststore ca.pem \
--tls-cert cert.pem \
--tls-key key.pem
```

## Release notes

Release note: Added `rpk acl`, which adds support for ACL management.
Release note: Added support for passing TLS config through `--tls-cert`, `--tls-key`, `--tls-truststore`.
