### PR TITLE
Persistent HTTP connections

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -24,6 +24,7 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/timed_out_error.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/util/noncopyable_function.hh>
 
@@ -47,10 +48,12 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
 }
 
 ntp_archiver::ntp_archiver(
-  const storage::ntp_config& ntp, const configuration& conf)
+  const storage::ntp_config& ntp,
+  const configuration& conf,
+  s3::client_pool& pool)
   : _ntp(ntp.ntp())
   , _rev(ntp.get_revision())
-  , _client_conf(conf.client_config)
+  , _pool(pool)
   , _policy(_ntp)
   , _bucket(conf.bucket_name)
   , _remote(_ntp, _rev)
@@ -76,10 +79,10 @@ ss::future<download_manifest_result> ntp_archiver::download_manifest() {
     auto key = _remote.get_manifest_path();
     vlog(archival_log.debug, "Download manifest {}", key());
     auto path = s3::object_key(key().string());
-    s3::client client(_client_conf, _as);
+    auto [client, deleter] = co_await _pool.acquire();
     auto result = download_manifest_result::success;
     try {
-        auto resp = co_await client.get_object(_bucket, path);
+        auto resp = co_await client->get_object(_bucket, path);
         vlog(archival_log.debug, "Receive OK response from {}", path);
         co_await _remote.update(resp->as_input_stream());
     } catch (const s3::rest_error_response& err) {
@@ -99,8 +102,17 @@ ss::future<download_manifest_result> ntp_archiver::download_manifest() {
         } else {
             throw;
         }
+    } catch (const ss::timed_out_error& err) {
+        // Download failed because connection is unreliable, we have to retry
+        // later.
+        vlog(archival_log.debug, "Download {} timed-out {}", path, err);
+        result = download_manifest_result::backoff;
+    } catch (const std::system_error& err) {
+        // Failed download due to connectivity problems (e.g. broken pipe or
+        // connection refused or C-Ares timed-out request)
+        vlog(archival_log.debug, "Download {} failed {}", path, err);
+        result = download_manifest_result::backoff;
     }
-    co_await client.shutdown();
     co_return result;
 }
 
