### PR TITLE
operator: improve logging when resource changes

### DIFF
--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -99,7 +99,8 @@ func Update(
 	}
 	if !patchResult.IsEmpty() {
 		// need to set current version first otherwise the request would get rejected
-		logger.Info(fmt.Sprintf("Resource changed, updating %s. Diff: %v", modified.GetName(), string(patchResult.Patch)))
+		logger.Info(fmt.Sprintf("Resource %s (%s) changed, updating. Diff: %v",
+			modified.GetName(), modified.GetObjectKind().GroupVersionKind().Kind, string(patchResult.Patch)))
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(modified); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Cover letter

This improves operations experience with the operator because before it
was not obvious which kind of object was being updated.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
Improved operator logging when resource changed