### PR TITLE
operator/docs: Fix url to point at CRD not whole deployment

### DIFF
--- a/src/go/k8s/docs/external-connectivity-digital-ocean.md
+++ b/src/go/k8s/docs/external-connectivity-digital-ocean.md
@@ -27,7 +27,7 @@ helm install \
 ### - Install latest redpanda operator
 
 ```
-kubectl apply -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/default
+kubectl apply -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd
 helm repo add redpanda https://charts.vectorized.io/ && \
 helm repo update \
 helm install \

--- a/src/go/k8s/docs/external-connectivity-digital-ocean.md
+++ b/src/go/k8s/docs/external-connectivity-digital-ocean.md
@@ -27,19 +27,22 @@ helm install \
 ### - Install latest redpanda operator
 
 ```
-kubectl apply -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd
+VERSION=v21.4.15
+kubectl apply -k 'https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$VERSION'
 helm repo add redpanda https://charts.vectorized.io/ && \
 helm repo update \
 helm install \
   --namespace redpanda-system \
   --create-namespace redpanda-operator \
+  --version $VERSION \
   redpanda/redpanda-operator
 ```
 
 ### - Install cluster with external connectivity
 
 ```
-kubectl apply -f config/samples/external_connectivity.yaml
+VERSION=v21.4.15
+kubectl apply -f https://raw.githubusercontent.com/vectorizedio/redpanda/$VERSION/src/go/k8s/config/samples/external_connectivity.yaml
 ```
 
 ### - Get broker addresses


### PR DESCRIPTION
## Cover letter

The url was pointing to whole deployment. Helm chart only need CRD prerequisite.

Added the version to help @bmansheim 
