### PR TITLE
rpk/config: Restrict search paths to /etc/redpanda, ~, and ./

### DIFF
--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -12,7 +12,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"os"
 	fp "path/filepath"
 	"strings"
 
@@ -45,14 +44,6 @@ func addConfigPaths(v *viper.Viper) {
 	v.AddConfigPath("$HOME")
 	v.AddConfigPath(fp.Join("etc", "redpanda"))
 	v.AddConfigPath(".")
-	path, err := os.Getwd()
-	if err != nil {
-		log.Warnf("Error getting the current dir: %v", err)
-	} else {
-		for dir := fp.Dir(path); dir != string(fp.Separator); dir = fp.Dir(dir) {
-			v.AddConfigPath(dir)
-		}
-	}
 }
 
 func setDefaults(v *viper.Viper) {

--- a/src/go/rpk/pkg/config/find.go
+++ b/src/go/rpk/pkg/config/find.go
@@ -23,7 +23,7 @@ func FindConfigFile(fs afero.Fs) (string, error) {
 	var configPathProviders = []func() ([]string, error){
 		currentDirectory,
 		sysConfDirectory,
-		currentDirectoryParents,
+		homeDirectory,
 	}
 
 	lookedUpPaths := []string{}
@@ -62,21 +62,17 @@ func getCurrentDirectory() (string, error) {
 }
 
 func currentDirectory() ([]string, error) {
-	currentDir, err := getCurrentDirectory()
+	currentDir, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
 	return []string{currentDir}, nil
 }
 
-func currentDirectoryParents() ([]string, error) {
-	currentDir, err := getCurrentDirectory()
+func homeDirectory() ([]string, error) {
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}
-	var result []string
-	for dir := filepath.Dir(currentDir); dir != string(filepath.Separator); dir = filepath.Dir(dir) {
-		result = append(result, dir)
-	}
-	return result, nil
+	return []string{homeDir}, nil
 }

--- a/src/go/rpk/pkg/config/find_test.go
+++ b/src/go/rpk/pkg/config/find_test.go
@@ -32,32 +32,23 @@ func TestFindConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "should return config file from parent directory",
+			name: "should return config file from home directory",
 			before: func(fs afero.Fs) {
-				currentDir := currentDir()
-				fs.MkdirAll(currentDir, 0755)
-				createConfigIn(fs, filepath.Dir(currentDir))
+				createConfigIn(fs, homeDir())
 			},
-			want: filepath.Join(filepath.Dir(currentDir()), "redpanda.yaml"),
+			want: filepath.Join(homeDir(), "redpanda.yaml"),
 		},
 		{
 			name: "should return config file from 'etc' directory",
 			before: func(fs afero.Fs) {
-				createConfigIn(fs, "/etc/redpanda")
-				currentDir := currentDir()
-				fs.MkdirAll(currentDir, 0755)
-				createConfigIn(fs, filepath.Dir(currentDir))
+				createConfigIn(fs, filepath.Join("/", "etc", "redpanda"))
 			},
-			want: "/etc/redpanda/redpanda.yaml",
+			want: filepath.Join("/", "etc", "redpanda", "redpanda.yaml"),
 		},
 		{
 			name: "should return config file from current directory",
 			before: func(fs afero.Fs) {
-				createConfigIn(fs, "/etc/redpanda")
-				currentDir := currentDir()
-				fs.MkdirAll(currentDir, 0755)
-				createConfigIn(fs, filepath.Dir(currentDir))
-				createConfigIn(fs, currentDir)
+				createConfigIn(fs, currentDir())
 			},
 			want: filepath.Join(currentDir(), "redpanda.yaml"),
 		},
@@ -83,5 +74,10 @@ func createConfigIn(fs afero.Fs, path string) {
 
 func currentDir() string {
 	d, _ := os.Getwd()
+	return d
+}
+
+func homeDir() string {
+	d, _ := os.UserHomeDir()
 	return d
 }


### PR DESCRIPTION
Fix #1094
