### PR TITLE
rptest: tweaks to installation of test dependencies

### DIFF
--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -33,22 +33,6 @@ tasks:
     status:
     - test -f '{{.BUILD_ROOT}}/bin/docker-compose'
 
-  install-jdk-and-maven:
-    desc: install openjdk and maven
-    vars:
-      JDK_URL: https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz
-      MAVEN_URL: https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
-      JAVA_DIR: '{{.BUILD_ROOT}}/java'
-    cmds:
-    - mkdir -p '{{.JAVA_DIR}}'
-    - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.JDK_URL}}' | tar --strip-components=1 -C '{{.JAVA_DIR}}' -xz
-    - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 '{{.MAVEN_URL}}' | tar --strip-components=1 -C '{{.JAVA_DIR}}' -xz
-      # delete this (empty) folder; leaving it generates an error
-    - rm -r '{{.JAVA_DIR}}/lib/ext'
-    status:
-    - test -f '{{.JAVA_DIR}}/bin/java'
-    - test -f '{{.JAVA_DIR}}/bin/mvn'
-
   start-podman-socket-service:
     desc: start podman socket service (requires sudo)
     cmds:

--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -147,7 +147,7 @@ tasks:
           --cluster=ducktape.cluster.json.JsonCluster
           --cluster-file=/cluster.json
           --results-root=/build/tests/results
-          --globals='{"rp_install_path_root":"{{.RP_INSTALL_DIR}}","v_build_dir":"{{.BUILD_ROOT}}"}'
+          --globals='{"rp_install_path_root":"{{.RP_INSTALL_DIR}}"}'
           {{.DUCKTAPE_ARGS}}
 
   stop-compose-cluster:

--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -83,29 +83,10 @@ tasks:
     cmds:
     - ctest {{if eq .CI "1"}}"--output-on-failure" -LE "disable_on_ci"{{end}} {{.CTEST_ARGS}}
 
-  build-java-test-programs:
-    desc: build java programs used in integrations tests
-    deps:
-    - :dev:install-jdk-and-maven
-    cmds:
-    - |
-      PATH="{{.BUILD_ROOT}}/java/bin:$PATH"
-      mvn -v
-      function build {
-        mvn clean package --batch-mode \
-          --file {{.SRC_DIR}}/tests/java/$1/ \
-          --define maven.repo.local={{.BUILD_ROOT}}/java/maven-repository \
-          --define buildDir={{.BUILD_ROOT}}/java/$1/
-      }
-      build kafka-verifier
-      build compacted-log-verifier
-    status:
-    - test -f '{{.BUILD_ROOT}}/java/kafka-verifier/kafka-verifier.jar'
-    - test -f '{{.BUILD_ROOT}}/java/compacted-log-verifier/kafka-compacted-topics-verifier.jar'
-
   build-test-docker-image:
     desc: build image used in integration tests
     cmds:
+    - cp '{{.SRC_DIR}}/tests/docker/Dockerfile.dockerignore' '{{.SRC_DIR}}/.dockerignore'
     - |
       if [ '{{.CI}}' == '1' ]; then
         chmod 644 '{{.SRC_DIR}}/tests/docker/ssh/'* '{{.SRC_DIR}}/tests/setup.py'
@@ -115,13 +96,14 @@ tasks:
           --tag vectorized/redpanda-test-node \
           --file '{{.SRC_DIR}}/tests/docker/Dockerfile' \
           --cache-from docker.io/vectorized/redpanda-test-node:cache \
-          '{{.SRC_DIR}}/tests/'
+          '{{.SRC_DIR}}'
       else
         docker build \
           --tag vectorized/redpanda-test-node \
           --file '{{.SRC_DIR}}/tests/docker/Dockerfile' \
-          '{{.SRC_DIR}}/tests/'
+          '{{.SRC_DIR}}'
       fi
+    - rm '{{.SRC_DIR}}/.dockerignore'
 
   start-compose-cluster:
     desc: deploy a cluster using docker-compose
@@ -142,7 +124,6 @@ tasks:
     deps:
     - set-aio-max
     - start-compose-cluster
-    - build-java-test-programs
     vars:
       DUCKTAPE_ARGS: '{{default "--exit-first tests/rptest/test_suite_quick.yml" .DUCKTAPE_ARGS}}'
       RP_INSTALL_DIR_DEFAULT: '{{.BUILD_DIR}}'

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -21,14 +21,14 @@ ENV TZ="UTC" \
 # - allow user env variables in ssh sessions
 RUN apt update && \
     apt install -y \
