### PR TITLE
kafka: introduce latency-based queue depth control

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -609,6 +609,66 @@ configuration::configuration()
       std::nullopt)
   , superusers(
       *this, "superusers", "List of superuser usernames", required::no, {})
+  , kafka_qdc_latency_alpha(
+      *this,
+      "kafka_qdc_latency_alpha",
+      "Smoothing parameter for kafka queue depth control latency tracking.",
+      required::no,
+      0.002)
+  , kafka_qdc_window_size_ms(
+      *this,
+      "kafka_qdc_window_size_ms",
+      "Window size for kafka queue depth control latency tracking.",
+      required::no,
+      1500ms)
+  , kafka_qdc_window_count(
+      *this,
+      "kafka_qdc_window_count",
+      "Number of windows used in kafka queue depth control latency tracking.",
+      required::no,
+      12)
+  , kafka_qdc_enable(
+      *this,
+      "kafka_qdc_enable",
+      "Enable kafka queue depth control.",
+      required::no,
+      false)
+  , kafka_qdc_depth_alpha(
+      *this,
+      "kafka_qdc_depth_alpha",
+      "Smoothing factor for kafka queue depth control depth tracking.",
+      required::no,
+      0.8)
+  , kafka_qdc_max_latency_ms(
+      *this,
+      "kafka_qdc_max_latency_ms",
+      "Max latency threshold for kafka queue depth control depth tracking.",
+      required::no,
+      80ms)
+  , kafka_qdc_idle_depth(
+      *this,
+      "kafka_qdc_idle_depth",
+      "Queue depth when idleness is detected in kafka queue depth control.",
+      required::no,
+      10)
+  , kafka_qdc_min_depth(
+      *this,
+      "kafka_qdc_min_depth",
+      "Minimum queue depth used in kafka queue depth control.",
+      required::no,
+      1)
+  , kafka_qdc_max_depth(
+      *this,
+      "kafka_qdc_max_depth",
+      "Maximum queue depth used in kafka queue depth control.",
+      required::no,
+      100)
+  , kafka_qdc_depth_update_ms(
+      *this,
+      "kafka_qdc_depth_update_ms",
+      "Update frequency for kafka queue depth control.",
+      required::no,
+      7s)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -154,6 +154,20 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_trust_file;
     one_or_many_property<ss::sstring> superusers;
 
