### PR TITLE
operator: upgrade configurator and fixes

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -666,3 +666,7 @@ func statefulSetKind() string {
 	var statefulSet appsv1.StatefulSet
 	return statefulSet.Kind
 }
+
+func (r *StatefulSetResource) fullConfiguratorImage() string {
+	return fmt.Sprintf("%s:%s", configuratorContainerImage, r.configuratorTag)
+}

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -296,7 +296,7 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 					InitContainers: []corev1.Container{
 						{
 							Name:            configuratorContainerName,
-							Image:           configuratorContainerImage + ":" + r.configuratorTag,
+							Image:           r.fullConfiguratorImage(),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Env: []corev1.EnvVar{
 								{

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -122,6 +122,10 @@ func stsFromCluster(pandaCluster *redpandav1alpha1.Cluster) *v1.StatefulSet {
 					Namespace: pandaCluster.Namespace,
 				},
 				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name:  "redpanda-configurator",
+						Image: "vectorized/configurator:latest",
+					}},
 					Containers: []corev1.Container{
 						{
 							Name:  "redpanda",

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -97,7 +97,9 @@ func TestEnsure(t *testing.T) {
 		assert.NoError(t, err, tt.name)
 
 		if *actual.Spec.Replicas != *tt.expectedObject.Spec.Replicas || !reflect.DeepEqual(actual.Spec.Template.Spec.Containers[0].Resources.Requests, tt.expectedObject.Spec.Template.Spec.Containers[0].Resources.Requests) {
-			t.Errorf("%s: expecting replicas %d and resources %v, got replicas %d and resources %v", tt.name, *actual.Spec.Replicas, actual.Spec.Template.Spec.Containers[0].Resources.Requests, *tt.expectedObject.Spec.Replicas, tt.expectedObject.Spec.Template.Spec.Containers[0].Resources.Requests)
+			t.Errorf("%s: expecting replicas %d and resources %v, got replicas %d and resources %v", tt.name,
+				*tt.expectedObject.Spec.Replicas, tt.expectedObject.Spec.Template.Spec.Containers[0].Resources.Requests,
+				*actual.Spec.Replicas, actual.Spec.Template.Spec.Containers[0].Resources.Requests)
 		}
 
 		if len(actual.Spec.VolumeClaimTemplates) == 0 || !reflect.DeepEqual(actual.Spec.VolumeClaimTemplates[0].Spec, tt.expectedObject.Spec.VolumeClaimTemplates[0].Spec) {

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -54,14 +54,12 @@ func (r *StatefulSetResource) runPartitionedUpdate(
 	newRedpandaImage := r.pandaCluster.FullImageName()
 	newConfiguratorImage := r.fullConfiguratorImage()
 
+	r.logger.Info("Continuing cluster partitioned update",
+		"cluster image", newRedpandaImage,
+		"configurator image", newConfiguratorImage)
+
 	if err := r.updateUpgradingStatus(ctx, true); err != nil {
 		return err
-	}
-
-	if r.pandaCluster.Status.Upgrading {
-		r.logger.Info("Continuing cluster partitioned update",
-			"cluster image", newRedpandaImage,
-			"configurator image", newConfiguratorImage)
 	}
 
 	if err := r.partitionUpdateImage(ctx, sts, newRedpandaImage, newConfiguratorImage); err != nil {

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -60,11 +60,6 @@ func (r *StatefulSetResource) runPartitionedUpdate(
 		r.logger.Info("Continuing cluster partitioned update", "cluster image", newImage)
 	}
 
-	podSpec := &sts.Spec.Template.Spec
-	if err := r.modifyPodImage(podSpec, newImage); err != nil {
-		return err
-	}
-
 	if err := r.partitionUpdateImage(ctx, sts, newImage); err != nil {
 		return err
 	}
@@ -292,25 +287,6 @@ func (r *StatefulSetResource) rollingUpdatePartition(
 	if err := Update(ctx, sts, modifiedSts, r.Client, r.logger); err != nil {
 		return fmt.Errorf("failed to update StatefulSet (ordinal %d): %w", ordinal, err)
 	}
-
-	return nil
-}
-
-func (r *StatefulSetResource) modifyPodImage(
-	stsSpec *corev1.PodSpec, newImage string,
-) error {
-	return modifyContainerImage(stsSpec.Containers, redpandaContainerName, newImage)
-}
-
-func modifyContainerImage(
-	containers []corev1.Container, containerName, newImage string,
-) error {
-	container, err := findContainer(containers, containerName)
-	if err != nil {
-		return err
-	}
-
-	container.Image = newImage
 
 	return nil
 }

--- a/src/go/k8s/tests/e2e/update-conf-image/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/00-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-controller-manager
+  namespace: redpanda-system
+status:
+  readyReplicas: 1
+  replicas: 1 # Temporarily, the number of replicas becomes 2. We wait until the new version is up and running alone - or set maxSurge=0 in deployment.
+  observedGeneration: 2

--- a/src/go/k8s/tests/e2e/update-conf-image/00-configurator.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/00-configurator.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# Set specific configurator version - this will be reflected in all configurator containers of managed redpanda clusters (new or old)
+- command: kubectl patch deployment redpanda-controller-manager -n redpanda-system --type='json' -p='[{"op":"add", "path":"/spec/template/spec/containers/1/args/-", "value":"--configurator-tag=v21.4.11"}]'

--- a/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-image-cluster
+spec:
+  template:
+    spec:
+      initContainers:
+        - image: "vectorized/configurator:v21.4.11"
+      containers:
+        - image: "vectorized/redpanda:latest"
+status:
+  readyReplicas: 2

--- a/src/go/k8s/tests/e2e/update-conf-image/01-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/01-current-image.yaml
@@ -1,0 +1,23 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-image-cluster
+spec:
+  image: "vectorized/redpanda"
+  version: "latest"
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    adminApi:
+    - port: 9644
+    developerMode: true

--- a/src/go/k8s/tests/e2e/update-conf-image/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/02-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-controller-manager
+  namespace: redpanda-system
+status:
+  readyReplicas: 1
+  replicas: 1
+  observedGeneration: 3

--- a/src/go/k8s/tests/e2e/update-conf-image/02-new-configurator.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/02-new-configurator.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# Configurator version will become default (latest) and all redpanda configurators (one here) get updated to latest
+- command: kubectl patch deployment redpanda-controller-manager -n redpanda-system --type='json' -p='[{"op":"remove", "path":"/spec/template/spec/containers/1/args/4"}]'

--- a/src/go/k8s/tests/e2e/update-conf-image/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/03-assert.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-image-cluster
+spec:
+  template:
+    spec:
+      initContainers:
+        - image: "vectorized/configurator:latest"
+      containers:
+        - image: "vectorized/redpanda:latest"
+status:
+  readyReplicas: 2
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: update-image-cluster-0
+spec:
+  initContainers:
+    - name: redpanda-configurator
+      image: "vectorized/configurator:latest" 
+  containers:
+    - name: redpanda
+      image: "vectorized/redpanda:latest"
+status:
+  phase: "Running"
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: update-image-cluster-1
+spec:
+  containers:
+    - name: redpanda
+      image: "vectorized/redpanda:latest"
+status:
+  phase: "Running"


### PR DESCRIPTION
## Cover letter

The configurator is added as part of the upgrade process. Unlike the Redpanda image, the configurator's image tag is provided in the operator's process arguments (default being "latest").

To test this change, we update the running operator's spec with a tag, and afterwards remove it. In each case, the test checks that the configurator receives the right tag (when created or implicitly updated due to operator restart).

This PR also fixes a case where the upgrade wouldn't proceed. Since we introduced an `Update()` method (commit e4d0f3356dae21498a4e6a08fabc6c3ec925af7d) that receives a "current" and a "modified" version of the resource, we should not be updating the StatefulSet prior to updating. Instead it suffices to call`obj()`, which we already do, to generate the new StatefulSet instance.