### PR TITLE
Kafka offsets translation 

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -139,6 +139,10 @@ public:
         return _id_allocator_stm;
     }
 
+    const raft::configuration_manager& get_cfg_manager() const {
+        return _raft->get_configuration_manager();
+    }
+
     ss::shared_ptr<cluster::rm_stm>& rm_stm() { return _rm_stm; }
 
     size_t size_bytes() const { return _raft->log().size_bytes(); }

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -49,6 +49,7 @@ v_cc_library(
     server/logger.cc
     server/quota_manager.cc
     server/fetch_session_cache.cc
+    server/replicated_partition.cc
  DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/kafka/client/test/fixture.h
+++ b/src/v/kafka/client/test/fixture.h
@@ -67,4 +67,12 @@ public:
         add_topic(tp_ns, partitions).get();
         return tp_ns;
     }
+
+    model::topic_namespace create_topic(int partitions = 1, int topic = 0) {
+        auto topic_name = ssx::sformat("my_topic_{}", topic);
+        auto tp_ns = model::topic_namespace(
+          model::kafka_namespace, model::topic{topic_name});
+        add_topic(tp_ns, partitions).get();
+        return tp_ns;
+    }
 };

--- a/src/v/kafka/client/test/produce.cc
+++ b/src/v/kafka/client/test/produce.cc
@@ -78,7 +78,7 @@ FIXTURE_TEST(produce_reconnect, kafka_client_fixture) {
 
     info("Testing assertions");
     BOOST_REQUIRE_EQUAL(req0.error_code, kafka::error_code::none);
-    BOOST_REQUIRE_EQUAL(req0.base_offset, model::offset(1));
+    BOOST_REQUIRE_EQUAL(req0.base_offset, model::offset(0));
 
     client.stop().get();
 }

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -13,6 +13,8 @@
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
 #include "kafka/protocol/errors.h"
+#include "kafka/server/partition_proxy.h"
+#include "kafka/server/replicated_partition.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
 #include "model/namespace.h"
@@ -105,7 +107,8 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                 list_offsets_response::make_partition(
                   ntp.tp.partition, error_code::not_leader_for_partition));
           }