-      python3-pip \
-      openssh-server \
-      default-jre \
       build-essential \
-      libatomic1 \
       curl \
+      default-jre \
       iptables \
-      kafkacat && \
+      kafkacat \
+      libatomic1 \
+      openssh-server \
+      python3-pip && \
     rm -rf /var/lib/apt/lists/* && \
     echo 'PermitUserEnvironment yes' >> /etc/ssh/sshd_config
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -24,9 +24,14 @@ RUN apt update && \
       build-essential \
       curl \
       default-jdk \
+      cmake \
+      git \
+      golang \
       iptables \
-      kafkacat \
       libatomic1 \
+      libyajl-dev \
+      libsasl2-dev \
+      libssl-dev \
       maven \
       openssh-server \
       python3-pip && \
@@ -41,20 +46,29 @@ RUN mkdir -p /opt/node && \
 		tar -xf ${NODE_TAR} -C /opt/node --strip 1 && \
 		rm -rf ${NODE_TAR}
 
-# install kafka binary dependencies, kaf tool and librdkafka dev
+# install kafka binary dependencies, librdkafka dev, kafkacat and kaf tools
 ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
 RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.3.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.3.1" && \
     mkdir -p "/opt/kafka-2.4.1" && chmod a+rw /opt/kafka-2.4.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.4.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.4.1" && \
     mkdir -p "/opt/kafka-2.5.0" && chmod a+rw /opt/kafka-2.5.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.5.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.5.0" && \
     mkdir -p "/opt/kafka-2.7.0" && chmod a+rw /opt/kafka-2.7.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.7.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.7.0" && \
-    curl https://raw.githubusercontent.com/birdayz/kaf/master/godownloader.sh | bash && \
     mkdir /opt/librdkafka && \
-    curl -SL "https://github.com/edenhill/librdkafka/archive/v1.5.0.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka && \
+    curl -SL "https://github.com/edenhill/librdkafka/archive/v1.6.1.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka && \
     cd /opt/librdkafka && \
     ./configure && \
     make -j$(nproc) && \
+    make install && \
     cd /opt/librdkafka/tests && \
-    make build -j$(nproc)
+    make build -j$(nproc) && \
+    go get -u github.com/birdayz/kaf/cmd/kaf && \
+    mv /root/go/bin/kaf /usr/local/bin/ && \
+    mkdir /tmp/kafkacat && \
+    curl -SL "https://github.com/edenhill/kafkacat/archive/1.6.0.tar.gz" | tar -xz --strip-components=1 -C /tmp/kafkacat && \
+    cd /tmp/kafkacat && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig
 
 # copy source of test (java) programs
 COPY --chown=0:0 tests/java /tmp/java

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -23,10 +23,11 @@ RUN apt update && \
     apt install -y \
       build-essential \
       curl \
-      default-jre \
+      default-jdk \
       iptables \
       kafkacat \
       libatomic1 \
+      maven \
       openssh-server \
       python3-pip && \
     rm -rf /var/lib/apt/lists/* && \
@@ -55,13 +56,18 @@ RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFK
     cd /opt/librdkafka/tests && \
     make build -j$(nproc)
 
+# copy source of test (java) programs
+COPY --chown=0:0 tests/java /tmp/java
+RUN mvn clean package --batch-mode --file /tmp/java/kafka-verifier --define buildDir=/opt/kafka-verifier/ && \
+    mvn clean package --batch-mode --file /tmp/java/compacted-log-verifier --define buildDir=/opt/compacted-log-verifier
+
 # copy ssh keys
-COPY --chown=0:0 docker/ssh /root/.ssh
+COPY --chown=0:0 tests/docker/ssh /root/.ssh
 
 # install python dependencies and rptest package.
 # rptest package installed in editable mode so it can be overridden.
 # passes --force so system pip packages can be updated
-COPY --chown=0:0 setup.py /root/tests/
+COPY --chown=0:0 tests/setup.py /root/tests/
 RUN python3 -m pip install --upgrade --force pip && \
     python3 -m pip install --force --no-cache-dir -e /root/tests/
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -33,18 +33,12 @@ RUN apt update && \
       libsasl2-dev \
       libssl-dev \
       maven \
+      nodejs \
+      npm \
       openssh-server \
       python3-pip && \
     rm -rf /var/lib/apt/lists/* && \
     echo 'PermitUserEnvironment yes' >> /etc/ssh/sshd_config
-
-# install nodejs
-env NODE_VERSION="12.16.1"
-env NODE_TAR=/opt/node/nodejs-${NODE_VERSION}.tar.xz
-RUN mkdir -p /opt/node && \
-		curl https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz > ${NODE_TAR} && \
-		tar -xf ${NODE_TAR} -C /opt/node --strip 1 && \
-		rm -rf ${NODE_TAR}
 
 # install kafka binary dependencies, librdkafka dev, kafkacat and kaf tools
 ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"

--- a/tests/docker/Dockerfile.dockerignore
+++ b/tests/docker/Dockerfile.dockerignore
@@ -1,0 +1,4 @@
+**
+!tests/java
+!tests/docker/ssh
+!tests/setup.py

--- a/tests/rptest/clients/compacted_verifier.py
+++ b/tests/rptest/clients/compacted_verifier.py
@@ -16,7 +16,7 @@ class CompactedTopicVerifier:
     """
     def __init__(self, redpanda, topic='verifier_topic'):
         self._redpanda = redpanda
-        self.verifier_jar = f'{self._redpanda.v_build_dir}/java-build/compacted-log-verifier/kafka-compacted-topics-verifier.jar'
+        self.verifier_jar = f'/opt/compacted-log-verifier/kafka-compacted-topics-verifier.jar'
         self.state_path = f'{self._redpanda.v_build_dir}/ducktape/verifier.state'
         self.topic = topic
 

--- a/tests/rptest/clients/compacted_verifier.py
+++ b/tests/rptest/clients/compacted_verifier.py
@@ -17,7 +17,7 @@ class CompactedTopicVerifier:
     def __init__(self, redpanda, topic='verifier_topic'):
         self._redpanda = redpanda
         self.verifier_jar = f'/opt/compacted-log-verifier/kafka-compacted-topics-verifier.jar'
-        self.state_path = f'{self._redpanda.v_build_dir}/ducktape/verifier.state'
+        self.state_path = f'/tmp/ducktape/verifier.state'
         self.topic = topic
 
     def produce(self,

--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -35,8 +35,7 @@ class KafkaCat:
             try:
                 res = subprocess.check_output(
                     ["kafkacat", "-b",
-                     self._redpanda.brokers(), "-J"] + cmd,
-                    stderr=subprocess.STDOUT)
+                     self._redpanda.brokers(), "-J"] + cmd)
                 res = json.loads(res)
                 self._redpanda.logger.debug(json.dumps(res, indent=2))
                 return res

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -71,7 +71,6 @@ class RedpandaService(Service):
         self._enable_pp = enable_pp
         self._log_level = log_level
         self._topics = topics or ()
-        self.v_build_dir = self._context.globals.get("v_build_dir", None)
         self._admin = Admin(self)
 
     def sasl_enabled(self):

--- a/tests/rptest/wasm/wasm_build_tool.py
+++ b/tests/rptest/wasm/wasm_build_tool.py
@@ -60,10 +60,9 @@ class WasmBuildTool():
         return t.render(input_topics=inputs, output_topics=outputs)
 
     def _build_source(self, artifact_dir):
-        npm_env = {'PATH': f'/opt/node/bin:{os.getenv("PATH")}'}
         with DirectoryContext(artifact_dir) as _:
-            subprocess.run(["/opt/node/bin/npm", "install"], env=npm_env)
-            subprocess.run(["/opt/node/bin/npm", "run", "build"], env=npm_env)
+            subprocess.run(["npm", "install"])
+            subprocess.run(["npm", "run", "build"])
 
     def build_test_artifacts(self, script):
         artifact_dir = os.path.join(self.work_dir, script.dir_name)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -17,7 +17,7 @@ setup(
         'prometheus-client==0.9.0',
         'pyyaml==5.3.1',
         'kafka-python==2.0.2',
-        'confluent-kafka==1.6.0',
+        'confluent-kafka==1.6.1',
     ],
     scripts=[],
 )


### PR DESCRIPTION
Couple of tweaks to the installation of test dependencies:
  * Move compilation of homegrown java test programs inside the docker image
  * Install `kaf`, `librdkafka` and `kafkacat` from source