### PR TITLE
Introduced compaction quota

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -303,7 +303,8 @@ static storage::kvstore_config kvstore_config_from_global_config() {
       storage::debug_sanitize_files::no);
 }
 
-static storage::log_config manager_config_from_global_config() {
+static storage::log_config
+manager_config_from_global_config(scheduling_groups& sgs) {
     return storage::log_config(
       storage::log_config::storage_type::disk,
       config::shard_local_cfg().data_directory().as_sstring(),
@@ -322,7 +323,8 @@ static storage::log_config manager_config_from_global_config() {
         .min_size = config::shard_local_cfg().reclaim_min_size(),
         .max_size = config::shard_local_cfg().reclaim_max_size(),
       },
-      config::shard_local_cfg().readers_cache_eviction_timeout_ms());
+      config::shard_local_cfg().readers_cache_eviction_timeout_ms(),
+      sgs.compaction_sg());
 }
 
 // add additional services in here
@@ -349,7 +351,7 @@ void application::wire_up_redpanda_services() {
     construct_service(shard_table).get();
 
     syschecks::systemd_message("Intializing storage services").get();
-    auto log_cfg = manager_config_from_global_config();
+    auto log_cfg = manager_config_from_global_config(_scheduling_groups);
     log_cfg.reclaim_opts.background_reclaimer_sg
       = _scheduling_groups.cache_background_reclaim_sg();
     construct_service(storage, kvstore_config_from_global_config(), log_cfg)

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -30,6 +30,8 @@ public:
         _coproc = co_await ss::create_scheduling_group("coproc", 100);
         _cache_background_reclaim = co_await ss::create_scheduling_group(
           "cache_background_reclaim", 200);
+        _compaction = co_await ss::create_scheduling_group(
+          "log_compaction", 100);
     }
 
     ss::future<> destroy_groups() {
@@ -39,6 +41,7 @@ public:
         co_await destroy_scheduling_group(_cluster);
         co_await destroy_scheduling_group(_coproc);
         co_await destroy_scheduling_group(_cache_background_reclaim);
+        co_await destroy_scheduling_group(_compaction);
         co_return;
     }
 
@@ -50,6 +53,7 @@ public:
     ss::scheduling_group cache_background_reclaim_sg() {
         return _cache_background_reclaim;
     }
+    ss::scheduling_group compaction_sg() { return _compaction; }
 
 private:
     ss::scheduling_group _admin;
@@ -58,4 +62,5 @@ private:
     ss::scheduling_group _cluster;
     ss::scheduling_group _coproc;
     ss::scheduling_group _cache_background_reclaim;
+    ss::scheduling_group _compaction;
 };

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -94,7 +94,7 @@ private:
     model::offset read_start_offset() const;
 
     ss::future<> do_compact(compaction_config);
-    ss::future<> compact_adjacent_segments(
+    ss::future<compaction_result> compact_adjacent_segments(
       std::pair<segment_set::iterator, segment_set::iterator>,
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -552,7 +552,9 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
               "Aborting compaction of closed segment: {}", *segment));
         }
     }
-    co_await write_concatenated_compacted_index(path, segments, cfg);
+    auto compacted_idx_path = compacted_index_path(path);
+    co_await write_concatenated_compacted_index(
+      compacted_idx_path, segments, cfg);
     // concatenation process
     auto writer = co_await make_writer_handle(path, cfg.sanitize);
     auto output = co_await ss::make_file_output_stream(std::move(writer));

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -392,7 +392,10 @@ ss::future<> do_swap_data_file_handles(
       });
 }
 
-ss::future<> do_self_compact_segment(
+/**
+ * Executes segment compaction, returns size of compacted segment
+ */
+ss::future<size_t> do_self_compact_segment(
   ss::lw_shared_ptr<segment> s,
   compaction_config cfg,
   storage::probe& pb,
@@ -439,7 +442,10 @@ ss::future<> do_self_compact_segment(
                 s->index().swap_index_state(std::move(idx));
                 s->force_set_commit_offset_from_index();
                 s->release_batch_cache_index();
-                return s->index().flush().finally([l = std::move(lock)] {});
+                return s->index()
+                  .flush()
+                  .then([s] { return s->size_bytes(); })
+                  .finally([l = std::move(lock)] {});
             });
       });
 }
@@ -466,17 +472,18 @@ ss::future<> rebuild_compaction_index(
       });
 }
 
