### PR TITLE
rpk/start: Reduce startup time

### DIFF
--- a/src/go/rpk/pkg/api/api.go
+++ b/src/go/rpk/pkg/api/api.go
@@ -95,7 +95,11 @@ func SendMetrics(p MetricsPayload, conf config.Config) error {
 }
 
 func SendEnvironment(
-	fs afero.Fs, env EnvironmentPayload, conf config.Config, confJSON string,
+	fs afero.Fs,
+	env EnvironmentPayload,
+	conf config.Config,
+	confJSON string,
+	skipCloudCheck bool,
 ) error {
 	confMap := map[string]interface{}{}
 	err := json.Unmarshal([]byte(confJSON), &confMap)
@@ -104,16 +108,18 @@ func SendEnvironment(
 	}
 	cloudVendor := "N/A"
 	vmType := "N/A"
-	v, err := cloud.AvailableVendor()
-	if err != nil {
-		log.Debug(err)
-	} else {
-		cloudVendor = v.Name()
-		vt, err := v.VmType()
+	if !skipCloudCheck {
+		v, err := cloud.AvailableVendor()
 		if err != nil {
-			log.Debug("Error retrieving instance type: ", err)
+			log.Debug(err)
 		} else {
-			vmType = vt
+			cloudVendor = v.Name()
+			vt, err := v.VmType()
+			if err != nil {
+				log.Debug("Error retrieving instance type: ", err)
+			} else {
+				vmType = vt
+			}
 		}
 	}
 


### PR DESCRIPTION
Disable all checks when `--check=false` to reduce startup time.

Before:

0.09s user 0.06s system 6% cpu 2.195 total

After

0.07s user 0.07s system 13% cpu 1.040 total

Measured with:

```
time rpk redpanda start --check=false  -- --unknown-rp-flag
```

--unknown-rp-flag is passed so redpanda exits upon encountering an invalid flag.

Fixes: #1158 
