### PR TITLE
rpk/cloud: add version to the cloud config

### DIFF
--- a/src/go/rpk/pkg/vcloud/config/config.go
+++ b/src/go/rpk/pkg/vcloud/config/config.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	defaultConfigLocation = ".vcloud/config.yaml"
+	configVersion         = "v1"
 )
 
 var (
@@ -41,7 +42,14 @@ type vCloudReaderWriter struct {
 }
 
 type VCloudConfig struct {
-	Token string `yaml:"token,omitempty"`
+	Version string `yaml:"version"`
+	Token   string `yaml:"token,omitempty"`
+}
+
+func NewV1Config() *VCloudConfig {
+	return &VCloudConfig{
+		Version: configVersion,
+	}
 }
 
 func NewVCloudConfigReaderWriter(fs afero.Fs) ConfigReaderWriter {
@@ -96,7 +104,7 @@ func (rw *vCloudReaderWriter) getOrCreateConfigFile() (*VCloudConfig, error) {
 			return nil, err
 		}
 		log.Debugf("config file '%s' does not exist, going to create it", configLocation)
-		config := &VCloudConfig{}
+		config := NewV1Config()
 		err = rw.writeConfig(config)
 		return config, err
 	}


### PR DESCRIPTION
## Cover letter

This will make it possible in the future to change the format of the
config file if necessary.

```
rpk cloud login
Go to the following link in your browser (code: BPJR-GWPH):

https://vectorized-dev.us.auth0.com/activate?user_code=BPJR-GWPH

Waiting for authorization token to be issued...
Success!

cat ~/.vcloud/config.yaml
version: v1
token: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXV...
```

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
