### PR TITLE
kafka: use code generation for fetch request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,13 +83,15 @@ jobs:
   cpp:
     name: Lint files with clang-format
     runs-on: ubuntu-20.04
-    # Use ubuntu:groovy explicitly as it is the first version to have
-    # clang-format 11 available
-    container: ubuntu:groovy
+    # Use ubuntu:hirsute explicitly as it is the first version to have
+    # clang-format 12 available
+    container: ubuntu:hirsute
     steps:
 
     - name: Fetch clang-format
       run: apt-get update && apt-get install -y git clang-format
+      env:
+        DEBIAN_FRONTEND: noninteractive
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/src/v/coproc/tests/read_materialized_topic_test.cc
+++ b/src/v/coproc/tests/read_materialized_topic_test.cc
@@ -97,7 +97,8 @@ FIXTURE_TEST(test_read_from_materialized_topic, router_test_fixture) {
     req.data.topics = {
       {.name = output_topic,
        .fetch_partitions = {
-         {.partition_index = model::partition_id(0), .fetch_offset = model::offset(0)}}}};
+         {.partition_index = model::partition_id(0),
+          .fetch_offset = model::offset(0)}}}};
 
     // .. and read the same partition using a kafka client
     auto client = make_kafka_client().get0();
@@ -110,7 +111,8 @@ FIXTURE_TEST(test_read_from_materialized_topic, router_test_fixture) {
     BOOST_REQUIRE_EQUAL(
       resp.data.topics[0].partitions[0].error_code, kafka::error_code::none);
     BOOST_REQUIRE_EQUAL(
-      resp.data.topics[0].partitions[0].partition_index, model::partition_id(0));
+      resp.data.topics[0].partitions[0].partition_index,
+      model::partition_id(0));
     BOOST_REQUIRE(resp.data.topics[0].partitions[0].records);
     // TODO(rob) fix this assertion
     // BOOST_REQUIRE_EQUAL(

--- a/src/v/coproc/tests/read_materialized_topic_test.cc
+++ b/src/v/coproc/tests/read_materialized_topic_test.cc
@@ -105,13 +105,13 @@ FIXTURE_TEST(test_read_from_materialized_topic, router_test_fixture) {
     auto resp = client.dispatch(req, kafka::api_version(4)).get0();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    BOOST_REQUIRE_EQUAL(resp.partitions.size(), 1);
-    BOOST_REQUIRE_EQUAL(resp.partitions[0].name, output_topic);
+    BOOST_REQUIRE_EQUAL(resp.data.topics.size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.data.topics[0].name, output_topic);
     BOOST_REQUIRE_EQUAL(
-      resp.partitions[0].responses[0].error, kafka::error_code::none);
+      resp.data.topics[0].partitions[0].error_code, kafka::error_code::none);
     BOOST_REQUIRE_EQUAL(
-      resp.partitions[0].responses[0].id, model::partition_id(0));
-    BOOST_REQUIRE(resp.partitions[0].responses[0].record_set);
+      resp.data.topics[0].partitions[0].partition_index, model::partition_id(0));
+    BOOST_REQUIRE(resp.data.topics[0].partitions[0].records);
     // TODO(rob) fix this assertion
     // BOOST_REQUIRE_EQUAL(
     //   std::move(*resp.partitions[0].responses[0].record_set).release(),

--- a/src/v/coproc/tests/read_materialized_topic_test.cc
+++ b/src/v/coproc/tests/read_materialized_topic_test.cc
@@ -91,13 +91,13 @@ FIXTURE_TEST(test_read_from_materialized_topic, router_test_fixture) {
 
     // Connect a kafka client to the expected output topic
     kafka::fetch_request req;
-    req.max_bytes = std::numeric_limits<int32_t>::max();
-    req.min_bytes = 1; // At LEAST 'bytes_written' in src topic
-    req.max_wait_time = 2s;
-    req.topics = {
+    req.data.max_bytes = std::numeric_limits<int32_t>::max();
+    req.data.min_bytes = 1; // At LEAST 'bytes_written' in src topic
+    req.data.max_wait_ms = 2s;
+    req.data.topics = {
       {.name = output_topic,
-       .partitions = {
-         {.id = model::partition_id(0), .fetch_offset = model::offset(0)}}}};
+       .fetch_partitions = {
+         {.partition_index = model::partition_id(0), .fetch_offset = model::offset(0)}}}};
 
     // .. and read the same partition using a kafka client
     auto client = make_kafka_client().get0();

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -389,25 +389,26 @@ ss::future<fetch_response> consumer::fetch(
                           .try_emplace(
                             broker,
                             fetch_request{
+                              .data = {
                               .replica_id = consumer_replica_id,
-                              .max_wait_time = timeout,
+                              .max_wait_ms = timeout,
                               .min_bytes = 1,
                               .max_bytes = max_bytes.value_or(
                                 _config.consumer_request_max_bytes),
                               .isolation_level = 0, // READ_UNCOMMITTED
                               .session_id = session.id(),
                               .session_epoch = session.epoch(),
-                            })
+                            }})
                           .first->second;
 
-            if (req.topics.empty() || req.topics.back().name != t) {
-                req.topics.push_back(fetch_request::topic{.name{t}});
+            if (req.data.topics.empty() || req.data.topics.back().name != t) {
+                req.data.topics.push_back(fetch_request::topic{.name{t}});
             }
 
-            req.topics.back().partitions.push_back(fetch_request::partition{
-              .id = p,
+            req.data.topics.back().fetch_partitions.push_back(fetch_request::partition{
+              .partition_index = p,
               .fetch_offset = session.offset(tp),
-              .partition_max_bytes = max_bytes.value_or(
+              .max_bytes = max_bytes.value_or(
                 _config.consumer_request_max_bytes)});
         }
     }

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -405,11 +405,12 @@ ss::future<fetch_response> consumer::fetch(
                 req.data.topics.push_back(fetch_request::topic{.name{t}});
             }
 
-            req.data.topics.back().fetch_partitions.push_back(fetch_request::partition{
-              .partition_index = p,
-              .fetch_offset = session.offset(tp),
-              .max_bytes = max_bytes.value_or(
-                _config.consumer_request_max_bytes)});
+            req.data.topics.back().fetch_partitions.push_back(
+              fetch_request::partition{
+                .partition_index = p,
+                .fetch_offset = session.offset(tp),
+                .max_bytes = max_bytes.value_or(
+                  _config.consumer_request_max_bytes)});
         }
     }
 
@@ -420,10 +421,8 @@ ss::future<fetch_response> consumer::fetch(
           return dispatch_fetch(std::move(br));
       },
       fetch_response{
-        .data = {
-        .throttle_time_ms{},
-        .error_code = error_code::none,
-        .session_id = kafka::invalid_fetch_session_id}},
+        .data
+        = {.throttle_time_ms{}, .error_code = error_code::none, .session_id = kafka::invalid_fetch_session_id}},
       detail::reduce_fetch_response);
 }
 

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -32,18 +32,18 @@ model::offset fetch_session::offset(model::topic_partition_view tpv) const {
 
 bool fetch_session::apply(fetch_response& res) {
     if (_id == invalid_fetch_session_id) {
-        _id = fetch_session_id{res.session_id};
+        _id = fetch_session_id{res.data.session_id};
     }
-    vassert(res.session_id == _id, "session mismatch: {}", *this);
+    vassert(res.data.session_id == _id, "session mismatch: {}", *this);
 
     ++_epoch;
     for (auto& part : res) {
-        if (part.partition_response->has_error()) {
+        if (part.partition_response->error_code != error_code::none) {
             continue;
         }
         const auto& topic = part.partition->name;
-        const auto p_id = part.partition_response->id;
-        auto& record_set = part.partition_response->record_set;
+        const auto p_id = part.partition_response->partition_index;
+        auto& record_set = part.partition_response->records;
         if (!record_set || record_set->empty()) {
             continue;
         }

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -67,24 +67,25 @@ make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
         error = error_code::unknown_server_error;
     }
     fetch_response::partition_response pr{
-      .id{tp.partition},
-      .error = error,
+      .partition_index{tp.partition},
+      .error_code = error,
       .high_watermark{model::offset{-1}},
       .last_stable_offset{model::offset{-1}},
       .log_start_offset{model::offset{-1}},
-      .aborted_transactions{},
-      .record_set{}};
+      .aborted{},
+      .records{}};
 
     std::vector<fetch_response::partition_response> responses;
     responses.push_back(std::move(pr));
-    auto response = fetch_response::partition(tp.topic);
-    response.responses = std::move(responses);
+    auto response = fetch_response::partition{.name=tp.topic};
+    response.partitions = std::move(responses);
     std::vector<fetch_response::partition> parts;
     parts.push_back(std::move(response));
     return fetch_response{
-      .error = error,
-      .partitions = std::move(parts),
-    };
+      .data = {
+      .error_code = error,
+      .topics = std::move(parts),
+    }};
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -26,22 +26,23 @@ fetch_request make_fetch_request(
   std::chrono::milliseconds timeout) {
     std::vector<fetch_request::partition> partitions;
     partitions.push_back(fetch_request::partition{
-      .id{tp.partition},
+      .partition_index{tp.partition},
       .current_leader_epoch = 0,
       .fetch_offset{offset},
       .log_start_offset{model::offset{-1}},
-      .partition_max_bytes = max_bytes});
+      .max_bytes = max_bytes});
     std::vector<fetch_request::topic> topics;
     topics.push_back(fetch_request::topic{
-      .name{tp.topic}, .partitions{std::move(partitions)}});
+      .name{tp.topic}, .fetch_partitions{std::move(partitions)}});
 
     return fetch_request{
+      .data = {
       .replica_id{consumer_replica_id},
-      .max_wait_time{timeout},
+      .max_wait_ms{timeout},
       .min_bytes = 0,
       .max_bytes = max_bytes,
       .isolation_level = 0,
-      .topics{std::move(topics)}};
+      .topics{std::move(topics)}}};
 }
 
 fetch_response

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -37,12 +37,12 @@ fetch_request make_fetch_request(
 
     return fetch_request{
       .data = {
-      .replica_id{consumer_replica_id},
-      .max_wait_ms{timeout},
-      .min_bytes = 0,
-      .max_bytes = max_bytes,
-      .isolation_level = 0,
-      .topics{std::move(topics)}}};
+        .replica_id{consumer_replica_id},
+        .max_wait_ms{timeout},
+        .min_bytes = 0,
+        .max_bytes = max_bytes,
+        .isolation_level = 0,
+        .topics{std::move(topics)}}};
 }
 
 fetch_response
