### PR TITLE
operator/upgrade: switch from kafka to admin API for redpanda readiness

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -117,6 +117,7 @@ func (r *ClusterReconciler) Reconcile(
 		pki.OperatorClientCert(),
 		pki.AdminCert(),
 		pki.AdminAPINodeCert(),
+		pki.AdminAPIClientCert(),
 		sa.Key().Name,
 		r.configuratorTag,
 		log)

--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -3,7 +3,6 @@ module github.com/vectorizedio/redpanda/src/go/k8s
 go 1.15
 
 require (
-	github.com/Shopify/sarama v1.28.1-0.20210318150015-41df78df10a9
 	github.com/banzaicloud/k8s-objectmatcher v1.5.1
 	github.com/go-logr/logr v0.3.0
 	github.com/hashicorp/go-multierror v1.1.0

--- a/src/go/k8s/pkg/resources/certmanager/admin_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/admin_api.go
@@ -23,9 +23,14 @@ const (
 	AdminAPINodeCert = "admin-api-node"
 )
 
-// AdminAPINodeCert returns the namespaced name for the Admin API certificate used by node
+// AdminAPINodeCert returns the namespaced name for the Admin API certificate used by nodes
 func (r *PkiReconciler) AdminAPINodeCert() types.NamespacedName {
 	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + AdminAPINodeCert, Namespace: r.pandaCluster.Namespace}
+}
+
+// AdminAPIClientCert returns the namespaced name for the Admin API certificate used by clients
+func (r *PkiReconciler) AdminAPIClientCert() types.NamespacedName {
+	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + AdminAPIClientCert, Namespace: r.pandaCluster.Namespace}
 }
 
 func (r *PkiReconciler) prepareAdminAPI(

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -75,6 +75,7 @@ func TestEnsure_StatefulSet(t *testing.T) {
 		types.NamespacedName{},
 		types.NamespacedName{},
 		types.NamespacedName{},
+		types.NamespacedName{},
 		"",
 		"latest",
 		ctrl.Log.WithName("test"))

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -66,6 +66,7 @@ type StatefulSetResource struct {
 	internalClientCertSecretKey types.NamespacedName
 	adminCertSecretKey          types.NamespacedName
 	adminAPINodeCertSecretKey   types.NamespacedName
+	adminAPIClientCertSecretKey types.NamespacedName
 	serviceAccountName          string
 	configuratorTag             string
 	logger                      logr.Logger
@@ -85,6 +86,7 @@ func NewStatefulSet(
 	internalClientCertSecretKey types.NamespacedName,
 	adminCertSecretKey types.NamespacedName,
 	adminAPINodeCertSecretKey types.NamespacedName,
+	adminAPIClientCertSecretKey types.NamespacedName,
 	serviceAccountName string,
 	configuratorTag string,
 	logger logr.Logger,
@@ -101,6 +103,7 @@ func NewStatefulSet(
 		internalClientCertSecretKey,
 		adminCertSecretKey,
 		adminAPINodeCertSecretKey,
+		adminAPIClientCertSecretKey,
 		serviceAccountName,
 		configuratorTag,
 		logger.WithValues("Kind", statefulSetKind()),

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -84,6 +84,7 @@ func TestEnsure(t *testing.T) {
 			types.NamespacedName{},
 			types.NamespacedName{},
 			types.NamespacedName{},
+			types.NamespacedName{},
 			"",
 			"latest",
 			ctrl.Log.WithName("test"))

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -129,7 +129,7 @@ func (r *StatefulSetResource) partitionUpdateImage(
 		// Pod (if any) has rejoined its groups after restarting, i.e., is ready for I/O.
 		if err := r.ensureRedpandaGroupsReady(ctx, sts, replicas, ordinal+1); err != nil {
 			return &RequeueAfterError{RequeueAfter: requeueDuration,
-				Msg: fmt.Sprintf("redpanda on pod (ordinal: %d) not ready", ordinal)}
+				Msg: fmt.Sprintf("redpanda on pod (ordinal: %d) not ready: %s", ordinal, err)}
 		}
 
 		if err := r.rollingUpdatePartition(ctx, ordinal, sts); err != nil {
@@ -144,7 +144,7 @@ func (r *StatefulSetResource) partitionUpdateImage(
 	// Ensure 0th Pod is ready for I/O before completing the upgrade.
 	if err := r.ensureRedpandaGroupsReady(ctx, sts, replicas, 0); err != nil {
 		return &RequeueAfterError{RequeueAfter: requeueDuration,
-			Msg: fmt.Sprintf("redpanda on pod (ordinal: %d) not ready", 0)}
+			Msg: fmt.Sprintf("redpanda on pod (ordinal: %d) not ready: %s", 0, err)}
 	}
 
 	return nil

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -14,18 +14,19 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
-	"strconv"
 	"time"
 
-	"github.com/Shopify/sarama"
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 const requeueDuration = time.Second * 10
+const adminAPITimeout = time.Millisecond * 100
+
+var errRedpandaNotReady = errors.New("redpanda not ready")
 
 // runPartitionedUpdate handles image changes in the redpanda cluster CR by triggering
 // a rolling update (using partitions) against the statefulset underneath the CR.
@@ -42,7 +43,7 @@ const requeueDuration = time.Second * 10
 // starting from the last pod to the first; 4) in each iteration apply the update
 // on the pod and requeue until the pod is in ready state; 5) prior to a pod update
 // verify the previously updated pod and requeue as necessary. Currently, the
-// verification checks the pod has started listening in its Kafka API port and may be
+// verification checks the pod has started listening in its http Admin API port and may be
 // extended.
 func (r *StatefulSetResource) runPartitionedUpdate(
 	ctx context.Context, sts *appsv1.StatefulSet,
@@ -159,36 +160,25 @@ func (r *StatefulSetResource) ensureRedpandaGroupsReady(
 		return nil
 	}
 
-	if len(r.pandaCluster.Spec.Configuration.KafkaAPI) == 0 {
-		return nil // TODO
-	}
-	internalListener := r.pandaCluster.InternalListener()
-	port := strconv.Itoa(internalListener.Port)
-	headlessServiceWithPort := fmt.Sprintf("%s:%s", r.serviceFQDN, port)
+	headlessServiceWithPort := fmt.Sprintf("%s:%d", r.serviceFQDN,
+		r.pandaCluster.Spec.Configuration.AdminAPI.Port)
 
-	addresses := []string{fmt.Sprintf("%s-%d.%s", sts.Name, ordinal, headlessServiceWithPort)}
+	address := fmt.Sprintf("%s-%d.%s%s", sts.Name, ordinal, headlessServiceWithPort, "/v1/status/ready")
 
-	return r.queryRedpandaForTopicMembers(ctx, addresses, r.logger)
+	return r.queryRedpandaStatus(ctx, address)
 }
 
-// Used as a temporary indicator that Redpanda is ready until a health
-// endpoint is introduced or logic is added here that goes through all topics
-// metadata.
-func (r *StatefulSetResource) queryRedpandaForTopicMembers(
-	ctx context.Context, addresses []string, logger logr.Logger,
+// Temporarily using the status/ready endpoint until we have a specific one for upgrading.
+func (r *StatefulSetResource) queryRedpandaStatus(
+	ctx context.Context, address string,
 ) error {
-	logger.Info("Connect to Redpanda broker", "broker", addresses)
-
-	conf := sarama.NewConfig()
-	conf.Version = sarama.V2_4_0_0
-	conf.ClientID = "operator"
-	conf.Admin.Timeout = time.Second
+	client := &http.Client{Timeout: adminAPITimeout}
+	protocol := "http"
 
 	// TODO right now we support TLS only on one listener so if external
 	// connectivity is enabled, TLS is enabled only on external listener. This
 	// will be fixed by https://github.com/vectorizedio/redpanda/issues/1084
-	tlsListener := r.pandaCluster.KafkaTLSListener()
-	if tlsListener != nil && !tlsListener.External.Enabled {
+	if !r.pandaCluster.Spec.ExternalConnectivity.Enabled && r.pandaCluster.Spec.Configuration.TLS.AdminAPI.Enabled {
 		tlsConfig := tls.Config{MinVersion: tls.VersionTLS12} // TLS12 is min version allowed by gosec.
 		// For simplicity, we skip broker verification until per-listener
 		// TLS is available in Redpanda. This client calls the internal listener.
@@ -198,17 +188,28 @@ func (r *StatefulSetResource) queryRedpandaForTopicMembers(
 			return err
 		}
 
-		conf.Net.TLS.Enable = true
-		conf.Net.TLS.Config = &tlsConfig
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tlsConfig,
+		}
+		protocol = "https"
 	}
+	address = fmt.Sprintf("%s://%s", protocol, address)
 
-	consumer, err := sarama.NewConsumer(addresses, conf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
 	if err != nil {
-		logger.Error(err, "Error while creating consumer")
 		return err
 	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
 
-	return consumer.Close()
+	if resp.StatusCode != http.StatusOK {
+		return errRedpandaNotReady
+	}
+
+	return nil
 }
 
 // Populates crypto/TLS configuration for certificate used by the operator
@@ -216,11 +217,6 @@ func (r *StatefulSetResource) queryRedpandaForTopicMembers(
 func (r *StatefulSetResource) populateTLSConfigCert(
 	ctx context.Context, tlsConfig *tls.Config,
 ) error {
-	tlsListener := r.pandaCluster.KafkaTLSListener()
-	if tlsListener == nil || !tlsListener.TLS.RequireClientAuth {
-		return nil
-	}
-
 	var certSecret corev1.Secret
 	err := r.Get(ctx, r.adminAPIClientCertSecretKey, &certSecret)
 	if err != nil {

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  up-img-kafka-selfsigned-issuer
+  name:  up-img-admin-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  up-img-kafka-root-issuer
+  name:  up-img-admin-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name:  up-img-kafka-root-certificate
+  name:  up-img-admin-root-certificate
 status:
   conditions:
     - reason: Ready
@@ -45,7 +45,19 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name:  up-img-redpanda
+  name:  up-img-admin-api-node
+status:
+  conditions:
+    - reason: Ready
+      status: "True"
+      type: Ready
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name:  up-img-admin-api-client
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.4.8"
+  version: "v21.4.10"
   replicas: 2
   resources:
     requests:
@@ -19,10 +19,10 @@ spec:
     kafkaApi:
     - name: kafka
       port: 9092
-      tls:
-        enabled: true
-        requireClientAuth: true
     admin:
       port: 9644
     developerMode: true
-
+    tls:
+      adminApi:
+        enabled: true
+        requireClientAuth: true

--- a/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
@@ -10,7 +10,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  up-img-kafka-selfsigned-issuer
+  name:  up-img-admin-selfsigned-issuer
 status:
   conditions:
     - reason: IsReady
@@ -22,7 +22,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  up-img-kafka-root-issuer
+  name:  up-img-admin-root-issuer
 status:
   conditions:
     - reason: KeyPairVerified
@@ -33,7 +33,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: up-img-kafka-root-certificate
+  name: up-img-admin-root-certificate
 status:
   conditions:
     - reason: Ready
@@ -45,7 +45,7 @@ status:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: up-img-redpanda
+  name: up-img-admin-api-node
 status:
   conditions:
     - reason: Ready

--- a/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.4.8"
+  version: "v21.4.10"
   replicas: 2
   resources:
     requests:
@@ -19,8 +19,9 @@ spec:
     kafkaApi:
     - name: kafka
       port: 9092
-      tls:
-        enabled: true
     admin:
       port: 9644
     developerMode: true
+    tls:
+      adminApi:
+        enabled: true

--- a/src/go/k8s/tests/e2e/update-image/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: update-image-cluster
 spec:
   image: "vectorized/redpanda"
-  version: "v21.4.8"
+  version: "v21.4.10"
   replicas: 2
   resources:
     requests:


### PR DESCRIPTION
## Cover letter

1. With the introduction of SASL, calling any Kafka listener requires credentials. Although that is possible to do from the operator, it adds complexity.
2. It is our intention to use an upgrade-specific endpoint, which would be part of the http Admin API (not the Kafka API)

Due to the above, this PR changes the operator behavior such that it check the redpanda readiness using the Admin API. Since we don't have the ideal endpoint at the moment, we start by using `v1/state/ready` with the intention to develop an appropriate endpoint in the (hopefully near) future.
