### PR TITLE
rpk/cloud: First iteration of login implementation

### DIFF
--- a/src/go/rpk/build.sh
+++ b/src/go/rpk/build.sh
@@ -10,6 +10,8 @@
 
 version=$1
 rev=${2:-$(git rev-parse --short HEAD)}
+# auth0 clientId for the vectorized cloud, optional
+clientId=$3
 img_tag=${version:-latest}
 
 out_dir="$(go env GOOS)-$(go env GOARCH)"
@@ -18,7 +20,8 @@ mkdir -p "${out_dir}"
 
 ver_pkg='github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/version'
 cont_pkg='github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/container/common'
+auth0_pkg='github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud'
 
 go build \
-  -ldflags "-X ${ver_pkg}.version=${version} -X ${ver_pkg}.rev=${rev} -X ${cont_pkg}.tag=${img_tag}" \
+  -ldflags "-X ${ver_pkg}.version=${version} -X ${ver_pkg}.rev=${rev} -X ${cont_pkg}.tag=${img_tag} -X ${auth0_pkg}.clientId=${clientId}" \
   -o "${out_dir}" ./...

--- a/src/go/rpk/pkg/cli/cmd/cloud.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cmd
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/cloud"
+)
+
+func NewCloudCommand(fs afero.Fs) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "cloud",
+		Short: "Interact with Vectorized Cloud",
+	}
+
+	command.AddCommand(cloud.NewLoginCommand(fs))
+
+	return command
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/login.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloud
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud"
+)
+
+func NewLoginCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{
+		Use:   "login",
+		Short: "Login to vectorized cloud",
+		Long:  `Authorize rpk to access vectorized cloud with your user credentials.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			auth0Client := vcloud.NewDefaultAuth0Client()
+			token, err := vcloud.Login(auth0Client)
+			if err != nil {
+				return fmt.Errorf("login failed, please retry.\n%w", err)
+			}
+			log.Info("Success!")
+			log.Info(token.Token)
+			return nil
+		},
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -69,6 +69,7 @@ func Execute() {
 	rootCmd.AddCommand(NewContainerCommand())
 	rootCmd.AddCommand(NewTopicCommand(fs, mgr))
 	rootCmd.AddCommand(NewClusterCommand(fs, mgr))
+	rootCmd.AddCommand(NewCloudCommand(fs))
 
 	addPlatformDependentCmds(fs, mgr, rootCmd)
 

--- a/src/go/rpk/pkg/vcloud/auth0.go
+++ b/src/go/rpk/pkg/vcloud/auth0.go
@@ -1,0 +1,134 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package vcloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type TokenResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	AccessToken      string `json:"access_token"`
+	ExpiresIn        int    `json:"expires_in"`
+}
+
+// deviceCodeResponse holds information about the authorization
+// reference https://github.com/cli/oauth/blob/6b1e71c3614ec61205f1ffc9964b06dd61221385/device/device_flow.go#L39
+type DeviceCodeResponse struct {
+	// code to be entered into the browser by user
+	UserCode string `json:"user_code"`
+	// url user is asked to open for authorization
+	VerificationURI string `json:"verification_uri"`
+	// url for user to authorize including user code
+	VerificationURIComplete string `json:"verification_uri_complete"`
+
+	// The device verification code is 40 characters and used to verify the device.
+	DeviceCode string `json:"device_code"`
+	// The number of seconds before the deviceCode and userCode expire.
+	ExpiresIn int `json:"expires_in"`
+	// The minimum number of seconds that must pass before you can make a new access token request to
+	// complete the device authorization.
+	Interval int `json:"interval"`
+}
+
+type AuthClient interface {
+	GetToken(deviceCode string) (*TokenResponse, error)
+	GetDeviceCode(audience string) (*DeviceCodeResponse, error)
+}
+
+type Auth0Client struct {
+	clientId    string
+	auth0Domain string
+}
+
+const (
+	// CLI clientId
+	// TODO(av) replace with production clientId
+	clientId = "yMMbfD6xdKXW9DmIqAZDzTBPHgfI5MyX"
+	// TODO(av) should be configurable
+	defaultAuth0Domain = "vectorized-dev.us.auth0.com"
+
+	// url path to retrieve device code
+	deviceCodePath = "oauth/device/code"
+	// url path to retrieve token
+	tokenPath = "oauth/token"
+)
+
+func NewDefaultAuth0Client() AuthClient {
+	return &Auth0Client{
+		clientId:    clientId,
+		auth0Domain: defaultAuth0Domain,
+	}
+}
+
+// getToken queries auth0 token endpoint waiting for token to be issued
+// https://auth0.com/docs/flows/call-your-api-using-the-device-authorization-flow#request-tokens
+func (ac *Auth0Client) GetToken(deviceCode string) (*TokenResponse, error) {
+	requestBody := []byte(fmt.Sprintf("grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code=%s&client_id=%s", deviceCode, clientId))
+	deviceCodeUrl := fmt.Sprintf("https://%s/%s", defaultAuth0Domain, tokenPath)
+	req, err := http.NewRequest(http.MethodPost, deviceCodeUrl, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, fmt.Errorf("error creating token request. %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error calling token api: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading token response body: %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected status code. 200 != %d. Body: %s", resp.StatusCode, body)
+	}
+	var response TokenResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling token response: %w", err)
+	}
+	return &response, nil
+}
+
+func (ac *Auth0Client) GetDeviceCode(
+	audience string,
+) (*DeviceCodeResponse, error) {
+	requestBody := []byte(fmt.Sprintf("client_id=%s&audience=%s", clientId, yakAudience))
+	deviceCodeUrl := fmt.Sprintf("https://%s/%s", defaultAuth0Domain, deviceCodePath)
+	req, err := http.NewRequest(http.MethodPost, deviceCodeUrl, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, fmt.Errorf("error creating device code request. %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error calling device code api: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading device code step body: %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected status code. 200 != %d. Body: %s", resp.StatusCode, body)
+	}
+	var response DeviceCodeResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling the device code response: %w", err)
+	}
+	return &response, nil
+}

--- a/src/go/rpk/pkg/vcloud/auth0.go
+++ b/src/go/rpk/pkg/vcloud/auth0.go
@@ -53,10 +53,13 @@ type Auth0Client struct {
 	auth0Domain string
 }
 
+var (
+	// auth0 clientId
+	// TODO(av) replace default with production clientId
+	clientId string = "yMMbfD6xdKXW9DmIqAZDzTBPHgfI5MyX"
+)
+
 const (
-	// CLI clientId
-	// TODO(av) replace with production clientId
-	clientId = "yMMbfD6xdKXW9DmIqAZDzTBPHgfI5MyX"
 	// TODO(av) should be configurable
 	defaultAuth0Domain = "vectorized-dev.us.auth0.com"
 
@@ -76,7 +79,7 @@ func NewDefaultAuth0Client() AuthClient {
 // getToken queries auth0 token endpoint waiting for token to be issued
 // https://auth0.com/docs/flows/call-your-api-using-the-device-authorization-flow#request-tokens
 func (ac *Auth0Client) GetToken(deviceCode string) (*TokenResponse, error) {
-	requestBody := []byte(fmt.Sprintf("grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code=%s&client_id=%s", deviceCode, clientId))
+	requestBody := []byte(fmt.Sprintf("grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code=%s&client_id=%s", deviceCode, ac.clientId))
 	deviceCodeUrl := fmt.Sprintf("https://%s/%s", defaultAuth0Domain, tokenPath)
 	req, err := http.NewRequest(http.MethodPost, deviceCodeUrl, bytes.NewBuffer(requestBody))
 	if err != nil {
@@ -106,7 +109,7 @@ func (ac *Auth0Client) GetToken(deviceCode string) (*TokenResponse, error) {
 func (ac *Auth0Client) GetDeviceCode(
 	audience string,
 ) (*DeviceCodeResponse, error) {
-	requestBody := []byte(fmt.Sprintf("client_id=%s&audience=%s", clientId, yakAudience))
+	requestBody := []byte(fmt.Sprintf("client_id=%s&audience=%s", ac.clientId, yakAudience))
 	deviceCodeUrl := fmt.Sprintf("https://%s/%s", defaultAuth0Domain, deviceCodePath)
 	req, err := http.NewRequest(http.MethodPost, deviceCodeUrl, bytes.NewBuffer(requestBody))
 	if err != nil {

--- a/src/go/rpk/pkg/vcloud/login.go
+++ b/src/go/rpk/pkg/vcloud/login.go
@@ -1,0 +1,69 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package vcloud
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// audience of yak API in Auth0
+	// TODO(av) make it configurable to be able to work with production as well
+	yakAudience = "dev.vectorized.cloud"
+)
+
+var (
+	ErrTimeout = errors.New("authentication timed out")
+)
+
+type AuthToken struct {
+	Token string
+}
+
+// Login implements device flow of oauth2
+// reference https://auth0.com/docs/flows/call-your-api-using-the-device-authorization-flow
+func Login(auth0Client AuthClient) (*AuthToken, error) {
+	deviceCodeResponse, err := auth0Client.GetDeviceCode(yakAudience)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info(fmt.Sprintf("Go to the following link in your browser (code: %s):\n", deviceCodeResponse.UserCode))
+	log.Info(deviceCodeResponse.VerificationURIComplete)
+
+	log.Info("\nWaiting for authorization token to be issued...")
+	token, err := waitForToken(auth0Client, deviceCodeResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &AuthToken{token.AccessToken}, nil
+}
+
+func waitForToken(
+	auth0Client AuthClient, deviceCode *DeviceCodeResponse,
+) (*TokenResponse, error) {
+	checkInterval := time.Duration(deviceCode.Interval) * time.Second
+	expiresAt := time.Now().Add(time.Duration(deviceCode.ExpiresIn) * time.Second)
+	for {
+		time.Sleep(checkInterval)
+		token, err := auth0Client.GetToken(deviceCode.DeviceCode)
+		if err == nil {
+			return token, nil
+		}
+		log.Debug(err)
+		if time.Now().After(expiresAt) {
+			return nil, ErrTimeout
+		}
+	}
+}

--- a/src/go/rpk/pkg/vcloud/login_test.go
+++ b/src/go/rpk/pkg/vcloud/login_test.go
@@ -1,0 +1,80 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package vcloud_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud"
+)
+
+func TestLogin(t *testing.T) {
+	var tests = []struct {
+		name           string
+		tokenResponse  *vcloud.TokenResponse
+		tokenError     error
+		deviceResponse *vcloud.DeviceCodeResponse
+		deviceError    error
+
+		expectedError string
+		expectedToken string
+	}{
+		{"success",
+			&vcloud.TokenResponse{
+				AccessToken: "token",
+			},
+			nil,
+			&vcloud.DeviceCodeResponse{
+				VerificationURIComplete: "http://uri",
+				UserCode:                "123",
+				DeviceCode:              "1234",
+				Interval:                111,
+				ExpiresIn:               789,
+			},
+			nil,
+			"",
+			"token"},
+	}
+
+	for _, tt := range tests {
+		clientMock := &MockedAuth0Client{
+			tokenResponse:  tt.tokenResponse,
+			tokenError:     tt.tokenError,
+			deviceResponse: tt.deviceResponse,
+			deviceError:    tt.deviceError,
+		}
+		token, err := vcloud.Login(clientMock)
+		if tt.expectedError != "" && (err == nil || strings.Contains(err.Error(), tt.expectedError)) {
+			t.Errorf("%s: got unexpected error %v", tt.name, err)
+		}
+		if token.Token != tt.expectedToken {
+			t.Errorf("%s: got unexpected token. Expecting %s got %s", tt.name, tt.expectedToken, token.Token)
+		}
+	}
+}
+
+type MockedAuth0Client struct {
+	tokenResponse  *vcloud.TokenResponse
+	tokenError     error
+	deviceResponse *vcloud.DeviceCodeResponse
+	deviceError    error
+}
+
+func (mc *MockedAuth0Client) GetToken(
+	deviceCode string,
+) (*vcloud.TokenResponse, error) {
+	return mc.tokenResponse, mc.tokenError
+}
+func (mc *MockedAuth0Client) GetDeviceCode(
+	audience string,
+) (*vcloud.DeviceCodeResponse, error) {
+	return mc.deviceResponse, mc.deviceError
+}


### PR DESCRIPTION
## Cover letter

This introduces new `rpk cloud login` command. This command is hidden for now and it's not suitable to be used in the current shape. It implements auth0 device flow. https://auth0.com/docs/flows/call-your-api-using-the-device-authorization-flow#request-tokens

It right now only authorizes user and then prints out the token. Next step will be to introduce config to actually store the token but I would like to do this in separate PR. This is from my local run:

```
rpk git:(av/cloud-login) ✗ ./darwin-amd64/rpk cloud login -v
Go to the following link in your browser (code: HQRZ-TCTH):

https://vectorized-dev.us.auth0.com/activate?user_code=HQRZ-TCTH

Waiting for authorization token to be issued...
Success!
eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlZlQVUzVm12OV85b0s5Q0dvbEU5dyJ9.eyJodHRwczovL2Nsb3VkLnZlY3Rvcml6ZWQuaW8vb3JnYW5pemF0aW9uX2lkIjoyLCJodHRwczovL2Nsb3VkLnZlY3Rvcml6ZWQuaW8vcm9sZXMiOlsiQ2xpZW50IEFkbWluIl0sImh0dHBzOi8vY2xvdWQudmVjdG9yaXplZC5pby9wZXJtaXNzaW9ucyI6WyJtYW5hZ2U6b3JnYW5pemF0aW9uLWluZm8iLCJyZWFkOm9yZ2FuaXphdGlvbi1pbmZvIiwid3JpdGU6b3JnYW5pemF0aW9uLWluZm8iXSwiaXNzIjoiaHR0cHM6Ly92ZWN0b3JpemVkLWRldi51cy5hdXRoMC5jb20vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMTEzNTY5NTI2NTM2MzI2MDk0NjkiLCJhdWQiOiJkZXYudmVjdG9yaXplZC5jbG91ZCIsImlhdCI6MTYxOTQ0MDE1MCwiZXhwIjoxNjE5NTI2NTUwLCJhenAiOiJ5TU1iZkQ2eGRLWFc5RG1JcUFaRHpUQlBIZ2ZJNU15WCIsInBlcm1pc3Npb25zIjpbIm1hbmFnZTpvcmdhbml6YXRpb24taW5mbyIsInJlYWQ6b3JnYW5pemF0aW9uLWluZm8iLCJ3cml0ZTpvcmdhbml6YXRpb24taW5mbyJdfQ.fjafhPoJuoOH84A5_7uXneswtHi0JZ3pOGTJJKQdvJagMdayK4miouKd0lyEi7hHWoINBN2rnyALsC0EKLyrpEjIdTnV26VIhMQcxMQezJy526-vT-jGiZPo8V_RReGq9zMuD-76DJzRI-vJWvIvTmc4TwmL-rGmZFCakinoEKEtGddTH2e4f11MEcMyCqyk5qrGzQXR9yW2QiZHRDG0Wi7uBePIS7gqK7rPOsbGZ7T88SxQeyvzrkgL3EHa66Y4mexo3E_jPTka1Eh7frTMxioZ5EfeLufeS4gWXcmsTYF7Wvz8fEDEib5T5XNLi-xktrAMgXSsLkZEy4oUeBPswQ
```

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
