### PR TITLE
Integration of the transaction processing with the consumer groups

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -51,6 +51,7 @@ v_cc_library(
     persisted_stm.cc
     tm_stm.cc
     rm_stm.cc
+    tx_utils.cc
     security_manager.cc
     security_frontend.cc
   DEPS

--- a/src/v/cluster/id_allocator_frontend.h
+++ b/src/v/cluster/id_allocator_frontend.h
@@ -56,6 +56,8 @@ private:
     ss::sharded<rpc::connection_cache>& _connection_cache;
     ss::sharded<partition_leaders_table>& _leaders;
     std::unique_ptr<cluster::controller>& _controller;
+    int16_t _metadata_dissemination_retries{1};
+    std::chrono::milliseconds _metadata_dissemination_retry_delay_ms;
 
     ss::future<allocate_id_reply> dispatch_allocate_id_to_leader(
       model::node_id, model::timeout_clock::duration);

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -49,6 +49,13 @@ ss::future<result<raft::replicate_result>> partition::replicate(
     return _raft->replicate(std::move(r), std::move(opts));
 }
 
+ss::future<result<raft::replicate_result>> partition::replicate(
+  model::term_id term,
+  model::record_batch_reader&& r,
+  raft::replicate_options opts) {
+    return _raft->replicate(term, std::move(r), std::move(opts));
+}
+
 ss::future<checked<raft::replicate_result, kafka::error_code>>
 partition::replicate(
   model::batch_identity bid,

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -41,6 +41,9 @@ public:
     ss::future<result<raft::replicate_result>>
     replicate(model::record_batch_reader&&, raft::replicate_options);
 
+    ss::future<result<raft::replicate_result>> replicate(
+      model::term_id, model::record_batch_reader&&, raft::replicate_options);
+
     ss::future<checked<raft::replicate_result, kafka::error_code>> replicate(
       model::batch_identity,
       model::record_batch_reader&&,

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -99,6 +99,8 @@ public:
         return raft::details::next_offset(_raft->last_visible_index());
     }
 
+    model::term_id term() { return _raft->term(); }
+
     model::offset dirty_offset() const {
         return _raft->log().offsets().dirty_offset;
     }

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/persisted_stm.h"
+#include "cluster/tx_utils.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
@@ -45,9 +46,6 @@ namespace cluster {
 class rm_stm final : public persisted_stm {
 public:
     static constexpr const int8_t tx_snapshot_version = 0;
-    using producer_id = named_type<int64_t, struct producer_identity_id>;
-    using producer_epoch = named_type<int16_t, struct producer_identity_epoch>;
-
     struct tx_range {
         model::producer_identity pid;
         model::offset first;
@@ -148,7 +146,8 @@ private:
     struct log_state {
         // we enforce monotonicity of epochs related to the same producer_id
         // and fence off out of order requests
-        absl::flat_hash_map<producer_id, producer_epoch> fence_pid_epoch;
+        absl::flat_hash_map<model::producer_id, model::producer_epoch>
+          fence_pid_epoch;
         // a map from session id (aka producer_identity) to its current tx
         absl::flat_hash_map<model::producer_identity, tx_range> ongoing_map;
         // a heap of the first offsets of the ongoing transactions

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -65,6 +65,11 @@ struct tm_transaction {
         model::term_id etag;
     };
 
+    struct tx_group {
+        kafka::group_id group_id;
+        model::term_id etag;
+    };
+
     // id of an application executing a transaction. in the early
     // drafts of Kafka protocol transactional_id used to be named
     // application_id
@@ -79,6 +84,7 @@ struct tm_transaction {
     model::tx_seq tx_seq;
     tx_status status;
     std::vector<tx_partition> partitions;
+    std::vector<tx_group> groups;
     // version of tm_tx, used to perform conditional updates
     tm_etag etag;
 
@@ -124,6 +130,8 @@ public:
       kafka::transactional_id,
       tm_etag,
       std::vector<tm_transaction::tx_partition>);
+    bool add_group(
+      kafka::transactional_id, tm_etag, kafka::group_id, model::term_id);
 
     // redpanda acks a transaction after a decision to commit / abort
     // is persisted but before tx is executed; without a coordination

--- a/src/v/cluster/tx_utils.cc
+++ b/src/v/cluster/tx_utils.cc
@@ -1,0 +1,30 @@
+#include "cluster/logger.h"
+#include "cluster/types.h"
+#include "kafka/protocol/request_reader.h"
+#include "kafka/protocol/response_writer.h"
+#include "model/record.h"
+#include "raft/consensus_utils.h"
+#include "raft/errc.h"
+#include "raft/types.h"
+#include "storage/parser_utils.h"
+#include "storage/record_batch_builder.h"
+
+namespace cluster {
+
+model::record_batch make_fence_batch(
+  model::control_record_version version, model::producer_identity pid) {
+    iobuf key;
+    kafka::response_writer w(key);
+    w.write(version);
+
+    storage::record_batch_builder builder(
+      tx_fence_batch_type, model::offset(0));
+    builder.set_producer_identity(pid.id, pid.epoch);
+    builder.set_control_type();
+    builder.add_raw_kw(
+      std::move(key), std::nullopt, std::vector<model::record_header>());
+
+    return std::move(builder).build();
+}
+
+} // namespace cluster

--- a/src/v/cluster/tx_utils.h
+++ b/src/v/cluster/tx_utils.h
@@ -1,0 +1,20 @@
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "kafka/protocol/errors.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "raft/consensus.h"
+#include "raft/errc.h"
+#include "raft/logger.h"
+#include "raft/state_machine.h"
+#include "raft/types.h"
+#include "storage/snapshot.h"
+#include "utils/expiring_promise.h"
+#include "utils/mutex.h"
+
+namespace cluster {
+
+model::record_batch
+  make_fence_batch(model::control_record_version, model::producer_identity);
+
+}

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -33,6 +33,8 @@ static constexpr model::record_batch_type id_allocator_stm_batch_type{8};
 static constexpr model::record_batch_type tx_prepare_batch_type{9};
 static constexpr model::record_batch_type tx_fence_batch_type{10};
 static constexpr model::record_batch_type tm_update_batch_type{11};
+static constexpr model::record_batch_type group_prepare_tx_batch_type{14};
+
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
 using broker_ptr = ss::lw_shared_ptr<model::broker>;
 
@@ -109,6 +111,17 @@ struct begin_group_tx_request {
 };
 struct begin_group_tx_reply {
     model::term_id etag;
+    tx_errc ec;
+};
+struct prepare_group_tx_request {
+    model::ntp ntp;
+    kafka::group_id group_id;
+    model::term_id etag;
+    model::producer_identity pid;
+    model::tx_seq tx_seq;
+    model::timeout_clock::duration timeout;
+};
+struct prepare_group_tx_reply {
     tx_errc ec;
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -56,6 +56,7 @@ enum class tx_errc {
     conflict,
     fenced,
     stale,
+    not_coordinator
 };
 struct tx_errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::tx_errc"; }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -34,6 +34,7 @@ static constexpr model::record_batch_type tx_prepare_batch_type{9};
 static constexpr model::record_batch_type tx_fence_batch_type{10};
 static constexpr model::record_batch_type tm_update_batch_type{11};
 static constexpr model::record_batch_type group_prepare_tx_batch_type{14};
+static constexpr model::record_batch_type group_commit_tx_batch_type{15};
 
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
 using broker_ptr = ss::lw_shared_ptr<model::broker>;
@@ -122,6 +123,16 @@ struct prepare_group_tx_request {
     model::timeout_clock::duration timeout;
 };
 struct prepare_group_tx_reply {
+    tx_errc ec;
+};
+struct commit_group_tx_request {
+    model::ntp ntp;
+    model::producer_identity pid;
+    model::tx_seq tx_seq;
+    kafka::group_id group_id;
+    model::timeout_clock::duration timeout;
+};
+struct commit_group_tx_reply {
     tx_errc ec;
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -35,6 +35,7 @@ static constexpr model::record_batch_type tx_fence_batch_type{10};
 static constexpr model::record_batch_type tm_update_batch_type{11};
 static constexpr model::record_batch_type group_prepare_tx_batch_type{14};
 static constexpr model::record_batch_type group_commit_tx_batch_type{15};
+static constexpr model::record_batch_type group_abort_tx_batch_type{16};
 
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
 using broker_ptr = ss::lw_shared_ptr<model::broker>;
@@ -133,6 +134,16 @@ struct commit_group_tx_request {
     model::timeout_clock::duration timeout;
 };
 struct commit_group_tx_reply {
+    tx_errc ec;
+};
+struct abort_group_tx_request {
+    model::ntp ntp;
+    kafka::group_id group_id;
+    model::producer_identity pid;
+    model::tx_seq tx_seq;
+    model::timeout_clock::duration timeout;
+};
+struct abort_group_tx_reply {
     tx_errc ec;
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -56,7 +56,11 @@ enum class tx_errc {
     conflict,
     fenced,
     stale,
-    not_coordinator
+    not_coordinator,
+    coordinator_not_available,
+    preparing_rebalance,
+    rebalance_in_progress,
+    coordinator_load_in_progress
 };
 struct tx_errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::tx_errc"; }
@@ -95,6 +99,18 @@ inline const std::error_category& tx_error_category() noexcept {
 inline std::error_code make_error_code(tx_errc e) noexcept {
     return std::error_code(static_cast<int>(e), tx_error_category());
 }
+
+struct begin_group_tx_request {
+    model::ntp ntp;
+    kafka::group_id group_id;
+    model::producer_identity pid;
+    model::tx_seq tx_seq;
+    model::timeout_clock::duration timeout;
+};
+struct begin_group_tx_reply {
+    model::term_id etag;
+    tx_errc ec;
+};
 
 /// Join request sent by node to join raft-0
 struct join_request {

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -40,6 +40,7 @@ v_cc_library(
     ${handlers_srcs}
     server/requests.cc
     server/member.cc
+    server/group_stm.cc
     server/group.cc
     server/group_router.cc
     server/group_manager.cc

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(protocol)
 set(handlers_srcs
   server/handlers/api_versions.cc
   server/handlers/metadata.cc
+  server/handlers/txn_offset_commit.cc
   server/handlers/list_groups.cc
   server/handlers/find_coordinator.cc
   server/handlers/describe_configs.cc

--- a/src/v/kafka/protocol/fwd.h
+++ b/src/v/kafka/protocol/fwd.h
@@ -46,6 +46,8 @@ struct metadata_request;
 struct metadata_response;
 struct offset_commit_request;
 struct offset_commit_response;
+struct txn_offset_commit_request;
+struct txn_offset_commit_response;
 struct offset_fetch_request;
 struct offset_fetch_response;
 struct produce_request;

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -52,7 +52,9 @@ set(schemata
   produce_request.json
   produce_response.json
   metadata_request.json
-  metadata_response.json)
+  metadata_response.json
+  txn_offset_commit_request.json
+  txn_offset_commit_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -80,6 +80,14 @@ path_type_map = {
         },
         "MemberId": ("kafka::member_id", "string"),
     },
+    "TxnOffsetCommitRequestData": {
+        "Topics": {
+            "Partitions": {
+                "PartitionIndex": ("model::partition_id", "int32"),
+                "CommittedOffset": ("model::offset", "int64"),
+            },
+        }
+    },
     "JoinGroupRequestData": {
         "MemberId": ("kafka::member_id", "string"),
         "GroupInstanceId": ("kafka::group_instance_id", "string"),
@@ -311,6 +319,10 @@ STRUCT_TYPES = [
     "MetadataRequestTopic",
     "MetadataResponseTopic",
     "MetadataResponsePartition",
+    "TxnOffsetCommitRequestTopic",
+    "TxnOffsetCommitResponseTopic",
+    "TxnOffsetCommitResponsePartition",
+    "TxnOffsetCommitRequestPartition",
 ]
 
 SCALAR_TYPES = list(basic_type_map.keys())

--- a/src/v/kafka/protocol/schemata/txn_offset_commit_request.json
+++ b/src/v/kafka/protocol/schemata/txn_offset_commit_request.json
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 28,
+  "type": "request",
+  "name": "TxnOffsetCommitRequest",
+  // Version 1 is the same as version 0.
+  //
+  // Version 2 adds the committed leader epoch.
+  "validVersions": "0-2",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "TransactionalId", "type": "string", "versions": "0+",
+      "about": "The ID of the transaction." },
+    { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
+      "about": "The ID of the group." },
+    { "name": "ProducerId", "type": "int64", "versions": "0+", "entityType": "producerId",
+      "about": "The current producer ID in use by the transactional ID." },
+    { "name": "ProducerEpoch", "type": "int16", "versions": "0+",
+      "about": "The current epoch associated with the producer ID." },
+    { "name": "Topics", "type" : "[]TxnOffsetCommitRequestTopic", "versions": "0+",
+      "about": "Each topic that we want to committ offsets for.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]TxnOffsetCommitRequestPartition", "versions": "0+",
+        "about": "The partitions inside the topic that we want to committ offsets for.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The index of the partition within the topic." },
+        { "name": "CommittedOffset", "type": "int64", "versions": "0+",
+          "about": "The message offset to be committed." },
+        { "name": "CommittedLeaderEpoch", "type": "int32", "versions": "2+", "default": "-1", "ignorable": true,
+          "about": "The leader epoch of the last consumed record." },
+        { "name": "CommittedMetadata", "type": "string", "versions": "0+", "nullableVersions": "0+",
+          "about": "Any associated metadata the client wants to keep." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/txn_offset_commit_response.json
+++ b/src/v/kafka/protocol/schemata/txn_offset_commit_response.json
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 28,
+  "type": "response",
+  "name": "TxnOffsetCommitResponse",
+  // Starting in version 1, on quota violation, brokers send out responses before throttling.
+  // Version 2 is the same as version 1.
+  "validVersions": "0-2",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "Topics", "type": "[]TxnOffsetCommitResponseTopic", "versions": "0+",
+      "about": "The responses for each topic.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]TxnOffsetCommitResponsePartition", "versions": "0+",
+        "about": "The responses for each partition in the topic.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partitition index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The error code, or 0 if there was no error." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/txn_offset_commit.h
+++ b/src/v/kafka/protocol/txn_offset_commit.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/txn_offset_commit_request.h"
+#include "kafka/protocol/schemata/txn_offset_commit_response.h"
+#include "kafka/server/request_context.h"
+#include "kafka/server/response.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/timestamp.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+namespace kafka {
+
+struct txn_offset_commit_response;
+
+struct txn_offset_commit_api final {
+    using response_type = txn_offset_commit_response;
+
+    static constexpr const char* name = "txn offset commit";
+    static constexpr api_key key = api_key(28);
+};
+
+struct txn_offset_commit_request final {
+    using api_type = txn_offset_commit_api;
+
+    txn_offset_commit_request_data data;
+
+    // set during request processing after mapping group to ntp
+    model::ntp ntp;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const txn_offset_commit_request& r) {
+    return os << r.data;
+}
+
+struct txn_offset_commit_response final {
+    using api_type = txn_offset_commit_api;
+
+    txn_offset_commit_response_data data;
+
+    txn_offset_commit_response() = default;
+
+    txn_offset_commit_response(
+      const txn_offset_commit_request& request, error_code error) {
+        for (const auto& t : request.data.topics) {
+            txn_offset_commit_response_topic tmp{.name = t.name};
+            for (const auto& p : t.partitions) {
+                tmp.partitions.push_back({
+                  .partition_index = p.partition_index,
+                  .error_code = error,
+                });
+            }
+            data.topics.push_back(std::move(tmp));
+        }
+    }
+
+    void encode(const request_context& ctx, response& resp) {
+        data.encode(resp.writer(), ctx.header().version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const txn_offset_commit_response& r) {
+    return os << r.data;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -12,6 +12,7 @@
 #include "bytes/bytes.h"
 #include "cluster/partition.h"
 #include "cluster/simple_batch_builder.h"
+#include "cluster/tx_utils.h"
 #include "config/configuration.h"
 #include "kafka/protocol/schemata/describe_groups_response.h"
 #include "kafka/protocol/sync_group.h"
@@ -1178,6 +1179,33 @@ void group::fail_offset_commit(
 
 void group::reset_tx_state(model::term_id term) { _term = term; }
 
+cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx_errc ec) {
+    cluster::begin_group_tx_reply reply;
+    reply.ec = ec;
+    return reply;
+}
+
+ss::future<cluster::begin_group_tx_reply>
+group::begin_tx(cluster::begin_group_tx_request r) {
+    if (_partition->term() != _term) {
+        co_return make_begin_tx_reply(cluster::tx_errc::timeout);
+    }
+
+    // TODO: https://app.clubhouse.io/vectorized/story/2194
+    // (auto-abort txes with the the same producer_id but older epoch)
+
+    auto [_, inserted] = _volatile_txs.try_emplace(r.pid, volatile_tx());
+
+    if (!inserted) {
+        co_return make_begin_tx_reply(cluster::tx_errc::timeout);
+    }
+
+    cluster::begin_group_tx_reply reply;
+    reply.etag = _term;
+    reply.ec = cluster::tx_errc::none;
+    co_return reply;
+}
+
 ss::future<txn_offset_commit_response>
 group::store_txn_offsets(txn_offset_commit_request r) {
     if (_partition->term() != _term) {
@@ -1293,6 +1321,28 @@ group::handle_txn_offset_commit(txn_offset_commit_request r) {
         vlog(klog.error, "Unexpected group state {} for {}", _state, *this);
         co_return txn_offset_commit_response(
           r, error_code::unknown_server_error);
+    }
+}
+
+ss::future<cluster::begin_group_tx_reply>
+group::handle_begin_tx(cluster::begin_group_tx_request r) {
+    if (in_state(group_state::dead)) {
+        cluster::begin_group_tx_reply reply;
+        reply.ec = cluster::tx_errc::coordinator_not_available;
+        co_return reply;
+    } else if (
+      in_state(group_state::empty) || in_state(group_state::stable)
+      || in_state(group_state::preparing_rebalance)) {
+        co_return co_await begin_tx(std::move(r));
+    } else if (in_state(group_state::completing_rebalance)) {
+        cluster::begin_group_tx_reply reply;
+        reply.ec = cluster::tx_errc::rebalance_in_progress;
+        co_return reply;
+    } else {
+        vlog(klog.error, "Unexpected group state {} for {}", _state, *this);
+        cluster::begin_group_tx_reply reply;
+        reply.ec = cluster::tx_errc::timeout;
+        co_return reply;
     }
 }
 

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1264,6 +1264,12 @@ cluster::commit_group_tx_reply make_commit_tx_reply(cluster::tx_errc ec) {
     return reply;
 }
 
+cluster::abort_group_tx_reply make_abort_tx_reply(cluster::tx_errc ec) {
+    cluster::abort_group_tx_reply reply;
+    reply.ec = ec;
+    return reply;
+}
+
 ss::future<cluster::begin_group_tx_reply>
 group::begin_tx(cluster::begin_group_tx_request r) {
     if (_partition->term() != _term) {
@@ -1350,6 +1356,45 @@ group::prepare_tx(cluster::prepare_group_tx_request r) {
     }
     _prepared_txs.try_emplace(r.pid, ptx);
     co_return cluster::prepare_group_tx_reply();
+}
+
+ss::future<cluster::abort_group_tx_reply>
+group::abort_tx(cluster::abort_group_tx_request r) {
+    // TODO: https://app.clubhouse.io/vectorized/story/2197
+    // (check for tx_seq to prevent old abort requests aborting
+    // new transactions in the same session)
+
+    auto tx = aborted_tx{.group_id = r.group_id, .tx_seq = r.tx_seq};
+
+    iobuf key;
+    kafka::response_writer w(key);
+    // TODO: https://app.clubhouse.io/vectorized/story/2200
+    // include producer_id+type into key to make it unique-ish
+    // to prevent being GCed by the compaction
+    w.write(aborted_tx_record_version());
+    storage::record_batch_builder builder(
+      cluster::group_abort_tx_batch_type, model::offset(0));
+    builder.set_producer_identity(r.pid.id, r.pid.epoch);
+    builder.set_control_type();
+    builder.add_raw_kw(
+      std::move(key),
+      reflection::to_iobuf(std::move(tx)),
+      std::vector<model::record_header>());
+    auto batch = std::move(builder).build();
+    auto reader = model::make_memory_record_batch_reader(std::move(batch));
+
+    auto e = co_await _partition->replicate(
+      std::move(reader),
+      raft::replicate_options(raft::consistency_level::quorum_ack));
+
+    if (!e) {
+        co_return make_abort_tx_reply(cluster::tx_errc::timeout);
+    }
+
+    _volatile_txs.erase(r.pid);
+    _prepared_txs.erase(r.pid);
+
+    co_return cluster::abort_group_tx_reply();
 }
 
 ss::future<txn_offset_commit_response>
@@ -1526,6 +1571,28 @@ group::handle_prepare_tx(cluster::prepare_group_tx_request r) {
     } else {
         vlog(klog.error, "Unexpected group state {} for {}", _state, *this);
         cluster::prepare_group_tx_reply reply;
+        reply.ec = cluster::tx_errc::timeout;
+        co_return reply;
+    }
+}
+
+ss::future<cluster::abort_group_tx_reply>
+group::handle_abort_tx(cluster::abort_group_tx_request r) {
+    if (in_state(group_state::dead)) {
+        cluster::abort_group_tx_reply reply;
+        reply.ec = cluster::tx_errc::coordinator_not_available;
+        co_return reply;
+    } else if (
+      in_state(group_state::stable) || in_state(group_state::empty)
+      || in_state(group_state::preparing_rebalance)) {
+        co_return co_await abort_tx(std::move(r));
+    } else if (in_state(group_state::completing_rebalance)) {
+        cluster::abort_group_tx_reply reply;
+        reply.ec = cluster::tx_errc::rebalance_in_progress;
+        co_return reply;
+    } else {
+        vlog(klog.error, "Unexpected group state {} for {}", _state, *this);
+        cluster::abort_group_tx_reply reply;
         reply.ec = cluster::tx_errc::timeout;
         co_return reply;
     }

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1176,6 +1176,8 @@ void group::fail_offset_commit(
     }
 }
 
+void group::reset_tx_state(model::term_id term) { _term = term; }
+
 ss::future<offset_commit_response>
 group::store_offsets(offset_commit_request&& r) {
     cluster::simple_batch_builder builder(

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -406,6 +406,15 @@ public:
         _offsets[std::move(tp)] = std::move(md);
     }
 
+    bool try_upsert_offset(model::topic_partition tp, offset_metadata md) {
+        auto [o_it, inserted] = _offsets.try_emplace(tp, std::move(md));
+        if (!inserted && o_it->second.log_offset < md.log_offset) {
+            o_it->second = std::move(md);
+            inserted = true;
+        }
+        return inserted;
+    }
+
     // helper for the kafka api: describe groups
     described_group describe() const;
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -96,6 +96,7 @@ std::ostream& operator<<(std::ostream&, group_state gs);
 ss::sstring group_state_to_kafka_name(group_state);
 cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx_errc);
 cluster::prepare_group_tx_reply make_prepare_tx_reply(cluster::tx_errc);
+cluster::commit_group_tx_reply make_commit_tx_reply(cluster::tx_errc);
 
 /// \brief A Kafka group.
 ///
@@ -109,6 +110,7 @@ public:
       0};
     static constexpr model::control_record_version prepared_tx_record_version{
       0};
+    static constexpr model::control_record_version commit_tx_record_version{0};
 
     struct offset_metadata {
         model::offset log_offset;
@@ -411,6 +413,9 @@ public:
 
     void reset_tx_state(model::term_id);
 
+    ss::future<cluster::commit_group_tx_reply>
+    commit_tx(cluster::commit_group_tx_request r);
+
     ss::future<cluster::begin_group_tx_reply>
       begin_tx(cluster::begin_group_tx_request);
 
@@ -433,6 +438,9 @@ public:
 
     ss::future<offset_commit_response>
     handle_offset_commit(offset_commit_request&& r);
+
+    ss::future<cluster::commit_group_tx_reply>
+    handle_commit_tx(cluster::commit_group_tx_request r);
 
     ss::future<offset_fetch_response>
     handle_offset_fetch(offset_fetch_request&& r);

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -394,6 +394,8 @@ public:
     void fail_offset_commit(
       const model::topic_partition& tp, const offset_metadata& md);
 
+    void reset_tx_state(model::term_id);
+
     ss::future<offset_commit_response> store_offsets(offset_commit_request&& r);
 
     ss::future<offset_commit_response>
@@ -426,6 +428,10 @@ public:
     ss::future<>
     remove_topic_partitions(const std::vector<model::topic_partition>& tps);
 
+    const ss::lw_shared_ptr<cluster::partition> partition() const {
+        return _partition;
+    }
+
 private:
     using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
     using protocol_support = absl::node_hash_map<kafka::protocol_name, int>;
@@ -450,6 +456,8 @@ private:
     config::configuration& _conf;
     ss::lw_shared_ptr<cluster::partition> _partition;
     absl::node_hash_map<model::topic_partition, offset_metadata> _offsets;
+
+    model::term_id _term;
     absl::node_hash_map<model::topic_partition, offset_metadata>
       _pending_offset_commits;
 };

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -95,6 +95,7 @@ std::ostream& operator<<(std::ostream&, group_state gs);
 
 ss::sstring group_state_to_kafka_name(group_state);
 cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx_errc);
+cluster::prepare_group_tx_reply make_prepare_tx_reply(cluster::tx_errc);
 
 /// \brief A Kafka group.
 ///
@@ -106,6 +107,8 @@ public:
 
     static constexpr model::control_record_version fence_control_record_version{
       0};
+    static constexpr model::control_record_version prepared_tx_record_version{
+      0};
 
     struct offset_metadata {
         model::offset log_offset;
@@ -113,6 +116,12 @@ public:
         ss::sstring metadata;
         // BUG: support leader_epoch (KIP-320)
         // https://github.com/vectorizedio/redpanda/issues/1181
+    };
+
+    struct group_prepared_tx {
+        model::producer_identity pid;
+        kafka::group_id group_id;
+        absl::node_hash_map<model::topic_partition, offset_metadata> offsets;
     };
 
     group(
@@ -405,6 +414,9 @@ public:
     ss::future<cluster::begin_group_tx_reply>
       begin_tx(cluster::begin_group_tx_request);
 
+    ss::future<cluster::prepare_group_tx_reply>
+      prepare_tx(cluster::prepare_group_tx_request);
+
     ss::future<txn_offset_commit_response>
     store_txn_offsets(txn_offset_commit_request r);
 
@@ -415,6 +427,9 @@ public:
 
     ss::future<cluster::begin_group_tx_reply>
     handle_begin_tx(cluster::begin_group_tx_request r);
+
+    ss::future<cluster::prepare_group_tx_reply>
+    handle_prepare_tx(cluster::prepare_group_tx_request r);
 
     ss::future<offset_commit_response>
     handle_offset_commit(offset_commit_request&& r);
@@ -434,6 +449,8 @@ public:
         }
         return inserted;
     }
+
+    void insert_prepared(group_prepared_tx);
 
     // helper for the kafka api: describe groups
     described_group describe() const;
@@ -489,7 +506,12 @@ private:
         absl::node_hash_map<model::topic_partition, volatile_offset> offsets;
     };
 
+    struct prepared_tx {
+        absl::node_hash_map<model::topic_partition, offset_metadata> offsets;
+    };
+
     absl::node_hash_map<model::producer_identity, volatile_tx> _volatile_txs;
+    absl::node_hash_map<model::producer_identity, prepared_tx> _prepared_txs;
 };
 
 using group_ptr = ss::lw_shared_ptr<group>;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -94,6 +94,7 @@ enum class group_state {
 std::ostream& operator<<(std::ostream&, group_state gs);
 
 ss::sstring group_state_to_kafka_name(group_state);
+cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx_errc);
 
 /// \brief A Kafka group.
 ///
@@ -102,6 +103,9 @@ class group {
 public:
     using clock_type = ss::lowres_clock;
     using duration_type = clock_type::duration;
+
+    static constexpr model::control_record_version fence_control_record_version{
+      0};
 
     struct offset_metadata {
         model::offset log_offset;
@@ -398,6 +402,9 @@ public:
 
     void reset_tx_state(model::term_id);
 
+    ss::future<cluster::begin_group_tx_reply>
+      begin_tx(cluster::begin_group_tx_request);
+
     ss::future<txn_offset_commit_response>
     store_txn_offsets(txn_offset_commit_request r);
 
@@ -405,6 +412,9 @@ public:
 
     ss::future<txn_offset_commit_response>
     handle_txn_offset_commit(txn_offset_commit_request r);
+
+    ss::future<cluster::begin_group_tx_reply>
+    handle_begin_tx(cluster::begin_group_tx_request r);
 
     ss::future<offset_commit_response>
     handle_offset_commit(offset_commit_request&& r);

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -246,7 +246,7 @@ ss::future<> group_manager::handle_partition_leader_change(
                   0,
                   std::numeric_limits<size_t>::max(),
                   kafka_read_priority(),
-                  raft::data_batch_type,
+                  std::nullopt,
                   std::nullopt,
                   std::nullopt);
 
@@ -255,17 +255,16 @@ ss::future<> group_manager::handle_partition_leader_change(
                           model::record_batch_reader reader) {
                       return std::move(reader)
                         .consume(recovery_batch_consumer(p->as), timeout)
-                        .then(
-                          [this, term, p](recovery_batch_consumer_state state) {
-                              // avoid trying to recover if we stopped the
-                              // reader because an abort was requested
-                              if (p->as.abort_requested()) {
-                                  return ss::make_ready_future<>();
-                              }
-                              return recover_partition(
-                                       term, p->partition, std::move(state))
-                                .then([p] { p->loading = false; });
-                          });
+                        .then([this, term, p](
+                                recovery_batch_consumer_state state) {
+                            // avoid trying to recover if we stopped the
+                            // reader because an abort was requested
+                            if (p->as.abort_requested()) {
+                                return ss::make_ready_future<>();
+                            }
+                            return recover_partition(term, p, std::move(state))
+                              .then([p] { p->loading = false; });
+                        });
                   });
             })
             .finally([unit = std::move(unit)] {});
@@ -279,20 +278,22 @@ ss::future<> group_manager::handle_partition_leader_change(
  */
 ss::future<> group_manager::recover_partition(
   model::term_id term,
-  ss::lw_shared_ptr<cluster::partition> p,
+  ss::lw_shared_ptr<attached_partition> p,
   recovery_batch_consumer_state ctx) {
     for (auto& [_, group] : _groups) {
-        if (group->partition()->ntp() == p->ntp()) {
+        if (group->partition()->ntp() == p->partition->ntp()) {
             group->reset_tx_state(term);
         }
     }
+    p->term = term;
+    p->fence_pid_epoch = std::move(ctx.fence_pid_epoch);
 
     for (auto& [group_id, group_stm] : ctx.groups) {
         if (group_stm.has_data()) {
             auto group = get_group(group_id);
             if (!group) {
                 group = ss::make_lw_shared<kafka::group>(
-                  group_id, group_state::empty, _conf, p);
+                  group_id, group_state::empty, _conf, p->partition);
                 _groups.emplace(group_id, group);
                 group->reschedule_all_member_heartbeats();
             }
@@ -333,24 +334,36 @@ ss::future<> group_manager::recover_partition(
 
 ss::future<ss::stop_iteration>
 recovery_batch_consumer::operator()(model::record_batch batch) {
-    if (unlikely(batch.header().type != raft::data_batch_type)) {
-        klog.trace("ignorning batch with type {}", int(batch.header().type));
-        return ss::make_ready_future<ss::stop_iteration>(
-          ss::stop_iteration::no);
-    }
     if (as.abort_requested()) {
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::yes);
     }
-    batch_base_offset = batch.base_offset();
-    return ss::do_with(
-             std::move(batch),
-             [this](model::record_batch& batch) {
-                 return model::for_each_record(batch, [this](model::record& r) {
-                     return handle_record(std::move(r));
-                 });
-             })
-      .then([] { return ss::stop_iteration::no; });
+
+    if (batch.header().type == raft::data_batch_type) {
+        batch_base_offset = batch.base_offset();
+        return ss::do_with(
+                 std::move(batch),
+                 [this](model::record_batch& batch) {
+                     return model::for_each_record(
+                       batch, [this](model::record& r) {
+                           return handle_record(std::move(r));
+                       });
+                 })
+          .then([] { return ss::stop_iteration::no; });
+    } else if (batch.header().type == cluster::tx_fence_batch_type) {
+        auto bid = model::batch_identity::from(batch.header());
+        auto [fence_it, _] = st.fence_pid_epoch.try_emplace(
+          bid.pid.get_id(), bid.pid.get_epoch());
+        if (bid.pid.get_epoch() >= fence_it->second) {
+            fence_it->second = bid.pid.get_epoch();
+        }
+        return ss::make_ready_future<ss::stop_iteration>(
+          ss::stop_iteration::no);
+    } else {
+        klog.trace("ignorning batch with type {}", int(batch.header().type));
+        return ss::make_ready_future<ss::stop_iteration>(
+          ss::stop_iteration::no);
+    }
 }
 
 ss::future<> recovery_batch_consumer::handle_record(model::record r) {
@@ -367,6 +380,8 @@ ss::future<> recovery_batch_consumer::handle_record(model::record r) {
     case group_log_record_key::type::noop:
         // skip control structure
         return ss::make_ready_future<>();
+
+        // todo: process tx commit offset by caching in group
 
     default:
         return ss::make_exception_future<>(std::runtime_error(fmt::format(
@@ -605,6 +620,95 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
           return group->handle_txn_offset_commit(std::move(r))
             .finally([unit = std::move(unit)] {});
       });
+}
+
+ss::future<cluster::begin_group_tx_reply>
+group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
+    auto p = get_attached_partition(r.ntp);
+    if (!p || !p->catchup_lock.try_read_lock()) {
+        // transaction operations can't run in parallel with loading
+        // state from the log (happens once per term change)
+        vlog(klog.trace, "can't process a tx: coordinator_load_in_progress");
+        return ss::make_ready_future<cluster::begin_group_tx_reply>(
+          make_begin_tx_reply(cluster::tx_errc::coordinator_load_in_progress));
+    }
+
+    return do_begin_tx(p, std::move(r)).finally([p] {
+        p->catchup_lock.read_unlock();
+    });
+}
+
+ss::future<cluster::begin_group_tx_reply> group_manager::do_begin_tx(
+  ss::lw_shared_ptr<attached_partition> partition,
+  cluster::begin_group_tx_request&& r) {
+    auto error = validate_group_status(
+      r.ntp, r.group_id, offset_commit_api::key);
+    if (error != error_code::none) {
+        if (error == error_code::not_coordinator) {
+            co_return make_begin_tx_reply(cluster::tx_errc::not_coordinator);
+        } else {
+            co_return make_begin_tx_reply(cluster::tx_errc::timeout);
+        }
+    }
+
+    if (partition->partition->term() != partition->term) {
+        co_return make_begin_tx_reply(cluster::tx_errc::not_coordinator);
+    }
+
+    auto fence_it = partition->fence_pid_epoch.find(r.pid.get_id());
+    if (
+      fence_it == partition->fence_pid_epoch.end()
+      || r.pid.get_epoch() > fence_it->second) {
+        // TODO: https://app.clubhouse.io/vectorized/story/2200
+        // include producer_id into key to make it unique-ish
+        // to prevent being GCed by the compaction
+        auto batch = cluster::make_fence_batch(
+          fence_control_record_version, r.pid);
+        auto reader = model::make_memory_record_batch_reader(std::move(batch));
+        auto e = co_await partition->partition->replicate(
+          partition->term,
+          std::move(reader),
+          raft::replicate_options(raft::consistency_level::quorum_ack));
+
+        if (!e) {
+            vlog(
+              klog.error,
+              "Error \"{}\" on replicating pid:{} fencing batch",
+              e.error(),
+              r.pid);
+            co_return make_begin_tx_reply(cluster::tx_errc::timeout);
+        }
+
+        // we need to re-look up the current fencing token for
+        // current producer id because it might have been updated
+        // by a concurrent request while this fiber was waiting
+        // on partition->replicate
+        fence_it = partition->fence_pid_epoch.find(r.pid.get_id());
+    }
+
+    if (fence_it == partition->fence_pid_epoch.end()) {
+        partition->fence_pid_epoch.emplace(r.pid.get_id(), r.pid.get_epoch());
+    } else if (r.pid.get_epoch() >= fence_it->second) {
+        fence_it->second = r.pid.get_epoch();
+    } else {
+        vlog(
+          klog.error, "pid {} fenced out by epoch {}", r.pid, fence_it->second);
+        co_return make_begin_tx_reply(cluster::tx_errc::fenced);
+    }
+
+    auto group = get_group(r.group_id);
+    if (!group) {
+        // <kafka>the group is not relying on Kafka for group management, so
+        // allow the commit</kafka>
+        group = ss::make_lw_shared<kafka::group>(
+          r.group_id, group_state::empty, _conf, partition->partition);
+        group->reset_tx_state(partition->term);
+        _groups.emplace(r.group_id, group);
+        _groups.rehash(0);
+    }
+
+    auto reply = co_await group->handle_begin_tx(std::move(r));
+    co_return reply;
 }
 
 ss::future<offset_commit_response>

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -388,6 +388,34 @@ recovery_batch_consumer::operator()(model::record_batch batch) {
 
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::no);
+    } else if (batch.header().type == cluster::group_commit_tx_batch_type) {
+        vassert(
+          batch.record_count() == 1,
+          "commit batch must contain a single record");
+        auto r = batch.copy_records();
+        auto& record = *r.begin();
+        auto key_buf = record.release_key();
+        kafka::request_reader buf_reader(std::move(key_buf));
+        auto version = model::control_record_version(buf_reader.read_int16());
+
+        const auto& hdr = batch.header();
+        auto bid = model::batch_identity::from(hdr);
+
+        vassert(
+          version == group::commit_tx_record_version,
+          "unknown group inflight tx record version: {} expected: {}",
+          version,
+          group::commit_tx_record_version);
+
+        auto val_buf = record.release_value();
+        auto val = reflection::from_iobuf<group_log_commit_tx>(
+          std::move(val_buf));
+
+        auto [group_it, _] = st.groups.try_emplace(val.group_id, group_stm());
+        group_it->second.commit(bid.pid);
+
+        return ss::make_ready_future<ss::stop_iteration>(
+          ss::stop_iteration::no);
     } else if (batch.header().type == cluster::tx_fence_batch_type) {
         auto bid = model::batch_identity::from(batch.header());
         auto [fence_it, _] = st.fence_pid_epoch.try_emplace(
@@ -655,6 +683,43 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
           }
 
           return group->handle_txn_offset_commit(std::move(r))
+            .finally([unit = std::move(unit)] {});
+      });
+}
+
+ss::future<cluster::commit_group_tx_reply>
+group_manager::commit_tx(cluster::commit_group_tx_request&& r) {
+    auto p = get_attached_partition(r.ntp);
+    if (!p || !p->catchup_lock.try_read_lock()) {
+        // transaction operations can't run in parallel with loading
+        // state from the log (happens once per term change)
+        vlog(klog.trace, "can't process a tx: coordinator_load_in_progress");
+        return ss::make_ready_future<cluster::commit_group_tx_reply>(
+          make_commit_tx_reply(cluster::tx_errc::coordinator_load_in_progress));
+    }
+    p->catchup_lock.read_unlock();
+
+    return p->catchup_lock.hold_read_lock().then(
+      [this, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
+          auto error = validate_group_status(
+            r.ntp, r.group_id, offset_commit_api::key);
+          if (error != error_code::none) {
+              if (error == error_code::not_coordinator) {
+                  return ss::make_ready_future<cluster::commit_group_tx_reply>(
+                    make_commit_tx_reply(cluster::tx_errc::not_coordinator));
+              } else {
+                  return ss::make_ready_future<cluster::commit_group_tx_reply>(
+                    make_commit_tx_reply(cluster::tx_errc::timeout));
+              }
+          }
+
+          auto group = get_group(r.group_id);
+          if (!group) {
+              return ss::make_ready_future<cluster::commit_group_tx_reply>(
+                make_commit_tx_reply(cluster::tx_errc::timeout));
+          }
+
+          return group->handle_commit_tx(std::move(r))
             .finally([unit = std::move(unit)] {});
       });
 }

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -214,50 +214,58 @@ ss::future<> group_manager::handle_partition_leader_change(
      * partition.
      */
     p->loading = true;
-    if (leader_id == _self.id()) {
-        auto timeout
-          = ss::lowres_clock::now()
-            + config::shard_local_cfg().kafka_group_recovery_timeout_ms();
-        /*
-         * we just became leader. make sure the log is up-to-date. see
-         * struct group_log_record_key{} for more details.
-         */
-        return inject_noop(p->partition, timeout).then([this, timeout, p] {
-            /*
-             * the full log is read and deduplicated. the dedupe processing is
-             * based on the record keys, so this code should be ready to
-             * transparently take advantage of key-based compaction in the
-             * future.
-             */
-            storage::log_reader_config reader_config(
-              p->partition->start_offset(),
-              model::model_limits<model::offset>::max(),
-              0,
-              std::numeric_limits<size_t>::max(),
-              kafka_read_priority(),
-              raft::data_batch_type,
-              std::nullopt,
-              std::nullopt);
-
-            return p->partition->make_reader(reader_config)
-              .then([this, p, timeout](model::record_batch_reader reader) {
-                  return std::move(reader)
-                    .consume(recovery_batch_consumer(p->as), timeout)
-                    .then([this, p](recovery_batch_consumer_state state) {
-                        // avoid trying to recover if we stopped the reader
-                        // because an abort was requested
-                        if (p->as.abort_requested()) {
-                            return ss::make_ready_future<>();
-                        }
-                        return recover_partition(p->partition, std::move(state))
-                          .then([p] { p->loading = false; });
-                    });
-              });
-        });
-    } else {
+    if (leader_id != _self.id()) {
         // TODO: we are not yet handling group / partition deletion
         return ss::make_ready_future<>();
     }
+
+    auto timeout
+      = ss::lowres_clock::now()
+        + config::shard_local_cfg().kafka_group_recovery_timeout_ms();
+    /*
+     * we just became leader. make sure the log is up-to-date. see
+     * struct group_log_record_key{} for more details. _catchup_lock
+     * is rarely contended we take a writer lock only when leadership
+     * changes (infrequent event)
+     */
+    return p->catchup_lock.hold_write_lock().then(
+      [this, timeout, p](ss::basic_rwlock<>::holder unit) {
+          return inject_noop(p->partition, timeout)
+            .then([this, timeout, p] {
+                /*
+                 * the full log is read and deduplicated. the dedupe
+                 * processing is based on the record keys, so this code
+                 * should be ready to transparently take advantage of
+                 * key-based compaction in the future.
+                 */
+                storage::log_reader_config reader_config(
+                  p->partition->start_offset(),
+                  model::model_limits<model::offset>::max(),
+                  0,
+                  std::numeric_limits<size_t>::max(),
+                  kafka_read_priority(),
+                  raft::data_batch_type,
+                  std::nullopt,
+                  std::nullopt);
+
+                return p->partition->make_reader(reader_config)
+                  .then([this, p, timeout](model::record_batch_reader reader) {
+                      return std::move(reader)
+                        .consume(recovery_batch_consumer(p->as), timeout)
+                        .then([this, p](recovery_batch_consumer_state state) {
+                            // avoid trying to recover if we stopped the
+                            // reader because an abort was requested
+                            if (p->as.abort_requested()) {
+                                return ss::make_ready_future<>();
+                            }
+                            return recover_partition(
+                                     p->partition, std::move(state))
+                              .then([p] { p->loading = false; });
+                        });
+                  });
+            })
+            .finally([unit = std::move(unit)] {});
+      });
 }
 
 /*

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -147,6 +147,9 @@ public:
     ss::future<cluster::begin_group_tx_reply>
     begin_tx(cluster::begin_group_tx_request&&);
 
+    ss::future<cluster::prepare_group_tx_reply>
+    prepare_tx(cluster::prepare_group_tx_request&&);
+
     /// \brief Handle a OffsetFetch request
     ss::future<offset_fetch_response>
     offset_fetch(offset_fetch_request&& request);

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -153,6 +153,9 @@ public:
     ss::future<cluster::prepare_group_tx_reply>
     prepare_tx(cluster::prepare_group_tx_request&&);
 
+    ss::future<cluster::abort_group_tx_reply>
+    abort_tx(cluster::abort_group_tx_request&&);
+
     /// \brief Handle a OffsetFetch request
     ss::future<offset_fetch_response>
     offset_fetch(offset_fetch_request&& request);

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -187,7 +187,9 @@ private:
     cluster::notification_id_type _topic_table_notify_handle;
 
     void handle_leader_change(
-      ss::lw_shared_ptr<cluster::partition>, std::optional<model::node_id>);
+      model::term_id,
+      ss::lw_shared_ptr<cluster::partition>,
+      std::optional<model::node_id>);
 
     void handle_topic_delta(const std::vector<cluster::topic_table_delta>&);
 
@@ -195,11 +197,14 @@ private:
       const std::vector<model::topic_partition>&);
 
     ss::future<> handle_partition_leader_change(
+      model::term_id,
       ss::lw_shared_ptr<attached_partition>,
       std::optional<model::node_id> leader_id);
 
     ss::future<> recover_partition(
-      ss ::lw_shared_ptr<cluster::partition>, recovery_batch_consumer_state);
+      model::term_id,
+      ss ::lw_shared_ptr<cluster::partition>,
+      recovery_batch_consumer_state);
 
     ss::future<> inject_noop(
       ss::lw_shared_ptr<cluster::partition> p,

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -173,6 +173,7 @@ private:
         ss::semaphore sem{1};
         ss::abort_source as;
         ss::lw_shared_ptr<cluster::partition> partition;
+        ss::basic_rwlock<> catchup_lock;
 
         explicit attached_partition(ss::lw_shared_ptr<cluster::partition> p)
           : loading(true)
@@ -203,6 +204,15 @@ private:
     ss::future<> inject_noop(
       ss::lw_shared_ptr<cluster::partition> p,
       ss::lowres_clock::time_point timeout);
+
+    [[maybe_unused]] ss::lw_shared_ptr<attached_partition>
+    get_attached_partition(model::ntp ntp) {
+        auto it = _partitions.find(ntp);
+        if (it == _partitions.end()) {
+            return nullptr;
+        }
+        return it->second;
+    }
 
     ss::sharded<raft::group_manager>& _gm;
     ss::sharded<cluster::partition_manager>& _pm;

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -21,6 +21,7 @@
 #include "kafka/protocol/offset_commit.h"
 #include "kafka/protocol/offset_fetch.h"
 #include "kafka/protocol/sync_group.h"
+#include "kafka/protocol/txn_offset_commit.h"
 #include "kafka/server/group.h"
 #include "kafka/server/group_stm.h"
 #include "kafka/server/member.h"
@@ -136,6 +137,9 @@ public:
     ss::future<offset_commit_response>
     offset_commit(offset_commit_request&& request);
 
+    ss::future<txn_offset_commit_response>
+    txn_offset_commit(txn_offset_commit_request&& request);
+
     /// \brief Handle a OffsetFetch request
     ss::future<offset_fetch_response>
     offset_fetch(offset_fetch_request&& request);
@@ -210,7 +214,7 @@ private:
       ss::lw_shared_ptr<cluster::partition> p,
       ss::lowres_clock::time_point timeout);
 
-    [[maybe_unused]] ss::lw_shared_ptr<attached_partition>
+    ss::lw_shared_ptr<attached_partition>
     get_attached_partition(model::ntp ntp) {
         auto it = _partitions.find(ntp);
         if (it == _partitions.end()) {

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -144,6 +144,9 @@ public:
     ss::future<txn_offset_commit_response>
     txn_offset_commit(txn_offset_commit_request&& request);
 
+    ss::future<cluster::commit_group_tx_reply>
+    commit_tx(cluster::commit_group_tx_request&& request);
+
     ss::future<cluster::begin_group_tx_reply>
     begin_tx(cluster::begin_group_tx_request&&);
 

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -234,15 +234,7 @@ struct group_log_record_key {
  * deduplicate both group and commit metadata snapshots.
  */
 struct recovery_batch_consumer_state {
-    absl::node_hash_map<kafka::group_id, group_log_group_metadata>
-      loaded_groups;
-
-    absl::flat_hash_set<kafka::group_id> removed_groups;
-
-    absl::node_hash_map<
-      group_log_offset_key,
-      std::pair<model::offset, group_log_offset_metadata>>
-      loaded_offsets;
+    absl::node_hash_map<kafka::group_id, group_stm> groups;
 };
 
 struct recovery_batch_consumer {

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -149,6 +149,10 @@ public:
         return route_tx(std::move(request), &group_manager::prepare_tx);
     }
 
+    auto abort_tx(cluster::abort_group_tx_request&& request) {
+        return route_tx(std::move(request), &group_manager::abort_tx);
+    }
+
     auto offset_fetch(offset_fetch_request&& request) {
         return route(std::move(request), &group_manager::offset_fetch);
     }

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -137,6 +137,10 @@ public:
         return route(std::move(request), &group_manager::txn_offset_commit);
     }
 
+    auto commit_tx(cluster::commit_group_tx_request&& request) {
+        return route_tx(std::move(request), &group_manager::commit_tx);
+    }
+
     auto begin_tx(cluster::begin_group_tx_request&& request) {
         return route_tx(std::move(request), &group_manager::begin_tx);
     }

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -133,6 +133,10 @@ public:
         return route(std::move(request), &group_manager::offset_commit);
     }
 
+    auto txn_offset_commit(txn_offset_commit_request&& request) {
+        return route(std::move(request), &group_manager::txn_offset_commit);
+    }
+
     auto offset_fetch(offset_fetch_request&& request) {
         return route(std::move(request), &group_manager::offset_fetch);
     }

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -141,6 +141,10 @@ public:
         return route_tx(std::move(request), &group_manager::begin_tx);
     }
 
+    auto prepare_tx(cluster::prepare_group_tx_request&& request) {
+        return route_tx(std::move(request), &group_manager::prepare_tx);
+    }
+
     auto offset_fetch(offset_fetch_request&& request) {
         return route(std::move(request), &group_manager::offset_fetch);
     }

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -137,6 +137,10 @@ public:
         return route(std::move(request), &group_manager::txn_offset_commit);
     }
 
+    auto begin_tx(cluster::begin_group_tx_request&& request) {
+        return route_tx(std::move(request), &group_manager::begin_tx);
+    }
+
     auto offset_fetch(offset_fetch_request&& request) {
         return route(std::move(request), &group_manager::offset_fetch);
     }

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -19,6 +19,40 @@ void group_stm::update_offset(
       .log_offset = offset, .metadata = std::move(meta)};
 }
 
+void group_stm::update_prepared(
+  model::offset offset, group_log_prepared_tx val) {
+    auto tx = group::group_prepared_tx{
+      .pid = val.pid, .group_id = val.group_id};
+
+    auto [prepared_it, inserted] = _prepared_txs.try_emplace(
+      tx.pid.get_id(), tx);
+    if (!inserted && prepared_it->second.pid.epoch > tx.pid.epoch) {
+        klog.warn(
+          "a logged tx {} is fenced off by prev logged tx {}",
+          val.pid,
+          prepared_it->second.pid);
+        return;
+    } else if (!inserted && prepared_it->second.pid.epoch < tx.pid.epoch) {
+        klog.warn(
+          "a logged tx {} overwrites prev logged tx {}",
+          val.pid,
+          prepared_it->second.pid);
+        prepared_it->second.pid = tx.pid;
+        prepared_it->second.offsets.clear();
+    }
+
+    for (const auto& tx_offset : val.offsets) {
+        group::offset_metadata md{
+          .log_offset = offset,
+          .offset = tx_offset.offset,
+          .metadata = tx_offset.metadata.value_or(""),
+        };
+        // BUG: support leader_epoch (KIP-320)
+        // https://github.com/vectorizedio/redpanda/issues/1181
+        prepared_it->second.offsets[tx_offset.tp] = md;
+    }
+}
+
 std::ostream& operator<<(std::ostream& os, const group_log_offset_key& key) {
     fmt::print(
       os,

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -79,6 +79,17 @@ void group_stm::commit(model::producer_identity pid) {
     _prepared_txs.erase(prepared_it);
 }
 
+void group_stm::abort(
+  model::producer_identity pid, [[maybe_unused]] model::tx_seq tx_seq) {
+    auto prepared_it = _prepared_txs.find(pid.get_id());
+    if (prepared_it == _prepared_txs.end()) {
+        return;
+    } else if (prepared_it->second.pid.epoch != pid.epoch) {
+        return;
+    }
+    _prepared_txs.erase(prepared_it);
+}
+
 std::ostream& operator<<(std::ostream& os, const group_log_offset_key& key) {
     fmt::print(
       os,

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -1,0 +1,38 @@
+#include "kafka/server/group_stm.h"
+
+namespace kafka {
+
+void group_stm::overwrite_metadata(group_log_group_metadata&& metadata) {
+    _metadata = std::move(metadata);
+    _is_loaded = true;
+}
+
+void group_stm::remove_offset(model::topic_partition key) {
+    _offsets.erase(key);
+}
+
+void group_stm::update_offset(
+  model::topic_partition key,
+  model::offset offset,
+  group_log_offset_metadata&& meta) {
+    _offsets[key] = logged_metadata{
+      .log_offset = offset, .metadata = std::move(meta)};
+}
+
+std::ostream& operator<<(std::ostream& os, const group_log_offset_key& key) {
+    fmt::print(
+      os,
+      "group {} topic {} partition {}",
+      key.group(),
+      key.topic(),
+      key.partition());
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const group_log_offset_metadata& md) {
+    fmt::print(os, "offset {}", md.offset());
+    return os;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -1,0 +1,113 @@
+#pragma once
+#include "cluster/fwd.h"
+#include "cluster/partition.h"
+#include "kafka/protocol/fwd.h"
+#include "kafka/server/logger.h"
+#include "kafka/server/member.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/log.hh>
+
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
+
+#include <iosfwd>
+#include <optional>
+#include <vector>
+
+namespace kafka {
+
+/**
+ * the value type of a group metadata log record.
+ */
+struct group_log_group_metadata {
+    kafka::protocol_type protocol_type;
+    kafka::generation_id generation;
+    std::optional<kafka::protocol_name> protocol;
+    std::optional<kafka::member_id> leader;
+    int32_t state_timestamp;
+    std::vector<member_state> members;
+};
+
+/**
+ * the key type for offset commit records.
+ */
+struct group_log_offset_key {
+    kafka::group_id group;
+    model::topic topic;
+    model::partition_id partition;
+
+    bool operator==(const group_log_offset_key& other) const = default;
+
+    friend std::ostream& operator<<(std::ostream&, const group_log_offset_key&);
+};
+
+/**
+ * the value type for offset commit records.
+ */
+struct group_log_offset_metadata {
+    model::offset offset;
+    int32_t leader_epoch;
+    std::optional<ss::sstring> metadata;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const group_log_offset_metadata&);
+};
+
+} // namespace kafka
+
+namespace std {
+template<>
+struct hash<kafka::group_log_offset_key> {
+    size_t operator()(const kafka::group_log_offset_key& key) const {
+        size_t h = 0;
+        boost::hash_combine(h, hash<ss::sstring>()(key.group));
+        boost::hash_combine(h, hash<ss::sstring>()(key.topic));
+        boost::hash_combine(h, hash<model::partition_id>()(key.partition));
+        return h;
+    }
+};
+} // namespace std
+
+namespace kafka {
+
+class group_stm {
+public:
+    struct logged_metadata {
+        model::offset log_offset;
+        group_log_offset_metadata metadata;
+    };
+
+    void overwrite_metadata(group_log_group_metadata&&);
+    void remove() {
+        _offsets.clear();
+        _is_loaded = false;
+        _is_removed = true;
+    }
+    void update_offset(
+      model::topic_partition, model::offset, group_log_offset_metadata&&);
+    void remove_offset(model::topic_partition);
+    bool has_data() const {
+        return !_is_removed && (_is_loaded || _offsets.size() > 0);
+    }
+    bool is_removed() const { return _is_removed; }
+
+    const absl::node_hash_map<model::topic_partition, logged_metadata>&
+    offsets() const {
+        return _offsets;
+    }
+
+private:
+    absl::node_hash_map<model::topic_partition, logged_metadata> _offsets;
+    group_log_group_metadata _metadata;
+    bool _is_loaded{false};
+    bool _is_removed{false};
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -75,6 +75,10 @@ struct group_log_prepared_tx {
     std::vector<group_log_prepared_tx_offset> offsets;
 };
 
+struct group_log_commit_tx {
+    kafka::group_id group_id;
+};
+
 } // namespace kafka
 
 namespace std {
@@ -109,6 +113,7 @@ public:
       model::topic_partition, model::offset, group_log_offset_metadata&&);
     void remove_offset(model::topic_partition);
     void update_prepared(model::offset, group_log_prepared_tx);
+    void commit(model::producer_identity);
     bool has_data() const {
         return !_is_removed && (_is_loaded || _offsets.size() > 0);
     }

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -109,11 +109,13 @@ public:
         _is_loaded = false;
         _is_removed = true;
     }
+
     void update_offset(
       model::topic_partition, model::offset, group_log_offset_metadata&&);
     void remove_offset(model::topic_partition);
     void update_prepared(model::offset, group_log_prepared_tx);
     void commit(model::producer_identity);
+    void abort(model::producer_identity, model::tx_seq);
     bool has_data() const {
         return !_is_removed && (_is_loaded || _offsets.size() > 0);
     }

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -2,6 +2,7 @@
 #include "cluster/fwd.h"
 #include "cluster/partition.h"
 #include "kafka/protocol/fwd.h"
+#include "kafka/server/group.h"
 #include "kafka/server/logger.h"
 #include "kafka/server/member.h"
 #include "kafka/types.h"

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -37,3 +37,4 @@
 #include "kafka/server/handlers/sasl_authenticate.h"
 #include "kafka/server/handlers/sasl_handshake.h"
 #include "kafka/server/handlers/sync_group.h"
+#include "kafka/server/handlers/txn_offset_commit.h"

--- a/src/v/kafka/server/handlers/txn_offset_commit.cc
+++ b/src/v/kafka/server/handlers/txn_offset_commit.cc
@@ -1,0 +1,36 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/handlers/txn_offset_commit.h"
+
+#include "cluster/topics_frontend.h"
+#include "kafka/server/group_manager.h"
+#include "kafka/server/group_router.h"
+#include "kafka/server/logger.h"
+#include "kafka/server/request_context.h"
+#include "kafka/server/response.h"
+#include "utils/remote.h"
+#include "utils/to_string.h"
+
+#include <seastar/core/print.hh>
+
+namespace kafka {
+
+template<>
+ss::future<response_ptr> txn_offset_commit_handler::handle(
+  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
+    return ss::do_with(std::move(ctx), [](request_context& ctx) {
+        txn_offset_commit_request request;
+        request.decode(ctx.reader(), ctx.header().version);
+        return ss::make_exception_future<response_ptr>(std::runtime_error(
+          fmt::format("Unsupported API {}", ctx.header().key)));
+    });
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/txn_offset_commit.cc
+++ b/src/v/kafka/server/handlers/txn_offset_commit.cc
@@ -22,15 +22,139 @@
 
 namespace kafka {
 
+struct txn_offset_commit_ctx {
+    request_context rctx;
+    txn_offset_commit_request request;
+    ss::smp_service_group ssg;
+
+    // topic partitions found not to existent prior to processing. responses for
+    // these are patched back into the final response after processing.
+    absl::flat_hash_map<
+      model::topic,
+      std::vector<txn_offset_commit_response_partition>>
+      nonexistent_tps;
+
+    txn_offset_commit_ctx(
+      request_context&& rctx,
+      txn_offset_commit_request&& request,
+      ss::smp_service_group ssg)
+      : rctx(std::move(rctx))
+      , request(std::move(request))
+      , ssg(ssg) {}
+};
+
+ss::future<response_ptr> txn_offset_commit(txn_offset_commit_ctx& octx) {
+    return octx.rctx.groups()
+      .txn_offset_commit(std::move(octx.request))
+      .then([&octx](txn_offset_commit_response resp) {
+          if (unlikely(!octx.nonexistent_tps.empty())) {
+              /*
+               * copy over partitions for topics that had some partitions
+               * that were processed normally.
+               */
+              for (auto& topic : resp.data.topics) {
+                  auto it = octx.nonexistent_tps.find(topic.name);
+                  if (it != octx.nonexistent_tps.end()) {
+                      topic.partitions.insert(
+                        topic.partitions.end(),
+                        it->second.begin(),
+                        it->second.end());
+                      octx.nonexistent_tps.erase(it);
+                  }
+              }
+              /*
+               * the remaining nonexistent topics are moved into the
+               * response directly.
+               */
+              for (auto& topic : octx.nonexistent_tps) {
+                  resp.data.topics.push_back(txn_offset_commit_response_topic{
+                    .name = topic.first,
+                    .partitions = std::move(topic.second),
+                  });
+              }
+          }
+          return octx.rctx.respond(std::move(resp));
+      });
+}
+
 template<>
 ss::future<response_ptr> txn_offset_commit_handler::handle(
-  request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
-    return ss::do_with(std::move(ctx), [](request_context& ctx) {
-        txn_offset_commit_request request;
-        request.decode(ctx.reader(), ctx.header().version);
-        return ss::make_exception_future<response_ptr>(std::runtime_error(
-          fmt::format("Unsupported API {}", ctx.header().key)));
-    });
+  request_context ctx, ss::smp_service_group ssg) {
+    txn_offset_commit_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+
+    klog.trace("Handling request {}", request);
+
+    txn_offset_commit_ctx octx(std::move(ctx), std::move(request), ssg);
+
+    /*
+     * offset commit will operate normally on topic-partitions in the request
+     * that exist, while returning partial errors for those that do not exist.
+     * in order to deal with this we filter out nonexistent topic-partitions,
+     * and pass those that exist on to the group membership layer.
+     *
+     * TODO: the filtering is expensive for large requests. there are two things
+     * that can be done to speed this up. first, the metadata cache should
+     * provide an interface for efficiently searching for topic-partitions.
+     * second, the code generator should be extended to allow the generated
+     * structures to contain extra fields. in this case, we could introduce a
+     * flag to mark topic-partitions to be ignored by the group membership
+     * subsystem.
+     */
+    for (auto it = octx.request.data.topics.begin();
+         it != octx.request.data.topics.end();) {
+        /*
+         * check if topic exists
+         */
+        const auto topic_name = model::topic(it->name);
+        model::topic_namespace_view tn(model::kafka_namespace, topic_name);
+
+        if (const auto& md = octx.rctx.metadata_cache().get_topic_metadata(tn);
+            md) {
+            /*
+             * check if each partition exists
+             */
+            auto split = std::partition(
+              it->partitions.begin(),
+              it->partitions.end(),
+              [&md](const txn_offset_commit_request_partition& p) {
+                  return std::any_of(
+                    md->partitions.cbegin(),
+                    md->partitions.cend(),
+                    [&p](const model::partition_metadata& pmd) {
+                        return pmd.id == p.partition_index;
+                    });
+              });
+            /*
+             * build responses for nonexistent topic partitions
+             */
+            if (split != it->partitions.end()) {
+                auto& parts = octx.nonexistent_tps[it->name];
+                for (auto part = split; part != it->partitions.end(); part++) {
+                    parts.push_back(txn_offset_commit_response_partition{
+                      .partition_index = part->partition_index,
+                      .error_code = error_code::unknown_topic_or_partition,
+                    });
+                }
+                it->partitions.erase(split, it->partitions.end());
+            }
+            ++it;
+        } else {
+            /*
+             * the topic doesn't exist. build all partition responses.
+             */
+            auto& parts = octx.nonexistent_tps[it->name];
+            for (const auto& part : it->partitions) {
+                parts.push_back(txn_offset_commit_response_partition{
+                  .partition_index = part.partition_index,
+                  .error_code = error_code::unknown_topic_or_partition,
+                });
+            }
+            it = octx.request.data.topics.erase(it);
+        }
+    }
+
+    return ss::do_with(std::move(octx), txn_offset_commit);
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/txn_offset_commit.h
+++ b/src/v/kafka/server/handlers/txn_offset_commit.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/txn_offset_commit.h"
+#include "kafka/server/handlers/handler.h"
+
+namespace kafka {
+
+using txn_offset_commit_handler = handler<txn_offset_commit_api, 0, 2>;
+
+}

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -250,6 +250,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<create_acls_handler>(std::move(ctx), g);
     case delete_acls_handler::api::key:
         return do_process<delete_acls_handler>(std::move(ctx), g);
+    case txn_offset_commit_handler::api::key:
+        return do_process<txn_offset_commit_handler>(std::move(ctx), g);
     };
     return ss::make_exception_future<response_ptr>(
       std::runtime_error(fmt::format("Unsupported API {}", ctx.header().key)));

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -417,10 +417,15 @@ struct record_batch_header {
 };
 
 using tx_seq = named_type<int64_t, struct tm_tx_seq>;
-
+using producer_id = named_type<int64_t, struct producer_identity_id>;
+using producer_epoch = named_type<int16_t, struct producer_identity_epoch>;
 struct producer_identity {
     int64_t id{-1};
     int16_t epoch{0};
+
+    model::producer_id get_id() { return model::producer_id(id); }
+
+    model::producer_epoch get_epoch() { return model::producer_epoch(epoch); }
 
     auto operator<=>(const producer_identity&) const = default;
 

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -17,7 +17,7 @@ namespace model {
 
 using record_batch_type = named_type<int8_t, struct model_record_batch_type>;
 
-constexpr std::array<record_batch_type, 15> well_known_record_batch_types{
+constexpr std::array<record_batch_type, 16> well_known_record_batch_types{
   record_batch_type(),   // unknown - used for debugging
   record_batch_type(1),  // raft::data
   record_batch_type(2),  // raft::configuration
@@ -33,5 +33,6 @@ constexpr std::array<record_batch_type, 15> well_known_record_batch_types{
   record_batch_type(12), // controller user management command batch type
   record_batch_type(13), // controller acl management command batch type
   record_batch_type(14), // group_prepare_tx_batch_type
+  record_batch_type(15), // group_commit_tx_batch_type
 };
 } // namespace model

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -17,7 +17,7 @@ namespace model {
 
 using record_batch_type = named_type<int8_t, struct model_record_batch_type>;
 
-constexpr std::array<record_batch_type, 14> well_known_record_batch_types{
+constexpr std::array<record_batch_type, 15> well_known_record_batch_types{
   record_batch_type(),   // unknown - used for debugging
   record_batch_type(1),  // raft::data
   record_batch_type(2),  // raft::configuration
@@ -32,5 +32,6 @@ constexpr std::array<record_batch_type, 14> well_known_record_batch_types{
   record_batch_type(11), // tm_update_batch_type
   record_batch_type(12), // controller user management command batch type
   record_batch_type(13), // controller acl management command batch type
+  record_batch_type(14), // group_prepare_tx_batch_type
 };
 } // namespace model

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -17,7 +17,7 @@ namespace model {
 
 using record_batch_type = named_type<int8_t, struct model_record_batch_type>;
 
-constexpr std::array<record_batch_type, 16> well_known_record_batch_types{
+constexpr std::array<record_batch_type, 17> well_known_record_batch_types{
   record_batch_type(),   // unknown - used for debugging
   record_batch_type(1),  // raft::data
   record_batch_type(2),  // raft::configuration
@@ -34,5 +34,6 @@ constexpr std::array<record_batch_type, 16> well_known_record_batch_types{
   record_batch_type(13), // controller acl management command batch type
   record_batch_type(14), // group_prepare_tx_batch_type
   record_batch_type(15), // group_commit_tx_batch_type
+  record_batch_type(16), // group_abort_tx_batch_type
 };
 } // namespace model


### PR DESCRIPTION
## Cover letter

Redpanda uses a variant of 2PC protocol for the transactional processing. It describes the processing in terms of transaction manager (an entity responsible for orchestration of the transactions) and resource manager (the actual data nodes participating in the transaction).

Right now we support partitions as the only kind of the resource manager. This change adds the resource manager API to the consumer groups consisting of begin_tx, prepare_tx, commit_tx and abort_tx RPCs.

Most of the change is off the current code flow so the risk is moderate. The only part which may affect non transactional execution is [this commit](https://github.com/vectorizedio/redpanda/pull/1182/commits/08a161c7fc31f96ee96056f0b7ee3fb521bea5d4) please dedicate the most attention reviewing that commit.

Redpanda transactions are ACID compatible and just like Kafka transactions they both fall on its weaker isolation spectre.

**A**(tomicity). Redpanda/Kafka transactions provide atomicity of writes (all or nothing cross partition writes) but it doesn't provide atomicity of reads (MAV isolation level) since it's possible to read some effects of a transaction but not all.

**C**(onsisency) isn't applicable to Redpanda/Kafka because they don't support database constrains and triggers.

**I**(solation). Redpanda/Kafka provides Read Comitted isolation level.

**D**(urability). Durability means that data is persisted to disk and transient power outage doesn't lead to data loss. Redpanda is always durable with acks=all settings. Kafka maybe configured to be durable with acks=all and flushing to disk on each write.

When clients initiate a transaction they must specify a transactional id. It acts as an identifier of the client and current session. So when a client opens a session Redpanda / Kafka closes all previous sessions corresponding to the same tx id and makes sure that its pending transaction is either committed or aborted.

Application controls access pattern and when it's witten in a way when clients with different transactional id access different set of data (different partitions and different consumer groups) the isolation level jumps from Read Comitted to MAV.

Redpanda / Kafka transaction doesn't provide a way to express preconditions on data so when they modify the same resource (consumer groups) we use LWW policy to resolve the conflicts.

The PR introduces the following tx control handlers on the consumer group side:

**begin_tx** maybe set a fencing and returns current term

**txn_offset_commit** caches the new offset in memory

**prepare_tx** (if the term hasn't changed since begin) write the cached offset to disk

**commit_tx** makes the written offsets visible

**abort_tx** abandons the cached / written offsets

In most cases it takes one flush before acknowledging the tx (prepare_tx)