### PR TITLE
rpk/cli/common: Fix nil check

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -194,7 +194,7 @@ func CreateProducer(
 		}
 		// If no SCRAM config was set, try to look for it in the
 		// config file.
-		if scram == nil {
+		if errors.Is(err, ErrNoCredentials) {
 			scram = &conf.Rpk.SCRAM
 		}
 


### PR DESCRIPTION
Check for the specific error instead of checking if the returned object is nil.
