### PR TITLE
archival: Fix archival storage CI

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -118,7 +118,7 @@ class RedpandaService(Service):
         cmd = (f"nohup {self.find_binary('redpanda')}"
                f" --redpanda-cfg {RedpandaService.CONFIG_FILE}"
                f" --default-log-level {self._log_level}"
-               f" --logger-log-level=exception=debug "
+               f" --logger-log-level=exception=debug:archival=debug "
                f" --kernel-page-cache=true "
                f" --overprovisioned "
                f" --smp 3 "

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -12,7 +12,6 @@ quick:
   - tests/
 
   excluded:
-  - tests/archival_test.py
   - tests/librdkafka_test.py
   - tests/rpk_test.py
   - tests/demo_test.py


### PR DESCRIPTION
## Cover Letter

This PR enables archival test on CI. It also introduces the fix for the problem that caused the CI failure.

#### Problem 1
The kafka cli client in redpanda test driver generate skewed workload in some cases. Original test created topic with two partitions and replicated factor equal to three. In some cases most messages generated by the tool went to the same partition (this happens only on CI). This caused failure because test expected to find two partition manifests in MinIO storage. The new version creates a topic with one partition and replicated factor equal to three. It shouldn't affect correctness but disables this failure scenario.

#### Problem 2
The ListObjects REST API call in MinIO is eventually consistent and sometimes this leads to failures on CI. The test used this API call to verify the state of the MinIO storage. In some cases all segments and manifests were uploaded correctly but ListObjects continued to return stale data. This problem sometimes affects the cleanup process which can also lead to failures.

The workaround for the problem uses data from manifest. The manifest location is known in advance. The code fetches it and extracts the list of uploaded segments. The manifests are also added to this list providing us with the data that we expect to receive from ListObjects request. This works because the manifest is fetched using the GetObject API call which provides "read your own writes" guarantee. The actual ListObjects request is used as a fallback mechanism in case of any failure.

Fixes #1216 
