### PR TITLE
Add sasl/scram to rpk's pandaproxy client schema

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1257,6 +1257,67 @@ rpk:
 `,
 		},
 		{
+			name: "shall write config with pandproxy client SASL mechanism and SCRAM credentials",
+			conf: func() *Config {
+				c := getValidConfig()
+				mechanism := "abc"
+				username := "user"
+				password := "pass"
+				c.PandaproxyClient = &PandaproxyClient{
+					SASLMechanism: &mechanism,
+					SCRAMUsername: &username,
+					SCRAMPassword: &password,
+				}
+				return c
+			},
+			wantErr: false,
+			expected: `config_file: /etc/redpanda/redpanda.yaml
+pandaproxy: {}
+pandaproxy_client:
+  sasl_mechanism: abc
+  scram_password: pass
+  scram_username: user
+redpanda:
+  admin:
+  - address: 0.0.0.0
+    port: 9644
+  data_directory: /var/lib/redpanda/data
+  developer_mode: false
+  kafka_api:
+  - address: 0.0.0.0
+    port: 9092
+  node_id: 0
+  rpc_server:
+    address: 0.0.0.0
+    port: 33145
+  seed_servers:
+  - host:
+      address: 127.0.0.1
+      port: 33145
+  - host:
+      address: 127.0.0.1
+      port: 33146
+rpk:
+  coredump_dir: /var/lib/redpanda/coredumps
+  enable_memory_locking: true
+  enable_usage_stats: true
+  overprovisioned: false
+  tune_aio_events: true
+  tune_clocksource: true
+  tune_coredump: true
+  tune_cpu: true
+  tune_disk_irq: true
+  tune_disk_nomerges: true
+  tune_disk_scheduler: true
+  tune_disk_write_cache: true
+  tune_fstrim: true
+  tune_network: true
+  tune_swappiness: true
+  tune_transparent_hugepages: true
+  well_known_io: vendor:vm:storage
+`,
+		},
+		{
 			name: "shall write config with archival configuration",
 			conf: func() *Config {
 				c := getValidConfig()

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -61,8 +61,11 @@ type Pandaproxy struct {
 }
 
 type PandaproxyClient struct {
-	Brokers   []SocketAddress `yaml:"brokers,omitempty" mapstructure:"brokers,omitempty" json:"brokers,omitempty"`
-	BrokerTLS ServerTLS       `yaml:"broker_tls,omitempty" mapstructure:"broker_tls,omitempty" json:"brokerTls,omitempty"`
+	Brokers       []SocketAddress `yaml:"brokers,omitempty" mapstructure:"brokers,omitempty" json:"brokers,omitempty"`
+	BrokerTLS     ServerTLS       `yaml:"broker_tls,omitempty" mapstructure:"broker_tls,omitempty" json:"brokerTls,omitempty"`
+	SASLMechanism *string         `yaml:"sasl_mechanism,omitempty" mapstructure:"sasl_mechanism,omitempty" json:"saslMechanism,omitempty"`
+	SCRAMUsername *string         `yaml:"scram_username,omitempty" mapstructure:"scram_username,omitempty" json:"scramUsername,omitempty"`
+	SCRAMPassword *string         `yaml:"scram_password,omitempty" mapstructure:"scram_password,omitempty" json:"scramPassword,omitempty"`
 }
 
 type SeedServer struct {


### PR DESCRIPTION
## Cover letter

Adding scram credentials and sasl mechanism configuration to rpk's pandaproxy client schema. This is useful for the operator to populate the corresponding `redpanda.yaml` fields.