### PR TITLE
rpk: Fix flaky admin tests

### DIFF
--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -174,7 +174,7 @@ func sendToMultiple(
 			}
 		}
 	}
-	return nil, err
+	return nil, err.ErrorOrNil()
 }
 
 func send(

--- a/src/go/rpk/pkg/api/admin/admin_test.go
+++ b/src/go/rpk/pkg/api/admin/admin_test.go
@@ -36,7 +36,7 @@ func TestCreateUser(t *testing.T) {
 
 	rand.Seed(time.Now().Unix())
 
-	nNodes := rand.Int31n(6)
+	nNodes := rand.Int31n(6) + 1
 	urls := []string{}
 
 	for i := 0; i < int(nNodes); i++ {
@@ -70,7 +70,7 @@ func TestDeleteUser(t *testing.T) {
 	username := "Lola"
 
 	rand.Seed(time.Now().Unix())
-	nNodes := rand.Int31n(6)
+	nNodes := rand.Int31n(6) + 1
 	urls := []string{}
 
 	for i := 0; i < int(nNodes); i++ {
@@ -101,7 +101,7 @@ func TestDeleteUser(t *testing.T) {
 
 func TestListUsers(t *testing.T) {
 	rand.Seed(time.Now().Unix())
-	nNodes := rand.Int31n(6)
+	nNodes := rand.Int31n(6) + 1
 	urls := []string{}
 
 	for i := 0; i < int(nNodes); i++ {


### PR DESCRIPTION
## Cover letter

The `multierror.Group` always returns the error. The assertion was right
that error is not niled. The library has helper function `ErrorOrNil()`
that should be used.

The rand.Int31n returns none negative pseudo-random number including 0.
Tests that will have 0 urls does not make sanse.

Ref:
// Int31n returns, as an int32, a non-negative pseudo-random number in [0,n)
// from the default Source.