@@ -77,15 +77,15 @@ make_fetch_response(const model::topic_partition& tp, std::exception_ptr ex) {
 
     std::vector<fetch_response::partition_response> responses;
     responses.push_back(std::move(pr));
-    auto response = fetch_response::partition{.name=tp.topic};
+    auto response = fetch_response::partition{.name = tp.topic};
     response.partitions = std::move(responses);
     std::vector<fetch_response::partition> parts;
     parts.push_back(std::move(response));
     return fetch_response{
       .data = {
-      .error_code = error,
-      .topics = std::move(parts),
-    }};
+        .error_code = error,
+        .topics = std::move(parts),
+      }};
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -402,7 +402,8 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
                   fetch_responses[i].end(),
                   [&](const auto& res) {
                       return res.partition->name == t.name
-                             && res.partition_response->partition_index == p.partition_index;
+                             && res.partition_response->partition_index
+                                  == p.partition_index;
                   });
                 BOOST_REQUIRE(part_it != fetch_responses[i].end());
                 auto expected_offset

--- a/src/v/kafka/client/test/consumer_group.cc
+++ b/src/v/kafka/client/test/consumer_group.cc
@@ -296,13 +296,13 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
           [&](kafka::member_id m_id) {
               auto res
                 = client.consumer_fetch(group_id, m_id, 200ms, 1_MiB).get();
-              BOOST_REQUIRE_EQUAL(res.error, kafka::error_code::none);
-              BOOST_REQUIRE_EQUAL(res.partitions.size(), 3);
-              for (const auto& p : res.partitions) {
-                  BOOST_REQUIRE_EQUAL(p.responses.size(), 1);
-                  const auto& res = p.responses[0];
-                  BOOST_REQUIRE_EQUAL(res.error, kafka::error_code::none);
-                  BOOST_REQUIRE(!!res.record_set);
+              BOOST_REQUIRE_EQUAL(res.data.error_code, kafka::error_code::none);
+              BOOST_REQUIRE_EQUAL(res.data.topics.size(), 3);
+              for (const auto& p : res.data.topics) {
+                  BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);
+                  const auto& res = p.partitions[0];
+                  BOOST_REQUIRE_EQUAL(res.error_code, kafka::error_code::none);
+                  BOOST_REQUIRE(!!res.records);
               }
               return res;
           })
@@ -402,11 +402,11 @@ FIXTURE_TEST(consumer_group, kafka_client_fixture) {
                   fetch_responses[i].end(),
                   [&](const auto& res) {
                       return res.partition->name == t.name
-                             && res.partition_response->id == p.partition_index;
+                             && res.partition_response->partition_index == p.partition_index;
                   });
                 BOOST_REQUIRE(part_it != fetch_responses[i].end());
                 auto expected_offset
-                  = part_it->partition_response->record_set->last_offset();
+                  = part_it->partition_response->records->last_offset();
                 BOOST_REQUIRE_EQUAL(p.committed_offset(), expected_offset);
             }
         }

--- a/src/v/kafka/client/test/fetch.cc
+++ b/src/v/kafka/client/test/fetch.cc
@@ -53,7 +53,8 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
         BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);
         BOOST_REQUIRE_EQUAL(p.partitions[0].partition_index, ntp.tp.partition);
         BOOST_REQUIRE_EQUAL(
-          p.partitions[0].error_code, kafka::error_code::unknown_topic_or_partition);
+          p.partitions[0].error_code,
+          kafka::error_code::unknown_topic_or_partition);
     }
 
     info("Adding known topic");

--- a/src/v/kafka/client/test/fetch.cc
+++ b/src/v/kafka/client/test/fetch.cc
@@ -48,12 +48,12 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
           model::topic("unknown"), model::partition_id(0));
         auto res{
           client.fetch_partition(ntp.tp, model::offset(0), 1024, 1000ms).get()};
-        const auto& p = res.partitions[0];
+        const auto& p = res.data.topics[0];
         BOOST_REQUIRE_EQUAL(p.name, ntp.tp.topic);
-        BOOST_REQUIRE_EQUAL(p.responses.size(), 1);
-        BOOST_REQUIRE_EQUAL(p.responses[0].id, ntp.tp.partition);
+        BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);
+        BOOST_REQUIRE_EQUAL(p.partitions[0].partition_index, ntp.tp.partition);
         BOOST_REQUIRE_EQUAL(
-          p.responses[0].error, kafka::error_code::unknown_topic_or_partition);
+          p.partitions[0].error_code, kafka::error_code::unknown_topic_or_partition);
     }
 
     info("Adding known topic");
@@ -68,12 +68,12 @@ FIXTURE_TEST(fetch, kafka_client_fixture) {
         client.config().retries.set_value(size_t(3));
         auto res{
           client.fetch_partition(ntp.tp, model::offset(0), 1024, 1000ms).get()};
-        const auto& p = res.partitions[0];
+        const auto& p = res.data.topics[0];
         BOOST_REQUIRE_EQUAL(p.name, ntp.tp.topic);
-        BOOST_REQUIRE_EQUAL(p.responses.size(), 1);
-        auto const& r = p.responses[0];
-        BOOST_REQUIRE_EQUAL(r.id, ntp.tp.partition);
-        BOOST_REQUIRE_EQUAL(r.error, kafka::error_code::none);
+        BOOST_REQUIRE_EQUAL(p.partitions.size(), 1);
+        auto const& r = p.partitions[0];
+        BOOST_REQUIRE_EQUAL(r.partition_index, ntp.tp.partition);
+        BOOST_REQUIRE_EQUAL(r.error_code, kafka::error_code::none);
     }
 
     client.stop().get();

--- a/src/v/kafka/client/test/fetch_session.cc
+++ b/src/v/kafka/client/test/fetch_session.cc
@@ -42,11 +42,11 @@ kafka::fetch_response make_fetch_response(
   std::optional<kafka::batch_reader> record_set) {
     kafka::fetch_response res{
       .data = {
-      .throttle_time_ms = std::chrono::milliseconds{0},
-      .error_code = kafka::error_code::none,
-      .session_id = s_id,
-      .topics{}}};
-    kafka::fetch_response::partition p{.name=tpv.topic};
+        .throttle_time_ms = std::chrono::milliseconds{0},
+        .error_code = kafka::error_code::none,
+        .session_id = s_id,
+        .topics{}}};
+    kafka::fetch_response::partition p{.name = tpv.topic};
     p.partitions.push_back(kafka::fetch_response::partition_response{
       .partition_index = tpv.partition,
       .error_code = kafka::error_code::none,

--- a/src/v/kafka/client/test/fetch_session.cc
+++ b/src/v/kafka/client/test/fetch_session.cc
@@ -41,20 +41,21 @@ kafka::fetch_response make_fetch_response(
   model::topic_partition_view tpv,
   std::optional<kafka::batch_reader> record_set) {
     kafka::fetch_response res{
-      .throttle_time = std::chrono::milliseconds{0},
-      .error = kafka::error_code::none,
+      .data = {
+      .throttle_time_ms = std::chrono::milliseconds{0},
+      .error_code = kafka::error_code::none,
       .session_id = s_id,
-      .partitions{}};
-    kafka::fetch_response::partition p(tpv.topic);
-    p.responses.push_back(kafka::fetch_response::partition_response{
-      .id = tpv.partition,
-      .error = kafka::error_code::none,
+      .topics{}}};
+    kafka::fetch_response::partition p{.name=tpv.topic};
+    p.partitions.push_back(kafka::fetch_response::partition_response{
+      .partition_index = tpv.partition,
+      .error_code = kafka::error_code::none,
       .high_watermark = model::offset{-1},
       .last_stable_offset = model::offset{-1},
       .log_start_offset = model::offset{-1},
-      .aborted_transactions = {},
-      .record_set{std::move(record_set)}});
-    res.partitions.push_back(std::move(p));
+      .aborted = {},
+      .records{std::move(record_set)}});
+    res.data.topics.push_back(std::move(p));
     return res;
 }
 

--- a/src/v/kafka/protocol/batch_reader.h
+++ b/src/v/kafka/protocol/batch_reader.h
@@ -64,4 +64,9 @@ private:
     bool _do_load_slice_failed{false};
 };
 
