### PR TITLE
Introduce group transaction fencing

### DIFF
--- a/src/v/cluster/rm_group_proxy.h
+++ b/src/v/cluster/rm_group_proxy.h
@@ -26,12 +26,8 @@ public:
       model::timeout_clock::duration)
       = 0;
 
-    virtual ss::future<begin_group_tx_reply> begin_group_tx_locally(
-      kafka::group_id,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration)
-      = 0;
+    virtual ss::future<begin_group_tx_reply>
+      begin_group_tx_locally(begin_group_tx_request) = 0;
 
     virtual ss::future<prepare_group_tx_reply> prepare_group_tx(
       kafka::group_id,
@@ -41,13 +37,8 @@ public:
       model::timeout_clock::duration)
       = 0;
 
-    virtual ss::future<prepare_group_tx_reply> prepare_group_tx_locally(
-      kafka::group_id,
-      model::term_id,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration)
-      = 0;
+    virtual ss::future<prepare_group_tx_reply>
+      prepare_group_tx_locally(prepare_group_tx_request) = 0;
 
     virtual ss::future<commit_group_tx_reply> commit_group_tx(
       kafka::group_id,
@@ -56,19 +47,14 @@ public:
       model::timeout_clock::duration)
       = 0;
 
-    virtual ss::future<commit_group_tx_reply> commit_group_tx_locally(
-      kafka::group_id,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration)
-      = 0;
+    virtual ss::future<commit_group_tx_reply>
+      commit_group_tx_locally(commit_group_tx_request) = 0;
 
     virtual ss::future<abort_group_tx_reply> abort_group_tx(
       kafka::group_id, model::producer_identity, model::timeout_clock::duration)
       = 0;
 
-    virtual ss::future<abort_group_tx_reply> abort_group_tx_locally(
-      kafka::group_id, model::producer_identity, model::timeout_clock::duration)
-      = 0;
+    virtual ss::future<abort_group_tx_reply>
+      abort_group_tx_locally(abort_group_tx_request) = 0;
 };
 } // namespace cluster

