### PR TITLE
rpk cloud get namespaces/clusters

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cloud.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud.go
@@ -24,6 +24,7 @@ func NewCloudCommand(fs afero.Fs) *cobra.Command {
 
 	command.AddCommand(cloud.NewLoginCommand(fs))
 	command.AddCommand(cloud.NewLogoutCommand(fs))
+	command.AddCommand(cloud.NewGetCommand(fs))
 
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/cloud/clusters.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/clusters.go
@@ -1,0 +1,81 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloud
+
+import (
+	"errors"
+	"io"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/config"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/ui"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/yak"
+)
+
+func NewClustersCommand(fs afero.Fs) *cobra.Command {
+	var (
+		namespaceName string
+	)
+	command := &cobra.Command{
+		Use:   "clusters",
+		Short: "Get clusters in given namespace",
+		Long:  `List clusters that you have created in your namespace in your vectorized cloud organization.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if namespaceName == "" {
+				return errors.New("please provide --namespace flag")
+			}
+			yakClient := yak.NewYakClient(config.NewVCloudConfigReaderWriter(fs))
+			return GetClusters(yakClient, log.StandardLogger().Out, namespaceName)
+		},
+	}
+
+	command.Flags().StringVarP(
+		&namespaceName,
+		"namespace",
+		"n",
+		"",
+		"Namespace name from your vectorized cloud organization",
+	)
+
+	return command
+}
+
+func GetClusters(
+	c yak.CloudApiClient, out io.Writer, namespaceName string,
+) error {
+	clusters, err := c.GetClusters(namespaceName)
+	if _, ok := err.(yak.ErrLoginTokenMissing); ok {
+		log.Info("Please run `rpk cloud login` first. ")
+		return err
+	}
+
+	if err != nil {
+		return err
+	}
+
+	printFormattedClusters(clusters, out)
+	return nil
+}
+
+func printFormattedClusters(clusters []*yak.Cluster, out io.Writer) {
+	t := ui.NewVcloudTable(out)
+	t.SetHeader([]string{"id", "name", "ready"})
+	for _, c := range clusters {
+		t.Append([]string{
+			c.Id,
+			c.Name,
+			strconv.FormatBool(c.Ready),
+		})
+	}
+	t.Render()
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/clusters_test.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/clusters_test.go
@@ -1,0 +1,67 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloud_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/cloud"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/yak"
+)
+
+func TestClusters(t *testing.T) {
+	tests := []struct {
+		name           string
+		client         yak.CloudApiClient
+		expectedOutput []string
+		expectedError  string
+	}{
+		{
+			"success",
+			&mockYakClient{},
+			[]string{"notready", "false"},
+			"",
+		},
+		{
+			"not logged in",
+			&erroredYakClient{yak.ErrLoginTokenMissing{errors.New("inner")}},
+			[]string{"rpk cloud login"},
+			"retrieving login token",
+		},
+		{
+			"generic client error",
+			&erroredYakClient{errors.New("other error")},
+			[]string{},
+			"other error",
+		},
+	}
+
+	for _, tt := range tests {
+		var buf bytes.Buffer
+		logrus.SetOutput(&buf)
+		err := cloud.GetClusters(tt.client, &buf, "ns")
+		if len(tt.expectedOutput) > 0 {
+			for _, s := range tt.expectedOutput {
+				if !strings.Contains(buf.String(), s) {
+					t.Errorf("%s: expecting string %s in output %s", tt.name, s, buf.String())
+				}
+			}
+		}
+		if tt.expectedError != "" {
+			if err == nil || !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("%s: expecting error %s got %v", tt.name, tt.expectedError, err)
+			}
+		}
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/get.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/get.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloud
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewGetCommand(fs afero.Fs) *cobra.Command {
+	command := &cobra.Command{
+		Use:    "get",
+		Short:  "Get resource from Vectorized cloud",
+		Hidden: true,
+	}
+
+	command.AddCommand(NewNamespacesCommand(fs))
+
+	return command
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/get.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/get.go
@@ -22,6 +22,7 @@ func NewGetCommand(fs afero.Fs) *cobra.Command {
 	}
 
 	command.AddCommand(NewNamespacesCommand(fs))
+	command.AddCommand(NewClustersCommand(fs))
 
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/cloud/namespaces.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/namespaces.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloud
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/config"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/ui"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/yak"
+)
+
+func NewNamespacesCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{
+		Use:     "namespaces",
+		Aliases: []string{"ns"},
+		Short:   "Get namespaces in your vectorized cloud",
+		Long:    `List namespaces that you have created in your vectorized cloud organization.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			yakClient := yak.NewYakClient(config.NewVCloudConfigReaderWriter(fs))
+			return GetNamespaces(yakClient, logrus.StandardLogger().Out)
+		},
+	}
+}
+
+func GetNamespaces(c yak.CloudApiClient, out io.Writer) error {
+	ns, err := c.GetNamespaces()
+	if _, ok := err.(yak.ErrLoginTokenMissing); ok {
+		log.Info("Please run `rpk cloud login` first. ")
+		return err
+	}
+	if err != nil {
+		return err
+	}
+
+	printFormatted(ns, out)
+	return nil
+}
+
+func printFormatted(ns []*yak.Namespace, out io.Writer) {
+	t := ui.NewVcloudTable(out)
+	t.SetHeader([]string{"id", "name", "clusters"})
+	for _, n := range ns {
+		t.Append([]string{
+			n.Id,
+			n.Name,
+			fmt.Sprint(len(n.ClusterIds)),
+		})
+	}
+	t.Render()
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/namespaces_test.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/namespaces_test.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloud_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/cloud"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/yak"
+)
+
+func TestNamespaces(t *testing.T) {
+	tests := []struct {
+		name           string
+		client         yak.CloudApiClient
+		expectedOutput []string
+		expectedError  string
+	}{
+		{
+			name:           "success",
+			client:         &mockYakClient{},
+			expectedOutput: []string{"test", "2"},
+			expectedError:  "",
+		},
+		{
+			name:           "not logged in",
+			client:         &erroredYakClient{yak.ErrLoginTokenMissing{errors.New("inner")}},
+			expectedOutput: []string{"rpk cloud login"},
+			expectedError:  "retrieving login token",
+		},
+		{
+			name:           "generic client error",
+			client:         &erroredYakClient{errors.New("other error")},
+			expectedOutput: []string{},
+			expectedError:  "other error",
+		},
+	}
+
+	for _, tt := range tests {
+		var buf bytes.Buffer
+		logrus.SetOutput(&buf)
+		err := cloud.GetNamespaces(tt.client, &buf)
+		if len(tt.expectedOutput) > 0 {
+			for _, s := range tt.expectedOutput {
+				if !strings.Contains(buf.String(), s) {
+					t.Errorf("%s: expecting string %s in output %s", tt.name, s, buf.String())
+				}
+			}
+		}
+		if tt.expectedError != "" {
+			if err == nil || !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("%s: expecting error %s got %v", tt.name, tt.expectedError, err)
+			}
+		}
+	}
+}
+
+// Yak client returning fixed mocked responses
+type mockYakClient struct {
+}
+
+func (yc *mockYakClient) GetNamespaces() ([]*yak.Namespace, error) {
+	return []*yak.Namespace{
+		{
+			Id:         "test",
+			Name:       "test",
+			ClusterIds: []string{"1", "2"},
+		},
+	}, nil
+}
+
+// Yak client returning error provided on creation
+type erroredYakClient struct {
+	err error
+}
+
+func (yc *erroredYakClient) GetNamespaces() ([]*yak.Namespace, error) {
+	return nil, yc.err
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/namespaces_test.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/namespaces_test.go
@@ -80,11 +80,29 @@ func (yc *mockYakClient) GetNamespaces() ([]*yak.Namespace, error) {
 	}, nil
 }
 
