### PR TITLE
tweaks for building/testing arm64 builds

### DIFF
--- a/src/v/syschecks/syschecks.h
+++ b/src/v/syschecks/syschecks.h
@@ -17,7 +17,10 @@
 #include <seastar/core/future.hh>
 #include <seastar/util/log.hh>
 
+#if !defined __aarch64__
 #include <cpuid.h>
+#endif
+
 #include <cstdint>
 #include <filesystem>
 
@@ -26,6 +29,7 @@ namespace syschecks {
 extern ss::logger checklog;
 
 static inline void initialize_intrinsics() {
+#if !defined __aarch64__
     // https://gcc.gnu.org/onlinedocs/gcc/x86-Built-in-Functions.html#index-_005f_005fbuiltin_005fcpu_005finit-1
     //
     // This built-in function needs to be invoked along with the built-in
@@ -34,12 +38,15 @@ static inline void initialize_intrinsics() {
     // before any constructors are called. The CPU detection code is
     // automatically executed in a very high priority constructor.
     __builtin_cpu_init();
+#endif
 }
 static inline void cpu() {
+#if !defined __aarch64__
     // Do not use the macros __SSE4_2__ because we need to detect at runtime
     if (!__builtin_cpu_supports("sse4.2")) {
         throw std::runtime_error("sse4.2 support is required to run");
     }
+#endif
 }
 
 ss::future<> disk(const ss::sstring& path);

--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -26,9 +26,12 @@ tasks:
 
   install-docker-compose:
     desc: install docker-compose
+    vars:
+      SYSTEM_PROCESSOR:
+        sh: 'uname -m'
     cmds:
     - mkdir -p '{{.BUILD_ROOT}}/bin/'
-    - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 "https://github.com/docker/compose/releases/download/1.28.5/docker-compose-$(uname -s)-$(uname -m)" -o '{{.BUILD_ROOT}}/bin/docker-compose'
+    - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --output '{{.BUILD_ROOT}}/bin/docker-compose' 'https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.1-ls39/docker-compose-{{if eq .SYSTEM_PROCESSOR "aarch64"}}arm64{{else}}amd64{{end}}'
     - chmod +x '{{.BUILD_ROOT}}/bin/docker-compose'
     status:
     - test -f '{{.BUILD_ROOT}}/bin/docker-compose'

--- a/taskfiles/rpk.yml
+++ b/taskfiles/rpk.yml
@@ -6,8 +6,7 @@ tasks:
     vars:
       RPK_VERSION: '{{default "latest" .TAG_NAME}}'
     env:
-      GOOS: '{{default "linux" .GOOS}}'
-      GOARCH: '{{default "amd64" .GOARCH}}'
+      GOOS: '{{OS | lower}}'
       GOPATH: '{{.BUILD_ROOT}}/go'
       CGO_ENABLED: "0"
     dir: "{{.SRC_DIR}}/src/go/rpk"


### PR DESCRIPTION
tweaks to make build and ducktape tests work on arm64 machines:
  * Add macro for skipping the import of cpuid.h on arm64 machines
  * Install arch-specific docker-compose binaries
  * skip explicitly setting GOARCH when building rpk