### PR TITLE
kafka/client: Support TLS handshake

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -241,6 +241,17 @@ void application::hydrate_config(const po::variables_map& cfg) {
             vassert(!kafka_api.empty(), "There are no kafka_api listeners");
             _proxy_client_config->brokers.set_value(
               std::vector<unresolved_address>{kafka_api[0].address});
+            const auto& kafka_api_tls
+              = config::shard_local_cfg().kafka_api_tls.value();
+            if (!kafka_api_tls.empty()) {
+                vassert(
+                  kafka_api[0].name == kafka_api_tls[0].name,
+                  "pandaproxy_client.broker_tls could not be inferred from "
+                  "kafka_api_tls: {}",
+                  kafka_api_tls);
+                _proxy_client_config->broker_tls.set_value(
+                  kafka_api_tls[0].config);
+            }
         }
         _proxy_config->for_each(config_printer("pandaproxy"));
         _proxy_client_config->for_each(config_printer("pandaproxy_client"));


### PR DESCRIPTION
## Cover letter

* kafka/client: make_broker also does TLS handshake
* pandaproxy: Set default TLS for broker

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/13d5ff5606f46c4e1acb12c1648136820b8dcd59..faa539eedc31140d5e700df4eb47accd61a99ab7)
* Use a temporary to hopefully workaround a gcc ICE

## Release notes

Release note: Pandaproxy now supports TLS to brokers
