### PR TITLE
Waiting for all topic partitions to be created

### DIFF
--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -45,8 +45,10 @@ controller_api::controller_api(
 
 ss::future<std::vector<ntp_reconciliation_state>>
 controller_api::get_reconciliation_state(std::vector<model::ntp> ntps) {
-    return ssx::async_transform(ntps, [this](const model::ntp& ntp) {
-        return get_reconciliation_state(ntp);
+    return ss::do_with(std::move(ntps), [this](std::vector<model::ntp>& ntps) {
+        return ssx::async_transform(ntps, [this](const model::ntp& ntp) {
+            return get_reconciliation_state(ntp);
+        });
     });
 }
 

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -104,8 +104,7 @@ controller_api::get_reconciliation_state(model::ntp ntp) {
     std::vector<backend_operation> ops;
     const auto shards = boost::irange<ss::shard_id>(0, ss::smp::count);
     for (auto shard : shards) {
-        auto local_deltas = co_await get_remote_core_deltas(
-          std::move(ntp), shard);
+        auto local_deltas = co_await get_remote_core_deltas(ntp, shard);
 
         std::transform(
           local_deltas.begin(),

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -161,6 +161,11 @@ ss::future<response_ptr> create_topics_handler::handle(
           return ctx.topics_frontend()
             .create_topics(
               std::move(to_create), to_timeout(request.data.timeout_ms))
+            .then([&ctx, tout = to_timeout(request.data.timeout_ms)](
+                    std::vector<cluster::topic_result> c_res) mutable {
+                return wait_for_topics(c_res, ctx.controller_api(), tout)
+                  .then([c_res = std::move(c_res)]() mutable { return c_res; });
+            })
             .then([&ctx,
                    response = std::move(response),
                    tout = to_timeout(request.data.timeout_ms)](

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "cluster/fwd.h"
+#include "cluster/types.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/handlers/topics/validators.h"
 #include "model/timeout_clock.h"
@@ -184,4 +185,10 @@ ss::future<std::vector<model::node_id>> wait_for_leaders(
   cluster::metadata_cache&,
   std::vector<cluster::topic_result>,
   model::timeout_clock::time_point);
+
+ss::future<> wait_for_topics(
+  std::vector<cluster::topic_result>,
+  cluster::controller_api&,
+  model::timeout_clock::time_point);
+
 } // namespace kafka

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -47,7 +47,9 @@ protocol::protocol(
   ss::sharded<security::credential_store>& credentials,
   ss::sharded<security::authorizer>& authorizer,
   ss::sharded<cluster::security_frontend>& sec_fe,
-  std::optional<qdc_monitor::config> qdc_config) noexcept
+  std::optional<qdc_monitor::config> qdc_config,
+  ss::sharded<cluster::controller_api>& controller_api) noexcept
+
   : _smp_group(smp)
   , _topics_frontend(tf)
   , _metadata_cache(meta)
@@ -62,7 +64,8 @@ protocol::protocol(
       config::shard_local_cfg().enable_idempotence.value())
   , _credentials(credentials)
   , _authorizer(authorizer)
-  , _security_frontend(sec_fe) {
+  , _security_frontend(sec_fe)
+  , _controller_api(controller_api) {
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);
     }

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -42,7 +42,8 @@ public:
       ss::sharded<security::credential_store>&,
       ss::sharded<security::authorizer>&,
       ss::sharded<cluster::security_frontend>&,
-      std::optional<qdc_monitor::config>) noexcept;
+      std::optional<qdc_monitor::config>,
+      ss::sharded<cluster::controller_api>&) noexcept;
 
     ~protocol() noexcept override = default;
     protocol(const protocol&) = delete;
@@ -101,6 +102,10 @@ public:
           ss::semaphore_units<>());
     }
 
+    cluster::controller_api& controller_api() {
+        return _controller_api.local();
+    }
+
 private:
     ss::smp_service_group _smp_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
@@ -117,6 +122,7 @@ private:
     ss::sharded<security::authorizer>& _authorizer;
     ss::sharded<cluster::security_frontend>& _security_frontend;
     std::optional<qdc_monitor> _qdc_mon;
+    ss::sharded<cluster::controller_api>& _controller_api;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -160,6 +160,10 @@ public:
 
     security::authorizer& authorizer() { return _conn->server().authorizer(); }
 
+    cluster::controller_api& controller_api() {
+        return _conn->server().controller_api();
+    }
+
 private:
     ss::lw_shared_ptr<connection_context> _conn;
     request_header _header;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -717,7 +717,9 @@ void application::start_redpanda() {
             controller->get_credential_store(),
             controller->get_authorizer(),
             controller->get_security_frontend(),
-            qdc_config);
+            qdc_config,
+            controller->get_api());
+
           s.set_protocol(std::move(proto));
       })
       .get();

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -86,7 +86,8 @@ public:
           app.controller->get_credential_store(),
           app.controller->get_authorizer(),
           app.controller->get_security_frontend(),
-          std::nullopt);
+          std::nullopt,
+          app.controller->get_api());
     }
 
     // creates single node with default configuration


### PR DESCRIPTION
## Cover letter

Using `cluster::controller_api` to wait for creation of all topic partitions when creating a topic. After create/autocreate topic succeed client is immediately  able to produce to the topic without receiving errors.

Fixes: #1256 

## Release notes

Fixed compatibility issues that was related with the fact that topic partitions were not ready to receive traffic immediately after topic was created.
