### PR TITLE
rpk/container: Allow using an arbitrary image

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start_test.go
@@ -60,7 +60,7 @@ func TestStart(t *testing.T) {
 				}, nil
 			},
 			expectedErrMsg: "Couldn't pull image and a local one" +
-				" wasn't found either.",
+				" wasn't found either: Can't pull",
 		},
 		{
 			name: "it should fail if the img couldn't be pulled bc of internet conn issues",
@@ -107,7 +107,7 @@ Please check your internet connection and try again.`,
 				}, nil
 			},
 			expectedErrMsg: "Couldn't pull image and a local one" +
-				" wasn't found either.",
+				" wasn't found either: Can't pull",
 		},
 		{
 			name: "it should fail if creating the network fails",
@@ -495,7 +495,7 @@ Please check your internet connection and try again.`,
 				check = tt.check
 			}
 			retries := uint(10)
-			err = startCluster(c, tt.nodes, check, retries)
+			err = startCluster(c, tt.nodes, check, retries, common.DefaultImage())
 			if tt.expectedErrMsg != "" {
 				require.EqualError(st, err, tt.expectedErrMsg)
 			} else {


### PR DESCRIPTION
Add a hidden `--image` flag to `rpk container start` which allows users to pass an arbitrary docker image reference. This flag is meant for debugging and making local testing easier, by enabling developers to run something like `rpk container start --image redpanda:local` and preventing rpk from asttempting to pull an image from the registry.