-
+          auto k_partition = make_partition_proxy<replicated_partition>(
+            partition);
           /*
            * the responses for earliest/latest timestamp queries do not require
            * that the actual timestamp be returned. only the offset is required.
@@ -115,21 +118,23 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                 list_offsets_response::make_partition(
                   ntp.tp.partition,
                   model::timestamp(-1),
-                  partition->start_offset()));
+                  k_partition.start_offset()));
 
           } else if (timestamp == list_offsets_request::latest_timestamp) {
               const auto offset = isolation_lvl
                                       == model::isolation_level::read_committed
-                                    ? partition->last_stable_offset()
-                                    : partition->high_watermark();
+                                    ? k_partition.last_stable_offset()
+                                    : k_partition.high_watermark();
 
               return ss::make_ready_future<list_offset_partition_response>(
                 list_offsets_response::make_partition(
                   ntp.tp.partition, model::timestamp(-1), offset));
           }
 
-          return partition->timequery(timestamp, kafka_read_priority())
-            .then([partition, id = ntp.tp.partition](
+          return k_partition.timequery(timestamp, kafka_read_priority())
+            .then([partition,
+                   id = ntp.tp.partition,
+                   k_partition = std::move(k_partition)](
                     std::optional<storage::timequery_result> res) {
                 if (res) {
                     return ss::make_ready_future<
@@ -139,7 +144,9 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                 }
                 return ss::make_ready_future<list_offset_partition_response>(
                   list_offsets_response::make_partition(
-                    id, model::timestamp(-1), partition->last_stable_offset()));
+                    id,
+                    model::timestamp(-1),
+                    k_partition.last_stable_offset()));
             });
       });
 }

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -15,6 +15,7 @@
 #include "cluster/shard_table.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/kafka_batch_adapter.h"
+#include "kafka/server/replicated_partition.h"
 #include "likely.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -29,6 +30,7 @@
 
 #include <seastar/core/execution_stage.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/util/log.hh>
 
 #include <boost/container_hash/extensions.hpp>
@@ -111,38 +113,36 @@ static const failure_type<error_code>
  */
 static ss::future<produce_response::partition> partition_append(
   model::partition_id id,
-  ss::lw_shared_ptr<cluster::partition> partition,
+  ss::lw_shared_ptr<replicated_partition> partition,
   model::batch_identity bid,
   model::record_batch_reader reader,
   int16_t acks,
   int32_t num_records) {
     return partition
       ->replicate(bid, std::move(reader), acks_to_replicate_options(acks))
-      .then_wrapped(
-        [partition, id, num_records = num_records](
-          ss::future<checked<raft::replicate_result, kafka::error_code>> f) {
-            produce_response::partition p{.partition_index = id};
-            try {
-                auto r = f.get0();
-                if (r.has_value()) {
-                    // have to subtract num_of_records - 1 as base_offset
-                    // is inclusive
-                    p.base_offset = model::offset(
-                      r.value().last_offset() - (num_records - 1));
-                    p.error_code = error_code::none;
-                    partition->probe().add_records_produced(num_records);
-                } else if (r == not_leader_for_partition) {
-                    p.error_code = error_code::not_leader_for_partition;
-                } else if (r == out_of_order_sequence_number) {
-                    p.error_code = error_code::out_of_order_sequence_number;
-                } else {
-                    p.error_code = error_code::unknown_server_error;
-                }
-            } catch (...) {
-                p.error_code = error_code::unknown_server_error;
-            }
-            return p;
-        });
+      .then_wrapped([partition, id, num_records = num_records](
+                      ss::future<checked<model::offset, kafka::error_code>> f) {
+          produce_response::partition p{.partition_index = id};
+          try {
+              auto r = f.get0();
+              if (r.has_value()) {
+                  // have to subtract num_of_records - 1 as base_offset
+                  // is inclusive
+                  p.base_offset = model::offset(r.value() - (num_records - 1));
+                  p.error_code = error_code::none;
+                  partition->probe().add_records_produced(num_records);
+              } else if (r == not_leader_for_partition) {
+                  p.error_code = error_code::not_leader_for_partition;
+              } else if (r == out_of_order_sequence_number) {
+                  p.error_code = error_code::out_of_order_sequence_number;
+              } else {
+                  p.error_code = error_code::unknown_server_error;
+              }
+          } catch (...) {
+              p.error_code = error_code::unknown_server_error;
+          }
+          return p;
+      });
 }
 
 /**
@@ -215,7 +215,7 @@ static ss::future<produce_response::partition> produce_topic_partition(
           }
           return partition_append(
             ntp.tp.partition,
-            partition,
+            ss::make_lw_shared<replicated_partition>(std::move(partition)),
             bid,
             std::move(reader),
             acks,

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/server/partition_proxy.h"
+#include "storage/log.h"
+
+namespace kafka {
+class materialized_partition final : public kafka::partition_proxy::impl {
+public:
+    explicit materialized_partition(storage::log log)
+      : _log(log) {}
+
+    const model::ntp& ntp() const final { return _log.config().ntp(); }
+    model::offset start_offset() const final {
+        return _log.offsets().start_offset;
+    }
+
+    model::offset high_watermark() const final {
+        return _log.offsets().dirty_offset;
+    }
+
+    model::offset last_stable_offset() const final {
+        return _log.offsets().dirty_offset;
+    }
+
+    ss::future<model::record_batch_reader> make_reader(
+      storage::log_reader_config cfg,
+      std::optional<model::timeout_clock::time_point>) final {
+        return _log.make_reader(cfg);
+    }
+
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(model::timestamp ts, ss::io_priority_class io_pc) final {
+        storage::timequery_config cfg(ts, _log.offsets().dirty_offset, io_pc);
+        return _log.timequery(cfg);
+    };
+
+private:
+    storage::log _log;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/offset_translator.h
+++ b/src/v/kafka/server/offset_translator.h
@@ -1,0 +1,65 @@
+#pragma once
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "raft/configuration_manager.h"
+
+namespace kafka {
+/**
+ * Offset translator performs conversion between kafka offsets, which doesn't
+ * include raft configuration batches and log offsets which includes
+ */
+class offset_translator {
+public:
+    explicit offset_translator(const raft::configuration_manager& config_mgr)
+      : _cfg_mgr(config_mgr) {}
+
+    model::offset to_kafka_offset(model::offset o) const {
+        auto d = delta(o);
+        return model::offset(o - d);
+    }
+
+    model::offset from_kafka_offset(
+      model::offset kafka_offset, model::offset hint = model::offset{}) const {
+        if (kafka_offset == model::offset::max()) {
+            return kafka_offset;
+        }
+
+        auto next_cfg_it = _cfg_mgr.lower_bound(std::max(hint, kafka_offset));
+        // fast exit, current offset is larger than last config batch
+        // offset, just add delta
+        if (next_cfg_it == _cfg_mgr.end()) {
+            --next_cfg_it;
+            return kafka_offset + next_cfg_it->second.idx();
+        }
+
+        auto delta = model::offset(next_cfg_it->second.idx() - 1);
+        // largest kafka offset that is achievable before reaching next
+        // control batch
+        auto max_cfg_ko = next_cfg_it->first - delta;
+        while (max_cfg_ko <= kafka_offset) {
+            // skip to the next configuration batch
+            ++next_cfg_it;
+            // since we jumped over to next config batch we can just increment
+            // delta
+            ++delta;
+            if (next_cfg_it == _cfg_mgr.end()) {
+                break;
+            }
+            max_cfg_ko = next_cfg_it->first - delta;
+        }
+        return kafka_offset + delta;
+    }
+
+private:
+    int64_t delta(model::offset o) const {
+        auto it = _cfg_mgr.lower_bound(o);
+        if (it != _cfg_mgr.begin()) {
+            --it;
+        }
+        return it->second.idx();
+    }
+
+    const raft::configuration_manager& _cfg_mgr;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/partition.h"
+#include "model/fundamental.h"
+#include "storage/types.h"
+
+#include <optional>
+
+namespace kafka {
+
+/**
+ * Kafka layer wrapper for partition, this wrapper performs offsets translation
+ * to eliminate offset skew caused by existantece of Raft configuration batches.
+ */
+class partition_proxy {
+public:
+    struct impl {
+        virtual const model::ntp& ntp() const = 0;
+        virtual model::offset start_offset() const = 0;
+        virtual model::offset high_watermark() const = 0;
+        virtual model::offset last_stable_offset() const = 0;
+        virtual ss::future<model::record_batch_reader> make_reader(
+          storage::log_reader_config,
+          std::optional<model::timeout_clock::time_point>)
+          = 0;
+        virtual ss::future<std::optional<storage::timequery_result>>
+          timequery(model::timestamp, ss::io_priority_class) = 0;
+        virtual ~impl() noexcept = default;
+    };
+
+    explicit partition_proxy(std::unique_ptr<impl> impl) noexcept
+      : _impl(std::move(impl)) {}
+
+    model::offset start_offset() const { return _impl->start_offset(); }
+
+    model::offset high_watermark() const { return _impl->high_watermark(); }
+
+    model::offset last_stable_offset() const {
+        return _impl->last_stable_offset();
+    }
+
+    const model::ntp& ntp() const { return _impl->ntp(); }
+
+    ss::future<model::record_batch_reader> make_reader(
+      storage::log_reader_config cfg,
+      std::optional<model::timeout_clock::time_point> deadline = std::nullopt) {
+        return _impl->make_reader(cfg, deadline);
+    }
+
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(model::timestamp ts, ss::io_priority_class io_pc) {
+        return _impl->timequery(ts, io_pc);
+    }
+
+private:
+    std::unique_ptr<impl> _impl;
+};
+
+template<typename Impl, typename... Args>
+partition_proxy make_partition_proxy(Args&&... args) {
+    return partition_proxy(std::make_unique<Impl>(std::forward<Args>(args)...));
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/replicated_partition.h"
+
+#include "kafka/protocol/errors.h"
+#include "model/fundamental.h"
+#include "storage/types.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <optional>
+
+namespace kafka {
+replicated_partition::replicated_partition(
+  ss::lw_shared_ptr<cluster::partition> p) noexcept
+  : _partition(p)
+  , _translator(
+      ss::make_lw_shared<offset_translator>(_partition->get_cfg_manager())){
+
+    };
+
+ss::future<model::record_batch_reader> replicated_partition::make_reader(
+  storage::log_reader_config cfg,
+  std::optional<model::timeout_clock::time_point> deadline) {
+    cfg.start_offset = _translator->from_kafka_offset(cfg.start_offset);
+    cfg.max_offset = _translator->from_kafka_offset(cfg.max_offset);
+    cfg.type_filter = {raft::data_batch_type};
+
+    class reader : public model::record_batch_reader::impl {
+    public:
+        reader(
+          std::unique_ptr<model::record_batch_reader::impl> underlying,
+          ss::lw_shared_ptr<offset_translator> tr)
+          : _underlying(std::move(underlying))
+          , _translator(std::move(tr)) {}
+
+        bool is_end_of_stream() const final {
+            return _underlying->is_end_of_stream();
+        }
+
+        void print(std::ostream& os) final {
+            fmt::print(os, "kaka::partition reader for ");
+            _underlying->print(os);
+        }
+        using storage_t = model::record_batch_reader::storage_t;
+        using data_t = model::record_batch_reader::data_t;
+        using foreign_data_t = model::record_batch_reader::foreign_data_t;
+
+        model::record_batch_reader::data_t& get_batches(storage_t& st) {
+            if (std::holds_alternative<data_t>(st)) {
+                return std::get<data_t>(st);
+            } else {
+                return *std::get<foreign_data_t>(st).buffer;
+            }
+        }
+
+        ss::future<storage_t>
+        do_load_slice(model::timeout_clock::time_point t) final {
+            return _underlying->do_load_slice(t).then([this](storage_t recs) {
+                for (auto& batch : get_batches(recs)) {
+                    batch.header().base_offset = _translator->to_kafka_offset(
+                      batch.base_offset());
+                }
+                return recs;
+            });
+        }
+
+    private:
+        std::unique_ptr<model::record_batch_reader::impl> _underlying;
+        ss::lw_shared_ptr<offset_translator> _translator;
+    };
+    auto tr = _translator;
+    auto rdr = co_await _partition->make_reader(cfg, deadline);
+    co_return model::make_record_batch_reader<reader>(
+      std::move(rdr).release(), std::move(tr));
+}
+
+ss::future<std::optional<storage::timequery_result>>
+replicated_partition::timequery(
+  model::timestamp ts, ss::io_priority_class io_pc) {
+    return _partition->timequery(ts, io_pc).then(
+      [this](std::optional<storage::timequery_result> r) {
+          if (r) {
+              r->offset = _translator->to_kafka_offset(r->offset);
+          }
+          return r;
+      });
+}
+
+ss::future<result<model::offset>> replicated_partition::replicate(
+  model::record_batch_reader rdr, raft::replicate_options opts) {
+    using ret_t = result<model::offset>;
+    return _partition->replicate(std::move(rdr), opts)
+      .then([this](result<raft::replicate_result> r) {
+          if (!r) {
+              return ret_t(r.error());
+          }
+          return ret_t(_translator->to_kafka_offset(r.value().last_offset));
+      });
+}
+ss::future<checked<model::offset, kafka::error_code>>
+replicated_partition::replicate(
+  model::batch_identity batch_id,
+  model::record_batch_reader&& rdr,
+  raft::replicate_options opts) {
+    using ret_t = checked<model::offset, kafka::error_code>;
+    return _partition->replicate(batch_id, std::move(rdr), opts)
+      .then([this](checked<raft::replicate_result, kafka::error_code> r) {
+          if (!r) {
+              return ret_t(r.error());
+          }
+          return ret_t(_translator->to_kafka_offset(r.value().last_offset));
+      });
+}
+} // namespace kafka

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -26,7 +26,7 @@ replicated_partition::replicated_partition(
       ss::make_lw_shared<offset_translator>(_partition->get_cfg_manager())){
 
     };
-
+// TODO: use previous translation speed up lookup
 ss::future<model::record_batch_reader> replicated_partition::make_reader(
   storage::log_reader_config cfg,
   std::optional<model::timeout_clock::time_point> deadline) {

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/partition.h"
+#include "cluster/partition_probe.h"
+#include "kafka/server/offset_translator.h"
+#include "kafka/server/partition_proxy.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "raft/types.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <memory>
+
+namespace kafka {
+
+class replicated_partition final : public kafka::partition_proxy::impl {
+public:
+    explicit replicated_partition(
+      ss::lw_shared_ptr<cluster::partition> p) noexcept;
+
+    const model::ntp& ntp() const final { return _partition->ntp(); }
+
+    model::offset start_offset() const final {
+        return _translator->to_kafka_offset(_partition->start_offset());
+    }
+
+    model::offset high_watermark() const final {
+        return _translator->to_kafka_offset(_partition->high_watermark());
+    }
+
+    model::offset last_stable_offset() const final {
+        return _translator->to_kafka_offset(_partition->last_stable_offset());
+    }
+
+    ss::future<std::optional<storage::timequery_result>>
+    timequery(model::timestamp ts, ss::io_priority_class io_pc) final;
+
+    ss::future<result<model::offset>>
+      replicate(model::record_batch_reader, raft::replicate_options);
+
+    ss::future<checked<model::offset, kafka::error_code>> replicate(
+      model::batch_identity,
+      model::record_batch_reader&&,
+      raft::replicate_options);
+
+    ss::future<model::record_batch_reader> make_reader(
+      storage::log_reader_config cfg,
+      std::optional<model::timeout_clock::time_point>) final;
+
+    cluster::partition_probe& probe() { return _partition->probe(); }
+
+private:
+    ss::lw_shared_ptr<cluster::partition> _partition;
+    ss::lw_shared_ptr<offset_translator> _translator;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -13,6 +13,15 @@ rp_test(
   LABELS kafka
 )
 
+rp_test(
+  UNIT_TEST
+  BINARY_NAME test_translation
+  SOURCES
+    translation_test.cc
+  LIBRARIES v::seastar_testing_main v::raft v::kafka
+  LABELS kafka
+)
+
 set(srcs
   member_test.cc
   group_test.cc

--- a/src/v/kafka/server/tests/translation_test.cc
+++ b/src/v/kafka/server/tests/translation_test.cc
@@ -1,0 +1,185 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/offset_translator.h"
+#include "random/generators.h"
+#include "storage/api.h"
+#include "storage/kvstore.h"
+#include "storage/log_manager.h"
+#include "test_utils/fixture.h"
+
+using namespace kafka;                // NOLINT
+using namespace std::chrono_literals; // NOLINT
+
+struct offset_translator_fixture {
+    offset_translator_fixture()
+      : _test_dir(
+        fmt::format("test_{}", random_generators::gen_alphanum_string(6)))
+      , _api(make_kv_cfg(), make_log_cfg())
+      , _log(raft::group_id(0), test_ntp)
+      , config_manager(
+          raft::group_configuration({}, model::revision_id(0)),
+          raft::group_id(0),
+          _api,
+          _log)
+      , tr(config_manager) {
+        _api.start().get();
+    }
+
+    storage::kvstore_config make_kv_cfg() const {
+        return storage::kvstore_config(
+          1_MiB, 10ms, _test_dir, storage::debug_sanitize_files::yes);
+    }
+
+    storage::log_config make_log_cfg() const {
+        return storage::log_config(
+          storage::log_config::storage_type::disk,
+          _test_dir,
+          100_MiB,
+          storage::debug_sanitize_files::yes);
+    }
+    model::ntp test_ntp = model::ntp(
+      model::ns("test"), model::topic("tp"), model::partition_id(0));
+    ss::sstring _test_dir;
+    raft::ctx_log _log;
+    storage::api _api;
+    raft::configuration_manager config_manager;
+    offset_translator tr;
+
+    ~offset_translator_fixture() { _api.stop().get(); }
+
+    void validate_offset_translation(
+      model::offset log_offset, model::offset kafka_offset) {
+        BOOST_REQUIRE_EQUAL(tr.to_kafka_offset(log_offset), kafka_offset);
+        BOOST_REQUIRE_EQUAL(tr.from_kafka_offset(kafka_offset), log_offset);
+    }
+};
+
+FIXTURE_TEST(test_translating_to_kafka_offsets, offset_translator_fixture) {
+    std::vector<raft::offset_configuration> cfgs;
+    std::set<model::offset> config_offsets{
+      model::offset(0),
+      model::offset(1),
+      // data batch @ 2 -> kafka 0
+      model::offset(3),
+      model::offset(4),
+      model::offset(5),
+      // data batch @ 6 -> kafka 1
+      model::offset(7),
+      model::offset(8),
+      // data batch @ 9 -> kafka 3
+      model::offset(10)};
+    cfgs.reserve(config_offsets.size());
+
+    for (auto& o : config_offsets) {
+        cfgs.emplace_back(
+          o, raft::group_configuration({}, model::revision_id(0)));
+    }
+
+    config_manager.add(std::move(cfgs)).get();
+    validate_offset_translation(model::offset(2), model::offset(0));
+    validate_offset_translation(model::offset(6), model::offset(1));
+    validate_offset_translation(model::offset(9), model::offset(2));
+    validate_offset_translation(model::offset(11), model::offset(3));
+    validate_offset_translation(model::offset(12), model::offset(4));
+}
+
+FIXTURE_TEST(
+  test_translating_to_kafka_offsets_first, offset_translator_fixture) {
+    std::vector<raft::offset_configuration> cfgs;
+    std::set<model::offset> config_offsets{// data batch @ 0 -> kafka 0
+                                           // data batch @ 1 -> kafka 1
+                                           model::offset(2),
+                                           model::offset(3),
+                                           model::offset(4),
+                                           model::offset(5),
+                                           model::offset(6),
+                                           // data batch @ 7 -> kafka 2
+                                           model::offset(8),
+                                           // data batch @ 9 -> kafka 3
+                                           model::offset(10)};
+    cfgs.reserve(config_offsets.size());
+
+    for (auto& o : config_offsets) {
+        cfgs.emplace_back(
+          o, raft::group_configuration({}, model::revision_id(0)));
+    }
+
+    config_manager.add(std::move(cfgs)).get();
+    validate_offset_translation(model::offset(0), model::offset(0));
+    validate_offset_translation(model::offset(1), model::offset(1));
+    validate_offset_translation(model::offset(7), model::offset(2));
+    validate_offset_translation(model::offset(9), model::offset(3));
+    validate_offset_translation(model::offset(11), model::offset(4));
+}
+
+FIXTURE_TEST(random_translation_test, offset_translator_fixture) {
+    auto cfgs_count = 1000;
+    std::vector<raft::offset_configuration> cfgs;
+    std::set<model::offset> config_offsets;
+    cfgs.reserve(config_offsets.size());
+    /**
+     * control batches in random places
+     */
+    for (auto i = 0; i < cfgs_count; ++i) {
+        config_offsets.emplace(random_generators::get_int(10000));
+    }
+
+    for (auto& o : config_offsets) {
+        cfgs.emplace_back(
+          o, raft::group_configuration({}, model::revision_id(0)));
+    }
+
+    config_manager.add(std::move(cfgs)).get();
+    // go over whole offset space
+    for (auto o : boost::irange(0, 11000)) {
+        model::offset log_offset(o);
+
+        if (config_offsets.contains(log_offset)) {
+            continue;
+        }
+        auto kafka_offset = tr.to_kafka_offset(log_offset);
+        auto reverse_log_offset = tr.from_kafka_offset(kafka_offset);
+        BOOST_REQUIRE_EQUAL(log_offset, reverse_log_offset);
+    }
+}
+
+FIXTURE_TEST(random_translation_test_with_hint, offset_translator_fixture) {
+    auto cfgs_count = 1000;
+    std::vector<raft::offset_configuration> cfgs;
+    std::set<model::offset> config_offsets;
+    cfgs.reserve(config_offsets.size());
+    /**
+     * control batches in random places
+     */
+    for (auto i = 0; i < cfgs_count; ++i) {
+        config_offsets.emplace(random_generators::get_int(10000));
+    }
+
+    for (auto& o : config_offsets) {
+        cfgs.emplace_back(
+          o, raft::group_configuration({}, model::revision_id(0)));
+    }
+
+    config_manager.add(std::move(cfgs)).get();
+    // go over whole offset space
+    model::offset prev_log_offset;
+    for (auto o : boost::irange(0, 11000)) {
+        model::offset log_offset(o);
+
+        if (config_offsets.contains(log_offset)) {
+            continue;
+        }
+        auto kafka_offset = tr.to_kafka_offset(log_offset);
+        auto reverse_log_offset = tr.from_kafka_offset(
+          kafka_offset, prev_log_offset);
+        prev_log_offset = reverse_log_offset;
+        BOOST_REQUIRE_EQUAL(log_offset, reverse_log_offset);
+    }
+}

--- a/src/v/pandaproxy/test/consumer_group.cc
+++ b/src/v/pandaproxy/test/consumer_group.cc
@@ -169,7 +169,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
-          res.body, R"({"offsets":[{"partition":0,"offset":1}]})");
+          res.body, R"({"offsets":[{"partition":0,"offset":0}]})");
     }
     {
         info("Consume from topic");
@@ -188,7 +188,7 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":3}])");
+          R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":0},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":1},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":2}])");
     }
 
     {
@@ -250,13 +250,13 @@ FIXTURE_TEST(pandaproxy_consumer_group, pandaproxy_test_fixture) {
     }
 
     {
-        info("Get consumer offsets (expect 3)");
+        info("Get consumer offsets (expect 2)");
         auto res = get_consumer_offsets(client, group_id, member_id);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"({"offsets":[{"topic":"t","partition":0,"offset":3,"metadata":""}]})");
+          R"({"offsets":[{"topic":"t","partition":0,"offset":2,"metadata":""}]})");
     }
 
     {

--- a/src/v/pandaproxy/test/fetch.cc
+++ b/src/v/pandaproxy/test/fetch.cc
@@ -135,11 +135,11 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
-          res.body, R"({"offsets":[{"partition":0,"offset":1}]})");
+          res.body, R"({"offsets":[{"partition":0,"offset":0}]})");
     }
 
     {
-        info("Fetch offset 0 - expect offsets 0-3");
+        info("Fetch offset 0 - expect offsets 0-2");
         set_client_config("retries", size_t(0));
         auto res = http_request(
           client,
@@ -153,11 +153,11 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":3}])");
+          R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":0},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":1},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":2}])");
     }
 
     {
-        info("Produce to known topic - offset 4");
+        info("Produce to known topic - offset 3");
         set_client_config("retries", size_t(0));
         auto body = iobuf();
         body.append(batch_2_body.data(), batch_2_body.size());
@@ -172,15 +172,15 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
-          res.body, R"({"offsets":[{"partition":0,"offset":4}]})");
+          res.body, R"({"offsets":[{"partition":0,"offset":3}]})");
     }
 
     {
-        info("Fetch offset 4 - expect offset 4");
+        info("Fetch offset 3 - expect offset 3");
         auto res = http_request(
           client,
           "/topics/t/partitions/0/"
-          "records?offset=4&max_bytes=1024&timeout=5000",
+          "records?offset=3&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
           ppj::serialization_format::v2,
           ppj::serialization_format::binary_v2);
@@ -189,11 +189,11 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":null,"value":"bXVsdGliYXRjaA==","partition":0,"offset":4}])");
+          R"([{"topic":"t","key":null,"value":"bXVsdGliYXRjaA==","partition":0,"offset":3}])");
     }
 
     {
-        info("Fetch offset 2 - expect offsets 1-4");
+        info("Fetch offset 2 - expect offsets 0-3");
         auto res = http_request(
           client,
           "/topics/t/partitions/0/"
@@ -206,7 +206,7 @@ FIXTURE_TEST(pandaproxy_fetch, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":1},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":2},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":3},{"topic":"t","key":null,"value":"bXVsdGliYXRjaA==","partition":0,"offset":4}])");
+          R"([{"topic":"t","key":null,"value":"dmVjdG9yaXplZA==","partition":0,"offset":0},{"topic":"t","key":null,"value":"cGFuZGFwcm94eQ==","partition":0,"offset":1},{"topic":"t","key":null,"value":"bXVsdGlicm9rZXI=","partition":0,"offset":2},{"topic":"t","key":null,"value":"bXVsdGliYXRjaA==","partition":0,"offset":3}])");
     }
 }
 
