### PR TITLE
pandaproxy: Consumer group validation, fixes, and tests

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -412,6 +412,14 @@ pandaproxy_client:
   # Default: 100ms
   produce_batch_delay_ms: 100
 
+  # Interval (in milliseconds) for consumer request timeout
+  # Default: 100ms
+  consumer_request_timeout_ms: 100
+
+  # Max bytes to fetch per request
+  # Default: 1MiB
+  consumer_request_max_bytes: 1048576
+      
   # Timeout (in milliseconds) for consumer session
   # Default: 10s
   consumer_session_timeout_ms: 10000

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -142,8 +142,8 @@ public:
     ss::future<fetch_response> consumer_fetch(
       const group_id& g_id,
       const member_id& m_id,
-      std::chrono::milliseconds timeout,
-      int32_t max_bytes);
+      std::optional<std::chrono::milliseconds> timeout,
+      std::optional<int32_t> max_bytes);
 
     ss::future<> update_metadata() { return _wait_or_start_update_metadata(); }
 

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -67,6 +67,18 @@ configuration::configuration()
       "Delay (in milliseconds) to wait before sending batch",
       config::required::no,
       100ms)
+  , consumer_request_timeout(
+      *this,
+      "consumer_request_timeout_ms",
+      "Interval (in milliseconds) for consumer request timeout",
+      config::required::no,
+      100ms)
+  , consumer_request_max_bytes(
+      *this,
+      "consumer_request_max_bytes",
+      "Max bytes to fetch per request",
+      config::required::no,
+      1_MiB)
   , consumer_session_timeout(
       *this,
       "consumer_session_timeout_ms",

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -33,6 +33,8 @@ struct configuration final : public config::config_store {
     config::property<int32_t> produce_batch_record_count;
     config::property<int32_t> produce_batch_size_bytes;
     config::property<std::chrono::milliseconds> produce_batch_delay;
+    config::property<std::chrono::milliseconds> consumer_request_timeout;
+    config::property<int32_t> consumer_request_max_bytes;
     config::property<std::chrono::milliseconds> consumer_session_timeout;
     config::property<std::chrono::milliseconds> consumer_rebalance_timeout;
     config::property<std::chrono::milliseconds> consumer_heartbeat_interval;

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -70,7 +70,7 @@ public:
     ss::future<offset_commit_response>
     offset_commit(std::vector<offset_commit_request_topic> topics);
     ss::future<fetch_response>
-    fetch(std::chrono::milliseconds timeout, int32_t max_bytes);
+    fetch(std::chrono::milliseconds timeout, std::optional<int32_t> max_bytes);
 
 private:
     bool is_leader() const {

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -315,8 +315,13 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 post_consumer_offsets(server::request_t rq, server::reply_t rp) {
-    auto group_id = kafka::group_id(rq.req->param["group_name"]);
-    auto member_id = kafka::member_id(rq.req->param["instance"]);
+    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    parse::accept_header(
+      *rq.req,
+      {json::serialization_format::json_v2, json::serialization_format::none});
+
+    auto group_id{parse::request_param<kafka::group_id>(*rq.req, "group_name")};
+    auto member_id{parse::request_param<kafka::member_id>(*rq.req, "instance")};
 
     // If the request is empty, commit all offsets
     auto req_data = rq.req->content.length() == 0

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -192,6 +192,19 @@ create_consumer(server::request_t rq, server::reply_t rp) {
     auto req_data = ppj::rjson_parse(
       rq.req->content.data(), ppj::create_consumer_request_handler());
 
+    if (req_data.format != "binary") {
+        throw parse::error(
+          parse::error_code::invalid_param, "format must be binary");
+    }
+    if (req_data.auto_offset_reset != "earliest") {
+        throw parse::error(
+          parse::error_code::invalid_param, "auto.offset must be earliest");
+    }
+    if (req_data.auto_commit_enable != "false") {
+        throw parse::error(
+          parse::error_code::invalid_param, "auto.commit must be false");
+    }
+
     return rq.ctx.client.create_consumer(group_id, req_data.name)
       .then([group_id, res_fmt, rq{std::move(rq)}, rp{std::move(rp)}](
               kafka::member_id name) mutable {

--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -33,8 +33,8 @@ namespace pandaproxy::json {
 struct create_consumer_request {
     kafka::member_id name{kafka::no_member};
     ss::sstring format{"binary"};
-    ss::sstring auto_offset_reset;
-    ss::sstring auto_commit_enable;
+    ss::sstring auto_offset_reset{"earliest"};
+    ss::sstring auto_commit_enable{"false"};
     ss::sstring fetch_min_bytes;
     ss::sstring consumer_request_timeout_ms;
 };

--- a/src/v/pandaproxy/parsing/httpd.h
+++ b/src/v/pandaproxy/parsing/httpd.h
@@ -14,6 +14,7 @@
 #include "pandaproxy/json/types.h"
 #include "pandaproxy/parsing/exceptions.h"
 #include "pandaproxy/parsing/from_chars.h"
+#include "reflection/type_traits.h"
 #include "vassert.h"
 
 #include <seastar/http/request.hh>
@@ -30,7 +31,7 @@ namespace ppj = pandaproxy::json;
 
 template<typename T>
 T parse_param(std::string_view type, std::string_view key, ss::sstring value) {
-    if (value.empty()) {
+    if (!reflection::is_std_optional_v<T> && value.empty()) {
         throw error(
           error_code::empty_param,
           fmt::format("Missing mandatory {} '{}'", type, key));

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -178,7 +178,10 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
             group_id(),
             member_id(),
             "1000",
-            "1000000"));
+            "1000000"),
+          boost::beast::http::verb::get,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::binary_v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -219,7 +219,9 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           fmt::format(
             "/consumers/{}/instances/{}/offsets", group_id(), member_id()),
           std::move(body),
-          boost::beast::http::verb::post);
+          boost::beast::http::verb::post,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::json_v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::no_content);
     }
@@ -240,7 +242,9 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           client,
           fmt::format(
             "/consumers/{}/instances/{}/offsets", group_id(), member_id()),
-          boost::beast::http::verb::post);
+          boost::beast::http::verb::post,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::json_v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::no_content);
     }

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -46,7 +46,9 @@ auto get_consumer_offsets(
       client,
       fmt::format("/consumers/{}/instances/{}/offsets", g_id(), m_id()),
       std::move(body),
-      boost::beast::http::verb::get);
+      boost::beast::http::verb::get,
+      ppj::serialization_format::json_v2,
+      ppj::serialization_format::json_v2);
     return res;
 };
 


### PR DESCRIPTION
## Cover letter

Improvements for Pandaproxy consumers:
* Improve header and request parameter validation for `fetch`, `get_offsets`, `post_offsets`
* Validation of unsupported `create_consumer` features

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/101d2b60117e43ab48242a2b9ef951c89a749683..3c700cabd23a48aff866e4b7fcaec46aa1e85a57)
* Set `consumer_request_max_bytes` default to `1MiB`

## Release notes

Release note: Pandaproxy: Improve error handling and validation for consumer groups
