### PR TITLE
Compaction backlog controller

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -345,7 +345,7 @@ configuration::configuration()
       "log_compaction_interval_ms",
       "How often do we trigger background compaction",
       required::no,
-      5min)
+      10s)
   , retention_bytes(
       *this,
       "retention_bytes",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -547,6 +547,47 @@ configuration::configuration()
       "Interval between iterations of controller backend housekeeping loop",
       required::no,
       1s)
+  , compaction_ctrl_update_interval_ms(
+      *this, "compaction_ctrl_update_interval_ms", "", required::no, 30s)
+  , compaction_ctrl_p_coeff(
+      *this,
+      "compaction_ctrl_p_coeff",
+      "proportional coefficient for compaction PID controller. This has to be "
+      "negative since compaction backlog should decrease when number of "
+      "compaction shares increases",
+      required::no,
+      -12.5)
+  , compaction_ctrl_i_coeff(
+      *this,
+      "compaction_ctrl_i_coeff",
+      "integral coefficient for compaction PID controller.",
+      required::no,
+      0.0)
+  , compaction_ctrl_d_coeff(
+      *this,
+      "compaction_ctrl_d_coeff",
+      "derivative coefficient for compaction PID controller.",
+      required::no,
+      0.2)
+  , compaction_ctrl_min_shares(
+      *this,
+      "compaction_ctrl_min_shares",
+      "minimum number of IO and CPU shares that compaction process can use",
+      required::no,
+      10)
+  , compaction_ctrl_max_shares(
+      *this,
+      "compaction_ctrl_max_shares",
+      "maximum number of IO and CPU shares that compaction process can use",
+      required::no,
+      1000)
+  , compaction_ctrl_backlog_size(
+      *this,
+      "compaction_ctrl_backlog_size",
+      "target backlog size for compaction controller. if not set compaction "
+      "target compaction backlog would be equal to ",
+      required::no,
+      std::nullopt)
   , cloud_storage_enabled(
       *this,
       "cloud_storage_enabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -141,6 +141,15 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       controller_backend_housekeeping_interval_ms;
 
+    // Compaction controller
+    property<std::chrono::milliseconds> compaction_ctrl_update_interval_ms;
+    property<double> compaction_ctrl_p_coeff;
+    property<double> compaction_ctrl_i_coeff;
+    property<double> compaction_ctrl_d_coeff;
+    property<int16_t> compaction_ctrl_min_shares;
+    property<int16_t> compaction_ctrl_max_shares;
+    property<std::optional<size_t>> compaction_ctrl_backlog_size;
+
     // Archival storage
     property<bool> cloud_storage_enabled;
     property<std::optional<ss::sstring>> cloud_storage_access_key;

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -31,6 +31,7 @@
 #include "rpc/server.h"
 #include "seastarx.h"
 #include "security/credential_store.h"
+#include "storage/compaction_controller.h"
 #include "storage/fwd.h"
 
 #include <seastar/core/app-template.hh>
@@ -138,6 +139,8 @@ private:
     ss::sharded<pandaproxy::rest::proxy> _proxy;
     ss::sharded<kafka::client::client> _schema_registry_client;
     ss::sharded<pandaproxy::schema_registry::service> _schema_registry;
+    ss::sharded<storage::compaction_controller> _compaction_controller;
+
     ss::metrics::metric_groups _metrics;
     kafka::rm_group_proxy_impl _rm_group_proxy;
     // run these first on destruction

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -31,6 +31,7 @@ v_cc_library(
     parser_utils.cc
     readers_cache.cc
     backlog_controller.cc
+    compaction_controller.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -30,6 +30,7 @@ v_cc_library(
     compaction_reducers.cc
     parser_utils.cc
     readers_cache.cc
+    backlog_controller.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/backlog_controller.cc
+++ b/src/v/storage/backlog_controller.cc
@@ -1,0 +1,159 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "storage/backlog_controller.h"
+
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+#include "ssx/sformat.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/metrics.hh>
+#include <seastar/core/reactor.hh>
+
+#include <limits>
+
+namespace storage {
+
+backlog_controller_config::backlog_controller_config(
+  double kp,
+  double ki,
+  double kd,
+  int64_t normalization_factor,
+  int64_t sp,
+  int initial_shares,
+  std::chrono::milliseconds interval,
+  ss::scheduling_group sg,
+  ss::io_priority_class iop,
+  int min,
+  int max)
+  : proportional_coeff(kp)
+  , integral_coeff(ki)
+  , derivative_coeff(kd)
+  , normalization_factor(normalization_factor)
+  , setpoint(sp)
+  , initial_shares(initial_shares)
+  , sampling_interval(interval)
+  , scheduling_group(sg)
+  , io_priority(iop)
+  , min_shares(min)
+  , max_shares(max) {}
+
+backlog_controller::backlog_controller(
+  std::unique_ptr<sampler> sampler,
+  ss::logger& logger,
+  backlog_controller_config cfg)
+  : _sampler(std::move(sampler))
+  , _log(logger)
+  , _proportional_coeff(cfg.proportional_coeff)
+  , _integral_coeff(cfg.integral_coeff)
+  , _derivative_coeff(cfg.derivative_coeff)
+  , _norm(cfg.normalization_factor)
+  , _sampling_interval(cfg.sampling_interval)
+  , _scheduling_group(cfg.scheduling_group)
+  , _io_priority(cfg.io_priority)
+  , _setpoint(cfg.setpoint / _norm)
+  , _current_shares(cfg.initial_shares)
+  , _min_shares(cfg.min_shares)
+  , _max_shares(cfg.max_shares) {}
+
+ss::future<> backlog_controller::start() {
+    _current_backlog = co_await _sampler->sample_backlog() / _norm;
+    _prev_error = _setpoint - _current_backlog;
+    _sampling_timer.set_callback([this] {
+        (void)ss::with_gate(_gate, [this] {
+            return update().then([this] {
+                if (!_gate.is_closed()) {
+                    _sampling_timer.arm(_sampling_interval);
+                }
+            });
+        });
+    });
+    _sampling_timer.arm(_sampling_interval);
+}
+
+void backlog_controller::update_setpoint(int64_t v) {
+    vlog(_log.info, "new setpoint value: {}", v);
+    _setpoint = v;
+}
+
+ss::future<> backlog_controller::stop() {
+    _sampling_timer.cancel();
+    return _gate.close();
+}
+
+ss::future<> backlog_controller::update() {
+    _current_backlog = co_await _sampler->sample_backlog() / _norm;
+    auto current_err = _setpoint - _current_backlog;
+
+    static constexpr int64_t max_error = std::numeric_limits<int32_t>::max();
+    _error_integral = std::clamp(
+      _error_integral + current_err, -max_error, max_error);
+
+    auto update = static_cast<double>(current_err);
+    if (_integral_coeff != 0.00) {
+        update += _integral_coeff * static_cast<double>(_error_integral);
+    }
+    if (_derivative_coeff != 0.00) {
+        update += _derivative_coeff
+                  * static_cast<double>(current_err - _prev_error);
+    }
+    update *= _proportional_coeff;
+    _current_shares = std::clamp(
+      static_cast<int>(update), _min_shares, _max_shares);
+    vlog(
+      _log.trace,
+      "state update: {{setpoint: {}, current_backlog: {}, current_error: {}, "
+      "prev_error: {}, shares_update: {}, current_share: {} }}",
+      _setpoint,
+      _current_backlog,
+      current_err,
+      _prev_error,
+      update,
+      _current_shares);
+
+    // update error sample
+    _prev_error = current_err;
+
+    co_await set();
+}
+
+ss::future<> backlog_controller::set() {
+    vlog(_log.debug, "updating shares {}", _current_shares);
+    _scheduling_group.set_shares(static_cast<float>(_current_shares));
+    return ss::engine().update_shares_for_class(_io_priority, _current_shares);
+}
+
+void backlog_controller::setup_metrics(const ss::sstring& controller_label) {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+    namespace sm = ss::metrics;
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name(
+        ssx::sformat("{}:backlog:controller", controller_label)),
+      {
+        sm::make_gauge(
+          "error",
+          [this] { return _prev_error; },
+          sm::description("current controller error, i.e difference between "
+                          "set point and backlog size")),
+        sm::make_gauge(
+          "shares",
+          [this] { return _current_shares; },
+          sm::description("controller output, i.e. number of shares")),
+        sm::make_gauge(
+          "backlog_size",
+          [this] { return _current_backlog; },
+          sm::description("controller backlog")),
+
+      });
+}
+
+} // namespace storage

--- a/src/v/storage/backlog_controller.h
+++ b/src/v/storage/backlog_controller.h
@@ -1,0 +1,130 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+#include "seastarx.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/metrics_registration.hh>
+#include <seastar/core/timer.hh>
+#include <seastar/util/log.hh>
+
+namespace storage {
+struct backlog_controller_config {
+    backlog_controller_config(
+      double proportional_coeff,
+      double integral_coeff,
+      double derivative_coeff,
+      int64_t normalization_factor,
+      int64_t setpoint,
+      int initial_shares,
+      std::chrono::milliseconds sampling_interval,
+      ss::scheduling_group sg,
+      ss::io_priority_class iopc,
+      int min_shares,
+      int max_shares);
+
+    double proportional_coeff;
+    double integral_coeff;
+    double derivative_coeff;
+    int64_t normalization_factor;
+    int64_t setpoint;
+    int initial_shares;
+    std::chrono::milliseconds sampling_interval;
+    ss::scheduling_group scheduling_group;
+    ss::io_priority_class io_priority;
+    int min_shares;
+    int max_shares;
+};
+/**
+ * Backlog controller is PID controller implementation to manage amount of
+ * seastar CPU and IO shares. This contoller works in an negative feedback loop
+ * using a backlog size as process value and amount of shares as a control
+ * value.
+ *
+ *                    ┌────────────────────┐            ┌──────────────┐
+ *   set backlog size │                    │ set shares │              │
+ *       ───────────┬─┤ backlog_controller ├────────────┤ some process │
+ *                - │ │                    │            │              │
+ *                  │ └────────────────────┘            └──────┬───────┘
+ *                  │                                          │
+ *                  │                                          │
+ *                  └──────────────────────────────────────────┘
+ *                                 current backlog size
+ *
+ * Backlog controller uses PID controller design to calculate the output shares.
+ *
+ *
+ *                 ┌────────────────────────┐
+ *                 │                        │
+ *               P │          error         ├─────┐
+ *                 │                        │     │
+ *                 └────────────────────────┘     │
+ *                                                │
+ *                 ┌────────────────────────┐     │
+ *                 │                        │    ┌▼┐      ┌─────┐ shares
+ *               I │ k_i*(aggregated_error) ├───►│+├─────►│ k_p ├──────►
+ *                 │                        │    └▲┘      └─────┘
+ *                 └────────────────────────┘     │
+ *                                                │
+ *                 ┌────────────────────────┐     │
+ *                 │                        │     │
+ *               D │  k_d*(err - prev_err)  ├─────┘
+ *                 │                        │
+ *                 └────────────────────────┘
+ *
+ * Both the integral and derivative actions of the controller can be disabled
+ * by setting corresponding coefficient to 0.
+ */
+class backlog_controller {
+public:
+    struct sampler {
+        virtual ss::future<int64_t> sample_backlog() = 0;
+        virtual ~sampler() noexcept = default;
+    };
+
+    backlog_controller(
+      std::unique_ptr<sampler>, ss::logger&, backlog_controller_config);
+
+    void update_setpoint(int64_t);
+    ss::future<> start();
+    ss::future<> stop();
+
+    void setup_metrics(const ss::sstring&);
+
+private:
+    ss::future<> set();
+    ss::future<> update();
+
+    void accumulate_error(int64_t);
+
+    std::unique_ptr<sampler> _sampler;
+    ss::logger& _log;
+    double _proportional_coeff; // controller 'gain' -  proportional coefficient
+    double _integral_coeff;     // integral part coefficient
+    double _derivative_coeff;   // derivative part coefficient
+    int64_t _norm;
+    std::chrono::milliseconds _sampling_interval;
+    ss::timer<> _sampling_timer;
+    // controlled resources
+    ss::scheduling_group _scheduling_group;
+    ss::io_priority_class _io_priority;
+    // state
+    int64_t _current_backlog{0};
+    int64_t _prev_error{0};
+    int64_t _error_integral{0};
+    int64_t _setpoint;
+    int _current_shares;
+    int _min_shares;
+    int _max_shares;
+    ss::gate _gate;
+    ss::metrics::metric_groups _metrics;
+};
+} // namespace storage

--- a/src/v/storage/compaction_controller.cc
+++ b/src/v/storage/compaction_controller.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "storage/compaction_controller.h"
+
+#include "storage/api.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace storage {
+static ss::logger compaction_log{"compaction_ctrl"};
+
+ss::future<int64_t> compaction_backlog_sampler::sample_backlog() {
+    co_return _api.local().log_mgr().compaction_backlog();
+}
+
+compaction_controller::compaction_controller(
+  ss::sharded<api>& api, backlog_controller_config cfg)
+  : _ctrl(
+    std::make_unique<compaction_backlog_sampler>(api), compaction_log, cfg) {
+    _ctrl.setup_metrics("storage:compaction");
+}
+
+} // namespace storage

--- a/src/v/storage/compaction_controller.h
+++ b/src/v/storage/compaction_controller.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "storage/backlog_controller.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace storage {
+
+struct compaction_backlog_sampler : public backlog_controller::sampler {
+    explicit compaction_backlog_sampler(ss::sharded<api>& api)
+      : _api(api) {}
+
+    ss::future<int64_t> sample_backlog() final;
+
+private:
+    ss::sharded<api>& _api;
+};
+/**
+ * PID controller to controll compaction scheduling and IO shares
+ */
+class compaction_controller {
+public:
+    compaction_controller(ss::sharded<api>&, backlog_controller_config);
+
+    ss::future<> start() { return _ctrl.start(); }
+    ss::future<> stop() { return _ctrl.stop(); }
+
+private:
+    backlog_controller _ctrl;
+};
+
+} // namespace storage

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -287,6 +287,7 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
           "segment {} compaction result: {}",
           seg->reader().filename(),
           result);
