### PR TITLE
docs: Change cert-manager version to 1.2.0

### DIFF
--- a/docs/www/quick-start-kubernetes.md
+++ b/docs/www/quick-start-kubernetes.md
@@ -28,7 +28,7 @@ You'll need to install:
 - Kubernetes v1.16 or above
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) v1.16 or above
 - [helm](https://github.com/helm/helm/releases) v3.0.0 or above
-- [cert-manager](https://cert-manager.io/docs/installation/kubernetes/) v1.3.0 or above
+- [cert-manager](https://cert-manager.io/docs/installation/kubernetes/) v1.2.0 or above
 
     Follow the instructions to verify that cert-manager is ready to create certificates.
 
@@ -98,7 +98,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.3.0 \
+  --version v1.2.0 \
   --set installCRDs=true
 ```
 


### PR DESCRIPTION
## Cover letter

Changes the cert-manager minimum version to 1.2.0 because that is the version that we tested.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
