### PR TITLE
docs: Add migration/replication procedure

### DIFF
--- a/docs/www/acls.md
+++ b/docs/www/acls.md
@@ -1,9 +1,9 @@
 ---
-title: Authorization & Authentication
+title: Authorization & authentication
 order: 1
 ---
 
-# Authorization & Authentication
+# Authorization & authentication
 
 Security should be at the heart of the design of any software project, and Redpanda is not an exception. Today, I wanna introduce the different built-in mechanisms by which you will be able to make your Redpanda cluster more secure. By following this guide, you will familiarize yourself with the available authorization and authentication methods that Redpanda support, both at a conceptual level and at a technical level through hands-on examples.
 
@@ -74,7 +74,7 @@ rpk topic describe 'test-topic'
 
 ### SASL/ SCRAM
 
-Redpanda also supports client authentication via SASL/ SCRAM (that is, the Simple Authentication and Security Layer protocol, using the Salted Challenge Response Authentication Mechanism), which is based on usernames & passwords.
+Redpanda also supports client authentication via SASL/SCRAM (that is, the Simple Authentication and Security Layer protocol, using the Salted Challenge Response Authentication Mechanism), which is based on usernames & passwords.
 
 To enable it, set `redpanda.enable_sasl` to `true` in the configuration file, as well as list at least one "superuser" which after created will have permissions for all operations on the clusters.
 
@@ -98,11 +98,11 @@ $ rpk acl user create \
 Created user 'admin'
 ```
 
-> Refer to the next section, _Managing users_, for more details on `rpk acl user`.
+Refer to the next section, _Managing users_, for more details on `rpk acl user`.
 
 You're now able to use the created identity to interact with the Kafka API. For example:
 
-**Note**: If you still have the TLS config from the previous section, you'll also need to pass the TLS flags.
+> **Note**: If you still have the TLS config from the previous section, you'll also need to pass the TLS flags.
 
 ```cmd
 $ rpk topic describe test-topic \
@@ -124,7 +124,7 @@ $ rpk topic describe test-topic \
   0                   1               [1]        [1]               0               
 ```
 
-#### **Managing users**
+#### Managing users
 
 While having a superuser is a must to get started, it's not really a good idea to either share the superuser's credentials everywhere or to make everyone a superuser.
 

--- a/docs/www/kubernetes-external-connect.md
+++ b/docs/www/kubernetes-external-connect.md
@@ -89,15 +89,15 @@ We'll use Helm to install cert-manager:
 1. Install the latest redpanda operator:
 
   ```
