### PR TITLE
Pandaproxy: support json_v2 for produce and consume

### DIFF
--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -56,10 +56,10 @@ ss::future<server::reply_t>
 get_topics_names(server::request_t rq, server::reply_t rp) {
     parse::content_type_header(
       *rq.req,
-      {json::serialization_format::json_v2, json::serialization_format::none});
+      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req,
-      {json::serialization_format::json_v2, json::serialization_format::none});
+      {json::serialization_format::v2, json::serialization_format::none});
     rq.req.reset();
     auto make_list_topics_req = []() {
         return kafka::metadata_request{.list_all_topics = true};
@@ -87,7 +87,7 @@ get_topics_names(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 get_topics_records(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    parse::content_type_header(*rq.req, {json::serialization_format::v2});
     auto res_fmt = parse::accept_header(
       *rq.req, {json::serialization_format::binary_v2});
 
@@ -122,7 +122,7 @@ post_topics_name(server::request_t rq, server::reply_t rp) {
       *rq.req, {json::serialization_format::binary_v2});
     auto res_fmt = parse::accept_header(
       *rq.req,
-      {json::serialization_format::json_v2, json::serialization_format::none});
+      {json::serialization_format::v2, json::serialization_format::none});
 
     auto topic = parse::request_param<model::topic>(*rq.req, "topic_name");
 
@@ -154,10 +154,10 @@ static ss::sstring make_consumer_uri(
 
 ss::future<server::reply_t>
 create_consumer(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    parse::content_type_header(*rq.req, {json::serialization_format::v2});
     auto res_fmt = parse::accept_header(
       *rq.req,
-      {json::serialization_format::json_v2, json::serialization_format::none});
+      {json::serialization_format::v2, json::serialization_format::none});
 
     auto group_id = parse::request_param<kafka::group_id>(
       *rq.req, "group_name");
@@ -194,10 +194,10 @@ create_consumer(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 remove_consumer(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    parse::content_type_header(*rq.req, {json::serialization_format::v2});
     parse::accept_header(
       *rq.req,
-      {json::serialization_format::json_v2, json::serialization_format::none});
+      {json::serialization_format::v2, json::serialization_format::none});
 
     auto group_id = parse::request_param<kafka::group_id>(
       *rq.req, "group_name");
@@ -211,10 +211,10 @@ remove_consumer(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 subscribe_consumer(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    parse::content_type_header(*rq.req, {json::serialization_format::v2});
     auto res_fmt = parse::accept_header(
       *rq.req,
-      {json::serialization_format::json_v2, json::serialization_format::none});
+      {json::serialization_format::v2, json::serialization_format::none});
 
     auto group_id = parse::request_param<kafka::group_id>(
       *rq.req, "group_name");
@@ -236,7 +236,7 @@ ss::future<server::reply_t>
 consumer_fetch(server::request_t rq, server::reply_t rp) {
     parse::content_type_header(
       *rq.req,
-      {json::serialization_format::json_v2, json::serialization_format::none});
+      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req, {json::serialization_format::binary_v2});
 
@@ -264,10 +264,10 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 get_consumer_offsets(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    parse::content_type_header(*rq.req, {json::serialization_format::v2});
     auto res_fmt = parse::accept_header(
       *rq.req,
-      {json::serialization_format::json_v2, json::serialization_format::none});
+      {json::serialization_format::v2, json::serialization_format::none});
 
     auto group_id{parse::request_param<kafka::group_id>(*rq.req, "group_name")};
     auto member_id{parse::request_param<kafka::member_id>(*rq.req, "instance")};
@@ -288,10 +288,10 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 post_consumer_offsets(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(*rq.req, {json::serialization_format::json_v2});
+    parse::content_type_header(*rq.req, {json::serialization_format::v2});
     parse::accept_header(
       *rq.req,
-      {json::serialization_format::json_v2, json::serialization_format::none});
+      {json::serialization_format::v2, json::serialization_format::none});
 
     auto group_id{parse::request_param<kafka::group_id>(*rq.req, "group_name")};
     auto member_id{parse::request_param<kafka::member_id>(*rq.req, "instance")};

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -91,7 +91,9 @@ get_topics_records(server::request_t rq, server::reply_t rp) {
       *rq.req,
       {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
-      *rq.req, {json::serialization_format::binary_v2});
+      *rq.req,
+      {json::serialization_format::binary_v2,
+       json::serialization_format::json_v2});
 
     auto tp{model::topic_partition{
       parse::request_param<model::topic>(*rq.req, "topic_name"),
@@ -121,7 +123,9 @@ get_topics_records(server::request_t rq, server::reply_t rp) {
 ss::future<server::reply_t>
 post_topics_name(server::request_t rq, server::reply_t rp) {
     auto req_fmt = parse::content_type_header(
-      *rq.req, {json::serialization_format::binary_v2});
+      *rq.req,
+      {json::serialization_format::binary_v2,
+       json::serialization_format::json_v2});
     auto res_fmt = parse::accept_header(
       *rq.req,
       {json::serialization_format::v2, json::serialization_format::none});
@@ -167,9 +171,10 @@ create_consumer(server::request_t rq, server::reply_t rp) {
     auto req_data = ppj::rjson_parse(
       rq.req->content.data(), ppj::create_consumer_request_handler());
 
-    if (req_data.format != "binary") {
+    if (req_data.format != "binary" && req_data.format != "json") {
         throw parse::error(
-          parse::error_code::invalid_param, "format must be binary");
+          parse::error_code::invalid_param,
+          "format must be 'binary' or 'json'");
     }
     if (req_data.auto_offset_reset != "earliest") {
         throw parse::error(
@@ -240,7 +245,9 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
       *rq.req,
       {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
-      *rq.req, {json::serialization_format::binary_v2});
+      *rq.req,
+      {json::serialization_format::binary_v2,
+       json::serialization_format::json_v2});
 
     auto group_id{parse::request_param<kafka::group_id>(*rq.req, "group_name")};
     auto name{parse::request_param<kafka::member_id>(*rq.req, "instance")};

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -52,33 +52,6 @@ namespace ppj = pandaproxy::json;
 
 namespace pandaproxy {
 
-ppj::serialization_format parse_serialization_format(std::string_view accept) {
-    std::vector<std::string_view> none = {
-      "", "*/*", "application/json", "application/vnd.kafka.v2+json"};
-
-    std::vector<ss::sstring> results;
-    boost::split(
-      results, accept, boost::is_any_of(",; "), boost::token_compress_on);
-
-    if (std::any_of(results.begin(), results.end(), [](std::string_view v) {
-            return v == "application/vnd.kafka.binary.v2+json";
-        })) {
-        return ppj::serialization_format::binary_v2;
-    }
-
-    if (std::any_of(
-          results.begin(), results.end(), [&none](std::string_view lhs) {
-              return std::any_of(
-                none.begin(), none.end(), [lhs](std::string_view rhs) {
-                    return lhs == rhs;
-                });
-          })) {
-        return ppj::serialization_format::none;
-    }
-
-    return ppj::serialization_format::unsupported;
-}
-
 ss::future<server::reply_t>
 get_topics_names(server::request_t rq, server::reply_t rp) {
     parse::content_type_header(

--- a/src/v/pandaproxy/handlers.cc
+++ b/src/v/pandaproxy/handlers.cc
@@ -87,7 +87,9 @@ get_topics_names(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 get_topics_records(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(*rq.req, {json::serialization_format::v2});
+    parse::content_type_header(
+      *rq.req,
+      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req, {json::serialization_format::binary_v2});
 

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -68,6 +68,8 @@ public:
             [[fallthrough]];
         case serialization_format::binary_v2:
             return encode_base64(w, std::move(buf));
+        case serialization_format::json_v2:
+            return encode_json(w, std::move(buf));
         case serialization_format::unsupported:
             [[fallthrough]];
         default:
@@ -82,6 +84,18 @@ public:
         }
         // TODO Ben: Implement custom OutputStream to prevent this linearization
         return w.String(iobuf_to_base64(buf));
+    };
+
+    bool encode_json(rapidjson::Writer<rapidjson::StringBuffer>& w, iobuf buf) {
+        if (buf.empty()) {
+            return w.Null();
+        }
+        iobuf_parser p{std::move(buf)};
+        auto str = p.read_string(p.bytes_left());
+        static_assert(str.padding(), "StringStream requires null termination");
+        rapidjson::Reader reader;
+        rapidjson::StringStream ss{str.c_str()};
+        return reader.Parse(ss, w);
     };
 
 private:

--- a/src/v/pandaproxy/json/iobuf.h
+++ b/src/v/pandaproxy/json/iobuf.h
@@ -78,7 +78,7 @@ public:
     bool
     encode_base64(rapidjson::Writer<rapidjson::StringBuffer>& w, iobuf buf) {
         if (buf.empty()) {
-            return w.String("", 0);
+            return w.Null();
         }
         // TODO Ben: Implement custom OutputStream to prevent this linearization
         return w.String(iobuf_to_base64(buf));

--- a/src/v/pandaproxy/json/requests/test/fetch.cc
+++ b/src/v/pandaproxy/json/requests/test/fetch.cc
@@ -93,7 +93,7 @@ SEASTAR_THREAD_TEST_CASE(test_produce_fetch_one) {
     ppj::rjson_serialize_fmt(fmt)(w, std::move(res));
 
     auto expected
-      = R"([{"topic":"topic1","key":"KgAAAAAAAAA=","value":"","partition":1,"offset":42},{"topic":"topic2","key":"KgAAAAAAAAA=","value":"","partition":2,"offset":42}])";
+      = R"([{"topic":"topic1","key":"KgAAAAAAAAA=","value":null,"partition":1,"offset":42},{"topic":"topic2","key":"KgAAAAAAAAA=","value":null,"partition":2,"offset":42}])";
 
     BOOST_REQUIRE_EQUAL(str_buf.GetString(), expected);
 }

--- a/src/v/pandaproxy/json/types.h
+++ b/src/v/pandaproxy/json/types.h
@@ -18,6 +18,7 @@ namespace pandaproxy::json {
 
 enum class serialization_format : uint8_t {
     none = 0,
+    v2,
     json_v2,
     binary_v2,
     unsupported
@@ -27,8 +28,10 @@ inline std::string_view name(serialization_format fmt) {
     switch (fmt) {
     case pandaproxy::json::serialization_format::none:
         return "none";
-    case pandaproxy::json::serialization_format::json_v2:
+    case pandaproxy::json::serialization_format::v2:
         return "application/vnd.kafka.v2+json";
+    case pandaproxy::json::serialization_format::json_v2:
+        return "application/vnd.kafka.json.v2+json";
     case pandaproxy::json::serialization_format::binary_v2:
         return "application/vnd.kafka.binary.v2+json";
     case pandaproxy::json::serialization_format::unsupported:

--- a/src/v/pandaproxy/parsing/test/httpd.cc
+++ b/src/v/pandaproxy/parsing/test/httpd.cc
@@ -44,6 +44,13 @@ static const std::vector<
     // Prefer first entry
     {name(ppjfmt::json_v2), {ppjfmt::json_v2, ppjfmt::none}, ppjfmt::json_v2},
     {"", {ppjfmt::json_v2, ppjfmt::none}, ppjfmt::json_v2},
+    // Support two types
+    {name(ppjfmt::json_v2),
+     {ppjfmt::json_v2, ppjfmt::binary_v2},
+     ppjfmt::json_v2},
+    {name(ppjfmt::binary_v2),
+     {ppjfmt::json_v2, ppjfmt::binary_v2},
+     ppjfmt::binary_v2},
     // Unsupported
     {name(ppjfmt::json_v2),
      {ppjfmt::binary_v2, ppjfmt::none},

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -188,7 +188,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":"","value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":"","value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":"","value":"bXVsdGlicm9rZXI=","partition":0,"offset":3}])");
+          R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":3}])");
     }
 
     {

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -47,8 +47,8 @@ auto get_consumer_offsets(
       fmt::format("/consumers/{}/instances/{}/offsets", g_id(), m_id()),
       std::move(body),
       boost::beast::http::verb::get,
-      ppj::serialization_format::json_v2,
-      ppj::serialization_format::json_v2);
+      ppj::serialization_format::v2,
+      ppj::serialization_format::v2);
     return res;
 };
 
@@ -80,8 +80,8 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           fmt::format("/consumers/{}", group_id()),
           std::move(req_body_buf),
           boost::beast::http::verb::post,
-          ppj::serialization_format::json_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2,
+          ppj::serialization_format::v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
 
@@ -99,7 +99,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
             member_id()));
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
-          to_header_value(ppj::serialization_format::json_v2));
+          to_header_value(ppj::serialization_format::v2));
     }
     info("Member id: {}", member_id);
 
@@ -131,8 +131,8 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
             "/consumers/{}/instances/{}/subscription", group_id(), member_id()),
           std::move(req_body_buf),
           boost::beast::http::verb::post,
-          ppj::serialization_format::json_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2,
+          ppj::serialization_format::v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
     }
@@ -164,7 +164,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           std::move(body),
           boost::beast::http::verb::post,
           ppj::serialization_format::binary_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -182,7 +182,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
             "1000",
             "1000000"),
           boost::beast::http::verb::get,
-          ppj::serialization_format::json_v2,
+          ppj::serialization_format::v2,
           ppj::serialization_format::binary_v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -220,8 +220,8 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
             "/consumers/{}/instances/{}/offsets", group_id(), member_id()),
           std::move(body),
           boost::beast::http::verb::post,
-          ppj::serialization_format::json_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2,
+          ppj::serialization_format::v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::no_content);
     }
@@ -243,8 +243,8 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           fmt::format(
             "/consumers/{}/instances/{}/offsets", group_id(), member_id()),
           boost::beast::http::verb::post,
-          ppj::serialization_format::json_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2,
+          ppj::serialization_format::v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::no_content);
     }
@@ -265,8 +265,8 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           client,
           fmt::format("/consumers/{}/instances/{}", group_id(), member_id()),
           boost::beast::http::verb::delete_,
-          ppj::serialization_format::json_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2,
+          ppj::serialization_format::v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::no_content);
     }
