### PR TITLE
rpk cloud logout

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cloud.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud.go
@@ -23,6 +23,7 @@ func NewCloudCommand(fs afero.Fs) *cobra.Command {
 	}
 
 	command.AddCommand(cloud.NewLoginCommand(fs))
+	command.AddCommand(cloud.NewLogoutCommand(fs))
 
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/login.go
@@ -32,7 +32,7 @@ func NewLoginCommand(fs afero.Fs) *cobra.Command {
 				return fmt.Errorf("error reading token from config file: %w", err)
 			}
 			auth0Client := vcloud.NewDefaultAuth0Client()
-			if err == config.ErrConfigFileDoesNotExist {
+			if err == config.ErrConfigFileDoesNotExist || token == "" {
 				// no config file, have to log in
 				return login(auth0Client, configRW)
 			}

--- a/src/go/rpk/pkg/cli/cmd/cloud/logout.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/logout.go
@@ -1,0 +1,36 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloud
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/config"
+)
+
+func NewLogoutCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Logout from vectorized cloud",
+		Long:  `If there's a token stored locally after you've logged in, it will be wiped out.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configRW := config.NewVCloudConfigReaderWriter(fs)
+			// write an empty string to the config
+			err := configRW.WriteToken("")
+			if err != nil {
+				log.Info("Error while logging out:")
+				return err
+			}
+			log.Info("Logged out!")
+			return nil
+		},
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/cloud/logout_test.go
+++ b/src/go/rpk/pkg/cli/cmd/cloud/logout_test.go
@@ -1,0 +1,36 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package cloud_test
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/cloud"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/vcloud/config"
+)
+
+func TestLogout(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	configRW := config.NewVCloudConfigReaderWriter(fs)
+	err := configRW.WriteToken("xxx")
+	require.NoError(t, err)
+
+	cmd := cloud.NewLogoutCommand(fs)
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	token, err := configRW.ReadToken()
+	require.NoError(t, err)
+	if token != "" {
+		t.Fatalf("Expecting empty token after logout called, got %s", token)
+	}
+}


### PR DESCRIPTION
## Cover letter

`rpk cloud logout` command

```
rpk cloud login
Go to the following link in your browser (code: HJRG-GJWD):

https://vectorized-dev.us.auth0.com/activate?user_code=HJRG-GJWD

Waiting for authorization token to be issued...
Success!

rpk cloud logout
Logged out!

rpk cloud logout
Logged out!

cat ~/.vcloud/config.yaml
{}

rpk cloud login
Go to the following link in your browser (code: GRTN-GWMD):

https://vectorized-dev.us.auth0.com/activate?user_code=GRTN-GWMD

Waiting for authorization token to be issued...
Success!
```

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
