### PR TITLE
rpk: report client host and id in `cluster offsets` command

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/offsets_test.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/offsets_test.go
@@ -64,8 +64,8 @@ func TestOffsetsCmd(t *testing.T) {
 		{
 			name: "create should output info about the created topic (custom values)",
 			cmd:  NewOffsetsCommand,
-			expectedOutput: `  GROUP    TOPIC    PARTITION  LAG  LAG %     COMMITTED  LATEST  CONSUMER  
-  group-0  topic-0  0          -50  0.000000  100        50      -         
+			expectedOutput: `  GROUP    TOPIC    PARTITION  LAG  LAG %     COMMITTED  LATEST  CONSUMER  CLIENT-HOST  CLIENT-ID  
+  group-0  topic-0  0          -50  0.000000  100        50      -                                 
 `,
 		},
 	}

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -113,7 +113,7 @@ ss::future<> consumer::join() {
     auto req_builder = [me{shared_from_this()}]() {
         const auto& cfg = me->_config;
         join_group_request req{};
-        req.client_id = "test_client";
+        req.client_id = kafka::client_id("test_client");
         req.data = {
           .group_id = me->_group_id,
           .session_timeout_ms = cfg.consumer_session_timeout(),

--- a/src/v/kafka/protocol/join_group.h
+++ b/src/v/kafka/protocol/join_group.h
@@ -47,7 +47,8 @@ struct join_group_request final {
 
     // extra context from request header set in decode
     api_version version;
-    std::optional<ss::sstring> client_id;
+    std::optional<kafka::client_id> client_id;
+    kafka::client_host client_host;
 
     // set during request processing after mapping group to ntp
     model::ntp ntp;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -74,6 +74,7 @@ public:
 
     ss::future<> process_one_request();
     bool is_finished_parsing() const;
+    ss::net::inet_address client_host() const { return _client_addr; }
 
 private:
     // used to pass around some internal state

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -555,6 +555,8 @@ ss::future<join_group_response> group::add_member_and_rebalance(
       std::move(member_id),
       id(),
       std::move(r.data.group_instance_id),
+      r.client_id.value_or(client_id("")),
+      r.client_host,
       r.data.session_timeout_ms,
       r.data.rebalance_timeout_ms,
       std::move(r.data.protocol_type),
@@ -1343,9 +1345,8 @@ group::handle_offset_fetch(offset_fetch_request&& r) {
 }
 
 kafka::member_id group::generate_member_id(const join_group_request& r) {
-    auto client_id = r.client_id ? *r.client_id : "";
-    auto id = r.data.group_instance_id ? (*r.data.group_instance_id)()
-                                       : client_id;
+    auto cid = r.client_id ? *r.client_id : kafka::client_id("");
+    auto id = r.data.group_instance_id ? (*r.data.group_instance_id)() : cid();
     boost::uuids::uuid uuid = boost::uuids::random_generator()();
     return kafka::member_id(ssx::sformat("{}-{}", id, uuid));
 }

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -317,3 +317,131 @@ struct recovery_batch_consumer {
 };
 
 } // namespace kafka
+
+namespace reflection {
+
+/*
+ * new code + new version: will see extra bytes for client host/id
+ * new code + old version: will observe no extra bytes
+ * old code + old/new version: will not read new appended fields
+ *
+ * on the wire we write out a version that is compatible with old code and then
+ * append the additional client host/id information for each member. then when
+ * deserializing we process the appended data by updating the old versions from
+ * disk in the new in-memory structs which contain the extra member metadata.
+ * old code skips over the appended data.
+ */
+template<>
+struct adl<kafka::group_log_group_metadata> {
+    struct member_state_v0 {
+        kafka::member_id id;
+        std::chrono::milliseconds session_timeout;
+        std::chrono::milliseconds rebalance_timeout;
+        std::optional<kafka::group_instance_id> instance_id;
+        kafka::protocol_type protocol_type;
+        std::vector<kafka::member_protocol> protocols;
+        iobuf assignment;
+    };
+
+    struct group_log_group_metadata_v0 {
+        kafka::protocol_type protocol_type;
+        kafka::generation_id generation;
+        std::optional<kafka::protocol_name> protocol;
+        std::optional<kafka::member_id> leader;
+        int32_t state_timestamp;
+        std::vector<member_state_v0> members;
+    };
+
+    struct client_host_id {
+        kafka::client_id id;
+        kafka::client_host host;
+    };
+
+    void to(iobuf& out, kafka::group_log_group_metadata&& data) {
+        // create instance of old version of members
+        std::vector<member_state_v0> members_v0;
+        members_v0.reserve(data.members.size());
+        for (auto& member : data.members) {
+            members_v0.push_back(member_state_v0{
+              .id = std::move(member.id),
+              .session_timeout = member.session_timeout,
+              .rebalance_timeout = member.rebalance_timeout,
+              .instance_id = std::move(member.instance_id),
+              .protocol_type = std::move(member.protocol_type),
+              .protocols = std::move(member.protocols),
+              .assignment = std::move(member.assignment),
+            });
+        }
+
+        // create instance of old version of group metadata
+        group_log_group_metadata_v0 metadata_v0{
+          .protocol_type = std::move(data.protocol_type),
+          .generation = data.generation,
+          .protocol = std::move(data.protocol),
+          .leader = std::move(data.leader),
+          .state_timestamp = data.state_timestamp,
+          .members = std::move(members_v0),
+        };
+
+        // this puts a version on disk that older code can read
+        serialize(out, std::move(metadata_v0));
+
+        // now append the client host/id information for new code
+        std::vector<client_host_id> client_info;
+        client_info.reserve(data.members.size());
+        for (auto& member : data.members) {
+            client_info.push_back(client_host_id{
+              .id = std::move(member.client_id),
+              .host = std::move(member.client_host),
+            });
+        }
+        serialize(out, std::move(client_info));
+    }
+
+    kafka::group_log_group_metadata from(iobuf_parser& in) {
+        auto metadata_v0 = adl<group_log_group_metadata_v0>{}.from(in);
+
+        std::vector<client_host_id> client_info;
+        if (in.bytes_left()) {
+            client_info = adl<std::vector<client_host_id>>{}.from(in);
+            vassert(
+              client_info.size() == metadata_v0.members.size(),
+              "Expected client info size {} got {}",
+              metadata_v0.members.size(),
+              client_info.size());
+        }
+
+        std::vector<kafka::member_state> members_out;
+        members_out.reserve(metadata_v0.members.size());
+
+        for (auto& member : metadata_v0.members) {
+            members_out.push_back(kafka::member_state{
+              .id = std::move(member.id),
+              .session_timeout = member.session_timeout,
+              .rebalance_timeout = member.rebalance_timeout,
+              .instance_id = std::move(member.instance_id),
+              .protocol_type = std::move(member.protocol_type),
+              .protocols = std::move(member.protocols),
+              .assignment = std::move(member.assignment),
+            });
+        }
+
+        for (size_t i = 0; i < client_info.size(); i++) {
+            members_out[i].client_id = std::move(client_info[i].id);
+            members_out[i].client_host = std::move(client_info[i].host);
+        }
+
+        kafka::group_log_group_metadata metadata_out{
+          .protocol_type = std::move(metadata_v0.protocol_type),
+          .generation = metadata_v0.generation,
+          .protocol = std::move(metadata_v0.protocol),
+          .leader = std::move(metadata_v0.leader),
+          .state_timestamp = metadata_v0.state_timestamp,
+          .members = std::move(members_out),
+        };
+
+        return metadata_out;
+    }
+};
+
+} // namespace reflection

--- a/src/v/kafka/server/handlers/join_group.cc
+++ b/src/v/kafka/server/handlers/join_group.cc
@@ -28,8 +28,10 @@ void join_group_request::decode(request_context& ctx) {
     data.decode(ctx.reader(), ctx.header().version);
     version = ctx.header().version;
     if (ctx.header().client_id) {
-        client_id = ss::sstring(*ctx.header().client_id);
+        client_id = kafka::client_id(ss::sstring(*ctx.header().client_id));
     }
+    client_host = kafka::client_host(
+      fmt::format("{}", ctx.connection()->client_host()));
 }
 
 void join_group_response::encode(const request_context& ctx, response& resp) {

--- a/src/v/kafka/server/member.cc
+++ b/src/v/kafka/server/member.cc
@@ -102,6 +102,8 @@ described_group_member group_member::describe_without_metadata() const {
     described_group_member desc{
       .member_id = id(),
       .group_instance_id = group_instance_id(),
+      .client_id = _state.client_id,
+      .client_host = _state.client_host,
     };
     return desc;
 }

--- a/src/v/kafka/server/member.h
+++ b/src/v/kafka/server/member.h
@@ -52,6 +52,8 @@ struct member_state {
     kafka::protocol_type protocol_type;
     std::vector<member_protocol> protocols;
     iobuf assignment;
+    kafka::client_id client_id;
+    kafka::client_host client_host;
 
     member_state copy() const {
         return member_state{
@@ -62,6 +64,8 @@ struct member_state {
           .protocol_type = protocol_type,
           .protocols = protocols,
           .assignment = assignment.copy(),
+          .client_id = client_id,
+          .client_host = client_host,
         };
     }
 
@@ -78,6 +82,8 @@ public:
       kafka::member_id member_id,
       kafka::group_id group_id,
       std::optional<kafka::group_instance_id> group_instance_id,
+      kafka::client_id client_id,
+      kafka::client_host client_host,
       duration_type session_timeout,
       duration_type rebalance_timeout,
       kafka::protocol_type protocol_type,
@@ -91,6 +97,8 @@ public:
           std::move(protocol_type),
           std::move(protocols),
           iobuf(),
+          std::move(client_id),
+          std::move(client_host),
         }),
         std::move(group_id)) {}
 

--- a/src/v/kafka/server/member.h
+++ b/src/v/kafka/server/member.h
@@ -65,14 +65,7 @@ struct member_state {
         };
     }
 
-    bool operator==(const member_state& other) const {
-        return id == other.id && session_timeout == other.session_timeout
-               && rebalance_timeout == other.rebalance_timeout
-               && instance_id == other.instance_id
-               && protocol_type == other.protocol_type
-               && protocols == other.protocols
-               && assignment == other.assignment;
-    }
+    friend bool operator==(const member_state&, const member_state&) = default;
 };
 
 /// \brief A Kafka group member.

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -57,6 +57,8 @@ static member_ptr get_group_member(
       kafka::member_id(id),
       kafka::group_id("g"),
       kafka::group_instance_id("i"),
+      kafka::client_id("client-id"),
+      kafka::client_host("client-host"),
       std::chrono::seconds(1),
       std::chrono::milliseconds(2),
       kafka::protocol_type("p"),
@@ -150,6 +152,8 @@ SEASTAR_THREAD_TEST_CASE(rebalance_timeout) {
       kafka::member_id("m"),
       kafka::group_id("g"),
       kafka::group_instance_id("i"),
+      kafka::client_id("client-id"),
+      kafka::client_host("client-host"),
       std::chrono::seconds(1),
       std::chrono::milliseconds(2),
       kafka::protocol_type("p"),
@@ -159,6 +163,8 @@ SEASTAR_THREAD_TEST_CASE(rebalance_timeout) {
       kafka::member_id("n"),
       kafka::group_id("g"),
       kafka::group_instance_id("i"),
+      kafka::client_id("client-id"),
+      kafka::client_host("client-host"),
       std::chrono::seconds(1),
       std::chrono::seconds(3),
       kafka::protocol_type("p"),
@@ -361,6 +367,8 @@ SEASTAR_THREAD_TEST_CASE(supports_protocols) {
       kafka::member_id("m"),
       kafka::group_id("g"),
       kafka::group_instance_id("i"),
+      kafka::client_id("client-id"),
+      kafka::client_host("client-host"),
       std::chrono::seconds(1),
       std::chrono::seconds(3),
       kafka::protocol_type("p"),
@@ -389,6 +397,8 @@ SEASTAR_THREAD_TEST_CASE(supports_protocols) {
       kafka::member_id("n"),
       kafka::group_id("g"),
       kafka::group_instance_id("i"),
+      kafka::client_id("client-id"),
+      kafka::client_host("client-host"),
       std::chrono::seconds(1),
       std::chrono::seconds(3),
       kafka::protocol_type("p"),
@@ -431,14 +441,14 @@ SEASTAR_THREAD_TEST_CASE(leader_rejoined) {
 SEASTAR_THREAD_TEST_CASE(generate_member_id) {
     join_group_request r;
 
-    r.client_id = ss::sstring("dog");
+    r.client_id = kafka::client_id(ss::sstring("dog"));
     r.data.group_instance_id = std::nullopt;
     auto m = group::generate_member_id(r);
     auto [id, uuid] = split_member_id(m);
     BOOST_TEST(id == "dog");
     BOOST_TEST(is_uuid(uuid));
 
-    r.client_id = ss::sstring("dog");
+    r.client_id = kafka::client_id(ss::sstring("dog"));
     r.data.group_instance_id = kafka::group_instance_id("cat");
     m = group::generate_member_id(r);
     std::tie(id, uuid) = split_member_id(m);

--- a/src/v/kafka/server/tests/member_test.cc
+++ b/src/v/kafka/server/tests/member_test.cc
@@ -27,6 +27,8 @@ static group_member get_member() {
       kafka::member_id("m"),
       kafka::group_id("g"),
       kafka::group_instance_id("i"),
+      kafka::client_id("client-id"),
+      kafka::client_host("client-host"),
       std::chrono::seconds(1),
       std::chrono::milliseconds(2),
       kafka::protocol_type("p"),

--- a/src/v/kafka/server/tests/member_test.cc
+++ b/src/v/kafka/server/tests/member_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "kafka/server/group_manager.h"
 #include "kafka/server/member.h"
 #include "kafka/types.h"
 #include "utils/to_string.h"
@@ -173,6 +174,136 @@ SEASTAR_THREAD_TEST_CASE(member_serde) {
     auto m1 = kafka::group_member(std::move(m1_state), m0.group_id());
 
     BOOST_REQUIRE(m1.state() == m0.state());
+}
+
+struct member_state_old {
+    kafka::member_id id;
+    std::chrono::milliseconds session_timeout;
+    std::chrono::milliseconds rebalance_timeout;
+    std::optional<kafka::group_instance_id> instance_id;
+    kafka::protocol_type protocol_type;
+    std::vector<member_protocol> protocols;
+    iobuf assignment;
+};
+
+struct group_log_group_metadata_old {
+    kafka::protocol_type protocol_type;
+    kafka::generation_id generation;
+    std::optional<kafka::protocol_name> protocol;
+    std::optional<kafka::member_id> leader;
+    int32_t state_timestamp;
+    std::vector<member_state_old> members;
+};
+
+// new code + old version. will see empty strings for client id/host
+SEASTAR_THREAD_TEST_CASE(group_log_group_metadata_compat0) {
+    group_log_group_metadata_old old;
+    old.protocol_type = kafka::protocol_type("asdf");
+    old.state_timestamp = 333333;
+
+    old.members.push_back(member_state_old{
+      .id = member_id("foobar"),
+      .protocols = {{.name = protocol_name("asdf")}}});
+    old.members.push_back(member_state_old{
+      .id = member_id("foobar1"),
+      .protocols = {{.name = protocol_name("asdf1")}}});
+
+    auto old_buf = reflection::to_iobuf(std::move(old));
+
+    auto new_out = reflection::from_iobuf<group_log_group_metadata>(
+      std::move(old_buf));
+
+    BOOST_REQUIRE(new_out.protocol_type == "asdf");
+    BOOST_REQUIRE(new_out.state_timestamp == 333333);
+    BOOST_REQUIRE(new_out.members.size() == 2);
+    BOOST_REQUIRE(new_out.members[0].id == "foobar");
+    BOOST_REQUIRE(new_out.members[0].protocols.size() == 1);
+    BOOST_REQUIRE(new_out.members[0].protocols[0].name == "asdf");
+    BOOST_REQUIRE(new_out.members[0].client_id == "");
+    BOOST_REQUIRE(new_out.members[0].client_host == "");
+    BOOST_REQUIRE(new_out.members[1].id == "foobar1");
+    BOOST_REQUIRE(new_out.members[1].protocols.size() == 1);
+    BOOST_REQUIRE(new_out.members[1].protocols[0].name == "asdf1");
+    BOOST_REQUIRE(new_out.members[1].client_id == "");
+    BOOST_REQUIRE(new_out.members[1].client_host == "");
+}
+
+// new code + new version. will see client id/host
+SEASTAR_THREAD_TEST_CASE(group_log_group_metadata_compat1) {
+    group_log_group_metadata md;
+    md.protocol_type = kafka::protocol_type("asdf");
+    md.state_timestamp = 333333;
+
+    md.members.push_back(member_state{
+      .id = member_id("foobar"),
+      .protocols = {{.name = protocol_name("asdf")}},
+      .client_id = kafka::client_id("c0"),
+      .client_host = kafka::client_host("c1"),
+    });
+    md.members.push_back(member_state{
+      .id = member_id("foobar1"),
+      .protocols = {{.name = protocol_name("asdf1")}},
+      .client_id = kafka::client_id("c2"),
+      .client_host = kafka::client_host("c3"),
+    });
+
+    auto old_buf = reflection::to_iobuf(std::move(md));
+
+    auto new_out = reflection::from_iobuf<group_log_group_metadata>(
+      std::move(old_buf));
+
+    BOOST_REQUIRE(new_out.protocol_type == "asdf");
+    BOOST_REQUIRE(new_out.state_timestamp == 333333);
+    BOOST_REQUIRE(new_out.members.size() == 2);
+    BOOST_REQUIRE(new_out.members[0].id == "foobar");
+    BOOST_REQUIRE(new_out.members[0].protocols.size() == 1);
+    BOOST_REQUIRE(new_out.members[0].protocols[0].name == "asdf");
+    BOOST_REQUIRE(new_out.members[0].client_id == "c0");
+    BOOST_REQUIRE(new_out.members[0].client_host == "c1");
+    BOOST_REQUIRE(new_out.members[1].id == "foobar1");
+    BOOST_REQUIRE(new_out.members[1].protocols.size() == 1);
+    BOOST_REQUIRE(new_out.members[1].protocols[0].name == "asdf1");
+    BOOST_REQUIRE(new_out.members[1].client_id == "c2");
+    BOOST_REQUIRE(new_out.members[1].client_host == "c3");
+}
+
+// old code + new version. doesn't see client id/host
+SEASTAR_THREAD_TEST_CASE(group_log_group_metadata_compat2) {
+    group_log_group_metadata md;
+    md.protocol_type = kafka::protocol_type("asdf");
+    md.state_timestamp = 333333;
+
+    md.members.push_back(member_state{
+      .id = member_id("foobar"),
+      .protocols = {{.name = protocol_name("asdf")}},
+      .client_id = kafka::client_id("c0"),
+      .client_host = kafka::client_host("c1"),
+    });
+    md.members.push_back(member_state{
+      .id = member_id("foobar1"),
+      .protocols = {{.name = protocol_name("asdf1")}},
+      .client_id = kafka::client_id("c2"),
+      .client_host = kafka::client_host("c3"),
+    });
+
+    auto old_buf = reflection::to_iobuf(std::move(md));
+
+    auto new_out = reflection::from_iobuf<group_log_group_metadata_old>(
+      std::move(old_buf));
+
+    BOOST_REQUIRE(new_out.protocol_type == "asdf");
+    BOOST_REQUIRE(new_out.state_timestamp == 333333);
+    BOOST_REQUIRE(new_out.members.size() == 2);
+    BOOST_REQUIRE(new_out.members[0].id == "foobar");
+    BOOST_REQUIRE(new_out.members[0].protocols.size() == 1);
+    BOOST_REQUIRE(new_out.members[0].protocols[0].name == "asdf");
+    // BOOST_REQUIRE(new_out.members[0].client_id == "c0");
+    // BOOST_REQUIRE(new_out.members[0].client_host == "c1");
+    BOOST_REQUIRE(new_out.members[1].id == "foobar1");
+    BOOST_REQUIRE(new_out.members[1].protocols.size() == 1);
+    BOOST_REQUIRE(new_out.members[1].protocols[0].name == "asdf1");
+    // BOOST_REQUIRE(new_out.members[1].client_id == "c2");
+    // BOOST_REQUIRE(new_out.members[1].client_host == "c3");
 }
 
 } // namespace kafka

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -56,6 +56,9 @@ using protocol_type = named_type<ss::sstring, struct kafka_protocol_type>;
 /// Kafka group protocol name.
 using protocol_name = named_type<ss::sstring, struct kafka_protocol>;
 
+using client_id = named_type<ss::sstring, struct kafka_client_id_type>;
+using client_host = named_type<ss::sstring, struct kafka_client_host_type>;
+
 /// An unknown / missing member id (Kafka protocol specific)
 static inline const member_id unknown_member_id("");
 


### PR DESCRIPTION
## Cover letter

Show client id and client host when reporting consumer group member information.

Fixes: https://github.com/vectorizedio/redpanda/issues/967

```
[nwatkins@gordon kafka_2.12-2.6.0]$ ~/src/redpanda/vbuild/go/linux/bin/rpk cluster offsets                                                                                                                                            
  GROUP    TOPIC  PARTITION  LAG  LAG %  COMMITTED  LATEST  CONSUMER                                     CLIENT-HOST  CLIENT-ID                                                                                                       
  foo-g-1  foo    0          -    -      -          5       sarama-32ae57eb-8b04-4ee3-b529-729a6f965e7c  127.0.0.1    sarama           
```