+inline std::ostream& operator<<(std::ostream& os, const batch_reader& reader) {
+    fmt::print(os, "{{size {}}}", reader.size_bytes());
+    return os;
+}
+
 } // namespace kafka

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -12,9 +12,9 @@
 #pragma once
 
 #include "cluster/partition.h"
+#include "kafka/protocol/batch_reader.h"
 #include "kafka/protocol/schemata/fetch_request.h"
 #include "kafka/protocol/schemata/fetch_response.h"
-#include "kafka/protocol/batch_reader.h"
 #include "kafka/server/fetch_session.h"
 #include "kafka/server/partition_proxy.h"
 #include "kafka/server/request_context.h"
@@ -242,7 +242,8 @@ struct fetch_response final {
           , t_end_(end)
           , filter_(enable_filtering) {
             if (likely(state_.partition != t_end_)) {
-                state_.partition_response = state_.partition->partitions.begin();
+                state_.partition_response
+                  = state_.partition->partitions.begin();
                 state_.is_new_topic = true;
                 normalize();
             }
@@ -309,7 +310,8 @@ struct fetch_response final {
     };
 
     iterator begin(bool enable_filtering = false) {
-        return iterator(data.topics.begin(), data.topics.end(), enable_filtering);
+        return iterator(
+          data.topics.begin(), data.topics.end(), enable_filtering);
     }
 
     iterator end() { return iterator(data.topics.end(), data.topics.end()); }

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -453,7 +453,7 @@ struct op_context {
               request.cend(),
               [f = std::forward<Func>(f)](
                 const fetch_request::const_iterator::value_type& p) {
-                  f(fetch_partition{
+                  f(fetch_session_partition{
                     .topic = p.topic->name,
                     .partition = p.partition->id,
                     .max_bytes = p.partition->partition_max_bytes,

--- a/src/v/kafka/protocol/response_writer.h
+++ b/src/v/kafka/protocol/response_writer.h
@@ -128,6 +128,13 @@ public:
         return write(std::move(*rdr).release());
     }
 
+    uint32_t write(std::optional<batch_reader>& rdr) {
+        if (!rdr) {
+            return write(std::optional<iobuf>());
+        }
+        return write(std::move(*rdr).release());
+    }
+
     // write bytes directly to output without a length prefix
     uint32_t write_direct(iobuf&& f) {
         auto size = f.size_bytes();

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -54,7 +54,8 @@ set(schemata
   metadata_request.json
   metadata_response.json
   txn_offset_commit_request.json
-  txn_offset_commit_response.json)
+  txn_offset_commit_response.json
+  fetch_request.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -55,7 +55,8 @@ set(schemata
   metadata_response.json
   txn_offset_commit_request.json
   txn_offset_commit_response.json
-  fetch_request.json)
+  fetch_request.json
+  fetch_response.json)
 
 set(srcs)
 foreach(schema ${schemata})

--- a/src/v/kafka/protocol/schemata/fetch_request.json
+++ b/src/v/kafka/protocol/schemata/fetch_request.json
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1,
+  "type": "request",
+  "name": "FetchRequest",
+  //
+  // Version 1 is the same as version 0.
+  //
+  // Starting in Version 2, the requestor must be able to handle Kafka Log
+  // Message format version 1.
+  //
+  // Version 3 adds MaxBytes.  Starting in version 3, the partition ordering in
+  // the request is now relevant.  Partitions will be processed in the order
+  // they appear in the request.
+  //
+  // Version 4 adds IsolationLevel.  Starting in version 4, the reqestor must be
+  // able to handle Kafka log message format version 2.
+  //
+  // Version 5 adds LogStartOffset to indicate the earliest available offset of
+  // partition data that can be consumed.
+  //
+  // Version 6 is the same as version 5.
+  //
+  // Version 7 adds incremental fetch request support.
+  //
+  // Version 8 is the same as version 7.
+  //
+  // Version 9 adds CurrentLeaderEpoch, as described in KIP-320.
+  //
+  // Version 10 indicates that we can use the ZStd compression algorithm, as
+  // described in KIP-110.
+  //
+  "validVersions": "0-11",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "ReplicaId", "type": "int32", "versions": "0+",
+      "about": "The broker ID of the follower, of -1 if this request is from a consumer." },
+    { "name": "MaxWaitMs", "type": "int32", "versions": "0+",
+      "about": "The maximum time in milliseconds to wait for the response." },
+    { "name": "MinBytes", "type": "int32", "versions": "0+",
+      "about": "The minimum bytes to accumulate in the response." },
+    { "name": "MaxBytes", "type": "int32", "versions": "3+", "default": "0x7fffffff", "ignorable": true,
+      "about": "The maximum bytes to fetch.  See KIP-74 for cases where this limit may not be honored." },
+    { "name": "IsolationLevel", "type": "int8", "versions": "4+", "default": "0", "ignorable": false,
+      "about": "This setting controls the visibility of transactional records. Using READ_UNCOMMITTED (isolation_level = 0) makes all records visible. With READ_COMMITTED (isolation_level = 1), non-transactional and COMMITTED transactional records are visible. To be more concrete, READ_COMMITTED returns all data from offsets smaller than the current LSO (last stable offset), and enables the inclusion of the list of aborted transactions in the result, which allows consumers to discard ABORTED transactional records" },
+    { "name": "SessionId", "type": "int32", "versions": "7+", "default": "0", "ignorable": false,
+      "about": "The fetch session ID." },
+    { "name": "SessionEpoch", "type": "int32", "versions": "7+", "default": "-1", "ignorable": false,
+      "about": "The fetch session epoch, which is used for ordering requests in a session" },
+    { "name": "Topics", "type": "[]FetchTopic", "versions": "0+",
+      "about": "The topics to fetch.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The name of the topic to fetch." },
+      { "name": "FetchPartitions", "type": "[]FetchPartition", "versions": "0+",
+        "about": "The partitions to fetch.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index." },
+        { "name": "CurrentLeaderEpoch", "type": "int32", "versions": "9+", "default": "-1", "ignorable": true,
+          "about": "The current leader epoch of the partition." },
+        { "name": "FetchOffset", "type": "int64", "versions": "0+",
+          "about": "The message offset." },
+        { "name": "LogStartOffset", "type": "int64", "versions": "5+", "default": "-1", "ignorable": false,
+          "about": "The earliest available offset of the follower replica.  The field is only used when the request is sent by the follower."},
+        { "name": "MaxBytes", "type": "int32", "versions": "0+",
+          "about": "The maximum bytes to fetch from this partition.  See KIP-74 for cases where this limit may not be honored." }
+      ]}
+    ]},
+    { "name": "Forgotten", "type": "[]ForgottenTopic", "versions": "7+", "ignorable": false,
+      "about": "In an incremental fetch request, the partitions to remove.", "fields": [
+      { "name": "Name", "type": "string", "versions": "7+", "entityType": "topicName",
+        "about": "The partition name." },
+      { "name": "ForgottenPartitionIndexes", "type": "[]int32", "versions": "7+",
+        "about": "The partitions indexes to forget." }
+    ]},
+    { "name": "RackId", "type":  "string", "versions": "11+", "default": "", "ignorable": true,
+      "about": "Rack ID of the consumer making this request"}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/fetch_response.json
+++ b/src/v/kafka/protocol/schemata/fetch_response.json
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1,
+  "type": "response",
+  "name": "FetchResponse",
+  //
+  // Version 1 adds throttle time.
+  //
+  // Version 2 and 3 are the same as version 1. 
+  //
+  // Version 4 adds features for transactional consumption.
+  //
+  // Version 5 adds LogStartOffset to indicate the earliest available offset of
+  // partition data that can be consumed.
+  //
+  // Starting in version 6, we may return KAFKA_STORAGE_ERROR as an error code.
+  //
+  // Version 7 adds incremental fetch request support.
+  //
+  // Starting in version 8, on quota violation, brokers send out responses before throttling.
+  //
+  // Version 9 is the same as version 8.
+  //
+  // Version 10 indicates that the response data can use the ZStd compression
+  // algorithm, as described in KIP-110.
+  //
+  "validVersions": "0-11",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "7+", "ignorable": false,
+      "about": "The top level response error code." },
+    { "name": "SessionId", "type": "int32", "versions": "7+", "default": "0", "ignorable": false,
+      "about": "The fetch session ID, or 0 if this is not part of a fetch session." },
+    { "name": "Topics", "type": "[]FetchableTopicResponse", "versions": "0+",
+      "about": "The response topics.", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "Partitions", "type": "[]FetchablePartitionResponse", "versions": "0+",
+        "about": "The topic partitions.", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partiiton index." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The error code, or 0 if there was no fetch error." },
+        { "name": "HighWatermark", "type": "int64", "versions": "0+",
+          "about": "The current high water mark." },
+        { "name": "LastStableOffset", "type": "int64", "versions": "4+", "default": "-1", "ignorable": true,
+          "about": "The last stable offset (or LSO) of the partition. This is the last offset such that the state of all transactional records prior to this offset have been decided (ABORTED or COMMITTED)" },
+        { "name": "LogStartOffset", "type": "int64", "versions": "5+", "default": "-1", "ignorable": true,
+          "about": "The current log start offset." },
+        { "name": "Aborted", "type": "[]AbortedTransaction", "versions": "4+", "nullableVersions": "4+", "ignorable": false,
+          "about": "The aborted transactions.",  "fields": [
+          { "name": "ProducerId", "type": "int64", "versions": "4+", "entityType": "producerId",
+            "about": "The producer id associated with the aborted transaction." },
+          { "name": "FirstOffset", "type": "int64", "versions": "4+",
+            "about": "The first offset in the aborted transaction." }
+        ]},
+        { "name": "PreferredReadReplica", "type": "int32", "versions": "11+", "ignorable": true,
+          "about": "The preferred read replica for the consumer to use on its next fetch request"},
+        { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+",
+          "about": "The record data." }
+      ]}
+    ]}
+  ]
+}