@@ -258,15 +258,15 @@ FIXTURE_TEST(pandaproxy_fetch_json_v2, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
-          res.body, R"({"offsets":[{"partition":0,"offset":1}]})");
+          res.body, R"({"offsets":[{"partition":0,"offset":0}]})");
     }
 
     {
-        info("Fetch offset 2 as json - expect offsets 1-2");
+        info("Fetch offset 1 as json - expect offsets 0-1");
         auto res = http_request(
           client,
           "/topics/t/partitions/0/"
-          "records?offset=2&max_bytes=1024&timeout=5000",
+          "records?offset=1&max_bytes=1024&timeout=5000",
           boost::beast::http::verb::get,
           ppj::serialization_format::v2,
           ppj::serialization_format::json_v2);
@@ -275,6 +275,6 @@ FIXTURE_TEST(pandaproxy_fetch_json_v2, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
           res.body,
-          R"([{"topic":"t","key":null,"value":{"object":["vectorized"]},"partition":0,"offset":1},{"topic":"t","key":null,"value":{"object":["pandaproxy"]},"partition":0,"offset":2}])");
+          R"([{"topic":"t","key":null,"value":{"object":["vectorized"]},"partition":0,"offset":0},{"topic":"t","key":null,"value":{"object":["pandaproxy"]},"partition":0,"offset":1}])");
     }
 }

