### PR TITLE
kafka/client always authenticate broker connection

### DIFF
--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "kafka/client/configuration.h"
 #include "kafka/client/exceptions.h"
 #include "kafka/client/transport.h"
 #include "model/metadata.h"
@@ -84,8 +85,8 @@ private:
 
 using shared_broker_t = ss::lw_shared_ptr<broker>;
 
-ss::future<shared_broker_t>
-make_broker(model::node_id node_id, unresolved_address addr);
+ss::future<shared_broker_t> make_broker(
+  model::node_id node_id, unresolved_address addr, const configuration& config);
 
 struct broker_hash {
     using is_transparent = void;

--- a/src/v/kafka/client/brokers.cc
+++ b/src/v/kafka/client/brokers.cc
@@ -61,9 +61,9 @@ ss::future<> brokers::apply(std::vector<metadata_response::broker>&& res) {
         return ssx::parallel_transform(
                  new_brokers_begin,
                  new_brokers.end(),
-                 [](const metadata_response::broker& b) {
+                 [this](const metadata_response::broker& b) {
                      return make_broker(
-                       b.node_id, unresolved_address(b.host, b.port));
+                       b.node_id, unresolved_address(b.host, b.port), _config);
                  })
           .then([this, &new_brokers, new_brokers_begin](
                   std::vector<shared_broker_t> broker_endpoints) mutable {

--- a/src/v/kafka/client/brokers.h
+++ b/src/v/kafka/client/brokers.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "kafka/client/broker.h"
+#include "kafka/client/configuration.h"
 #include "kafka/protocol/metadata.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
@@ -31,7 +32,8 @@ class brokers {
       = absl::flat_hash_set<shared_broker_t, broker_hash, broker_eq>;
 
 public:
-    brokers() = default;
+    explicit brokers(const configuration& config)
+      : _config(config){};
     brokers(const brokers&) = delete;
     brokers(brokers&&) = default;
     brokers& operator=(brokers const&) = delete;
@@ -59,6 +61,7 @@ public:
     ss::future<bool> empty() const;
 
 private:
+    const configuration& _config;
     /// \brief Brokers map a model::node_id to a client.
     brokers_t _brokers;
     /// \brief Next broker to select with round-robin

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -54,58 +54,11 @@ client::client(const YAML::Node& cfg)
                   return mitigate_error(std::move(ex));
               }} {}
 
-ss::future<> client::do_authenticate(shared_broker_t broker) {
-    if (_config.sasl_mechanism().empty()) {
-        vlog(kclog.debug, "Connecting to broker without authentication");
-        co_return;
-    }
-
-    auto mechanism = _config.sasl_mechanism();
-
-    if (
-      mechanism != security::scram_sha256_authenticator::name
-      && mechanism != security::scram_sha512_authenticator::name) {
-        throw broker_error{
-          broker->id(),
-          error_code::sasl_authentication_failed,
-          fmt_with_ctx(ssx::sformat, "Unknown mechanism: {}", mechanism)};
-    }
-
-    auto username = _config.scram_username();
-
-    vlog(
-      kclog.debug,
-      "Connecting to broker with authentication: {}:{}",
-      mechanism,
-      username);
-
-    // perform handshake
-    co_await do_sasl_handshake(broker, mechanism);
-
-    auto password = _config.scram_password();
-
-    if (username.empty() || password.empty()) {
-        throw broker_error{
-          broker->id(),
-          error_code::sasl_authentication_failed,
-          "Username or password is empty"};
-    }
-
-    if (mechanism == security::scram_sha256_authenticator::name) {
-        co_await do_authenticate_scram256(
-          broker, std::move(username), std::move(password));
-
-    } else if (mechanism == security::scram_sha512_authenticator::name) {
-        co_await do_authenticate_scram512(
-          broker, std::move(username), std::move(password));
-    }
-}
-
 ss::future<> client::do_connect(unresolved_address addr) {
     return ss::try_with_gate(_gate, [this, addr]() {
         return make_broker(unknown_node_id, addr)
           .then([this](shared_broker_t broker) {
-              return do_authenticate(broker).then([this, broker] {
+              return do_authenticate(broker, _config).then([this, broker] {
                   return broker
                     ->dispatch(metadata_request{.list_all_topics = true})
                     .then([this, broker](metadata_response res) {

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -157,8 +157,6 @@ private:
     /// \brief Connect and update metdata.
     ss::future<> do_connect(unresolved_address addr);
 
-    ss::future<> do_authenticate(shared_broker_t);
-
     /// \brief Update metadata
     ///
     /// If an existing update is in progress, the future returned will be

--- a/src/v/kafka/client/sasl_client.h
+++ b/src/v/kafka/client/sasl_client.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "kafka/client/broker.h"
+#include "kafka/client/configuration.h"
 #include "kafka/protocol/sasl_authenticate.h"
 #include "kafka/protocol/sasl_handshake.h"
 #include "random/generators.h"
@@ -20,6 +21,7 @@
 
 namespace kafka::client {
 
+ss::future<> do_authenticate(shared_broker_t, const configuration& config);
 /*
  * SASL handshake negotiates mechanism. In this case that process is simple: if
  * the server doesn't support the requested mechanism there is no fallback.

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -828,7 +828,7 @@ class PandaProxySASLTest(RedpandaTest):
                 f"Listed {listed_topics} expected {expected_topics}")
             return listed_topics == expected_topics
 
-        wait_until(lambda: topics_appeared,
+        wait_until(topics_appeared,
                    timeout_sec=20,
                    backoff_sec=2,
                    err_msg="Timeout waiting for topics to appear.")


### PR DESCRIPTION
## Cover letter

make_broker is used in a number of places; authentication is always
required (when enabled).

Fixes a bug where sasl is enabled, but auth is not attempted:

Proxy response:
```
{'error_code': 50302, 'message': '{ node: -1 }, { error_code: broker_not_available [8] }'}
```
Logs:
```
INFO  2021-04-30 04:06:45,832 [shard 4] kafka - connection_context.cc:134 - Detected error processing request: std::runtime_error (Unexpected request during authentication: 3)
```

## Release notes

Release note: Pandaproxy: Now works with SASL