@@ -277,8 +277,8 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           client,
           fmt::format("/consumers/{}/instances/{}", group_id(), member_id()),
           boost::beast::http::verb::delete_,
-          ppj::serialization_format::json_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2,
+          ppj::serialization_format::v2);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::not_found);
     }

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -209,3 +209,72 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":3},{"topic":"t","key":null,"value":"bXVsdGliYXRjaA==","partition":0,"offset":4}])");
     }
 }
+
+FIXTURE_TEST(pandaproxy_fetch_json_v2, pandaproxy_test_fixture) {
+    using namespace std::chrono_literals;
+
+    set_client_config("retry_base_backoff_ms", 10ms);
+    set_client_config("produce_batch_delay_ms", 0ms);
+
+    info("Waiting for leadership");
+    wait_for_controller_leadership().get();
+
+    info("Connecting client");
+    auto client = make_client();
+    const ss::sstring batch_body(
+      R"({
+   "records":[
+      {
+         "key": null,
+         "value":{"object":["vectorized"]},
+         "partition":0
+      },
+      {
+         "value":{"object":["pandaproxy"]},
+         "partition":0
+      }
+   ]
+})");
+
+    info("Adding known topic");
+    auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
+    auto ntp = make_default_ntp(tp.topic, tp.partition);
+    add_topic(model::topic_namespace_view(ntp)).get();
+
+    {
+        info("Produce to known topic - offsets 1-3");
+        // Will require a metadata update
+        set_client_config("retries", size_t(5));
+        auto body = iobuf();
+        body.append(batch_body.data(), batch_body.size());
+        auto res = http_request(
+          client,
+          "/topics/t",
+          std::move(body),
+          boost::beast::http::verb::post,
+          ppj::serialization_format::json_v2,
+          ppj::serialization_format::v2);
+
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(
+          res.body, R"({"offsets":[{"partition":0,"offset":1}]})");
+    }
+
+    {
+        info("Fetch offset 2 as json - expect offsets 1-2");
+        auto res = http_request(
+          client,
+          "/topics/t/partitions/0/"
+          "records?offset=2&max_bytes=1024&timeout=5000",
+          boost::beast::http::verb::get,
+          ppj::serialization_format::v2,
+          ppj::serialization_format::json_v2);
+
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+        BOOST_REQUIRE_EQUAL(
+          res.body,
+          R"([{"topic":"t","key":null,"value":{"object":["vectorized"]},"partition":0,"offset":1},{"topic":"t","key":null,"value":{"object":["pandaproxy"]},"partition":0,"offset":2}])");
+    }
+}

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -153,7 +153,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":"","value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":"","value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":"","value":"bXVsdGlicm9rZXI=","partition":0,"offset":3}])");
+          R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":3}])");
     }
 
     {
@@ -189,7 +189,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":"","value":"bXVsdGliYXRjaA==","partition":0,"offset":4}])");
+          R"([{"topic":"t","key":null,"value":"bXVsdGliYXRjaA==","partition":0,"offset":4}])");
     }
 
     {
@@ -206,6 +206,6 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":"","value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":"","value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":"","value":"bXVsdGlicm9rZXI=","partition":0,"offset":3},{"topic":"t","key":"","value":"bXVsdGliYXRjaA==","partition":0,"offset":4}])");
+          R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":3},{"topic":"t","key":null,"value":"bXVsdGliYXRjaA==","partition":0,"offset":4}])");
     }
 }

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -67,7 +67,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           "/topics//partitions/0/"
           "records?max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
