### PR TITLE
task: added ability to build single specific targets

### DIFF
--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -61,7 +61,7 @@ tasks:
     cmds:
     - |
       PATH={{.LLVM_INSTALL_PATH}}/bin:$PATH
-      ninja -C '{{.BUILD_DIR}}' -j'{{div .TOTAL_PHYSICAL_MEMORY .GB_PER_BUILD_CORE}}'
+      ninja {{.TARGETS}} -C '{{.BUILD_DIR}}' -j'{{div .TOTAL_PHYSICAL_MEMORY .GB_PER_BUILD_CORE}}'
 
   set-aio-max:
     desc: set minimum required value for fs.aio-max-nr sysctl option


### PR DESCRIPTION
It is very useful to be able to build specific ninja targets right from
the repo main directory.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
