### PR TITLE
Caching readers in storage layer

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -9,6 +9,7 @@
 
 #include "config/configuration.h"
 
+#include "config/base_property.h"
 #include "model/metadata.h"
 #include "units.h"
 
@@ -41,6 +42,12 @@ configuration::configuration()
       "256MiB)",
       required::no,
       256_MiB)
+  , readers_cache_eviction_timeout_ms(
+      *this,
+      "readers_cache_eviction_timeout_ms",
+      "Duration after which inactive readers will be evicted from cache",
+      required::no,
+      30s)
   , rpc_server(
       *this,
       "rpc_server",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -44,6 +44,7 @@ struct configuration final : public config_store {
     property<bool> developer_mode;
     property<uint64_t> log_segment_size;
     property<uint64_t> compacted_log_segment_size;
+    property<std::chrono::milliseconds> readers_cache_eviction_timeout_ms;
     // Network
     property<unresolved_address> rpc_server;
     property<tls_config> rpc_server_tls;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -320,7 +320,8 @@ static storage::log_config manager_config_from_global_config() {
         .stable_window = config::shard_local_cfg().reclaim_stable_window(),
         .min_size = config::shard_local_cfg().reclaim_min_size(),
         .max_size = config::shard_local_cfg().reclaim_max_size(),
-      });
+      },
+      config::shard_local_cfg().readers_cache_eviction_timeout_ms());
 }
 
 // add additional services in here

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -29,6 +29,7 @@ v_cc_library(
     segment_utils.cc
     compaction_reducers.cc
     parser_utils.cc
+    readers_cache.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -18,6 +18,7 @@
 #include "storage/log.h"
 #include "storage/log_reader.h"
 #include "storage/probe.h"
+#include "storage/readers_cache.h"
 #include "storage/segment_appender.h"
 #include "storage/segment_reader.h"
 #include "storage/types.h"
@@ -87,6 +88,9 @@ private:
     ss::future<model::record_batch_reader>
       make_unchecked_reader(log_reader_config);
 
+    ss::future<model::record_batch_reader>
+      make_cached_reader(log_reader_config);
+
     model::offset read_start_offset() const;
 
     ss::future<> do_compact(compaction_config);
@@ -144,6 +148,7 @@ private:
     std::optional<eviction_monitor> _eviction_monitor;
     model::offset _max_collectible_offset;
     size_t _max_segment_size;
+    std::unique_ptr<readers_cache> _readers_cache;
 };
 
 } // namespace storage

--- a/src/v/storage/fwd.h
+++ b/src/v/storage/fwd.h
@@ -19,5 +19,6 @@ class log_manager;
 class ntp_config;
 class segment;
 class snapshot_manager;
+class readers_cache;
 
 } // namespace storage

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -15,6 +15,7 @@
 #include "prometheus/prometheus_sanitize.h"
 #include "raft/types.h"
 #include "reflection/adl.h"
+#include "storage/parser.h"
 #include "storage/record_batch_builder.h"
 #include "storage/segment_set.h"
 #include "storage/types.h"
@@ -536,12 +537,22 @@ void kvstore::replay_segments_in_thread(segment_set segs) {
     save_snapshot().get();
 }
 
