### PR TITLE
External k8s access

### DIFF
--- a/docs/www/kubernetes-external-connect.md
+++ b/docs/www/kubernetes-external-connect.md
@@ -1,0 +1,148 @@
+---
+title: Connect to a Kubernetes cluster from an external client
+order: 0
+---
+
+# Connect to a Kubernetes cluster from an external client
+
+The [Kubernetes Quick Start guide](quick-start-kubernetes.md) describes how to quickly get up and running with a Kubernetes cluster.
+Those instructions only provide access to the cluster from within the Kuberenetes network.
+
+Here we'll show you an example of how to set up Kubernetes in
+[Google GKE](https://cloud.google.com/kubernetes-engine), [Amazon EKS](https://aws.amazon.com/eks), or [Digital Ocean](https://cloud.digitalocean.com/)
+so you can work with Redpanda from outside of the Kubernetes network.
+
+Let's get started...
+
+## Create a Kubernetes cluster
+
+1. Create a 3-node cluster:
+
+<tabs>
+
+  <tab id="AWS EKS">
+
+  Use the [EKS Getting Started](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html) guide to set up EKS.
+  When you finish, you'll have `eksctl` installed so that you can create and delete clusters in EKS.
+  Then, create an EKS cluster with:
+
+  ```
+  eksctl create cluster \
+  --name redpanda \
+  --nodegroup-name standard-workers \
+  --node-type m5.xlarge \
+  --nodes 3 \
+  --nodes-min 1 \
+  --nodes-max 4 \
+  --node-ami auto
+  ```
+
+  It will take about 10-15 minutes for the process to finish.
+
+  </tab>
+
+  <tab id="Google GKE">
+
+  First complete the "Before You Begin" steps described in [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart).
+  Then, create a cluster with:
+
+  ```
+  gcloud container clusters create redpanda --machine-type e2-standard-4 --cluster-version 1.19 && \
+  gcloud container clusters get-credentials redpanda
+  ```
+
+  **_Note_** - You may need to add a `--region`, `--zone`, or `--project` to this command.
+
+  </tab>
+  <tab id="Digital Ocean">
+
+  First, set up your [Digital Ocean account](https://docs.digitalocean.com/products/getting-started/) and install [`doctl`](https://docs.digitalocean.com/reference/doctl/how-to/install/).
+
+  Then you can create a cluster for your Redpanda deployment:
+
+  ```
+  doctl kubernetes cluster create redpanda --wait --size s-2vcpu-4gb
+  ```
+
+  </tab>
+</tabs>
+
+2. Install cert-manager:
+
+  ```bash
+  helm repo add jetstack https://charts.jetstack.io && \
+  helm repo update && \
+  helm install \
+    cert-manager jetstack/cert-manager \
+    --namespace cert-manager \
+    --create-namespace \
+    --version v1.2.0 \
+    --set installCRDs=true
+  ```
+
+3. Install the latest redpanda operator:
+
+  ```
+  VERSION=v21.4.15
+  kubectl apply -k 'https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$VERSION'
+  helm repo add redpanda https://charts.vectorized.io/ && \
+  helm repo update \
+  helm install \
+    --namespace redpanda-system \
+    --create-namespace redpanda-operator \
+    --version $VERSION \
+    redpanda/redpanda-operator
+  ```
+
+4. Install a cluster with external connectivity:
+
+  ```
+  VERSION=v21.4.15
+  kubectl apply -f https://raw.githubusercontent.com/vectorizedio/redpanda/$VERSION/src/go/k8s/config/samples/external_connectivity.yaml
+  ```
+
+5. For GKE only, open the firewall for access to the cluster:
+  
+  a. Get the port number that Redpanda is listening on:
+
+      ```
+      kubectl get service external-connectivity-external -o=jsonpath='{.spec.ports[0].nodePort}'
+      ```
+
+      The port is shown in the command output.
+
+  b. Create a firewall rule that allows traffic to Redpanda on that port:
+
+    ```
+    gcloud compute firewall-rules create redpanda-nodeport --allow tcp:<port_number>
+    ```
+
+    The port that Redpanda is listening on is shown in the command output, for example:
+
+    `30249`
+
+6. Get the addresses of the brokers:
+
+  ```
+  kubectl get clusters external-connectivity -o=jsonpath='{.status.nodes.external}'
+  ```
+
+  The broker addresses are shown in the command output, for example:
+
+  `["34.121.167.159:30249","34.71.125.54:30249","35.184.221.5:30249"]`
+
+7. From a remote machine that has `rpk` installed, get information about the cluster:
+
+  ```
+  rpk --brokers 34.121.167.159:30249,34.71.125.54:30249,35.184.221.5:30249 cluster info
+  ```
+
+8. Create a topic in your Redpanda cluster:
+
+  ```
+  rpk --brokers 34.121.167.159:30249,34.71.125.54:30249,35.184.221.5:30249 topic create chat-rooms -p 5
+  ```
+
+Now you know how to set up a Kubernetes cluster in a cloud and access it from a remote machine.
+
+Contact us in our [Slack](https://vectorized.io/slack) community so we can work together to implement your Kubernetes use cases.

--- a/docs/www/quick-start-kubernetes.md
+++ b/docs/www/quick-start-kubernetes.md
@@ -9,10 +9,10 @@ With Redpanda you can get up and running with streaming quickly
 and be fully compatible with the [Kafka ecosystem](https://cwiki.apache.org/confluence/display/KAFKA/Ecosystem).
 
 This quick start guide can help you get started with Redpanda for development and testing purposes.
-For production or benchmarking, setup a [production deployment](/docs/production-deployment).
-
-Using [Helm](https://helm.sh/) is the fastest way to get started with Redpanda on Kubernetes.
 To get up and running you need to create a cluster and deploy the Redpanda operator on the cluster.
+
+- For production or benchmarking, setup a [production deployment](/docs/production-deployment).
+- You can also set up a [Kubernetes cluster with external access](/docs/kubernetes-external-connect)
 
 > **_Note_** - Run a container inside the Kubernetes cluster to communicate with the Redpanda cluster.
 > Currently, a load balancer is not automatically created during deployment by default.
@@ -60,7 +60,7 @@ You can either create a Kubernetes cluster on your local machine or on a cloud p
   --name redpanda \
   --nodegroup-name standard-workers \
   --node-type m5.xlarge \
-  --nodes 3 \
+  --nodes 1 \
   --nodes-min 1 \
   --nodes-max 4 \
   --node-ami auto
@@ -91,7 +91,6 @@ You can [install cert-manager with a CRD](https://cert-manager.io/docs/installat
 but here's the command to install using helm:
 
 ```
-kubectl create namespace cert-manager && \
 helm repo add jetstack https://charts.jetstack.io && \
 helm repo update && \
 helm install \
@@ -105,7 +104,7 @@ helm install \
 We recommend that you use [the verification procedure](https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation) in the cert-manager docs
 to verify that cert-manager is working correcly.
 
-## Using Helm to install Redpanda
+## Use Helm to install Redpanda
 
 1. Using Helm, add the Redpanda chart repository and update it:
 
@@ -117,7 +116,7 @@ to verify that cert-manager is working correcly.
 2. Just to simplify the commands, create a variable for the version number:
 
     ```
-    export version=v21.4.13
+    export VERSION=v21.4.15
     ```
 
     **_Note_** - You can find the latest version number of the operator in the [list of operator releases](https://github.com/vectorizedio/redpanda/releases).
@@ -126,7 +125,7 @@ to verify that cert-manager is working correcly.
 
     ```
     kubectl apply \
-    -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$version
+    -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$VERSION
     ```
 
 4. Install the Redpanda operator on your Kubernetes cluster with:
@@ -135,6 +134,7 @@ to verify that cert-manager is working correcly.
     helm install \
     --namespace redpanda-system \
     --create-namespace redpanda-operator \
+    --version $VERSION \
     redpanda/redpanda-operator
     ```
 
@@ -166,7 +166,7 @@ Let's try setting up a Redpanda topic to handle a stream of events from a chat a
 
         kubectl -n chat-with-me run -ti --rm \
         --restart=Never \
-        --image vectorized/redpanda:$version \
+        --image vectorized/redpanda:$VERSION \
         -- rpk --brokers one-node-cluster-0.one-node-cluster.chat-with-me.svc.cluster.local:9092 \
         cluster info
     
@@ -174,7 +174,7 @@ Let's try setting up a Redpanda topic to handle a stream of events from a chat a
 
         kubectl -n chat-with-me run -ti --rm \
         --restart=Never \
-        --image vectorized/redpanda:$version \
+        --image vectorized/redpanda:$VERSION \
         -- rpk --brokers one-node-cluster-0.one-node-cluster.chat-with-me.svc.cluster.local:9092 \
         topic create chat-rooms -p 5
 
@@ -182,10 +182,13 @@ Let's try setting up a Redpanda topic to handle a stream of events from a chat a
 
         kubectl -n chat-with-me run -ti --rm \
         --restart=Never \
-        --image vectorized/redpanda:$version \
+        --image vectorized/redpanda:$VERSION \
         -- rpk --brokers one-node-cluster-0.one-node-cluster.chat-with-me.svc.cluster.local:9092 \
         topic list
 
 As you can see, the commands from the "rpk" pod created a 5 partition topic in for the chat rooms.
 
-Contact us in our [Slack](https://vectorized.io/slack) community so we can work together to implement your Kubernetes use cases.
+## Next steps
+
+- Contact us in our [Slack](https://vectorized.io/slack) community so we can work together to implement your Kubernetes use cases.
+- Check out how to set up a Kubernetes cluster with [access from an external machine](kubernetes-external-connect.md).


### PR DESCRIPTION
## Cover letter

Adds procedure for setting up a Kubernetes cluster with access from outside of the Kubernetes network.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
