### PR TITLE
operator/sts: use default mode in configmap volume

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -210,8 +210,6 @@ func preparePVCResource(
 // obj returns resource managed client.Object
 // nolint:funlen // The complexity of obj function will be address in the next version TODO
 func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
-	var configMapDefaultMode int32 = 0754
-
 	var clusterLabels = labels.ForCluster(r.pandaCluster)
 
 	pvc := preparePVCResource(datadirName, r.pandaCluster.Namespace, r.pandaCluster.Spec.Storage, clusterLabels)
@@ -276,7 +274,6 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: ConfigMapKey(r.pandaCluster).Name,
 									},
-									DefaultMode: &configMapDefaultMode,
 								},
 							},
 						},

--- a/src/go/k8s/tests/e2e/update/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/03-assert.yaml
@@ -10,7 +10,7 @@ spec:
         persistentVolumeClaim:
           claimName: datadir
       - configMap:
-          defaultMode: 492
+          defaultMode: 420
           name: update-cluster-base
         name: configmap-dir
       - emptyDir: {}


### PR DESCRIPTION
## Cover letter

In the past we included a shell script in the ConfigMap that would be executed through an init container. The ConfigMap doesn't include this shell script anymore. Hence, we can remove the previous access mode (and use the default one instead).