--- a/src/v/kafka/protocol/schemata/fetch_response.json
+++ b/src/v/kafka/protocol/schemata/fetch_response.json
@@ -70,7 +70,7 @@
           { "name": "FirstOffset", "type": "int64", "versions": "4+",
             "about": "The first offset in the aborted transaction." }
         ]},
-        { "name": "PreferredReadReplica", "type": "int32", "versions": "11+", "ignorable": true,
+        { "name": "PreferredReadReplica", "type": "int32", "versions": "11+", "default": "-1", "ignorable": true,
           "about": "The preferred read replica for the consumer to use on its next fetch request"},
         { "name": "Records", "type": "bytes", "versions": "0+", "nullableVersions": "0+",
           "about": "The record data." }

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -212,6 +212,15 @@ path_type_map = {
             },
         },
     },
+    "FetchRequestData": {
+        "MaxWaitMs": ("std::chrono::milliseconds", "int32"),
+        "Topics": {
+            "FetchPartitions": {
+                "PartitionIndex": ("model::partition_id", "int32"),
+                "FetchOffset": ("model::offset", "int64"),
+            },
+        },
+    },
 }
 
 # a few kafka field types specify an entity type
@@ -333,6 +342,9 @@ STRUCT_TYPES = [
     "TxnOffsetCommitResponseTopic",
     "TxnOffsetCommitResponsePartition",
     "TxnOffsetCommitRequestPartition",
+    "FetchTopic",
+    "ForgottenTopic",
+    "FetchPartition",
 ]
 
 SCALAR_TYPES = list(basic_type_map.keys())

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -262,6 +262,16 @@ struct_renames = {
 }
 # yapf: enable
 
