### PR TITLE
Add archival storage metrics

### DIFF
--- a/src/v/archival/CMakeLists.txt
+++ b/src/v/archival/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     service.cc
     ntp_archiver_service.cc
     manifest.cc
+    probe.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "archival/probe.h"
 #include "archival/types.h"
 #include "model/fundamental.h"
 #include "storage/log_manager.h"
@@ -35,7 +36,8 @@ std::ostream& operator<<(std::ostream& s, const upload_candidate& c);
 /// but uses ntp as a key to extract the data when needed.
 class archival_policy {
 public:
-    explicit archival_policy(model::ntp ntp);
+    explicit archival_policy(
+      model::ntp ntp, service_probe& svc_probe, ntp_level_probe& ntp_probe);
 
     /// \brief regurn next upload candidate
     ///
@@ -59,6 +61,8 @@ private:
     find_segment(model::offset last_offset, storage::log_manager& lm);
 
     model::ntp _ntp;
+    service_probe& _svc_probe;
+    ntp_level_probe& _ntp_probe;
 };
 
 } // namespace archival

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/probe.h"
+
+#include "prometheus/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+#include <seastar/core/smp.hh>
+
+namespace archival {
+
+ntp_level_probe::ntp_level_probe(
+  per_ntp_metrics_disabled disabled, model::ntp ntp)
+  : _ntp(std::move(ntp))
+  , _uploaded()
+  , _missing()
+  , _pending() {
+    if (disabled) {
+        return;
+    }
+    namespace sm = ss::metrics;
+
+    auto ns_label = sm::label("namespace");
+    auto topic_label = sm::label("topic");
+    auto partition_label = sm::label("partition");
+    const std::vector<sm::label_instance> labels = {
+      ns_label(ntp.ns()),
+      topic_label(ntp.tp.topic()),
+      partition_label(ntp.tp.partition()),
+    };
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("ntp_archiver"),
+      {
+        sm::make_counter(
+          "missing",
+          [this] { return _missing; },
+          sm::description("Missing offsets due to gaps"),
+          labels),
+        sm::make_counter(
+          "uploaded",
+          [this] { return _uploaded; },
+          sm::description("Uploaded offsets"),
+          labels),
+        sm::make_gauge(
+          "pending",
+          [this] { return _pending; },
+          sm::description("Pending offsets"),
+          labels),
+      });
+}
+
+service_probe::service_probe(service_metrics_disabled disabled)
+  : _cnt_gaps()
+  , _cnt_topic_manifest_uploads()
+  , _cnt_partition_manifest_uploads()
+  , _cnt_start_archiving_ntp()
+  , _cnt_stop_archiving_ntp()
+  , _cnt_manifest_backoff()
+  , _cnt_reconciliations()
+  , _cnt_successful_uploads()
+  , _cnt_failed_uploads()
+  , _cnt_upload_backoff() {
+    if (disabled) {
+        return;
+    }
+    namespace sm = ss::metrics;
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("archival_service"),
+      {
+        sm::make_counter(
+          "num_gaps",
+          [this] { return _cnt_gaps; },
+          sm::description("Number of detected offset gaps")),
+        sm::make_counter(
+          "topic_manifest_uploads",
+          [this] { return _cnt_topic_manifest_uploads; },
+          sm::description("Number of topic manifest uploads")),
+        sm::make_counter(
+          "partition_manifest_uploads",
+          [this] { return _cnt_partition_manifest_uploads; },
+          sm::description("Number of partition manifest (re)uploads")),
+        sm::make_counter(
+          "start_archiving_ntp",
+          [this] { return _cnt_start_archiving_ntp; },
+          sm::description("Start archiving ntp event counter")),
+        sm::make_counter(
+          "stop_archiving_ntp",
+          [this] { return _cnt_stop_archiving_ntp; },
+          sm::description("Stop archiving ntp event counter")),
+        sm::make_gauge(
+          "num_archived_ntp",
+          [this] { return _cnt_start_archiving_ntp - _cnt_stop_archiving_ntp; },
+          sm::description("Total number of ntp that archiver manages")),
+        sm::make_counter(
+          "manifest_backoff",
+          [this] { return _cnt_manifest_backoff; },
+          sm::description("Number of times backoff was applied during manifest "
+                          "upload/download")),
+        sm::make_counter(
+          "num_reconciliations",
+          [this] { return _cnt_reconciliations; },
+          sm::description("Number of reconciliation loop iterations")),
+        sm::make_counter(
+          "successful_uploads",
+          [this] { return _cnt_successful_uploads; },
+          sm::description("Number of completed log-segment uploads")),
+        sm::make_counter(
+          "failed_uploads",
+          [this] { return _cnt_failed_uploads; },
+          sm::description("Number of failed log-segment uploads")),
+        sm::make_counter(
+          "upload_backoff",
+          [this] { return _cnt_upload_backoff; },
+          sm::description(
+            "Number of times backoff  was applied during log-segment uploads")),
+      });
+}
+
+} // namespace archival

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "archival/types.h"
+#include "model/fundamental.h"
+#include "seastarx.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+#include <cstdint>
+
+namespace archival {
+
+/// \brief Per-ntp archval service probe
+///
+/// For every NTP we need to track how much log we've already uploaded,
+/// how much data we're missing (e.g. because it was compacted before upload)
+/// and how much work remains.
+///
+/// The unit of measure is offset delta.
+class ntp_level_probe {
+public:
+    ntp_level_probe(per_ntp_metrics_disabled disabled, model::ntp ntp);
+
+    /// Register log-segment upload
+    void uploaded(model::offset offset_delta) { _uploaded += offset_delta; }
+
+    /// Register gap
+    void gap_detected(model::offset offset_delta) { _missing += offset_delta; }
+
+    /// Register the offset the ought to be uploaded
+    void upload_lag(model::offset offset_delta) { _pending = offset_delta; }
+
+private:
+    /// NTP of the probe
+    model::ntp _ntp;
+    /// Uploaded offsets
+    int64_t _uploaded;
+    /// Missing offsets due to gaps
+    int64_t _missing;
+    /// Width of the offset range yet to be uploaded
+    int64_t _pending;
+
+    ss::metrics::metric_groups _metrics;
+};
+
+/// Service level probe
+class service_probe {
+public:
+    explicit service_probe(service_metrics_disabled disabled);
+
+    /// Increment gap counter (global)
+    void add_gap() { _cnt_gaps++; }
+
+    /// Register topic manifest upload
+    void topic_manifest_upload() { _cnt_topic_manifest_uploads++; }
+
+    /// Register manifest (re)upload
+    void partition_manifest_upload() { _cnt_partition_manifest_uploads++; }
+
+    /// Count new ntp archiving event
+    void start_archiving_ntp() { _cnt_start_archiving_ntp++; }
+
+    /// Count the removal (from the archival subsystem on this shard)
+    /// of the ntp event
+    void stop_archiving_ntp() { _cnt_stop_archiving_ntp++; }
+
+    /// Register backof invocation during manifest upload or download
+    void manifest_backoff() { _cnt_manifest_backoff++; }
+
+    /// Count reconciliation loop iterations (liveliness probe)
+    void reconciliation() { _cnt_reconciliations++; }
+
+    /// Register successfull uploads
+    void successful_upload(size_t n) { _cnt_successful_uploads += n; }
+
+    /// Register failed uploads
+    void failed_upload(size_t n) { _cnt_failed_uploads += n; }
+
+    /// Register backoff during log-segment upload
+    void upload_backoff() { _cnt_upload_backoff++; }
+
+private:
+    /// Number of gaps dected
+    uint64_t _cnt_gaps;
+    /// Number of topic manifest uploads
+    uint64_t _cnt_topic_manifest_uploads;
+    /// Number of manifest (re)uploads
+    uint64_t _cnt_partition_manifest_uploads;
+    /// Start archiving npt event counter
+    uint64_t _cnt_start_archiving_ntp;
+    /// Stop archiving npt event counter
+    uint64_t _cnt_stop_archiving_ntp;
+    /// Number of times backoff was applied during manifest upload/download
+    uint64_t _cnt_manifest_backoff;
+    /// Number of reconciliation loop iterations
+    uint64_t _cnt_reconciliations;
+    /// Number of completed log-segment uploads
+    uint64_t _cnt_successful_uploads;
+    /// Number of failed log-segment uploads
+    uint64_t _cnt_failed_uploads;
+    /// Number of times backoff  was applied during log-segment uploads
+    uint64_t _cnt_upload_backoff;
+
+    ss::metrics::metric_groups _metrics;
+};
+
+} // namespace archival

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "archival/manifest.h"
 #include "archival/ntp_archiver_service.h"