-          ppj::serialization_format::json_v2,
+          ppj::serialization_format::v2,
           ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
@@ -85,7 +85,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           "/topics//partitions/0/"
           "records?offset=0&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
-          ppj::serialization_format::json_v2,
+          ppj::serialization_format::v2,
           ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
@@ -103,7 +103,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           "/topics/t/partitions/0/"
           "records?offset=0&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
-          ppj::serialization_format::json_v2,
+          ppj::serialization_format::v2,
           ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
@@ -130,7 +130,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           std::move(body),
           boost::beast::http::verb::post,
           ppj::serialization_format::binary_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -146,7 +146,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           "/topics/t/partitions/0/"
           "records?offset=0&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
-          ppj::serialization_format::json_v2,
+          ppj::serialization_format::v2,
           ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
@@ -167,7 +167,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           std::move(body),
           boost::beast::http::verb::post,
           ppj::serialization_format::binary_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -182,7 +182,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           "/topics/t/partitions/0/"
           "records?offset=4&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
-          ppj::serialization_format::json_v2,
+          ppj::serialization_format::v2,
           ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(
@@ -199,7 +199,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           "/topics/t/partitions/0/"
           "records?offset=2&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
-          ppj::serialization_format::json_v2,
+          ppj::serialization_format::v2,
           ppj::serialization_format::binary_v2);
 
         BOOST_REQUIRE_EQUAL(

--- a/src/v/pandaproxy/test/list_topics.cc
+++ b/src/v/pandaproxy/test/list_topics.cc
@@ -35,7 +35,7 @@ FIXTURE_TEST(pandaproxy_list_topics, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(res.body, R"([])");
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
-          to_header_value(serialization_format::json_v2));
+          to_header_value(serialization_format::v2));
     }
 
     info("Adding known topic");