-batch_consumer::consume_result kvstore::replay_consumer::consume_batch_start(
-  model::record_batch_header header, size_t, size_t) {
+batch_consumer::consume_result kvstore::replay_consumer::accept_batch_start(
+  const model::record_batch_header&) const {
     if (_store->_gate.is_closed()) {
         // early out on shutdown
         return batch_consumer::consume_result::stop_parser;
     }
+    return batch_consumer::consume_result::accept_batch;
+}
+
+void kvstore::replay_consumer::skip_batch_start(
+  model::record_batch_header h, size_t, size_t) {
+    vassert(false, "kvstore should never skip batches, header: {}", h);
+}
+
+void kvstore::replay_consumer::consume_batch_start(
+  model::record_batch_header header, size_t, size_t) {
     vassert(header.record_count > 0, "Unexpected empty batch");
     vassert(
       header.base_offset == _store->_next_offset,
@@ -549,7 +560,6 @@ batch_consumer::consume_result kvstore::replay_consumer::consume_batch_start(
       header.base_offset,
       _store->_next_offset);
     _header = header;
-    return batch_consumer::consume_result::accept_batch;
 }
 
 void kvstore::replay_consumer::consume_records(iobuf&& records) {

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -540,7 +540,7 @@ batch_consumer::consume_result kvstore::replay_consumer::consume_batch_start(
   model::record_batch_header header, size_t, size_t) {
     if (_store->_gate.is_closed()) {
         // early out on shutdown
-        return stop_parser::yes;
+        return batch_consumer::consume_result::stop_parser;
     }
     vassert(header.record_count > 0, "Unexpected empty batch");
     vassert(
@@ -549,7 +549,7 @@ batch_consumer::consume_result kvstore::replay_consumer::consume_batch_start(
       header.base_offset,
       _store->_next_offset);
     _header = header;
-    return skip_batch::no;
+    return batch_consumer::consume_result::accept_batch;
 }
 
 void kvstore::replay_consumer::consume_records(iobuf&& records) {

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -175,7 +175,11 @@ private:
         explicit replay_consumer(kvstore* store)
           : _store(store) {}
 
-        consume_result consume_batch_start(
+        consume_result
+        accept_batch_start(const model::record_batch_header&) const override;
+        void consume_batch_start(
+          model::record_batch_header header, size_t, size_t) override;
+        void skip_batch_start(
           model::record_batch_header header, size_t, size_t) override;
         void consume_records(iobuf&&) override;
         stop_parser consume_batch_end() override;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -80,7 +80,8 @@ struct log_config {
       std::chrono::milliseconds compaction_ival,
       std::chrono::milliseconds del_ret,
       with_cache c,
-      batch_cache::reclaim_options recopts) noexcept
+      batch_cache::reclaim_options recopts,
+      std::chrono::milliseconds rdrs_cache_eviction_timeout) noexcept
       : stype(type)
       , base_dir(std::move(directory))
       , max_segment_size(segment_size)
@@ -92,7 +93,8 @@ struct log_config {
       , compaction_interval(compaction_ival)
       , delete_retention(del_ret)
       , cache(c)
-      , reclaim_opts(recopts) {}
+      , reclaim_opts(recopts)
+      , readers_cache_eviction_timeout(rdrs_cache_eviction_timeout) {}
 
     ~log_config() noexcept = default;
     // must be enabled so that we can do ss::sharded<>.start(config);
@@ -124,7 +126,8 @@ struct log_config {
       .min_size = 128_KiB,
       .max_size = 4_MiB,
     };
-
+    std::chrono::milliseconds readers_cache_eviction_timeout
+      = std::chrono::seconds(30);
     friend std::ostream& operator<<(std::ostream& o, const log_config&);
 }; // namespace storage
 

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -61,11 +61,18 @@ public:
       , _timeout(timeout)
       , _next_cached_batch(next_cached_batch) {}
 
-    consume_result consume_batch_start(
+    consume_result
+    accept_batch_start(const model::record_batch_header&) const override;
+
+    void consume_batch_start(
       model::record_batch_header,
       size_t physical_base_offset,
       size_t bytes_on_disk) override;
 
+    void skip_batch_start(
+      model::record_batch_header,
+      size_t physical_base_offset,
+      size_t bytes_on_disk) override;
     void consume_records(iobuf&&) override;
     stop_parser consume_batch_end() override;
     void print(std::ostream&) const override;

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -168,6 +168,33 @@ public:
         _config = cfg;
         _iterator.next_seg = _iterator.current_reader_seg;
     };
+
+    /**
+     * Return next read request lower bound. i.e. lowest offset that can be read
+     * using this reader. This way we can match requested offsets with cached
+     * readers.
+     */
+    model::offset next_read_lower_bound() const { return _config.start_offset; }
+
+    /**
+     * Base offset of first locked segment in read lock lease
+     */
+    model::offset lease_range_base_offset() const {
+        if (_lease->range.empty()) {
+            return model::offset{};
+        }
+        return _lease->range.front()->offsets().base_offset;
+    }
+    /**
+     * Last offset of last locked segment in read lock lease
+     */
+    model::offset lease_range_end_offset() const {
+        if (_lease->range.empty()) {
+            return model::offset{};
+        }
+        return _lease->range.back()->offsets().dirty_offset;
+    }
+
     /**
      * Indicates if current reader may be reused for future reads.
      *

--- a/src/v/storage/log_replayer.cc
+++ b/src/v/storage/log_replayer.cc
@@ -40,7 +40,14 @@ public:
     checksumming_consumer& operator=(checksumming_consumer&&) noexcept = delete;
     ~checksumming_consumer() noexcept override = default;
 
-    consume_result consume_batch_start(
+    consume_result
+    accept_batch_start(const model::record_batch_header&) const final {
+        return batch_consumer::consume_result::accept_batch;
+    }
+    void skip_batch_start(model::record_batch_header, size_t, size_t) override {
+    }
+
+    void consume_batch_start(
       model::record_batch_header header,
       size_t physical_base_offset,
       size_t size_on_disk) override {
@@ -48,7 +55,6 @@ public:
         _file_pos_to_end_of_batch = size_on_disk + physical_base_offset;
         _crc = crc32();
         model::crc_record_batch_header(_crc, header);
-        return batch_consumer::consume_result::accept_batch;
     }
 
     void consume_records(iobuf&& records) override {

--- a/src/v/storage/log_replayer.cc
+++ b/src/v/storage/log_replayer.cc
@@ -48,7 +48,7 @@ public:
         _file_pos_to_end_of_batch = size_on_disk + physical_base_offset;
         _crc = crc32();
         model::crc_record_batch_header(_crc, header);
-        return skip_batch::no;
+        return batch_consumer::consume_result::accept_batch;
     }
 
     void consume_records(iobuf&& records) override {

--- a/src/v/storage/parser.h
+++ b/src/v/storage/parser.h
@@ -30,16 +30,19 @@ namespace storage {
 
 class batch_consumer {
 public:
-    /// \brief this tag is useful for when the user wants to
-    /// find a particular offset - think a scan - and we need to skip
-    /// the current batch to get to it
-    using skip_batch = ss::bool_class<struct skip_batch_tag>;
-
     /// \brief  stopping the parser, may or may not be an error condition
     /// it is a public interface indended to signal the internals of the parser
     /// wether to continue or not.
     using stop_parser = ss::bool_class<struct stop_parser_tag>;
-    using consume_result = std::variant<stop_parser, skip_batch>;
+    /**
+     * Consume results informs parser what it the expected outcome of consume
+     * batch start decision
+     */
+    enum class consume_result : int8_t {
+        accept_batch, // accept batch
+        stop_parser,  // stop parsing and do not consume batch records
+        skip_batch,   // skip given batch without consuming records
+    };
 
     batch_consumer() noexcept = default;
     batch_consumer(const batch_consumer&) = default;

--- a/src/v/storage/parser.h
+++ b/src/v/storage/parser.h
@@ -51,7 +51,26 @@ public:
     batch_consumer& operator=(batch_consumer&&) noexcept = default;
     virtual ~batch_consumer() noexcept = default;
 
-    virtual consume_result consume_batch_start(
+    /**
+     * returns consume result, allow consumer to decide if batch header should
+     * be consumed, it may be called more than once with the same header.
+     */
+    virtual consume_result
+    accept_batch_start(const model::record_batch_header&) const = 0;
+
+    /**
+     * unconditionally consumes batch start
+     */
+    virtual void consume_batch_start(
+      model::record_batch_header,
+      size_t physical_base_offset,
+      size_t size_on_disk)
+      = 0;
+
+    /**
+     * unconditionally skip batch
+     */
+    virtual void skip_batch_start(
       model::record_batch_header,
       size_t physical_base_offset,
       size_t size_on_disk)

--- a/src/v/storage/parser.h
+++ b/src/v/storage/parser.h
@@ -106,7 +106,7 @@ private:
 private:
     std::unique_ptr<batch_consumer> _consumer;
     ss::input_stream<char> _input;
-    model::record_batch_header _header;
+    std::optional<model::record_batch_header> _header;
     parser_errc _err = parser_errc::none;
     size_t _bytes_consumed{0};
     size_t _physical_base_offset{0};

--- a/src/v/storage/parser.h
+++ b/src/v/storage/parser.h
@@ -92,6 +92,8 @@ private:
     /// \brief consumes _one_ full batch.
     ss::future<result<batch_consumer::stop_parser>> consume_one();
 
+    /// \brief read and parses header from input_file_stream
+    ss::future<result<model::record_batch_header>> read_header();
     /// \brief parses and _stores_ the header into _header variable
     ss::future<result<batch_consumer::stop_parser>> consume_header();
 

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "storage/readers_cache.h"
+
+#include "model/fundamental.h"
+#include "storage/types.h"
+#include "utils/gate_guard.h"
+#include "utils/mutex.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+
+#include <algorithm>
+#include <chrono>
+
+namespace storage {
+
+readers_cache::readers_cache(
+  model::ntp ntp, std::chrono::milliseconds eviction_timeout)
+  : _ntp(std::move(ntp))
+  , _eviction_timeout(eviction_timeout) {
+    // setup eviction timer
+    _eviction_timer.set_callback([this] {
+        (void)ss::with_gate(_gate, [this] {
+            return maybe_evict().finally([this] {
+                if (!_gate.is_closed()) {
+                    _eviction_timer.arm(_eviction_timeout);
+                }
+            });
+        });
+    });
+
+    _eviction_timer.arm(_eviction_timeout);
+}
+
+model::record_batch_reader
+readers_cache::put(std::unique_ptr<log_reader> reader) {
+    if (
+      _gate.is_closed()
+      || reader->lease_range_base_offset() < model::offset{0}) {
+        // do not cache reader with empty lease
+        return model::record_batch_reader(std::move(reader));
+    }
+    // check if requested reader belongs to one of the locked range
+    auto lock_it = std::find_if(
+      _locked_offset_ranges.begin(),
+      _locked_offset_ranges.end(),
+      [&reader](const offset_range& range) {
+          return reader->lease_range_base_offset() > range.second
+                 || reader->lease_range_end_offset() < range.first;
+      });
+
+    // range locked, do not insert into the cache
+    if (lock_it != _locked_offset_ranges.end()) {
+        return model::record_batch_reader(std::move(reader));
+    }
+
+    if (reader->lease_range_base_offset())
+        vlog(
+          stlog.trace,
+          "{} - adding reader [{},{}]",
+          _ntp,
+          reader->lease_range_base_offset(),
+          reader->lease_range_end_offset());
+
+    auto ptr = new entry{.reader = std::move(reader)}; // NOLINT
+    _in_use.push_back(*ptr);
+    return ptr->make_cached_reader(this);
+}
+
+std::optional<model::record_batch_reader>
+readers_cache::get_reader(const log_reader_config& cfg) {
+    vlog(stlog.trace, "{} - trying to get reader for: {}", _ntp, cfg);
+    intrusive_list<entry, &entry::_hook> to_evict;
+    /**
+     * We use linear search since _readers intrusive list is small.
+     */
+    auto it = _readers.begin();
+    while (it != _readers.end()) {
+        const auto is_valid = it->reader->is_reusable() && it->valid;
+        // TODO: think about relaxing this equality condition
+        const auto offset_matches = it->reader->next_read_lower_bound()
+                                    == cfg.start_offset;
+        // if invalid we will dispose this entry in background
+        if (!is_valid) {
+            it = _readers.erase_and_dispose(
+              it, [&to_evict](entry* e) { to_evict.push_back(*e); });
+            continue;
+        }
+        if (offset_matches && is_valid) {
+            // found matching reader
+            break;
+        }
+        ++it;
+    }
+    /**
+     * dispose unused readers in background
+     */
+    dispose_in_background(std::move(to_evict));
+    if (it == _readers.end()) {
+        vlog(stlog.trace, "{} - reader cache miss for: {}", _ntp, cfg);
+        return std::nullopt;
+    }
+    auto& e = *it;
+    vlog(stlog.trace, "{} - reader cache hit for: {}", _ntp, cfg);
+    it->reader->reset_config(cfg);
+
+    // we use cached_reader wrapper to track reader usage, when cached_reader is
+    // destroyed we unlock reader and trigger eviction
+    e._hook.unlink();
+    _in_use.push_back(e);
+    return e.make_cached_reader(this);
+}
+
+ss::future<> readers_cache::wait_for_no_inuse_readers() {
+    return _in_use_reader_destroyed.wait([this] { return _in_use.empty(); });
+}
+
+ss::future<> readers_cache::stop() {
+    if (_eviction_timer.armed()) {
+        _eviction_timer.cancel();
+    }
+    /**
+     * First we close the gate, this will prevent new readers from being
+     * insterted to the cache
+     */
+    co_await _gate.close();
+    /**
+     * Next we wait for all active readers to finish
+     */
+    co_await wait_for_no_inuse_readers();
+    /**
+     * Close and dispose cached readers
+     */
+    for (auto& r : _readers) {
+        co_await r.reader->finally();
+    }
+    _readers.clear_and_dispose([](entry* e) {
+        delete e; // NOLINT
+    });
+}
+
+ss::future<readers_cache::range_lock_holder>
+readers_cache::evict_segment_readers(ss::lw_shared_ptr<segment> s) {
+    vlog(
+      stlog.debug,
+      "{} - evicting reader from cache, segment [{},{}] removal",
+      _ntp,
+      s->offsets().base_offset,
+      s->offsets().dirty_offset);
+    return evict_range(s->offsets().base_offset, s->offsets().dirty_offset);
+}
+
+ss::future<readers_cache::range_lock_holder>
+readers_cache::evict_prefix_truncate(model::offset o) {
+    vlog(stlog.debug, "{} - evicting reader prefix truncate {}", _ntp, o);
+    offset_range range{model::offset::min(), o};
+    _locked_offset_ranges.push_back(range);
+    return evict_if(
+             [o](entry& e) { return e.reader->next_read_lower_bound() <= o; })
+      .then([this, range = std::move(range)]() mutable {
+          return range_lock_holder(std::move(range), this);
+      });
+    ;
+}
+
+ss::future<readers_cache::range_lock_holder>
+readers_cache::evict_truncate(model::offset o) {
+    vlog(stlog.debug, "{} - evicting reader truncate {}", _ntp, o);
+    offset_range range{o, model::offset::max()};
+    _locked_offset_ranges.push_back(range);
+    return evict_if(
+             [o](entry& e) { return e.reader->lease_range_end_offset() >= o; })
+      .then([this, range = std::move(range)]() mutable {
+          return range_lock_holder(std::move(range), this);
+      });
+}
+
+ss::future<readers_cache::range_lock_holder>
+readers_cache::evict_range(model::offset base, model::offset end) {
+    vlog(
+      stlog.debug,
+      "{} - evicting reader from cache, range [{},{}]",
+      _ntp,
+      base,
+      end);
+    offset_range range{base, end};
+    _locked_offset_ranges.push_back(range);
+    return evict_if([base, end](entry& e) {
+               return !(
+                 e.reader->lease_range_base_offset() > end
+                 || e.reader->lease_range_end_offset() < base);
+           })
+      .then([this, range = std::move(range)]() mutable {
+          return range_lock_holder(std::move(range), this);
+      });
+}
+
+model::record_batch_reader
+readers_cache::entry::make_cached_reader(readers_cache* cache) {
+    class cached_reader_impl final : public model::record_batch_reader::impl {
+    public:
+        explicit cached_reader_impl(entry* e, readers_cache* c)
+          : _underlying(e->reader.get())
+          , _guard(e, c) {}
+        cached_reader_impl(cached_reader_impl&&) noexcept = default;
+        cached_reader_impl& operator=(cached_reader_impl&&) noexcept = default;
+
+        cached_reader_impl(const cached_reader_impl&) noexcept = delete;
+        cached_reader_impl&
+        operator=(const cached_reader_impl&) noexcept = delete;
+
+        bool is_end_of_stream() const final {
+            return _underlying->is_end_of_stream();
+        };
+
+        ss::future<model::record_batch_reader::storage_t>
+        do_load_slice(model::timeout_clock::time_point tout) final {
+            return _underlying->do_load_slice(tout);
+        }
+
+        ss::future<> finally() noexcept final { return ss::now(); }
+
+        void print(std::ostream& o) final { return _underlying->print(o); };
+        ~cached_reader_impl() final = default;
+
+    private:
+        log_reader* _underlying;
+        entry_guard _guard;
+    };
+
+    return model::make_record_batch_reader<cached_reader_impl>(this, cache);
+}
+
+readers_cache::~readers_cache() {
+    vassert(
+      _readers.empty() && _in_use.empty(),
+      "readers cache have to be closed before destorying");
+}
+
+ss::future<>
+readers_cache::dispose_entries(intrusive_list<entry, &entry::_hook> entries) {
+    for (auto& e : entries) {
+        co_await e.reader->finally();
+    }
+
+    entries.clear_and_dispose([this](entry* e) {
+        vlog(
+          stlog.trace,
+          "{} - removing reader: [{},{}] lower_bound: {}",
+          _ntp,
+          e->reader->lease_range_base_offset(),
+          e->reader->lease_range_end_offset(),
+          e->reader->next_read_lower_bound());
+        delete e; // NOLINT
+    });
+}
+
+void readers_cache::dispose_in_background(
+  intrusive_list<entry, &entry::_hook> entries) {
+    try {
+        (void)ss::with_gate(
+          _gate, [this, entries = std::move(entries)]() mutable {
+              return dispose_entries(std::move(entries));
+          });
+    } catch (const ss::gate_closed_exception& e) {
+        vlog(stlog.debug, "gate closed while disposing reader");
+    }
+}
+
+void readers_cache::dispose_in_background(entry* e) {
+    try {
+        (void)ss::with_gate(_gate, [this, e] {
+            return e->reader->finally().finally([this, e] {
+                vlog(
+                  stlog.trace,
+                  "{} - removing reader: [{},{}] lower_bound: {}",
+                  _ntp,
+                  e->reader->lease_range_base_offset(),
+                  e->reader->lease_range_end_offset(),
+                  e->reader->next_read_lower_bound());
+                delete e; // NOLINT
+            });
+        });
+    } catch (const ss::gate_closed_exception& e) {
+        vlog(stlog.debug, "gate closed while disposing reader");
+    }
+}
+
+ss::future<> readers_cache::maybe_evict() {
+    auto now = ss::lowres_clock::now();
+    co_await evict_if([this, now](entry& e) {
+        const auto invalid = !e.reader->is_reusable() || !e.valid;
+        const auto outdated = e.last_used + _eviction_timeout < now;
+        return invalid || outdated;
+    });
+}
+
+} // namespace storage

--- a/src/v/storage/readers_cache.h
+++ b/src/v/storage/readers_cache.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "random/generators.h"
+#include "storage/log_reader.h"
+#include "storage/types.h"
+#include "utils/intrusive_list_helpers.h"
+#include "vlog.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/coroutine.hh>
+
+namespace storage {
+/**
+ * The cache holds reader instances and allows user to query for reader using
+ * reader configuration. If any of the readers kept in a cache matches given
+ * query its configuration is reset and it is returned to the caller. Caller is
+ * responsible for adding readers to the cache using `put()` method. Since
+ * readers keep read lock to underlying segments `readers_cache` exposes
+ * interface to force readers eviction in face of truncation and segments
+ * removal. Readers are evicted from the cache according to LRU policy and
+ * automatically when they can not longer be reused (f.e. EOF).
+ */
+class readers_cache {
+public:
+    using offset_range = std::pair<model::offset, model::offset>;
+    class range_lock_holder {
+    public:
+        range_lock_holder(offset_range rng, readers_cache* c)
+          : _range(std::move(rng))
+          , _cache(c) {}
+
+        range_lock_holder(const range_lock_holder&) = delete;
+        range_lock_holder(range_lock_holder&&) = default;
+
+        range_lock_holder& operator=(const range_lock_holder&) = delete;
+        range_lock_holder& operator=(range_lock_holder&&) = default;
+
+        ~range_lock_holder() {
+            std::erase(_cache->_locked_offset_ranges, _range);
+        }
+
+    private:
+        offset_range _range;
+        readers_cache* _cache;
+    };
+    explicit readers_cache(model::ntp, std::chrono::milliseconds);
+    std::optional<model::record_batch_reader>
+    get_reader(const log_reader_config&);
+
+    model::record_batch_reader put(std::unique_ptr<log_reader> reader);
+
+    /**
+     * Evict readers. No new readers holding log to given offset can be added to
+     * the cache under range_lock_holder is destroyed
+     */
+    ss::future<range_lock_holder> evict_prefix_truncate(model::offset);
+    ss::future<range_lock_holder>
+    evict_segment_readers(ss::lw_shared_ptr<segment> s);
+    ss::future<range_lock_holder> evict_truncate(model::offset);
+    ss::future<range_lock_holder> evict_range(model::offset, model::offset);
+
+    ss::future<> stop();
+    readers_cache() noexcept = default;
+    readers_cache(readers_cache&&) = delete;
+    readers_cache(const readers_cache&) = delete;
+    readers_cache& operator=(readers_cache&&) = delete;
+    readers_cache& operator=(const readers_cache&) = delete;
+
+    ~readers_cache();
+
+private:
+    struct entry;
+    void touch(entry* e) {
+        e->last_used = ss::lowres_clock::now();
+        e->_hook.unlink();
+        _readers.push_back(*e);
+    };
+
+    /**
+     * Entry kept in lru readers list
+     */
+    struct entry {
+        model::record_batch_reader make_cached_reader(readers_cache*);
+        std::unique_ptr<log_reader> reader;
+        ss::lowres_clock::time_point last_used = ss::lowres_clock::now();
+        bool valid = true;
+        intrusive_list_hook _hook;
+    };
+    /**
+     * RAII based entry lock guard, it touches entry in a cache and handles
+     * locking logic. Entry is unlocked when cached reader is destroyed
+     */
+    struct entry_guard {
+        entry_guard(entry_guard&&) noexcept = default;
+        entry_guard& operator=(entry_guard&&) noexcept = default;
+
+        entry_guard(const entry_guard&) = delete;
+        entry_guard& operator=(const entry_guard&) = delete;
+
+        explicit entry_guard(entry* e, readers_cache* c)
+          : _e(e)
+          , _cache(c) {}
+
+        ~entry_guard() noexcept {
+            _e->_hook.unlink();
+            if (_e->reader->is_reusable()) {
+                _cache->_readers.push_back(*_e);
+            } else {
+                _cache->dispose_in_background(_e);
+            }
+            _cache->_in_use_reader_destroyed.broadcast();
+        }
+
+    private:
+        entry* _e;
+        readers_cache* _cache;
+    };
+
+    ss::future<> maybe_evict();
+    ss::future<> dispose_entries(intrusive_list<entry, &entry::_hook>);
+    void dispose_in_background(intrusive_list<entry, &entry::_hook>);
+    void dispose_in_background(entry* e);
+    ss::future<> wait_for_no_inuse_readers();
+    template<typename Predicate>
+    ss::future<> evict_if(Predicate predicate) {
+        intrusive_list<entry, &entry::_hook> to_evict;
+        // lock reders to make sure no new readers will be added
+        for (auto it = _readers.begin(); it != _readers.end();) {
+            auto should_evict = predicate(*it);
+            if (should_evict) {
+                // marking reader as invlid to prevent any further use
+                it->valid = false;
+                it = _readers.erase_and_dispose(
+                  it, [&to_evict](entry* e) { to_evict.push_back(*e); });
+            } else {
+                ++it;
+            }
+        }
+        for (auto& r : _in_use) {
+            if (predicate(r)) {
+                // marking reader as invlid to prevent further reuse
+                r.valid = false;
+            }
+        }
+        co_await dispose_entries(std::move(to_evict));
+    }
+
+    model::ntp _ntp;
+    std::chrono::milliseconds _eviction_timeout;
+    ss::gate _gate;
+    ss::timer<> _eviction_timer;
+    /**
+     * when reader is in use we push it to _in_use intrusive list, otherwise it
+     * is stored in _readers.
+     */
+    intrusive_list<entry, &entry::_hook> _readers;
+    intrusive_list<entry, &entry::_hook> _in_use;
+    /**
+     * When offset range is locked any new readers for given offset will not be
+     * added to cache.
+     */
+    std::vector<offset_range> _locked_offset_ranges;
+    ss::condition_variable _in_use_reader_destroyed;
+};
+} // namespace storage

--- a/src/v/storage/readers_cache.h
+++ b/src/v/storage/readers_cache.h
@@ -14,6 +14,7 @@
 #include "model/record_batch_reader.h"
 #include "random/generators.h"
 #include "storage/log_reader.h"
+#include "storage/readers_cache_probe.h"
 #include "storage/types.h"
 #include "utils/intrusive_list_helpers.h"
 #include "vlog.h"
@@ -161,6 +162,7 @@ private:
     std::chrono::milliseconds _eviction_timeout;
     ss::gate _gate;
     ss::timer<> _eviction_timer;
+    readers_cache_probe _probe;
     /**
      * when reader is in use we push it to _in_use intrusive list, otherwise it
      * is stored in _readers.

--- a/src/v/storage/readers_cache_probe.h
+++ b/src/v/storage/readers_cache_probe.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "model/fundamental.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+#include <bits/stdint-uintn.h>
+
+namespace storage {
+
+class readers_cache_probe {
+public:
+    void reader_added() { _readers_added++; }
+    void reader_evicted() { _readers_evicted++; }
+    void cache_hit() { _cache_hits++; }
+    void cache_miss() { _cache_misses++; }
+
+    void setup_metrics(const model::ntp& ntp);
+
+private:
+    uint64_t _readers_added{0};
+    uint64_t _readers_evicted{0};
+    uint64_t _cache_misses{0};
+    uint64_t _cache_hits{0};
+
+    ss::metrics::metric_groups _metrics;
+};
+} // namespace storage

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -13,6 +13,7 @@
 
 #include "storage/batch_cache.h"
 #include "storage/compacted_index_writer.h"
+#include "storage/fwd.h"
 #include "storage/segment_appender.h"
 #include "storage/segment_index.h"
 #include "storage/segment_reader.h"
@@ -80,7 +81,7 @@ public:
 
     ss::future<> close();
     ss::future<> flush();
-    ss::future<> release_appender();
+    ss::future<> release_appender(readers_cache*);
     ss::future<> truncate(model::offset, size_t physical);
 
     /// main write interface
@@ -159,6 +160,7 @@ private:
     ss::future<> remove_tombstones();
     ss::future<> compaction_index_batch(const model::record_batch&);
     ss::future<> do_compaction_index_batch(const model::record_batch&);
+    void release_appender_in_background(readers_cache* readers_cache);
 
     struct appender_callbacks : segment_appender::callbacks {
         explicit appender_callbacks(segment* segment)

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -513,9 +513,8 @@ ss::future<> self_compact_segment(
                     return self_compact_segment(s, cfg, pb, readers_cache);
                 });
           }
-          default:
-              __builtin_unreachable();
           }
+          __builtin_unreachable();
       })
       .then([s] { s->mark_as_finished_self_compaction(); })
       .finally([&pb] { pb.segment_compacted(); });

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -20,6 +20,7 @@
 #include "storage/compacted_index.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/compaction_reducers.h"
+#include "storage/fwd.h"
 #include "storage/index_state.h"
 #include "storage/lock_manager.h"
 #include "storage/log_reader.h"
@@ -392,7 +393,10 @@ ss::future<> do_swap_data_file_handles(
 }
 
 ss::future<> do_self_compact_segment(
-  ss::lw_shared_ptr<segment> s, compaction_config cfg, storage::probe& pb) {
+  ss::lw_shared_ptr<segment> s,
+  compaction_config cfg,
+  storage::probe& pb,
+  storage::readers_cache& readers_cache) {
     return s->read_lock()
       .then([cfg, s, &pb](ss::rwlock::holder h) {
           if (s->is_closed()) {
@@ -407,16 +411,20 @@ ss::future<> do_self_compact_segment(
                 return do_copy_segment_data(s, cfg, pb, std::move(h));
             });
       })
-      .then([s](storage::index_state idx) {
-          return s->write_lock().then(
-            [s, idx = std::move(idx)](ss::rwlock::holder h) mutable {
-                using type = std::tuple<index_state, ss::rwlock::holder>;
-                if (s->is_closed()) {
-                    return ss::make_exception_future<type>(
-                      segment_closed_exception());
-                }
-                return ss::make_ready_future<type>(
-                  std::make_tuple(std::move(idx), std::move(h)));
+      .then([s, &readers_cache](storage::index_state idx) {
+          return readers_cache.evict_segment_readers(s).then(
+            [s,
+             idx = std::move(idx)](readers_cache::range_lock_holder) mutable {
+                return s->write_lock().then(
+                  [s, idx = std::move(idx)](ss::rwlock::holder h) mutable {
+                      using type = std::tuple<index_state, ss::rwlock::holder>;
+                      if (s->is_closed()) {
+                          return ss::make_exception_future<type>(
+                            segment_closed_exception());
+                      }
+                      return ss::make_ready_future<type>(
+                        std::make_tuple(std::move(idx), std::move(h)));
+                  });
             });
       })
       .then([cfg, s, &pb](std::tuple<index_state, ss::rwlock::holder> h) {
@@ -459,7 +467,10 @@ ss::future<> rebuild_compaction_index(
 }
 
 ss::future<> self_compact_segment(
-  ss::lw_shared_ptr<segment> s, compaction_config cfg, storage::probe& pb) {
+  ss::lw_shared_ptr<segment> s,
+  compaction_config cfg,
+  storage::probe& pb,
+  storage::readers_cache& readers_cache) {
     if (s->has_appender()) {
         return ss::make_exception_future<>(std::runtime_error(fmt::format(
           "Cannot compact an active segment. cfg:{} - segment:{}", cfg, s)));
@@ -470,42 +481,42 @@ ss::future<> self_compact_segment(
     auto idx_path = std::filesystem::path(s->reader().filename());
     idx_path.replace_extension(".compaction_index");
     return detect_compaction_index_state(idx_path, cfg)
-      .then(
-        [idx_path, s, cfg, &pb](compacted_index::recovery_state state) mutable {
-            switch (state) {
-            case compacted_index::recovery_state::recovered: {
-                vlog(stlog.info, "detected {} is already compacted", idx_path);
-                return ss::now();
-            }
-            case compacted_index::recovery_state::nonrecovered:
-                return do_self_compact_segment(s, cfg, pb);
-            case compacted_index::recovery_state::missing:
-                [[fallthrough]];
-            case compacted_index::recovery_state::needsrebuild: {
-                vlog(
-                  stlog.warn,
-                  "Detected corrupt or missing index file:{}, recovering...",
-                  idx_path);
-                pb.corrupted_compaction_index();
-                return s->read_lock()
-                  .then([s, cfg, &pb, idx_path](ss::rwlock::holder h) {
-                      return rebuild_compaction_index(
-                        create_segment_full_reader(s, cfg, pb, std::move(h)),
-                        idx_path,
-                        cfg);
-                  })
-                  .then([s, cfg, &pb, idx_path] {
-                      vlog(
-                        stlog.info,
-                        "recovered index: {}, attempting compaction again",
-                        idx_path);
-                      return self_compact_segment(s, cfg, pb);
-                  });
-            }
-            default:
-                __builtin_unreachable();
-            }
-        })
+      .then([idx_path, s, cfg, &pb, &readers_cache](
+              compacted_index::recovery_state state) mutable {
+          switch (state) {
+          case compacted_index::recovery_state::recovered: {
+              vlog(stlog.info, "detected {} is already compacted", idx_path);
+              return ss::now();
+          }
+          case compacted_index::recovery_state::nonrecovered:
+              return do_self_compact_segment(s, cfg, pb, readers_cache);
+          case compacted_index::recovery_state::missing:
+              [[fallthrough]];
+          case compacted_index::recovery_state::needsrebuild: {
+              vlog(
+                stlog.warn,
+                "Detected corrupt or missing index file:{}, recovering...",
+                idx_path);
+              pb.corrupted_compaction_index();
+              return s->read_lock()
+                .then([s, cfg, &pb, idx_path](ss::rwlock::holder h) {
+                    return rebuild_compaction_index(
+                      create_segment_full_reader(s, cfg, pb, std::move(h)),
+                      idx_path,
+                      cfg);
+                })
+                .then([s, cfg, &pb, idx_path, &readers_cache] {
+                    vlog(
+                      stlog.info,
+                      "recovered index: {}, attempting compaction again",
+                      idx_path);
+                    return self_compact_segment(s, cfg, pb, readers_cache);
+                });
+          }
+          default:
+              __builtin_unreachable();
+          }
+      })
       .then([s] { s->mark_as_finished_self_compaction(); })
       .finally([&pb] { pb.segment_compacted(); });
 }

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -16,6 +16,7 @@
 #include "storage/compacted_index_writer.h"
 #include "storage/compacted_offset_list.h"
 #include "storage/probe.h"
+#include "storage/readers_cache.h"
 #include "storage/segment.h"
 #include "storage/segment_appender.h"
 #include "utils/named_type.h"
@@ -33,7 +34,8 @@ namespace storage::internal {
 ss::future<> self_compact_segment(
   ss::lw_shared_ptr<storage::segment>,
   storage::compaction_config,
-  storage::probe&);
+  storage::probe&,
+  storage::readers_cache&);
 
 /*
  * Concatentate segments into a minimal new segment.


### PR DESCRIPTION
## Cover letter

Disk log readers are underlie by `seastar::file_input_stream` which dispatches background read-aheads to speed up reading. In previous implementation we throw away the reader even tho the underlying input stream could be reused for next read. 

Introduced readers cache in storage layer. The cache allow us to reuse readers and prevents I/O operation wasting. 

Fixes: #955

## Release notes

- Major read performance improvement for non cached reads.