+    // kakfa queue depth control: latency ewma
+    property<double> kafka_qdc_latency_alpha;
+    property<std::chrono::milliseconds> kafka_qdc_window_size_ms;
+    property<size_t> kafka_qdc_window_count;
+
+    // kakfa queue depth control: queue depth ewma and control
+    property<bool> kafka_qdc_enable;
+    property<double> kafka_qdc_depth_alpha;
+    property<std::chrono::milliseconds> kafka_qdc_max_latency_ms;
+    property<size_t> kafka_qdc_idle_depth;
+    property<size_t> kafka_qdc_min_depth;
+    property<size_t> kafka_qdc_max_depth;
+    property<std::chrono::milliseconds> kafka_qdc_depth_update_ms;
+
     configuration();
 
     void read_yaml(const YAML::Node& root_node) override;

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -81,6 +81,7 @@ private:
     struct session_resources {
         ss::lowres_clock::duration backpressure_delay;
         ss::semaphore_units<> memlocks;
+        ss::semaphore_units<> queue_units;
         std::unique_ptr<hdr_hist::measurement> method_latency;
     };
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -470,7 +470,6 @@ static ss::future<> do_fill_fetch_responses(
     return ss::parallel_for_each(range, [&results, &responses](size_t idx) {
         auto& res = results[idx];
         auto& resp_it = responses[idx];
-        vlog(klog.trace, "fetch reader {}", res.reader);
         // error case
         if (!res.reader) {
             resp_it.set(

--- a/src/v/kafka/server/queue_depth_monitor.h
+++ b/src/v/kafka/server/queue_depth_monitor.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/server/logger.h"
+#include "utils/queue_depth_control.h"
+#include "vlog.h"
+
+namespace kafka {
+
+struct qdc_monitor {
+    struct config {
+        double latency_alpha;
+        std::chrono::milliseconds max_latency;
+        size_t window_count;
+        std::chrono::milliseconds window_size;
+        double depth_alpha;
+        size_t idle_depth;
+        size_t min_depth;
+        size_t max_depth;
+        std::chrono::milliseconds depth_update_freq;
+    };
+
+    exponential_moving_average<std::chrono::steady_clock::duration> ema;
+    queue_depth_control qdc;
+    ss::timer<ss::lowres_clock> timer;
+    ss::lowres_clock::time_point last_update;
+
+    /*
+     * ema is initialized with an average of half the max latency. there
+     * isn't really a perfect value here. its purpose is to bootstrap the
+     * algorithm and is irrelevant after a full time window has elapsed.
+     */
+    explicit qdc_monitor(const config& cfg)
+      : ema(cfg.latency_alpha, cfg.max_latency / 2, cfg.window_count)
+      , qdc(
+          cfg.max_latency,
+          cfg.depth_alpha,
+          cfg.idle_depth,
+          cfg.min_depth,
+          cfg.max_depth) {
+        /*
+         * start the queue depth control algorithm. on each timer invocation we
+         * advance the latency tracker and optionally update the queue depth.
+         */
+        timer.set_callback([this, update_freq = cfg.depth_update_freq] {
+            auto now = ss::lowres_clock::now();
+            if ((now - last_update) < update_freq) {
+                ema.tick();
+                return;
+            }
+            auto sample = ema.sample();
+            ema.tick();
+            last_update = now;
+            qdc.update(sample);
+            vlog(
+              klog.debug,
+              "Updating queue depth to {} at latency {}",
+              qdc.depth(),
+              sample);
+        });
+
+        timer.arm_periodic(cfg.window_size);
+        last_update = ss::lowres_clock::now();
+    }
+};
+
+} // namespace kafka

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -85,7 +85,8 @@ public:
           app.id_allocator_frontend,
           app.controller->get_credential_store(),
           app.controller->get_authorizer(),
-          app.controller->get_security_frontend());
+          app.controller->get_security_frontend(),
+          std::nullopt);
     }
 
     // creates single node with default configuration

--- a/src/v/utils/ema.h
+++ b/src/v/utils/ema.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include <chrono>
+#include <vector>
+
+/*
+ * exponential weighted moving average
+ *
+ * 1. Create smoothing factor, initial average, window count
+ * 2. Update the current window by calling `update`
+ * 3. Call `tick` to advance to the next time window
+ *
+ * The implementation does not account for missed ticks, so it is best to drive
+ * ticks with a timer which is often convenient when used in some control algo.
+ * This has the added advantage that high frequency updates are cheaper because
+ * they do not need to test for and initialize new time windows.
+ *
+ * TODO:
+ *  - Generalize this on the type being counted. The structure of this ewma
+ *  utility is generic, but the implementation assumes that it is parameterized
+ *  on std::chrono durations.
+ */
+template<typename Duration>
+class exponential_moving_average {
+public:
+    using duration = Duration;
+
+    // clamp to zero below this threshold
+    static constexpr double zero_clamp = 0.001;
+
+    struct window {
+        duration total{0};
+        size_t count{0};
+    };
+
+    exponential_moving_average(
+      double smoothing_factor, duration init, size_t num_windows)
+      : _alpha(smoothing_factor)
+      , _windows(num_windows, window{.total = init, .count = 1})
+      , _current(0) {}
+
+    void update(duration sample) {
+        _windows[_current].count++;
+        _windows[_current].total += sample;
+    }
+
+    void tick() {
+        _current = (_current + 1) % _windows.size();
+        _windows[_current] = window{};
+    }
+
+    double sample() {
+        double lat_t = 0.0;
+
+        // visit windows from oldest to newest
+        auto idx = (_current + 1) % _windows.size();
+        for (auto cnt = 0U; cnt < _windows.size(); cnt++) {
+            auto& w = _windows[idx];
+
+            // current latency observation
+            double lat_cur = 0.0;
+            if (w.count > 0) {
+                auto total
+                  = std::chrono::duration_cast<std::chrono::microseconds>(
+                    w.total);
+                lat_cur = static_cast<double>(total.count())
+                          / static_cast<double>(w.count * 1000);
+            }
+
+            // apply update
+            lat_t = (1.0 - _alpha) * lat_cur + _alpha * lat_t;
+
+            // next window with wrap around
+            idx = (idx + 1) % _windows.size();
+        }
+
+        if (lat_t < zero_clamp) {
+            return 0.;
+        }
+
+        return lat_t;
+    }
+
+private:
+    const double _alpha;
+    std::vector<window> _windows;
+    size_t _current;
+};

--- a/src/v/utils/queue_depth_control.h
+++ b/src/v/utils/queue_depth_control.h
@@ -1,0 +1,81 @@
+#pragma once
+#include "seastarx.h"
+#include "utils/ema.h"
+
+#include <seastar/core/semaphore.hh>
+
+/*
+ * exponential moving average queue depth control. given a maximum latency
+ * update the number of units available in the contained semaphore which can be
+ * used to limit queue depth to control latency.
+ *
+ * when updated with a sample of `0` idleness is assumed. when idle if the depth
+ * falls below the idle depth then idle depth takes precedence. otherwise, the
+ * depth is constrained by min/max depth configuration parameters.
+ */
+class queue_depth_control {
+public:
+    queue_depth_control(
+      std::chrono::milliseconds max_latency,
+      double smoothing_factor,
+      size_t idle_depth,
+      size_t min_depth,
+      size_t max_depth)
+      : _max_latency(max_latency.count()) // NOLINT
+      , _gamma(smoothing_factor)
+      , _idle_depth(idle_depth)
+      , _min_depth(min_depth)
+      , _max_depth(max_depth)
+      , _curr_depth(_idle_depth)
+      , _queue(_curr_depth) {}
+
+    void update(const double sample) {
+        auto new_depth = static_cast<size_t>(
+          (1.0 - _gamma) * static_cast<double>(_curr_depth));
+
+        // if it appears we've gone idle no windowing update is made based on
+        // the current latency measurement, and the overall queue depth will
+        // begin to decrease reverting eventually to the idle depth.
+        if (sample > 0) {
+            new_depth += static_cast<size_t>(
+              (_gamma
+               * ((_max_latency / sample) * static_cast<double>(_curr_depth))));
+        }
+
+        // apply depth bounds
+        if (new_depth < _min_depth) {
+            new_depth = _min_depth;
+        } else if (new_depth > _max_depth) {
+            new_depth = _max_depth;
+        }
+
+        // revert to idle
+        if (sample == 0 && new_depth < _idle_depth) {
+            new_depth = _idle_depth;
+        }
+
+        // adjust allowed queue depth
+        if (new_depth < _curr_depth) {
+            _queue.consume(_curr_depth - new_depth);
+        } else if (new_depth > _curr_depth) {
+            _queue.signal(new_depth - _curr_depth);
+        }
+
+        _curr_depth = new_depth;
+    }
+
+    size_t depth() const { return _curr_depth; }
+
+    ss::future<ss::semaphore_units<>> get_unit() {
+        return ss::get_units(_queue, 1);
+    }
+
+private:
+    const double _max_latency;
+    const double _gamma;
+    const size_t _idle_depth;
+    const size_t _min_depth;
+    const size_t _max_depth;
+    size_t _curr_depth;
+    ss::semaphore _queue;
+};


### PR DESCRIPTION
Kafka producers offering load that lead to saturation experienced high latencies
because produce requests were queueing up at the kafka layer above raft. While
raft applies backpressure properly, that backpressure is not propogated to the
kafka network connection and thus pressure never reaches the client (until
memory reservations are exhuasted).

This patch introduces a basic control algorithm that monitors produce latency
and adjusted the queue depth at the connection level with the goal of bounding
latency.

It is inspired by parda's control algorthm (fast '09) but does not apply
resource reservations, proportional allocations, or share latency information
with peers. it is therefore a very simple application of the approach.

There are many control algorithm parameters. The defaults in this PR are taken from
the paper. They seem to work alright, and but some more testing and tuning is probably
warranted.