+#include "archival/probe.h"
 #include "cluster/partition_manager.h"
 #include "model/fundamental.h"
 #include "s3/client.h"
@@ -167,6 +168,7 @@ private:
     ss::semaphore _stop_limit;
     ntp_upload_queue _queue;
     simple_time_jitter<ss::lowres_clock> _backoff{100ms};
+    service_probe _probe;
 };
 
 } // namespace internal

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -10,6 +10,7 @@
 
 #include "archival/tests/service_fixture.h"
 
+#include "archival/types.h"
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "random/generators.h"
@@ -85,6 +86,8 @@ archival::configuration get_configuration() {
     conf.client_config = s3conf;
     conf.bucket_name = s3::bucket_name("test-bucket");
     conf.connection_limit = archival::s3_connection_limit(2);
+    conf.svc_metrics_disabled = archival::service_metrics_disabled(true);
+    conf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled(true);
     return conf;
 }
 

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "seastar/core/sstring.hh"
+#include "seastar/util/bool_class.hh"
 #include "seastarx.h"
 #include "utils/named_type.h"
 
@@ -48,5 +49,10 @@ enum class manifest_version : int32_t {
 enum class topic_manifest_version : int32_t {
     v1 = 1,
 };
+
+using service_metrics_disabled
+  = ss::bool_class<struct service_metrics_disabled_tag>;
+using per_ntp_metrics_disabled
+  = ss::bool_class<struct per_ntp_metrics_disabled_tag>;
 
 } // namespace archival


### PR DESCRIPTION
## Cover letter

The PR adds archival storage metrics.
The metrics are split into two categories:
- service level metrics
- ntp level metrics

Service level metrics track things like number of manifest uploads and number of time backoff was applied. They are common for all partitions.
On NTP level we have three metrics
- uploaded offsets
- offsets that needs to be uploaded
- total gaps (every time we encounter a gap we add an offset range to the metric)