### PR TITLE
r/tests: reduced number of nodes in replace group test

### DIFF
--- a/src/v/raft/tests/membership_test.cc
+++ b/src/v/raft/tests/membership_test.cc
@@ -200,15 +200,11 @@ FIXTURE_TEST(replace_whole_group, raft_test_fixture) {
     gr.enable_all();
     info("replicating some batches");
     auto res = replicate_random_batches(gr, 5).get0();
-    // all nodes are replaced
+    // all nodes are replaced with new node
     gr.create_new_node(model::node_id(5));
-    gr.create_new_node(model::node_id(6));
-    gr.create_new_node(model::node_id(7));
     std::vector<model::broker> new_members;
-    new_members.reserve(3);
+    new_members.reserve(1);
     new_members.push_back(gr.get_member(model::node_id(5)).broker);
-    new_members.push_back(gr.get_member(model::node_id(6)).broker);
-    new_members.push_back(gr.get_member(model::node_id(7)).broker);
     bool success = false;
     info("replacing configuration");
     res = retry_with_leader(gr, 5, 5s, [new_members](raft_node& leader) {
@@ -270,6 +266,6 @@ FIXTURE_TEST(replace_whole_group, raft_test_fixture) {
     auto new_leader_id = gr.get_leader_id();
     if (new_leader_id) {
         auto& new_leader = gr.get_member(*new_leader_id);
-        BOOST_REQUIRE_EQUAL(new_leader.consensus->config().brokers().size(), 3);
+        BOOST_REQUIRE_EQUAL(new_leader.consensus->config().brokers().size(), 1);
     }
 }


### PR DESCRIPTION
Reduced number or concurrently running raft instances in
`replace_whole_group` test. In debug mode the test was failing in CI as
all of the raft instances are created on the same core, reduced number
or raft instances from 6 to 4 to minimize overhead and prevent test from
generating false failures.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
