### PR TITLE
operator: expose auto_create_topics_enabled

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -172,6 +172,8 @@ type RedpandaConfig struct {
 	DeveloperMode bool          `json:"developerMode,omitempty"`
 	// Number of partitions in the internal group membership topic
 	GroupTopicPartitions int `json:"groupTopicPartitions,omitempty"`
+	// Enable auto-creation of topics. Reference https://kafka.apache.org/documentation/#brokerconfigs_auto.create.topics.enable
+	AutoCreateTopics bool `json:"autoCreateTopics,omitempty"`
 }
 
 // AdminAPI is configuration of the redpanda Admin API

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -157,6 +157,9 @@ spec:
                           type: object
                       type: object
                     type: array
+                  autoCreateTopics:
+                    description: Enable auto-creation of topics. Reference https://kafka.apache.org/documentation/#brokerconfigs_auto.create.topics.enable
+                    type: boolean
                   developerMode:
                     type: boolean
                   groupTopicPartitions:

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -249,6 +249,11 @@ func (r *ConfigMapResource) createConfiguration(
 		cr.GroupTopicPartitions = &partitions
 	}
 
+	if cr.Other == nil {
+		cr.Other = make(map[string]interface{})
+	}
+	cr.Other["auto_create_topics_enabled"] = r.pandaCluster.Spec.Configuration.AutoCreateTopics
+
 	segmentSize := logSegmentSize
 	cr.LogSegmentSize = &segmentSize
 

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -119,6 +119,11 @@ func TestEnsure_ConfigMap(t *testing.T) {
 	assert.NoError(t, err)
 	originalResourceVersion := actual.ResourceVersion
 
+	data := actual.Data["redpanda.yaml"]
+	if !strings.Contains(data, "auto_create_topics_enabled: false") {
+		t.Fatalf("expecting configmap containing 'auto_create_topics_enabled: false' but got %v", data)
+	}
+
 	// calling ensure for second time to see the resource does not get updated
 	err = cm.Ensure(context.Background())
 	assert.NoError(t, err)
@@ -141,7 +146,7 @@ func TestEnsure_ConfigMap(t *testing.T) {
 	if actual.ResourceVersion == originalResourceVersion {
 		t.Fatalf("expecting version to get updated after resource update but is %s", originalResourceVersion)
 	}
-	data := actual.Data["redpanda.yaml"]
+	data = actual.Data["redpanda.yaml"]
 	if !strings.Contains(data, "cert_file") || !strings.Contains(data, "port: 1111") {
 		t.Fatalf("expecting configmap updated but got %v", data)
 	}


### PR DESCRIPTION
## Cover letter

Exposes this config value in CRD.

Fixes #1240 

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
Operator can be now configured with expose auto_create_topics_enabled