### PR TITLE
operator/tests: ensure rollout of new operator instance is completed

### DIFF
--- a/src/go/k8s/tests/e2e/update-conf-image/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/00-assert.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
-  - command: ../../hack/wait-for-webhook-ready.sh
+  - command: kubectl rollout status deployment redpanda-controller-manager -n redpanda-system && ../../hack/wait-for-webhook-ready.sh

--- a/src/go/k8s/tests/e2e/update-conf-image/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/02-assert.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
-  - command: ../../hack/wait-for-webhook-ready.sh
+  - command: kubectl rollout status deployment redpanda-controller-manager -n redpanda-system && ../../hack/wait-for-webhook-ready.sh


### PR DESCRIPTION
## Cover letter
Making sure we don't use the old operator instance.
(https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-status-em-)