### PR TITLE
update go to 1.16 for both operator and rpk

### DIFF
--- a/.github/workflows/k8s-build-and-test.yml
+++ b/.github/workflows/k8s-build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13.6
+        go-version: 1.16.3
       id: go
 
     - uses: azure/setup-kubectl@v1

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13.6
+        go-version: 1.16.3
       id: go
 
     - name: Set up Node

--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -130,7 +130,7 @@ controller-gen:
 # Download kuttl locally if necessary
 KUTTL = $(shell pwd)/bin/kubectl-kuttl
 kuttl:
-	$(call go-get-tool,$(KUTTL),github.com/kudobuilder/kuttl/cmd/kubectl-kuttl@v0.8.0)
+	$(call go-get-tool,$(KUTTL),github.com/kudobuilder/kuttl/cmd/kubectl-kuttl@v0.8.1)
 
 # Download crlfmt locally if necessary
 CRLFMT = $(shell pwd)/bin/crlfmt

--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -1,6 +1,6 @@
 module github.com/vectorizedio/redpanda/src/go/k8s
 
-go 1.15
+go 1.16
 
 require (
 	github.com/banzaicloud/k8s-objectmatcher v1.5.1

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -51,4 +51,4 @@ require (
 	mvdan.cc/sh/v3 v3.2.1
 )
 
-go 1.13
+go 1.16

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -92,7 +92,6 @@ github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -129,9 +128,7 @@ github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
-github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -301,7 +298,6 @@ github.com/tklauser/numcpus v0.1.0 h1:BQeAuOQKZtytv8qblsFbi9mhTfXQdFFkyX0vaV6B4t
 github.com/tklauser/numcpus v0.1.0/go.mod h1:i3up9VjARpkV00NkBbexuDd0RAVQz4rV5Gl8miYgd5k=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
-github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/scram v1.0.3 h1:nTadYh2Fs4BK2xdldEa2g5bbaZp0/+1nJMMPtPxS/to=
 github.com/xdg/scram v1.0.3/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=

--- a/src/go/rpk/pkg/cli/cmd/generate/grafana_test.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/grafana_test.go
@@ -42,7 +42,7 @@ func TestGrafanaHostNoServer(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Get http://localhost:8888/metrics: dial tcp")
+	require.Contains(t, err.Error(), "Get \"http://localhost:8888/metrics\": dial tcp")
 	require.Contains(t, err.Error(), "connect: connection refused")
 }
 

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -125,7 +125,7 @@ func TestParseSeeds(t *testing.T) {
 		{
 			name:           "it should fail if the host is empty",
 			arg:            []string{" :1234"},
-			expectedErrMsg: "Couldn't parse seed ' :1234': parse // :1234: invalid character \" \" in host name",
+			expectedErrMsg: "Couldn't parse seed ' :1234': parse \"// :1234\": invalid character \" \" in host name",
 		},
 	}
 
@@ -538,7 +538,7 @@ func TestStartCommand(t *testing.T) {
 		args: []string{
 			"-s", "host:port",
 		},
-		expectedErrMsg: "Couldn't parse seed 'host:port': parse //host:port: invalid port \":port\" after host",
+		expectedErrMsg: "Couldn't parse seed 'host:port': parse \"//host:port\": invalid port \":port\" after host",
 	}, {
 		name: "it should parse the --rpc-addr and persist it",
 		args: []string{
@@ -587,7 +587,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 			"--rpc-addr", "host:nonnumericport",
 		},
-		expectedErrMsg: "parse //host:nonnumericport: invalid port \":nonnumericport\" after host",
+		expectedErrMsg: "parse \"//host:nonnumericport\": invalid port \":nonnumericport\" after host",
 	}, {
 		name: "if --rpc-addr wasn't passed, it should fall back to REDPANDA_RPC_ADDRESS and persist it",
 		args: []string{
@@ -749,7 +749,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 			"--kafka-addr", "host:nonnumericport",
 		},
-		expectedErrMsg: "parse //host:nonnumericport: invalid port \":nonnumericport\" after host",
+		expectedErrMsg: "parse \"//host:nonnumericport\": invalid port \":nonnumericport\" after host",
 	}, {
 		name: "if --kafka-addr wasn't passed, it should fall back to REDPANDA_KAFKA_ADDRESS and persist it",
 		args: []string{
@@ -864,7 +864,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 			"--advertise-kafka-addr", "host:nonnumericport",
 		},
-		expectedErrMsg: "parse //host:nonnumericport: invalid port \":nonnumericport\" after host",
+		expectedErrMsg: "parse \"//host:nonnumericport\": invalid port \":nonnumericport\" after host",
 	}, {
 		name: "if --advertise-kafka-addr, it should fall back to REDPANDA_ADVERTISE_KAFKA_ADDRESS and persist it",
 		args: []string{
@@ -1027,7 +1027,7 @@ func TestStartCommand(t *testing.T) {
 			"--install-dir", "/var/lib/redpanda",
 			"--advertise-rpc-addr", "host:nonnumericport",
 		},
-		expectedErrMsg: "parse //host:nonnumericport: invalid port \":nonnumericport\" after host",
+		expectedErrMsg: "parse \"//host:nonnumericport\": invalid port \":nonnumericport\" after host",
 	}, {
 		name: "if --advertise-rpc-addr wasn't passed, it should fall back to REDPANDA_ADVERTISE_RPC_ADDRESS and persist it",
 		args: []string{


### PR DESCRIPTION
## Cover letter

I don't think there's any reason we can't use go 1.16.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
