### PR TITLE
operator: remove unnecessary nodeport check

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -266,15 +266,6 @@ func (r *ClusterReconciler) createExternalNodesList(
 		return []string{}, []string{}, fmt.Errorf("failed to retrieve node port service %s: %w", nodePortName, err)
 	}
 
-	// we now support only one external kafka and admin port
-	expectedPortLength := 2
-	if externalAdminListener == nil || externalKafkaListener == nil {
-		expectedPortLength = 1
-	}
-	if len(nodePortSvc.Spec.Ports) != expectedPortLength {
-		return []string{}, []string{}, fmt.Errorf("node port service %s: %w", nodePortName, errNodePortMissing)
-	}
-
 	for _, port := range nodePortSvc.Spec.Ports {
 		if port.NodePort == 0 {
 			return []string{}, []string{}, fmt.Errorf("node port service %s, port %s is 0: %w", nodePortName, port.Name, errNodePortMissing)

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -121,17 +121,6 @@ func (r *StatefulSetResource) Ensure(ctx context.Context) error {
 			return fmt.Errorf("failed to retrieve node port service %s: %w", r.nodePortName, err)
 		}
 
-		// TODO(av) clean this up and unify with the same code in cluster_controller status handling
-		externalKafkaListener := r.pandaCluster.ExternalListener()
-		externalAdminListener := r.pandaCluster.AdminAPIExternal()
-		expectedPortLength := 2
-		if externalAdminListener == nil || externalKafkaListener == nil {
-			expectedPortLength = 1
-		}
-		if len(r.nodePortSvc.Spec.Ports) != expectedPortLength {
-			return fmt.Errorf("node port service %s: %w", r.nodePortName, errNodePortMissing)
-		}
-
 		for _, port := range r.nodePortSvc.Spec.Ports {
 			if port.NodePort == 0 {
 				return fmt.Errorf("node port service %s, port %s is 0: %w", r.nodePortName, port.Name, errNodePortMissing)


### PR DESCRIPTION
## Cover letter

The nodeport service is created in the controller and contains listeners depending on the conditions of this same check. Hence, this check doesn't seem needed anymore. If reviewers see a reason to keep, please let me know, otherwise, let's remove this.