+        _compaction_ratio.update(result.compaction_ratio());
         // if we compacted segment return, otherwise loop
         if (result.did_compact()) {
             co_return;
@@ -300,6 +301,7 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
           "adjejcent segments of {}, compaction result: {}",
           config().ntp(),
           r);
+        _compaction_ratio.update(r.compaction_ratio());
     }
 }
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -512,7 +512,8 @@ ss::future<> disk_log_impl::compact(compaction_config cfg) {
     if (config().is_compacted() && !_segs.empty()) {
         f = f.then([this, cfg] { return do_compact(cfg); });
     }
-    return f;
+    return f.then(
+      [this] { _probe.set_compaction_ration(_compaction_ratio.get()); });
 }
 
 ss::future<> disk_log_impl::gc(compaction_config cfg) {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -22,6 +22,7 @@
 #include "storage/segment_appender.h"
 #include "storage/segment_reader.h"
 #include "storage/types.h"
+#include "utils/moving_average.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
@@ -149,6 +150,8 @@ private:
     model::offset _max_collectible_offset;
     size_t _max_segment_size;
     std::unique_ptr<readers_cache> _readers_cache;
+    // average ratio of segment sizes after segment size before compaction
+    moving_average<double, 5> _compaction_ratio{1.0};
 };
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -81,6 +81,8 @@ public:
     size_t size_bytes() const override { return _probe.partition_size(); }
     ss::future<> update_configuration(ntp_config::default_overrides) final;
 
