### PR TITLE
rpc/transport: moved dns name resolving into rpc::trasport::connect

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -73,8 +73,7 @@ write_random_batches(ss::lw_shared_ptr<storage::segment> seg) { // NOLINT
 }
 
 archival::configuration get_configuration() {
-    ss::ipv4_addr ip_addr = {httpd_host_name, httpd_port_number};
-    ss::socket_address server_addr(ip_addr);
+    unresolved_address server_addr(httpd_host_name, httpd_port_number);
     s3::configuration s3conf{
       .uri = s3::access_point_uri(httpd_host_name),
       .access_key = s3::public_key_str("acess-key"),

--- a/src/v/coproc/pacemaker.cc
+++ b/src/v/coproc/pacemaker.cc
@@ -34,7 +34,7 @@
 namespace coproc {
 
 rpc::transport_configuration
-wasm_transport_cfg(const ss::socket_address& addr) {
+wasm_transport_cfg(const unresolved_address& addr) {
     return rpc::transport_configuration{
       .server_addr = addr,
       .max_queued_bytes = static_cast<uint32_t>(
@@ -49,7 +49,7 @@ rpc::backoff_policy wasm_transport_backoff() {
     return rpc::make_exponential_backoff_policy<rpc::clock_type>(1s, 10s);
 }
 
-pacemaker::pacemaker(ss::socket_address addr, ss::sharded<storage::api>& api)
+pacemaker::pacemaker(unresolved_address addr, ss::sharded<storage::api>& api)
   : _shared_res(
     rpc::reconnect_transport(
       wasm_transport_cfg(addr), wasm_transport_backoff()),

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -41,7 +41,7 @@ public:
      * @param address of coprocessor engine
      * @param reference to the storage layer
      */
-    pacemaker(ss::socket_address, ss::sharded<storage::api>&);
+    pacemaker(unresolved_address, ss::sharded<storage::api>&);
 
     /**
      * Begins the offset tracking fiber

--- a/src/v/coproc/tests/utils/coproc_slim_fixture.cc
+++ b/src/v/coproc/tests/utils/coproc_slim_fixture.cc
@@ -58,8 +58,7 @@ ss::future<> coproc_slim_fixture::start() {
       .then([this] { return _storage.invoke_on_all(&storage::api::start); })
       .then([this] {
           return _pacemaker.start(
-            ss::socket_address(ss::net::inet_address("127.0.0.1"), 43189),
-            std::ref(_storage));
+            unresolved_address("127.0.0.1", 43189), std::ref(_storage));
       })
       .then(
         [this] { return _pacemaker.invoke_on_all(&coproc::pacemaker::start); })

--- a/src/v/http/demo/client.cc
+++ b/src/v/http/demo/client.cc
@@ -83,8 +83,8 @@ inline std::ostream& operator<<(std::ostream& out, const test_conf& cfg) {
 
 test_conf cfg_from(boost::program_options::variables_map& m) {
     rpc::transport_configuration client_cfg;
-    client_cfg.server_addr = ss::socket_address(
-      ss::ipv4_addr(m["ip"].as<std::string>(), m["port"].as<uint16_t>()));
+    client_cfg.server_addr = unresolved_address(
+      m["ip"].as<std::string>(), m["port"].as<uint16_t>());
     return test_conf{
       .chunk_size = m["chunk-size"].as<std::size_t>(),
       .data = m["data"].as<std::string>(),

--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -16,14 +16,10 @@ namespace kafka::client {
 
 ss::future<shared_broker_t>
 make_broker(model::node_id node_id, unresolved_address addr) {
-    return rpc::resolve_dns(std::move(addr))
-      .then([](ss::socket_address addr) {
-          auto client = ss::make_lw_shared<transport>(
-            rpc::base_transport::configuration{.server_addr = addr});
-          return client->connect().then(
-            [client]() mutable { return std::move(client); });
-      })
-      .then([node_id, addr](ss::lw_shared_ptr<transport> client) {
+    auto client = ss::make_lw_shared<transport>(
+      rpc::base_transport::configuration{.server_addr = addr});
+    return client->connect()
+      .then([node_id, addr = std::move(addr), client] {
           vlog(
             kclog.info,
             "connected to broker:{} - {}:{}",

--- a/src/v/pandaproxy/test/pandaproxy_fixture.h
+++ b/src/v/pandaproxy/test/pandaproxy_fixture.h
@@ -32,7 +32,7 @@ public:
 
     http::client make_client() {
         rpc::base_transport::configuration transport_cfg;
-        transport_cfg.server_addr = rpc::resolve_dns({"localhost", 8082}).get();
+        transport_cfg.server_addr = unresolved_address{"localhost", 8082};
         return http::client(transport_cfg);
     }
 

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -181,8 +181,11 @@ extract_peer(ss::sstring peer) {
         throw std::runtime_error(fmt::format("Could not parse peer:{}", peer));
     }
     int32_t n = boost::lexical_cast<int32_t>(parts[0]);
+    std::vector<ss::sstring> address_parts;
+    boost::split(parts, parts[1], boost::is_any_of(":"));
     rpc::transport_configuration cfg;
-    cfg.server_addr = ss::ipv4_addr(parts[1]);
+    cfg.server_addr = unresolved_address(
+      address_parts[0], boost::lexical_cast<int16_t>(address_parts[1]));
     return {model::node_id(n), cfg};
 }
 

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -270,17 +270,14 @@ struct raft_node {
                     if (c.contains(broker.id())) {
                         return seastar::make_ready_future<>();
                     }
-                    return rpc::resolve_dns(broker.rpc_address())
-                      .then([this, &broker, &c](ss::socket_address addr) {
-                          return c.emplace(
-                            broker.id(),
-                            {.server_addr = addr,
-                             .disable_metrics = rpc::metrics_disabled::yes},
-                            rpc::make_exponential_backoff_policy<
-                              rpc::clock_type>(
-                              std::chrono::milliseconds(1),
-                              std::chrono::milliseconds(1)));
-                      });
+
+                    return c.emplace(
+                      broker.id(),
+                      {.server_addr = broker.rpc_address(),
+                       .disable_metrics = rpc::metrics_disabled::yes},
+                      rpc::make_exponential_backoff_policy<rpc::clock_type>(
+                        std::chrono::milliseconds(1),
+                        std::chrono::milliseconds(1)));
                 })
               .get0();
         }

--- a/src/v/raft/tron/client.cc
+++ b/src/v/raft/tron/client.cc
@@ -150,8 +150,8 @@ private:
 inline load_gen_cfg cfg_from_opts_in_thread(
   boost::program_options::variables_map& m, ss::sharded<hdr_hist>* h) {
     rpc::transport_configuration client_cfg;
-    client_cfg.server_addr = ss::socket_address(
-      ss::ipv4_addr(m["ip"].as<std::string>(), m["port"].as<uint16_t>()));
+    client_cfg.server_addr = unresolved_address(
+      m["ip"].as<std::string>(), m["port"].as<uint16_t>());
     auto ca_cert = m["ca-cert"].as<std::string>();
     if (ca_cert != "") {
         auto builder = ss::tls::credentials_builder();

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -171,7 +171,10 @@ extract_peer(ss::sstring peer) {
     }
     int32_t n = boost::lexical_cast<int32_t>(parts[0]);
     rpc::transport_configuration cfg;
-    cfg.server_addr = ss::ipv4_addr(parts[1]);
+    std::vector<ss::sstring> address_parts;
+    boost::split(parts, parts[1], boost::is_any_of(":"));
+    cfg.server_addr = unresolved_address(
+      address_parts[0], boost::lexical_cast<int16_t>(address_parts[1]));
     return {model::node_id(n), cfg};
 }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -354,13 +354,11 @@ void application::wire_up_redpanda_services() {
       .get();
 
     if (coproc_enabled()) {
-        auto coproc_supervisor_server_addr
-          = rpc::resolve_dns(
-              config::shard_local_cfg().coproc_supervisor_server())
-              .get0();
         syschecks::systemd_message("Building coproc pacemaker").get();
         construct_service(
-          pacemaker, coproc_supervisor_server_addr, std::ref(storage))
+          pacemaker,
+          config::shard_local_cfg().coproc_supervisor_server(),
+          std::ref(storage))
           .get();
     }
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -178,13 +178,9 @@ public:
     }
 
     ss::future<kafka::client::transport> make_kafka_client() {
-        return rpc::resolve_dns(
-                 config::shard_local_cfg().kafka_api()[0].address)
-          .then([](ss::socket_address addr) {
-              return kafka::client::transport(
-                rpc::base_transport::configuration{
-                  .server_addr = addr,
-                });
+        return ss::make_ready_future<kafka::client::transport>(
+          rpc::base_transport::configuration{
+            .server_addr = config::shard_local_cfg().kafka_api()[0].address,
           });
     }
 

--- a/src/v/rpc/client_probe.h
+++ b/src/v/rpc/client_probe.h
@@ -11,9 +11,9 @@
 
 #pragma once
 #include "rpc/logger.h"
+#include "utils/unresolved_address.h"
 
 #include <seastar/core/metrics_registration.hh>
-#include <seastar/net/socket_defs.hh>
 
 #include <iosfwd>
 
@@ -72,7 +72,7 @@ public:
     void setup_metrics(
       ss::metrics::metric_groups& mgs,
       const std::optional<ss::sstring>& service_name,
-      const ss::socket_address& target_addr);
+      const unresolved_address& target_addr);
 
 private:
     uint64_t _requests = 0;

--- a/src/v/rpc/demo/client.cc
+++ b/src/v/rpc/demo/client.cc
@@ -176,8 +176,8 @@ private:
 inline load_gen_cfg
 cfg_from(boost::program_options::variables_map& m, ss::sharded<hdr_hist>* h) {
     rpc::transport_configuration client_cfg;
-    client_cfg.server_addr = ss::socket_address(
-      ss::ipv4_addr(m["ip"].as<std::string>(), m["port"].as<uint16_t>()));
+    client_cfg.server_addr = unresolved_address(
+      m["ip"].as<std::string>(), m["port"].as<uint16_t>());
     auto ca_cert = m["ca-cert"].as<std::string>();
     if (ca_cert != "") {
         auto builder = ss::tls::credentials_builder();

--- a/src/v/rpc/probes.cc
+++ b/src/v/rpc/probes.cc
@@ -99,11 +99,11 @@ std::ostream& operator<<(std::ostream& o, const server_probe& p) {
 void client_probe::setup_metrics(
   ss::metrics::metric_groups& mgs,
   const std::optional<ss::sstring>& service_name,
-  const ss::socket_address& target_addr) {
+  const unresolved_address& target_addr) {
     namespace sm = ss::metrics;
     auto target = sm::label("target");
     std::vector<sm::label_instance> labels = {
-      target(ssx::sformat("{}:{}", target_addr.addr(), target_addr.port()))};
+      target(ssx::sformat("{}:{}", target_addr.host(), target_addr.port()))};
     if (service_name) {
         labels.push_back(sm::label("service_name")(*service_name));
     }

--- a/src/v/rpc/reconnect_transport.h
+++ b/src/v/rpc/reconnect_transport.h
@@ -40,7 +40,7 @@ public:
     ss::future<result<transport*>> get_connected(clock_type::time_point);
     ss::future<result<transport*>> get_connected(clock_type::duration);
 
-    const ss::socket_address& server_address() const {
+    const unresolved_address& server_address() const {
         return _transport.server_address();
     }
 

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -10,6 +10,7 @@
 #include "rpc/transport.h"
 
 #include "likely.h"
+#include "rpc/dns.h"
 #include "rpc/logger.h"
 #include "rpc/netbuf.h"
 #include "rpc/parse_utils.h"
@@ -93,8 +94,9 @@ ss::future<> base_transport::do_connect(clock_type::time_point timeout) {
           server_address()));
     }
     try {
+        auto resolved_address = co_await resolve_dns(server_address());
         ss::connected_socket fd = co_await connect_with_timeout(
-          server_address(), timeout);
+          resolved_address, timeout);
 
         if (_creds) {
             fd = co_await ss::tls::wrap_client(

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -45,7 +45,7 @@ struct client_context_impl;
 class base_transport {
 public:
     struct configuration {
-        ss::socket_address server_addr;
+        unresolved_address server_addr;
         ss::shared_ptr<ss::tls::certificate_credentials> credentials;
         rpc::metrics_disabled disable_metrics = rpc::metrics_disabled::no;
         /// Optional server name indication (SNI) for TLS connection
@@ -66,7 +66,7 @@ public:
 
     [[gnu::always_inline]] bool is_valid() const { return _fd && !_in.eof(); }
 
-    const ss::socket_address& server_address() const { return _server_addr; }
+    const unresolved_address& server_address() const { return _server_addr; }
 
 protected:
     virtual void fail_outstanding_futures() {}
@@ -80,7 +80,7 @@ private:
     ss::future<> do_connect(clock_type::time_point);
 
     std::unique_ptr<ss::connected_socket> _fd;
-    ss::socket_address _server_addr;
+    unresolved_address _server_addr;
     ss::shared_ptr<ss::tls::certificate_credentials> _creds;
     std::optional<ss::sstring> _tls_sni_hostname;
 };
@@ -226,7 +226,7 @@ public:
         return _transport.is_valid();
     }
 
-    const ss::socket_address& server_address() const {
+    const unresolved_address& server_address() const {
         return _transport.server_address();
     }
 

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -14,6 +14,7 @@
 #include "likely.h"
 #include "outcome.h"
 #include "seastarx.h"
+#include "utils/unresolved_address.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
@@ -216,7 +217,7 @@ struct server_configuration {
       : name(std::move(n)) {}
 };
 struct transport_configuration {
-    ss::socket_address server_addr;
+    unresolved_address server_addr;
     /// \ brief The default timeout PER connection body. After we
     /// parse the header of the connection we need to
     /// make sure that we at some point receive some

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -94,11 +94,9 @@ ss::future<configuration> configuration::make_configuration(
         client_cfg.credentials
           = co_await cred_builder.build_reloadable_certificate_credentials();
     }
-    auto addr = co_await ss::net::dns::resolve_name(
-      client_cfg.uri(), ss::net::inet_address::family::INET);
     constexpr uint16_t default_port = 443;
-    client_cfg.server_addr = ss::socket_address(
-      addr, overrides.port ? *overrides.port : default_port);
+    client_cfg.server_addr = unresolved_address(
+      client_cfg.uri(), overrides.port ? *overrides.port : default_port);
     co_return client_cfg;
 }
 


### PR DESCRIPTION
## Cover letter

Every time we create an RPC client we have to perform DNS name resolution. Previously `rpc::transport_configuration` used already resolved `socket_address`, this way DNS resolve call had to be done outside of the RPC transport. It isn't correct since it would require additional retry logic in case DNS resolve would fail and additionally name resolution has to be done every time we reconnect transport since name mapping might changed.

Moving DNS resolution to be part of `rpc::transport::connect()` method execution allow us to leverage already existing retries logic and forces DNS resolving every time transport reconnects.

## Release notes

- fixes connectivity issues we were recently seeing in cloud deployments