--- a/src/v/pandaproxy/test/produce.cc
+++ b/src/v/pandaproxy/test/produce.cc
@@ -59,13 +59,13 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
           std::move(body),
           boost::beast::http::verb::post,
           ppj::serialization_format::binary_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
-          to_header_value(serialization_format::json_v2));
+          to_header_value(serialization_format::v2));
         BOOST_REQUIRE_EQUAL(
           res.body,
           R"({"offsets":[{"partition":0,"error_code":3,"offset":-1}]})");
@@ -88,7 +88,7 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
           std::move(body),
           boost::beast::http::verb::post,
           ppj::serialization_format::binary_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
@@ -107,7 +107,7 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
           std::move(body),
           boost::beast::http::verb::post,
           ppj::serialization_format::binary_v2,
-          ppj::serialization_format::json_v2);
+          ppj::serialization_format::v2);
 
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -18,7 +18,7 @@ quick:
   - tests/compacted_term_rolled_recovery_test.py
   - tests/compacted_topic_verifier_test.py
   - tests/compaction_recovery_test.py
-  - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group
+  - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group_binary_v2
   - tests/pandaproxy_test.py::PandaProxyTest.test_subscribe_consumer_validation
   - tests/pandaproxy_test.py::PandaProxyTest.test_remove_consumer_validation
   - tests/wasm_failure_recovery_test.py

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -19,6 +19,7 @@ quick:
   - tests/compacted_topic_verifier_test.py
   - tests/compaction_recovery_test.py
   - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group_binary_v2
