### PR TITLE
operator: annotation to disable reconciliation of cluster

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -88,6 +88,13 @@ func (r *ClusterReconciler) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("unable to retrieve Cluster resource: %w", err)
 	}
 
+	managedAnnotationKey := redpandav1alpha1.GroupVersion.Group + "/managed"
+	if managed, exists := redpandaCluster.Annotations[managedAnnotationKey]; exists && managed == "false" {
+		log.Info(fmt.Sprintf("management of %s is disabled; to enable it, change the '%s' annotation to true or remove it",
+			redpandaCluster.Name, managedAnnotationKey))
+		return ctrl.Result{}, nil
+	}
+
 	nodeports := []resources.NamedServicePort{}
 	internalListener := redpandaCluster.InternalListener()
 	externalListener := redpandaCluster.ExternalListener()


### PR DESCRIPTION
## Cover letter

Introducing an annotation that is applied on a cluster CR and disables the reconciliation of that CR. This is useful when 1) we want to upgrade the operator without triggering a restart of all Clusters at the same time (and potentially change the CR version in the meantime); 2) we want to perform an operation that is out of line with the operator's logic, such as during a complex upgrade scenario.

To disable reconciliation for `one-node-cluster` in namespace `default`, add this annotation:
```
ANNOTATION='redpanda.vectorized.io/managed=false'
kubectl annotate --overwrite cluster one-node-cluster -n default $ANNOTATION
```

Once the annotation is added, the logs will include the following message:

```
INFO	controllers.redpanda.Cluster	management of one-node-cluster is disabled; edit 'redpanda.vectorized.io/managed' to enable	{"redpandacluster": "default/one-node-cluster"}
```

To remove the annotation set `ANNOTATION` to `'redpanda.vectorized.io/managed-'`


## Release notes

Ability to disable reconciliation for specific redpanda clusters.