### PR TITLE
Feature/group responses

### DIFF
--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -31,10 +31,55 @@ import errors, { DisableResponseCode } from "./errors";
 import { Logger } from "winston";
 import Logging from "../utilities/Logging";
 import requireNative from "./require-native";
+import { isNtpEqual } from "../utilities/domain";
+import { find } from "../utilities/Map";
+
+function groupByTopic(
+  processBatchReplyItems: ProcessBatchReplyItem[]
+): ProcessBatchReplyItem[] {
+  interface GroupByResultTopic {
+    id: [ProcessBatchReplyItem["ntp"], ProcessBatchReplyItem["coprocessorId"]];
+    value: ProcessBatchReplyItem;
+  }
+
+  const values = processBatchReplyItems
+    .reduce((prev, result) => {
+      const prevProcessBatch = find(
+        prev,
+        ([ntp, coprocId]) =>
+          isNtpEqual(result.ntp, ntp) && coprocId === result.coprocessorId
+      );
+
+      if (prevProcessBatch === undefined) {
+        return prev.set([result.ntp, result.coprocessorId], result);
+      } else {
+        const [ntpIdTuple, prevResult] = prevProcessBatch;
+        if (
+          prevResult.resultRecordBatch === undefined ||
+          result.resultRecordBatch === undefined
+        ) {
+          return prev.set(ntpIdTuple, {
+            ...prevResult,
+            resultRecordBatch: undefined,
+          });
+        }
+        const newResult: ProcessBatchReplyItem = {
+          ...prevResult,
+          resultRecordBatch: prevResult.resultRecordBatch.concat(
+            result.resultRecordBatch
+          ),
+        };
+        return prev.set(ntpIdTuple, newResult);
+      }
+    }, new Map<GroupByResultTopic["id"], GroupByResultTopic["value"]>())
+    .values();
+  return [...values];
+}
 
 export class ProcessBatchServer extends SupervisorServer {
   private readonly repository: Repository;
   private logger: Logger;
+
   constructor() {
     super();
     // TODO Can lookup the port redpanda is listening for copros on in the redpanda.yaml file
@@ -200,7 +245,7 @@ export class ProcessBatchServer extends SupervisorServer {
     );
 
     return Promise.all(results).then(
-      (coprocessorResults) => coprocessorResults.flat(),
+      (coprocessorResults) => groupByTopic(coprocessorResults.flat()),
       (e) => {
         this.logger.error(e);
         return Logging.close().then(() => process.exit(1));

--- a/src/js/modules/utilities/domain.ts
+++ b/src/js/modules/utilities/domain.ts
@@ -1,0 +1,9 @@
+import { Ntp } from "../domain/generatedRpc/generatedClasses";
+
+export const isNtpEqual = (ntp1: Ntp, ntp2: Ntp): boolean => {
+  return (
+    ntp1.topic === ntp2.topic &&
+    ntp1.namespace === ntp2.namespace &&
+    ntp1.partition === ntp2.partition
+  );
+};


### PR DESCRIPTION
## Cover letter

this change allows joining result process_batch by its NTP and coprocessor id, it avoids when someone send multiple records batch returns multiples result for same coproc and ntp