### PR TITLE
Fixed updating nodes configuration metadata

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -22,6 +22,7 @@
 #include "reflection/adl.h"
 #include "storage/api.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
@@ -86,7 +87,14 @@ ss::future<> members_manager::start_config_changes_watcher() {
     // handle initial configuration
     return handle_raft0_cfg_update(_raft0->config()).then([this] {
         if (is_already_member()) {
-            return maybe_update_current_node_configuration();
+            (void)ss::with_gate(_gate, [this] {
+                return maybe_update_current_node_configuration();
+            }).handle_exception_type([](const ss::gate_closed_exception& e) {
+                vlog(
+                  clusterlog.debug,
+                  "unable to update node configuration, gate closed - {}",
+                  e);
+            });
         }
         return ss::now();
     });
@@ -398,7 +406,7 @@ ss::future<> members_manager::validate_configuration_invariants() {
 
 ss::future<result<configuration_update_reply>>
 members_manager::do_dispatch_configuration_update(
-  const model::broker& target, model::broker updated_cfg) {
+  model::broker target, model::broker updated_cfg) {
     if (target.id() == _self.id()) {
         return handle_configuration_update_request(
           configuration_update_request(std::move(updated_cfg), _self.id()));
@@ -425,44 +433,43 @@ members_manager::do_dispatch_configuration_update(
       });
 }
 
+model::broker get_update_request_target(
+  std::optional<model::node_id> current_leader,
+  const std::vector<broker_ptr>& brokers) {
+    if (current_leader) {
+        auto it = std::find_if(
+          brokers.cbegin(),
+          brokers.cend(),
+          [current_leader](const broker_ptr& b) {
+              return b->id() == current_leader;
+          });
+
+        if (it != brokers.cend()) {
+            return **it;
+        }
+    }
+    return *brokers[random_generators::get_int(brokers.size() - 1)];
+}
+
 ss::future<>
 members_manager::dispatch_configuration_update(model::broker broker) {
     // right after start current node has no information about the current
-    // leader (it may never receive one as its addres might have been changed),
-    // dispatch request to any cluster node, it will eventually forward it to
-    // current leader
-
-    return ss::do_with(
-      _members_table.local().all_brokers(),
-      [this, broker](std::vector<broker_ptr>& all_brokers) mutable {
-          return ss::repeat([this, &all_brokers, broker]() mutable {
-              // shuffle brokers
-              std::shuffle(
-                all_brokers.begin(),
-                all_brokers.end(),
-                random_generators::internal::gen);
-              // pick one
-              auto it = std::find_if(
-                std::cbegin(all_brokers),
-                std::cend(all_brokers),
-                [this](const broker_ptr& ptr) {
-                    return ptr->id() != _self.id();
-                });
-
-              // if current node is the only node in the cluster, handle locally
-              auto& target = it != std::cend(all_brokers) ? *it->get() : _self;
-
-              return do_dispatch_configuration_update(target, broker)
-                .then([](result<configuration_update_reply> r) {
-                    if (r.has_error()) {
-                        return ss::make_ready_future<ss::stop_iteration>(
-                          ss::stop_iteration::no);
-                    }
-                    return ss::make_ready_future<ss::stop_iteration>(
-                      ss::stop_iteration::yes);
-                });
-          });
-      });
+    // leader (it may never receive one as its addres might have been
+    // changed), dispatch request to any cluster node, it will eventually
+    // forward it to current leader
+    bool update_success = false;
+    while (!update_success) {
+        auto brokers = _members_table.local().all_brokers();
+        auto target = get_update_request_target(
+          _raft0->get_leader_id(), brokers);
+        auto r = co_await do_dispatch_configuration_update(target, broker);
+        if (r.has_error() || r.value().success == false) {
+            co_await ss::sleep_abortable(
+              _join_retry_jitter.base_duration(), _as.local());
+        } else {
+            update_success = true;
+        }
+    }
 }
 
 ss::future<result<configuration_update_reply>>

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -81,7 +81,7 @@ private:
     ss::future<> maybe_update_current_node_configuration();
     ss::future<> dispatch_configuration_update(model::broker);
     ss::future<result<configuration_update_reply>>
-    do_dispatch_configuration_update(const model::broker&, model::broker);
+      do_dispatch_configuration_update(model::broker, model::broker);
 
     model::offset _last_seen_configuration_offset;
     std::vector<config::seed_server> _seed_servers;

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -15,6 +15,7 @@ redpanda:
   developer_mode: true
   data_directory: "{{data_dir}}"
   node_id: {{node_id}}
+  join_retry_timeout_ms: 200
   rpc_server:
     address: "{{node.account.hostname}}"
     port: 33145

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -15,7 +15,6 @@ quick:
   - tests/librdkafka_test.py
   - tests/rpk_test.py
   - tests/demo_test.py
-  - tests/configuration_update_test.py
   - tests/compacted_term_rolled_recovery_test.py
   - tests/compacted_topic_verifier_test.py
   - tests/compaction_recovery_test.py


### PR DESCRIPTION
## Cover letter

Configuration update retries weren't correctly handled in redpanda. This lead to the situation in which configuration updates weren't propagated. Added retries to configuration updates logic.

Fixes: N/A

## Release notes
 - fix: fixed propagating configuration updates i.e. addresses, ports etc.
