### PR TITLE
pandaproxy: Improve config defaults

### DIFF
--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -124,7 +124,7 @@ static inline ostream& operator<<(ostream& o, const config::key_cert& c) {
 }
 static inline ostream& operator<<(ostream& o, const config::tls_config& c) {
     o << "{ "
-      << "enabled: " << c.is_enabled()
+      << "enabled: " << c.is_enabled() << " "
       << "key/cert files: " << c.get_key_cert_files() << " "
       << "ca file: " << c.get_truststore_file() << " "
       << "client_auth_required: " << c.get_require_client_auth() << " }";

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -243,14 +243,14 @@ void application::hydrate_config(const po::variables_map& cfg) {
               std::vector<unresolved_address>{kafka_api[0].address});
             const auto& kafka_api_tls
               = config::shard_local_cfg().kafka_api_tls.value();
-            if (!kafka_api_tls.empty()) {
-                vassert(
-                  kafka_api[0].name == kafka_api_tls[0].name,
-                  "pandaproxy_client.broker_tls could not be inferred from "
-                  "kafka_api_tls: {}",
-                  kafka_api_tls);
-                _proxy_client_config->broker_tls.set_value(
-                  kafka_api_tls[0].config);
+            auto tls_it = std::find_if(
+              kafka_api_tls.begin(),
+              kafka_api_tls.end(),
+              [&kafka_api](const config::endpoint_tls_config& tls) {
+                  return tls.name == kafka_api[0].name;
+              });
+            if (tls_it != kafka_api_tls.end()) {
+                _proxy_client_config->broker_tls.set_value(tls_it->config);
             }
         }
         _proxy_config->for_each(config_printer("pandaproxy"));


### PR DESCRIPTION
## Cover letter

Fix an issue where Redpanda startup is prevented if `pandaproxy_client.broker_tls` can't be inferred.

```
ERROR 2021-05-06 11:20:15,214 [shard 0] assert - Assert failure: (../../../src/v/redpanda/application.cc:251) 'kafka_api[0].name == kafka_api_tls[0].name' pandaproxy_client.broker_tls could not be inferred from kafka_api_tls: {{name: kafka-external, tls_config: { enabled: 1key/cert files: {{ key_file: /etc/tls/certs/tls.key cert_file: /etc/tls/certs/tls.crt }} ca file: {/etc/tls/certs/ca/ca.crt} client_auth_required: 1 }}}
```

The TLS config inference in #1333 had some bad assumptions:
* For each kafka_api, there is a corresponding kafka_api_tls
* The ordering is likely to be the same

Now there is a search by name. No match is ok. Empty name is ok. Redpanda is not prevented from starting.

## Release notes

Release note: Pandaproxy: Improve configuration defaults.
