### PR TITLE
rpk: Use adv. API addr

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -132,21 +132,21 @@ func DeduceBrokers(
 			return []string{"127.0.0.1:9092"}
 		}
 
-		if len(conf.Redpanda.KafkaApi) == 0 {
+		if len(conf.Redpanda.AdvertisedKafkaApi) == 0 {
 			log.Trace(
-				"The config file contains no kafka listeners." +
-					" Empty redpanda.kafka_api.",
+				"The config file contains no advertised kafka listeners." +
+					" Empty redpanda.advertised_kafka_api.",
 			)
 			return []string{}
 		}
 
-		// Add the seed servers' Kafka addrs.
+		// Add the seed servers' advertised kafka addrs.
 		if len(conf.Redpanda.SeedServers) > 0 {
 			for _, b := range conf.Redpanda.SeedServers {
 				addr := fmt.Sprintf(
 					"%s:%d",
 					b.Host.Address,
-					conf.Redpanda.KafkaApi[0].Port,
+					conf.Redpanda.AdvertisedKafkaApi[0].Port,
 				)
 				bs = append(bs, addr)
 			}
@@ -154,8 +154,8 @@ func DeduceBrokers(
 		// Add the current node's Kafka addr.
 		selfAddr := fmt.Sprintf(
 			"%s:%d",
-			conf.Redpanda.KafkaApi[0].Address,
-			conf.Redpanda.KafkaApi[0].Port,
+			conf.Redpanda.AdvertisedKafkaApi[0].Address,
+			conf.Redpanda.AdvertisedKafkaApi[0].Port,
 		)
 		bs = append(bs, selfAddr)
 		log.Debugf(

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -77,7 +77,7 @@ func TestDeduceBrokers(t *testing.T) {
 		},
 		config: func() (*config.Config, error) {
 			conf := config.Default()
-			conf.Redpanda.KafkaApi = []config.NamedSocketAddress{{
+			conf.Redpanda.AdvertisedKafkaApi = []config.NamedSocketAddress{{
 				SocketAddress: config.SocketAddress{
 					Address: "192.168.25.88",
 					Port:    1235,
@@ -97,7 +97,7 @@ func TestDeduceBrokers(t *testing.T) {
 		name: "it should prioritize the config over the default broker addr",
 		config: func() (*config.Config, error) {
 			conf := config.Default()
-			conf.Redpanda.KafkaApi = []config.NamedSocketAddress{{
+			conf.Redpanda.AdvertisedKafkaApi = []config.NamedSocketAddress{{
 				SocketAddress: config.SocketAddress{
 					Address: "192.168.25.87",
 					Port:    1234,


### PR DESCRIPTION
Have rpk use `redpanda.advertised_kafka_api` instead of `redpanda.kafka_api`, so that if there's a local config file, it uses the advertised listeners' addresses.  

Fix #1099 
