### PR TITLE
rpk/start: Add support for Pandaproxy

### DIFF
--- a/docs/www/production-deployment.md
+++ b/docs/www/production-deployment.md
@@ -22,6 +22,7 @@ For the best performance the following are strongly recommended:
 - The following ports need to be opened
   - `33145` - Internal RPC Port
   - `9092` - Kafka API Port
+  - `8082` - Pandaproxy Port
   - `9644` - Prometheus & HTTP Admin port
 
 ## Installation
@@ -99,7 +100,7 @@ cd gcp
 #### Step 1: Prerequisites
 
 You will need an existing subnet to deploy the VMs into. The subnet's attached
-firewall should allow inbound traffic on ports 22, 3000, 8888, 8889, 9090,
+firewall should allow inbound traffic on ports 22, 3000, 8082, 8888, 8889, 9090,
 9092, 9644 and 33145. This module adds the `rp-node` tag to the deployed VMs,
 which can be used as the target tag for the firewall rule.
 

--- a/docs/www/quick-start-docker.md
+++ b/docs/www/quick-start-docker.md
@@ -27,7 +27,7 @@ With a 1-node cluster you can test out a simple implementation of Redpanda.
 # make sure you update the version of v21.4.6 to the latest release https://github.com/vectorizedio/redpanda/releases
 
 
