### PR TITLE
Wasm/js/fix crash on invalid coproc

### DIFF
--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -196,17 +196,13 @@ export class ProcessBatchServer extends SupervisorServer {
       this.fireException
     );
 
-    return Promise.allSettled(results).then((coprocessorResults) => {
-      const array: ProcessBatchReplyItem[][] = [];
-      coprocessorResults.forEach((result) => {
-        if (result.status === "rejected") {
-          console.error(result.reason);
-        } else {
-          array.push(result.value);
-        }
-      });
-      return array.flat();
-    });
+    return Promise.all(results).then(
+      (coprocessorResults) => coprocessorResults.flat(),
+      (e) => {
+        this.logger.error(e);
+        return Logging.close().then(() => process.exit(1));
+      }
+    );
   }
 
   /**


### PR DESCRIPTION
now when the coprocessor fail when doesn't find the coprocessor
that needs to apply, the js process is going to close and save
the logs

