### PR TITLE
Fix wasm failure recovery within heartbeat timeout interval

### DIFF
--- a/src/js/modules/domain/generatedRpc/entitiesDefinition.json
+++ b/src/js/modules/domain/generatedRpc/entitiesDefinition.json
@@ -355,11 +355,11 @@
       ]
     },
     {
-      "className": "EmptyResponse",
+      "className": "StateSizeT",
       "fields": [
         {
-          "name": "empty",
-          "type": "int8"
+          "name": "size",
+          "type": "int64"
         }
       ]
     }

--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -15,7 +15,6 @@ import {
   DisableCoprosReply,
   DisableCoprosRequest,
   EmptyRequest,
-  EmptyResponse,
   EnableCoprocessor,
   EnableCoprocessorRequestData,
   EnableCoprosReply,
@@ -24,6 +23,7 @@ import {
   ProcessBatchReplyItem,
   ProcessBatchRequest,
   ProcessBatchRequestItem,
+  StateSizeT,
 } from "../domain/generatedRpc/generatedClasses";
 import { SupervisorServer } from "./serverAndClients/rpcServer";
 import { Handle } from "../domain/Handle";
@@ -99,8 +99,8 @@ export class ProcessBatchServer extends SupervisorServer {
     return Promise.resolve({ responses });
   }
 
-  heartbeat(input: EmptyRequest): Promise<EmptyResponse> {
-    return Promise.resolve({ empty: 0 });
+  heartbeat(input: EmptyRequest): Promise<StateSizeT> {
+    return Promise.resolve({ size: BigInt(this.repository.size()) });
   }
 
   validateEnableCoprocInput(

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -74,10 +74,6 @@ private:
 
     /// Used to make requests to the wasm engine
     script_dispatcher _dispatcher;
-
-    /// Used to determine if wasm engine is recovering from failure. Initialized
-    /// to true to initiate recovery at every startup
-    bool _last_heartbeat_failed{true};
 };
 
 } // namespace coproc::wasm

--- a/src/v/coproc/gen.json
+++ b/src/v/coproc/gen.json
@@ -27,7 +27,7 @@
     {
       "name": "heartbeat",
       "input_type": "empty_request",
-      "output_type": "empty_response"
+      "output_type": "state_size_t"
     }
   ]
 }

--- a/src/v/coproc/gen.json
+++ b/src/v/coproc/gen.json
@@ -1,35 +1,33 @@
 {
-    "namespace": "coproc",
-    "service_name": "supervisor",
-    "includes": [
-        "coproc/types.h"
-    ],
-    "js_include": "../../domain/generatedRpc/generatedClasses",
-    "methods": [
-        {
-            "name": "enable_coprocessors",
-            "input_type": "enable_copros_request",
-            "output_type": "enable_copros_reply"
-        },
-        {
-            "name": "disable_coprocessors",
-            "input_type": "disable_copros_request",
-            "output_type": "disable_copros_reply"
-        },
-        {
-            "name": "disable_all_coprocessors",
-            "input_type": "empty_request",
-            "output_type": "disable_copros_reply"
-        },
-        {
-            "name": "process_batch",
-            "input_type": "process_batch_request",
-            "output_type": "process_batch_reply"
-        },
-        {
-            "name": "heartbeat",
-            "input_type": "empty_request",
-            "output_type": "empty_response"
-        }
-    ]
+  "namespace": "coproc",
+  "service_name": "supervisor",
+  "includes": ["coproc/types.h"],
+  "js_include": "../../domain/generatedRpc/generatedClasses",
+  "methods": [
+    {
+      "name": "enable_coprocessors",
+      "input_type": "enable_copros_request",
+      "output_type": "enable_copros_reply"
+    },
+    {
+      "name": "disable_coprocessors",
+      "input_type": "disable_copros_request",
+      "output_type": "disable_copros_reply"
+    },
+    {
+      "name": "disable_all_coprocessors",
+      "input_type": "empty_request",
+      "output_type": "disable_copros_reply"
+    },
+    {
+      "name": "process_batch",
+      "input_type": "process_batch_request",
+      "output_type": "process_batch_reply"
+    },
+    {
+      "name": "heartbeat",
+      "input_type": "empty_request",
+      "output_type": "empty_response"
+    }
+  ]
 }

