### PR TITLE
kafka: add sasl authentication into kafka client

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -443,6 +443,20 @@ pandaproxy_client:
   # Default: 500ms
   consumer_heartbeat_interval_ms: 500
 
+  # SASL mechanism to use for authentication
+  # Supported: SCRAM-SHA-{256,512}
+  # Default: ""
+  # Support for SASL is disabled when no mechanism is specified.
+  sasl_mechanism: ""
+
+  # Username for SCRAM authentication mechanisms
+  # Default: ""
+  scram_username: ""
+
+  # Password for SCRAM authentication mechanisms
+  # Default: ""
+  scram_password: ""
+
 rpk:
   # TLS configuration to allow rpk to make requests to the redpanda API.
   tls:

--- a/src/v/kafka/client/CMakeLists.txt
+++ b/src/v/kafka/client/CMakeLists.txt
@@ -12,6 +12,7 @@ v_cc_library(
     partitioners.cc
     producer.cc
     topic_cache.cc
+    sasl_client.cc
   DEPS
     v::kafka
     v::ssx

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -157,6 +157,8 @@ private:
     /// \brief Connect and update metdata.
     ss::future<> do_connect(unresolved_address addr);
 
+    ss::future<> do_authenticate(shared_broker_t);
+
     /// \brief Update metadata
     ///
     /// If an existing update is in progress, the future returned will be

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -96,6 +96,24 @@ configuration::configuration()
       "consumer_heartbeat_interval_ms",
       "Interval (in milliseconds) for consumer heartbeats",
       config::required::no,
-      500ms) {}
+      500ms)
+  , sasl_mechanism(
+      *this,
+      "sasl_mechanism",
+      "The SASL mechanism to use when connecting",
+      config::required::no,
+      "")
+  , scram_username(
+      *this,
+      "scram_username",
+      "Username to use for SCRAM authentication mechanisms",
+      config::required::no,
+      "")
+  , scram_password(
+      *this,
+      "scram_password",
+      "Password to use for SCRAM authentication mechanisms",
+      config::required::no,
+      "") {}
 
 } // namespace kafka::client

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -39,6 +39,10 @@ struct configuration final : public config::config_store {
     config::property<std::chrono::milliseconds> consumer_rebalance_timeout;
     config::property<std::chrono::milliseconds> consumer_heartbeat_interval;
 
+    config::property<ss::sstring> sasl_mechanism;
+    config::property<ss::sstring> scram_username;
+    config::property<ss::sstring> scram_password;
+
     configuration();
     explicit configuration(const YAML::Node& cfg);
 };