+    int64_t compaction_backlog() const final;
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/fwd.h
+++ b/src/v/storage/fwd.h
@@ -20,5 +20,6 @@ class ntp_config;
 class segment;
 class snapshot_manager;
 class readers_cache;
+class compaction_controller;
 
 } // namespace storage

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -84,6 +84,8 @@ public:
         virtual ss::future<>
           update_configuration(ntp_config::default_overrides) = 0;
 
+        virtual int64_t compaction_backlog() const = 0;
+
     private:
         ntp_config _config;
 
@@ -176,6 +178,8 @@ public:
     ss::future<> update_configuration(ntp_config::default_overrides o) {
         return _impl->update_configuration(o);
     }
+
+    int64_t compaction_backlog() const { return _impl->compaction_backlog(); }
 
     std::ostream& print(std::ostream& o) const { return _impl->print(o); }
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -310,6 +310,15 @@ absl::flat_hash_set<model::ntp> log_manager::get_all_ntps() const {
     }
     return r;
 }
+int64_t log_manager::compaction_backlog() const {
+    return std::accumulate(
+      _logs.begin(),
+      _logs.end(),
+      int64_t(0),
+      [](int64_t acc, const logs_type::value_type& p) {
+          return acc + p.second.handle.compaction_backlog();
+      });
+}
 
 std::ostream& operator<<(std::ostream& o, log_config::storage_type t) {
     switch (t) {

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -216,6 +216,8 @@ public:
     /// Returns all ntp's managed by this instance
     absl::flat_hash_set<model::ntp> get_all_ntps() const;
 
+    int64_t compaction_backlog() const;
+
 private:
     using logs_type = absl::flat_hash_map<model::ntp, log_housekeeping_meta>;
 

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -312,6 +312,8 @@ struct mem_log_impl final : log::impl {
         return ss::now();
     }
 
+    int64_t compaction_backlog() const final { return 0; }
+
     ss::future<model::record_batch_reader>
     make_reader(log_reader_config cfg) final {
         auto it = std::lower_bound(

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -106,6 +106,11 @@ void probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _partition_bytes; },
           sm::description("Current size of partition in bytes"),
           labels),
+        sm::make_total_bytes(
+          "compaction_ratio",
+          [this] { return _compaction_ratio; },
+          sm::description("Average segment compaction ratio"),
+          labels),
       });
 }
 

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -67,6 +67,7 @@ public:
     size_t partition_size() const { return _partition_bytes; }
     void add_initial_segment(const segment&);
     void remove_partition_bytes(size_t remove) { _partition_bytes -= remove; }
