### PR TITLE
Make service monitor optional

### DIFF
--- a/.github/workflows/k8s-build-and-test.yml
+++ b/.github/workflows/k8s-build-and-test.yml
@@ -72,6 +72,10 @@ jobs:
       with:
         version: v3.3.1
 
+    - name: Adding prometheus helm repository
+      working-directory: src/go/k8s/helm-chart/charts
+      run: helm repo add prom https://prometheus-community.github.io/helm-charts
+
     - name: Run chart-testing (lint)
       working-directory: src/go/k8s/helm-chart/charts
       run: ct lint --debug --config ci/ct.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,6 @@ vbuild/
 /vtools/
 /Taskfile.yml
 /.dockerignore
+
+# helm chart dependencies
+*.tgz

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/Chart.lock
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 13.13.1
+digest: sha256:aba4816de5490484f7d0796a5d81c8ce772d9745a905edccbd15d5b532176647
+generated: "2021-05-07T23:15:42.150318+02:00"

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/Chart.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/Chart.yaml
@@ -16,3 +16,9 @@ sources:
 maintainers:
   - name: Vectorizedio
     email: support@vectorized.io
+
+dependencies:
+- name: kube-prometheus-stack
+  condition: monitoring.enabled
+  version: 13.13.1
+  repository: https://prometheus-community.github.io/helm-charts

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
@@ -16,6 +16,10 @@ webhook of cert-manager will prevent from creating mentioned
 resources. To verify that cert manager is ready please follow
 [the verifying the installation](https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation)
 
+The operator by default exposes metrics endpoint. By leveraging prometheus
+operator ServiceMonitor custom resource metrics can be automatically
+discovered.
+
 1. Install Redpanda operator CRDs:
 
 ```sh
@@ -35,6 +39,14 @@ kubectl apply -k 'https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd
 
 ```sh
 helm install --namespace redpanda-system --create-namespace redpanda-operator ./redpanda-operator
+```
+
+Alternative installation with kube-prometheus-stack that includes prometheus operator CRD
+```sh
+helm install --dependency-update \
+--namespace redpanda-system \
+--set monitoring.enabled=true \
+--create-namespace redpanda-operator ./redpanda-operator
 ```
 
 Other instruction will be visible after installation.

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
@@ -58,6 +58,7 @@ Other instruction will be visible after installation.
 | imagePullSecrets | list | `[]` | Redpanda Operator container registry pullSecret (ex: specify docker registry credentials) |
 | labels | string | `nil` | Allows to assign labels to the resources created by this helm chart |
 | logLevel | string | `"info"` | Set Redpanda Operator log level (debug, info, error, panic, fatal) |
+| monitoring | object | `{"enabled":false}` | Add service monitor to the deployment |
 | nameOverride | string | `""` | Override name of app |
 | nodeSelector | object | `{}` | Allows to schedule Redpanda Operator on specific nodes |
 | podAnnotations | object | `{}` | Allows setting additional annotations for Redpanda Operator PODs |

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/README.md.gotmpl
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/README.md.gotmpl
@@ -16,6 +16,10 @@ webhook of cert-manager will prevent from creating mentioned
 resources. To verify that cert manager is ready please follow
 [the verifying the installation](https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation)
 
+The operator by default exposes metrics endpoint. By leveraging prometheus
+operator ServiceMonitor custom resource metrics can be automatically
+discovered.
+
 1. Install Redpanda operator CRDs:
 
 ```sh
@@ -35,6 +39,14 @@ kubectl apply -k 'https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd
 
 ```sh
 helm install --namespace redpanda-system --create-namespace redpanda-operator ./redpanda-operator
+```
+
+Alternative installation with kube-prometheus-stack that includes prometheus operator CRD
+```sh
+helm install --dependency-update \
+--namespace redpanda-system \
+--set monitoring.enabled=true \
+--create-namespace redpanda-operator ./redpanda-operator
 ```
 
 Other instruction will be visible after installation.

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/servicemonitor.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/servicemonitor.yaml
@@ -9,6 +9,7 @@ the Business Source License, use of this software will be governed
 by the Apache License, Version 2.0
 */}}
 
+{{- if .Values.monitoring.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -29,3 +30,4 @@ spec:
   selector:
     matchLabels:
 {{ include "redpanda-operator.labels" . | indent 6 }}
+{{- end -}}

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
@@ -80,3 +80,7 @@ podLabels: {}
 
 # labels -- Allows to assign labels to the resources created by this helm chart
 labels:
+
+# monitoring -- Add service monitor to the deployment
+monitoring:
+  enabled: false


### PR DESCRIPTION
## Cover letter

The service monitor resource doesn't have information about required prometheus operator dependency. 

## Release notes

Release note: Make the service monitor resource optional.
