### PR TITLE
s3: Add probes for s3::client and http::client

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -116,6 +116,8 @@ scheduler_service_impl::get_archival_service_config() {
       "cloud_storage_access_key"));
     auto region = s3::aws_region_name(get_value_or_throw(
       config::shard_local_cfg().cloud_storage_region, "cloud_storage_region"));
+    auto disable_metrics = rpc::metrics_disabled(
+      config::shard_local_cfg().disable_metrics());
 
     // Set default overrides
     s3::default_overrides overrides;
@@ -132,7 +134,7 @@ scheduler_service_impl::get_archival_service_config() {
     overrides.port = config::shard_local_cfg().cloud_storage_api_endpoint_port;
 
     auto s3_conf = co_await s3::configuration::make_configuration(
-      access_key, secret_key, region, overrides);
+      access_key, secret_key, region, overrides, disable_metrics);
     archival::configuration cfg{
       .client_config = std::move(s3_conf),
       .bucket_name = s3::bucket_name(get_value_or_throw(

--- a/src/v/http/probe.h
+++ b/src/v/http/probe.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace http {
+
+/// Simple differential counting for requests
+struct diff_counter {
+    diff_counter() = default;
+    /// Count request start
+    void start() { _started++; }
+    /// Count request termination
+    void complete() { _completed++; }
+    /// Total number of completed requests
+    uint64_t total() const { return _completed; }
+    /// Number of active requests
+    uint64_t active() const {
+        if (_completed <= _started) {
+            return _started - _completed;
+        }
+        return 0;
+    }
+
+private:
+    uint64_t _started;
+    uint64_t _completed;
+};
+
+class client_probe {
+public:
+    enum class verb {
+        get,
+        put,
+        other,
+    };
+
+    client_probe() = default;
+
+    /// Register incomming traffic
+    void add_inbound_bytes(uint64_t bytes) { _in += bytes; }
+
+    /// Register outgoing traffic
+    void add_outbound_bytes(uint64_t bytes) { _out += bytes; }
+
+    /// RAII wrapper for per-request probe
+    struct subprobe {
+        verb v;
+        client_probe& probe;
+        subprobe(verb v, client_probe& p)
+          : v(v)
+          , probe(p) {
+            switch (v) {
+            case verb::get:
+                probe._get_requests.start();
+                break;
+            case verb::put:
+                probe._put_requests.start();
+                break;
+            default:
+                break;
+            }
+            probe._all_requests.start();
+        }
+        subprobe& operator=(const subprobe&) = delete;
+        subprobe& operator=(subprobe&&) = delete;
+        subprobe(const subprobe&) = delete;
+        subprobe(subprobe&&) = delete;
+        ~subprobe() {
+            switch (v) {
+            case verb::get:
+                probe._get_requests.complete();
+                break;
+            case verb::put:
+                probe._put_requests.complete();
+                break;
+            default:
+                break;
+            }
+            probe._all_requests.complete();
+        }
+    };
+
+    auto create_request_subprobe(verb v) { return subprobe(v, *this); }
+
+    void register_transport_error() { _transport_errors += 1; }
+
+    /// Return total incomming traffic
+    uint64_t get_inbound_bytes() const { return _in; }
+
+    /// Return total outgoing traffic
+    uint64_t get_outbound_bytes() const { return _out; }
+
+    /// Return total number of transport errors
+    uint64_t get_transport_errors() const { return _transport_errors; }
+
+    /// Get total number of GET requests
+    uint64_t get_total_get_requests() const { return _get_requests.total(); }
+
+    /// Get total number of PUT requests
+    uint64_t get_total_put_requests() const { return _put_requests.total(); }
+
+    /// Get total number of requests
+    uint64_t get_total_requests() const { return _all_requests.total(); }
+
+    /// Get number of in-flight GET requests
+    uint64_t get_active_get_requests() const { return _get_requests.active(); }
+
+    /// Get number of in-flight PUT requests
+    uint64_t get_active_put_requests() const { return _put_requests.active(); }
+
+    /// Get number of in-flight requests
+    uint64_t get_active_requests() const { return _all_requests.active(); }
+
+private:
+    /// Total inbound traffic size
+    uint64_t _in;
+    /// Total outbound traffic size
+    uint64_t _out;
+    /// Number of downloads
+    diff_counter _get_requests;
+    /// Number of uploads
+    diff_counter _put_requests;
+    /// All requests
+    diff_counter _all_requests;
+    /// Number of connection errors
+    uint64_t _transport_errors;
+};
+
+} // namespace http

--- a/src/v/s3/CMakeLists.txt
+++ b/src/v/s3/CMakeLists.txt
@@ -5,6 +5,7 @@ v_cc_library(
     client.cc
     signature.cc
     error.cc
+    client_probe.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -12,6 +12,8 @@
 
 #include "http/client.h"
 #include "rpc/transport.h"
+#include "rpc/types.h"
+#include "s3/client_probe.h"
 #include "s3/signature.h"
 #include "tristate.h"
 
@@ -56,6 +58,8 @@ struct configuration : rpc::base_transport::configuration {
     private_key_str secret_key;
     /// AWS region
     aws_region_name region;
+    /// Metrics probe (should be created for every aws account on every shard)
+    ss::lw_shared_ptr<client_probe> _probe;
 
     /// \brief opinionated configuraiton initialization
     /// Generates uri field from region, initializes credentials for the
@@ -72,7 +76,8 @@ struct configuration : rpc::base_transport::configuration {
       const public_key_str& pkey,
       const private_key_str& skey,
       const aws_region_name& region,
-      const default_overrides overrides = {});
+      const default_overrides& overrides = {},
+      rpc::metrics_disabled disable_metrics = rpc::metrics_disabled::yes);
 };
 
 std::ostream& operator<<(std::ostream& o, const configuration& c);
@@ -184,6 +189,7 @@ public:
 private:
     request_creator _requestor;
     http::client _client;
+    ss::lw_shared_ptr<client_probe> _probe;
 };
 
 } // namespace s3

--- a/src/v/s3/client_probe.cc
+++ b/src/v/s3/client_probe.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "prometheus/prometheus_sanitize.h"
+#include "s3/error.h"
+
+#include <seastar/core/metrics.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/smp.hh>
+
+#include <s3/client_probe.h>
+
+namespace s3 {
+
+client_probe::client_probe(
+  rpc::metrics_disabled disable, ss::sstring region, ss::sstring endpoint)
+  : http::client_probe()
+  , _total_rpc_errors(0)
+  , _total_slowdowns(0)
+  , _total_nosuchkeys(0) {
+    namespace sm = ss::metrics;
+    if (disable) {
+        return;
+    }
+
+    auto endpoint_label = sm::label("endpoint");
+    auto region_label = sm::label("region");
+    auto shard_label = sm::label("shard");
+
+    const std::vector<sm::label_instance> labels = {
+      endpoint_label(std::move(endpoint)),
+      region_label(std::move(region)),
+      shard_label(ss::this_shard_id())};
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("s3:client"),
+      {
+        sm::make_counter(
+          "total_uploads",
+          [this] { return get_total_put_requests(); },
+          sm::description("Number of completed PUT requests"),
+          labels),
+        sm::make_counter(
+          "total_downloads",
+          [this] { return get_total_get_requests(); },
+          sm::description("Number of completed GET requests"),
+          labels),
+        sm::make_counter(
+          "all_requests",
+          [this] { return get_total_requests(); },
+          sm::description(
+            "Number of completed HTTP requests (includes PUT and GET)"),
+          labels),
+        sm::make_gauge(
+          "active_uploads",
+          [this] { return get_active_put_requests(); },
+          sm::description("Number of active PUT requests at the moment"),
+          labels),
+        sm::make_gauge(
+          "active_downloads",
+          [this] { return get_active_get_requests(); },
+          sm::description("Number of active GET requests at the moment"),
+          labels),
+        sm::make_gauge(
+          "active_requests",
+          [this] { return get_active_requests(); },
+          sm::description("Number of active HTTP requests at the moment "
+                          "(includes PUT and GET)"),
+          labels),
+        sm::make_counter(
+          "total_inbound_bytes",
+          [this] { return get_inbound_bytes(); },
+          sm::description(
+            "Total number of bytes received from cloud storage bucket"),
+          labels),
+        sm::make_counter(
+          "total_outbound_bytes",
+          [this] { return get_outbound_bytes(); },
+          sm::description("Total number of bytes sent to cloud storage bucket"),
+          labels),
+        sm::make_counter(
+          "num_rpc_errors",
+          [this] { return _total_rpc_errors; },
+          sm::description("Total number of S3 REST API errors received from "
+                          "cloud storage provider"),
+          labels),
+        sm::make_counter(
+          "num_transport_errors",
+          [this] { return get_transport_errors(); },
+          sm::description("Total number of transport errors (TCP and TLS)"),
+          labels),
+        sm::make_counter(
+          "num_slowdowns",
+          [this] { return _total_slowdowns; },
+          sm::description("Total number of SlowDown errors received from cloud "
+                          "storage provider"),
+          labels),
+        sm::make_counter(
+          "num_nosuchkey",
+          [this] { return _total_nosuchkeys; },
+          sm::description(
+            "Total number of NoSuchKey errors received from cloud "
+            "storage provider"),
+          labels),
+      });
+}
+
+void client_probe::register_failure(s3_error_code err) {
+    if (err == s3_error_code::slow_down) {
+        _total_slowdowns += 1;
+    } else if (err == s3_error_code::no_such_key) {
+        _total_nosuchkeys += 1;
+    }
+    _total_rpc_errors += 1;
+}
+
+} // namespace s3

