### PR TITLE
kafka: support sasl handshake v0

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -10,16 +10,21 @@
  */
 #include "kafka/server/connection_context.h"
 
+#include "bytes/iobuf.h"
 #include "config/configuration.h"
+#include "kafka/protocol/sasl_authenticate.h"
 #include "kafka/server/protocol.h"
 #include "kafka/server/protocol_utils.h"
 #include "kafka/server/quota_manager.h"
 #include "kafka/server/request_context.h"
+#include "units.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/scattered_message.hh>
 #include <seastar/core/sleep.hh>
 
 #include <chrono>
+using namespace std::chrono_literals;
 
 namespace kafka {
 
@@ -28,6 +33,23 @@ ss::future<> connection_context::process_one_request() {
       .then([this](std::optional<size_t> sz) mutable {
           if (!sz) {
               return ss::make_ready_future<>();
+          }
+          /*
+           * Intercept the wire protocol when:
+           *
+           * 1. sasl is enabled (implied by 2)
+           * 2. during auth phase
+           * 3. handshake was v0
+           */
+          if (unlikely(
+                sasl().state()
+                  == security::sasl_server::sasl_state::authenticate
+                && sasl().handshake_v0())) {
+              return handle_auth_v0(*sz).handle_exception(
+                [this](std::exception_ptr e) {
+                    vlog(klog.info, "Detected error processing request: {}", e);
+                    _rs.conn->shutdown_input();
+                });
           }
           return parse_header(_rs.conn->input())
             .then(
@@ -45,6 +67,77 @@ ss::future<> connection_context::process_one_request() {
                   return dispatch_method_once(std::move(h.value()), s);
               });
       });
+}
+
+/*
+ * The SASL authentication flow for a client using version 0 of SASL handshake
+ * doesn't use an envelope request for tokens. This method intercepts the
+ * authentication phase and builds an envelope request so that all of the normal
+ * request processing can be re-used.
+ *
+ * Even though we build and decode a request/response, the payload is a small
+ * authentication string. https://github.com/vectorizedio/redpanda/issues/1315.
+ * When this ticket is complete we'll be able to easily remove this extra
+ * serialization step and and easily operate on non-encoded requests/responses.
+ */
+ss::future<> connection_context::handle_auth_v0(const size_t size) {
+    vlog(klog.debug, "Processing simulated SASL authentication request");
+
+    /*
+     * very generous upper bound for some added safety. generally the size is
+     * small and corresponds to the representation of hashes being exchanged but
+     * there is some flexibility as usernames, nonces, etc... have no strict
+     * limits. future non-SCRAM mechanisms may have other size requirements.
+     */
+    if (unlikely(size > 256_KiB)) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format, "Auth (handshake_v0) message too large", size));
+    }
+
+    const api_version version(0);
+    iobuf request_buf;
+    {
+        auto data = co_await read_iobuf_exactly(_rs.conn->input(), size);
+        sasl_authenticate_request request;
+        request.data.auth_bytes = iobuf_to_bytes(data);
+        response_writer writer(request_buf);
+        request.encode(writer, version);
+    }
+
+    sasl_authenticate_response response;
+    {
+        auto ctx = request_context(
+          shared_from_this(),
+          request_header{
+            .key = sasl_authenticate_api::key,
+            .version = version,
+          },
+          std::move(request_buf),
+          0s);
+        auto resp = co_await kafka::process_request(
+          std::move(ctx), _proto.smp_group());
+        auto data = std::move(*resp).release();
+        response.decode(std::move(data), version);
+    }
+
+    if (response.data.error_code != error_code::none) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "Auth (handshake v0) error {}: {}",
+          response.data.error_code,
+          response.data.error_message));
+    }
+
+    if (sasl().state() == security::sasl_server::sasl_state::failed) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format, "Auth (handshake v0) failed with unknown error"));
+    }
+
+    iobuf data;
+    response_writer writer(data);
+    writer.write(response.data.auth_bytes);
+    auto msg = iobuf_as_scattered(std::move(data));
+    co_await _rs.conn->write(std::move(msg));
 }
 
 bool connection_context::is_finished_parsing() const {

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -96,6 +96,8 @@ private:
     ss::future<> process_next_response();
     ss::future<> do_process(request_context);
 
+    ss::future<> handle_auth_v0(size_t);
+
 private:
     using sequence_id = named_type<uint64_t, struct kafka_protocol_sequence>;
     using map_t = absl::flat_hash_map<sequence_id, response_ptr>;

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -76,6 +76,14 @@ ss::future<response_ptr> do_process(
 static ss::future<response_ptr>
 handle_auth_handshake(request_context&& ctx, ss::smp_service_group g) {
     auto conn = ctx.connection();
+    if (ctx.header().version == api_version(0)) {
+        /*
+         * see connection_context::process_one_request for more info. when this
+         * is set the input connection is assumed to contain raw authentication
+         * tokens not wrapped in a normal kafka request envelope.
+         */
+        conn->sasl().set_handshake_v0();
+    }
     return do_process<sasl_handshake_handler>(std::move(ctx), g)
       .then([conn = std::move(conn)](response_ptr r) {
           if (conn->sasl().has_mechanism()) {

--- a/src/v/security/sasl_authentication.h
+++ b/src/v/security/sasl_authentication.h
@@ -62,9 +62,13 @@ public:
 
     const ss::sstring& principal() const { return _mechanism->principal(); }
 
+    bool handshake_v0() const { return _handshake_v0; }
+    void set_handshake_v0() { _handshake_v0 = true; }
+
 private:
     sasl_state _state;
     std::unique_ptr<sasl_mechanism> _mechanism;
+    bool _handshake_v0{false};
 };
 
 }; // namespace security

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -335,6 +335,9 @@ class RedpandaService(Service):
             map(lambda n: self.broker_address(n), self.nodes[:limit]))
         return brokers
 
+    def brokers_list(self, limit=None):
+        return [self.broker_address(n) for n in self.nodes[:limit]]
+
     def metrics(self, node):
         assert node in self.nodes
         url = f"http://{node.account.hostname}:9644/metrics"

--- a/tests/rptest/tests/scram_pythonlib_test.py
+++ b/tests/rptest/tests/scram_pythonlib_test.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import random
+import string
+import requests
+import time
+from ducktape.mark.resource import cluster
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+from kafka import KafkaAdminClient
+from kafka.admin import NewTopic
+
+
+class ScramPythonLibTest(RedpandaTest):
+    def __init__(self, test_context):
+        extra_rp_conf = dict(
+            developer_mode=True,
+            enable_sasl=True,
+        )
+        super(ScramPythonLibTest, self).__init__(test_context,
+                                                 num_brokers=3,
+                                                 extra_rp_conf=extra_rp_conf)
+
+    def make_superuser_client(self, password_override=None):
+        username, password, algorithm = self.redpanda.SUPERUSER_CREDENTIALS
+        password = password_override or password
+        return KafkaAdminClient(bootstrap_servers=self.redpanda.brokers_list(),
+                                security_protocol='SASL_PLAINTEXT',
+                                sasl_mechanism=algorithm,
+                                sasl_plain_username=username,
+                                sasl_plain_password=password,
+                                request_timeout_ms=30000,
+                                api_version_auto_timeout_ms=3000)
+
+    @cluster(num_nodes=3)
+    def test_scram_pythonlib(self):
+        topic = TopicSpec()
+        client = self.make_superuser_client()
+        client.create_topics([
+            NewTopic(name=topic.name, num_partitions=1, replication_factor=1)
+        ])
+        topics = set(client.list_topics())
+        self.redpanda.logger.info(f"Topics {topics}")
+        assert set([topic.name]) == topics


### PR DESCRIPTION
The SASL protocol consists of a handshake request and authentication request where the SASL authentication phase is an exchange of opaque blob data wrapped in a kafka request envelope.

However, when handshake v0 is handled, no authentication request follows on the wire. Instead, the wire will contain the raw token data without a request envelope. Therefore, we need to intercept normal request processing in this case and handle the tokens manually.

One simplification that is made is to construct synthetic authentication request envelopes and pass the request through normal request processing to be able to reuse as much of the SASL server state machine as possible.

Fixes: #1270