### PR TITLE
s/tests: moved index state test to unit tests

### DIFF
--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -52,12 +52,21 @@ rp_test(
 
 rp_test(
   UNIT_TEST
+  BINARY_NAME storage_log_index
+  SOURCES
+    index_state_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES Boost::unit_test_framework v::storage
+  LABELS storage
+)
+
+rp_test(
+  UNIT_TEST
   BINARY_NAME storage_multi_thread
   SOURCES
     batch_cache_test.cc
     record_batch_builder_test.cc
     snapshot_test.cc
-    index_state_test.cc
   LIBRARIES v::seastar_testing_main v::storage_test_utils
   LABELS storage
 )


### PR DESCRIPTION
Index state test is a test that doesn't use `SEASTAR_THREAD_TEST`. This
prevented rest of the test to run.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
