### PR TITLE
Build with g++-11

### DIFF
--- a/.github/workflows/redpanda-build.yml
+++ b/.github/workflows/redpanda-build.yml
@@ -13,7 +13,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build on ${{ matrix.container }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: ${{ matrix.container }}
     strategy:
       matrix:

--- a/.github/workflows/redpanda-build.yml
+++ b/.github/workflows/redpanda-build.yml
@@ -17,7 +17,7 @@ jobs:
     container: ${{ matrix.container }}
     strategy:
       matrix:
-        container: ['ubuntu:20.10']
+        container: ['ubuntu:21.04']
 
     steps:
         - name: checkout

--- a/.github/workflows/redpanda-build.yml
+++ b/.github/workflows/redpanda-build.yml
@@ -32,6 +32,14 @@ jobs:
         - name: install dependencies
           run: ./install-dependencies.sh
 
+        - name: install g++-11
+          run: |
+            DEBIAN_FRONTEND=noninteractive apt install -y g++-11
+            sudo update-alternatives \
+              --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 \
+              --slave /usr/bin/g++ g++ /usr/bin/g++-11
+            sudo update-alternatives --auto gcc
+
         # there is no analog to ${{ github.workspace }} for the home directory
         - name: prepare cache variables
           id: prepare_cache_variables

--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -34,13 +34,19 @@ public:
     io_fragment& operator=(io_fragment&& o) noexcept = delete;
     io_fragment(const io_fragment& o) = delete;
     io_fragment& operator=(const io_fragment& o) = delete;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
     ~io_fragment() noexcept = default;
+#pragma GCC diagnostic pop
 
     bool operator==(const io_fragment& o) const {
         return _used_bytes == o._used_bytes && _buf == o._buf;
     }
     bool operator!=(const io_fragment& o) const { return !(*this == o); }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
     bool is_empty() const { return _used_bytes == 0; }
+#pragma GCC diagnostic pop
     size_t available_bytes() const { return _buf.size() - _used_bytes; }
     void reserve(size_t reservation) {
         check_out_of_range(reservation, available_bytes());
@@ -109,5 +115,12 @@ private:
     ss::temporary_buffer<char> _buf;
     size_t _used_bytes;
 };
+
+inline void __attribute__((noinline)) dispose_io_fragment(io_fragment* f) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfree-nonheap-object"
+    delete f; // NOLINT
+#pragma GCC diagnostic pop
+}
 
 } // namespace details

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -186,9 +186,7 @@ private:
 };
 
 inline void iobuf::clear() {
-    _frags.clear_and_dispose([](fragment* f) {
-        delete f; // NOLINT
-    });
+    _frags.clear_and_dispose(&details::dispose_io_fragment);
     _size = 0;
 }
 inline iobuf::~iobuf() noexcept { clear(); }
@@ -276,7 +274,7 @@ inline void iobuf::reserve_memory(size_t reservation) {
     while (!b._frags.empty()) {
         b._frags.pop_back_and_dispose([this](fragment* f) {
             prepend(f->share());
-            delete f; // NOLINT
+            details::dispose_io_fragment(f);
         });
     }
 }
@@ -340,7 +338,7 @@ inline void iobuf::append(iobuf o) {
     while (!o._frags.empty()) {
         o._frags.pop_front_and_dispose([this](fragment* f) {
             append(f->share());
-            delete f; // NOLINT
+            details::dispose_io_fragment(f);
         });
     }
 }
@@ -351,7 +349,7 @@ inline void iobuf::append_fragments(iobuf o) {
         o._frags.pop_front_and_dispose([this](fragment* f) {
             auto frag = new fragment(f->share(), fragment::full{});
             append_take_ownership(frag);
-            delete f; // NOLINT
+            details::dispose_io_fragment(f);
         });
     }
 }
@@ -359,16 +357,12 @@ inline void iobuf::append_fragments(iobuf o) {
 inline void iobuf::pop_front() {
     oncore_debug_verify(_verify_shard);
     _size -= _frags.front().size();
-    _frags.pop_front_and_dispose([](fragment* f) {
-        delete f; // NOLINT
-    });
+    _frags.pop_front_and_dispose(&details::dispose_io_fragment);
 }
 inline void iobuf::pop_back() {
     oncore_debug_verify(_verify_shard);
     _size -= _frags.back().size();
-    _frags.pop_back_and_dispose([](fragment* f) {
-        delete f; // NOLINT
-    });
+    _frags.pop_back_and_dispose(&details::dispose_io_fragment);
 }
 inline void iobuf::trim_front(size_t n) {
     oncore_debug_verify(_verify_shard);

--- a/src/v/ssx/sformat.h
+++ b/src/v/ssx/sformat.h
@@ -28,7 +28,7 @@ namespace ssx {
 
 template<typename... Args>
 seastar::sstring sformat(fmt::string_view format_str, Args&&... args) {
-    auto size = fmt::formatted_size(format_str, args...);
+    auto size = fmt::formatted_size(format_str, std::forward<Args>(args)...);
     seastar::sstring buffer(seastar::sstring::initialized_later{}, size);
     fmt::format_to(buffer.data(), format_str, std::forward<Args>(args)...);
     return buffer;


### PR DESCRIPTION
## Cover letter

Build with g++-11

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/a973e4c2bfbfe3061a72fd3996a128004a13aae2..55e25d738fbecb0932df0f1d229e19840b40f41b)
* Rebased (abseil already updated)
* Built with gcc 11.1.0 available in Hirsute updates channel.

## Release notes

Release note: Redpanda is now built and tested on Ubuntu Hirsute with gcc 11.1
