### PR TITLE
github: updated pr template to automate issues closing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.
 
-Fixes issues: [#NNN, #NNN, ...]
+Fixes: #NNN, #NNN, ...
 
 ## Release notes
 


### PR DESCRIPTION
Updated PR template to enable github to automatically close issues
related with given PR. In order for github to automatically close the
issue when PR is merged list of issues have to be listed after `Fixes:`
statement.

Current template prevent github to automatically close issues.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
