### PR TITLE
Disable archival tests on CI

### DIFF
--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -12,6 +12,7 @@ quick:
   - tests/
 
   excluded:
+  - tests/archival_test.py
   - tests/librdkafka_test.py
   - tests/rpk_test.py
   - tests/demo_test.py


### PR DESCRIPTION
## Cover letter

Temporary disable archival_test.py on CI until it gets stable.