--- a/src/v/coproc/script_dispatcher.h
+++ b/src/v/coproc/script_dispatcher.h
@@ -47,7 +47,8 @@ public:
     ss::future<std::error_code> disable_all_coprocessors();
 
     /// Invoke this to query weather the wasm engine is up or not
-    ss::future<bool> heartbeat(int8_t connect_attempts = 3);
+    ss::future<result<rpc::client_context<state_size_t>>>
+    heartbeat(int8_t connect_attempts = 3);
 
 private:
     /// The following methods are introduced to sidestep an issue detected when

--- a/src/v/coproc/tests/utils/supervisor.h
+++ b/src/v/coproc/tests/utils/supervisor.h
@@ -20,6 +20,7 @@
 #include <seastar/core/map_reduce.hh>
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_set.h>
 
 namespace coproc {
 using script_map_t = absl::btree_map<script_id, std::unique_ptr<coprocessor>>;
@@ -66,10 +67,11 @@ public:
     process_batch(process_batch_request&&, rpc::streaming_context&) final;
 
     /// Called to verify the supervisor is up
-    ss::future<empty_response>
+    ss::future<state_size_t>
     heartbeat(empty_request&&, rpc::streaming_context&) final;
 
 private:
+    ss::future<absl::node_hash_set<script_id>> registered_scripts();
     ss::future<disable_copros_reply::ack> disable_coprocessor(script_id);
     ss::future<enable_copros_reply::data> enable_coprocessor(script_id, iobuf);
     ss::future<enable_copros_reply::data> launch(

--- a/src/v/coproc/types.h
+++ b/src/v/coproc/types.h
@@ -77,7 +77,7 @@ struct enable_copros_reply {
 
 /// Stub for what should be 0 parameter method, 'disable_all_coprocessors'
 using empty_request = named_type<int8_t, struct empty_req_tag>;
-using empty_response = named_type<int8_t, struct empty_resp_tag>;
+using state_size_t = named_type<int64_t, struct state_size_tag>;
 
 /// \brief deregistration request, remove all topics registered to a coprocessor
 /// with id 'script_id'.

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -79,13 +79,6 @@ class WasmTest(RedpandaTest):
         self.logger.info(
             f"Begin manually triggered restart of wasm engine on node {node}")
         node.account.kill_process("bin/node", clean_shutdown=False)
-        # TODO: This sleep is put here to ensure that redpanda will initiate
-        # a failure recovery mechanism. In the event the wasm engine restarts
-        # too quickly, it will have responded to all heartbeats, and redpanda will
-        # falsely think that the state between the wasm engine and itself are
-        # in-sync when they will not be. Github issue #1140 has been filed to keep
-        # track of this issue.
-        time.sleep(3)
         self.redpanda.start_wasm_engine(node)
 
     def restart_redpanda(self, node):


### PR DESCRIPTION
This PR fixes an issue with the failure recovery mechanism within v/coproc. Currently a heartbeat mechanism is used to determine when the wasm engine is up or not, if the wasm engine doesn't respond to the heartbeat within 1s its considered to be lost, and upon next connection the failure recovery mechanism will be initiated. However this does not tell us anything about the wasm engines internal state. 

Consider the case where the wasm engine crashes, and quickly restarts, within this 1s heartbeat interval. Redpanda would not have started the failure recovery mechanism, and since the wasm engine keeps all state in memory it is now lost and there is a discrepancy between what redpanda and the wasm engine believe the state of the world (all registered coprocessors) is.

This PR modifies the heartbeat endpoint to return an integer which represents the number of registered scripts. If this value returned doesn't match what redpanda believes to be true, state is wiped and reconciled. This works irrespective of the interval in which the wasm engine awakes from failure. 