### PR TITLE
Introduce rm_stm transaction fencing

### DIFF
--- a/src/v/cluster/rm_partition_frontend.cc
+++ b/src/v/cluster/rm_partition_frontend.cc
@@ -55,6 +55,7 @@ bool rm_partition_frontend::is_leader_of(const model::ntp& ntp) const {
 ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
   model::ntp ntp,
   model::producer_identity pid,
+  model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
     auto nt = model::topic_namespace_view(ntp.ns, ntp.tp.topic);
 
@@ -73,18 +74,19 @@ ss::future<begin_tx_reply> rm_partition_frontend::begin_tx(
     auto _self = _controller->self();
 
     if (leader == _self) {
-        return do_begin_tx(ntp, pid);
+        return do_begin_tx(ntp, pid, tx_seq);
     }
 
     vlog(clusterlog.trace, "dispatching begin tx to {} from {}", leader, _self);
 
-    return dispatch_begin_tx(leader.value(), ntp, pid, timeout);
+    return dispatch_begin_tx(leader.value(), ntp, pid, tx_seq, timeout);
 }
 
 ss::future<begin_tx_reply> rm_partition_frontend::dispatch_begin_tx(
   model::node_id leader,
   model::ntp ntp,
   model::producer_identity pid,
+  model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
     return _connection_cache.local()
       .with_node_client<cluster::tx_gateway_client_protocol>(
@@ -92,9 +94,9 @@ ss::future<begin_tx_reply> rm_partition_frontend::dispatch_begin_tx(
         ss::this_shard_id(),
         leader,
         timeout,
-        [ntp, pid, timeout](tx_gateway_client_protocol cp) {
+        [ntp, pid, tx_seq, timeout](tx_gateway_client_protocol cp) {
             return cp.begin_tx(
-              begin_tx_request{.ntp = ntp, .pid = pid},
+              begin_tx_request{.ntp = ntp, .pid = pid, .tx_seq = tx_seq},
               rpc::client_opts(model::timeout_clock::now() + timeout));
         })
       .then(&rpc::get_ctx_data<begin_tx_reply>)
@@ -110,7 +112,7 @@ ss::future<begin_tx_reply> rm_partition_frontend::dispatch_begin_tx(
 }
 
 ss::future<begin_tx_reply> rm_partition_frontend::do_begin_tx(
-  model::ntp ntp, model::producer_identity pid) {
+  model::ntp ntp, model::producer_identity pid, model::tx_seq tx_seq) {
     if (!is_leader_of(ntp)) {
         vlog(clusterlog.warn, "current node isn't the leader for {}", ntp);
         return ss::make_ready_future<begin_tx_reply>(
@@ -126,7 +128,9 @@ ss::future<begin_tx_reply> rm_partition_frontend::do_begin_tx(
     }
 
     return _partition_manager.invoke_on(
-      *shard, _ssg, [ntp, pid](cluster::partition_manager& mgr) mutable {
+      *shard,
+      _ssg,
+      [ntp, pid, tx_seq](cluster::partition_manager& mgr) mutable {
           auto partition = mgr.get(ntp);
           if (!partition) {
               vlog(clusterlog.warn, "can't get partition by {} ntp", ntp);
@@ -143,8 +147,8 @@ ss::future<begin_tx_reply> rm_partition_frontend::do_begin_tx(
                 begin_tx_reply{.ntp = ntp, .ec = tx_errc::stm_not_found});
           }
 
-          return stm->begin_tx(pid).then(
-            [ntp](checked<model::term_id, tx_errc> etag) {
+          return stm->begin_tx(pid, tx_seq)
+            .then([ntp](checked<model::term_id, tx_errc> etag) {
                 if (!etag) {
                     return begin_tx_reply{
                       .ntp = ntp, .ec = tx_errc::leader_not_found};

--- a/src/v/cluster/rm_partition_frontend.h
+++ b/src/v/cluster/rm_partition_frontend.h
@@ -35,7 +35,10 @@ public:
       cluster::controller*);
 
     ss::future<begin_tx_reply> begin_tx(
-      model::ntp, model::producer_identity, model::timeout_clock::duration);
+      model::ntp,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration);
     ss::future<prepare_tx_reply> prepare_tx(
       model::ntp,
       model::term_id,
@@ -68,9 +71,10 @@ private:
       model::node_id,
       model::ntp,
       model::producer_identity,
+      model::tx_seq,
       model::timeout_clock::duration);
     ss::future<begin_tx_reply>
-      do_begin_tx(model::ntp, model::producer_identity);
+      do_begin_tx(model::ntp, model::producer_identity, model::tx_seq);
     ss::future<prepare_tx_reply> dispatch_prepare_tx(
       model::node_id,
       model::ntp,

--- a/src/v/cluster/rm_partition_frontend.h
+++ b/src/v/cluster/rm_partition_frontend.h
@@ -52,7 +52,10 @@ public:
       model::tx_seq,
       model::timeout_clock::duration);
     ss::future<abort_tx_reply> abort_tx(
-      model::ntp, model::producer_identity, model::timeout_clock::duration);
+      model::ntp,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration);
 
 private:
     ss::smp_service_group _ssg;
@@ -105,9 +108,13 @@ private:
       model::node_id,
       model::ntp,
       model::producer_identity,
+      model::tx_seq,
       model::timeout_clock::duration);
     ss::future<abort_tx_reply> do_abort_tx(
-      model::ntp, model::producer_identity, model::timeout_clock::duration);
+      model::ntp,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration);
 
     friend tx_gateway;
 };

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -84,7 +84,7 @@ public:
     explicit rm_stm(ss::logger&, raft::consensus*);
 
     ss::future<checked<model::term_id, tx_errc>>
-      begin_tx(model::producer_identity);
+      begin_tx(model::producer_identity, model::tx_seq);
     ss::future<tx_errc> prepare_tx(
       model::term_id,
       model::partition_id,
@@ -162,6 +162,11 @@ private:
         absl::flat_hash_map<model::producer_identity, seq_entry> seq_table;
     };
 
+    struct preparing_info {
+        bool has_applied;
+        model::tx_seq tx_seq;
+    };
+
     struct mem_state {
         // once raft's term has passed mem_state::term we wipe mem_state
         // and wait until log_state catches up with current committed index.
@@ -179,17 +184,17 @@ private:
         absl::flat_hash_map<model::producer_identity, model::offset> estimated;
         // a set of ongoing sessions. we use it  to prevent some client protocol
         // errors like the transactional writes outside of a transaction
-        absl::btree_set<model::producer_identity> expected;
+        absl::flat_hash_map<model::producer_identity, model::tx_seq> expected;
         // 'prepare' command may be replicated but reject during the apply phase
         // because of the fencing and race with abort. we use this field to
         // let a 'prepare' initator know the status of the 'prepare' command
         // once state_machine::apply catches up with the prepare's offset
-        absl::flat_hash_map<model::producer_identity, bool> has_prepare_applied;
+        absl::flat_hash_map<model::producer_identity, preparing_info> preparing;
 
         void forget(model::producer_identity pid) {
             expected.erase(pid);
             estimated.erase(pid);
-            has_prepare_applied.erase(pid);
+            preparing.erase(pid);
             auto tx_start_it = tx_start.find(pid);
             if (tx_start_it != tx_start.end()) {
                 tx_starts.erase(tx_start_it->second);

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -93,8 +93,8 @@ public:
       model::timeout_clock::duration);
     ss::future<tx_errc> commit_tx(
       model::producer_identity, model::tx_seq, model::timeout_clock::duration);
-    ss::future<tx_errc>
-      abort_tx(model::producer_identity, model::timeout_clock::duration);
+    ss::future<tx_errc> abort_tx(
+      model::producer_identity, model::tx_seq, model::timeout_clock::duration);
 
     model::offset last_stable_offset();
     ss::future<std::vector<rm_stm::tx_range>>
@@ -121,6 +121,11 @@ private:
         raft::replicate_options);
 
     void compact_snapshot();
+
+    enum abort_origin { present, past, future };
+
+    abort_origin
+    get_abort_origin(const model::producer_identity&, model::tx_seq) const;
 
     ss::future<> apply(model::record_batch) override;
     void apply_prepare(rm_stm::prepare_marker);

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -67,6 +67,7 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto tx_seq = model::tx_seq(0);
 
     wait_for_leader();
     wait_for_meta_initialized();
@@ -90,7 +91,7 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
 
     auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid2).get0();
+    auto term_op = stm.begin_tx(pid2, tx_seq).get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid2, 0, 5, true);
@@ -109,11 +110,10 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
 
     auto term = term_op.value();
     auto op = stm
-                .prepare_tx(
-                  term, model::partition_id(0), pid2, model::tx_seq(0), 2'000ms)
+                .prepare_tx(term, model::partition_id(0), pid2, tx_seq, 2'000ms)
                 .get0();
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
-    op = stm.commit_tx(pid2, model::tx_seq(0), 2'000ms).get0();
+    op = stm.commit_tx(pid2, tx_seq, 2'000ms).get0();
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
     aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
@@ -131,6 +131,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto tx_seq = model::tx_seq(0);
 
     wait_for_leader();
     wait_for_meta_initialized();
@@ -154,7 +155,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
 
     auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid2).get0();
+    auto term_op = stm.begin_tx(pid2, tx_seq).get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid2, 0, 5, true);
@@ -196,6 +197,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto tx_seq = model::tx_seq(0);
 
     wait_for_leader();
     wait_for_meta_initialized();
@@ -219,7 +221,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
 
     auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid2).get0();
+    auto term_op = stm.begin_tx(pid2, tx_seq).get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid2, 0, 5, true);
@@ -238,8 +240,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
 
     auto term = term_op.value();
     auto op = stm
-                .prepare_tx(
-                  term, model::partition_id(0), pid2, model::tx_seq(0), 2'000ms)
+                .prepare_tx(term, model::partition_id(0), pid2, tx_seq, 2'000ms)
                 .get0();
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
 
@@ -300,6 +301,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto tx_seq = model::tx_seq(0);
 
     wait_for_leader();
     wait_for_meta_initialized();
@@ -316,11 +318,11 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid20).get0();
+    auto term_op = stm.begin_tx(pid20, tx_seq).get0();
     BOOST_REQUIRE((bool)term_op);
 
     auto pid21 = model::producer_identity{.id = 2, .epoch = 1};
-    term_op = stm.begin_tx(pid21).get0();
+    term_op = stm.begin_tx(pid21, tx_seq).get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid20, 0, 5, true);
@@ -341,6 +343,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
+    auto tx_seq = model::tx_seq(0);
 
     wait_for_leader();
     wait_for_meta_initialized();
@@ -357,7 +360,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid20).get0();
+    auto term_op = stm.begin_tx(pid20, tx_seq).get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid20, 0, 5, true);

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -172,7 +172,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     aborted_txs = stm.aborted_transactions(min_offset, max_offset).get0();
     BOOST_REQUIRE_EQUAL(aborted_txs.size(), 0);
 
-    auto op = stm.abort_tx(pid2, 2'000ms).get0();
+    auto op = stm.abort_tx(pid2, tx_seq, 2'000ms).get0();
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
     BOOST_REQUIRE(
       stm.wait_no_throw(_raft.get()->committed_offset(), 2'000ms).get0());
@@ -244,7 +244,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
                 .get0();
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
 
-    op = stm.abort_tx(pid2, 2'000ms).get0();
+    op = stm.abort_tx(pid2, tx_seq, 2'000ms).get0();
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
     BOOST_REQUIRE(
       stm.wait_no_throw(_raft.get()->committed_offset(), 2'000ms).get0());
@@ -372,7 +372,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
                  .get0();
     BOOST_REQUIRE((bool)offset_r);
 
-    auto op = stm.abort_tx(pid20, 2'000ms).get0();
+    auto op = stm.abort_tx(pid20, tx_seq, 2'000ms).get0();
     BOOST_REQUIRE_EQUAL(op, cluster::tx_errc::none);
 
     rreader = make_rreader(pid20, 0, 5, true);

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -64,7 +64,7 @@ tx_gateway::commit_tx(commit_tx_request&& request, rpc::streaming_context&) {
 ss::future<abort_tx_reply>
 tx_gateway::abort_tx(abort_tx_request&& request, rpc::streaming_context&) {
     return _rm_partition_frontend.local().do_abort_tx(
-      request.ntp, request.pid, request.timeout);
+      request.ntp, request.pid, request.tx_seq, request.timeout);
 }
 
 ss::future<begin_group_tx_reply> tx_gateway::begin_group_tx(

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -40,7 +40,8 @@ tx_gateway::init_tm_tx(init_tm_tx_request&& request, rpc::streaming_context&) {
 
 ss::future<begin_tx_reply>
 tx_gateway::begin_tx(begin_tx_request&& request, rpc::streaming_context&) {
-    return _rm_partition_frontend.local().do_begin_tx(request.ntp, request.pid);
+    return _rm_partition_frontend.local().do_begin_tx(
+      request.ntp, request.pid, request.tx_seq);
 }
 
 ss::future<prepare_tx_reply>

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -683,8 +683,8 @@ tx_gateway_frontend::do_abort_tm_tx(
     tx = changed_tx.value();
     std::vector<ss::future<abort_tx_reply>> pfs;
     for (auto rm : tx.partitions) {
-        pfs.push_back(
-          _rm_partition_frontend.local().abort_tx(rm.ntp, tx.pid, timeout));
+        pfs.push_back(_rm_partition_frontend.local().abort_tx(
+          rm.ntp, tx.pid, tx.tx_seq, timeout));
     }
     std::vector<ss::future<abort_group_tx_reply>> gfs;
     for (auto group : tx.groups) {
@@ -843,8 +843,8 @@ ss::future<checked<tm_transaction, tx_errc>> tx_gateway_frontend::reabort_tm_tx(
   tm_transaction tx, model::timeout_clock::duration timeout) {
     std::vector<ss::future<abort_tx_reply>> pfs;
     for (auto rm : tx.partitions) {
-        pfs.push_back(
-          _rm_partition_frontend.local().abort_tx(rm.ntp, tx.pid, timeout));
+        pfs.push_back(_rm_partition_frontend.local().abort_tx(
+          rm.ntp, tx.pid, tx.tx_seq, timeout));
     }
     std::vector<ss::future<abort_group_tx_reply>> gfs;
     for (auto group : tx.groups) {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -424,7 +424,7 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
                 res_topic.results.push_back(res_partition);
             } else {
                 bfs.push_back(_rm_partition_frontend.local().begin_tx(
-                  ntp, tx.pid, timeout));
+                  ntp, tx.pid, tx.tx_seq, timeout));
             }
         }
         response.results.push_back(res_topic);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -57,6 +57,9 @@ enum class tx_errc {
     partition_not_found,
     stm_not_found,
     partition_not_exists,
+    // when a request times out a client should not do any assumptions about its
+    // effect. the request may time out before reaching the server, the request
+    // may be successuly processed or may fail and the reply times out
     timeout,
     conflict,
     fenced,
@@ -66,19 +69,18 @@ enum class tx_errc {
     preparing_rebalance,
     rebalance_in_progress,
     coordinator_load_in_progress,
-    unknown_server_error
+    // an unspecified error happened, the effect of the request is unknown
+    // the error code is very similar to timeout
+    unknown_server_error,
+    // an unspecified error happened, a client may assume it had zero effect on
+    // the target node
+    request_rejected
 };
 struct tx_errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::tx_errc"; }
 
     std::string message(int c) const final {
         switch (static_cast<tx_errc>(c)) {
-        case tx_errc::stale:
-            return "Stale";
-        case tx_errc::fenced:
-            return "Fenced";
-        case tx_errc::conflict:
-            return "Conflict";
         case tx_errc::none:
             return "None";
         case tx_errc::leader_not_found:
@@ -93,6 +95,26 @@ struct tx_errc_category final : public std::error_category {
             return "Partition not exists";
         case tx_errc::timeout:
             return "Timeout";
+        case tx_errc::conflict:
+            return "Conflict";
+        case tx_errc::fenced:
+            return "Fenced";
+        case tx_errc::stale:
+            return "Stale";
+        case tx_errc::not_coordinator:
+            return "Not coordinator";
+        case tx_errc::coordinator_not_available:
+            return "Coordinator not available";
+        case tx_errc::preparing_rebalance:
+            return "Preparing rebalance";
+        case tx_errc::rebalance_in_progress:
+            return "Rebalance in progress";
+        case tx_errc::coordinator_load_in_progress:
+            return "Coordinator load in progress";
+        case tx_errc::unknown_server_error:
+            return "Unknown server error";
+        case tx_errc::request_rejected:
+            return "Request rejected";
         default:
             return "cluster::tx_errc::unknown";
         }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -209,6 +209,7 @@ struct commit_tx_reply {
 struct abort_tx_request {
     model::ntp ntp;
     model::producer_identity pid;
+    model::tx_seq tx_seq;
     model::timeout_clock::duration timeout;
 };
 struct abort_tx_reply {


### PR DESCRIPTION
Introduce fencing to prevent deleayed commit or abort requests from affecting ongoing fresher transactions

Kafka transaction doesn't have a transaction identifier and uses session identifier (pid, epoch) instead. As a result commit or abort requests issued for an old tx within the same session may be delayed on the wire and may accidentally affect ongoing newer transaction.

Redpanda fixes the problem by introducing tx_seq and using the triplets of (pid, epoch, tx_seq) for intra cluster transaction identification.

[ch2219] [ch2197]