--- a/src/v/kafka/client/exceptions.h
+++ b/src/v/kafka/client/exceptions.h
@@ -23,6 +23,9 @@
 namespace kafka::client {
 
 struct broker_error final : exception_base {
+    broker_error(model::node_id n_id, error_code e, std::string_view msg)
+      : exception_base{e, fmt::format("{{ node: {} }}, {}: {}", n_id, e, msg)}
+      , node_id{n_id} {}
     broker_error(model::node_id n_id, error_code e)
       : exception_base{e, fmt::format("{{ node: {} }}, {}", n_id, e)}
       , node_id{n_id} {}

--- a/src/v/kafka/client/sasl_client.cc
+++ b/src/v/kafka/client/sasl_client.cc
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/client/sasl_client.h"
+
+namespace kafka::client {
+
+ss::future<> do_sasl_handshake(shared_broker_t broker, ss::sstring mechanism) {
+    sasl_handshake_request req;
+    req.data.mechanism = std::move(mechanism);
+
+    auto resp = co_await broker->dispatch(req);
+    if (resp.data.error_code != error_code::none) {
+        throw broker_error{broker->id(), resp.data.error_code};
+    }
+}
+
+static ss::future<security::server_first_message> send_scram_client_first(
+  const shared_broker_t& broker,
+  const security::client_first_message& client_first) {
+    sasl_authenticate_request client_first_req;
+    {
+        auto msg = client_first.message();
+        client_first_req.data.auth_bytes = bytes(msg.cbegin(), msg.cend());
+    }
+    auto client_first_resp = co_await broker->dispatch(client_first_req);
+    if (client_first_resp.data.error_code != error_code::none) {
+        throw broker_error{
+          broker->id(),
+          client_first_resp.data.error_code,
+          client_first_resp.data.error_message.value_or("<no error message>")};
+    }
+    co_return security::server_first_message(client_first_resp.data.auth_bytes);
+}
+
+static ss::future<security::server_final_message> send_scram_client_final(
+  const shared_broker_t& broker,
+  const security::client_final_message& client_final) {
+    sasl_authenticate_request client_last_req;
+    {
+        auto msg = client_final.message();
+        client_last_req.data.auth_bytes = bytes(msg.cbegin(), msg.cend());
+    }
+
+    auto client_last_resp = co_await broker->dispatch(client_last_req);
+
+    if (client_last_resp.data.error_code != error_code::none) {
+        throw broker_error{
+          broker->id(),
+          client_last_resp.data.error_code,
+          client_last_resp.data.error_message.value_or("<no error message>")};
+    }
+
+    co_return security::server_final_message(
+      std::move(client_last_resp.data.auth_bytes));
+}
+
+template<typename ScramAlgo>
+static ss::future<> do_authenticate_scram(
+  shared_broker_t broker, ss::sstring username, ss::sstring password) {
+    /*
+     * send client first message
+     */
+    const auto nonce = random_generators::gen_alphanum_string(130);
+    const security::client_first_message client_first(username, nonce);
+
+    /*
+     * handle server first response
+     */
+    const auto server_first = co_await send_scram_client_first(
+      broker, client_first);
+
+    if (!std::string_view(server_first.nonce())
+           .starts_with(std::string_view(nonce))) {
+        throw broker_error{
+          broker->id(),
+          error_code::sasl_authentication_failed,
+          "Server nonce doesn't match client nonce"};
+    }
+
+    if (server_first.iterations() < ScramAlgo::min_iterations) {
+        throw broker_error{
+          broker->id(),
+          error_code::sasl_authentication_failed,
+          fmt_with_ctx(
+            ssx::sformat,
+            "Server minimum iterations {} < required {}",
+            server_first.iterations(),
+            ScramAlgo::min_iterations)};
+    }
+
+    /*
+     * send client final message
+     */
+    security::client_final_message client_final(
+      bytes("n,,"), server_first.nonce());
+
+    auto salted_password = ScramAlgo::hi(
+      bytes(password.cbegin(), password.cend()),
+      server_first.salt(),
+      server_first.iterations());
+
+    client_final.set_proof(ScramAlgo::client_proof(
+      salted_password, client_first, server_first, client_final));
+
+    const auto server_final = co_await send_scram_client_final(
+      broker, client_final);
+
+    /*
+     * handle server final response
+     */
+    if (server_final.error()) {
+        throw broker_error{
+          broker->id(),
+          error_code::sasl_authentication_failed,
+          server_final.error().value()};
+    }
+
+    auto server_key = ScramAlgo::server_key(salted_password);
+    auto server_sig = ScramAlgo::server_signature(
+      server_key, client_first, server_first, client_final);
+
+    if (server_final.signature() != server_sig) {
+        throw broker_error{
+          broker->id(),
+          error_code::sasl_authentication_failed,
+          "Server signature does not match calculated signature"};
+    }
+}
+
+ss::future<> do_authenticate_scram256(
+  shared_broker_t broker, ss::sstring username, ss::sstring password) {
+    return do_authenticate_scram<security::scram_sha256>(
+      std::move(broker), std::move(username), std::move(password));
+}
+
+ss::future<> do_authenticate_scram512(
+  shared_broker_t broker, ss::sstring username, ss::sstring password) {
+    return do_authenticate_scram<security::scram_sha512>(
+      std::move(broker), std::move(username), std::move(password));
+}
+
+} // namespace kafka::client

--- a/src/v/kafka/client/sasl_client.h
+++ b/src/v/kafka/client/sasl_client.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/client/broker.h"
+#include "kafka/protocol/sasl_authenticate.h"
+#include "kafka/protocol/sasl_handshake.h"
+#include "random/generators.h"
+#include "security/scram_algorithm.h"
+#include "security/scram_authenticator.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace kafka::client {
+
+/*
+ * SASL handshake negotiates mechanism. In this case that process is simple: if
+ * the server doesn't support the requested mechanism there is no fallback.
+ */
+ss::future<> do_sasl_handshake(shared_broker_t broker, ss::sstring mechanism);
+
+ss::future<> do_authenticate_scram256(
+  shared_broker_t broker, ss::sstring username, ss::sstring password);
+
+ss::future<> do_authenticate_scram512(
+  shared_broker_t broker, ss::sstring username, ss::sstring password);
+
+} // namespace kafka::client

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -139,6 +139,10 @@ public:
             return dispatch(std::move(r), api_version(2));
         } else if constexpr (std::is_same_v<type, create_topics_request>) {
             return dispatch(std::move(r), api_version(4));
+        } else if constexpr (std::is_same_v<type, sasl_handshake_request>) {
+            return dispatch(std::move(r), api_version(1));
+        } else if constexpr (std::is_same_v<type, sasl_authenticate_request>) {
+            return dispatch(std::move(r), api_version(1));
         }
     }
 