-docker run -ti --rm -p 9092:9092 vectorized/redpanda:v21.4.6 start --overprovisioned --smp 1  --memory 1G  --reserve-memory 0M --node-id 0 --check=false
+docker run -ti --rm -p 8082:8082 -p 9092:9092 vectorized/redpanda:v21.4.6 start --overprovisioned --smp 1  --memory 1G  --reserve-memory 0M --node-id 0 --check=false
 
 ```
 
@@ -60,6 +60,7 @@ docker run -d \
 --name=redpanda-1 \
 --hostname=redpanda-1 \
 --net=redpandanet \
+-p 8082:8082 \
 -p 9092:9092 \
 -v "redpanda1:/var/lib/redpanda/data" \
 vectorized/redpanda start \
@@ -69,6 +70,8 @@ vectorized/redpanda start \
 --overprovisioned \
 --node-id 0 \
 --check=false \
+--pandaproxy-addr 0.0.0.0:8082 \
+--advertise-pandaproxy-addr 127.0.0.1:8082 \
 --kafka-addr 0.0.0.0:9092 \
 --advertise-kafka-addr 127.0.0.1:9092 \
 --rpc-addr 0.0.0.0:33145 \
@@ -88,6 +91,8 @@ vectorized/redpanda start \
 --node-id 1 \
 --seeds "redpanda-1:33145" \
 --check=false \
+--pandaproxy-addr 0.0.0.0:8083 \
+--advertise-pandaproxy-addr 127.0.0.1:8083 \
 --kafka-addr 0.0.0.0:9093 \
 --advertise-kafka-addr 127.0.0.1:9093 \
 --rpc-addr 0.0.0.0:33146 \
@@ -107,6 +112,8 @@ vectorized/redpanda start \
 --node-id 2 \
 --seeds "redpanda-1:33145" \
 --check=false \
+--pandaproxy-addr 0.0.0.0:8084 \
+--advertise-pandaproxy-addr 127.0.0.1:8084 \
 --kafka-addr 0.0.0.0:9094 \
 --advertise-kafka-addr 127.0.0.1:9094 \
 --rpc-addr 0.0.0.0:33147 \

--- a/docs/www/rpk-commands.md
+++ b/docs/www/rpk-commands.md
@@ -48,18 +48,20 @@ Usage:
   rpk redpanda start [flags]
 
 Flags:
-      --advertise-kafka-addr strings   The list of Kafka addresses to advertise (<host>:<port>)
+      --advertise-kafka-addr strings   A comma-separated list of Kafka addresses to advertise (<name>://<host>:<port>)
+      --advertise-pandaproxy-addr      A comma-separated list of Pandaproxy addresses to advertise (<name>://<host>:<port>)
       --advertise-rpc-addr string      The advertised RPC address (<host>:<port>)
-      --check                  When set to false will disable system checking before starting redpanda (default: true)
-      --config string          Redpanda config file, if not set the file will be searched for in the default locations
-      --install-dir string     Directory where redpanda has been installed
-      --kafka-addr strings             The list of Kafka listener addresses to bind to (<host>:<port>)
+      --check                          When set to false will disable system checking before starting redpanda (default: true)
+      --config string                  Redpanda config file, if not set the file will be searched for in the default locations
+      --install-dir string             Directory where redpanda has been installed
+      --kafka-addr strings             A comma-separated list of Kafka listener addresses to bind to (<name>://<host>:<port>)
       --node-id int                    The node ID. Must be an integer and must be unique within a cluster
+      --pandaproxy-addr                A comma-separated list of Pandaproxy listener addresses to bind to (<name>://<host>:<port>)
       --rpc-addr string                The RPC address to bind to (<host>:<port>)
   -s, --seeds strings                  A comma-separated list of seed node addresses (<host>[:<port>]) to connect to
-      --timeout duration       The maximum time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default: 10s)
-      --tune                   When present will enable tuning before starting redpanda
-      --well-known-io string   The cloud vendor and VM type, in the format <vendor>:<vm type>:<storage type>
+      --timeout duration               The maximum time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default: 10s)
+      --tune                           When present will enable tuning before starting redpanda
+      --well-known-io string           The cloud vendor and VM type, in the format <vendor>:<vm type>:<storage type>
 ```
 
 ### redpanda mode

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -137,6 +137,10 @@ func startCluster(
 	if err != nil {
 		return err
 	}
+	seedProxyPort, err := net.GetFreePort()
+	if err != nil {
+		return err
+	}
 	seedRPCPort, err := net.GetFreePort()
 	if err != nil {
 		return err
@@ -149,6 +153,7 @@ func startCluster(
 		c,
 		seedID,
 		seedKafkaPort,
+		seedProxyPort,
 		seedRPCPort,
 		seedMetricsPort,
 		netID,
@@ -184,6 +189,10 @@ func startCluster(
 			if err != nil {
 				return err
 			}
+			proxyPort, err := net.GetFreePort()
+			if err != nil {
+				return err
+			}
 			rpcPort, err := net.GetFreePort()
 			if err != nil {
 				return err
@@ -204,6 +213,7 @@ func startCluster(
 				c,
 				id,
 				kafkaPort,
+				proxyPort,
 				rpcPort,
 				metricsPort,
 				netID,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -335,13 +335,13 @@ func NewStartCommand(
 		&kafkaAddr,
 		"kafka-addr",
 		[]string{},
-		"The list of Kafka listener addresses to bind to (<host>:<port>)",
+		"A comma-separated list of Kafka listener addresses to bind to (<name>://<host>:<port>)",
 	)
 	command.Flags().StringSliceVar(
 		&proxyAddr,
 		"pandaproxy-addr",
 		[]string{},
-		"The list of Pandaproxy listener addresses to bind to (<host>:<port>)",
+		"A comma-separated list of Pandaproxy listener addresses to bind to (<name>://<host>:<port>)",
 	)
 	command.Flags().StringVar(
 		&rpcAddr,
@@ -353,13 +353,13 @@ func NewStartCommand(
 		&advertisedKafka,
 		"advertise-kafka-addr",
 		[]string{},
-		"The list of Kafka addresses to advertise (<host>:<port>)",
+		"A comma-separated list of Kafka addresses to advertise (<name>://<host>:<port>)",
 	)
 	command.Flags().StringSliceVar(
 		&advertisedProxy,
 		"advertise-pandaproxy-addr",
 		[]string{},
-		"The list of Pandaproxy addresses to advertise (<host>:<port>)",
+		"A comma-separated list of Pandaproxy addresses to advertise (<name>://<host>:<port>)",
 	)
 	command.Flags().StringVar(
 		&advertisedRPC,

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -28,6 +28,7 @@ const (
 	ModeProd = "prod"
 
 	DefaultKafkaPort = 9092
+	DefaultProxyPort = 8082
 	DefaultAdminPort = 9644
 )
 


### PR DESCRIPTION
## Cover letter

Support command line and env for Pandaproxy:
* `--pandaproxy-addr` / `REDPANDA_PANDAPROXY_ADDRESS`
* `--advertise-pandaproxy-addr` / `REDPANDA_ADVERTISE_PANDAPROXY_ADDRESS`

Also improve a bunch of docs.

Changes in [force-pushes](https://github.com/vectorizedio/redpanda/compare/ededf429020382c521888ab85d8878127a9e8407..a43e38556f239ad0ddebedc262407599f8491812)

* nil check for `config,Pandaproxy`
* nil check for `advProxyApi` insteadk of `advKafkaApi`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/a43e38556f239ad0ddebedc262407599f8491812..82550e5e92e1f8df0aad631e0e7a2f77d57c830a)
* Rebase over #1098 

Changes in [force-pushes](https://github.com/vectorizedio/redpanda/compare/82550e5e92e1f8df0aad631e0e7a2f77d57c830a..350154256d2139fa873a649b6a09ab73d4a0873d)
* Docs Improvements
## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