-  VERSION=v21.4.15
-  kubectl apply -k 'https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$VERSION'
-  helm repo add redpanda https://charts.vectorized.io/ && \
-  helm repo update \
-  helm install \
-    --namespace redpanda-system \
-    --create-namespace redpanda-operator \
-    --version $VERSION \
-    redpanda/redpanda-operator
+VERSION=v21.4.15
+kubectl apply -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$VERSION
+helm repo add redpanda https://charts.vectorized.io/ && \
+helm repo update \
+helm install \
+  --namespace redpanda-system \
+  --create-namespace redpanda-operator \
+  --version $VERSION \
+  redpanda/redpanda-operator
   ```
 
 2. Install a cluster with external connectivity:

--- a/docs/www/mirrormaker-migration.md
+++ b/docs/www/mirrormaker-migration.md
@@ -3,6 +3,8 @@ title: Migrating data to Redpanda
 order: 2
 ---
 
+# Migrating data to Redpanda
+
 One of the more elegant aspects of Redpanda is that it is compatible with the [Kafka API and ecosystem](/docs/www/faq.md).
 So, when you want to migrate data from Kafka or replicate data between Redpanda clusters,
 MirrorMaker 2 tool, bundled in the [Kafka download package](https://kafka.apache.org/downloads), is a natural solution.

--- a/docs/www/mirrormaker-migration.md
+++ b/docs/www/mirrormaker-migration.md
@@ -1,0 +1,104 @@
+---
+title: Migrating data to Redpanda
+order: 2
+---
+
+One of the more elegant aspects of Redpanda is that it is compatible with the [Kafka API and ecosystem](/docs/www/faq.md).
+So, when you want to migrate data from Kafka or replicate data between Redpanda clusters,
+MirrorMaker 2 tool, bundled in the [Kafka download package](https://kafka.apache.org/downloads), is a natural solution.
+
+In this article, we'll go through the process of configuring MirrorMaker to replicate from one Redpanda cluster to another.
+For all of the details on MirrorMaker and its options, check out the [Kafka documentation](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330).
+
+## Prerequisites
+
+To set up the replication, we'll need:
+
+- 2 Redpanda clusters - You can set up these clusters in any deployment you like, including [Kubernetes](/docs/www/quick-start-kubernetes.md), [Docker](/docs/www/quick-start-docker.md), [Linux](/docs/www/quick-start-linux.md), or [MacOS](/docs/www/quick-start-macos.md).
+    The key points here are:
+    - Make sure that the IP addresses and ports on each cluster are accessible by the  MirrorMaker.
+    - Create topics in the destination cluster that match the names of the topics that you want to replicate from the source cluster.
+
+- An instance of MirrorMaker - You can set up a separate system with MirrorMaker or run MirrorMaker on one of the Redpanda clusters.
+
+## Installing MirrorMaker
+
+MirrorMaker 2 is run by a shell script that is part of the Kafka download package.
+To install MirrorMaker on the machine that you want to run the replication between the clusters:
+
+1. Download the latest [Kafka download package](https://kafka.apache.org/downloads).
+
+    For example:
+
+    ```
+    curl -O https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz
+    ```
+
+2. Extract the files from the archive:
+
+    ```
+    tar -xvf kafka_2.13-2.8.0.tgz
+    ```
+
+## Create the MirrorMaker config files
+
+MirrorMaker uses configuration files to get the connection details for the clusters.
+You need to have one config file for the source cluster and another for the destination or mirror cluster.
+In this example, we'll assume the file structure:
+
+```
+.
+└── kafka_2.13-2.8.0
+    └── bin
+        └── kafka-mirror-maker.sh
+```
+
+To create the MirrorMaker configuration files:
+
+1. In the base directory, create the config for consuming from the source cluster with:
+
+    ```
+    cat << EOF > consumer.config
+    bootstrap.servers=34.107.64.237:31098
+    exclude.internal.topics=true
+    client.id=mirror_maker_consumer
+    group.id=mirror_maker_consumer
+    EOF
+    ```
+
+    The `bootstrap.servers` address is either:
+
+    - For Kafka - The zookeeper address
+    - For Redpanda - The address of one or more of the cluster nodes
+
+2. Create the config for producing to the destination cluster with:
+
+    ```
+    cat << EOF > producer.config
+    bootstrap.servers=34.107.5.41:31432
+    acks=1
+    batch.size=50
+    client.id=mirror_maker_test_producer
+    EOF
+    ```
+
+This is of course a simplified example of the config files.
+You can experiment with the other options for the [producer config](https://kafka.apache.org/documentation.html#producerconfigs) and [consumer config](https://kafka.apache.org/documentation.html#consumerconfigs) to get the results that you need.
+
+## Run MirrorMaker to start replication
+
+To start the replication from the source cluster to the destination cluster, from the `kafka_2.12-2.8.0/bin/` directory, run:
+
+```
+cd kafka_2.12-2.8.0/bin/ && \
+./kafka-mirror-maker.sh --consumer.config ../../redpanda.config --num.streams 1 --producer.config ../../redpanda-mirror.config --whitelist=".*"
+```
+
+With this command, MirrorMaker consumes events from all topics in the source cluster and produces them to the same topics in the destination cluster, if those topics exist.
+
+## Next steps
+
+After you have this basic replication running, you can:
+
+- Use [consumer-offset-checker](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330#Kafkamirroring(MirrorMaker)-Howtocheckwhetheramirroriskeepingup) to verify that the data is synchronized.
+- Use the [MirrorMaker parameters](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330#Kafkamirroring(MirrorMaker)-Importconfigurationparametersforthemirrormaker) to specify timeouts, buffer sizes, and filter the topics by regex.


### PR DESCRIPTION
## Cover letter

Adds an article to help customers migrate data from existing Kafka solutions or replicate data from one Redpanda to another.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
