### PR TITLE
pandaproxy: Don't connect to brokers at startup 

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -24,6 +24,7 @@
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
+#include "random/generators.h"
 #include "seastarx.h"
 #include "ssx/future-util.h"
 #include "utils/unresolved_address.h"
@@ -116,6 +117,9 @@ ss::future<> client::do_connect(unresolved_address addr) {
 }
 
 ss::future<> client::connect() {
+    std::shuffle(
+      _seeds.begin(), _seeds.end(), random_generators::internal::gen);
+
     return ss::do_with(size_t{0}, [this](size_t& retries) {
         return retry_with_mitigation(
           _config.retries(),

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -170,7 +170,9 @@ ss::future<> client::update_metadata(wait_or_start::tag) {
                   return apply(std::move(res));
               })
               .finally([]() { vlog(kclog.trace, "updated metadata"); });
-        });
+        })
+          .handle_exception_type(
+            [this](const broker_error&) { return connect(); });
     });
 }
 

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -156,21 +156,22 @@ ss::future<> client::stop() noexcept {
 ss::future<> client::update_metadata(wait_or_start::tag) {
     return ss::try_with_gate(_gate, [this]() {
         vlog(kclog.debug, "updating metadata");
-        return _brokers.any().then([this](shared_broker_t broker) {
-            return broker->dispatch(metadata_request{.list_all_topics = true})
-              .then([this](metadata_response res) {
-                  // Create new seeds from the returned set of brokers
-                  std::vector<unresolved_address> seeds;
-                  seeds.reserve(res.data.brokers.size());
-                  for (const auto& b : res.data.brokers) {
-                      seeds.emplace_back(b.host, b.port);
-                  }
-                  std::swap(_seeds, seeds);
+        return _brokers.any()
+          .then([this](shared_broker_t broker) {
+              return broker->dispatch(metadata_request{.list_all_topics = true})
+                .then([this](metadata_response res) {
+                    // Create new seeds from the returned set of brokers
+                    std::vector<unresolved_address> seeds;
+                    seeds.reserve(res.data.brokers.size());
+                    for (const auto& b : res.data.brokers) {
+                        seeds.emplace_back(b.host, b.port);
+                    }
+                    std::swap(_seeds, seeds);
 
-                  return apply(std::move(res));
-              })
-              .finally([]() { vlog(kclog.trace, "updated metadata"); });
-        })
+                    return apply(std::move(res));
+                })
+                .finally([]() { vlog(kclog.trace, "updated metadata"); });
+          })
           .handle_exception_type(
             [this](const broker_error&) { return connect(); });
     });

--- a/src/v/pandaproxy/proxy.cc
+++ b/src/v/pandaproxy/proxy.cc
@@ -73,18 +73,8 @@ proxy::proxy(const YAML::Node& config, const YAML::Node& client_config)
       make_context(_config, _client)) {}
 
 ss::future<> proxy::start() {
-    return seastar::when_all_succeed(
-             [this]() {
-                 _server.routes(get_proxy_routes());
-                 return _server.start();
-             },
-             [this]() {
-                 return _client.connect().handle_exception_type(
-                   [](const kafka::client::broker_error& e) {
-                       vlog(plog.debug, "Failed to connect to broker: {}", e);
-                   });
-             })
-      .discard_result();
+    _server.routes(get_proxy_routes());
+    return _server.start();
 }
 
 ss::future<> proxy::stop() {


### PR DESCRIPTION
## Cover letter

* Defer connecting to brokers until first use.
* When updating metadata, handle no brokers by connecting
* Shuffle seeds before connecting

Fixes #1259, Fixes #1284

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/ace49f1970ec0e055c9a93dc6aa47ff93b1d4dc0..d9d5d02f12b79dcbaa47ea0c5eb4b6e896f2bc04)
* Shuffle seeds before connecting
* Split and reword commits

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/d9d5d02f12b79dcbaa47ea0c5eb4b6e896f2bc04..28ae5ffaba0a20303a314d30b2ac0698e3dd5b3c)
* Use thread-local ransom generator

## Release notes

Release note: none
