### PR TITLE
Build nodejs from source

### DIFF
--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -12,13 +12,15 @@ tasks:
       JS_ROOT: "{{.SRC_DIR}}/src/js"
       NODE_VERSION: '12.16.1'
       NODE_ROOT: "{{.BUILD_ROOT}}/node"
-      NODE_PKG: "node-v{{.NODE_VERSION}}-linux-x64"
-      NODE_URL: "https://nodejs.org/dist/v{{.NODE_VERSION}}/{{.NODE_PKG}}.tar.xz"
+      NODE_PKG: "node-v{{.NODE_VERSION}}"
+      NODE_URL: "https://nodejs.org/dist/v{{.NODE_VERSION}}/node-v{{.NODE_VERSION}}.tar.xz"
     cmds:
     - mkdir -p "{{.NODE_ROOT}}"
     - curl "{{.NODE_URL}}" > "{{.NODE_ROOT}}/{{.NODE_PKG}}.tar.xz"
     - tar -xf "{{.NODE_ROOT}}/{{.NODE_PKG}}.tar.xz" -C "{{.NODE_ROOT}}" --strip 1
     - rm -rf "{{.NODE_ROOT}}/{{.NODE_PKG}}.tar.xz"
+    - "{{.NODE_ROOT}}/configure --prefix {{.NODE_ROOT}}"
+    - "cd {{.NODE_ROOT}} && make -j$(nproc) install"
     status:
     - test -f "{{.NODE_ROOT}}/bin/node"
     - test -f "{{.NODE_ROOT}}/bin/npm"


### PR DESCRIPTION
This is necessary for future packing work. We must build nodejs from source in order to package it with redpanda.