@@ -115,12 +127,11 @@ ss::future<> ntp_archiver::upload_manifest() {
     std::vector<s3::object_tag> tags = {{"rp-type", "partition-manifest"}};
     while (!_gate.is_closed() && backoff_quota-- > 0) {
         bool slowdown = false;
-        s3::client client(_client_conf, _as);
+        auto [client, deleter] = co_await _pool.acquire();
         try {
             auto [is, size] = _remote.serialize();
-            co_await client.put_object(
+            co_await client->put_object(
               _bucket, path, size, std::move(is), tags);
-            co_await client.shutdown();
         } catch (const s3::rest_error_response& err) {
             vlog(
               archival_log.error,
@@ -172,8 +183,7 @@ ss::future<> ntp_archiver::upload_manifest() {
 
 const manifest& ntp_archiver::get_remote_manifest() const { return _remote; }
 
-ss::future<bool> ntp_archiver::upload_segment(
-  ss::semaphore& req_limit, upload_candidate candidate) {
+ss::future<bool> ntp_archiver::upload_segment(upload_candidate candidate) {
     gate_guard guard{_gate};
     vlog(
       archival_log.debug,
@@ -188,8 +198,7 @@ ss::future<bool> ntp_archiver::upload_segment(
       segment_name(candidate.exposed_name));
     std::vector<s3::object_tag> tags = {{"rp-type", "segment"}};
     while (!_gate.is_closed() && backoff_quota-- > 0) {
-        auto units = co_await ss::get_units(req_limit, 1);
-        s3::client client(_client_conf, _as);
+        auto [client, deleter] = co_await _pool.acquire();
         auto stream = candidate.source->reader().data_stream(
           candidate.file_offset, ss::default_priority_class());
         bool slowdown = false;
@@ -200,13 +209,12 @@ ss::future<bool> ntp_archiver::upload_segment(
           s3path);
         try {
             // Segment upload attempt
-            co_await client.put_object(
+            co_await client->put_object(
               _bucket,
               s3::object_key(s3path().string()),
               candidate.content_length,
               std::move(stream),
               tags);
-            co_await client.shutdown();
         } catch (const s3::rest_error_response& err) {
             vlog(
               archival_log.error,
@@ -246,11 +254,16 @@ ss::future<bool> ntp_archiver::upload_segment(
         }
         break;
     }
+    vlog(
+      archival_log.debug,
+      "Finished segment upload for {}, path {}",
+      _ntp,
+      s3path);
     co_return true;
 }
 
-ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
-  ss::semaphore& req_limit, storage::log_manager& lm) {
+ss::future<ntp_archiver::batch_result>
+ntp_archiver::upload_next_candidates(storage::log_manager& lm) {
     vlog(archival_log.debug, "Uploading next candidates called for {}", _ntp);
     gate_guard guard{_gate};
     auto mlock = co_await ss::get_units(_mutex, 1);
@@ -293,7 +306,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
             continue;
         }
         offset = upload.source->offsets().committed_offset + model::offset(1);
-        flist.emplace_back(upload_segment(req_limit, upload));
+        flist.emplace_back(upload_segment(upload));
         manifest::segment_meta m{
           .is_compacted = upload.source->is_compacted_segment(),
           .size_bytes = upload.content_length,

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -12,6 +12,7 @@
 
 #include "archival/logger.h"
 #include "archival/ntp_archiver_service.h"
+#include "archival/types.h"
 #include "cluster/partition_manager.h"
 #include "cluster/topic_table.h"
 #include "config/configuration.h"
@@ -154,12 +155,12 @@ scheduler_service_impl::scheduler_service_impl(
   ss::sharded<cluster::partition_manager>& pm,
   ss::sharded<cluster::topic_table>& tt)
   : _conf(conf)
+  , _pool(conf.connection_limit(), conf.client_config)
   , _partition_manager(pm)
   , _topic_table(tt)
   , _storage_api(api)
   , _jitter(conf.interval, 1ms)
   , _gc_jitter(conf.gc_interval, 1ms)
-  , _conn_limit(conf.connection_limit())
   , _stop_limit(conf.connection_limit()) {}
 
 scheduler_service_impl::scheduler_service_impl(
@@ -193,18 +194,22 @@ ss::future<> scheduler_service_impl::start() {
 ss::future<> scheduler_service_impl::stop() {
     vlog(archival_log.info, "Scheduler service stop");
     _timer.cancel();
-    _as.request_abort();
-    std::vector<ss::future<>> outstanding;
-    for (auto& it : _queue) {
-        auto fut = ss::with_semaphore(
-          _stop_limit, 1, [it] { return it.second.archiver->stop(); });
-        outstanding.emplace_back(std::move(fut));
-    }
-    return ss::do_with(
-      std::move(outstanding), [this](std::vector<ss::future<>>& outstanding) {
-          return ss::when_all_succeed(outstanding.begin(), outstanding.end())
-            .then([this] { return _gate.close(); });
-      });
+    _as.request_abort(); // interrupt possible sleep
+    return _pool.stop().then([this] {
+        std::vector<ss::future<>> outstanding;
+        for (auto& it : _queue) {
+            auto fut = ss::with_semaphore(
+              _stop_limit, 1, [it] { return it.second.archiver->stop(); });
+            outstanding.emplace_back(std::move(fut));
+        }
+        return ss::do_with(
+          std::move(outstanding),
+          [this](std::vector<ss::future<>>& outstanding) {
+              return ss::when_all_succeed(
+                       outstanding.begin(), outstanding.end())
+                .finally([this] { return _gate.close(); });
+          });
+    });
 }
 
 ss::lw_shared_ptr<ntp_archiver> scheduler_service_impl::get_upload_candidate() {
@@ -217,21 +222,19 @@ ss::future<> scheduler_service_impl::upload_topic_manifest(
     auto cfg = _topic_table.local().get_topic_cfg(view);
     if (cfg) {
         try {
-            auto units = co_await ss::get_units(_conn_limit, 1);
             vlog(archival_log.info, "Uploading topic manifest {}", view);
-            s3::client client(_conf.client_config, _as);
+            auto [client, deleter] = co_await _pool.acquire();
             topic_manifest tm(*cfg, rev);
             auto [istr, size_bytes] = tm.serialize();
             auto key = tm.get_manifest_path();
             vlog(archival_log.debug, "Topic manifest object key is '{}'", key);
             std::vector<s3::object_tag> tags = {{"rp-type", "topic-manifest"}};
-            co_await client.put_object(
+            co_await client->put_object(
               _conf.bucket_name,
               s3::object_key(key),
               size_bytes,
               std::move(istr),
               tags);
-            co_await client.shutdown();
         } catch (const s3::rest_error_response& err) {
             vlog(
               archival_log.error,
@@ -264,7 +267,7 @@ scheduler_service_impl::create_archivers(std::vector<model::ntp> to_create) {
                     return ss::now();
                 }
                 auto svc = ss::make_lw_shared<ntp_archiver>(
-                  log->config(), _conf);
+                  log->config(), _conf, _pool);
                 return ss::repeat([this, svc, ntp] {
                     return svc->download_manifest()
                       .then(
@@ -351,7 +354,7 @@ scheduler_service_impl::remove_archivers(std::vector<model::ntp> to_remove) {
           vlog(archival_log.info, "removing archiver for {}", ntp.path());
           auto archiver = _queue[ntp];
           return ss::with_semaphore(
-                   _conn_limit, 1, [archiver] { return archiver->stop(); })
+                   _stop_limit, 1, [archiver] { return archiver->stop(); })
             .finally([this, ntp] {
                 vlog(archival_log.info, "archiver stopped {}", ntp.path());
                 _queue.erase(ntp);
@@ -427,7 +430,7 @@ ss::future<> scheduler_service_impl::run_uploads() {
                     archival_log.debug,
                     "Checking {} for S3 upload candidates",
                     archiver->get_ntp());
-                  return archiver->upload_next_candidates(_conn_limit, lm);
+                  return archiver->upload_next_candidates(lm);
               });
 
             auto results = co_await ss::when_all_succeed(

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -154,6 +154,7 @@ private:
       model::topic_namespace_view view, model::revision_id rev);
 
     configuration _conf;
+    s3::client_pool _pool;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<cluster::topic_table>& _topic_table;
     ss::sharded<storage::api>& _storage_api;
@@ -163,7 +164,6 @@ private:
     ss::timer<ss::lowres_clock> _gc_timer;
     ss::gate _gate;
     ss::abort_source _as;
-    ss::semaphore _conn_limit;
     ss::semaphore _stop_limit;
     ntp_upload_queue _queue;
     simple_time_jitter<ss::lowres_clock> _backoff{100ms};

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -125,7 +125,9 @@ compare_json_objects(const std::string_view& lhs, const std::string_view& rhs) {
 
 FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
     set_expectations_and_listen(default_expectations);
-    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto conf = get_configuration();
+    s3::client_pool pool(conf.connection_limit(), conf.client_config);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration(), pool);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
     archiver.download_manifest().get();
     auto expected = load_manifest(manifest_payload);
@@ -134,7 +136,9 @@ FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
 
 FIXTURE_TEST(test_upload_manifest, s3_imposter_fixture) { // NOLINT
     set_expectations_and_listen(default_expectations);
-    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto conf = get_configuration();
+    s3::client_pool pool(conf.connection_limit(), conf.client_config);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration(), pool);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
     auto pm = const_cast<manifest*>( // NOLINT
       &archiver.get_remote_manifest());
@@ -163,7 +167,9 @@ FIXTURE_TEST(test_upload_manifest, s3_imposter_fixture) { // NOLINT
 // NOLINTNEXTLINE
 FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     set_expectations_and_listen(default_expectations);
-    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration());
+    auto conf = get_configuration();
+    s3::client_pool pool(conf.connection_limit(), conf.client_config);
+    archival::ntp_archiver archiver(get_ntp_conf(), get_configuration(), pool);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
     std::vector<segment_desc> segments = {
@@ -172,10 +178,8 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     };
     init_storage_api_local(segments);
 
-    ss::semaphore limit(2);
     auto res = archiver
-                 .upload_next_candidates(
-                   limit, get_local_storage_api().log_mgr())
+                 .upload_next_candidates(get_local_storage_api().log_mgr())
                  .get0();
     BOOST_REQUIRE_EQUAL(res.num_succeded, 2);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -84,7 +84,7 @@ archival::configuration get_configuration() {
     archival::configuration conf;
     conf.client_config = s3conf;
     conf.bucket_name = s3::bucket_name("test-bucket");
-    conf.connection_limit = archival::s3_connection_limit(10);
+    conf.connection_limit = archival::s3_connection_limit(2);
     return conf;
 }
 

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -11,18 +11,29 @@
 
 #include "bytes/details/io_iterator_consumer.h"
 #include "bytes/iobuf.h"
+#include "http/logger.h"
+#include "rpc/backoff_policy.h"
+#include "rpc/types.h"
+#include "utils/gate_guard.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/timed_out_error.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/net/tls.hh>
 
 #include <boost/beast/core/buffer_traits.hpp>
+#include <boost/beast/core/error.hpp>
+#include <boost/beast/core/impl/error.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 #include <chrono>
 #include <exception>
@@ -45,6 +56,7 @@ client::client(
   const ss::abort_source* as,
   ss::lw_shared_ptr<client_probe> probe)
   : rpc::base_transport(cfg)
+  , _connect_gate()
   , _as(as)
   , _probe(std::move(probe)) {
     if (!_probe) {
@@ -58,30 +70,86 @@ void client::check() const {
     }
 }
 
-ss::future<client::request_response_t>
-client::make_request(client::request_header&& header) {
+ss::future<client::request_response_t> client::make_request(
+  client::request_header&& header, ss::lowres_clock::duration timeout) {
     vlog(http_log.trace, "client.make_request {}", header);
     auto verb = header.method();
+    auto target = header.target();
     auto req = ss::make_shared<request_stream>(this, std::move(header));
     auto res = ss::make_shared<response_stream>(this, verb);
     if (is_valid()) {
-        // already connected
         return ss::make_ready_future<request_response_t>(
           std::make_tuple(req, res));
     }
-    return connect()
-      .then([req, res] {
+    return get_connected(timeout)
+      .then([req, res, target](reconnect_result_t r) {
+          if (r == reconnect_result_t::timed_out) {
+              vlog(
+                http_log.warn,
+                "make_request timed-out connection attempt {}",
+                target);
+              ss::timed_out_error err;
+              return ss::make_exception_future<client::request_response_t>(err);
+          }
           return ss::make_ready_future<request_response_t>(
             std::make_tuple(req, res));
       })
-      .handle_exception_type([this](const ss::tls::verification_error& err) {
-          return shutdown().then([err] {
+      .handle_exception_type([this](ss::tls::verification_error err) {
+          return stop().then([err = std::move(err)] {
               return ss::make_exception_future<client::request_response_t>(err);
           });
       });
 }
 
-ss::future<> client::shutdown() { return stop(); }
+ss::future<reconnect_result_t>
+client::get_connected(ss::lowres_clock::duration timeout) {
+    vlog(
+      http_log.debug,
+      "about to start connecting, {}, is-closed {}",
+      is_valid(),
+      _dispatch_gate.is_closed());
+    auto current = ss::lowres_clock::now();
+    const auto deadline = current + timeout;
+    const auto interval = 1s; // 500ms;
+    while (!_connect_gate.is_closed() && current < deadline) {
+        if (_as != nullptr) {
+            _as->check();
+        }
+        // Reconnect attempts have to stop if:
+        // - shutdown method was called
+        // - abort was requested
+        // - unrecoverable error occured
+        // - timeout reached
+        try {
+            // base_transport::connect calls _dispatcher_gate.close
+            // on every reconnect. Because of that concurrent call
+            // to base_transport::stop could lead to failure because
+            // _dispatcher_gate is already closed. We need to synchronize
+            // this loop with the `stop` call.
+            gate_guard gg(_connect_gate);
+            co_await connect(current + interval);
+            break;
+        } catch (const std::system_error& err) {
+            vlog(http_log.trace, "connection refused {}", err);
+        } catch (const ss::timed_out_error&) {
+            vlog(http_log.trace, "connection timeout");
+        }
+        current = ss::lowres_clock::now();
+        // Any TLS error have to be propagated because it's not
+        // transient. It won't help to try once again.
+    }
+    vlog(http_log.debug, "connected, {}", is_valid());
+    co_return is_valid() ? reconnect_result_t::connected
+                         : reconnect_result_t::timed_out;
+}
+
+ss::future<> client::stop() {
+    co_await _connect_gate.close();
+    // Can safely stop base_transport
+    co_return co_await base_transport::stop();
+}
+
+void client::fail_outstanding_futures() noexcept { shutdown(); }
 
 ss::future<ss::temporary_buffer<char>> client::receive() {
     return _in.read()
@@ -153,7 +221,7 @@ iobuf_to_constbufseq(const iobuf& iobuf) {
     return seq;
 }
 
-ss::future<> client::response_stream::shutdown() { return _client->shutdown(); }
+ss::future<> client::response_stream::shutdown() { return _client->stop(); }
 
 /// Return failed future if ec is set, otherwise return future in ready state
 static ss::future<iobuf> fail_on_error(const boost::beast::error_code& ec) {
@@ -198,7 +266,13 @@ ss::future<iobuf> client::response_stream::recv_some() {
               // we'll have to manually check the headers and the last chunk
               // status.
               boost::beast::error_code ec;
-              _parser.put_eof(ec);
+              if (!_parser.is_header_done()) {
+                  // We can't put EOF before all header bytes are received
+                  ec = boost::beast::http::make_error_code(
+                    boost::beast::http::error::short_read);
+              } else {
+                  _parser.put_eof(ec);
+              }
               return fail_on_error(ec);
           }
           _buffer.append(std::move(chunk));
@@ -252,8 +326,13 @@ ss::future<iobuf> client::response_stream::recv_some() {
       })
       .handle_exception_type([this](const ss::tls::verification_error& err) {
           _client->_probe->register_transport_error();
-          return _client->shutdown().then(
+          return _client->stop().then(
             [err] { return ss::make_exception_future<iobuf>(err); });
+      })
+      .handle_exception_type([this](const std::system_error& ec) {
+          vlog(http_log.error, "receive error {}", ec);
+          _client->shutdown();
+          return ss::make_exception_future<iobuf>(ec);
       });
 }
 
@@ -324,9 +403,14 @@ ss::future<> client::request_stream::send_some(iobuf&& seq) {
             })
             .handle_exception_type(
               [this](const ss::tls::verification_error& err) {
-                  return _client->shutdown().then(
+                  return _client->stop().then(
                     [err] { return ss::make_exception_future<>(err); });
-              });
+              })
+            .handle_exception_type([this](const std::system_error& ec) {
+                vlog(http_log.error, "send error {}", ec);
+                _client->shutdown();
+                return ss::make_exception_future<>(ec);
+            });
       });
 }
 
@@ -422,8 +506,10 @@ struct request_data_sink final : ss::data_sink_impl {
 };
 
 ss::future<client::response_stream_ref> client::request(
-  client::request_header&& header, ss::input_stream<char>& input) {
-    return make_request(std::move(header))
+  client::request_header&& header,
+  ss::input_stream<char>& input,
+  ss::lowres_clock::duration timeout) {
+    return make_request(std::move(header), timeout)
       .then([&input](request_response_t reqresp) mutable {
           auto [request, response] = std::move(reqresp);
           auto fsend = ss::do_with(
@@ -439,9 +525,9 @@ ss::future<client::response_stream_ref> client::request(
       });
 }
 
-ss::future<client::response_stream_ref>
-client::request(client::request_header&& header) {
-    return make_request(std::move(header))
+ss::future<client::response_stream_ref> client::request(
+  client::request_header&& header, ss::lowres_clock::duration timeout) {
+    return make_request(std::move(header), timeout)
       .then([](request_response_t reqresp) mutable {
           auto [request, response] = std::move(reqresp);
           return request->send_some(iobuf())

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -17,17 +17,23 @@
 #include "http/iobuf_body.h"
 #include "http/logger.h"
 #include "http/probe.h"
+#include "rpc/backoff_policy.h"
 #include "rpc/transport.h"
 #include "rpc/types.h"
 #include "seastarx.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/circular_buffer.hh>
+#include <seastar/core/deleter.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/core/weak_ptr.hh>
 
 #include <boost/beast/core.hpp>
 #include <boost/beast/core/error.hpp>
@@ -38,11 +44,14 @@
 #include <boost/optional/optional.hpp>
 #include <boost/system/system_error.hpp>
 
+#include <chrono>
 #include <exception>
 #include <stdexcept>
 #include <string>
 
 namespace http {
+
+using namespace std::chrono_literals;
 
 using http_response
   = boost::beast::http::response<boost::beast::http::string_body>;
@@ -50,6 +59,13 @@ using http_request
   = boost::beast::http::request<boost::beast::http::string_body>;
 using http_serializer
   = boost::beast::http::request_serializer<boost::beast::http::string_body>;
+
+constexpr ss::lowres_clock::duration default_connect_timeout = 5s;
+
+enum class reconnect_result_t {
+    connected,
+    timed_out,
+};
 
 /// Http client
 class client : protected rpc::base_transport {
@@ -69,7 +85,15 @@ public:
       const rpc::base_transport::configuration& cfg,
       const ss::abort_source& as);
 
-    ss::future<> shutdown();
+    ss::future<> stop();
+    using rpc::base_transport::shutdown;
+
+    /// Return immediately if connected or make connection attempts
+    /// until success, timeout or error
+    ss::future<reconnect_result_t>
+    get_connected(ss::lowres_clock::duration timeout);
+
+    void fail_outstanding_futures() noexcept override;
 
     // Response state machine
     class response_stream final
@@ -174,7 +198,9 @@ public:
 
     // Make http_request, if the transport is not yet connected it will connect
     // first otherwise the future will resolve immediately.
-    ss::future<request_response_t> make_request(request_header&& header);
+    ss::future<request_response_t> make_request(
+      request_header&& header,
+      ss::lowres_clock::duration timeout = default_connect_timeout);
 
     /// Utility function that executes request with the body and returns
     /// stream. Returned future becomes ready when the body is sent.
@@ -184,9 +210,13 @@ public:
     /// \param input in an input stream that contains request body octets
     /// \param limits is a set of limitation for a query
     /// \returns response stream future
-    ss::future<response_stream_ref>
-    request(request_header&& header, ss::input_stream<char>& input);
-    ss::future<response_stream_ref> request(request_header&& header);
+    ss::future<response_stream_ref> request(
+      request_header&& header,
+      ss::input_stream<char>& input,
+      ss::lowres_clock::duration timeout = default_connect_timeout);
+    ss::future<response_stream_ref> request(
+      request_header&& header,
+      ss::lowres_clock::duration timeout = default_connect_timeout);
 
 private:
     /// Do it all private c-tor
@@ -206,6 +236,7 @@ private:
     /// Throw exception if _as is aborted
     void check() const;
 
+    ss::gate _connect_gate;
     const ss::abort_source* _as;
     ss::lw_shared_ptr<http::client_probe> _probe;
 };


### PR DESCRIPTION
## Cover letter

Connections in HTTP 1.1 are persistent by default. But archival storage didn't use it before. All connections created using our S3 client were transient. This PR implements persistent connections by doing the following steps

- make http_client reusable by allowing to reconnect after the connection drops
- handle errors in such way that allows the client to be reused
- implement connection pool for S3 client
- use connection pool in archival storage subsystem instead of transient S3 connections

This PR is a resubmission of the #1296 that was reverted due to a unit-test bug that caused CI failure.
Additional changes include:
- fix error in http parser that didn't handled empty response well (the error wasn't generated)
- fix concurrency bug in base_transport

## Release notes

N/A