+
+def make_context_field(path):
+    """
+    For a given path return a special field to be added to a generated
+    structure. This structure will not be encoded/decoded on the wire and is
+    used to add some extra context.
+    """
+    return None
+
+
 # a listing of expected struct types
 STRUCT_TYPES = [
     "ApiVersionsRequestKey",
@@ -446,6 +456,7 @@ class StructType(FieldType):
     def __init__(self, name, fields, path=()):
         super().__init__(snake_case(name))
         self.fields = [Field.create(f, path) for f in fields]
+        self.context_field = make_context_field(path)
 
     @property
     def is_struct(self):
@@ -664,6 +675,12 @@ struct {{ struct.name }} {
     {{ info[0] }} {{ field.name }}{ {{- field.default_value() -}} };
     {%- endif %}
 {%- endfor %}
+{%- if struct.context_field %}
+
+    // extra context not part of kafka protocol.
+    // added by redpanda. see generator.py:make_context_field.
+    {{ struct.context_field[0] }} {{ struct.context_field[1] -}};
+{%- endif %}
 {% endmacro %}
 
 namespace kafka {

--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -22,7 +22,7 @@
 
 namespace kafka {
 
-struct fetch_partition {
+struct fetch_session_partition {
     model::topic topic;
     model::partition_id partition;
     int32_t max_bytes;
@@ -41,10 +41,10 @@ struct fetch_partition {
 class fetch_partitions_linked_hash_map {
 private:
     struct entry {
-        explicit entry(kafka::fetch_partition partition)
+        explicit entry(kafka::fetch_session_partition partition)
           : partition(std::move(partition)) {}
 
-        kafka::fetch_partition partition;
+        kafka::fetch_session_partition partition;
         intrusive_list_hook _hook;
     };
 
@@ -112,7 +112,7 @@ public:
           "partitions map and insertion order list sizes are not equal.");
     }
 
-    void emplace(kafka::fetch_partition v) {
+    void emplace(kafka::fetch_session_partition v) {
         auto e = std::make_unique<entry>(std::move(v));
         auto [it, success] = partitions.emplace(
           model::topic_partition_view(
@@ -155,7 +155,7 @@ public:
         using debug = absl::container_internal::hashtable_debug_internal::
           HashtableDebugAccess<underlying_t>;
         return debug::AllocatedByteSize(partitions)
-               + partitions.size() * sizeof(fetch_partition);
+               + partitions.size() * sizeof(fetch_session_partition);
     }
 
     iterator begin() { return partitions.begin(); }

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -12,9 +12,9 @@
 
 namespace kafka {
 
-static fetch_partition make_fetch_partition(
+static fetch_session_partition make_fetch_partition(
   const model::topic& tp, const fetch_request::partition& p) {
-    return fetch_partition{
+    return fetch_session_partition{
       .topic = tp,
       .partition = p.id,
       .max_bytes = p.partition_max_bytes,

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -16,8 +16,8 @@ static fetch_session_partition make_fetch_partition(
   const model::topic& tp, const fetch_request::partition& p) {
     return fetch_session_partition{
       .topic = tp,
-      .partition = p.id,
-      .max_bytes = p.partition_max_bytes,
+      .partition = p.partition_index,
+      .max_bytes = p.max_bytes,
       .fetch_offset = p.fetch_offset,
       .high_watermark = model::offset(-1),
     };
@@ -27,11 +27,11 @@ void update_fetch_session(fetch_session& session, const fetch_request& req) {
     for (auto it = req.cbegin(); it != req.cend(); ++it) {
         auto& topic = *it->topic;
         auto& partition = *it->partition;
-        model::topic_partition tp(topic.name, partition.id);
+        model::topic_partition tp(topic.name, partition.partition_index);
 
         if (auto s_it = session.partitions().find(tp);
             s_it != session.partitions().end()) {
-            s_it->second->partition.max_bytes = partition.partition_max_bytes;
+            s_it->second->partition.max_bytes = partition.max_bytes;
             s_it->second->partition.fetch_offset = partition.fetch_offset;
         } else {
             session.partitions().emplace(
@@ -39,8 +39,8 @@ void update_fetch_session(fetch_session& session, const fetch_request& req) {
         }
     }
 
-    for (auto& ft : req.forgotten_topics) {
-        for (auto& fp : ft.partitions) {
+    for (auto& ft : req.data.forgotten) {
+        for (auto& fp : ft.forgotten_partition_indexes) {
             model::topic_partition tp(ft.name, model::partition_id(fp));
             session.partitions().erase(
               model::topic_partition_view(ft.name, model::partition_id(fp)));
@@ -67,8 +67,8 @@ fetch_session_cache::fetch_session_cache(
 
 fetch_session_ctx
 fetch_session_cache::maybe_get_session(const fetch_request& req) {
-    fetch_session_id session_id{req.session_id};
-    fetch_session_epoch epoch{req.session_epoch};
+    fetch_session_id session_id{req.data.session_id};
+    fetch_session_epoch epoch{req.data.session_epoch};
 
     if (req.is_full_fetch_request()) {
         // Any session specified in a FULL fetch request will be closed.

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -605,7 +605,7 @@ static std::vector<shard_fetch> group_requests_by_shard(op_context& octx) {
      * group fetch requests by shard
      */
     octx.for_each_fetch_partition(
-      [&resp_it, &octx, &shard_fetches](const fetch_partition& fp) {
+      [&resp_it, &octx, &shard_fetches](const fetch_session_partition& fp) {
           // if this is not an initial fetch we are allowed to skip
           // partions that aleready have an error or we have enough data
           if (!octx.initial_fetch) {
@@ -786,7 +786,7 @@ void op_context::create_response_placeholders() {
         std::for_each(
           session_ctx.session()->partitions().cbegin_insertion_order(),
           session_ctx.session()->partitions().cend_insertion_order(),
-          [this, &last_topic](const fetch_partition& fp) {
+          [this, &last_topic](const fetch_session_partition& fp) {
               if (last_topic != fp.topic) {
                   response.partitions.emplace_back(fp.topic);
                   last_topic = fp.topic;
@@ -804,7 +804,7 @@ void op_context::create_response_placeholders() {
 }
 
 bool update_fetch_partition(
-  const fetch_response::partition_response& resp, fetch_partition& partition) {
+  const fetch_response::partition_response& resp, fetch_session_partition& partition) {
     bool include = false;
     if (resp.record_set && resp.record_set->size_bytes() > 0) {
         // Partitions with new data are always included in the response.

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -368,7 +368,9 @@ static std::vector<shard_fetch> group_requests_by_shard(op_context& octx) {
                 = !resp_it->partition_response->records->empty()
                   && octx.over_min_bytes();
 
-              if (resp_it->partition_response->error_code != error_code::none || has_enough_data) {
+              if (
+                resp_it->partition_response->error_code != error_code::none
+                || has_enough_data) {
                   ++resp_it;
                   return;
               }
@@ -511,7 +513,8 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
 
 // insert and reserve space for a new topic in the response
 void op_context::start_response_topic(const fetch_request::topic& topic) {
-    auto& p = response.data.topics.emplace_back(fetchable_topic_response{.name=topic.name});
+    auto& p = response.data.topics.emplace_back(
+      fetchable_topic_response{.name = topic.name});
     p.partitions.reserve(topic.fetch_partitions.size());
 }
 
@@ -543,7 +546,8 @@ void op_context::create_response_placeholders() {
           session_ctx.session()->partitions().cend_insertion_order(),
           [this, &last_topic](const fetch_session_partition& fp) {
               if (last_topic != fp.topic) {
-                  response.data.topics.emplace_back(fetchable_topic_response{.name=fp.topic});
+                  response.data.topics.emplace_back(
+                    fetchable_topic_response{.name = fp.topic});
                   last_topic = fp.topic;
               }
               fetch_response::partition_response p{
@@ -559,7 +563,8 @@ void op_context::create_response_placeholders() {
 }
 
 bool update_fetch_partition(
-  const fetch_response::partition_response& resp, fetch_session_partition& partition) {
+  const fetch_response::partition_response& resp,
+  fetch_session_partition& partition) {
     bool include = false;
     if (resp.records && resp.records->size_bytes() > 0) {
         // Partitions with new data are always included in the response.
@@ -599,7 +604,8 @@ ss::future<response_ptr> op_context::send_response() && {
 
     for (auto it = response.begin(true); it != response.end(); ++it) {
         if (it->is_new_topic) {
-            final_response.data.topics.emplace_back(fetchable_topic_response{.name=it->partition->name});
+            final_response.data.topics.emplace_back(
+              fetchable_topic_response{.name = it->partition->name});
             final_response.data.topics.back().partitions.reserve(
               it->partition->partitions.size());
         }
@@ -610,8 +616,7 @@ ss::future<response_ptr> op_context::send_response() && {
           .high_watermark = it->partition_response->high_watermark,
           .last_stable_offset = it->partition_response->last_stable_offset,
           .log_start_offset = it->partition_response->log_start_offset,
-          .aborted = std::move(
-            it->partition_response->aborted),
+          .aborted = std::move(it->partition_response->aborted),
           .records = std::move(it->partition_response->records)};
 
         final_response.data.topics.back().partitions.push_back(std::move(r));

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -40,128 +40,17 @@
 
 namespace kafka {
 
-void fetch_response::encode(const request_context& ctx, response& resp) {
-    auto& writer = resp.writer();
-    auto version = ctx.header().version;
-
-    writer.write(int32_t(throttle_time.count())); // v1
-
-    if (version >= api_version(7)) {
-        writer.write(error);
-        writer.write(session_id);
-    }
-
-    writer.write_array(
-      partitions, [version](partition& p, response_writer& writer) {
-          writer.write(p.name);
-          writer.write_array(
-            p.responses,
-            [version](partition_response& r, response_writer& writer) {
-                writer.write(r.id);
-                writer.write(r.error);
-                writer.write(int64_t(r.high_watermark));
-                writer.write(int64_t(r.last_stable_offset)); // v4
-                if (version >= api_version(5)) {
-                    writer.write(int64_t(r.log_start_offset));
-                }
-                writer.write_array( // v4
-                  r.aborted_transactions,
-                  [](const aborted_transaction& t, response_writer& writer) {
-                      writer.write(t.producer_id);
-                      writer.write(int64_t(t.first_offset));
-                  });
-                if (version >= api_version(11)) {
-                    writer.write(r.preferred_read_replica);
-                }
-                writer.write(std::move(r.record_set));
-            });
-      });
-}
-
-void fetch_response::decode(iobuf buf, api_version version) {
-    request_reader reader(std::move(buf));
-
-    throttle_time = std::chrono::milliseconds(reader.read_int32()); // v1
-
-    error = version >= api_version(7) ? error_code(reader.read_int16())
-                                      : kafka::error_code::none;
-
-    session_id = version >= api_version(7) ? reader.read_int32() : 0;
-
-    partitions = reader.read_array([version](request_reader& reader) {
-        partition p(model::topic(reader.read_string()));
-        p.responses = reader.read_array([version](request_reader& reader) {
-            return partition_response{
-              .id = model::partition_id(reader.read_int32()),
-              .error = error_code(reader.read_int16()),
-              .high_watermark = model::offset(reader.read_int64()),
-              .last_stable_offset = model::offset(reader.read_int64()), // v4
-              .log_start_offset = model::offset(
-                version >= api_version(5) ? reader.read_int64() : -1),
-              .aborted_transactions = reader.read_array( // v4
-                [](request_reader& reader) {
-                    return aborted_transaction{
-                      .producer_id = reader.read_int64(),
-                      .first_offset = model::offset(reader.read_int64()),
-                    };
-                }),
-              .preferred_read_replica = version >= api_version(11)
-                                          ? model::node_id{reader.read_int32()}
-                                          : model::node_id{-1},
-              .record_set = reader.read_nullable_batch_reader()};
-        });
-        return p;
-    });
-}
-
-std::ostream&
-operator<<(std::ostream& o, const fetch_response::aborted_transaction& t) {
-    fmt::print(
-      o, "{{producer {} first_off {}}}", t.producer_id, t.first_offset);
-    return o;
-}
-
-std::ostream&
-operator<<(std::ostream& o, const fetch_response::partition_response& p) {
-    fmt::print(
-      o,
-      "{{id {} err {} high_water {} last_stable_off {} aborted {} "
-      "record_set_len {}}}",
-      p.id,
-      p.error,
-      p.high_watermark,
-      p.last_stable_offset,
-      p.aborted_transactions,
-      (p.record_set ? p.record_set->size_bytes() : -1));
-    return o;
-}
-
-std::ostream& operator<<(std::ostream& o, const fetch_response::partition& p) {
-    fmt::print(o, "{{name {} responses {}}}", p.name, p.responses);
-    return o;
-}
-
-std::ostream& operator<<(std::ostream& o, const fetch_response& r) {
-    fmt::print(
-      o,
-      "{{session_id {} error {} partitions {}}}",
-      r.session_id,
-      r.error,
-      r.partitions);
-    return o;
-}
-
 /**
  * Make a partition response error.
  */
 static fetch_response::partition_response
 make_partition_response_error(model::partition_id p_id, error_code error) {
     return fetch_response::partition_response{
-      .id = p_id,
-      .error = error,
+      .partition_index = p_id,
+      .error_code = error,
       .high_watermark = model::offset(-1),
       .last_stable_offset = model::offset(-1),
-      .record_set = batch_reader(),
+      .records = batch_reader(),
     };
 }
 
@@ -359,9 +248,9 @@ static ss::future<> do_fill_fetch_responses(
              pid = res.partition,
              resp_it = resp_it](kafka_batch_serializer::result res) mutable {
                 fetch_response::partition_response resp{
-                  .id = pid,
-                  .error = error_code::none,
-                  .record_set = batch_reader(std::move(res.data)),
+                  .partition_index = pid,
+                  .error_code = error_code::none,
+                  .records = batch_reader(std::move(res.data)),
                 };
                 resp_it.set(std::move(resp));
                 resp_it->partition_response->log_start_offset = so;
@@ -476,10 +365,10 @@ static std::vector<shard_fetch> group_requests_by_shard(op_context& octx) {
           // partions that aleready have an error or we have enough data
           if (!octx.initial_fetch) {
               bool has_enough_data
-                = !resp_it->partition_response->record_set->empty()
+                = !resp_it->partition_response->records->empty()
                   && octx.over_min_bytes();
 
-              if (resp_it->partition_response->has_error() || has_enough_data) {
+              if (resp_it->partition_response->error_code != error_code::none || has_enough_data) {
                   ++resp_it;
                   return;
               }
@@ -574,10 +463,10 @@ fetch_handler::handle(request_context rctx, ss::smp_service_group ssg) {
     return ss::do_with(op_context(std::move(rctx), ssg), [](op_context& octx) {
         // top-level error is used for session-level errors
         if (octx.session_ctx.has_error()) {
-            octx.response.error = octx.session_ctx.error();
+            octx.response.data.error_code = octx.session_ctx.error();
             return std::move(octx).send_response();
         }
-        octx.response.error = error_code::none;
+        octx.response.data.error_code = error_code::none;
         // first fetch, do not wait
         return fetch_topic_partitions(octx)
           .then([&octx] {
@@ -602,7 +491,7 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
      */
     request.decode(rctx.reader(), rctx.header().version);
     if (likely(!request.data.topics.empty())) {
-        response.partitions.reserve(request.data.topics.size());
+        response.data.topics.reserve(request.data.topics.size());
     }
 
     if (auto delay = request.debounce_delay(); delay) {
@@ -622,18 +511,18 @@ op_context::op_context(request_context&& ctx, ss::smp_service_group ssg)
 
 // insert and reserve space for a new topic in the response
 void op_context::start_response_topic(const fetch_request::topic& topic) {
-    auto& p = response.partitions.emplace_back(topic.name);
-    p.responses.reserve(topic.fetch_partitions.size());
+    auto& p = response.data.topics.emplace_back(fetchable_topic_response{.name=topic.name});
+    p.partitions.reserve(topic.fetch_partitions.size());
 }
 
 void op_context::start_response_partition(const fetch_request::partition& p) {
-    response.partitions.back().responses.push_back(
+    response.data.topics.back().partitions.push_back(
       fetch_response::partition_response{
-        .id = p.partition_index,
-        .error = error_code::none,
+        .partition_index = p.partition_index,
+        .error_code = error_code::none,
         .high_watermark = model::offset(-1),
         .last_stable_offset = model::offset(-1),
-        .record_set = batch_reader()});
+        .records = batch_reader()});
 }
 
 void op_context::create_response_placeholders() {
@@ -654,17 +543,17 @@ void op_context::create_response_placeholders() {
           session_ctx.session()->partitions().cend_insertion_order(),
           [this, &last_topic](const fetch_session_partition& fp) {
               if (last_topic != fp.topic) {
-                  response.partitions.emplace_back(fp.topic);
+                  response.data.topics.emplace_back(fetchable_topic_response{.name=fp.topic});
                   last_topic = fp.topic;
               }
               fetch_response::partition_response p{
-                .id = fp.partition,
-                .error = error_code::none,
+                .partition_index = fp.partition,
+                .error_code = error_code::none,
                 .high_watermark = fp.high_watermark,
                 .last_stable_offset = fp.high_watermark,
-                .record_set = batch_reader()};
+                .records = batch_reader()};
 
-              response.partitions.back().responses.push_back(std::move(p));
+              response.data.topics.back().partitions.push_back(std::move(p));
           });
     }
 }
@@ -672,7 +561,7 @@ void op_context::create_response_placeholders() {
 bool update_fetch_partition(
   const fetch_response::partition_response& resp, fetch_session_partition& partition) {
     bool include = false;
-    if (resp.record_set && resp.record_set->size_bytes() > 0) {
+    if (resp.records && resp.records->size_bytes() > 0) {
         // Partitions with new data are always included in the response.
         include = true;
     }
@@ -680,7 +569,7 @@ bool update_fetch_partition(
         partition.high_watermark = model::offset(resp.high_watermark);
         return true;
     }
-    if (resp.error != error_code::none) {
+    if (resp.error_code != error_code::none) {
         // Partitions with errors are always included in the response.
         // We also set the cached highWatermark to an invalid offset, -1.
         // This ensures that when the error goes away, we re-send the
@@ -694,38 +583,38 @@ bool update_fetch_partition(
 ss::future<response_ptr> op_context::send_response() && {
     // Sessionless fetch
     if (session_ctx.is_sessionless()) {
-        response.session_id = invalid_fetch_session_id;
+        response.data.session_id = invalid_fetch_session_id;
         return rctx.respond(std::move(response));
     }
     // bellow we handle incremental fetches, set response session id
-    response.session_id = session_ctx.session()->id();
+    response.data.session_id = session_ctx.session()->id();
     if (session_ctx.is_full_fetch()) {
         return rctx.respond(std::move(response));
     }
 
     fetch_response final_response;
-    final_response.error = response.error;
-    final_response.session_id = response.session_id;
-    final_response.throttle_time = response.throttle_time;
+    final_response.data.error_code = response.data.error_code;
+    final_response.data.session_id = response.data.session_id;
+    final_response.data.throttle_time_ms = response.data.throttle_time_ms;
 
     for (auto it = response.begin(true); it != response.end(); ++it) {
         if (it->is_new_topic) {
-            final_response.partitions.emplace_back(it->partition->name);
-            final_response.partitions.back().responses.reserve(
-              it->partition->responses.size());
+            final_response.data.topics.emplace_back(fetchable_topic_response{.name=it->partition->name});
+            final_response.data.topics.back().partitions.reserve(
+              it->partition->partitions.size());
         }
 
         fetch_response::partition_response r{
-          .id = it->partition_response->id,
-          .error = it->partition_response->error,
+          .partition_index = it->partition_response->partition_index,
+          .error_code = it->partition_response->error_code,
           .high_watermark = it->partition_response->high_watermark,
           .last_stable_offset = it->partition_response->last_stable_offset,
           .log_start_offset = it->partition_response->log_start_offset,
-          .aborted_transactions = std::move(
-            it->partition_response->aborted_transactions),
-          .record_set = std::move(it->partition_response->record_set)};
+          .aborted = std::move(
+            it->partition_response->aborted),
+          .records = std::move(it->partition_response->records)};
 
-        final_response.partitions.back().responses.push_back(std::move(r));
+        final_response.data.topics.back().partitions.push_back(std::move(r));
     }
 
     return rctx.respond(std::move(final_response));
@@ -739,24 +628,24 @@ op_context::response_iterator::response_iterator(
 void op_context::response_iterator::set(
   fetch_response::partition_response&& response) {
     vassert(
-      response.id == _it->partition_response->id,
+      response.partition_index == _it->partition_response->partition_index,
       "Response and current partition ids have to be the same. Current "
       "response {}, update {}",
-      _it->partition_response->id,
-      response.id);
+      _it->partition_response->partition_index,
+      response.partition_index);
 
-    if (response.has_error()) {
+    if (response.error_code != error_code::none) {
         _ctx->response_error = true;
     }
-    auto& current_resp_data = _it->partition_response->record_set;
+    auto& current_resp_data = _it->partition_response->records;
     if (current_resp_data) {
         auto sz = current_resp_data->size_bytes();
         _ctx->response_size -= sz;
         _ctx->bytes_left += sz;
     }
 
-    if (response.record_set) {
-        auto sz = response.record_set->size_bytes();
+    if (response.records) {
+        auto sz = response.records->size_bytes();
         _ctx->response_size += sz;
         _ctx->bytes_left -= std::min(_ctx->bytes_left, sz);
     }
@@ -766,7 +655,7 @@ void op_context::response_iterator::set(
     if (!_ctx->session_ctx.is_sessionless()) {
         auto& session_partitions = _ctx->session_ctx.session()->partitions();
         auto key = model::topic_partition_view(
-          _it->partition->name, _it->partition_response->id);
+          _it->partition->name, _it->partition_response->partition_index);
 
         if (auto it = session_partitions.find(key);
             it != session_partitions.end()) {

--- a/src/v/kafka/server/tests/fetch_session_test.cc
+++ b/src/v/kafka/server/tests/fetch_session_test.cc
@@ -26,9 +26,9 @@
 
 using namespace std::chrono_literals; // NOLINT
 struct fixture {
-    static kafka::fetch_partition make_fetch_partition(
+    static kafka::fetch_session_partition make_fetch_partition(
       model::topic topic, model::partition_id p_id, model::offset offset) {
-        return kafka::fetch_partition{
+        return kafka::fetch_session_partition{
           .topic = std::move(topic),
           .partition = p_id,
           .max_bytes = 1_MiB,

--- a/src/v/kafka/server/tests/fetch_session_test.cc
+++ b/src/v/kafka/server/tests/fetch_session_test.cc
@@ -44,11 +44,12 @@ struct fixture {
         };
 
         for (int i = 0; i < partitions_count; ++i) {
-            fetch_topic.fetch_partitions.push_back(kafka::fetch_request::partition{
-              .partition_index = model::partition_id(i),
-              .fetch_offset = model::offset(i * 10),
-              .max_bytes = 100_KiB,
-            });
+            fetch_topic.fetch_partitions.push_back(
+              kafka::fetch_request::partition{
+                .partition_index = model::partition_id(i),
+                .fetch_offset = model::offset(i * 10),
+                .max_bytes = 100_KiB,
+              });
         }
         return fetch_topic;
     }
@@ -149,9 +150,12 @@ FIXTURE_TEST(test_session_operations, fixture) {
         BOOST_REQUIRE_EQUAL(ctx.session()->partitions().size(), 3);
         for (const auto& fp : rng) {
             BOOST_REQUIRE_EQUAL(fp.topic, req.data.topics[0].name);
-            BOOST_REQUIRE_EQUAL(fp.partition, req.data.topics[0].fetch_partitions[i].partition_index);
             BOOST_REQUIRE_EQUAL(
-              fp.fetch_offset, req.data.topics[0].fetch_partitions[i].fetch_offset);
+              fp.partition,
+              req.data.topics[0].fetch_partitions[i].partition_index);
+            BOOST_REQUIRE_EQUAL(
+              fp.fetch_offset,
+              req.data.topics[0].fetch_partitions[i].fetch_offset);
             BOOST_REQUIRE_EQUAL(
               fp.max_bytes, req.data.topics[0].fetch_partitions[i].max_bytes);
             i++;
@@ -193,7 +197,8 @@ FIXTURE_TEST(test_session_operations, fixture) {
 
             BOOST_REQUIRE_EQUAL(fp.topic, req.data.topics[t_idx].name);
             BOOST_REQUIRE_EQUAL(
-              fp.partition, req.data.topics[t_idx].fetch_partitions[p_idx].partition_index);
+              fp.partition,
+              req.data.topics[t_idx].fetch_partitions[p_idx].partition_index);
             BOOST_REQUIRE_EQUAL(
               fp.fetch_offset,
               req.data.topics[t_idx].fetch_partitions[p_idx].fetch_offset);

--- a/src/v/kafka/server/tests/fetch_session_test.cc
+++ b/src/v/kafka/server/tests/fetch_session_test.cc
@@ -40,14 +40,14 @@ struct fixture {
     make_fetch_request_topic(model::topic tp, int partitions_count) {
         kafka::fetch_request::topic fetch_topic{
           .name = std::move(tp),
-          .partitions = {},
+          .fetch_partitions = {},
         };
 
         for (int i = 0; i < partitions_count; ++i) {
-            fetch_topic.partitions.push_back(kafka::fetch_request::partition{
-              .id = model::partition_id(i),
+            fetch_topic.fetch_partitions.push_back(kafka::fetch_request::partition{
+              .partition_index = model::partition_id(i),
               .fetch_offset = model::offset(i * 10),
-              .partition_max_bytes = 100_KiB,
+              .max_bytes = 100_KiB,
             });
         }
         return fetch_topic;
@@ -129,9 +129,9 @@ FIXTURE_TEST(test_fetch_session_basic_operations, fixture) {
 FIXTURE_TEST(test_session_operations, fixture) {
     kafka::fetch_session_cache cache(120s);
     kafka::fetch_request req;
-    req.session_epoch = kafka::initial_fetch_session_epoch;
-    req.session_id = kafka::invalid_fetch_session_id;
-    req.topics = {make_fetch_request_topic(model::topic("test"), 3)};
+    req.data.session_epoch = kafka::initial_fetch_session_epoch;
+    req.data.session_id = kafka::invalid_fetch_session_id;
+    req.data.topics = {make_fetch_request_topic(model::topic("test"), 3)};
     {
         BOOST_TEST_MESSAGE("create new session");
         auto ctx = cache.maybe_get_session(req);
@@ -148,28 +148,28 @@ FIXTURE_TEST(test_session_operations, fixture) {
         auto i = 0;
         BOOST_REQUIRE_EQUAL(ctx.session()->partitions().size(), 3);
         for (const auto& fp : rng) {
-            BOOST_REQUIRE_EQUAL(fp.topic, req.topics[0].name);
-            BOOST_REQUIRE_EQUAL(fp.partition, req.topics[0].partitions[i].id);
+            BOOST_REQUIRE_EQUAL(fp.topic, req.data.topics[0].name);
+            BOOST_REQUIRE_EQUAL(fp.partition, req.data.topics[0].fetch_partitions[i].partition_index);
             BOOST_REQUIRE_EQUAL(
-              fp.fetch_offset, req.topics[0].partitions[i].fetch_offset);
+              fp.fetch_offset, req.data.topics[0].fetch_partitions[i].fetch_offset);
             BOOST_REQUIRE_EQUAL(
-              fp.max_bytes, req.topics[0].partitions[i].partition_max_bytes);
+              fp.max_bytes, req.data.topics[0].fetch_partitions[i].max_bytes);
             i++;
         }
 
-        req.session_id = ctx.session()->id();
-        req.session_epoch = ctx.session()->epoch();
+        req.data.session_id = ctx.session()->id();
+        req.data.session_epoch = ctx.session()->epoch();
     }
 
     BOOST_TEST_MESSAGE("test updating session");
     {
-        req.topics[0].partitions.erase(
-          std::next(req.topics[0].partitions.begin()));
+        req.data.topics[0].fetch_partitions.erase(
+          std::next(req.data.topics[0].fetch_partitions.begin()));
         // add 2 partitons from new topic, forget one from the first topic
-        req.topics.push_back(
+        req.data.topics.push_back(
           make_fetch_request_topic(model::topic("test-new"), 2));
-        req.forgotten_topics.push_back(kafka::fetch_request::forgotten_topic{
-          .name = model::topic("test"), .partitions = {1}});
+        req.data.forgotten.push_back(kafka::fetch_request::forgotten_topic{
+          .name = model::topic("test"), .forgotten_partition_indexes = {1}});
 
         auto ctx = cache.maybe_get_session(req);
 
@@ -191,22 +191,22 @@ FIXTURE_TEST(test_session_operations, fixture) {
             auto t_idx = i < 2 ? 0 : 1;
             auto p_idx = i < 2 ? i : i - 2;
 
-            BOOST_REQUIRE_EQUAL(fp.topic, req.topics[t_idx].name);
+            BOOST_REQUIRE_EQUAL(fp.topic, req.data.topics[t_idx].name);
             BOOST_REQUIRE_EQUAL(
-              fp.partition, req.topics[t_idx].partitions[p_idx].id);
+              fp.partition, req.data.topics[t_idx].fetch_partitions[p_idx].partition_index);
             BOOST_REQUIRE_EQUAL(
               fp.fetch_offset,
-              req.topics[t_idx].partitions[p_idx].fetch_offset);
+              req.data.topics[t_idx].fetch_partitions[p_idx].fetch_offset);
             BOOST_REQUIRE_EQUAL(
               fp.max_bytes,
-              req.topics[t_idx].partitions[p_idx].partition_max_bytes);
+              req.data.topics[t_idx].fetch_partitions[p_idx].max_bytes);
             i++;
         }
     }
     BOOST_TEST_MESSAGE("removing session");
     {
-        req.session_epoch = kafka::final_fetch_session_epoch;
-        req.topics = {};
+        req.data.session_epoch = kafka::final_fetch_session_epoch;
+        req.data.topics = {};
 
         auto ctx = cache.maybe_get_session(req);
 

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -41,7 +41,8 @@ SEASTAR_THREAD_TEST_CASE(partition_iterator) {
                   BOOST_TEST(!res.empty());
                   BOOST_TEST(res.back().topic == v.topic->name);
               }
-              return model::topic_partition(v.topic->name, v.partition->partition_index);
+              return model::topic_partition(
+                v.topic->name, v.partition->partition_index);
           });
         return res;
     };
@@ -109,7 +110,8 @@ SEASTAR_THREAD_TEST_CASE(partition_iterator) {
              {.partition_index = model::partition_id(101)}}});
         req.data.topics.push_back(
           {.name = model::topic("t1"),
-           .fetch_partitions = {{.partition_index = model::partition_id(102)}}});
+           .fetch_partitions = {
+             {.partition_index = model::partition_id(102)}}});
         auto parts = transform(req);
         BOOST_TEST(parts.size() == 3);
         BOOST_TEST(parts[0].topic == model::topic("t0"));
@@ -260,7 +262,8 @@ FIXTURE_TEST(fetch_one, redpanda_thread_fixture) {
         BOOST_REQUIRE(resp.data.topics[0].name == topic());
         BOOST_REQUIRE(resp.data.topics[0].partitions.size() == 1);
         BOOST_REQUIRE(
-          resp.data.topics[0].partitions[0].error_code == kafka::error_code::none);
+          resp.data.topics[0].partitions[0].error_code
+          == kafka::error_code::none);
         BOOST_REQUIRE(resp.data.topics[0].partitions[0].partition_index == pid);
         BOOST_REQUIRE(resp.data.topics[0].partitions[0].records);
         BOOST_REQUIRE(
@@ -270,7 +273,8 @@ FIXTURE_TEST(fetch_one, redpanda_thread_fixture) {
 
 FIXTURE_TEST(fetch_response_iterator_test, redpanda_thread_fixture) {
     static auto make_partition = [](ss::sstring topic) {
-        return kafka::fetch_response::partition{.name=model::topic(std::move(topic))};
+        return kafka::fetch_response::partition{
+          .name = model::topic(std::move(topic))};
     };
 
     static auto make_partition_response = [](int id) {
@@ -287,14 +291,20 @@ FIXTURE_TEST(fetch_response_iterator_test, redpanda_thread_fixture) {
         response.data.topics.push_back(make_partition("tp-2"));
         response.data.topics.push_back(make_partition("tp-3"));
 
-        response.data.topics[0].partitions.push_back(make_partition_response(0));
-        response.data.topics[0].partitions.push_back(make_partition_response(1));
-        response.data.topics[0].partitions.push_back(make_partition_response(2));
+        response.data.topics[0].partitions.push_back(
+          make_partition_response(0));
+        response.data.topics[0].partitions.push_back(
+          make_partition_response(1));
+        response.data.topics[0].partitions.push_back(
+          make_partition_response(2));
 
-        response.data.topics[1].partitions.push_back(make_partition_response(0));
+        response.data.topics[1].partitions.push_back(
+          make_partition_response(0));
 
-        response.data.topics[2].partitions.push_back(make_partition_response(0));
-        response.data.topics[2].partitions.push_back(make_partition_response(1));
+        response.data.topics[2].partitions.push_back(
+          make_partition_response(0));
+        response.data.topics[2].partitions.push_back(
+          make_partition_response(1));
         return response;
     };
     kafka::op_context ctx(
@@ -313,7 +323,8 @@ FIXTURE_TEST(fetch_response_iterator_test, redpanda_thread_fixture) {
             BOOST_REQUIRE_EQUAL(it->partition_response->partition_index(), 0);
         } else {
             BOOST_REQUIRE_EQUAL(it->partition->name(), "tp-3");
-            BOOST_REQUIRE_EQUAL(it->partition_response->partition_index(), i - 4);
+            BOOST_REQUIRE_EQUAL(
+              it->partition_response->partition_index(), i - 4);
         }
         BOOST_REQUIRE_EQUAL(
           it->partition->name, wrapper_iterator->partition->name);
@@ -425,9 +436,11 @@ FIXTURE_TEST(fetch_multi_partitions_debounce, redpanda_thread_fixture) {
     size_t total_size = 0;
     for (int i = 0; i < 6; ++i) {
         BOOST_REQUIRE_EQUAL(
-          resp.data.topics[0].partitions[i].error_code, kafka::error_code::none);
+          resp.data.topics[0].partitions[i].error_code,
+          kafka::error_code::none);
         BOOST_REQUIRE_EQUAL(
-          resp.data.topics[0].partitions[i].partition_index, model::partition_id(i));
+          resp.data.topics[0].partitions[i].partition_index,
+          model::partition_id(i));
         BOOST_REQUIRE(resp.data.topics[0].partitions[i].records);
 
         total_size += resp.data.topics[0].partitions[i].records->size_bytes();
@@ -571,9 +584,11 @@ FIXTURE_TEST(fetch_multi_topics, redpanda_thread_fixture) {
     size_t total_size = 0;
     for (int i = 0; i < 6; ++i) {
         BOOST_REQUIRE_EQUAL(
-          resp.data.topics[0].partitions[i].error_code, kafka::error_code::none);
+          resp.data.topics[0].partitions[i].error_code,
+          kafka::error_code::none);
         BOOST_REQUIRE_EQUAL(
-          resp.data.topics[0].partitions[i].partition_index, model::partition_id(i));
+          resp.data.topics[0].partitions[i].partition_index,
+          model::partition_id(i));
         BOOST_REQUIRE(resp.data.topics[0].partitions[i].records);
 
         total_size += resp.data.topics[0].partitions[i].records->size_bytes();

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -87,18 +87,18 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
     ss::future<kafka::fetch_response> fetch_next() {
         kafka::fetch_request::partition partition;
         partition.fetch_offset = fetch_offset;
-        partition.id = model::partition_id(0);
+        partition.partition_index = model::partition_id(0);
         partition.log_start_offset = model::offset(0);
-        partition.partition_max_bytes = 1_MiB;
+        partition.max_bytes = 1_MiB;
         kafka::fetch_request::topic topic;
         topic.name = test_topic;
-        topic.partitions.push_back(partition);
+        topic.fetch_partitions.push_back(partition);
 
         kafka::fetch_request req;
-        req.min_bytes = 1;
-        req.max_bytes = 10_MiB;
-        req.max_wait_time = 1000ms;
-        req.topics.push_back(std::move(topic));
+        req.data.min_bytes = 1;
+        req.data.max_bytes = 10_MiB;
+        req.data.max_wait_ms = 1000ms;
+        req.data.topics.push_back(std::move(topic));
 
         return consumer->dispatch(std::move(req), kafka::api_version(4))
           .then([this](kafka::fetch_response resp) {

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -143,7 +143,7 @@ static iobuf handle_request(kafka::request_context&& ctx) {
     case kafka::fetch_api::key: {
         vlog(rlog.info, "kafka::fetch_api::key");
         kafka::fetch_request r;
-        r.decode(ctx);
+        r.decode(ctx.reader(), ctx.header().version);
         r.encode(writer, ctx.header().version);
         break;
     }

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -86,7 +86,8 @@ public:
         w.StartArray();
         for (auto& v : res) {
             auto r = std::move(*v.partition_response);
-            model::topic_partition_view tpv(v.partition->name, r.partition_index);
+            model::topic_partition_view tpv(
+              v.partition->name, r.partition_index);
             while (r.records && !r.records->empty()) {
                 auto adapter = r.records->consume_batch();
                 if (

--- a/src/v/pandaproxy/json/requests/fetch.h
+++ b/src/v/pandaproxy/json/requests/fetch.h
@@ -78,17 +78,17 @@ public:
       kafka::fetch_response&& res) {
         // Eager check for errors
         for (auto& v : res) {
-            if (v.partition_response->has_error()) {
-                throw serialize_error(v.partition_response->error);
+            if (v.partition_response->error_code != kafka::error_code::none) {
+                throw serialize_error(v.partition_response->error_code);
             }
         }
 
         w.StartArray();
         for (auto& v : res) {
             auto r = std::move(*v.partition_response);
-            model::topic_partition_view tpv(v.partition->name, r.id);
-            while (r.record_set && !r.record_set->empty()) {
-                auto adapter = r.record_set->consume_batch();
+            model::topic_partition_view tpv(v.partition->name, r.partition_index);
+            while (r.records && !r.records->empty()) {
+                auto adapter = r.records->consume_batch();
                 if (
                   !adapter.batch
                   || adapter.batch->header().attrs.is_control()) {

--- a/src/v/pandaproxy/json/requests/test/fetch.cc
+++ b/src/v/pandaproxy/json/requests/test/fetch.cc
@@ -49,20 +49,21 @@ auto make_fetch_response(
     std::vector<kafka::fetch_response::partition> parts;
     for (const auto& tp : tps) {
         kafka::fetch_response::partition res{tp.topic};
-        res.responses.push_back(kafka::fetch_response::partition_response{
-          .id{tp.partition},
-          .error = kafka::error_code::none,
+        res.partitions.push_back(kafka::fetch_response::partition_response{
+          .partition_index{tp.partition},
+          .error_code = kafka::error_code::none,
           .high_watermark{model::offset{0}},
           .last_stable_offset{model::offset{1}},
           .log_start_offset{model::offset{0}},
-          .aborted_transactions{},
-          .record_set{make_record_set(offset, count)}});
+          .aborted{},
+          .records{make_record_set(offset, count)}});
         parts.push_back(std::move(res));
     }
     return kafka::fetch_response{
-      .error = kafka::error_code::none,
-      .partitions = std::move(parts),
-    };
+      .data = {
+      .error_code = kafka::error_code::none,
+      .topics = std::move(parts),
+    }};
 }
 
 SEASTAR_THREAD_TEST_CASE(test_produce_fetch_empty) {

--- a/src/v/pandaproxy/json/requests/test/fetch.cc
+++ b/src/v/pandaproxy/json/requests/test/fetch.cc
@@ -61,9 +61,9 @@ auto make_fetch_response(
     }
     return kafka::fetch_response{
       .data = {
-      .error_code = kafka::error_code::none,
-      .topics = std::move(parts),
-    }};
+        .error_code = kafka::error_code::none,
+        .topics = std::move(parts),
+      }};
 }
 
 SEASTAR_THREAD_TEST_CASE(test_produce_fetch_empty) {

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -285,7 +285,7 @@ public:
         iobuf buf;
         kafka::fetch_request request;
         // do not use incremental fetch requests
-        request.max_wait_time = std::chrono::milliseconds::zero();
+        request.data.max_wait_ms = std::chrono::milliseconds::zero();
         kafka::response_writer writer(buf);
         request.encode(writer, encoder_context.header().version);
 

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -205,8 +205,8 @@ CONCEPT(requires requires(Func f, Iterator i) {
 // clang-format on
 inline auto parallel_transform(Iterator begin, Iterator end, Func func) {
     using value_type = typename std::iterator_traits<Iterator>::value_type;
-    using future = decltype(
-      seastar::futurize_invoke(std::move(func), std::move(*begin)));
+    using future = decltype(seastar::futurize_invoke(
+      std::move(func), std::move(*begin)));
     std::vector<future> res;
     res.reserve(std::distance(begin, end));
     std::transform(

--- a/src/v/utils/copy_range.h
+++ b/src/v/utils/copy_range.h
@@ -102,8 +102,8 @@ inline ss::future<Container> copy_range(
 template<typename Container, typename Range, typename AsyncAction>
 CONCEPT(requires requires(AsyncAction aa, Range r, Container c) {
     ss::futurize_invoke(aa, *r.begin());
-    requires ss::is_future<decltype(
-      ss::futurize_invoke(aa, *r.begin()))>::value;
+    requires ss::is_future<decltype(ss::futurize_invoke(
+      aa, *r.begin()))>::value;
     *std::inserter(c, c.end()) = ss::futurize_invoke(aa, *r.begin()).get0();
 })
 inline ss::future<Container> copy_range(Range& r, AsyncAction action) {


### PR DESCRIPTION
Converts kafka fetch request to use code generation for on-write types. This completes transition of the Kafka API in redpanda to use code generation.