+  - tests/pandaproxy_test.py::PandaProxyTest.test_consumer_group_json_v2
   - tests/pandaproxy_test.py::PandaProxyTest.test_subscribe_consumer_validation
   - tests/pandaproxy_test.py::PandaProxyTest.test_remove_consumer_validation
   - tests/wasm_failure_recovery_test.py

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -40,6 +40,11 @@ HTTP_PRODUCE_BINARY_V2_TOPIC_HEADERS = {
     "Content-Type": "application/vnd.kafka.binary.v2+json"
 }
 
+HTTP_PRODUCE_JSON_V2_TOPIC_HEADERS = {
+    "Accept": "application/vnd.kafka.v2+json",
+    "Content-Type": "application/vnd.kafka.json.v2+json"
+}
+
 HTTP_CREATE_CONSUMER_HEADERS = {
     "Accept": "application/vnd.kafka.v2+json",
     "Content-Type": "application/vnd.kafka.v2+json"
@@ -57,6 +62,11 @@ HTTP_REMOVE_CONSUMER_HEADERS = {
 
 HTTP_CONSUMER_FETCH_BINARY_V2_HEADERS = {
     "Accept": "application/vnd.kafka.binary.v2+json",
+    "Content-Type": "application/vnd.kafka.v2+json"
+}
+
+HTTP_CONSUMER_FETCH_JSON_V2_HEADERS = {
+    "Accept": "application/vnd.kafka.json.v2+json",
     "Content-Type": "application/vnd.kafka.v2+json"
 }
 
@@ -715,6 +725,59 @@ class PandaProxyTest(RedpandaTest):
         assert len(co_res["offsets"]) == 9
         for i in range(len(co_res["offsets"])):
             assert co_res["offsets"][i]["offset"] == 1
+
+        # Remove consumer
+        self.logger.info("Remove consumer")
+        rc_res = c0.remove()
+        assert rc_res.status_code == requests.codes.no_content
+
+    @cluster(num_nodes=3)
+    def test_consumer_group_json_v2(self):
+        """
+        Create a consumer group and use it
+        """
+
+        group_id = f"pandaproxy-group-{uuid.uuid4()}"
+
+        # Create 3 topics
+        topics = self._create_topics(create_topic_names(3), 3, 3)
+
+        for name in topics:
+            self.logger.info(f"Producing to topic: {name}")
+            produce_result_raw = self._produce_topic(
+                name,
+                '''
+            {
+                "records": [
+                    {"value": {"object":["vectorized"]}, "partition": 0},
+                    {"value": {"object":["pandaproxy"]}, "partition": 0},
+                    {"value": {"object":["multibroker"]}, "partition": 0}
+                ]
+            }''',
+                headers=HTTP_PRODUCE_JSON_V2_TOPIC_HEADERS)
+            print(produce_result_raw.content)
+            assert produce_result_raw.status_code == requests.codes.ok
+
+        # Create a consumer
+        self.logger.info("Create a consumer")
+        cc_res = self._create_consumer(group_id)
+        assert cc_res.status_code == requests.codes.ok
+        c0 = Consumer(cc_res.json())
+
+        # Subscribe a consumer
+        self.logger.info(f"Subscribe consumer to topics: {topics}")
+        sc_res = c0.subscribe(topics)
+        assert sc_res.status_code == requests.codes.ok
+
+        # Fetch from a consumer
+        self.logger.info(f"Consumer fetch")
+        cf_res = c0.fetch(headers=HTTP_CONSUMER_FETCH_JSON_V2_HEADERS)
+        assert cf_res.status_code == requests.codes.ok
+        fetch_result = cf_res.json()
+        # 3 topics * 3 msg
+        assert len(fetch_result) == 3 * 3
+        for r in fetch_result:
+            assert r["value"]["object"]
 
         # Remove consumer
         self.logger.info("Remove consumer")

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -450,7 +450,7 @@ class PandaProxyTest(RedpandaTest):
         expected = json.loads(data)
         assert len(fetch_result_0) == 1
         assert fetch_result_0[0]["topic"] == name
-        assert fetch_result_0[0]["key"] == ''
+        assert fetch_result_0[0]["key"] is None
         assert fetch_result_0[0]["value"] == expected["records"][0]["value"]
         assert fetch_result_0[0]["partition"] == expected["records"][0][
             "partition"]

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -35,7 +35,7 @@ HTTP_FETCH_TOPIC_HEADERS = {
     "Content-Type": "application/vnd.kafka.v2+json"
 }
 
-HTTP_PRODUCE_TOPIC_HEADERS = {
+HTTP_PRODUCE_BINARY_V2_TOPIC_HEADERS = {
     "Accept": "application/vnd.kafka.v2+json",
     "Content-Type": "application/vnd.kafka.binary.v2+json"
 }
@@ -55,7 +55,7 @@ HTTP_REMOVE_CONSUMER_HEADERS = {
     "Content-Type": "application/vnd.kafka.v2+json"
 }
 
-HTTP_CONSUMER_FETCH_HEADERS = {
+HTTP_CONSUMER_FETCH_BINARY_V2_HEADERS = {
     "Accept": "application/vnd.kafka.binary.v2+json",
     "Content-Type": "application/vnd.kafka.v2+json"
 }
@@ -86,7 +86,7 @@ class Consumer:
         res = requests.delete(self.base_uri, headers=headers)
         return res
 
-    def fetch(self, headers=HTTP_CONSUMER_FETCH_HEADERS):
+    def fetch(self, headers=HTTP_CONSUMER_FETCH_BINARY_V2_HEADERS):
         res = requests.get(f"{self.base_uri}/records", headers=headers)
         return res
 
@@ -146,7 +146,10 @@ class PandaProxyTest(RedpandaTest):
     def _get_topics(self, headers=HTTP_GET_TOPICS_HEADERS):
         return requests.get(f"{self._base_uri()}/topics", headers=headers)
 
-    def _produce_topic(self, topic, data, headers=HTTP_PRODUCE_TOPIC_HEADERS):
+    def _produce_topic(self,
+                       topic,
+                       data,
+                       headers=HTTP_PRODUCE_BINARY_V2_TOPIC_HEADERS):
         return requests.post(f"{self._base_uri()}/topics/{topic}",
                              data,
                              headers=headers)
@@ -633,7 +636,7 @@ class PandaProxyTest(RedpandaTest):
         assert sc_res.status_code == requests.codes.no_content
 
     @cluster(num_nodes=3)
-    def test_consumer_group(self):
+    def test_consumer_group_binary_v2(self):
         """
         Create a consumer group and use it
         """

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -393,10 +393,9 @@ class PandaProxyTest(RedpandaTest):
             name,
             0,
             headers={"Accept": "application/vnd.kafka.binary.v2+json"})
-        assert fetch_raw_result.status_code == requests.codes.unsupported_media_type
+        assert fetch_raw_result.status_code == requests.codes.not_found
         fetch_result = fetch_raw_result.json()
-        assert fetch_result[
-            "error_code"] == requests.codes.unsupported_media_type
+        assert fetch_result["error_code"] == 40402
 
         self.logger.info(f"Consuming with no accept header")
         fetch_raw_result = self._fetch_topic(


### PR DESCRIPTION
## Cover letter

There's still a failing test for fetch - should be a minor issue.

Support `json_v2` serialisation format for produce and consume.

* Fix `json_v2` vs `v2`
  * `v2` represents the overall protocol
  * `json_v2` represents the produce/consumer serialisation protocol
* pandaproxy: Support `json_v2`
* pandaproxy: A null key/value should report `null` instead of empty string`""` (with `binary_v2`)
* pandaproxy: Fetch now support` not specifying `Content-Type`, the same as `consumer_fetch`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/005d22f1725cfc8c3dd9e43877c76ce74499841d..91839d18fe0fa069456152f5b88eeb4fcf9c5745)

* Rebase over #1155 
* Fix consume: `rjson_serialize_impl<iobuf>::encode_json`
* pandaproxy: A null key/value should report `null` instead of empty string`""` (with `binary_v2`)
* pandaproxy: Fetch now supports not specifying `Content-Type`, the same as `consumer_fetch`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/91839d18fe0fa069456152f5b88eeb4fcf9c5745..2304181bc44ebebcdc19aab6abc4f51f6a05328c)
* Swap `GetLength()` for `GetSize()` because gcc-10.2 can't see `GetLength()`, for some unfathomable reason.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/2304181bc44ebebcdc19aab6abc4f51f6a05328c..8f27eb76725174dad6f5edf3de41d662cd87fd09)

* Add a `static_assert` requiring/documenting  a null-terminated string

## Release notes

Release note: Pandaproxy: Support json_v2 serialisation for produce and consume
