### PR TITLE
Exception logging in operator developer mode

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -481,6 +481,7 @@ func overprovisioned(developerMode bool, limits corev1.ResourceList) []string {
 			"--reserve-memory " + redpandav1alpha1.ReserveMemoryString,
 			"--smp=1",
 			"--kernel-page-cache=true",
+			"--logger-log-level=exception=debug",
 			"--default-log-level=debug",
 		}
 	}

--- a/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
@@ -34,6 +34,7 @@ spec:
             - --reserve-memory 1M
             - --smp=1
             - --kernel-page-cache=true
+            - --logger-log-level=exception=debug
             - --default-log-level=debug
 status:
   readyReplicas: 1

--- a/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
@@ -34,6 +34,7 @@ spec:
             - --reserve-memory 1M
             - --smp=1
             - --kernel-page-cache=true
+            - --logger-log-level=exception=debug
             - --default-log-level=debug
 status:
   readyReplicas: 1

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -744,7 +744,7 @@ func parseFlags(flags []string) map[string]string {
 		parts := strings.Split(trimmed, "=")
 		if len(parts) >= 2 {
 			name := strings.Trim(parts[0], " ")
-			value := strings.Trim(parts[1], " ")
+			value := strings.Join(parts[1:], "=")
 			parsed[name] = value
 			continue
 		}

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -1233,10 +1233,14 @@ func TestExtraFlags(t *testing.T) {
 			"--bool-flag", "false",
 			"--kernel-page-cache", "1",
 			"--another-arbitrary-seastar-flag", "",
+			"--logger-log-level", "exception=debug",
+			"--logger-log-level2=exception=debug",
 		},
 		expected: map[string]string{
 			"kernel-page-cache":              "1",
 			"another-arbitrary-seastar-flag": "",
+			"logger-log-level":               "exception=debug",
+			"logger-log-level2":              "exception=debug",
 		},
 	}, {
 		name: "it should return an empty map if there are no unknown flags",


### PR DESCRIPTION
## Cover letter

This PR is based on https://github.com/vectorizedio/redpanda/pull/1148

For developer convenience exception logging was added in developer mode. 

## Release notes

When developer mode is enabled the cluster will log Redpanda exceptions.
