### PR TITLE
Fix for wasm reconciliation bugs

### DIFF
--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -194,7 +194,7 @@ ss::future<> event_listener::do_start() {
         /// There is a discrepency between the number of registered coprocs
         /// according to redpanda and according to the wasm engine.
         /// Reconcile all state from offset 0.
-        if (!co_await _dispatcher.disable_all_coprocessors()) {
+        if (co_await _dispatcher.disable_all_coprocessors()) {
             vlog(
               coproclog.error,
               "Failed to reset wasm_engine state, will keep retrying...");

--- a/src/v/coproc/script_dispatcher.h
+++ b/src/v/coproc/script_dispatcher.h
@@ -33,14 +33,16 @@ public:
     /// The wasm engine will be sent the list of coprocessors to enable
     /// Upon retrival of each successful ack, the script will be registered with
     /// the pacemaker.
-    ss::future<std::error_code> enable_coprocessors(enable_copros_request);
+    ss::future<result<std::vector<script_id>>>
+      enable_coprocessors(enable_copros_request);
 
     /// Called when removal commands arrive on the coproc_internal_topic
     ///
     /// The wasm engine will be send the list of coprocessor ids to remove from
     /// its internal map. Upon retrival of each successful ack, the script will
     /// be deregistered from the pacemaker.
-    ss::future<std::error_code> disable_coprocessors(disable_copros_request);
+    ss::future<result<std::vector<script_id>>>
+      disable_coprocessors(disable_copros_request);
 
     /// Invoke this after fatal error has occurred and its desired to clear all
     /// state from the wasm engine.
@@ -57,6 +59,7 @@ private:
       add_sources(script_id, std::vector<topic_namespace_policy>);
     ss::future<std::vector<coproc::errc>> remove_sources(script_id);
     ss::future<> remove_all_sources();
+    ss::future<bool> script_exists(script_id);
 
     /// Return std::nullopt only when the abort source is triggered,
     /// otherwise will forever loop attempting to re-connect to the wasm


### PR DESCRIPTION
This PR addresses two seperate issues:

1. Incorrect comparison when checking the response of `script_dispatcher::disable_all_coprocessors()`. Bug introduced in #1203 

2. A latent bug observed when #1203 was pushed. The state accumulated within the event_listener was not in sync with the wasm_engine (and the true state of the pacemaker) in the cases where scripts must be immediately deregistered. (This occurs when a user publishes a script that subscribes to topic that don't exist). Now that we can compare the expected state with the observed state within the wasm engine (number returned by the heartbeat call) this inconsistency was detected and failure mechanism was initiated.