--- a/src/v/cluster/rm_group_proxy.h
+++ b/src/v/cluster/rm_group_proxy.h
@@ -20,11 +20,17 @@ namespace cluster {
 class rm_group_proxy {
 public:
     virtual ss::future<begin_group_tx_reply> begin_group_tx(
-      kafka::group_id, model::producer_identity, model::timeout_clock::duration)
+      kafka::group_id,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration)
       = 0;
 
     virtual ss::future<begin_group_tx_reply> begin_group_tx_locally(
-      kafka::group_id, model::producer_identity, model::timeout_clock::duration)
+      kafka::group_id,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration)
       = 0;
 
     virtual ss::future<prepare_group_tx_reply> prepare_group_tx(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -424,7 +424,7 @@ ss::future<tx_errc> rm_stm::commit_tx(
     co_return tx_errc::none;
 }
 
-rm_stm::abort_origin rm_stm::get_abort_origin(
+abort_origin rm_stm::get_abort_origin(
   const model::producer_identity& pid, model::tx_seq tx_seq) const {
     auto expected_it = _mem_state.expected.find(pid);
     if (expected_it != _mem_state.expected.end()) {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -122,8 +122,6 @@ private:
 
     void compact_snapshot();
 
-    enum abort_origin { present, past, future };
-
     abort_origin
     get_abort_origin(const model::producer_identity&, model::tx_seq) const;
 

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -69,36 +69,22 @@ tx_gateway::abort_tx(abort_tx_request&& request, rpc::streaming_context&) {
 
 ss::future<begin_group_tx_reply> tx_gateway::begin_group_tx(
   begin_group_tx_request&& request, rpc::streaming_context&) {
-    return _rm_group_proxy->begin_group_tx_locally(
-      std::move(request.group_id),
-      request.pid,
-      request.tx_seq,
-      request.timeout);
+    return _rm_group_proxy->begin_group_tx_locally(std::move(request));
 };
 
 ss::future<prepare_group_tx_reply> tx_gateway::prepare_group_tx(
   prepare_group_tx_request&& request, rpc::streaming_context&) {
-    return _rm_group_proxy->prepare_group_tx_locally(
-      std::move(request.group_id),
-      request.etag,
-      request.pid,
-      request.tx_seq,
-      request.timeout);
+    return _rm_group_proxy->prepare_group_tx_locally(std::move(request));
 };
 
 ss::future<commit_group_tx_reply> tx_gateway::commit_group_tx(
   commit_group_tx_request&& request, rpc::streaming_context&) {
-    return _rm_group_proxy->commit_group_tx_locally(
-      std::move(request.group_id),
-      request.pid,
-      request.tx_seq,
-      request.timeout);
+    return _rm_group_proxy->commit_group_tx_locally(std::move(request));
 };
 
 ss::future<abort_group_tx_reply> tx_gateway::abort_group_tx(
   abort_group_tx_request&& request, rpc::streaming_context&) {
-    return _rm_group_proxy->abort_group_tx_locally(
-      std::move(request.group_id), request.pid, request.timeout);
+    return _rm_group_proxy->abort_group_tx_locally(std::move(request));
 }
 
 } // namespace cluster

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -70,7 +70,10 @@ tx_gateway::abort_tx(abort_tx_request&& request, rpc::streaming_context&) {
 ss::future<begin_group_tx_reply> tx_gateway::begin_group_tx(
   begin_group_tx_request&& request, rpc::streaming_context&) {
     return _rm_group_proxy->begin_group_tx_locally(
-      std::move(request.group_id), request.pid, request.timeout);
+      std::move(request.group_id),
+      request.pid,
+      request.tx_seq,
+      request.timeout);
 };
 
 ss::future<prepare_group_tx_reply> tx_gateway::prepare_group_tx(

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -539,15 +539,15 @@ ss::future<add_offsets_tx_reply> tx_gateway_frontend::do_add_offsets_to_tx(
         co_return add_offsets_tx_reply{
           .error_code = tx_errc::unknown_server_error};
     }
+    auto tx = tx_opt.value();
 
     auto group_info = co_await _rm_group_proxy->begin_group_tx(
-      request.group_id, pid, timeout);
+      request.group_id, pid, tx.tx_seq, timeout);
     if (group_info.ec != tx_errc::none) {
         vlog(clusterlog.warn, "error on begining group tx: {}", group_info.ec);
         co_return add_offsets_tx_reply{.error_code = group_info.ec};
     }
 
-    auto tx = tx_opt.value();
     auto has_added = stm->add_group(
       tx.id, tx.etag, request.group_id, group_info.etag);
     if (!has_added) {

--- a/src/v/cluster/tx_utils.h
+++ b/src/v/cluster/tx_utils.h
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
@@ -17,4 +30,6 @@ namespace cluster {
 model::record_batch
   make_fence_batch(model::control_record_version, model::producer_identity);
 
-}
+enum class abort_origin : int8_t { present, past, future };
+
+} // namespace cluster

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1197,9 +1197,9 @@ void group::fail_offset_commit(
 
 void group::reset_tx_state(model::term_id term) { _term = term; }
 
-void group::insert_prepared(group_prepared_tx tx) {
-    _prepared_txs[tx.pid] = prepared_tx{
-      .tx_seq = tx.tx_seq, .offsets = std::move(tx.offsets)};
+void group::insert_prepared(prepared_tx tx) {
+    auto pid = tx.pid;
+    _prepared_txs[pid] = std::move(tx);
 }
 
 ss::future<cluster::commit_group_tx_reply>

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1503,7 +1503,9 @@ group::handle_commit_tx(cluster::commit_group_tx_request r) {
     } else if (
       in_state(group_state::empty) || in_state(group_state::stable)
       || in_state(group_state::preparing_rebalance)) {
-        co_return co_await commit_tx(std::move(r));
+        co_return co_await _tx_mutex.with([this, r = std::move(r)]() mutable {
+            return commit_tx(std::move(r));
+        });
     } else if (in_state(group_state::completing_rebalance)) {
         co_return make_commit_tx_reply(cluster::tx_errc::rebalance_in_progress);
     } else {
@@ -1520,7 +1522,9 @@ group::handle_txn_offset_commit(txn_offset_commit_request r) {
     } else if (
       in_state(group_state::empty) || in_state(group_state::stable)
       || in_state(group_state::preparing_rebalance)) {
-        co_return co_await store_txn_offsets(std::move(r));
+        co_return co_await _tx_mutex.with([this, r = std::move(r)]() mutable {
+            return store_txn_offsets(std::move(r));
+        });
     } else if (in_state(group_state::completing_rebalance)) {
         co_return txn_offset_commit_response(
           r, error_code::rebalance_in_progress);
@@ -1540,7 +1544,9 @@ group::handle_begin_tx(cluster::begin_group_tx_request r) {
     } else if (
       in_state(group_state::empty) || in_state(group_state::stable)
       || in_state(group_state::preparing_rebalance)) {
-        co_return co_await begin_tx(std::move(r));
+        co_return co_await _tx_mutex.with([this, r = std::move(r)]() mutable {
+            return begin_tx(std::move(r));
+        });
     } else if (in_state(group_state::completing_rebalance)) {
         cluster::begin_group_tx_reply reply;
         reply.ec = cluster::tx_errc::rebalance_in_progress;
@@ -1562,7 +1568,9 @@ group::handle_prepare_tx(cluster::prepare_group_tx_request r) {
     } else if (
       in_state(group_state::stable) || in_state(group_state::empty)
       || in_state(group_state::preparing_rebalance)) {
-        co_return co_await prepare_tx(std::move(r));
+        co_return co_await _tx_mutex.with([this, r = std::move(r)]() mutable {
+            return prepare_tx(std::move(r));
+        });
     } else if (in_state(group_state::completing_rebalance)) {
         cluster::prepare_group_tx_reply reply;
         reply.ec = cluster::tx_errc::rebalance_in_progress;
@@ -1584,7 +1592,9 @@ group::handle_abort_tx(cluster::abort_group_tx_request r) {
     } else if (
       in_state(group_state::stable) || in_state(group_state::empty)
       || in_state(group_state::preparing_rebalance)) {
-        co_return co_await abort_tx(std::move(r));
+        co_return co_await _tx_mutex.with([this, r = std::move(r)]() mutable {
+            return abort_tx(std::move(r));
+        });
     } else if (in_state(group_state::completing_rebalance)) {
         cluster::abort_group_tx_reply reply;
         reply.ec = cluster::tx_errc::rebalance_in_progress;

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1415,7 +1415,7 @@ group::prepare_tx(cluster::prepare_group_tx_request r) {
           .metadata = offset.metadata.value_or("")};
         ptx.offsets[tp] = md;
     }
-    _prepared_txs.try_emplace(r.pid, ptx);
+    _prepared_txs[r.pid] = ptx;
     co_return make_prepare_tx_reply(cluster::tx_errc::none);
 }
 

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1330,10 +1330,13 @@ group::begin_tx(cluster::begin_group_tx_request r) {
 
     // TODO: https://app.clubhouse.io/vectorized/story/2194
     // (auto-abort txes with the the same producer_id but older epoch)
-    auto [_, inserted] = _volatile_txs.try_emplace(r.pid, volatile_tx());
+    auto [_, inserted] = _volatile_txs.try_emplace(
+      r.pid, volatile_tx{.tx_seq = r.tx_seq});
 
     if (!inserted) {
-        co_return make_begin_tx_reply(cluster::tx_errc::timeout);
+        // TODO: https://app.clubhouse.io/vectorized/story/2194
+        // (auto-abort txes with the the same producer_id but older epoch)
+        co_return make_begin_tx_reply(cluster::tx_errc::request_rejected);
     }
 
     cluster::begin_group_tx_reply reply;

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1369,7 +1369,7 @@ group::abort_tx(cluster::abort_group_tx_request r) {
     // (check for tx_seq to prevent old abort requests aborting
     // new transactions in the same session)
 
-    auto tx = aborted_tx{.group_id = r.group_id, .tx_seq = r.tx_seq};
+    auto tx = group_log_aborted_tx{.group_id = r.group_id, .tx_seq = r.tx_seq};
 
     // TODO: https://app.clubhouse.io/vectorized/story/2200
     // include producer_id+type into key to make it unique-ish

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1201,7 +1201,10 @@ void group::fail_offset_commit(
     }
 }
 
-void group::reset_tx_state(model::term_id term) { _term = term; }
+void group::reset_tx_state(model::term_id term) {
+    _term = term;
+    _volatile_txs.clear();
+}
 
 void group::insert_prepared(prepared_tx tx) {
     auto pid = tx.pid;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -469,6 +469,13 @@ public:
 
     void insert_prepared(group_prepared_tx);
 
+    void try_set_fence(model::producer_id id, model::producer_epoch epoch) {
+        auto [fence_it, _] = _fence_pid_epoch.try_emplace(id, epoch);
+        if (fence_it->second < epoch) {
+            fence_it->second = epoch;
+        }
+    }
+
     // helper for the kafka api: describe groups
     described_group describe() const;
 
@@ -511,6 +518,8 @@ private:
 
     mutex _tx_mutex;
     model::term_id _term;
+    absl::node_hash_map<model::producer_id, model::producer_epoch>
+      _fence_pid_epoch;
     absl::node_hash_map<model::topic_partition, offset_metadata>
       _pending_offset_commits;
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -123,10 +123,9 @@ public:
         // https://github.com/vectorizedio/redpanda/issues/1181
     };
 
-    struct group_prepared_tx {
+    struct prepared_tx {
         model::producer_identity pid;
         model::tx_seq tx_seq;
-        kafka::group_id group_id;
         absl::node_hash_map<model::topic_partition, offset_metadata> offsets;
     };
 
@@ -468,7 +467,7 @@ public:
         return inserted;
     }
 
-    void insert_prepared(group_prepared_tx);
+    void insert_prepared(prepared_tx);
 
     void try_set_fence(model::producer_id id, model::producer_epoch epoch) {
         auto [fence_it, _] = _fence_pid_epoch.try_emplace(id, epoch);
@@ -533,11 +532,6 @@ private:
     struct volatile_tx {
         model::tx_seq tx_seq;
         absl::node_hash_map<model::topic_partition, volatile_offset> offsets;
-    };
-
-    struct prepared_tx {
-        model::tx_seq tx_seq;
-        absl::node_hash_map<model::topic_partition, offset_metadata> offsets;
     };
 
     absl::node_hash_map<model::producer_identity, volatile_tx> _volatile_txs;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -128,11 +128,6 @@ public:
         absl::node_hash_map<model::topic_partition, offset_metadata> offsets;
     };
 
-    struct aborted_tx {
-        kafka::group_id group_id;
-        model::tx_seq tx_seq;
-    };
-
     group(
       kafka::group_id id,
       group_state s,

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "cluster/fwd.h"
 #include "cluster/partition.h"
+#include "cluster/tx_utils.h"
 #include "kafka/protocol/fwd.h"
 #include "kafka/server/logger.h"
 #include "kafka/server/member.h"
@@ -498,6 +499,9 @@ private:
     friend std::ostream& operator<<(std::ostream&, const group&);
 
     model::record_batch checkpoint(const assignments_type& assignments);
+
+    cluster::abort_origin
+    get_abort_origin(const model::producer_identity&, model::tx_seq) const;
 
     kafka::group_id _id;
     group_state _state;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -19,6 +19,7 @@
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "seastarx.h"
+#include "utils/mutex.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -508,6 +509,7 @@ private:
     ss::lw_shared_ptr<cluster::partition> _partition;
     absl::node_hash_map<model::topic_partition, offset_metadata> _offsets;
 
+    mutex _tx_mutex;
     model::term_id _term;
     absl::node_hash_map<model::topic_partition, offset_metadata>
       _pending_offset_commits;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -530,6 +530,7 @@ private:
     };
 
     struct volatile_tx {
+        model::tx_seq tx_seq;
         absl::node_hash_map<model::topic_partition, volatile_offset> offsets;
     };
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -125,6 +125,7 @@ public:
 
     struct group_prepared_tx {
         model::producer_identity pid;
+        model::tx_seq tx_seq;
         kafka::group_id group_id;
         absl::node_hash_map<model::topic_partition, offset_metadata> offsets;
     };
@@ -535,6 +536,7 @@ private:
     };
 
     struct prepared_tx {
+        model::tx_seq tx_seq;
         absl::node_hash_map<model::topic_partition, offset_metadata> offsets;
     };
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -515,6 +515,7 @@ private:
     config::configuration& _conf;
     ss::lw_shared_ptr<cluster::partition> _partition;
     absl::node_hash_map<model::topic_partition, offset_metadata> _offsets;
+    model::violation_recovery_policy _recovery_policy;
 
     mutex _tx_mutex;
     model::term_id _term;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -286,7 +286,6 @@ ss::future<> group_manager::recover_partition(
         }
     }
     p->term = term;
-    p->fence_pid_epoch = std::move(ctx.fence_pid_epoch);
 
     for (auto& [group_id, group_stm] : ctx.groups) {
         if (group_stm.has_data()) {
@@ -307,6 +306,10 @@ ss::future<> group_manager::recover_partition(
                     meta.metadata.metadata.value_or(""),
                   });
             }
+
+            for (auto& [id, epoch] : group_stm.fences()) {
+                group->try_set_fence(id, epoch);
+            }
         }
     }
 
@@ -322,6 +325,9 @@ ss::future<> group_manager::recover_partition(
         }
         for (const auto& [_, tx] : group_stm.prepared_txs()) {
             group->insert_prepared(tx);
+        }
+        for (auto& [id, epoch] : group_stm.fences()) {
+            group->try_set_fence(id, epoch);
         }
     }
 
@@ -445,12 +451,30 @@ recovery_batch_consumer::operator()(model::record_batch batch) {
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::no);
     } else if (batch.header().type == cluster::tx_fence_batch_type) {
-        auto bid = model::batch_identity::from(batch.header());
-        auto [fence_it, _] = st.fence_pid_epoch.try_emplace(
-          bid.pid.get_id(), bid.pid.get_epoch());
-        if (bid.pid.get_epoch() >= fence_it->second) {
-            fence_it->second = bid.pid.get_epoch();
-        }
+        vassert(
+          batch.record_count() == 1,
+          "fence batch must contain a single record");
+        auto r = batch.copy_records();
+        auto& record = *r.begin();
+        auto key_buf = record.release_key();
+        kafka::request_reader buf_reader(std::move(key_buf));
+        auto version = model::control_record_version(buf_reader.read_int16());
+
+        vassert(
+          version == group::fence_control_record_version,
+          "unknown group abort tx record version: {} expected: {}",
+          version,
+          group::fence_control_record_version);
+
+        const auto& hdr = batch.header();
+        auto bid = model::batch_identity::from(hdr);
+
+        auto val_buf = record.release_value();
+        auto val = reflection::from_iobuf<group_log_fencing>(
+          std::move(val_buf));
+
+        auto [group_it, _] = st.groups.try_emplace(val.group_id, group_stm());
+        group_it->second.try_set_fence(bid.pid.get_id(), bid.pid.get_epoch());
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::no);
     } else {
@@ -762,83 +786,32 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
         return ss::make_ready_future<cluster::begin_group_tx_reply>(
           make_begin_tx_reply(cluster::tx_errc::coordinator_load_in_progress));
     }
+    p->catchup_lock.read_unlock();
 
-    return do_begin_tx(p, std::move(r)).finally([p] {
-        p->catchup_lock.read_unlock();
-    });
-}
+    return p->catchup_lock.hold_read_lock().then(
+      [this, p, r = std::move(r)](ss::basic_rwlock<>::holder unit) mutable {
+          auto error = validate_group_status(
+            r.ntp, r.group_id, offset_commit_api::key);
+          if (error != error_code::none) {
+              auto ec = error == error_code::not_coordinator
+                          ? cluster::tx_errc::not_coordinator
+                          : cluster::tx_errc::timeout;
+              return ss::make_ready_future<cluster::begin_group_tx_reply>(
+                make_begin_tx_reply(ec));
+          }
 
-ss::future<cluster::begin_group_tx_reply> group_manager::do_begin_tx(
-  ss::lw_shared_ptr<attached_partition> partition,
-  cluster::begin_group_tx_request&& r) {
-    auto error = validate_group_status(
-      r.ntp, r.group_id, offset_commit_api::key);
-    if (error != error_code::none) {
-        if (error == error_code::not_coordinator) {
-            co_return make_begin_tx_reply(cluster::tx_errc::not_coordinator);
-        } else {
-            co_return make_begin_tx_reply(cluster::tx_errc::timeout);
-        }
-    }
+          auto group = get_group(r.group_id);
+          if (!group) {
+              group = ss::make_lw_shared<kafka::group>(
+                r.group_id, group_state::empty, _conf, p->partition);
+              group->reset_tx_state(p->term);
+              _groups.emplace(r.group_id, group);
+              _groups.rehash(0);
+          }
 
-    if (partition->partition->term() != partition->term) {
-        co_return make_begin_tx_reply(cluster::tx_errc::not_coordinator);
-    }
-
-    auto fence_it = partition->fence_pid_epoch.find(r.pid.get_id());
-    if (
-      fence_it == partition->fence_pid_epoch.end()
-      || r.pid.get_epoch() > fence_it->second) {
-        // TODO: https://app.clubhouse.io/vectorized/story/2200
-        // include producer_id into key to make it unique-ish
-        // to prevent being GCed by the compaction
-        auto batch = cluster::make_fence_batch(
-          fence_control_record_version, r.pid);
-        auto reader = model::make_memory_record_batch_reader(std::move(batch));
-        auto e = co_await partition->partition->replicate(
-          partition->term,
-          std::move(reader),
-          raft::replicate_options(raft::consistency_level::quorum_ack));
-
-        if (!e) {
-            vlog(
-              klog.error,
-              "Error \"{}\" on replicating pid:{} fencing batch",
-              e.error(),
-              r.pid);
-            co_return make_begin_tx_reply(cluster::tx_errc::timeout);
-        }
-
-        // we need to re-look up the current fencing token for
-        // current producer id because it might have been updated
-        // by a concurrent request while this fiber was waiting
-        // on partition->replicate
-        fence_it = partition->fence_pid_epoch.find(r.pid.get_id());
-    }
-
-    if (fence_it == partition->fence_pid_epoch.end()) {
-        partition->fence_pid_epoch.emplace(r.pid.get_id(), r.pid.get_epoch());
-    } else if (r.pid.get_epoch() >= fence_it->second) {
-        fence_it->second = r.pid.get_epoch();
-    } else {
-        vlog(
-          klog.error, "pid {} fenced out by epoch {}", r.pid, fence_it->second);
-        co_return make_begin_tx_reply(cluster::tx_errc::fenced);
-    }
-
-    auto group = get_group(r.group_id);
-    if (!group) {
-        // <kafka>the group is not relying on Kafka for group management, so
-        // allow the commit</kafka>
-        group = ss::make_lw_shared<kafka::group>(
-          r.group_id, group_state::empty, _conf, partition->partition);
-        group->reset_tx_state(partition->term);
-        _groups.emplace(r.group_id, group);
-        _groups.rehash(0);
-    }
-
-    auto reply = co_await group->handle_begin_tx(std::move(r));
-    co_return reply;
+          return group->handle_begin_tx(std::move(r))
+            .finally([unit = std::move(unit)] {});
+      });
 }
 
 ss::future<cluster::prepare_group_tx_reply>

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -436,7 +436,7 @@ recovery_batch_consumer::operator()(model::record_batch batch) {
         auto bid = model::batch_identity::from(hdr);
 
         auto val_buf = record.release_value();
-        auto val = reflection::from_iobuf<group::aborted_tx>(
+        auto val = reflection::from_iobuf<group_log_aborted_tx>(
           std::move(val_buf));
 
         auto [group_it, _] = st.groups.try_emplace(val.group_id, group_stm());

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -398,7 +398,7 @@ recovery_batch_consumer::operator()(model::record_batch batch) {
                      batch, group::prepared_tx_record_version)
                      .cmd;
 
-        auto [group_it, _] = st.groups.try_emplace(val.group_id, group_stm());
+        auto [group_it, _] = st.groups.try_emplace(val.group_id);
         group_it->second.update_prepared(batch.last_offset(), val);
 
         return ss::make_ready_future<ss::stop_iteration>(
@@ -407,8 +407,7 @@ recovery_batch_consumer::operator()(model::record_batch batch) {
         auto cmd = parse_tx_batch<group_log_commit_tx>(
           batch, group::commit_tx_record_version);
 
-        auto [group_it, _] = st.groups.try_emplace(
-          cmd.cmd.group_id, group_stm());
+        auto [group_it, _] = st.groups.try_emplace(cmd.cmd.group_id);
         group_it->second.commit(cmd.pid);
 
         return ss::make_ready_future<ss::stop_iteration>(
@@ -417,8 +416,7 @@ recovery_batch_consumer::operator()(model::record_batch batch) {
         auto cmd = parse_tx_batch<group_log_aborted_tx>(
           batch, group::aborted_tx_record_version);
 
-        auto [group_it, _] = st.groups.try_emplace(
-          cmd.cmd.group_id, group_stm());
+        auto [group_it, _] = st.groups.try_emplace(cmd.cmd.group_id);
         group_it->second.abort(cmd.pid, cmd.cmd.tx_seq);
 
         return ss::make_ready_future<ss::stop_iteration>(
@@ -427,8 +425,7 @@ recovery_batch_consumer::operator()(model::record_batch batch) {
         auto cmd = parse_tx_batch<group_log_fencing>(
           batch, group::fence_control_record_version);
 
-        auto [group_it, _] = st.groups.try_emplace(
-          cmd.cmd.group_id, group_stm());
+        auto [group_it, _] = st.groups.try_emplace(cmd.cmd.group_id);
         group_it->second.try_set_fence(cmd.pid.get_id(), cmd.pid.get_epoch());
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::no);

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -112,9 +112,6 @@ struct recovery_batch_consumer_state;
  */
 class group_manager {
 public:
-    static constexpr model::control_record_version fence_control_record_version{
-      0};
-
     group_manager(
       ss::sharded<raft::group_manager>& gm,
       ss::sharded<cluster::partition_manager>& pm,
@@ -195,8 +192,6 @@ private:
         ss::lw_shared_ptr<cluster::partition> partition;
         ss::basic_rwlock<> catchup_lock;
         model::term_id term{-1};
-        absl::flat_hash_map<model::producer_id, model::producer_epoch>
-          fence_pid_epoch;
 
         explicit attached_partition(ss::lw_shared_ptr<cluster::partition> p)
           : loading(true)
@@ -205,9 +200,6 @@ private:
 
     cluster::notification_id_type _leader_notify_handle;
     cluster::notification_id_type _topic_table_notify_handle;
-
-    ss::future<cluster::begin_group_tx_reply> do_begin_tx(
-      ss::lw_shared_ptr<attached_partition>, cluster::begin_group_tx_request&&);
 
     void handle_leader_change(
       model::term_id,
@@ -277,8 +269,6 @@ struct group_log_record_key {
  */
 struct recovery_batch_consumer_state {
     absl::node_hash_map<kafka::group_id, group_stm> groups;
-    absl::flat_hash_map<model::producer_id, model::producer_epoch>
-      fence_pid_epoch;
 };
 
 struct recovery_batch_consumer {

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -246,6 +246,12 @@ private:
     model::broker _self;
 };
 
+template<typename T>
+struct group_tx_cmd {
+    model::producer_identity pid;
+    T cmd;
+};
+
 /**
  * the key type for group membership log records.
  *

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -21,8 +21,7 @@ void group_stm::update_offset(
 
 void group_stm::update_prepared(
   model::offset offset, group_log_prepared_tx val) {
-    auto tx = group::group_prepared_tx{
-      .pid = val.pid, .tx_seq = val.tx_seq, .group_id = val.group_id};
+    auto tx = group::prepared_tx{.pid = val.pid, .tx_seq = val.tx_seq};
 
     auto [prepared_it, inserted] = _prepared_txs.try_emplace(
       tx.pid.get_id(), tx);

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -22,7 +22,7 @@ void group_stm::update_offset(
 void group_stm::update_prepared(
   model::offset offset, group_log_prepared_tx val) {
     auto tx = group::group_prepared_tx{
-      .pid = val.pid, .group_id = val.group_id};
+      .pid = val.pid, .tx_seq = val.tx_seq, .group_id = val.group_id};
 
     auto [prepared_it, inserted] = _prepared_txs.try_emplace(
       tx.pid.get_id(), tx);

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -68,6 +68,10 @@ struct group_log_prepared_tx_offset {
     std::optional<ss::sstring> metadata;
 };
 
+struct group_log_fencing {
+    kafka::group_id group_id;
+};
+
 struct group_log_prepared_tx {
     kafka::group_id group_id;
     // TODO: get rid of pid, we have it in the headers
@@ -121,6 +125,12 @@ public:
     void update_prepared(model::offset, group_log_prepared_tx);
     void commit(model::producer_identity);
     void abort(model::producer_identity, model::tx_seq);
+    void try_set_fence(model::producer_id id, model::producer_epoch epoch) {
+        auto [fence_it, _] = _fence_pid_epoch.try_emplace(id, epoch);
+        if (fence_it->second < epoch) {
+            fence_it->second = epoch;
+        }
+    }
     bool has_data() const {
         return !_is_removed && (_is_loaded || _offsets.size() > 0);
     }
@@ -136,10 +146,17 @@ public:
         return _offsets;
     }
 
+    const absl::node_hash_map<model::producer_id, model::producer_epoch>&
+    fences() const {
+        return _fence_pid_epoch;
+    }
+
 private:
     absl::node_hash_map<model::topic_partition, logged_metadata> _offsets;
     absl::node_hash_map<model::producer_id, group::group_prepared_tx>
       _prepared_txs;
+    absl::node_hash_map<model::producer_id, model::producer_epoch>
+      _fence_pid_epoch;
     group_log_group_metadata _metadata;
     bool _is_loaded{false};
     bool _is_removed{false};

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -137,7 +137,7 @@ public:
     }
     bool is_removed() const { return _is_removed; }
 
-    const absl::node_hash_map<model::producer_id, group::group_prepared_tx>&
+    const absl::node_hash_map<model::producer_id, group::prepared_tx>&
     prepared_txs() const {
         return _prepared_txs;
     }
@@ -154,8 +154,7 @@ public:
 
 private:
     absl::node_hash_map<model::topic_partition, logged_metadata> _offsets;
-    absl::node_hash_map<model::producer_id, group::group_prepared_tx>
-      _prepared_txs;
+    absl::node_hash_map<model::producer_id, group::prepared_tx> _prepared_txs;
     absl::node_hash_map<model::producer_id, model::producer_epoch>
       _fence_pid_epoch;
     group_log_group_metadata _metadata;

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -79,6 +79,11 @@ struct group_log_commit_tx {
     kafka::group_id group_id;
 };
 
+struct group_log_aborted_tx {
+    kafka::group_id group_id;
+    model::tx_seq tx_seq;
+};
+
 } // namespace kafka
 
 namespace std {

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -76,6 +76,7 @@ struct group_log_prepared_tx {
     kafka::group_id group_id;
     // TODO: get rid of pid, we have it in the headers
     model::producer_identity pid;
+    model::tx_seq tx_seq;
     std::vector<group_log_prepared_tx_offset> offsets;
 };
 

--- a/src/v/kafka/server/rm_group_frontend.cc
+++ b/src/v/kafka/server/rm_group_frontend.cc
@@ -136,8 +136,12 @@ ss::future<cluster::begin_group_tx_reply> rm_group_frontend::begin_group_tx(
     auto _self = _controller->self();
 
     if (leader == _self) {
-        co_return co_await begin_group_tx_locally(
-          group_id, pid, tx_seq, timeout);
+        cluster::begin_group_tx_request req;
+        req.group_id = group_id;
+        req.pid = pid;
+        req.tx_seq = tx_seq;
+        req.timeout = timeout;
+        co_return co_await begin_group_tx_locally(std::move(req));
     }
 
     vlog(klog.trace, "dispatching begin group tx to {} from {}", leader, _self);
@@ -182,17 +186,8 @@ rm_group_frontend::dispatch_begin_group_tx(
 }
 
 ss::future<cluster::begin_group_tx_reply>
-rm_group_frontend::begin_group_tx_locally(
-  kafka::group_id group_id,
-  model::producer_identity pid,
-  model::tx_seq tx_seq,
-  model::timeout_clock::duration timeout) {
-    cluster::begin_group_tx_request req;
-    req.group_id = group_id;
-    req.pid = pid;
-    req.tx_seq = tx_seq;
-    req.timeout = timeout;
-    co_return co_await _group_router.local().begin_tx(std::move(req));
+rm_group_frontend::begin_group_tx_locally(cluster::begin_group_tx_request req) {
+    return _group_router.local().begin_tx(std::move(req));
 }
 
 ss::future<cluster::prepare_group_tx_reply> rm_group_frontend::prepare_group_tx(
@@ -226,8 +221,13 @@ ss::future<cluster::prepare_group_tx_reply> rm_group_frontend::prepare_group_tx(
     auto _self = _controller->self();
 
     if (leader == _self) {
-        co_return co_await prepare_group_tx_locally(
-          group_id, etag, pid, tx_seq, timeout);
+        cluster::prepare_group_tx_request req;
+        req.group_id = group_id;
+        req.etag = etag;
+        req.pid = pid;
+        req.tx_seq = tx_seq;
+        req.timeout = timeout;
+        co_return co_await prepare_group_tx_locally(std::move(req));
     }
 
     vlog(klog.trace, "dispatching begin group tx to {} from {}", leader, _self);
@@ -277,19 +277,8 @@ rm_group_frontend::dispatch_prepare_group_tx(
 
 ss::future<cluster::prepare_group_tx_reply>
 rm_group_frontend::prepare_group_tx_locally(
-  kafka::group_id group_id,
-  model::term_id etag,
-  model::producer_identity pid,
-  model::tx_seq tx_seq,
-  model::timeout_clock::duration timeout) {
-    cluster::prepare_group_tx_request req;
-    req.group_id = group_id;
-    req.etag = etag;
-    req.pid = pid;
-    req.tx_seq = tx_seq;
-    req.timeout = timeout;
-
-    co_return co_await _group_router.local().prepare_tx(std::move(req));
+  cluster::prepare_group_tx_request req) {
+    return _group_router.local().prepare_tx(std::move(req));
 }
 
 ss::future<cluster::commit_group_tx_reply> rm_group_frontend::commit_group_tx(
@@ -323,8 +312,12 @@ ss::future<cluster::commit_group_tx_reply> rm_group_frontend::commit_group_tx(
     auto _self = _controller->self();
 
     if (leader == _self) {
-        co_return co_await commit_group_tx_locally(
-          group_id, pid, tx_seq, timeout);
+        cluster::commit_group_tx_request req;
+        req.group_id = group_id;
+        req.pid = pid;
+        req.tx_seq = tx_seq;
+        req.timeout = timeout;
+        co_return co_await commit_group_tx_locally(std::move(req));
     }
 
     vlog(
@@ -370,17 +363,8 @@ rm_group_frontend::dispatch_commit_group_tx(
 
 ss::future<cluster::commit_group_tx_reply>
 rm_group_frontend::commit_group_tx_locally(
-  kafka::group_id group_id,
-  model::producer_identity pid,
-  model::tx_seq tx_seq,
-  model::timeout_clock::duration timeout) {
-    cluster::commit_group_tx_request req;
-    req.group_id = group_id;
-    req.pid = pid;
-    req.tx_seq = tx_seq;
-    req.timeout = timeout;
-
-    co_return co_await _group_router.local().commit_tx(std::move(req));
+  cluster::commit_group_tx_request req) {
+    return _group_router.local().commit_tx(std::move(req));
 }
 
 ss::future<cluster::abort_group_tx_reply> rm_group_frontend::abort_group_tx(
@@ -412,7 +396,11 @@ ss::future<cluster::abort_group_tx_reply> rm_group_frontend::abort_group_tx(
     auto _self = _controller->self();
 
     if (leader == _self) {
-        co_return co_await abort_group_tx_locally(group_id, pid, timeout);
+        cluster::abort_group_tx_request req;
+        req.group_id = group_id;
+        req.pid = pid;
+        req.timeout = timeout;
+        co_return co_await abort_group_tx_locally(std::move(req));
     }
 
     vlog(klog.trace, "dispatching begin group tx to {} from {}", leader, _self);
@@ -451,16 +439,8 @@ rm_group_frontend::dispatch_abort_group_tx(
 }
 
 ss::future<cluster::abort_group_tx_reply>
-rm_group_frontend::abort_group_tx_locally(
-  kafka::group_id group_id,
-  model::producer_identity pid,
-  model::timeout_clock::duration timeout) {
-    cluster::abort_group_tx_request req;
-    req.group_id = group_id;
-    req.pid = pid;
-    req.timeout = timeout;
-
-    co_return co_await _group_router.local().abort_tx(std::move(req));
+rm_group_frontend::abort_group_tx_locally(cluster::abort_group_tx_request req) {
+    return _group_router.local().abort_tx(std::move(req));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/rm_group_frontend.h
+++ b/src/v/kafka/server/rm_group_frontend.h
@@ -46,10 +46,12 @@ public:
     ss::future<cluster::begin_group_tx_reply> begin_group_tx(
       kafka::group_id,
       model::producer_identity,
+      model::tx_seq,
       model::timeout_clock::duration);
     ss::future<cluster::begin_group_tx_reply> begin_group_tx_locally(
       kafka::group_id,
       model::producer_identity,
+      model::tx_seq,
       model::timeout_clock::duration);
     ss::future<cluster::prepare_group_tx_reply> prepare_group_tx(
       kafka::group_id,
@@ -96,6 +98,7 @@ private:
       model::node_id,
       kafka::group_id,
       model::producer_identity,
+      model::tx_seq,
       model::timeout_clock::duration);
     ss::future<cluster::prepare_group_tx_reply> dispatch_prepare_group_tx(
       model::node_id,
@@ -127,15 +130,18 @@ public:
     ss::future<cluster::begin_group_tx_reply> begin_group_tx(
       kafka::group_id group_id,
       model::producer_identity pid,
+      model::tx_seq tx_seq,
       model::timeout_clock::duration timeout) override {
-        return _target.local().begin_group_tx(group_id, pid, timeout);
+        return _target.local().begin_group_tx(group_id, pid, tx_seq, timeout);
     }
 
     ss::future<cluster::begin_group_tx_reply> begin_group_tx_locally(
       kafka::group_id group_id,
       model::producer_identity pid,
+      model::tx_seq tx_seq,
       model::timeout_clock::duration timeout) override {
-        return _target.local().begin_group_tx_locally(group_id, pid, timeout);
+        return _target.local().begin_group_tx_locally(
+          group_id, pid, tx_seq, timeout);
     }
 
     ss::future<cluster::prepare_group_tx_reply> prepare_group_tx(

--- a/src/v/kafka/server/rm_group_frontend.h
+++ b/src/v/kafka/server/rm_group_frontend.h
@@ -48,41 +48,29 @@ public:
       model::producer_identity,
       model::tx_seq,
       model::timeout_clock::duration);
-    ss::future<cluster::begin_group_tx_reply> begin_group_tx_locally(
-      kafka::group_id,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration);
+    ss::future<cluster::begin_group_tx_reply>
+      begin_group_tx_locally(cluster::begin_group_tx_request);
     ss::future<cluster::prepare_group_tx_reply> prepare_group_tx(
       kafka::group_id,
       model::term_id,
       model::producer_identity,
       model::tx_seq,
       model::timeout_clock::duration);
-    ss::future<cluster::prepare_group_tx_reply> prepare_group_tx_locally(
-      kafka::group_id,
-      model::term_id,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration);
+    ss::future<cluster::prepare_group_tx_reply>
+      prepare_group_tx_locally(cluster::prepare_group_tx_request);
     ss::future<cluster::commit_group_tx_reply> commit_group_tx(
       kafka::group_id,
       model::producer_identity,
       model::tx_seq,
       model::timeout_clock::duration);
-    ss::future<cluster::commit_group_tx_reply> commit_group_tx_locally(
-      kafka::group_id,
-      model::producer_identity,
-      model::tx_seq,
-      model::timeout_clock::duration);
+    ss::future<cluster::commit_group_tx_reply>
+      commit_group_tx_locally(cluster::commit_group_tx_request);
     ss::future<cluster::abort_group_tx_reply> abort_group_tx(
       kafka::group_id,
       model::producer_identity,
       model::timeout_clock::duration);
-    ss::future<cluster::abort_group_tx_reply> abort_group_tx_locally(
-      kafka::group_id,
-      model::producer_identity,
-      model::timeout_clock::duration);
+    ss::future<cluster::abort_group_tx_reply>
+      abort_group_tx_locally(cluster::abort_group_tx_request);
 
 private:
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
@@ -135,13 +123,9 @@ public:
         return _target.local().begin_group_tx(group_id, pid, tx_seq, timeout);
     }
 
-    ss::future<cluster::begin_group_tx_reply> begin_group_tx_locally(
-      kafka::group_id group_id,
-      model::producer_identity pid,
-      model::tx_seq tx_seq,
-      model::timeout_clock::duration timeout) override {
-        return _target.local().begin_group_tx_locally(
-          group_id, pid, tx_seq, timeout);
+    ss::future<cluster::begin_group_tx_reply>
+    begin_group_tx_locally(cluster::begin_group_tx_request req) override {
+        return _target.local().begin_group_tx_locally(std::move(req));
     }
 
     ss::future<cluster::prepare_group_tx_reply> prepare_group_tx(
@@ -154,14 +138,9 @@ public:
           group_id, etag, pid, tx_seq, timeout);
     }
 
-    ss::future<cluster::prepare_group_tx_reply> prepare_group_tx_locally(
-      kafka::group_id group_id,
-      model::term_id etag,
-      model::producer_identity pid,
-      model::tx_seq tx_seq,
-      model::timeout_clock::duration timeout) override {
-        return _target.local().prepare_group_tx_locally(
-          group_id, etag, pid, tx_seq, timeout);
+    ss::future<cluster::prepare_group_tx_reply>
+    prepare_group_tx_locally(cluster::prepare_group_tx_request req) override {
+        return _target.local().prepare_group_tx_locally(std::move(req));
     }
 
     ss::future<cluster::commit_group_tx_reply> commit_group_tx(
@@ -172,13 +151,9 @@ public:
         return _target.local().commit_group_tx(group_id, pid, tx_seq, timeout);
     }
 
-    ss::future<cluster::commit_group_tx_reply> commit_group_tx_locally(
-      kafka::group_id group_id,
-      model::producer_identity pid,
-      model::tx_seq tx_seq,
-      model::timeout_clock::duration timeout) override {
-        return _target.local().commit_group_tx_locally(
-          group_id, pid, tx_seq, timeout);
+    ss::future<cluster::commit_group_tx_reply>
+    commit_group_tx_locally(cluster::commit_group_tx_request req) override {
+        return _target.local().commit_group_tx_locally(std::move(req));
     }
 
     ss::future<cluster::abort_group_tx_reply> abort_group_tx(
@@ -188,11 +163,9 @@ public:
         return _target.local().abort_group_tx(group_id, pid, timeout);
     }
 
-    ss::future<cluster::abort_group_tx_reply> abort_group_tx_locally(
-      kafka::group_id group_id,
-      model::producer_identity pid,
-      model::timeout_clock::duration timeout) override {
-        return _target.local().abort_group_tx_locally(group_id, pid, timeout);
+    ss::future<cluster::abort_group_tx_reply>
+    abort_group_tx_locally(cluster::abort_group_tx_request req) override {
+        return _target.local().abort_group_tx_locally(std::move(req));
     }
 
 private:


### PR DESCRIPTION
Introduce tx_seq fencing to prevent delayed commit or abort requests from affecting ongoing fresher transactions on the consumer group level.

Kafka clients enforces one transaction per session and use session identifier (pid, epoch) to identify current transaction. As a result intra cluster delayed commit or abort requests (WriteTxnMarkers) issued for an old tx within the same session may be delayed and may accidentally affect newer transaction.

Redpanda fixes the problem by introducing tx_seq and using the triplets of (pid, epoch, tx_seq) for intra cluster transaction identification.

[ch2588] [ch2589]