+    void set_compaction_ration(double r) { _compaction_ratio = r; }
 
 private:
     uint64_t _partition_bytes = 0;
@@ -85,6 +86,7 @@ private:
     uint32_t _log_segments_active = 0;
     uint32_t _batch_parse_errors = 0;
     uint32_t _batch_write_errors = 0;
+    double _compaction_ratio = 1.0;
     ss::metrics::metric_groups _metrics;
 };
 } // namespace storage

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ rp_test(
     half_page_concurrent_dispatch.cc
     timequery_test.cc
     kvstore_test.cc
+    backlog_controller_test.cc
   LIBRARIES v::seastar_testing_main v::storage_test_utils
   LABELS storage
   ARGS "-- -c 1"

--- a/src/v/storage/tests/backlog_controller_test.cc
+++ b/src/v/storage/tests/backlog_controller_test.cc
@@ -1,0 +1,98 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "seastarx.h"
+#include "storage/backlog_controller.h"
+#include "test_utils/async.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/metrics_api.hh>
+#include <seastar/core/metrics_registration.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/util/log.hh>
+
+#include <cstdint>
+
+using namespace std::chrono_literals; // NOLINT
+static ss::logger ctrl_logger{"test-controller"};
+
+struct simple_backlog_sampler : storage::backlog_controller::sampler {
+    explicit simple_backlog_sampler(int64_t& b)
+      : current_backlog(b){};
+    ss::future<int64_t> sample_backlog() final { co_return current_backlog; }
+
+    int64_t& current_backlog;
+};
+
+struct backlog_controller_fixture {
+    const std::map<ss::sstring, ss::sstring> sch_group_label = {
+      {"group", "sch_control_gr"}, {"shard", "0"}};
+    backlog_controller_fixture()
+      : iopc(ss::engine().register_one_priority_class("io_control_gr", 100)) {
+        sg = ss::create_scheduling_group("sch_control_gr", 100).get();
+        /**
+         * Controller settings:
+         *
+         * proportional coefficient kp = -1.0 - negative reverse proportional to
+         * backlog integral coefficient ki = 0.4 derivative coefficient kd = 0.2
+         * initial setpoint sp = 20
+         * initial shares = 100
+         * min shares = 10
+         * max shares = 800
+         */
+        auto cfg = storage::backlog_controller_config(
+          -1.0, 0.4, 0.2, 1, 20, 100, 10ms, sg, iopc, 10, 800);
+
+        ctrl = std::make_unique<storage::backlog_controller>(
+          std::make_unique<simple_backlog_sampler>(backlog), ctrl_logger, cfg);
+    }
+
+    ss::io_priority_class iopc;
+    ss::scheduling_group sg;
+    std::unique_ptr<storage::backlog_controller> ctrl;
+    int64_t backlog{0};
+
+    int get_current_cpu_shares() const {
+        auto metrics = ss::metrics::impl::get_value_map();
+        auto it = std::find_if(
+          metrics.begin(),
+          metrics.end(),
+          [](const ss::metrics::impl::value_map::value_type& p) {
+              return p.first == "scheduler_shares";
+          });
+
+        auto m = it->second.find(sch_group_label);
+        return m->second->get_function()().i();
+    }
+};
+
+FIXTURE_TEST(test_feedback_loop, backlog_controller_fixture) {
+    ctrl->start().get0();
+    /**
+     * current backlog is equal to 0, setpoint is set to 20, error = 20.0
+     * since error hasn't changed and want some more backlog we will down
+     * schedule the group until min limit is reached
+     */
+    tests::cooperative_spin_wait_with_timeout(1500ms, [this] {
+        return get_current_cpu_shares() == 10;
+    }).get();
+
+    /**
+     * huge change in backlog size should cause immediate reaction of controller
+     */
+    backlog = 200;
+
+    tests::cooperative_spin_wait_with_timeout(1500ms, [this] {
+        return get_current_cpu_shares() == 800;
+    }).get();
+}

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -316,6 +316,11 @@ struct compaction_result {
 
     bool did_compact() const { return executed_compaction; }
 
+    double compaction_ratio() const {
+        return static_cast<double>(size_after)
+               / static_cast<double>(size_before);
+    }
+
     bool executed_compaction;
     size_t size_before;
     size_t size_after;

--- a/src/v/utils/moving_average.h
+++ b/src/v/utils/moving_average.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "likely.h"
+
+#include <array>
+#include <iterator>
+#include <numeric>
+
+/*
+ * simple moving average with configurable sample count
+ */
+
+template<typename T, size_t Samples>
+class moving_average {
+public:
+    explicit moving_average(T initial_value)
+      : _value(initial_value) {}
+
+    void update(T v) {
+        _running_sum -= _samples[_idx];
+        _samples[_idx] = v;
+        _running_sum += v;
+        _idx = (_idx + 1) % Samples;
+        if (unlikely(_valid_samples < Samples)) {
+            _valid_samples++;
+        }
+        _value = _running_sum / _valid_samples;
+    }
+
+    T get() const { return _value; }
+
+private:
+    std::array<T, Samples> _samples{0};
+    T _running_sum{0};
+    T _value{0};
+    size_t _idx{0};
+    size_t _valid_samples{0};
+};

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ rp_test(
     constexpr_string_switch.cc
     named_type_tests.cc
     tristate_test.cc
+    moving_average_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::utils
   LABELS utils

--- a/src/v/utils/tests/moving_average_test.cc
+++ b/src/v/utils/tests/moving_average_test.cc
@@ -1,0 +1,22 @@
+#include "utils/moving_average.h"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(test_moving_average) {
+    moving_average<int, 4> ma(0);
+
+    ma.update(1);
+    BOOST_REQUIRE_EQUAL(ma.get(), 1);
+    ma.update(2);
+    BOOST_REQUIRE_EQUAL(ma.get(), 1);
+    ma.update(3);
+    BOOST_REQUIRE_EQUAL(ma.get(), 2);
+    ma.update(6);
+
+    BOOST_REQUIRE_EQUAL(ma.get(), 3);
+
+    ma.update(9);
+
+    BOOST_REQUIRE_EQUAL(ma.get(), 5);
+}


### PR DESCRIPTION
## Cover letter

Implemented controller allowing us to automatically adjust log compaction priority taking current load and compaction backlog into account. This way users do not have to fine tune the compaction priority based on their use case but relay on redpanda to automatically adjust to current conditions. 

Fixes: #1390

## Release notes
- Introduced compaction controller to adapt rate of segments compaction to currently handled workload.