### PR TITLE
kafka: support legacy message formats and produce v0

### DIFF
--- a/src/v/bytes/iobuf_parser.h
+++ b/src/v/bytes/iobuf_parser.h
@@ -124,6 +124,10 @@ public:
         skip(len);
         return ret;
     }
+
+    iobuf share_no_consume(size_t len) {
+        return ref().share(bytes_consumed(), len);
+    }
 };
 
 inline std::ostream& operator<<(std::ostream& o, const iobuf_parser& p) {

--- a/src/v/bytes/utils.h
+++ b/src/v/bytes/utils.h
@@ -13,7 +13,7 @@
 #include "bytes/iobuf.h"
 #include "hashing/crc32c.h"
 
-inline void crc_extend_iobuf(crc32& crc, const iobuf& buf) {
+inline void crc_extend_iobuf(crc::crc32c& crc, const iobuf& buf) {
     auto in = iobuf::iterator_consumer(buf.cbegin(), buf.cend());
     (void)in.consume(buf.size_bytes(), [&crc](const char* src, size_t sz) {
         // NOLINTNEXTLINE

--- a/src/v/hashing/crc32.h
+++ b/src/v/hashing/crc32.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include <cstdint>
+#include <zlib.h>
+
+namespace crc {
+
+class crc32 {
+public:
+    crc32()
+      : _crc(::crc32(0L, Z_NULL, 0)) {}
+
+    void extend(const uint8_t* data, size_t size) {
+        _crc = ::crc32(_crc, data, size);
+    }
+
+    void extend(const char* data, size_t size) {
+        extend(
+          reinterpret_cast<const uint8_t*>(data), // NOLINT
+          size);
+    }
+
+    uint32_t value() const { return _crc; }
+
+private:
+    uint32_t _crc;
+};
+
+} // namespace crc

--- a/src/v/hashing/crc32c.h
+++ b/src/v/hashing/crc32c.h
@@ -14,7 +14,9 @@
 
 #include <type_traits>
 
-class crc32 {
+namespace crc {
+
+class crc32c {
 public:
     template<typename T, typename = std::enable_if_t<std::is_integral_v<T>, T>>
     void extend(T num) noexcept {
@@ -22,7 +24,7 @@ public:
         extend(reinterpret_cast<const uint8_t*>(&num), sizeof(T));
     }
     void extend(const uint8_t* data, size_t size) {
-        _crc = crc32c::Extend(_crc, data, size);
+        _crc = ::crc32c::Extend(_crc, data, size);
     }
     void extend(const char* data, size_t size) {
         extend(
@@ -36,3 +38,5 @@ public:
 private:
     uint32_t _crc = 0;
 };
+
+} // namespace crc

--- a/src/v/hashing/tests/hash_bench.cc
+++ b/src/v/hashing/tests/hash_bench.cc
@@ -49,7 +49,7 @@ PERF_TEST(fnv32_fn, header_hash) {
 }
 PERF_TEST(crc32_fn, header_hash) {
     auto buffer = random_generators::gen_alphanum_string(step_bytes);
-    crc32 crc;
+    crc::crc32c crc;
     perf_tests::start_measuring_time();
     crc.extend(buffer.data(), buffer.size());
     auto o = crc.value();

--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -87,7 +87,7 @@ model::record_batch_header kafka_batch_adapter::read_header(iobuf_parser& in) {
 }
 
 void kafka_batch_adapter::verify_crc(int32_t expected_crc, iobuf_parser in) {
-    auto crc = crc32();
+    auto crc = crc::crc32c();
 
     // 1. move the cursor to correct endpoint
     //   - 8 base offset

--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -183,4 +183,8 @@ iobuf kafka_batch_adapter::adapt(iobuf&& kbatch) {
     return remainder;
 }
 
+void kafka_batch_adapter::adapt_with_version(iobuf kbatch, api_version) {
+    adapt(std::move(kbatch));
+}
+
 } // namespace kafka

--- a/src/v/kafka/protocol/kafka_batch_adapter.h
+++ b/src/v/kafka/protocol/kafka_batch_adapter.h
@@ -15,6 +15,7 @@
 #include "kafka/types.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
+#include "storage/record_batch_builder.h"
 #include "utils/vint.h"
 
 namespace kafka {
@@ -62,6 +63,7 @@ public:
 
     bool v2_format;
     bool valid_crc;
+    bool legacy_error{false};
 
     std::optional<model::record_batch> batch;
 
@@ -70,6 +72,7 @@ public:
 private:
     void verify_crc(int32_t, iobuf_parser);
     model::record_batch_header read_header(iobuf_parser&);
+    void convert_message_set(storage::record_batch_builder&, iobuf, bool);
 };
 
 /*

--- a/src/v/kafka/protocol/kafka_batch_adapter.h
+++ b/src/v/kafka/protocol/kafka_batch_adapter.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "bytes/iobuf_parser.h"
+#include "kafka/types.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "utils/vint.h"
@@ -64,6 +65,8 @@ public:
 
     std::optional<model::record_batch> batch;
 
+    void adapt_with_version(iobuf, api_version);
+
 private:
     void verify_crc(int32_t, iobuf_parser);
     model::record_batch_header read_header(iobuf_parser&);
@@ -75,9 +78,10 @@ private:
  * types.
  */
 struct produce_request_record_data {
-    explicit produce_request_record_data(std::optional<iobuf>&& data) {
+    explicit produce_request_record_data(
+      std::optional<iobuf>&& data, api_version version) {
         if (data) {
-            adapter.adapt(std::move(*data));
+            adapter.adapt_with_version(std::move(*data), version);
         }
     }
 

--- a/src/v/kafka/protocol/legacy_message.h
+++ b/src/v/kafka/protocol/legacy_message.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "bytes/iobuf.h"
+#include "hashing/crc32.h"
+#include "kafka/server/logger.h"
+#include "model/record.h"
+#include "vlog.h"
+
+namespace kafka {
+
+/*
+ * Legacy messages are stored in message sets (effectively a packed array of
+ * serialized messags). There are two message types identified by magic values.
+ *
+ * Message V0
+ *   - offset
+ *   - length
+ *   - crc
+ *   - magic
+ *   - attributes
+ *
+ * Message V1
+ *   - Message V0
+ *   - timestamp
+ *
+ * Immediately after either message type is the optional key and optional value
+ * encoded with fixed width size prefix (standard kafka encoding). This differs
+ * from v2 which uses varint encoding.
+ *
+ * The crc covers the message bytes from the magic through the value. Unlike v2,
+ * legacy messages use crc32 not crc32c.
+ */
+struct legacy_message {
+    static constexpr uint16_t compression_mask = 0x07;
+
+    model::offset base_offset;
+    int32_t batch_length;
+    int32_t batch_crc;
+    int8_t magic;
+    int8_t attributes;
+    std::optional<model::timestamp> timestamp;
+    std::optional<iobuf> key;
+    std::optional<iobuf> value;
+
+    model::compression compression() const {
+        auto value = static_cast<uint8_t>(attributes) & compression_mask;
+        switch (value) {
+        case 0:
+            return model::compression::none;
+        case 1:
+            return model::compression::gzip;
+        case 2:
+            return model::compression::snappy;
+        case 3:
+            return model::compression::lz4;
+        default:
+            throw std::runtime_error(
+              fmt::format("Unknown compression value: {}", value));
+        }
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const legacy_message& m) {
+    fmt::print(
+      os,
+      "{{offset {} length {} crc {} magic {} attrs {}:{} ts {} key {} value "
+      "{}}}",
+      m.base_offset,
+      m.batch_length,
+      static_cast<uint32_t>(m.batch_crc),
+      m.magic,
+      m.attributes,
+      m.compression(),
+      m.timestamp,
+      m.key,
+      m.value);
+    return os;
+}
+
+inline std::optional<legacy_message>
+decode_legacy_batch(iobuf_parser& parser) {
+    auto base_offset = model::offset(parser.consume_be_type<int64_t>());
+    auto batch_length = parser.consume_be_type<int32_t>();
+    auto expected_crc = parser.consume_be_type<int32_t>();
+    // bytes covered by crc start immediately after the crc value
+    auto crc_parser = iobuf_parser(parser.share_no_consume(batch_length));
+    auto magic = parser.consume_type<int8_t>();
+    if (unlikely(magic != 0 && magic != 1)) {
+        vlog(klog.error, "Expected magic 0 or 1 got {}", magic);
+        return std::nullopt;
+    }
+    auto attributes = parser.consume_type<int8_t>();
+    std::optional<model::timestamp> timestamp;
+    if (magic == 1) {
+        timestamp = model::timestamp(parser.consume_be_type<int64_t>());
+    }
+
+    crc::crc32 computed_crc;
+    crc_parser.consume(
+      crc_parser.bytes_left(), [&computed_crc](const char* src, size_t n) {
+          computed_crc.extend(
+            reinterpret_cast<const uint8_t*>(src), n); // NOLINT
+          return ss::stop_iteration::no;
+      });
+
+    if (unlikely(static_cast<uint32_t>(expected_crc) != computed_crc.value())) {
+        vlog(
+          klog.error,
+          "Cannot validate legacy batch (magic={}) CRC. Expected {}. Computed "
+          "{}",
+          magic,
+          static_cast<uint32_t>(expected_crc),
+          computed_crc.value());
+        return std::nullopt;
+    }
+
+    auto key_size = parser.consume_be_type<int32_t>();
+    std::optional<iobuf> key;
+    if (key_size != -1) {
+        key = parser.share(key_size);
+    }
+
+    auto value_size = parser.consume_be_type<int32_t>();
+    std::optional<iobuf> value;
+    if (value_size != -1) {
+        value = parser.share(value_size);
+    }
+
+    return legacy_message{
+      .base_offset = base_offset,
+      .batch_length = batch_length,
+      .batch_crc = expected_crc,
+      .magic = magic,
+      .attributes = attributes,
+      .timestamp = timestamp,
+      .key = std::move(key),
+      .value = std::move(value),
+    };
+}
+
+} // namespace kafka

--- a/src/v/kafka/protocol/legacy_message.h
+++ b/src/v/kafka/protocol/legacy_message.h
@@ -69,8 +69,7 @@ struct legacy_message {
     }
 };
 
-inline std::ostream&
-operator<<(std::ostream& os, const legacy_message& m) {
+inline std::ostream& operator<<(std::ostream& os, const legacy_message& m) {
     fmt::print(
       os,
       "{{offset {} length {} crc {} magic {} attrs {}:{} ts {} key {} value "
@@ -87,8 +86,7 @@ operator<<(std::ostream& os, const legacy_message& m) {
     return os;
 }
 
-inline std::optional<legacy_message>
-decode_legacy_batch(iobuf_parser& parser) {
+inline std::optional<legacy_message> decode_legacy_batch(iobuf_parser& parser) {
     auto base_offset = model::offset(parser.consume_be_type<int64_t>());
     auto batch_length = parser.consume_be_type<int32_t>();
     auto expected_crc = parser.consume_be_type<int32_t>();

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -842,7 +842,11 @@ writer.write({{ fname }});
 {
     auto tmp = reader.{{ decoder }};
     if (tmp) {
+{%- if named_type == "kafka::produce_request_record_data" %}
+        {{ fname }} = {{ named_type }}(std::move(*tmp), version);
+{%- else %}
         {{ fname }} = {{ named_type }}(std::move(*tmp));
+{%- endif %}
     }
 }
 {%- else %}

--- a/src/v/kafka/server/handlers/produce.h
+++ b/src/v/kafka/server/handlers/produce.h
@@ -14,6 +14,6 @@
 
 namespace kafka {
 
-using produce_handler = handler<produce_api, 3, 7>;
+using produce_handler = handler<produce_api, 0, 7>;
 
 }

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -11,7 +11,6 @@
 
 #pragma once
 #include "bytes/bytes.h"
-#include "kafka/protocol/kafka_batch_adapter.h"
 #include "reflection/adl.h"
 #include "seastarx.h"
 #include "utils/named_type.h"
@@ -148,38 +147,6 @@ struct member_protocol {
 std::ostream& operator<<(std::ostream&, const member_protocol&);
 
 using assignments_type = std::unordered_map<member_id, bytes>;
-
-/*
- * Helper wrapper type that handles conversion when encoding/decoding produce
- * requests. This type replaces iobuf in the generated code for kafka request
- * types.
- */
-struct produce_request_record_data {
-    explicit produce_request_record_data(std::optional<iobuf>&& data) {
-        if (data) {
-            adapter.adapt(std::move(*data));
-        }
-    }
-
-    explicit produce_request_record_data(model::record_batch&& batch) {
-        adapter.v2_format = true;
-        adapter.valid_crc = true;
-        adapter.batch = std::move(batch);
-    }
-
-    kafka_batch_adapter adapter;
-};
-
-inline std::ostream&
-operator<<(std::ostream& os, const produce_request_record_data& data) {
-    fmt::print(
-      os,
-      "batch {} v2_format {} valid_crc {}",
-      data.adapter.batch ? data.adapter.batch->size_bytes() : -1,
-      data.adapter.v2_format,
-      data.adapter.valid_crc);
-    return os;
-}
 
 } // namespace kafka
 

--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -63,7 +63,8 @@ void crc_extend_all_cpu_to_be(crc::crc32c& crc, T... t) {
     ((crc_extend_cpu_to_be(crc, t)), ...);
 }
 
-void crc_record_batch_header(crc::crc32c& crc, const record_batch_header& header) {
+void crc_record_batch_header(
+  crc::crc32c& crc, const record_batch_header& header) {
     crc_extend_all_cpu_to_be(
       crc,
       header.attrs.value(),

--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -17,20 +17,20 @@
 namespace model {
 
 template<typename T, typename = std::enable_if_t<std::is_integral_v<T>, T>>
-void crc_extend_cpu_to_le(crc32& crc, T i) {
+void crc_extend_cpu_to_le(crc::crc32c& crc, T i) {
     auto j = ss::cpu_to_le(i);
     crc.extend(j);
 }
 
 template<typename... T>
-void crc_extend_all_cpu_to_le(crc32& crc, T... t) {
+void crc_extend_all_cpu_to_le(crc::crc32c& crc, T... t) {
     ((crc_extend_cpu_to_le(crc, t)), ...);
 }
 
 /// \brief uint32_t because that's what crc32c uses
 /// it is *only* record_batch_header.header_crc;
 uint32_t internal_header_only_crc(const record_batch_header& header) {
-    auto c = crc32();
+    auto c = crc::crc32c();
     crc_extend_all_cpu_to_le(
       c,
       /*Additional fields*/
@@ -53,17 +53,17 @@ uint32_t internal_header_only_crc(const record_batch_header& header) {
 }
 
 template<typename T, typename = std::enable_if_t<std::is_integral_v<T>, T>>
-void crc_extend_cpu_to_be(crc32& crc, T i) {
+void crc_extend_cpu_to_be(crc::crc32c& crc, T i) {
     auto j = ss::cpu_to_be(i);
     crc.extend(j);
 }
 
 template<typename... T>
-void crc_extend_all_cpu_to_be(crc32& crc, T... t) {
+void crc_extend_all_cpu_to_be(crc::crc32c& crc, T... t) {
     ((crc_extend_cpu_to_be(crc, t)), ...);
 }
 
-void crc_record_batch_header(crc32& crc, const record_batch_header& header) {
+void crc_record_batch_header(crc::crc32c& crc, const record_batch_header& header) {
     crc_extend_all_cpu_to_be(
       crc,
       header.attrs.value(),
@@ -77,7 +77,7 @@ void crc_record_batch_header(crc32& crc, const record_batch_header& header) {
 }
 
 int32_t crc_record_batch(const record_batch_header& hdr, const iobuf& records) {
-    auto crc = crc32();
+    auto crc = crc::crc32c();
     crc_record_batch_header(crc, hdr);
     crc_extend_iobuf(crc, records);
     return crc.value();

--- a/src/v/model/record_utils.h
+++ b/src/v/model/record_utils.h
@@ -20,7 +20,7 @@ struct record_batch_header;
 class record_batch;
 class record;
 
-void crc_record_batch_header(crc32&, const record_batch_header&);
+void crc_record_batch_header(crc::crc32c&, const record_batch_header&);
 
 /// \brief int32_t because that's what kafka uses
 int32_t crc_record_batch(const record_batch& b);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -56,7 +56,7 @@ public:
         model::term_id term{0};
 
         uint32_t crc() const {
-            crc32 c;
+            crc::crc32c c;
             c.extend(voted_for());
             c.extend(term());
             return c.value();
@@ -68,7 +68,7 @@ public:
         model::term_id term{0};
 
         uint32_t crc() const {
-            crc32 c;
+            crc::crc32c c;
             c.extend(voted_for.id()());
             c.extend(voted_for.revision()());
             c.extend(term());

--- a/src/v/rpc/types.cc
+++ b/src/v/rpc/types.cc
@@ -21,13 +21,13 @@
 
 namespace rpc {
 template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-void crc_one(crc32& crc, T t) {
+void crc_one(crc::crc32c& crc, T t) {
     T args_le = ss::cpu_to_le(t);
     crc.extend(args_le);
 }
 
 uint32_t checksum_header_only(const header& h) {
-    auto crc = crc32();
+    auto crc = crc::crc32c();
     crc_one(
       crc,
       static_cast<std::underlying_type_t<compression_type>>(h.compression));

--- a/src/v/storage/compacted_index_chunk_reader.cc
+++ b/src/v/storage/compacted_index_chunk_reader.cc
@@ -81,7 +81,9 @@ ss::future<> compacted_index_chunk_reader::verify_integrity() {
                    _file_size.value() - compacted_index::footer_size,
                    std::move(options)),
                  [](
-                   int32_t& max_bytes, crc::crc32c& crc, ss::input_stream<char>& in) {
+                   int32_t& max_bytes,
+                   crc::crc32c& crc,
+                   ss::input_stream<char>& in) {
                      return ss::do_until(
                               [&in, &max_bytes] {
                                   // stop condition

--- a/src/v/storage/compacted_index_chunk_reader.cc
+++ b/src/v/storage/compacted_index_chunk_reader.cc
@@ -74,14 +74,14 @@ ss::future<> compacted_index_chunk_reader::verify_integrity() {
         options.read_ahead = 1;
         return ss::do_with(
                  int32_t(_footer->size),
-                 crc32{},
+                 crc::crc32c{},
                  ss::make_file_input_stream(
                    _handle,
                    0,
                    _file_size.value() - compacted_index::footer_size,
                    std::move(options)),
                  [](
-                   int32_t& max_bytes, crc32& crc, ss::input_stream<char>& in) {
+                   int32_t& max_bytes, crc::crc32c& crc, ss::input_stream<char>& in) {
                      return ss::do_until(
                               [&in, &max_bytes] {
                                   // stop condition

--- a/src/v/storage/log_replayer.cc
+++ b/src/v/storage/log_replayer.cc
@@ -53,7 +53,7 @@ public:
       size_t size_on_disk) override {
         _header = header;
         _file_pos_to_end_of_batch = size_on_disk + physical_base_offset;
-        _crc = crc32();
+        _crc = crc::crc32c();
         model::crc_record_batch_header(_crc, header);
     }
 
@@ -88,7 +88,7 @@ private:
     model::record_batch_header _header;
     segment* _seg;
     log_replayer::checkpoint& _cfg;
-    crc32 _crc;
+    crc::crc32c _crc;
     size_t _file_pos_to_end_of_batch{0};
 };
 

--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -28,7 +28,9 @@ record_batch_builder::~record_batch_builder() {}
 
 model::record_batch record_batch_builder::build() && {
     int32_t offset_delta = 0;
-    auto now_ts = model::timestamp::now();
+    if (!_timestamp) {
+        _timestamp = model::timestamp::now();
+    }
 
     model::record_batch_header header = {
       .size_bytes = 0,
@@ -37,8 +39,8 @@ model::record_batch record_batch_builder::build() && {
       .crc = 0, // crc computed later
       .attrs = model::record_batch_attributes{} |= _compression,
       .last_offset_delta = static_cast<int32_t>(_records.size() - 1),
-      .first_timestamp = now_ts,
-      .max_timestamp = now_ts,
+      .first_timestamp = *_timestamp,
+      .max_timestamp = *_timestamp,
       .producer_id = _producer_id,
       .producer_epoch = _producer_epoch,
       .base_sequence = -1,

--- a/src/v/storage/record_batch_builder.cc
+++ b/src/v/storage/record_batch_builder.cc
@@ -56,7 +56,7 @@ model::record_batch record_batch_builder::build() && {
     iobuf records;
     for (auto& sr : _records) {
         auto rec_sz = record_size(offset_delta, sr);
-        auto kz = sr.key.size_bytes();
+        auto kz = sr.encoded_key_size;
         auto vz = sr.encoded_value_size;
         auto r = model::record(
           rec_sz,
@@ -82,7 +82,7 @@ uint32_t record_batch_builder::record_size(
     uint32_t size = sizeof(model::record_attributes::type)  // attributes
                     + zero_vint_size                        // timestamp delta
                     + vint::vint_size(offset_delta)         // offset_delta
-                    + vint::vint_size(r.key.size_bytes())   // key size
+                    + vint::vint_size(r.encoded_key_size)   // key size
                     + r.key.size_bytes()                    // key
                     + vint::vint_size(r.encoded_value_size) // value size
                     + r.value.size_bytes()                  // value

--- a/src/v/storage/record_batch_builder.h
+++ b/src/v/storage/record_batch_builder.h
@@ -25,12 +25,12 @@ public:
     record_batch_builder& operator=(const record_batch_builder&) = delete;
 
     virtual record_batch_builder&
-    add_raw_kv(iobuf&& key, std::optional<iobuf>&& value) {
+    add_raw_kv(std::optional<iobuf>&& key, std::optional<iobuf>&& value) {
         _records.emplace_back(std::move(key), std::move(value));
         return *this;
     }
     virtual record_batch_builder& add_raw_kw(
-      iobuf&& key,
+      std::optional<iobuf>&& key,
       std::optional<iobuf>&& value,
       std::vector<model::record_header> headers) {
         _records.emplace_back(
@@ -53,12 +53,17 @@ private:
     static constexpr int64_t zero_vint_size = vint::vint_size(0);
     struct serialized_record {
         serialized_record(
-          iobuf k,
+          std::optional<iobuf> k,
           std::optional<iobuf> v,
           std::vector<model::record_header> hdrs
           = std::vector<model::record_header>())
-          : key(std::move(k))
-          , headers(std::move(hdrs)) {
+          : headers(std::move(hdrs)) {
+            if (k) {
+                key = std::move(*k);
+                encoded_key_size = key.size_bytes();
+            } else {
+                encoded_key_size = -1;
+            }
             if (likely(v)) {
                 value = std::move(*v);
                 encoded_value_size = value.size_bytes();
@@ -68,6 +73,7 @@ private:
         }
 
         iobuf key;
+        int32_t encoded_key_size;
         iobuf value;
         int32_t encoded_value_size;
         std::vector<model::record_header> headers;

--- a/src/v/storage/record_batch_builder.h
+++ b/src/v/storage/record_batch_builder.h
@@ -51,6 +51,8 @@ public:
 
     void set_compression(model::compression c) { _compression = c; }
 
+    void set_timestamp(model::timestamp ts) { _timestamp = ts; }
+
 private:
     static constexpr int64_t zero_vint_size = vint::vint_size(0);
     struct serialized_record {
@@ -91,5 +93,6 @@ private:
     bool _transactional_type{false};
     std::vector<serialized_record> _records;
     model::compression _compression{model::compression::none};
+    std::optional<model::timestamp> _timestamp;
 };
 } // namespace storage

--- a/src/v/storage/record_batch_builder.h
+++ b/src/v/storage/record_batch_builder.h
@@ -49,6 +49,8 @@ public:
 
     void set_transactional_type() { _transactional_type = true; }
 
+    void set_compression(model::compression c) { _compression = c; }
+
 private:
     static constexpr int64_t zero_vint_size = vint::vint_size(0);
     struct serialized_record {
@@ -88,5 +90,6 @@ private:
     bool _is_control_type{false};
     bool _transactional_type{false};
     std::vector<serialized_record> _records;
+    model::compression _compression{model::compression::none};
 };
 } // namespace storage

--- a/src/v/storage/snapshot.cc
+++ b/src/v/storage/snapshot.cc
@@ -147,7 +147,7 @@ ss::future<snapshot_header> snapshot_reader::read_header() {
             "Invalid metadata size {}",
             hdr.metadata_size);
 
-          crc32 crc;
+          crc::crc32c crc;
           crc.extend(ss::cpu_to_le(hdr.metadata_crc));
           crc.extend(ss::cpu_to_le(hdr.version));
           crc.extend(ss::cpu_to_le(hdr.metadata_size));
@@ -184,7 +184,7 @@ ss::future<iobuf> snapshot_reader::read_metadata() {
                       "Corrupt snapshot. Failed to read metadata: {}", _path)));
               }
 
-              crc32 crc;
+              crc::crc32c crc;
               crc_extend_iobuf(crc, buf);
 
               if (header.metadata_crc != crc.value()) {
@@ -238,11 +238,11 @@ ss::future<> snapshot_writer::write_metadata(iobuf buf) {
     header.version = snapshot_header::supported_version;
     header.metadata_size = buf.size_bytes();
 
-    crc32 meta_crc;
+    crc::crc32c meta_crc;
     crc_extend_iobuf(meta_crc, buf);
     header.metadata_crc = meta_crc.value();
 
-    crc32 header_crc;
+    crc::crc32c header_crc;
     header_crc.extend(ss::cpu_to_le(header.metadata_crc));
     header_crc.extend(ss::cpu_to_le(header.version));
     header_crc.extend(ss::cpu_to_le(header.metadata_size));

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -84,7 +84,7 @@ private:
     size_t _max_mem;
     size_t _keys_mem_usage{0};
     compacted_index::footer _footer;
-    crc32 _crc;
+    crc::crc32c _crc;
 
     friend std::ostream& operator<<(std::ostream&, const spill_key_index&);
 };


### PR DESCRIPTION
Supports produce version 0 which requires handling older message formats as well. We handle these by translating into our internal record batch format.

Fixes: #873 
