### PR TITLE
operator: fix admin port name

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -164,14 +164,14 @@ func (r *ConfigMapResource) createConfiguration(
 	}
 
 	cr.AdminApi[0].Port = clusterCRPortOrRPKDefault(r.pandaCluster.AdminAPIInternal().Port, cr.AdminApi[0].Port)
-	cr.AdminApi[0].Name = InternalListenerName
+	cr.AdminApi[0].Name = AdminPortName
 	if r.pandaCluster.AdminAPIExternal() != nil {
 		externalAdminAPI := config.NamedSocketAddress{
 			SocketAddress: config.SocketAddress{
 				Address: cr.AdminApi[0].Address,
 				Port:    cr.AdminApi[0].Port + 1,
 			},
-			Name: ExternalListenerName,
+			Name: AdminPortExternalName,
 		}
 		cr.AdminApi = append(cr.AdminApi, externalAdminAPI)
 	}
@@ -203,9 +203,9 @@ func (r *ConfigMapResource) createConfiguration(
 	}
 	adminAPITLSListener := r.pandaCluster.AdminAPITLS()
 	if adminAPITLSListener != nil {
-		name := InternalListenerName
+		name := AdminPortName
 		if adminAPITLSListener.External.Enabled {
-			name = ExternalListenerName
+			name = AdminPortExternalName
 		}
 		adminTLS := config.ServerTLS{
 			Name:              name,

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -622,19 +622,18 @@ func (r *StatefulSetResource) portsConfiguration() string {
 }
 
 func (r *StatefulSetResource) getPorts() []corev1.ContainerPort {
+	ports := []corev1.ContainerPort{{
+		Name:          AdminPortName,
+		ContainerPort: int32(r.pandaCluster.AdminAPIInternal().Port),
+	}}
+	internalListener := r.pandaCluster.InternalListener()
+	ports = append(ports, corev1.ContainerPort{
+		Name:          InternalListenerName,
+		ContainerPort: int32(internalListener.Port),
+	})
+
 	if r.pandaCluster.ExternalListener() != nil &&
 		len(r.nodePortSvc.Spec.Ports) > 0 {
-		ports := []corev1.ContainerPort{
-			{
-				Name:          "admin-internal",
-				ContainerPort: int32(r.pandaCluster.AdminAPIInternal().Port),
-			},
-		}
-		internalListener := r.pandaCluster.InternalListener()
-		ports = append(ports, corev1.ContainerPort{
-			Name:          InternalListenerName,
-			ContainerPort: int32(internalListener.Port),
-		})
 		for _, port := range r.nodePortSvc.Spec.Ports {
 			ports = append(ports, corev1.ContainerPort{
 				Name: port.Name,
@@ -652,15 +651,6 @@ func (r *StatefulSetResource) getPorts() []corev1.ContainerPort {
 		return ports
 	}
 
-	ports := []corev1.ContainerPort{{
-		Name:          "admin",
-		ContainerPort: int32(r.pandaCluster.AdminAPIInternal().Port),
-	}}
-	internalListener := r.pandaCluster.InternalListener()
-	ports = append(ports, corev1.ContainerPort{
-		Name:          InternalListenerName,
-		ContainerPort: int32(internalListener.Port),
-	})
 	return ports
 }
 


### PR DESCRIPTION
## Cover letter

In some cases, the admin port name was either hard-coded or set to the Kafka listener's name (in the redpanda.yaml). Fixing it here.