--- a/src/v/pandaproxy/test/produce.cc
+++ b/src/v/pandaproxy/test/produce.cc
@@ -111,7 +111,7 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
-          res.body, R"({"offsets":[{"partition":0,"offset":1}]})");
+          res.body, R"({"offsets":[{"partition":0,"offset":0}]})");
     }
 
     {
@@ -130,6 +130,6 @@ FIXTURE_TEST(pandaproxy_produce, pandaproxy_test_fixture) {
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(
-          res.body, R"({"offsets":[{"partition":0,"offset":4}]})");
+          res.body, R"({"offsets":[{"partition":0,"offset":3}]})");
     }
 }

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -154,6 +154,12 @@ public:
      */
     ss::future<> remove_persistent_state();
 
+    const_iterator begin() const { return _configurations.begin(); }
+    const_iterator end() const { return _configurations.end(); }
+    const_iterator lower_bound(model::offset o) const {
+        return _configurations.lower_bound(o);
+    }
+
     friend std::ostream&
     operator<<(std::ostream&, const configuration_manager&);
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -300,6 +300,10 @@ public:
 
     std::vector<follower_metrics> get_follower_metrics() const;
 
+    const configuration_manager& get_configuration_manager() const {
+        return _configuration_manager;
+    }
+
 private:
     friend replicate_entries_stm;
     friend vote_stm;

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -456,6 +456,7 @@ enum class metadata_key : int8_t {
     config_latest_known_offset = 2,
     last_applied_offset = 3,
     unique_local_id = 4,
+    config_next_cfg_idx = 5,
     last
 };
 

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -346,13 +346,13 @@ class PandaProxyTest(RedpandaTest):
 
         produce_result = produce_result_raw.json()
         for o in produce_result["offsets"]:
