### PR TITLE
kubernetes: Enable Prometheus monitoring

### DIFF
--- a/src/go/k8s/config/default/kustomization.yaml
+++ b/src/go/k8s/config/default/kustomization.yaml
@@ -22,7 +22,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/src/go/k8s/config/default/manager_auth_proxy_patch.yaml
+++ b/src/go/k8s/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/src/go/k8s/config/prometheus/monitor.yaml
+++ b/src/go/k8s/config/prometheus/monitor.yaml
@@ -9,8 +9,15 @@ metadata:
   namespace: system
 spec:
   endpoints:
-    - path: /metrics
-      port: https
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+      - redpanda-system
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/clusterrole.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/clusterrole.yaml
@@ -32,27 +32,7 @@ rules:
   - cert-manager.io
   resources:
   - certificates
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - cert-manager.io
-  resources:
   - clusterissuers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - cert-manager.io
-  resources:
   - issuers
   verbs:
   - create
@@ -93,6 +73,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - watch
@@ -122,16 +103,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterroles
   verbs:
   - create

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/deployment.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/servicemonitor.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{/*
+Copyright 2020 Vectorized, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "redpanda-operator.name" . }}-metrics-monitor
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+{{ include "redpanda-operator.labels" . | indent 6 }}

--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -11,6 +11,7 @@ kindNodeCache: false
 commands:
   - command: "./hack/install-cert-manager.sh"
   - command: "kubectl apply -k ./config/crd"
+  - command: "kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml"
   - command: "helm install --set image.tag=latest --namespace helm-test --create-namespace redpanda-operator ./helm-chart/charts/redpanda-operator"
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_helm_e2e_artifacts

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -10,6 +10,7 @@ kindConfig: ./kind.yaml
 kindNodeCache: false
 commands:
   - command: "./hack/install-cert-manager.sh"
+  - command: "kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml"
   - command: "make deploy"
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_e2e_artifacts


### PR DESCRIPTION
## Cover letter and Release notes

Enable Prometheus monitoring for Redpanda operator.

Bump version of the kube-rbac-proxy to the latest available.

Add ServiceMonitor to the helm chart.

Sync the ClusterRole definition between helm and kustomize.
