### PR TITLE
Fix crash observed when multiple topics push to same materialized topic during term promotion

### DIFF
--- a/src/v/coproc/ntp_context.h
+++ b/src/v/coproc/ntp_context.h
@@ -97,7 +97,7 @@ struct shared_script_resources {
     /// the seastar reactor
     /// NOTE: Pointer stability is explicity requested due to the way iterators
     /// to elements within the collection are used
-    absl::node_hash_map<model::ntp, mutex> log_mtx;
+    absl::node_hash_map<model::ntp, std::pair<mutex, model::term_id>> log_mtx;
 
     explicit shared_script_resources(
       rpc::reconnect_transport t, storage::api& a)

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -273,9 +273,12 @@ ss::future<> script_context::process_one_reply(process_batch_reply::data e) {
     }
     auto ntp_ctx = found->second;
     return write_materialized(materialized_ntp, std::move(*e.reader))
-      .then([this, ntp_ctx](bool crc_parse_failure) {
-          if (crc_parse_failure) {
+      .then([this, ntp_ctx](write_response wr) {
+          if (wr == write_response::crc_failure) {
               vlog(coproclog.warn, "record_batch failed to pass crc checks");
+              return;
+          } else if (wr == write_response::term_too_old) {
+              vlog(coproclog.debug, "older term record detected, retrying");
               return;
           }
           auto ofound = ntp_ctx->offsets.find(_id);
@@ -299,8 +302,43 @@ ss::future<storage::log> get_log(storage::api& api, const model::ntp& ntp) {
       storage::ntp_config(ntp, api.log_mgr().config().base_dir));
 }
 
-ss::future<bool>
-write_checked(storage::log log, model::record_batch_reader reader) {
+/// Solution to case where scripts writing to the same materialized topic may
+/// attempt to write a record with a lower term_id then the logs base.
+class term_id_barrier {
+public:
+    explicit term_id_barrier(model::term_id last)
+      : _last(last) {}
+
+    ss::future<ss::stop_iteration> operator()(const model::record_batch& rb) {
+        /// If the situation is encountered, the consumer will be alerted,
+        /// and in the case below, the reference_window_consumer will not
+        /// attempt to further process the batch, i.e. aborting the write
+        if (rb.term() < _last) {
+            _exited_early = true;
+        }
+        return ss::make_ready_future<ss::stop_iteration>(
+          _exited_early ? ss::stop_iteration::yes : ss::stop_iteration::no);
+    }
+
+    std::optional<model::term_id> end_of_stream() {
+        return _exited_early ? std::nullopt : std::optional(_last);
+    }
+
+private:
+    bool _exited_early{false};
+    model::term_id _last;
+};
+
+ss::future<std::variant<script_context::write_response, model::term_id>>
+script_context::write_checked(
+  storage::log log,
+  model::term_id last_term,
+  model::record_batch_reader reader) {
+    using rt_val = std::variant<write_response, model::term_id>;
+    using consumption_result = std::tuple<
+      bool,
+      std::optional<model::term_id>,
+      ss::future<storage::append_result>>;
     const storage::log_append_config write_cfg{
       .should_fsync = storage::log_append_config::fsync::no,
       .io_priority = ss::default_priority_class(),
@@ -308,27 +346,56 @@ write_checked(storage::log log, model::record_batch_reader reader) {
     return std::move(reader)
       .for_each_ref(
         coproc::reference_window_consumer(
-          model::record_batch_crc_checker(), log.make_appender(write_cfg)),
+          model::record_batch_crc_checker(),
+          term_id_barrier(last_term),
+          log.make_appender(write_cfg)),
         model::no_timeout)
-      .then([](std::tuple<bool, ss::future<storage::append_result>> t) {
-          const auto& [crc_parse_success, _] = t;
-          return !crc_parse_success;
+      .then([](consumption_result rs) mutable {
+          bool crc_success = std::get<bool>(rs);
+          if (!crc_success) {
+              return ss::make_ready_future<rt_val>(write_response::crc_failure);
+          }
+          auto newest_term = std::get<std::optional<model::term_id>>(rs);
+          if (!newest_term) {
+              return ss::make_ready_future<rt_val>(
+                write_response::term_too_old);
+          }
+          return std::move(std::get<ss::future<storage::append_result>>(rs))
+            .then(
+              [](storage::append_result ar) { return rt_val(ar.last_term); });
       });
 }
 
-ss::future<bool> script_context::write_materialized(
+ss::future<script_context::write_response> script_context::write_materialized(
   const model::materialized_ntp& m_ntp, model::record_batch_reader reader) {
     auto found = _resources.log_mtx.find(m_ntp.input_ntp());
     if (found == _resources.log_mtx.end()) {
-        found = _resources.log_mtx.emplace(m_ntp.input_ntp(), mutex()).first;
+        found = _resources.log_mtx
+                  .emplace(
+                    m_ntp.input_ntp(),
+                    std::make_pair(mutex(), model::term_id{}))
+                  .first;
     }
-    return found->second.with(
-      [this, m_ntp, reader = std::move(reader)]() mutable {
-          return get_log(_resources.api, m_ntp.input_ntp())
-            .then([reader = std::move(reader)](storage::log log) mutable {
-                return write_checked(std::move(log), std::move(reader));
-            });
-      });
+    return found->second.first.with([this,
+                                     m_ntp,
+                                     reader = std::move(reader)]() mutable {
+        model::term_id last_term = _resources.log_mtx[m_ntp.input_ntp()].second;
+        return get_log(_resources.api, m_ntp.input_ntp())
+          .then([this, last_term, reader = std::move(reader)](
+                  storage::log log) mutable {
+              return write_checked(
+                std::move(log), last_term, std::move(reader));
+          })
+          .then([this,
+                 m_ntp](std::variant<write_response, model::term_id> written) {
+              if (std::holds_alternative<model::term_id>(written)) {
+                  model::term_id next_term = std::get<model::term_id>(written);
+                  _resources.log_mtx[m_ntp.input_ntp()].second = next_term;
+                  return write_response::success;
+              }
+              return std::get<write_response>(written);
+          });
+    });
 }
 
 } // namespace coproc

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -69,6 +69,8 @@ public:
     ss::future<> shutdown();
 
 private:
+    enum class write_response { success, crc_failure, term_too_old };
+
     ss::future<> do_execute();
 
     ss::future<>
@@ -84,8 +86,10 @@ private:
 
     ss::future<> process_reply(process_batch_reply);
     ss::future<> process_one_reply(process_batch_reply::data);
-    ss::future<bool> write_materialized(
+    ss::future<write_response> write_materialized(
       const model::materialized_ntp&, model::record_batch_reader);
+    ss::future<std::variant<write_response, model::term_id>>
+      write_checked(storage::log, model::term_id, model::record_batch_reader);
 
     std::size_t max_batch_size() const {
         return config::shard_local_cfg().coproc_max_batch_size.value();

--- a/tests/rptest/tests/wasm_redpanda_failure_recovery_test.py
+++ b/tests/rptest/tests/wasm_redpanda_failure_recovery_test.py
@@ -82,3 +82,36 @@ class WasmRPMultiInputTopicFailureRecoveryTest(WasmRedpandaFailureRecoveryTest
 
     def verify_results(self):
         return materialized_at_least_once_compare
+
+
+class WasmRPMeshFailureRecoveryTest(WasmRedpandaFailureRecoveryTest):
+    topics = (
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+        TopicSpec(partition_count=3,
+                  replication_factor=3,
+                  cleanup_policy=TopicSpec.CLEANUP_DELETE),
+    )
+
+    def __init__(self, test_context, num_records=10000, record_size=1024):
+        super(WasmRPMeshFailureRecoveryTest,
+              self).__init__(test_context,
+                             num_records=num_records,
+                             record_size=record_size)
+
+    def wasm_xfactor(self):
+        return 3
+
+    def wasm_test_outputs(self):
+        otopic_a = "output_topic_a"
+        otopic_b = "output_topic_b"
+        otopic_c = "output_topic_c"
+        return [[otopic_a, otopic_b, otopic_c], [otopic_a, otopic_b, otopic_c],
+                [otopic_a, otopic_b, otopic_c]]
+
+    def verify_results(self):
+        return materialized_at_least_once_compare

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -184,12 +184,13 @@ class WasmTest(RedpandaTest):
             if batch_total > 0:
                 self.records_recieved(batch_total)
 
-            return self._input_consumer.is_finished()
+            return self._input_consumer.is_finished() \
+                and self._output_consumer.is_finished()
 
-        [x.join() for x in self._producers]
         timeout, backoff = self.wasm_test_timeout()
         wait_until(all_done, timeout_sec=timeout, backoff_sec=backoff)
         try:
+            [x.join() for x in self._producers]
             self._input_consumer.join()
             self._output_consumer.join()
         except Exception as e:


### PR DESCRIPTION
- In the case where multiple scripts write to the same materialized topic,
during a term id promotion assertions from the storage layer have been
observed, noting that the term id of a record batch is lower then the current
logs tip.

- Solution is to store the known term_id and verify that all records being
pushed to a materialized log have a term at least as large as the last known.

