### PR TITLE
Persistent http connections

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -243,6 +243,11 @@ ss::future<bool> ntp_archiver::upload_segment(upload_candidate candidate) {
         }
         break;
     }
+    vlog(
+      archival_log.debug,
+      "Finished segment upload for {}, path {}",
+      _ntp,
+      s3path);
     co_return true;
 }
 

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -47,10 +47,12 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
 }
 
 ntp_archiver::ntp_archiver(
-  const storage::ntp_config& ntp, const configuration& conf)
+  const storage::ntp_config& ntp,
+  const configuration& conf,
+  s3::client_pool& pool)
   : _ntp(ntp.ntp())
   , _rev(ntp.get_revision())
-  , _client_conf(conf.client_config)
+  , _pool(pool)
   , _policy(_ntp)
   , _bucket(conf.bucket_name)
   , _remote(_ntp, _rev)
@@ -76,10 +78,10 @@ ss::future<download_manifest_result> ntp_archiver::download_manifest() {
     auto key = _remote.get_manifest_path();
     vlog(archival_log.debug, "Download manifest {}", key());
     auto path = s3::object_key(key().string());
-    s3::client client(_client_conf, _as);
+    auto [client, deleter] = co_await _pool.acquire();
     auto result = download_manifest_result::success;
     try {
-        auto resp = co_await client.get_object(_bucket, path);
+        auto resp = co_await client->get_object(_bucket, path);
         vlog(archival_log.debug, "Receive OK response from {}", path);
         co_await _remote.update(resp->as_input_stream());
     } catch (const s3::rest_error_response& err) {
@@ -100,7 +102,6 @@ ss::future<download_manifest_result> ntp_archiver::download_manifest() {
             throw;
         }
     }
-    co_await client.shutdown();
     co_return result;
 }
 