--- a/src/v/kafka/protocol/sasl_authenticate.h
+++ b/src/v/kafka/protocol/sasl_authenticate.h
@@ -57,6 +57,8 @@ struct sasl_authenticate_response final {
 
     sasl_authenticate_response_data data;
 
+    sasl_authenticate_response() = default;
+
     explicit sasl_authenticate_response(sasl_authenticate_response_data data)
       : data(std::move(data)) {}
 

--- a/src/v/kafka/protocol/sasl_handshake.h
+++ b/src/v/kafka/protocol/sasl_handshake.h
@@ -57,6 +57,8 @@ struct sasl_handshake_response final {
 
     sasl_handshake_response_data data;
 
+    sasl_handshake_response() = default;
+
     sasl_handshake_response(
       error_code error, std::vector<ss::sstring> mechanisms) {
         data.error_code = error;

--- a/src/v/security/scram_algorithm.cc
+++ b/src/v/security/scram_algorithm.cc
@@ -51,6 +51,9 @@
 // NOLINTNEXTLINE
 #define VALUE_SAFE_CHAR "[\\x01-\\x2b\\x2d-\\x3c\\x3e-\\x7f]"
 
+// NOLINTNEXTLINE
+#define VALUE_SAFE VALUE_SAFE_CHAR "+"
+
 // 1*(value-safe-char / "=2C" / "=3D")
 // NOLINTNEXTLINE
 #define SASLNAME "(?:" VALUE_SAFE_CHAR "|=2C|=3D)+"
@@ -72,6 +75,9 @@
 
 #define CLIENT_FINAL_MESSAGE_RE                                                \
     "c=(" BASE64 "),r=(" PRINTABLE ")" EXTENSIONS ",p=(" BASE64 ")"
+
+#define SERVER_FINAL_MESSAGE_RE                                                \
+    "(?:e=(" VALUE_SAFE "))|(?:v=(" BASE64 "))" EXTENSIONS
 
 /*
  * {ctre,std_re}_parse_client_{first,final} implementations are defined. ctre_*
@@ -99,6 +105,11 @@ struct client_final_match {
     bytes proof;
 };
 
+struct server_final_match {
+    std::optional<ss::sstring> error;
+    bytes signature;
+};
+
 #ifdef USE_CTRE
 static constexpr auto client_first_message_re = ctll::fixed_string{
   CLIENT_FIRST_MESSAGE_RE};
@@ -108,6 +119,9 @@ static constexpr auto server_first_message_re = ctll::fixed_string{
 
 static constexpr auto client_final_message_re = ctll::fixed_string{
   CLIENT_FINAL_MESSAGE_RE};
+
+static constexpr auto server_final_message_re = ctll::fixed_string{
+  SERVER_FINAL_MESSAGE_RE};
 
 static inline std::optional<client_first_match>
 ctre_parse_client_first(std::string_view message) {
@@ -164,10 +178,27 @@ ctre_parse_client_final(std::string_view message) {
     };
 }
 
+static inline std::optional<server_final_match>
+ctre_parse_server_final(std::string_view message) {
+    auto match = ctre::match<server_final_message_re>(message);
+    if (unlikely(!match)) {
+        return std::nullopt;
+    }
+
+    auto error = match.get<1>().to_view();
+    if (error.empty()) {
+        return server_final_match{
+          .signature = base64_to_bytes(match.get<2>().to_view()),
+        };
+    }
+    return server_final_match{.error{error}};
+}
+
 #else
 static const char* client_first_message_re = CLIENT_FIRST_MESSAGE_RE;
 static const char* server_first_message_re = SERVER_FIRST_MESSAGE_RE;
 static const char* client_final_message_re = CLIENT_FINAL_MESSAGE_RE;
+static const char* server_final_message_re = SERVER_FINAL_MESSAGE_RE;
 
 static inline std::optional<client_first_match>
 std_re_parse_client_first(std::string_view message) {
@@ -232,6 +263,25 @@ std_re_parse_client_final(std::string_view message) {
       .proof = base64_to_bytes(match[4].str()),
     };
 }
+
+static inline std::optional<server_final_match>
+std_re_parse_server_final(std::string_view message) {
+    static const std::regex re(
+      server_final_message_re, std::regex::ECMAScript | std::regex::optimize);
+    std::smatch match;
+    std::string m(message);
+    if (unlikely(!std::regex_match(m, match, re))) {
+        return std::nullopt;
+    }
+
+    auto error = match[1].str();
+    if (error.empty()) {
+        return server_final_match{
+          .signature = base64_to_bytes(match[2].str()),
+        };
+    }
+    return server_final_match{.error = std::move(error)};
+}
 #endif
 } // namespace details
 
@@ -259,6 +309,15 @@ parse_client_final(std::string_view message) {
     return details::ctre_parse_client_final(message);
 #else
     return details::std_re_parse_client_final(message);
+#endif
+}
+
+static inline std::optional<details::server_final_match>
+parse_server_final(std::string_view message) {
+#ifdef USE_CTRE
+    return details::ctre_parse_server_final(message);
+#else
+    return details::std_re_parse_server_final(message);
 #endif
 }
 
@@ -420,6 +479,21 @@ server_first_message::server_first_message(bytes_view data) {
           "Invalid SCRAM server first message iterations: {}",
           _iterations));
     }
+}
+
+server_final_message::server_final_message(bytes_view data) {
+    auto view = std::string_view(
+      reinterpret_cast<const char*>(data.data()), data.size()); // NOLINT
+    validate_utf8(view);
+
+    auto match = parse_server_final(view);
+    if (unlikely(!match)) {
+        throw scram_exception(fmt_with_ctx(
+          ssx::sformat, "Invalid SCRAM server final message: {}", view));
+    }
+
+    _error = std::move(match->error);
+    _signature = std::move(match->signature);
 }
 
 } // namespace security

--- a/src/v/security/scram_algorithm.h
+++ b/src/v/security/scram_algorithm.h
@@ -14,6 +14,7 @@
 #include "random/generators.h"
 #include "security/scram_credential.h"
 #include "ssx/sformat.h"
+#include "utils/base64.h"
 
 #include <absl/container/node_hash_map.h>
 
@@ -51,6 +52,10 @@ private:
  */
 class client_first_message {
 public:
+    client_first_message(ss::sstring username, ss::sstring nonce)
+      : _username(std::move(username))
+      , _nonce(std::move(nonce)) {}
+
     explicit client_first_message(bytes_view data);
 
     client_first_message(client_first_message&&) = delete;
@@ -66,6 +71,10 @@ public:
 
     ss::sstring bare_message() const {
         return ssx::sformat("n={},r={}", _username, _nonce);
+    }
+
+    ss::sstring message() const {
+        return ssx::sformat("n,{},{}", _authzid, bare_message());
     }
 
     bool token_authenticated() const;
@@ -95,13 +104,17 @@ public:
 
     explicit server_first_message(bytes_view);
 
-    server_first_message(server_first_message&&) = delete;
+    server_first_message(server_first_message&&) noexcept = default;
     server_first_message& operator=(server_first_message&&) = delete;
     server_first_message(const server_first_message&) = delete;
     server_first_message& operator=(const server_first_message&) = delete;
     ~server_first_message() noexcept = default;
 
     ss::sstring sasl_message() const;
+
+    const ss::sstring& nonce() const { return _nonce; }
+    const bytes& salt() const { return _salt; }
+    int iterations() const { return _iterations; }
 
 private:
     friend std::ostream& operator<<(std::ostream&, const server_first_message&);
@@ -118,6 +131,10 @@ class client_final_message {
 public:
     explicit client_final_message(bytes_view data);
 
+    client_final_message(bytes channel_binding, ss::sstring nonce)
+      : _channel_binding(std::move(channel_binding))
+      , _nonce(std::move(nonce)) {}
+
     client_final_message(client_final_message&&) = delete;
     client_final_message& operator=(client_final_message&&) = delete;
     client_final_message(const client_final_message&) = delete;
@@ -128,6 +145,12 @@ public:
     const bytes& proof() const { return _proof; }
     const bytes& channel_binding() const { return _channel_binding; }
     ss::sstring msg_no_proof() const;
+
+    void set_proof(bytes proof) { _proof = std::move(proof); }
+
+    ss::sstring message() const {
+        return ssx::sformat("{},p={}", msg_no_proof(), bytes_to_base64(_proof));
+    }
 
 private:
     friend std::ostream& operator<<(std::ostream&, const client_final_message&);
@@ -150,13 +173,15 @@ public:
 
     explicit server_final_message(bytes_view);
 
-    server_final_message(server_final_message&&) = delete;
+    server_final_message(server_final_message&&) noexcept = default;
     server_final_message& operator=(server_final_message&&) = delete;
     server_final_message(const server_final_message&) = delete;
     server_final_message& operator=(const server_final_message&) = delete;
     ~server_final_message() noexcept = default;
 
     ss::sstring sasl_message() const;
+    const std::optional<ss::sstring>& error() const { return _error; }
+    const bytes& signature() const { return _signature; }
 
 private:
     friend std::ostream& operator<<(std::ostream&, const server_final_message&);
@@ -228,7 +253,23 @@ public:
           iterations);
     }
 
-private:
+    static bytes client_proof(
+      bytes_view salted_password,
+      const client_first_message& client_first,
+      const server_first_message& server_first,
+      const client_final_message& client_final) {
+        auto c_key = client_key(salted_password);
+        HashType hash;
+        hash.update(c_key);
+        auto stored_key = hash.reset();
+        auto c_signature = client_signature(
+          bytes(stored_key.begin(), stored_key.end()),
+          client_first,
+          server_first,
+          client_final);
+        return c_key ^ c_signature;
+    }
+
     static bytes hi(bytes_view str, bytes_view salt, int iterations) {
         MacType mac(str);
         mac.update(salt);
@@ -245,6 +286,14 @@ private:
         return bytes(result.begin(), result.end());
     }
 
+    static bytes server_key(bytes_view salted_password) {
+        MacType mac(salted_password);
+        mac.update("Server Key");
+        auto result = mac.reset();
+        return bytes(result.begin(), result.end());
+    }
+
+private:
     static bytes salt_password(
       const ss::sstring& password, bytes_view salt, int iterations) {
         bytes password_bytes(password.begin(), password.end());
@@ -274,13 +323,6 @@ private:
           client_first.bare_message(),
           server_first.sasl_message(),
           client_final.msg_no_proof());
-    }
-
-    static bytes server_key(bytes_view salted_password) {
-        MacType mac(salted_password);
-        mac.update("Server Key");
-        auto result = mac.reset();
-        return bytes(result.begin(), result.end());
     }
 };
 

--- a/src/v/security/scram_algorithm.h
+++ b/src/v/security/scram_algorithm.h
@@ -93,6 +93,8 @@ public:
       , _salt(std::move(salt))
       , _iterations(iterations) {}
 
+    explicit server_first_message(bytes_view);
+
     server_first_message(server_first_message&&) = delete;
     server_first_message& operator=(server_first_message&&) = delete;
     server_first_message(const server_first_message&) = delete;

--- a/src/v/security/scram_algorithm.h
+++ b/src/v/security/scram_algorithm.h
@@ -148,6 +148,8 @@ public:
       : _error(std::move(error))
       , _signature(std::move(signature)) {}
 
+    explicit server_final_message(bytes_view);
+
     server_final_message(server_final_message&&) = delete;
     server_final_message& operator=(server_final_message&&) = delete;
     server_final_message(const server_final_message&) = delete;

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -222,7 +222,8 @@ class RedpandaService(Service):
                            node_id=self.idx(node),
                            enable_rp=self._enable_rp,
                            enable_pp=self._enable_pp,
-                           superuser=self.SUPERUSER_CREDENTIALS)
+                           superuser=self.SUPERUSER_CREDENTIALS,
+                           sasl_enabled=self.sasl_enabled())
 
         if self._extra_rp_conf:
             doc = yaml.full_load(conf)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -64,6 +64,11 @@ pandaproxy_client:
 
   retries: 10
   retry_base_backoff_ms: 10
+  {% if sasl_enabled %}
+  sasl_mechanism: {{superuser[2]}}
+  scram_username: {{superuser[0]}}
+  scram_password: {{superuser[1]}}
+  {% endif %}
 {% endif %}
 
 rpk:


### PR DESCRIPTION
Add sasl + scram authentication into the kafka client which allows the proxy to connect to sasl-enabled brokers.

Fixes: #1076