--- a/src/v/s3/client_probe.h
+++ b/src/v/s3/client_probe.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "http/probe.h"
+#include "model/fundamental.h"
+#include "rpc/types.h"
+#include "s3/error.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+#include <cstdint>
+
+namespace s3 {
+
+/// \brief S3 client probe
+///
+/// \note The goal of this is to measure billable traffic
+///       and performance related metrics. Since S3 client
+///       reuses the rpc::base_transport it can potentially
+///       use its probe. But this doesn't make much sence
+///       since S3 requires different approach in measuring.
+///       For instance, all connectoins are made to the same
+///       endpoint and we don't want to look at every individual
+///       http connection here because they can be transient.
+///       Approach that RPC package uses will lead to cardinality
+///       inflation in prometheous creating a lot of small
+///       time-series.
+class client_probe : public http::client_probe {
+public:
+    /// \brief Probe c-tor
+    ///
+    /// \param disable is used to switch the monitoring off
+    /// \param region is a cloud provider region
+    /// \param endpoint is a cloud provider endpoint
+    client_probe(
+      rpc::metrics_disabled disable, ss::sstring region, ss::sstring endpoint);
+
+    /// Register S3 rpc error
+    void register_failure(s3_error_code err);
+
+private:
+    /// Total number of rpc errors
+    uint64_t _total_rpc_errors;
+    /// Total number of SlowDown responses
+    uint64_t _total_slowdowns;
+    /// Total number of NoSuchKey responses
+    uint64_t _total_nosuchkeys;
+    ss::metrics::metric_groups _metrics;
+};
+
+} // namespace s3

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -12,6 +12,7 @@
 #include "bytes/iobuf_parser.h"
 #include "rpc/dns.h"
 #include "rpc/transport.h"
+#include "rpc/types.h"
 #include "s3/client.h"
 #include "s3/error.h"
 #include "s3/signature.h"
@@ -20,6 +21,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/http/function_handlers.hh>
@@ -161,6 +163,8 @@ s3::configuration transport_configuration() {
       .region = s3::aws_region_name("us-east-1"),
     };
     conf.server_addr = server_addr;
+    conf._probe = ss::make_lw_shared<s3::client_probe>(
+      rpc::metrics_disabled::yes, "region", "endpoint");
     return conf;
 }
 


### PR DESCRIPTION
## Cover letter

This PR adds metrics to http and s3 clients.
One probe is created per shard and S3 configuration combination (region and endpoint). All clients that works with the same S3 endpoint will share the same probe. The probe has the following metrics: input/output traffic in bytes, number of PUT/GET requests, number of transport errors, number of S3 REST API error responses, etc.
