### PR TITLE
coproc/js: add logger as attribute on coprocessor apply fn

### DIFF
--- a/src/js/modules/public/Coprocessor.ts
+++ b/src/js/modules/public/Coprocessor.ts
@@ -16,6 +16,8 @@
  * Deregister: the coprocessor function will deregister from
  *             the function batch, it won't apply to any next records
  */
+import { Logger } from "winston";
+
 export enum PolicyError {
   SkipOnFailure,
   Deregister,
@@ -73,7 +75,10 @@ interface Coprocessor {
   inputTopics: string[];
   policyError: PolicyError;
   globalId: bigint;
-  apply: (record: RecordBatch) => Promise<Map<Topic, RecordBatch>>;
+  apply: (
+    record: RecordBatch,
+    logger?: Logger
+  ) => Promise<Map<Topic, RecordBatch>>;
 }
 
 export { RecordBatchHeader, RecordHeader, Record, RecordBatch, Coprocessor };

--- a/src/js/modules/supervisors/Repository.ts
+++ b/src/js/modules/supervisors/Repository.ts
@@ -27,7 +27,7 @@ import LogService from "../utilities/Logging";
  */
 class Repository {
   private logger = LogService.createLogger("FileManager");
-
+  private wasmLogger = LogService.createLogger("coproc");
   constructor() {
     this.handles = new Map();
   }
@@ -189,7 +189,7 @@ class Repository {
           }
           try {
             return handle.coprocessor
-              .apply(createRecordBatch(recordBatch))
+              .apply(createRecordBatch(recordBatch), this.wasmLogger)
               .then((resultMap) =>
                 this.validateResultApply(
                   requestItem,


### PR DESCRIPTION
## Cover letter

Pass a Winston logger as an argument on coprocessor apply function, this because the user can't use `console.log("")` for print information on the terminal, because redpanda only saves logs for wasm engine on `/var/lib/redpanda/coprocessor/logs/wasm` via winston logger