-ss::future<> self_compact_segment(
+ss::future<compaction_result> self_compact_segment(
   ss::lw_shared_ptr<segment> s,
   compaction_config cfg,
   storage::probe& pb,
   storage::readers_cache& readers_cache) {
     if (s->has_appender()) {
-        return ss::make_exception_future<>(std::runtime_error(fmt::format(
-          "Cannot compact an active segment. cfg:{} - segment:{}", cfg, s)));
+        return ss::make_exception_future<compaction_result>(
+          std::runtime_error(fmt::format(
+            "Cannot compact an active segment. cfg:{} - segment:{}", cfg, s)));
     }
     if (s->finished_self_compaction()) {
-        return ss::now();
+        return ss::make_ready_future<compaction_result>(s->size_bytes());
     }
     auto idx_path = std::filesystem::path(s->reader().filename());
     idx_path.replace_extension(".compaction_index");
@@ -485,11 +492,15 @@ ss::future<> self_compact_segment(
               compacted_index::recovery_state state) mutable {
           switch (state) {
           case compacted_index::recovery_state::recovered: {
-              vlog(stlog.info, "detected {} is already compacted", idx_path);
-              return ss::now();
+              vlog(stlog.debug, "detected {} is already compacted", idx_path);
+              return ss::make_ready_future<compaction_result>(s->size_bytes());
           }
           case compacted_index::recovery_state::nonrecovered:
-              return do_self_compact_segment(s, cfg, pb, readers_cache);
+              return do_self_compact_segment(s, cfg, pb, readers_cache)
+                .then([before = s->size_bytes(), &pb](size_t sz_after) {
+                    pb.segment_compacted();
+                    return compaction_result(before, sz_after);
+                });
           case compacted_index::recovery_state::missing:
               [[fallthrough]];
           case compacted_index::recovery_state::needsrebuild: {
@@ -516,8 +527,10 @@ ss::future<> self_compact_segment(
           }
           __builtin_unreachable();
       })
-      .then([s] { s->mark_as_finished_self_compaction(); })
-      .finally([&pb] { pb.segment_compacted(); });
+      .then([s](compaction_result r) {
+          s->mark_as_finished_self_compaction();
+          return r;
+      });
 }
 
 ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -31,7 +31,7 @@ namespace storage::internal {
 
 /// \brief, this method will acquire it's own locks on the segment
 ///
-ss::future<> self_compact_segment(
+ss::future<compaction_result> self_compact_segment(
   ss::lw_shared_ptr<storage::segment>,
   storage::compaction_config,
   storage::probe&,

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -10,6 +10,7 @@
 #include "storage/types.h"
 
 #include "storage/ntp_config.h"
+#include "utils/human.h"
 #include "utils/to_string.h"
 
 #include <fmt/core.h>
@@ -107,6 +108,16 @@ std::ostream& operator<<(std::ostream& o, const compaction_config& c) {
       c.eviction_time,
       c.max_bytes.value_or(-1),
       c.sanitize);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const compaction_result& r) {
+    fmt::print(
+      o,
+      "{{executed_compaction: {}, size_before: {}, size_after: {}}}",
+      r.executed_compaction,
+      r.size_before,
+      r.size_after);
     return o;
 }
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -302,4 +302,23 @@ struct compaction_config {
 
     friend std::ostream& operator<<(std::ostream&, const compaction_config&);
 };
+
+struct compaction_result {
+    explicit compaction_result(size_t sz)
+      : executed_compaction(false)
+      , size_before(sz)
+      , size_after(sz) {}
+
+    compaction_result(size_t before, size_t after)
+      : executed_compaction(true)
+      , size_before(before)
+      , size_after(after) {}
+
+    bool did_compact() const { return executed_compaction; }
+
+    bool executed_compaction;
+    size_t size_before;
+    size_t size_after;
+    friend std::ostream& operator<<(std::ostream&, const compaction_result&);
+};
 } // namespace storage


### PR DESCRIPTION
## Cover letter
Introduced compaction quota together with some minor improvements in compaction logic. This PR is a first step required before introducing more advanced compaction controller. 

Improvements:
- not waiting for next compaction round when segment is already compacted before going to the next segment
- Introduced CPU scheduling group for compaction
- Prevent redpanda from logging false errors when removing staging concatenated segment

## Release notes
N/A