@@ -115,12 +116,11 @@ ss::future<> ntp_archiver::upload_manifest() {
     std::vector<s3::object_tag> tags = {{"rp-type", "partition-manifest"}};
     while (!_gate.is_closed() && backoff_quota-- > 0) {
         bool slowdown = false;
-        s3::client client(_client_conf, _as);
+        auto [client, deleter] = co_await _pool.acquire();
         try {
             auto [is, size] = _remote.serialize();
-            co_await client.put_object(
+            co_await client->put_object(
               _bucket, path, size, std::move(is), tags);
-            co_await client.shutdown();
         } catch (const s3::rest_error_response& err) {
             vlog(
               archival_log.error,
@@ -172,8 +172,7 @@ ss::future<> ntp_archiver::upload_manifest() {
 
 const manifest& ntp_archiver::get_remote_manifest() const { return _remote; }
 
-ss::future<bool> ntp_archiver::upload_segment(
-  ss::semaphore& req_limit, upload_candidate candidate) {
+ss::future<bool> ntp_archiver::upload_segment(upload_candidate candidate) {
     gate_guard guard{_gate};
     vlog(
       archival_log.debug,
@@ -188,8 +187,7 @@ ss::future<bool> ntp_archiver::upload_segment(
       segment_name(candidate.exposed_name));
     std::vector<s3::object_tag> tags = {{"rp-type", "segment"}};
     while (!_gate.is_closed() && backoff_quota-- > 0) {
-        auto units = co_await ss::get_units(req_limit, 1);
-        s3::client client(_client_conf, _as);
+        auto [client, deleter] = co_await _pool.acquire();
         auto stream = candidate.source->reader().data_stream(
           candidate.file_offset, ss::default_priority_class());
         bool slowdown = false;
@@ -200,13 +198,12 @@ ss::future<bool> ntp_archiver::upload_segment(
           s3path);
         try {
             // Segment upload attempt
-            co_await client.put_object(
+            co_await client->put_object(
               _bucket,
               s3::object_key(s3path().string()),
               candidate.content_length,
               std::move(stream),
               tags);
-            co_await client.shutdown();
         } catch (const s3::rest_error_response& err) {
             vlog(
               archival_log.error,
@@ -249,8 +246,8 @@ ss::future<bool> ntp_archiver::upload_segment(
     co_return true;
 }
 
-ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
-  ss::semaphore& req_limit, storage::log_manager& lm) {
+ss::future<ntp_archiver::batch_result>
+ntp_archiver::upload_next_candidates(storage::log_manager& lm) {
     vlog(archival_log.debug, "Uploading next candidates called for {}", _ntp);
     gate_guard guard{_gate};
     auto mlock = co_await ss::get_units(_mutex, 1);
@@ -293,7 +290,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
             continue;
         }
         offset = upload.source->offsets().committed_offset + model::offset(1);
-        flist.emplace_back(upload_segment(req_limit, upload));
+        flist.emplace_back(upload_segment(upload));
         manifest::segment_meta m{
           .is_compacted = upload.source->is_compacted_segment(),
           .size_bytes = upload.content_length,

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -154,6 +154,7 @@ private:
       model::topic_namespace_view view, model::revision_id rev);
 
     configuration _conf;
+    s3::client_pool _pool;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::topic_table>& _topic_table;
     ss::sharded<storage::api>& _storage_api;
@@ -163,7 +164,6 @@ private:
     ss::timer<ss::lowres_clock> _gc_timer;
     ss::gate _gate;
     ss::abort_source _as;
-    ss::semaphore _conn_limit;
     ss::semaphore _stop_limit;
     ntp_upload_queue _queue;
     simple_time_jitter<ss::lowres_clock> _backoff{100ms};

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -125,7 +125,9 @@ compare_json_objects(const std::string_view& lhs, const std::string_view& rhs) {
 
 FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
     set_expectations_and_listen(default_expectations);
-    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto conf = get_configuration();
+    s3::client_pool pool(conf.connection_limit(), conf.client_config);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration(), pool);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
     archiver.download_manifest().get();
     auto expected = load_manifest(manifest_payload);
@@ -134,7 +136,9 @@ FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
 
 FIXTURE_TEST(test_upload_manifest, s3_imposter_fixture) { // NOLINT
     set_expectations_and_listen(default_expectations);
-    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto conf = get_configuration();
+    s3::client_pool pool(conf.connection_limit(), conf.client_config);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration(), pool);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
     auto pm = const_cast<manifest*>( // NOLINT
       &archiver.get_remote_manifest());
@@ -163,7 +167,9 @@ FIXTURE_TEST(test_upload_manifest, s3_imposter_fixture) { // NOLINT
 // NOLINTNEXTLINE
 FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     set_expectations_and_listen(default_expectations);
-    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto conf = get_configuration();
+    s3::client_pool pool(conf.connection_limit(), conf.client_config);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration(), pool);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     std::vector<segment_desc> segments = {
@@ -172,10 +178,8 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     };
     init_storage_api_local(segments);
 
-    ss::semaphore limit(2);
     auto res = archiver
-                 .upload_next_candidates(
-                   limit, get_local_storage_api().log_mgr())
+                 .upload_next_candidates(get_local_storage_api().log_mgr())
                  .get0();
     BOOST_REQUIRE_EQUAL(res.num_succeded, 2);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -84,7 +84,7 @@ archival::configuration get_configuration() {
     archival::configuration conf;
     conf.client_config = s3conf;
     conf.bucket_name = s3::bucket_name("test-bucket");
-    conf.connection_limit = archival::s3_connection_limit(10);
+    conf.connection_limit = archival::s3_connection_limit(2);
     return conf;
 }
 

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -11,14 +11,21 @@
 
 #include "bytes/details/io_iterator_consumer.h"
 #include "bytes/iobuf.h"
+#include "rpc/backoff_policy.h"
+#include "rpc/types.h"
+#include "utils/gate_guard.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/timed_out_error.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/net/tls.hh>
 
@@ -58,30 +65,72 @@ void client::check() const {
     }
 }
 
-ss::future<client::request_response_t>
-client::make_request(client::request_header&& header) {
+ss::future<client::request_response_t> client::make_request(
+  client::request_header&& header, ss::lowres_clock::duration timeout) {
     vlog(http_log.trace, "client.make_request {}", header);
     auto verb = header.method();
     auto req = ss::make_shared<request_stream>(this, std::move(header));
     auto res = ss::make_shared<response_stream>(this, verb);
     if (is_valid()) {
-        // already connected
         return ss::make_ready_future<request_response_t>(
           std::make_tuple(req, res));
     }
-    return connect()
-      .then([req, res] {
+    return get_connected(timeout)
+      .then([req, res](reconnect_result_t r) {
+          if (r == reconnect_result_t::aborted) {
+              vlog(http_log.warn, "make_request aborted connection attempt");
+              ss::abort_requested_exception aborted;
+              return ss::make_exception_future<client::request_response_t>(
+                aborted);
+          }
           return ss::make_ready_future<request_response_t>(
             std::make_tuple(req, res));
       })
-      .handle_exception_type([this](const ss::tls::verification_error& err) {
-          return shutdown().then([err] {
+      .handle_exception_type([this](ss::tls::verification_error err) {
+          return stop().then([err = std::move(err)] {
               return ss::make_exception_future<client::request_response_t>(err);
           });
       });
 }
 
-ss::future<> client::shutdown() { return stop(); }
+ss::future<reconnect_result_t>
+client::get_connected(ss::lowres_clock::duration timeout) {
+    vlog(
+      http_log.debug,
+      "about to start connecting, {}, is-closed {}",
+      is_valid(),
+      _dispatch_gate.is_closed());
+    auto current = ss::lowres_clock::now();
+    const auto deadline = current + timeout;
+    const auto interval = 100ms;
+    while (!_dispatch_gate.is_closed()
+           && (_as == nullptr || !_as->abort_requested())
+           && current < deadline) {
+        // Reconnect attempts have to stop if:
+        // - shutdown method was called
+        // - abort was requested
+        // - unrecoverable error occured
+        // - timeout reached
+        try {
+            co_await connect(current + interval);
+            break;
+        } catch (const std::system_error& err) {
+            vlog(http_log.trace, "connection refused {}", err);
+        } catch (const ss::timed_out_error&) {
+            vlog(http_log.trace, "connection timeout");
+        }
+        current = ss::lowres_clock::now();
+        // Any TLS error have to be propagated because it's not
+        // transient. It won't help to try once again.
+    }
+    vlog(http_log.debug, "connected, {}", is_valid());
+    co_return is_valid() ? reconnect_result_t::connected
+                         : reconnect_result_t::aborted;
+}
+
+// ss::future<> client::shutdown() { return stop(); }
+
+void client::fail_outstanding_futures() noexcept { shutdown(); }
 
 ss::future<ss::temporary_buffer<char>> client::receive() {
     return _in.read()
@@ -153,7 +202,7 @@ iobuf_to_constbufseq(const iobuf& iobuf) {
     return seq;
 }
 
-ss::future<> client::response_stream::shutdown() { return _client->shutdown(); }
+ss::future<> client::response_stream::shutdown() { return _client->stop(); }
 
 /// Return failed future if ec is set, otherwise return future in ready state
 static ss::future<iobuf> fail_on_error(const boost::beast::error_code& ec) {
@@ -252,7 +301,7 @@ ss::future<iobuf> client::response_stream::recv_some() {
       })
       .handle_exception_type([this](const ss::tls::verification_error& err) {
           _client->_probe->register_transport_error();
-          return _client->shutdown().then(
+          return _client->stop().then(
             [err] { return ss::make_exception_future<iobuf>(err); });
       });
 }
@@ -324,7 +373,7 @@ ss::future<> client::request_stream::send_some(iobuf&& seq) {
             })
             .handle_exception_type(
               [this](const ss::tls::verification_error& err) {
-                  return _client->shutdown().then(
+                  return _client->stop().then(
                     [err] { return ss::make_exception_future<>(err); });
               });
       });
@@ -422,8 +471,10 @@ struct request_data_sink final : ss::data_sink_impl {
 };
 
 ss::future<client::response_stream_ref> client::request(
-  client::request_header&& header, ss::input_stream<char>& input) {
-    return make_request(std::move(header))
+  client::request_header&& header,
+  ss::input_stream<char>& input,
+  ss::lowres_clock::duration timeout) {
+    return make_request(std::move(header), timeout)
       .then([&input](request_response_t reqresp) mutable {
           auto [request, response] = std::move(reqresp);
           auto fsend = ss::do_with(
@@ -439,9 +490,9 @@ ss::future<client::response_stream_ref> client::request(
       });
 }
 
-ss::future<client::response_stream_ref>
-client::request(client::request_header&& header) {
-    return make_request(std::move(header))
+ss::future<client::response_stream_ref> client::request(
+  client::request_header&& header, ss::lowres_clock::duration timeout) {
+    return make_request(std::move(header), timeout)
       .then([](request_response_t reqresp) mutable {
           auto [request, response] = std::move(reqresp);
           return request->send_some(iobuf())

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -64,7 +64,7 @@ constexpr ss::lowres_clock::duration default_connect_timeout = 5s;
 
 enum class reconnect_result_t {
     connected,
-    aborted,
+    timed_out,
 };
 
 /// Http client

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -17,6 +17,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/temporary_buffer.hh>
@@ -28,7 +29,7 @@
 #include <seastar/http/routes.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/tcp.hh>
-#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 
 #include <boost/algorithm/string.hpp>
@@ -39,6 +40,8 @@
 #include <exception>
 #include <initializer_list>
 #include <optional>
+
+using namespace std::chrono_literals;
 
 static const uint16_t httpd_port_number = 8128;
 static const char* httpd_host_name = "127.0.0.1";
@@ -147,34 +150,30 @@ void test_http_request(
     server->stop().get();
 }
 
-SEASTAR_TEST_CASE(test_http_POST_roundtrip) {
-    return ss::async([] {
-        auto config = transport_configuration();
-        http::client::request_header header;
-        header.method(boost::beast::http::verb::post);
-        header.target("/echo");
-        header.insert(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(std::strlen(httpd_server_reply)));
-        header_set_host(header, config.server_addr);
-        header.insert(
-          boost::beast::http::field::content_type, "application/json");
-        test_http_request(
-          config,
-          std::move(header),
-          ss::sstring(httpd_server_reply),
-          [](http::client::response_header const& header, iobuf&& body) {
-              BOOST_REQUIRE_EQUAL(
-                header.result(), boost::beast::http::status::ok);
+SEASTAR_THREAD_TEST_CASE(test_http_POST_roundtrip) {
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::post);
+    header.target("/echo");
+    header.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(std::strlen(httpd_server_reply)));
+    header_set_host(header, config.server_addr);
+    header.insert(boost::beast::http::field::content_type, "application/json");
+    test_http_request(
+      config,
+      std::move(header),
+      ss::sstring(httpd_server_reply),
+      [](http::client::response_header const& header, iobuf&& body) {
+          BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
-              iobuf_parser parser(std::move(body));
-              std::string actual = parser.read_string(parser.bytes_left());
-              std::string expected
-                = "\"" + std::string(httpd_server_reply)
-                  + "\""; // sestar will return json string containing the
-              BOOST_REQUIRE_EQUAL(expected, actual);
-          });
-    });
+          iobuf_parser parser(std::move(body));
+          std::string actual = parser.read_string(parser.bytes_left());
+          std::string expected
+            = "\"" + std::string(httpd_server_reply)
+              + "\""; // sestar will return json string containing the
+          BOOST_REQUIRE_EQUAL(expected, actual);
+      });
 }
 
 /// Test http streaming requests e2e in ss::async
@@ -215,149 +214,126 @@ void test_http_streaming_request(
 }
 
 /// Check GET streaming request and skip method of the response data source
-SEASTAR_TEST_CASE(test_http_GET_streaming_roundtrip) {
-    return ss::async([] {
-        auto config = transport_configuration();
-        http::client::request_header header;
-        header.method(boost::beast::http::verb::get);
-        header.target("/get");
-        header.insert(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(0));
-        header_set_host(header, config.server_addr);
-        header.insert(
-          boost::beast::http::field::content_type, "application/json");
-        constexpr size_t skip_bytes = 100;
-        test_http_streaming_request(
-          config,
-          std::move(header),
-          std::nullopt,
-          skip_bytes,
-          [skip_bytes](
-            http::client::response_header const& header, iobuf&& body) {
-              BOOST_REQUIRE_EQUAL(
-                header.result(), boost::beast::http::status::ok);
+SEASTAR_THREAD_TEST_CASE(test_http_GET_streaming_roundtrip) {
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::get);
+    header.target("/get");
+    header.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(0));
+    header_set_host(header, config.server_addr);
+    header.insert(boost::beast::http::field::content_type, "application/json");
+    constexpr size_t skip_bytes = 100;
+    test_http_streaming_request(
+      config,
+      std::move(header),
+      std::nullopt,
+      skip_bytes,
+      [skip_bytes](http::client::response_header const& header, iobuf&& body) {
+          BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
-              iobuf_parser parser(std::move(body));
-              std::string actual = parser.read_string(parser.bytes_left());
-              std::string expected
-                = "\"" + std::string(httpd_server_reply)
-                  + "\""; // sestar will return json string containing the
-              expected = expected.substr(skip_bytes);
-              BOOST_REQUIRE_EQUAL(expected, actual);
-          });
-    });
+          iobuf_parser parser(std::move(body));
+          std::string actual = parser.read_string(parser.bytes_left());
+          std::string expected
+            = "\"" + std::string(httpd_server_reply)
+              + "\""; // sestar will return json string containing the
+          expected = expected.substr(skip_bytes);
+          BOOST_REQUIRE_EQUAL(expected, actual);
+      });
 }
 
-SEASTAR_TEST_CASE(test_http_POST_streaming_roundtrip) {
-    return ss::async([] {
-        auto config = transport_configuration();
-        http::client::request_header header;
-        header.method(boost::beast::http::verb::post);
-        header.target("/echo");
-        header.insert(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(std::strlen(httpd_server_reply)));
-        header_set_host(header, config.server_addr);
-        header.insert(
-          boost::beast::http::field::content_type, "application/json");
+SEASTAR_THREAD_TEST_CASE(test_http_POST_streaming_roundtrip) {
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::post);
+    header.target("/echo");
+    header.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(std::strlen(httpd_server_reply)));
+    header_set_host(header, config.server_addr);
+    header.insert(boost::beast::http::field::content_type, "application/json");
 
-        test_http_streaming_request(
-          config,
-          std::move(header),
-          ss::sstring(httpd_server_reply),
-          0,
-          [](http::client::response_header const& header, iobuf&& body) {
-              BOOST_REQUIRE_EQUAL(
-                header.result(), boost::beast::http::status::ok);
+    test_http_streaming_request(
+      config,
+      std::move(header),
+      ss::sstring(httpd_server_reply),
+      0,
+      [](http::client::response_header const& header, iobuf&& body) {
+          BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
 
-              iobuf_parser parser(std::move(body));
-              std::string actual = parser.read_string(parser.bytes_left());
-              std::string expected
-                = "\"" + std::string(httpd_server_reply)
-                  + "\""; // sestar will return json string containing the
-              BOOST_REQUIRE_EQUAL(expected, actual);
-          });
-    });
+          iobuf_parser parser(std::move(body));
+          std::string actual = parser.read_string(parser.bytes_left());
+          std::string expected
+            = "\"" + std::string(httpd_server_reply)
+              + "\""; // sestar will return json string containing the
+          BOOST_REQUIRE_EQUAL(expected, actual);
+      });
 }
 
-SEASTAR_TEST_CASE(test_error_500) {
-    return ss::async([] {
-        auto config = transport_configuration();
-        http::client::request_header header;
-        header.method(boost::beast::http::verb::get);
-        header.target("/fail-status-500");
-        header_set_host(header, config.server_addr);
-        header.insert(
-          boost::beast::http::field::content_type, "application/json");
-        test_http_request(
-          config,
-          std::move(header),
-          std::nullopt,
-          [](http::client::response_header const& header, iobuf&& body) {
-              BOOST_REQUIRE_EQUAL(
-                header.result(),
-                boost::beast::http::status::internal_server_error);
-              iobuf_parser parser(std::move(body));
-              std::string actual = parser.read_string(parser.bytes_left());
-              BOOST_REQUIRE(
-                actual.find("/fail-status-500") != std::string::npos);
-          });
-    });
+SEASTAR_THREAD_TEST_CASE(test_error_500) {
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::get);
+    header.target("/fail-status-500");
+    header_set_host(header, config.server_addr);
+    header.insert(boost::beast::http::field::content_type, "application/json");
+    test_http_request(
+      config,
+      std::move(header),
+      std::nullopt,
+      [](http::client::response_header const& header, iobuf&& body) {
+          BOOST_REQUIRE_EQUAL(
+            header.result(), boost::beast::http::status::internal_server_error);
+          iobuf_parser parser(std::move(body));
+          std::string actual = parser.read_string(parser.bytes_left());
+          BOOST_REQUIRE(actual.find("/fail-status-500") != std::string::npos);
+      });
 }
 
-SEASTAR_TEST_CASE(test_http_GET_roundtrip) {
+SEASTAR_THREAD_TEST_CASE(test_http_GET_roundtrip) {
     // No request data
-    return ss::async([] {
-        auto config = transport_configuration();
-        http::client::request_header header;
-        header.method(boost::beast::http::verb::get);
-        header.target("/get");
-        header_set_host(header, config.server_addr);
-        header.insert(
-          boost::beast::http::field::content_type, "application/json");
-        test_http_request(
-          config,
-          std::move(header),
-          std::nullopt,
-          [](http::client::response_header const& header, iobuf&& body) {
-              BOOST_REQUIRE_EQUAL(
-                header.result(), boost::beast::http::status::ok);
-              iobuf_parser parser(std::move(body));
-              std::string actual = parser.read_string(parser.bytes_left());
-              std::string expected = "\"" + std::string(httpd_server_reply)
-                                     + "\"";
-              BOOST_REQUIRE_EQUAL(expected, actual);
-          });
-    });
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::get);
+    header.target("/get");
+    header_set_host(header, config.server_addr);
+    header.insert(boost::beast::http::field::content_type, "application/json");
+    test_http_request(
+      config,
+      std::move(header),
+      std::nullopt,
+      [](http::client::response_header const& header, iobuf&& body) {
+          BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
+          iobuf_parser parser(std::move(body));
+          std::string actual = parser.read_string(parser.bytes_left());
+          std::string expected = "\"" + std::string(httpd_server_reply) + "\"";
+          BOOST_REQUIRE_EQUAL(expected, actual);
+      });
 }
 
-SEASTAR_TEST_CASE(test_http_PUT_roundtrip) {
+SEASTAR_THREAD_TEST_CASE(test_http_PUT_roundtrip) {
     // Send data and recv empty response
-    return ss::async([] {
-        auto config = transport_configuration();
-        http::client::request_header header;
-        header.method(boost::beast::http::verb::put);
-        header.target("/put");
-        header.insert(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(std::strlen(httpd_server_reply)));
-        header_set_host(header, config.server_addr);
-        header.insert(
-          boost::beast::http::field::content_type, "application/json");
-        test_http_request(
-          config,
-          std::move(header),
-          ss::sstring(httpd_server_reply),
-          [](http::client::response_header const& header, iobuf&& body) {
-              BOOST_REQUIRE_EQUAL(
-                header.result(), boost::beast::http::status::ok);
-              iobuf_parser parser(std::move(body));
-              std::string actual = parser.read_string(parser.bytes_left());
-              std::string expected = "\"\"";
-              BOOST_REQUIRE_EQUAL(expected, actual);
-          });
-    });
+    auto config = transport_configuration();
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::put);
+    header.target("/put");
+    header.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(std::strlen(httpd_server_reply)));
+    header_set_host(header, config.server_addr);
+    header.insert(boost::beast::http::field::content_type, "application/json");
+    test_http_request(
+      config,
+      std::move(header),
+      ss::sstring(httpd_server_reply),
+      [](http::client::response_header const& header, iobuf&& body) {
+          BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
+          iobuf_parser parser(std::move(body));
+          std::string actual = parser.read_string(parser.bytes_left());
+          std::string expected = "\"\"";
+          BOOST_REQUIRE_EQUAL(expected, actual);
+      });
 }
 
 /// Simple tcp server that can receive pre-defined request and
@@ -407,10 +383,11 @@ public:
 
 private:
     iobuf do_read_request() {
+        using namespace std::chrono_literals;
         // Read until _expected_data is fetched
         iobuf buffer;
         int it = 0;
-        const int max_iter = 100;
+        const int max_iter = 1000;
         while (it++ < max_iter) {
             auto tmpbuf = _fin.read().get0();
             buffer.append(std::move(tmpbuf));
@@ -422,6 +399,7 @@ private:
                     return std::move(buffer);
                 }
             }
+            ss::sleep(1ms).get();
         }
         throw std::runtime_error("Can't read request body");
     }
@@ -517,137 +495,127 @@ void test_impostor_request(
     server->stop();
 }
 
-SEASTAR_TEST_CASE(test_http_via_impostor) {
+SEASTAR_THREAD_TEST_CASE(test_http_via_impostor) {
     // Send data and recv response
-    return ss::async([] {
-        auto config = transport_configuration();
+    auto config = transport_configuration();
 
-        // Generate client request
-        http::client::request_header request_header;
-        request_header.method(boost::beast::http::verb::post);
-        request_header.target("/");
-        request_header.insert(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(std::strlen(httpd_server_reply)));
-        header_set_host(request_header, config.server_addr);
-        request_header.insert(
-          boost::beast::http::field::content_type, "application/json");
+    // Generate client request
+    http::client::request_header request_header;
+    request_header.method(boost::beast::http::verb::post);
+    request_header.target("/");
+    request_header.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(std::strlen(httpd_server_reply)));
+    header_set_host(request_header, config.server_addr);
+    request_header.insert(
+      boost::beast::http::field::content_type, "application/json");
 
-        // Generate server response
-        ss::sstring response_data = httpd_server_reply;
-        http::client::response_header resp_hdr;
-        resp_hdr.result(boost::beast::http::status::ok);
-        header_set_host(resp_hdr, config.server_addr);
-        resp_hdr.insert(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(response_data.size()));
-        auto full_response = get_response_header(resp_hdr) + response_data;
+    // Generate server response
+    ss::sstring response_data = httpd_server_reply;
+    http::client::response_header resp_hdr;
+    resp_hdr.result(boost::beast::http::status::ok);
+    header_set_host(resp_hdr, config.server_addr);
+    resp_hdr.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(response_data.size()));
+    auto full_response = get_response_header(resp_hdr) + response_data;
 
-        // Run test case
-        test_impostor_request(
-          config,
-          std::move(request_header),
-          ss::sstring(httpd_server_reply),
-          {full_response},
-          false,
-          [](http::client::response_header const& header, iobuf&& body) {
-              BOOST_REQUIRE_EQUAL(
-                header.result(), boost::beast::http::status::ok);
-              iobuf_parser parser(std::move(body));
-              std::string actual = parser.read_string(parser.bytes_left());
-              std::string expected = ss::sstring(httpd_server_reply);
-              BOOST_REQUIRE_EQUAL(expected, actual);
-          });
-    });
+    // Run test case
+    test_impostor_request(
+      config,
+      std::move(request_header),
+      ss::sstring(httpd_server_reply),
+      {full_response},
+      false,
+      [](http::client::response_header const& header, iobuf&& body) {
+          BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
+          iobuf_parser parser(std::move(body));
+          std::string actual = parser.read_string(parser.bytes_left());
+          std::string expected = ss::sstring(httpd_server_reply);
+          BOOST_REQUIRE_EQUAL(expected, actual);
+      });
 }
 
-SEASTAR_TEST_CASE(test_http_via_impostor_incorrect_reply) {
+SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_incorrect_reply) {
     // Send data and recv error message
-    return ss::async([] {
-        auto config = transport_configuration();
+    auto config = transport_configuration();
 
-        // Client request
-        http::client::request_header request_header;
-        request_header.method(boost::beast::http::verb::post);
-        request_header.target("/");
-        request_header.insert(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(std::strlen(httpd_server_reply)));
-        header_set_host(request_header, config.server_addr);
-        request_header.insert(
-          boost::beast::http::field::content_type, "application/json");
+    // Client request
+    http::client::request_header request_header;
+    request_header.method(boost::beast::http::verb::post);
+    request_header.target("/");
+    request_header.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(std::strlen(httpd_server_reply)));
+    header_set_host(request_header, config.server_addr);
+    request_header.insert(
+      boost::beast::http::field::content_type, "application/json");
 
-        // Generate server response
-        ss::sstring full_response = "not-correct-http-reply";
+    // Generate server response
+    ss::sstring full_response = "not-correct-http-reply";
 
-        test_impostor_request(
-          config,
-          std::move(request_header),
-          ss::sstring(httpd_server_reply),
-          {full_response},
-          false,
-          [](http::client::response_header const&, iobuf&&) {
-              BOOST_FAIL("Exception expected");
-          },
-          [](std::exception_ptr const& eptr) {
-              try {
-                  std::rethrow_exception(eptr);
-              } catch (boost::system::system_error const& e) {
-                  BOOST_REQUIRE(
-                    e.code() == boost::beast::http::error::bad_version);
-              }
-          });
-    });
+    test_impostor_request(
+      config,
+      std::move(request_header),
+      ss::sstring(httpd_server_reply),
+      {full_response},
+      false,
+      [](http::client::response_header const&, iobuf&&) {
+          BOOST_FAIL("Exception expected");
+      },
+      [](std::exception_ptr const& eptr) {
+          try {
+              std::rethrow_exception(eptr);
+          } catch (boost::system::system_error const& e) {
+              BOOST_REQUIRE(e.code() == boost::beast::http::error::bad_version);
+          }
+      });
 }
 
-SEASTAR_TEST_CASE(test_http_via_impostor_chunked_encoding) {
+SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_chunked_encoding) {
     // Send data and recv chunked response
-    return ss::async([] {
-        auto config = transport_configuration();
+    auto config = transport_configuration();
 
-        // Generate request
-        http::client::request_header request_header;
-        request_header.method(boost::beast::http::verb::post);
-        request_header.target("/");
-        request_header.insert(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(std::strlen(httpd_server_reply)));
-        header_set_host(request_header, config.server_addr);
-        request_header.insert(
-          boost::beast::http::field::content_type, "application/json");
+    // Generate request
+    http::client::request_header request_header;
+    request_header.method(boost::beast::http::verb::post);
+    request_header.target("/");
+    request_header.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(std::strlen(httpd_server_reply)));
+    header_set_host(request_header, config.server_addr);
+    request_header.insert(
+      boost::beast::http::field::content_type, "application/json");
 
-        // Generate response
-        http::chunked_encoder encoder{false};
-        ss::sstring response_data = httpd_server_reply;
-        http::client::response_header resp_hdr;
-        resp_hdr.result(boost::beast::http::status::ok);
-        resp_hdr.insert(
-          boost::beast::http::field::transfer_encoding, "chunked");
-        header_set_host(resp_hdr, config.server_addr);
-        auto header_str = get_response_header(resp_hdr);
-        iobuf outbuf;
-        outbuf.append(header_str.data(), header_str.size());
-        iobuf bodybuf;
-        bodybuf.append(response_data.data(), response_data.size());
-        outbuf.append(encoder.encode(std::move(bodybuf)));
-        outbuf.append(encoder.encode_eof());
-        iobuf_parser bufparser(std::move(outbuf));
+    // Generate response
+    http::chunked_encoder encoder{false};
+    ss::sstring response_data = httpd_server_reply;
+    http::client::response_header resp_hdr;
+    resp_hdr.result(boost::beast::http::status::ok);
+    resp_hdr.insert(boost::beast::http::field::transfer_encoding, "chunked");
+    header_set_host(resp_hdr, config.server_addr);
+    auto header_str = get_response_header(resp_hdr);
+    iobuf outbuf;
+    outbuf.append(header_str.data(), header_str.size());
+    iobuf bodybuf;
+    bodybuf.append(response_data.data(), response_data.size());
+    outbuf.append(encoder.encode(std::move(bodybuf)));
+    outbuf.append(encoder.encode_eof());
+    iobuf_parser bufparser(std::move(outbuf));
 
-        test_impostor_request(
-          config,
-          std::move(request_header),
-          ss::sstring(httpd_server_reply),
-          {bufparser.read_string(bufparser.bytes_left())},
-          false,
-          [](http::client::response_header const& header, iobuf&& body) {
-              BOOST_REQUIRE_EQUAL(
-                header.result(), boost::beast::http::status::ok);
-              iobuf_parser parser(std::move(body));
-              std::string actual = parser.read_string(parser.bytes_left());
-              std::string expected = ss::sstring(httpd_server_reply);
-              BOOST_REQUIRE_EQUAL(expected, actual);
-          });
-    });
+    test_impostor_request(
+      config,
+      std::move(request_header),
+      ss::sstring(httpd_server_reply),
+      {bufparser.read_string(bufparser.bytes_left())},
+      false,
+      [](http::client::response_header const& header, iobuf&& body) {
+          BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
+          iobuf_parser parser(std::move(body));
+          std::string actual = parser.read_string(parser.bytes_left());
+          std::string expected = ss::sstring(httpd_server_reply);
+          BOOST_REQUIRE_EQUAL(expected, actual);
+      });
 }
 
 /// Remove elements from the middle of the vector until it'll have only 'n'
@@ -669,132 +637,70 @@ struct range_t {
     size_t ixend;
 };
 
-ss::future<> run_framing_test_using_impostor(
+void run_framing_test_using_impostor(
   bool chunked, size_t n_iters, bool prefetch_headers) {
     // Send data and recv chunked response
-    return ss::async([chunked, n_iters, prefetch_headers] {
-        auto config = transport_configuration();
-        // Generate request
-        http::client::request_header request_header;
-        request_header.method(boost::beast::http::verb::post);
-        request_header.target("/");
-        request_header.insert(
+    auto config = transport_configuration();
+    // Generate request
+    http::client::request_header request_header;
+    request_header.method(boost::beast::http::verb::post);
+    request_header.target("/");
+    request_header.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(std::strlen(httpd_server_reply)));
+    header_set_host(request_header, config.server_addr);
+    request_header.insert(
+      boost::beast::http::field::content_type, "application/json");
+
+    // Generate response
+    ss::sstring response_data = httpd_server_reply;
+    http::client::response_header resp_hdr;
+    resp_hdr.result(boost::beast::http::status::ok);
+    if (chunked) {
+        resp_hdr.insert(
+          boost::beast::http::field::transfer_encoding, "chunked");
+    } else {
+        resp_hdr.insert(
           boost::beast::http::field::content_length,
-          boost::beast::to_static_string(std::strlen(httpd_server_reply)));
-        header_set_host(request_header, config.server_addr);
-        request_header.insert(
-          boost::beast::http::field::content_type, "application/json");
+          boost::beast::to_static_string(response_data.size()));
+    }
+    header_set_host(resp_hdr, config.server_addr);
+    auto header_str = get_response_header(resp_hdr);
 
-        // Generate response
-        ss::sstring response_data = httpd_server_reply;
-        http::client::response_header resp_hdr;
-        resp_hdr.result(boost::beast::http::status::ok);
-        if (chunked) {
-            resp_hdr.insert(
-              boost::beast::http::field::transfer_encoding, "chunked");
-        } else {
-            resp_hdr.insert(
-              boost::beast::http::field::content_length,
-              boost::beast::to_static_string(response_data.size()));
+    using split_t = std::vector<range_t>;
+    std::vector<split_t> splits;
+    for (size_t ix = 0; ix < response_data.size(); ix++) {
+        split_t sp;
+        if (ix != 0) {
+            sp.push_back({0, ix});
         }
-        header_set_host(resp_hdr, config.server_addr);
-        auto header_str = get_response_header(resp_hdr);
+        sp.push_back({ix, response_data.size()});
+        splits.push_back(std::move(sp));
+    }
+    // remove excessive work
+    remove_middle_elements(splits, n_iters);
 
-        using split_t = std::vector<range_t>;
-        std::vector<split_t> splits;
-        for (size_t ix = 0; ix < response_data.size(); ix++) {
-            split_t sp;
-            if (ix != 0) {
-                sp.push_back({0, ix});
-            }
-            sp.push_back({ix, response_data.size()});
-            splits.push_back(std::move(sp));
+    for (const auto& split : splits) {
+        http::chunked_encoder encoder{!chunked};
+        std::vector<ss::sstring> chunks{header_str};
+        for (auto [begin, end] : split) {
+            BOOST_ASSERT(begin < response_data.size());
+            BOOST_ASSERT(end <= response_data.size());
+            auto sub = response_data.substr(begin, end - begin);
+            ss::temporary_buffer<char> tmp(sub.data(), sub.size());
+            iobuf_parser pbuf(encoder.encode(std::move(tmp)));
+            chunks.push_back(pbuf.read_string(pbuf.bytes_left()));
         }
-        // remove excessive work
-        remove_middle_elements(splits, n_iters);
+        iobuf_parser ptail(encoder.encode_eof());
+        chunks.push_back(ptail.read_string(ptail.bytes_left()));
 
-        for (const auto& split : splits) {
-            http::chunked_encoder encoder{!chunked};
-            std::vector<ss::sstring> chunks{header_str};
-            for (auto [begin, end] : split) {
-                BOOST_ASSERT(begin < response_data.size());
-                BOOST_ASSERT(end <= response_data.size());
-                auto sub = response_data.substr(begin, end - begin);
-                ss::temporary_buffer<char> tmp(sub.data(), sub.size());
-                iobuf_parser pbuf(encoder.encode(std::move(tmp)));
-                chunks.push_back(pbuf.read_string(pbuf.bytes_left()));
-            }
-            iobuf_parser ptail(encoder.encode_eof());
-            chunks.push_back(ptail.read_string(ptail.bytes_left()));
-
-            test_impostor_request(
-              config,
-              request_header,
-              ss::sstring(httpd_server_reply),
-              chunks,
-              prefetch_headers,
-              [](http::client::response_header const& header, iobuf&& body) {
-                  BOOST_REQUIRE_EQUAL(
-                    header.result(), boost::beast::http::status::ok);
-                  iobuf_parser parser(std::move(body));
-                  std::string actual = parser.read_string(parser.bytes_left());
-                  std::string expected = ss::sstring(httpd_server_reply);
-                  BOOST_REQUIRE_EQUAL(expected, actual);
-              });
-        }
-    });
-}
-
-SEASTAR_TEST_CASE(test_http_via_impostor_framing) {
-    return run_framing_test_using_impostor(false, 32, false);
-}
-
-SEASTAR_TEST_CASE(test_http_via_impostor_framing_with_prefetch) {
-    return run_framing_test_using_impostor(false, 32, true);
-}
-
-SEASTAR_TEST_CASE(test_http_via_impostor_chunked_encoding_framing) {
-    return run_framing_test_using_impostor(true, 32, false);
-}
-
-SEASTAR_TEST_CASE(
-  test_http_via_impostor_chunked_encoding_framing_with_prefetch) {
-    return run_framing_test_using_impostor(true, 32, true);
-}
-
-SEASTAR_TEST_CASE(test_http_via_impostor_no_content_length) {
-    // Send data and recv response (no content length header)
-    return ss::async([] {
-        auto config = transport_configuration();
-
-        // Generate client request
-        http::client::request_header request_header;
-        request_header.method(boost::beast::http::verb::post);
-        request_header.target("/");
-        request_header.insert(
-          boost::beast::http::field::content_length,
-          boost::beast::to_static_string(std::strlen(httpd_server_reply)));
-        header_set_host(request_header, config.server_addr);
-        request_header.insert(
-          boost::beast::http::field::content_type, "application/json");
-
-        // Generate server response
-        ss::sstring response_data = httpd_server_reply;
-        http::client::response_header resp_hdr;
-        resp_hdr.result(boost::beast::http::status::ok);
-        header_set_host(resp_hdr, config.server_addr);
-        auto full_response = get_response_header(resp_hdr) + response_data;
-
-        // Run test case
         test_impostor_request(
           config,
-          std::move(request_header),
+          request_header,
           ss::sstring(httpd_server_reply),
-          {full_response},
-          false,
+          chunks,
+          prefetch_headers,
           [](http::client::response_header const& header, iobuf&& body) {
-              // Expect normal reply despite the absence of content-length
-              // header
               BOOST_REQUIRE_EQUAL(
                 header.result(), boost::beast::http::status::ok);
               iobuf_parser parser(std::move(body));
@@ -802,5 +708,88 @@ SEASTAR_TEST_CASE(test_http_via_impostor_no_content_length) {
               std::string expected = ss::sstring(httpd_server_reply);
               BOOST_REQUIRE_EQUAL(expected, actual);
           });
-    });
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_framing) {
+    run_framing_test_using_impostor(false, 32, false);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_framing_with_prefetch) {
+    run_framing_test_using_impostor(false, 32, true);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_chunked_encoding_framing) {
+    run_framing_test_using_impostor(true, 32, false);
+}
+
+SEASTAR_THREAD_TEST_CASE(
+  test_http_via_impostor_chunked_encoding_framing_with_prefetch) {
+    run_framing_test_using_impostor(true, 32, true);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_http_via_impostor_no_content_length) {
+    // Send data and recv response (no content length header)
+    auto config = transport_configuration();
+
+    // Generate client request
+    http::client::request_header request_header;
+    request_header.method(boost::beast::http::verb::post);
+    request_header.target("/");
+    request_header.insert(
+      boost::beast::http::field::content_length,
+      boost::beast::to_static_string(std::strlen(httpd_server_reply)));
+    header_set_host(request_header, config.server_addr);
+    request_header.insert(
+      boost::beast::http::field::content_type, "application/json");
+
+    // Generate server response
+    ss::sstring response_data = httpd_server_reply;
+    http::client::response_header resp_hdr;
+    resp_hdr.result(boost::beast::http::status::ok);
+    header_set_host(resp_hdr, config.server_addr);
+    auto full_response = get_response_header(resp_hdr) + response_data;
+
+    // Run test case
+    test_impostor_request(
+      config,
+      std::move(request_header),
+      ss::sstring(httpd_server_reply),
+      {full_response},
+      false,
+      [](http::client::response_header const& header, iobuf&& body) {
+          // Expect normal reply despite the absence of content-length
+          // header
+          BOOST_REQUIRE_EQUAL(header.result(), boost::beast::http::status::ok);
+          iobuf_parser parser(std::move(body));
+          std::string actual = parser.read_string(parser.bytes_left());
+          std::string expected = ss::sstring(httpd_server_reply);
+          BOOST_REQUIRE_EQUAL(expected, actual);
+      });
+}
+
+SEASTAR_THREAD_TEST_CASE(test_http_cancel_reconnect) {
+    auto config = transport_configuration();
+    ss::abort_source as;
+    http::client client(config, as);
+    auto fut = client.get_connected(10s);
+    ss::sleep(10ms).get();
+    BOOST_REQUIRE(fut.failed() == false);
+    BOOST_REQUIRE(fut.available() == false);
+    as.request_abort();
+    auto res = fut.get0();
+    BOOST_REQUIRE(res == http::reconnect_result_t::aborted);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_http_reconnect_graceful_shutdown) {
+    auto config = transport_configuration();
+    ss::abort_source as;
+    http::client client(config, as);
+    auto fut = client.get_connected(10s);
+    ss::sleep(10ms).get();
+    BOOST_REQUIRE(fut.failed() == false);
+    BOOST_REQUIRE(fut.available() == false);
+    client.stop().get();
+    ss::sleep(10ms).get();
+    BOOST_REQUIRE(fut.get() == http::reconnect_result_t::aborted);
 }

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -15,6 +15,7 @@
 #include "rpc/transport.h"
 #include "seastarx.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -777,8 +778,7 @@ SEASTAR_THREAD_TEST_CASE(test_http_cancel_reconnect) {
     BOOST_REQUIRE(fut.failed() == false);
     BOOST_REQUIRE(fut.available() == false);
     as.request_abort();
-    auto res = fut.get0();
-    BOOST_REQUIRE(res == http::reconnect_result_t::aborted);
+    BOOST_REQUIRE_THROW(fut.get(), ss::abort_requested_exception);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_http_reconnect_graceful_shutdown) {
@@ -791,5 +791,5 @@ SEASTAR_THREAD_TEST_CASE(test_http_reconnect_graceful_shutdown) {
     BOOST_REQUIRE(fut.available() == false);
     client.stop().get();
     ss::sleep(10ms).get();
-    BOOST_REQUIRE(fut.get() == http::reconnect_result_t::aborted);
+    BOOST_REQUIRE(fut.get() == http::reconnect_result_t::timed_out);
 }


### PR DESCRIPTION
## Cover letter

Connections in HTTP 1.1 are persistent by default. But archival storage didn't use it before. All connections created using our S3 client were transient. This PR implements persistent connections by doing the following steps
- make http_client reusable by allowing to reconnect after the connection drops
- handle errors in such way that allows the client to be reused
- implement connection pool for S3 client
- use connection pool in archival storage subsystem instead of transient S3 connections 

## Release notes

N/A