### PR TITLE
rpk start: Accept arbitrary kv pairs to set config values at startup.

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -52,7 +52,15 @@ func set(fs afero.Fs, mgr config.Manager) *cobra.Command {
 					return err
 				}
 			}
-			return mgr.Set(key, value, format, configPath)
+			_, err = mgr.Read(configPath)
+			if err != nil {
+				return err
+			}
+			err = mgr.Set(key, value, format)
+			if err != nil {
+				return err
+			}
+			return mgr.WriteLoaded()
 		},
 	}
 	c.Flags().StringVar(&format,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
 )
 
-func TestSet(t *testing.T) {
+func TestSetCmd(t *testing.T) {
 	tests := []struct {
 		name      string
 		key       string

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/utils"
 	vyaml "github.com/vectorizedio/redpanda/src/go/rpk/pkg/yaml"
@@ -53,72 +52,86 @@ func getValidConfig() *Config {
 	return conf
 }
 
-func TestSeto(t *testing.T) {
+func TestSet(t *testing.T) {
 	tests := []struct {
 		name      string
 		key       string
 		value     string
 		format    string
-		expected  interface{}
+		check     func(st *testing.T, c *Config, mgr *manager)
 		expectErr bool
 	}{
 		{
-			name:     "it should parse '1' as an int and not as bool (true)",
-			key:      "redpanda.node_id",
-			value:    "1",
-			format:   "single",
-			expected: 1,
+			name:   "it should parse '1' as an int and not as bool (true)",
+			key:    "redpanda.node_id",
+			value:  "1",
+			format: "single",
+			check: func(st *testing.T, c *Config, _ *manager) {
+				require.Exactly(st, 1, c.Redpanda.Id)
+			},
 		},
 		{
-			name:     "it should set single integer fields",
-			key:      "redpanda.node_id",
-			value:    "54312",
-			format:   "single",
-			expected: 54312,
+			name:   "it should set single integer fields",
+			key:    "redpanda.node_id",
+			value:  "54312",
+			format: "single",
+			check: func(st *testing.T, c *Config, _ *manager) {
+				require.Exactly(st, 54312, c.Redpanda.Id)
+			},
 		},
 		{
-			name:     "it should set single float fields",
-			key:      "redpanda.float_field",
-			value:    "42.3",
-			format:   "single",
-			expected: 42.3,
+			name:   "it should set single float fields",
+			key:    "redpanda.float_field",
+			value:  "42.3",
+			format: "single",
+			check: func(st *testing.T, _ *Config, mgr *manager) {
+				//require.True(st, ok, "Config map is of the wrong type")
+				require.Exactly(st, 42.3, mgr.v.Get("redpanda.float_field"))
+			},
 		},
 		{
-			name:     "it should set single string fields",
-			key:      "redpanda.data_directory",
-			value:    "'/var/lib/differentdir'",
-			format:   "single",
-			expected: "'/var/lib/differentdir'",
+			name:   "it should set single string fields",
+			key:    "redpanda.data_directory",
+			value:  "'/var/lib/differentdir'",
+			format: "single",
+			check: func(st *testing.T, c *Config, _ *manager) {
+				require.Exactly(st, "'/var/lib/differentdir'", c.Redpanda.Directory)
+			},
 		},
 		{
-			name:     "it should set single bool fields",
-			key:      "rpk.enable_usage_stats",
-			value:    "true",
-			format:   "single",
-			expected: true,
+			name:   "it should set single bool fields",
+			key:    "rpk.enable_usage_stats",
+			value:  "true",
+			format: "single",
+			check: func(st *testing.T, c *Config, _ *manager) {
+				require.Exactly(st, true, c.Rpk.EnableUsageStats)
+			},
 		},
 		{
 			name:   "it should partially set map fields (yaml)",
 			key:    "rpk",
 			value:  `tune_disk_irq: true`,
 			format: "yaml",
-			expected: map[string]interface{}{
-				"enable_usage_stats":         false,
-				"overprovisioned":            false,
-				"tune_network":               false,
-				"tune_disk_scheduler":        false,
-				"tune_disk_nomerges":         false,
-				"tune_disk_irq":              true,
-				"tune_cpu":                   false,
-				"tune_aio_events":            false,
-				"tune_clocksource":           false,
-				"tune_swappiness":            false,
-				"tune_transparent_hugepages": false,
-				"enable_memory_locking":      false,
-				"tune_fstrim":                false,
-				"tune_coredump":              false,
-				"tune_disk_write_cache":      false,
-				"coredump_dir":               "/var/lib/redpanda/coredump",
+			check: func(st *testing.T, c *Config, _ *manager) {
+				expected := RpkConfig{
+					EnableUsageStats:         false,
+					Overprovisioned:          false,
+					TuneNetwork:              false,
+					TuneDiskScheduler:        false,
+					TuneNomerges:             false,
+					TuneDiskIrq:              true,
+					TuneCpu:                  false,
+					TuneAioEvents:            false,
+					TuneClocksource:          false,
+					TuneSwappiness:           false,
+					TuneTransparentHugePages: false,
+					EnableMemoryLocking:      false,
+					TuneFstrim:               false,
+					TuneCoredump:             false,
+					TuneDiskWriteCache:       false,
+					CoredumpDir:              "/var/lib/redpanda/coredump",
+				}
+				require.Exactly(st, expected, c.Rpk)
 			},
 		},
 		{
@@ -129,19 +142,15 @@ func TestSeto(t *testing.T) {
 		  "port": 9092
 		}]`,
 			format: "json",
-			expected: []interface{}{
-				map[interface{}]interface{}{
-					"port":    9092,
-					"address": "192.168.54.2",
-				},
+			check: func(st *testing.T, c *Config, _ *manager) {
+				expected := []NamedSocketAddress{{
+					SocketAddress: SocketAddress{
+						Port:    9092,
+						Address: "192.168.54.2",
+					},
+				}}
+				require.Exactly(st, expected, c.Redpanda.KafkaApi)
 			},
-		},
-		{
-			name:      "it should fail if the new value is invalid",
-			key:       "redpanda",
-			value:     `{"data_directory": ""}`,
-			format:    "json",
-			expectErr: true,
 		},
 		{
 			name:      "it should fail if the value isn't well formatted (json)",
@@ -178,21 +187,18 @@ func TestSeto(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			mgr := NewManager(fs)
 			conf := Default()
-			err := mgr.Write(conf)
-			require.NoError(t, err)
-			err = mgr.Set(tt.key, tt.value, tt.format, conf.ConfigFile)
+			err := mgr.Set(tt.key, tt.value, tt.format)
 			if tt.expectErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			v := viper.New()
-			v.SetFs(fs)
-			v.SetConfigFile(conf.ConfigFile)
-			err = v.ReadInConfig()
-			require.NoError(t, err)
-			val := v.Get(tt.key)
-			require.Exactly(t, tt.expected, val)
+			if tt.check != nil {
+				conf, err = mgr.Get()
+				require.NoError(t, err)
+				m, _ := mgr.(*manager)
+				tt.check(t, conf, m)
+			}
 		})
 	}
 }
@@ -1613,6 +1619,27 @@ rpk:
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestWriteLoaded(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	mgr := NewManager(fs)
+	err := mgr.Set(
+		"rpk.admin",
+		`[{"address": "192.168.54.2","port": 9092}]`,
+		"json",
+	)
+	require.NoError(t, err)
+
+	mgr.WriteLoaded()
+	conf, err := mgr.Get()
+	require.NoError(t, err)
+
+	newMgr := NewManager(fs)
+	newConf, err := newMgr.Read(Default().ConfigFile)
+	require.NoError(t, err)
+
+	require.Exactly(t, conf, newConf)
 }
 
 func TestReadOrGenerate(t *testing.T) {

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -80,10 +80,27 @@ func TestSet(t *testing.T) {
 			},
 		},
 		{
+			name:  "it should detect single integer fields if format isn't passed",
+			key:   "redpanda.node_id",
+			value: "54312",
+			check: func(st *testing.T, c *Config, _ *manager) {
+				require.Exactly(st, 54312, c.Redpanda.Id)
+			},
+		},
+		{
 			name:   "it should set single float fields",
 			key:    "redpanda.float_field",
 			value:  "42.3",
 			format: "single",
+			check: func(st *testing.T, _ *Config, mgr *manager) {
+				//require.True(st, ok, "Config map is of the wrong type")
+				require.Exactly(st, 42.3, mgr.v.Get("redpanda.float_field"))
+			},
+		},
+		{
+			name:  "it should detect single float fields if format isn't passed",
+			key:   "redpanda.float_field",
+			value: "42.3",
 			check: func(st *testing.T, _ *Config, mgr *manager) {
 				//require.True(st, ok, "Config map is of the wrong type")
 				require.Exactly(st, 42.3, mgr.v.Get("redpanda.float_field"))
@@ -99,10 +116,26 @@ func TestSet(t *testing.T) {
 			},
 		},
 		{
+			name:  "it should detect single string fields if format isn't passed",
+			key:   "redpanda.data_directory",
+			value: "/var/lib/differentdir",
+			check: func(st *testing.T, c *Config, _ *manager) {
+				require.Exactly(st, "/var/lib/differentdir", c.Redpanda.Directory)
+			},
+		},
+		{
 			name:   "it should set single bool fields",
 			key:    "rpk.enable_usage_stats",
 			value:  "true",
 			format: "single",
+			check: func(st *testing.T, c *Config, _ *manager) {
+				require.Exactly(st, true, c.Rpk.EnableUsageStats)
+			},
+		},
+		{
+			name:  "it should detect single bool fields if format isn't passed",
+			key:   "rpk.enable_usage_stats",
+			value: "true",
 			check: func(st *testing.T, c *Config, _ *manager) {
 				require.Exactly(st, true, c.Rpk.EnableUsageStats)
 			},
@@ -135,6 +168,33 @@ func TestSet(t *testing.T) {
 			},
 		},
 		{
+			name: "it should detect yaml-formatted values if format isn't passed",
+			key:  "redpanda.kafka_api",
+			value: `- name: external
+  address: 192.168.73.45
+  port: 9092
+- name: internal
+  address: 10.21.34.58
+  port: 9092
+`,
+			check: func(st *testing.T, c *Config, _ *manager) {
+				expected := []NamedSocketAddress{{
+					Name: "external",
+					SocketAddress: SocketAddress{
+						Address: "192.168.73.45",
+						Port:    9092,
+					},
+				}, {
+					Name: "internal",
+					SocketAddress: SocketAddress{
+						Address: "10.21.34.58",
+						Port:    9092,
+					},
+				}}
+				require.Exactly(st, expected, c.Redpanda.KafkaApi)
+			},
+		},
+		{
 			name: "it should partially set map fields (json)",
 			key:  "redpanda.kafka_api",
 			value: `[{
@@ -150,6 +210,23 @@ func TestSet(t *testing.T) {
 					},
 				}}
 				require.Exactly(st, expected, c.Redpanda.KafkaApi)
+			},
+		},
+		{
+			name: "it should detect json-formatted values if format isn't passed",
+			key:  "redpanda.advertised_kafka_api",
+			value: `[{
+		  "address": "192.168.54.2",
+		  "port": 9092
+		}]`,
+			check: func(st *testing.T, c *Config, _ *manager) {
+				expected := []NamedSocketAddress{{
+					SocketAddress: SocketAddress{
+						Port:    9092,
+						Address: "192.168.54.2",
+					},
+				}}
+				require.Exactly(st, expected, c.Redpanda.AdvertisedKafkaApi)
 			},
 		},
 		{

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -2072,3 +2072,10 @@ func TestWriteAndGenerateNodeUuid(t *testing.T) {
 	require.NoError(t, err)
 	require.Exactly(t, conf, readConf)
 }
+
+func TestGet(t *testing.T) {
+	mgr := NewManager(afero.NewMemMapFs())
+	conf, err := mgr.Get()
+	require.NoError(t, err)
+	require.Exactly(t, Default(), conf)
+}

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -39,6 +39,8 @@ type Manager interface {
 	Read(path string) (*Config, error)
 	// Writes the config to Config.ConfigFile
 	Write(conf *Config) error
+	// Writes the currently-loaded config to redpanda.config_file
+	WriteLoaded() error
 	// Get the currently-loaded config
 	Get() (*Config, error)
 	// Reads the config from path, sets key to the given value (parsing it
@@ -298,6 +300,11 @@ func (m *manager) Write(conf *Config) error {
 	v.MergeConfigMap(currentMap)
 	v.MergeConfigMap(confMap)
 	return checkAndWrite(m.fs, v, conf.ConfigFile)
+}
+
+// Writes the currently loaded config.
+func (m *manager) WriteLoaded() error {
+	return checkAndWrite(m.fs, m.v, m.v.GetString("config_file"))
 }
 
 func write(v *viper.Viper, path string) error {

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -411,9 +411,11 @@ func unmarshal(v *viper.Viper) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	result.ConfigFile, err = absPath(v.ConfigFileUsed())
-	if err != nil {
-		return nil, err
+	if result.ConfigFile == "" {
+		result.ConfigFile, err = absPath(v.ConfigFileUsed())
+		if err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
 }

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -39,6 +39,8 @@ type Manager interface {
 	Read(path string) (*Config, error)
 	// Writes the config to Config.ConfigFile
 	Write(conf *Config) error
+	// Get the currently-loaded config
+	Get() (*Config, error)
 	// Reads the config from path, sets key to the given value (parsing it
 	// according to the format), and writes the config back
 	Set(key, value, format, path string) error
@@ -270,6 +272,10 @@ func (m *manager) WriteNodeUUID(conf *Config) error {
 	}
 	conf.NodeUuid = base58Encode(id.String())
 	return m.Write(conf)
+}
+
+func (m *manager) Get() (*Config, error) {
+	return unmarshal(m.v)
 }
 
 // Checks config and writes it to the given path.


### PR DESCRIPTION
Add a new flag to `rpk redpanda start`, `--set`, which allows passing multiple key-value pairs in the format <key>=<value>, where key is a field path, and value is a JSON object, a YAML object, or a single number (int or floating-point), bool or string.

Example:

rpk redpanda start [other flags] \
  --set redpanda.node_id=42 \
  --set 'rpk={"tune_disk_irq":false,"enable_usage_stats":true}' \
  --set 'redpanda.kafka_api=[{"name":"external","address":"192.168.78.34","port":9093}]'

Also, to support setting many config fields without writing to the SSD for each of them, `config.Manager#Set` now only sets the field and return with no additional side-effects.