-            assert o["offset"] == 1, f'error_code {o["error_code"]}'
+            assert o["offset"] == 0, f'error_code {o["error_code"]}'
 
         self.logger.info(f"Consuming from topic: {name}")
         kc = KafkaCat(self.redpanda)
-        assert kc.consume_one(name, 0, 1)["payload"] == "vectorized"
-        assert kc.consume_one(name, 1, 1)["payload"] == "pandaproxy"
-        assert kc.consume_one(name, 2, 1)["payload"] == "multibroker"
+        assert kc.consume_one(name, 0, 0)["payload"] == "vectorized"
+        assert kc.consume_one(name, 1, 0)["payload"] == "pandaproxy"
+        assert kc.consume_one(name, 2, 0)["payload"] == "multibroker"
 
         self.logger.info(f"Producing to topic without partition: {name}")
         produce_result_raw = self._produce_topic(
@@ -368,7 +368,7 @@ class PandaProxyTest(RedpandaTest):
         assert produce_result_raw.status_code == requests.codes.ok
         produce_result = produce_result_raw.json()
         for o in produce_result["offsets"]:
-            assert o["offset"] == 2, f'error_code {o["error_code"]}'
+            assert o["offset"] == 1, f'error_code {o["error_code"]}'
 
     @cluster(num_nodes=3)
     def test_fetch_topic_validation(self):
@@ -453,7 +453,7 @@ class PandaProxyTest(RedpandaTest):
         assert produce_result_raw.status_code == requests.codes.ok
         produce_result = produce_result_raw.json()
         for o in produce_result["offsets"]:
-            assert o["offset"] == 1, f'error_code {o["error_code"]}'
+            assert o["offset"] == 0, f'error_code {o["error_code"]}'
 
         self.logger.info(f"Consuming from topic: {name}")
         fetch_raw_result_0 = self._fetch_topic(name, 0)
@@ -466,7 +466,7 @@ class PandaProxyTest(RedpandaTest):
         assert fetch_result_0[0]["value"] == expected["records"][0]["value"]
         assert fetch_result_0[0]["partition"] == expected["records"][0][
             "partition"]
-        assert fetch_result_0[0]["offset"] == 1
+        assert fetch_result_0[0]["offset"] == 0
 
     @cluster(num_nodes=3)
     def test_create_consumer_validation(self):
@@ -724,7 +724,7 @@ class PandaProxyTest(RedpandaTest):
         co_res = co_res_raw.json()
         assert len(co_res["offsets"]) == 9
         for i in range(len(co_res["offsets"])):
-            assert co_res["offsets"][i]["offset"] == 1
+            assert co_res["offsets"][i]["offset"] == 0
 
         # Remove consumer
         self.logger.info("Remove consumer")


### PR DESCRIPTION
## Cover letter
Implemented offset translation from storage offset to kafka offset. Kafka offset doesn't included control batches. This way Kafka offset is always smaller or equal to current log offset.

Offset translation uses `raft::configuration_manager` as an index to track control batches.

Fixes: #1184 

## Release notes

- After this patch redpanda will not include control batches in offsets and data returned through Kafka API.