+func (yc *mockYakClient) GetClusters(
+	namespaceName string,
+) ([]*yak.Cluster, error) {
+	return []*yak.Cluster{
+		{
+			Id:    "notready",
+			Name:  "notready",
+			Ready: false,
+		},
+	}, nil
+}
+
 // Yak client returning error provided on creation
 type erroredYakClient struct {
 	err error
 }
 
 func (yc *erroredYakClient) GetNamespaces() ([]*yak.Namespace, error) {
+	return nil, yc.err
+}
+
+func (yc *erroredYakClient) GetClusters(
+	namespaceName string,
+) ([]*yak.Cluster, error) {
 	return nil, yc.err
 }

--- a/src/go/rpk/pkg/vcloud/ui/tables.go
+++ b/src/go/rpk/pkg/vcloud/ui/tables.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package ui
+
+import (
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+func NewVcloudTable(writer io.Writer) *tablewriter.Table {
+	table := tablewriter.NewWriter(writer)
+	table.SetBorder(false)
+	table.SetColumnSeparator("")
+	table.SetHeaderLine(false)
+	table.SetColWidth(80)
+	table.SetAutoWrapText(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	return table
+}

--- a/src/go/rpk/pkg/vcloud/yak/api.go
+++ b/src/go/rpk/pkg/vcloud/yak/api.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 )
+
 type CloudApiClient interface {
 	// GetNamespaces returns list of all namespaces available in the user's
 	// organization. Returns `ErrLoginTokenMissing` if token cannot be

--- a/src/go/rpk/pkg/vcloud/yak/api.go
+++ b/src/go/rpk/pkg/vcloud/yak/api.go
@@ -20,6 +20,12 @@ type CloudApiClient interface {
 	// retrieved. Returns `ErrNotAuthorized` if user is not authorized to list
 	// namespaces.
 	GetNamespaces() ([]*Namespace, error)
+	// GetClusters lists all redpanda clusters available in given namespace.
+	// Returns `ErrLoginTokenMissing` if token cannot be retrieved. Returns
+	// `ErrNotAuthorized` if user is not authorized to list clusters. Returns
+	// `ErrNamespaceDoesNotExists` if namespace of given name was not
+	// found.
+	GetClusters(namespaceName string) ([]*Cluster, error)
 }
 
 type Namespace struct {
@@ -28,12 +34,30 @@ type Namespace struct {
 	ClusterIds []string `json:"clusterIds,omitempty"`
 }
 
+// Cluster is definition of redpanda cluster
+type Cluster struct {
+	Id       string   `json:"id,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	Hosts    []string `json:"hosts,omitempty"`
+	Ready    bool     `json:"ready,omitempty"`
+	Provider string   `json:"provider,omitempty"`
+	Region   string   `json:"region,omitempty"`
+}
+
 type ErrLoginTokenMissing struct {
 	InnerError error
 }
 
 func (e ErrLoginTokenMissing) Error() string {
 	return fmt.Sprintf("Error retrieving login token: %v", e.InnerError)
+}
+
+type ErrNamespaceDoesNotExist struct {
+	Name string
+}
+
+func (e ErrNamespaceDoesNotExist) Error() string {
+	return fmt.Sprintf("Namespace %s does not exist", e.Name)
 }
 
 var (

--- a/src/go/rpk/pkg/vcloud/yak/api.go
+++ b/src/go/rpk/pkg/vcloud/yak/api.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package yak
+
+import (
+	"errors"
+	"fmt"
+)
+type CloudApiClient interface {
+	// GetNamespaces returns list of all namespaces available in the user's
+	// organization. Returns `ErrLoginTokenMissing` if token cannot be
+	// retrieved. Returns `ErrNotAuthorized` if user is not authorized to list
+	// namespaces.
+	GetNamespaces() ([]*Namespace, error)
+}
+
+type Namespace struct {
+	Id         string   `json:"id,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	ClusterIds []string `json:"clusterIds,omitempty"`
+}
+
+type ErrLoginTokenMissing struct {
+	InnerError error
+}
+
+func (e ErrLoginTokenMissing) Error() string {
+	return fmt.Sprintf("Error retrieving login token: %v", e.InnerError)
+}
+
+var (
+	ErrNotAuthorized = errors.New("User is not authorized to view this resource")
+)

--- a/src/go/rpk/pkg/vcloud/yak/client.go
+++ b/src/go/rpk/pkg/vcloud/yak/client.go
@@ -1,0 +1,75 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package yak
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/config"
+)
+
+type YakClient struct {
+	conf config.ConfigReaderWriter
+}
+
+const (
+	namespaceRoute = "namespace"
+
+	// TODO(av) make this configurable and point it to production
+	DefaultYakUrl = "https://backend.dev.vectorized.cloud"
+)
+
+func NewYakClient(conf config.ConfigReaderWriter) CloudApiClient {
+	return &YakClient{
+		conf: conf,
+	}
+}
+
+func (yc *YakClient) GetNamespaces() ([]*Namespace, error) {
+	token, err := yc.conf.ReadToken()
+	if err != nil {
+		return nil, ErrLoginTokenMissing{err}
+	}
+	url := fmt.Sprintf("%s/%s", DefaultYakUrl, namespaceRoute)
+	req, err := http.NewRequest(http.MethodGet, url, bytes.NewBuffer([]byte{}))
+	if err != nil {
+		return nil, fmt.Errorf("error creating new request. %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error calling api: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	// targetting HTTP codes 401, 403 which are used by yak
+	if resp.StatusCode > 400 && resp.StatusCode < 404 {
+		log.Debug(body)
+		return nil, ErrNotAuthorized
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("error retrieving resource, http code %d. %s", resp.StatusCode, body)
+	}
+	var namespaces []*Namespace
+	err = json.Unmarshal(body, &namespaces)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling response. %w", err)
+	}
+	return namespaces, nil
+}


### PR DESCRIPTION
## Cover letter

Adds `cloud get namespaces` and `cloud get clusters` commands.

```
rpk cloud get namespaces
  ID                                    NAME    CLUSTERS
  ef32e76b-0e23-4a44-893d-c3db5192d2b1  andres  1
  398a22d9-b086-4da5-8e64-154e16ae241f  ring0   1

rpk cloud get clusters
Error: please provide --namespace flag

rpk cloud get clusters -n ring0
  ID                                    NAME  READY
  564ecbd8-ca39-4dce-90cb-a6e6bffae9d3  TEST  true
```

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
