### PR TITLE
kafka: remove server bits from protocol layer

### DIFF
--- a/src/v/kafka/client/assignment_plans.cc
+++ b/src/v/kafka/client/assignment_plans.cc
@@ -9,6 +9,9 @@
 
 #include "kafka/client/assignment_plans.h"
 
+#include "kafka/protocol/request_reader.h"
+#include "kafka/protocol/response_writer.h"
+
 namespace kafka::client {
 
 sync_group_request_assignment

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -20,8 +20,8 @@
 
 #include <seastar/core/future.hh>
 
-#include <absl/container/flat_hash_set.h>
-#include <absl/container/node_hash_set.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 namespace kafka::client {
 

--- a/src/v/kafka/protocol/add_offsets_to_txn.h
+++ b/src/v/kafka/protocol/add_offsets_to_txn.h
@@ -15,8 +15,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/add_offsets_to_txn_request.h"
 #include "kafka/protocol/schemata/add_offsets_to_txn_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
@@ -59,8 +57,8 @@ struct add_offsets_to_txn_response final {
 
     add_offsets_to_txn_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/add_partitions_to_txn.h
+++ b/src/v/kafka/protocol/add_partitions_to_txn.h
@@ -15,8 +15,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/add_partitions_to_txn_request.h"
 #include "kafka/protocol/schemata/add_partitions_to_txn_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
@@ -59,8 +57,8 @@ struct add_partitions_to_txn_response final {
 
     add_partitions_to_txn_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/alter_configs.h
+++ b/src/v/kafka/protocol/alter_configs.h
@@ -14,8 +14,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/alter_configs_request.h"
 #include "kafka/protocol/schemata/alter_configs_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -59,8 +57,8 @@ struct alter_configs_response final {
 
     alter_configs_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/api_versions.h
+++ b/src/v/kafka/protocol/api_versions.h
@@ -13,8 +13,6 @@
 
 #include "kafka/protocol/schemata/api_versions_request.h"
 #include "kafka/protocol/schemata/api_versions_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
@@ -49,8 +47,8 @@ struct api_versions_response final {
 
     api_versions_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/api_versions.h
+++ b/src/v/kafka/protocol/api_versions.h
@@ -64,6 +64,4 @@ inline bool operator==(
            && a.max_version == b.max_version;
 }
 
-std::vector<api_versions_response_key> get_supported_apis();
-
 } // namespace kafka

--- a/src/v/kafka/protocol/api_versions.h
+++ b/src/v/kafka/protocol/api_versions.h
@@ -42,6 +42,11 @@ struct api_versions_request final {
     }
 };
 
+inline std::ostream&
+operator<<(std::ostream& os, const api_versions_request& r) {
+    return os << r.data;
+}
+
 struct api_versions_response final {
     using api_type = api_versions_api;
 
@@ -56,7 +61,10 @@ struct api_versions_response final {
     }
 };
 
-std::ostream& operator<<(std::ostream&, const api_versions_response&);
+inline std::ostream&
+operator<<(std::ostream& os, const api_versions_response& r) {
+    return os << r.data;
+}
 
 inline bool operator==(
   const api_versions_response_key& a, const api_versions_response_key& b) {

--- a/src/v/kafka/protocol/create_acls.h
+++ b/src/v/kafka/protocol/create_acls.h
@@ -13,8 +13,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/create_acls_request.h"
 #include "kafka/protocol/schemata/create_acls_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -58,8 +56,8 @@ struct create_acls_response final {
 
     create_acls_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/create_topics.h
+++ b/src/v/kafka/protocol/create_topics.h
@@ -13,8 +13,6 @@
 
 #include "kafka/protocol/schemata/create_topics_request.h"
 #include "kafka/protocol/schemata/create_topics_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
@@ -57,8 +55,8 @@ struct create_topics_response final {
 
     create_topics_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/delete_acls.h
+++ b/src/v/kafka/protocol/delete_acls.h
@@ -13,8 +13,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/delete_acls_request.h"
 #include "kafka/protocol/schemata/delete_acls_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -58,8 +56,8 @@ struct delete_acls_response final {
 
     delete_acls_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/delete_groups.h
+++ b/src/v/kafka/protocol/delete_groups.h
@@ -54,7 +54,9 @@ struct delete_groups_response final {
         data.results = std::move(results);
     }
 
-    void encode(const request_context&, response&);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
 
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);

--- a/src/v/kafka/protocol/delete_topics.h
+++ b/src/v/kafka/protocol/delete_topics.h
@@ -15,8 +15,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/delete_topics_request.h"
 #include "kafka/protocol/schemata/delete_topics_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
@@ -59,8 +57,8 @@ struct delete_topics_response final {
 
     delete_topics_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/describe_acls.h
+++ b/src/v/kafka/protocol/describe_acls.h
@@ -13,8 +13,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/describe_acls_request.h"
 #include "kafka/protocol/schemata/describe_acls_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -58,8 +56,8 @@ struct describe_acls_response final {
 
     describe_acls_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/describe_configs.h
+++ b/src/v/kafka/protocol/describe_configs.h
@@ -14,8 +14,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/describe_configs_request.h"
 #include "kafka/protocol/schemata/describe_configs_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -62,8 +60,8 @@ struct describe_configs_response final {
     describe_configs_response()
       : data({.throttle_time_ms = std::chrono::milliseconds(0)}) {}
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/describe_configs.h
+++ b/src/v/kafka/protocol/describe_configs.h
@@ -57,9 +57,6 @@ struct describe_configs_response final {
 
     describe_configs_response_data data;
 
-    describe_configs_response()
-      : data({.throttle_time_ms = std::chrono::milliseconds(0)}) {}
-
     void encode(response_writer& writer, api_version version) {
         data.encode(writer, version);
     }

--- a/src/v/kafka/protocol/describe_groups.h
+++ b/src/v/kafka/protocol/describe_groups.h
@@ -14,7 +14,6 @@
 #include "kafka/protocol/schemata/describe_groups_request.h"
 #include "kafka/protocol/schemata/describe_groups_response.h"
 #include "kafka/server/group.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 
 #include <seastar/core/future.hh>
@@ -55,7 +54,9 @@ struct describe_groups_response final {
 
     describe_groups_response_data data;
 
-    void encode(const request_context& ctx, response& resp);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
 
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);

--- a/src/v/kafka/protocol/describe_log_dirs.h
+++ b/src/v/kafka/protocol/describe_log_dirs.h
@@ -13,8 +13,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/describe_log_dirs_request.h"
 #include "kafka/protocol/schemata/describe_log_dirs_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -58,8 +56,8 @@ struct describe_log_dirs_response final {
 
     describe_log_dirs_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/end_txn.h
+++ b/src/v/kafka/protocol/end_txn.h
@@ -15,8 +15,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/end_txn_request.h"
 #include "kafka/protocol/schemata/end_txn_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
@@ -58,8 +56,8 @@ struct end_txn_response final {
 
     end_txn_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/fetch.h
+++ b/src/v/kafka/protocol/fetch.h
@@ -195,8 +195,8 @@ struct fetch_response final {
 
     fetch_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/find_coordinator.h
+++ b/src/v/kafka/protocol/find_coordinator.h
@@ -63,13 +63,11 @@ struct find_coordinator_response final {
 
     find_coordinator_response_data data;
 
-    find_coordinator_response()
-      : data({.throttle_time_ms = std::chrono::milliseconds(0)}) {}
+    find_coordinator_response() = default;
 
     find_coordinator_response(
       error_code error, model::node_id node, ss::sstring host, int32_t port)
       : data({
-        .throttle_time_ms = std::chrono::milliseconds(0),
         .error_code = error,
         .node_id = node,
         .host = std::move(host),

--- a/src/v/kafka/protocol/find_coordinator.h
+++ b/src/v/kafka/protocol/find_coordinator.h
@@ -53,6 +53,11 @@ struct find_coordinator_request final {
     }
 };
 
+inline std::ostream&
+operator<<(std::ostream& os, const find_coordinator_request& r) {
+    return os << r.data;
+}
+
 struct find_coordinator_response final {
     using api_type = find_coordinator_api;
 

--- a/src/v/kafka/protocol/find_coordinator.h
+++ b/src/v/kafka/protocol/find_coordinator.h
@@ -13,8 +13,6 @@
 
 #include "kafka/protocol/schemata/find_coordinator_request.h"
 #include "kafka/protocol/schemata/find_coordinator_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "seastarx.h"
 
@@ -81,8 +79,8 @@ struct find_coordinator_response final {
     explicit find_coordinator_response(error_code error)
       : find_coordinator_response(error, model::node_id(-1), "", -1) {}
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/heartbeat.h
+++ b/src/v/kafka/protocol/heartbeat.h
@@ -60,7 +60,6 @@ struct heartbeat_response final {
 
     explicit heartbeat_response(error_code error)
       : data({
-        .throttle_time_ms = std::chrono::milliseconds(0),
         .error_code = error,
       }) {}
 

--- a/src/v/kafka/protocol/heartbeat.h
+++ b/src/v/kafka/protocol/heartbeat.h
@@ -13,7 +13,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/heartbeat_request.h"
 #include "kafka/protocol/schemata/heartbeat_response.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
@@ -68,7 +67,9 @@ struct heartbeat_response final {
     heartbeat_response(const heartbeat_request&, error_code error)
       : heartbeat_response(error) {}
 
-    void encode(const request_context&, response&);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
 
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);

--- a/src/v/kafka/protocol/incremental_alter_configs.h
+++ b/src/v/kafka/protocol/incremental_alter_configs.h
@@ -14,8 +14,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/incremental_alter_configs_request.h"
 #include "kafka/protocol/schemata/incremental_alter_configs_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -59,8 +57,8 @@ struct incremental_alter_configs_response final {
 
     incremental_alter_configs_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/init_producer_id.h
+++ b/src/v/kafka/protocol/init_producer_id.h
@@ -15,8 +15,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/init_producer_id_request.h"
 #include "kafka/protocol/schemata/init_producer_id_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
@@ -59,8 +57,8 @@ struct init_producer_id_response final {
 
     init_producer_id_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/join_group.h
+++ b/src/v/kafka/protocol/join_group.h
@@ -13,7 +13,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/join_group_request.h"
 #include "kafka/protocol/schemata/join_group_response.h"
-#include "kafka/server/request_context.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
@@ -39,7 +38,6 @@ struct join_group_request final {
     join_group_request_data data;
 
     join_group_request() = default;
-    explicit join_group_request(request_context& ctx) { decode(ctx); }
     join_group_request(const join_group_request&) = delete;
     join_group_request& operator=(const join_group_request&) = delete;
     join_group_request(join_group_request&&) = default;
@@ -75,7 +73,9 @@ struct join_group_request final {
         data.encode(writer, version);
     }
 
-    void decode(request_context& ctx);
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
 };
 
 inline std::ostream& operator<<(std::ostream& os, const join_group_request& r) {

--- a/src/v/kafka/protocol/join_group.h
+++ b/src/v/kafka/protocol/join_group.h
@@ -13,7 +13,7 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/join_group_request.h"
 #include "kafka/protocol/schemata/join_group_response.h"
-#include "kafka/server/response.h"
+#include "kafka/server/request_context.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
@@ -120,7 +120,9 @@ struct join_group_response final {
         data.members = std::move(members);
     }
 
-    void encode(const request_context&, response&);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
 
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);

--- a/src/v/kafka/protocol/leave_group.h
+++ b/src/v/kafka/protocol/leave_group.h
@@ -13,7 +13,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/leave_group_request.h"
 #include "kafka/protocol/schemata/leave_group_response.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
@@ -69,7 +68,9 @@ struct leave_group_response final {
     leave_group_response(const leave_group_request&, error_code error)
       : leave_group_response(error) {}
 
-    void encode(const request_context&, response&);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
 
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);

--- a/src/v/kafka/protocol/leave_group.h
+++ b/src/v/kafka/protocol/leave_group.h
@@ -61,7 +61,6 @@ struct leave_group_response final {
 
     explicit leave_group_response(error_code error)
       : data({
-        .throttle_time_ms = std::chrono::milliseconds(0),
         .error_code = error,
       }) {}
 

--- a/src/v/kafka/protocol/list_groups.h
+++ b/src/v/kafka/protocol/list_groups.h
@@ -12,7 +12,6 @@
 #pragma once
 #include "kafka/protocol/schemata/list_groups_request.h"
 #include "kafka/protocol/schemata/list_groups_response.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "seastarx.h"
 
@@ -54,7 +53,9 @@ struct list_groups_response final {
 
     list_groups_response_data data;
 
-    void encode(const request_context& ctx, response& resp);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
 
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);

--- a/src/v/kafka/protocol/list_offsets.h
+++ b/src/v/kafka/protocol/list_offsets.h
@@ -14,7 +14,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/list_offset_request.h"
 #include "kafka/protocol/schemata/list_offset_response.h"
-#include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
@@ -99,17 +98,17 @@ struct list_offsets_response final {
           id, error, model::timestamp(-1), model::offset(-1));
     }
 
-    void encode(const request_context& ctx, response& resp) {
+    void encode(response_writer& writer, api_version version) {
         // convert to version zero in which the data model supported returning
         // multiple offsets instead of just one
-        if (ctx.header().version == api_version(0)) {
+        if (version == api_version(0)) {
             for (auto& topic : data.topics) {
                 for (auto& partition : topic.partitions) {
                     partition.old_style_offsets.push_back(partition.offset());
                 }
             }
         }
-        data.encode(resp.writer(), ctx.header().version);
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/metadata.h
+++ b/src/v/kafka/protocol/metadata.h
@@ -13,8 +13,6 @@
 
 #include "kafka/protocol/schemata/metadata_request.h"
 #include "kafka/protocol/schemata/metadata_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "model/metadata.h"
 #include "seastarx.h"
 
@@ -72,8 +70,8 @@ struct metadata_response {
 
     metadata_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/offset_commit.h
+++ b/src/v/kafka/protocol/offset_commit.h
@@ -15,7 +15,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/offset_commit_request.h"
 #include "kafka/protocol/schemata/offset_commit_response.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
@@ -77,7 +76,9 @@ struct offset_commit_response final {
         }
     }
 
-    void encode(const request_context&, response&);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
 
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);

--- a/src/v/kafka/protocol/offset_fetch.h
+++ b/src/v/kafka/protocol/offset_fetch.h
@@ -15,7 +15,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/offset_fetch_request.h"
 #include "kafka/protocol/schemata/offset_fetch_response.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
@@ -89,7 +88,9 @@ struct offset_fetch_response final {
         }
     }
 
-    void encode(const request_context&, response&);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
 
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);

--- a/src/v/kafka/protocol/produce.h
+++ b/src/v/kafka/protocol/produce.h
@@ -15,8 +15,6 @@
 #include "kafka/protocol/kafka_batch_adapter.h"
 #include "kafka/protocol/schemata/produce_request.h"
 #include "kafka/protocol/schemata/produce_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/timestamp.h"
 #include "seastarx.h"
@@ -92,7 +90,7 @@ struct produce_response final {
 
     produce_response_data data;
 
-    void encode(const request_context& ctx, response& resp) {
+    void encode(response_writer& writer, api_version version) {
         // normalize errors
         for (auto& r : data.responses) {
             for (auto& p : r.partitions) {
@@ -103,7 +101,7 @@ struct produce_response final {
                 }
             }
         }
-        data.encode(resp.writer(), ctx.header().version);
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/sasl_authenticate.h
+++ b/src/v/kafka/protocol/sasl_authenticate.h
@@ -12,8 +12,6 @@
 
 #include "kafka/protocol/schemata/sasl_authenticate_request.h"
 #include "kafka/protocol/schemata/sasl_authenticate_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "seastarx.h"
 
@@ -62,8 +60,8 @@ struct sasl_authenticate_response final {
     explicit sasl_authenticate_response(sasl_authenticate_response_data data)
       : data(std::move(data)) {}
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/sasl_handshake.h
+++ b/src/v/kafka/protocol/sasl_handshake.h
@@ -12,8 +12,6 @@
 
 #include "kafka/protocol/schemata/sasl_handshake_request.h"
 #include "kafka/protocol/schemata/sasl_handshake_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "seastarx.h"
 
@@ -65,8 +63,8 @@ struct sasl_handshake_response final {
         data.mechanisms = std::move(mechanisms);
     }
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -732,7 +732,6 @@ namespace kafka {
 
 class request_reader;
 class response_writer;
-class request_context;
 class response;
 
 {% for struct in struct.structs() %}
@@ -886,7 +885,7 @@ void {{ struct.name }}::decode(iobuf buf, [[maybe_unused]] api_version version) 
 void {{ struct.name }}::encode(response_writer&, api_version) {}
 void {{ struct.name }}::decode(request_reader&, api_version) {}
 {%- else %}
-void {{ struct.name }}::encode(const request_context&, response&) {}
+void {{ struct.name }}::encode(response_writer&, api_version&) {}
 void {{ struct.name }}::decode(iobuf, api_version) {}
 {%- endif %}
 {%- endif %}

--- a/src/v/kafka/protocol/sync_group.h
+++ b/src/v/kafka/protocol/sync_group.h
@@ -13,7 +13,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/sync_group_request.h"
 #include "kafka/protocol/schemata/sync_group_response.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
@@ -86,7 +85,9 @@ struct sync_group_response final {
     sync_group_response(const sync_group_request&, error_code error)
       : sync_group_response(error) {}
 
-    void encode(const request_context&, response&);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
 
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);

--- a/src/v/kafka/protocol/sync_group.h
+++ b/src/v/kafka/protocol/sync_group.h
@@ -74,7 +74,6 @@ struct sync_group_response final {
 
     sync_group_response(error_code error, bytes assignment)
       : data({
-        .throttle_time_ms = std::chrono::milliseconds(0),
         .error_code = error,
         .assignment = std::move(assignment),
       }) {}

--- a/src/v/kafka/protocol/txn_offset_commit.h
+++ b/src/v/kafka/protocol/txn_offset_commit.h
@@ -15,8 +15,6 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/schemata/txn_offset_commit_request.h"
 #include "kafka/protocol/schemata/txn_offset_commit_response.h"
-#include "kafka/server/request_context.h"
-#include "kafka/server/response.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
@@ -78,8 +76,8 @@ struct txn_offset_commit_response final {
         }
     }
 
-    void encode(const request_context& ctx, response& resp) {
-        data.encode(resp.writer(), ctx.header().version);
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
     }
 
     void decode(iobuf buf, api_version version) {

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -14,6 +14,7 @@
 #include "cluster/simple_batch_builder.h"
 #include "cluster/tx_utils.h"
 #include "config/configuration.h"
+#include "kafka/protocol/response_writer.h"
 #include "kafka/protocol/schemata/describe_groups_response.h"
 #include "kafka/protocol/sync_group.h"
 #include "kafka/server/group_manager.h"

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -18,6 +18,7 @@
 #include "kafka/protocol/describe_groups.h"
 #include "kafka/protocol/offset_commit.h"
 #include "kafka/protocol/offset_fetch.h"
+#include "kafka/protocol/request_reader.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "model/record.h"

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -15,11 +15,6 @@
 
 namespace kafka {
 
-std::ostream& operator<<(std::ostream& os, const api_versions_response& r) {
-    os << r.data;
-    return os;
-}
-
 template<typename... Ts>
 struct type_list {};
 

--- a/src/v/kafka/server/handlers/api_versions.h
+++ b/src/v/kafka/server/handlers/api_versions.h
@@ -21,4 +21,6 @@ struct api_versions_handler : public handler<api_versions_api, 0, 2> {
     static api_versions_response handle_raw(request_context& ctx);
 };
 
+std::vector<api_versions_response_key> get_supported_apis();
+
 } // namespace kafka

--- a/src/v/kafka/server/handlers/delete_groups.cc
+++ b/src/v/kafka/server/handlers/delete_groups.cc
@@ -23,11 +23,6 @@
 
 namespace kafka {
 
-void delete_groups_response::encode(
-  const request_context& ctx, response& resp) {
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 template<>
 ss::future<response_ptr> delete_groups_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {

--- a/src/v/kafka/server/handlers/describe_groups.cc
+++ b/src/v/kafka/server/handlers/describe_groups.cc
@@ -22,11 +22,6 @@
 
 namespace kafka {
 
-void describe_groups_response::encode(
-  const request_context& ctx, response& resp) {
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 template<>
 ss::future<response_ptr>
 describe_groups_handler::handle(request_context ctx, ss::smp_service_group) {

--- a/src/v/kafka/server/handlers/heartbeat.cc
+++ b/src/v/kafka/server/handlers/heartbeat.cc
@@ -21,10 +21,6 @@
 
 namespace kafka {
 
-void heartbeat_response::encode(const request_context& ctx, response& resp) {
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 template<>
 ss::future<response_ptr> heartbeat_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {

--- a/src/v/kafka/server/handlers/join_group.cc
+++ b/src/v/kafka/server/handlers/join_group.cc
@@ -34,10 +34,6 @@ void join_group_request::decode(request_context& ctx) {
       fmt::format("{}", ctx.connection()->client_host()));
 }
 
-void join_group_response::encode(const request_context& ctx, response& resp) {
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 template<>
 ss::future<response_ptr> join_group_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {

--- a/src/v/kafka/server/handlers/join_group.cc
+++ b/src/v/kafka/server/handlers/join_group.cc
@@ -24,20 +24,21 @@ std::ostream& operator<<(std::ostream& o, const member_protocol& p) {
     return ss::fmt_print(o, "{}:{}", p.name, p.metadata.size());
 }
 
-void join_group_request::decode(request_context& ctx) {
-    data.decode(ctx.reader(), ctx.header().version);
-    version = ctx.header().version;
+static void decode_request(request_context& ctx, join_group_request& req) {
+    req.decode(ctx.reader(), ctx.header().version);
+    req.version = ctx.header().version;
     if (ctx.header().client_id) {
-        client_id = kafka::client_id(ss::sstring(*ctx.header().client_id));
+        req.client_id = kafka::client_id(ss::sstring(*ctx.header().client_id));
     }
-    client_host = kafka::client_host(
+    req.client_host = kafka::client_host(
       fmt::format("{}", ctx.connection()->client_host()));
 }
 
 template<>
 ss::future<response_ptr> join_group_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
-    join_group_request request(ctx);
+    join_group_request request;
+    decode_request(ctx, request);
 
     if (request.data.group_instance_id) {
         co_return co_await ctx.respond(

--- a/src/v/kafka/server/handlers/leave_group.cc
+++ b/src/v/kafka/server/handlers/leave_group.cc
@@ -21,10 +21,6 @@
 
 namespace kafka {
 
-void leave_group_response::encode(const request_context& ctx, response& resp) {
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 template<>
 ss::future<response_ptr> leave_group_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {

--- a/src/v/kafka/server/handlers/list_groups.cc
+++ b/src/v/kafka/server/handlers/list_groups.cc
@@ -19,10 +19,6 @@
 
 namespace kafka {
 
-void list_groups_response::encode(const request_context& ctx, response& resp) {
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 template<>
 ss::future<response_ptr> list_groups_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -40,19 +40,6 @@ void list_offsets_request::compute_duplicate_topics() {
     }
 }
 
-void list_offsets_response::encode(const request_context& ctx, response& resp) {
-    // convert to version zero in which the data model supported returning
-    // multiple offsets instead of just one
-    if (ctx.header().version == api_version(0)) {
-        for (auto& topic : data.topics) {
-            for (auto& partition : topic.partitions) {
-                partition.old_style_offsets.push_back(partition.offset());
-            }
-        }
-    }
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 struct list_offsets_ctx {
     request_context rctx;
     list_offsets_request request;

--- a/src/v/kafka/server/handlers/offset_commit.cc
+++ b/src/v/kafka/server/handlers/offset_commit.cc
@@ -28,11 +28,6 @@
 
 namespace kafka {
 
-void offset_commit_response::encode(
-  const request_context& ctx, response& resp) {
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 struct offset_commit_ctx {
     request_context rctx;
     offset_commit_request request;

--- a/src/v/kafka/server/handlers/offset_fetch.cc
+++ b/src/v/kafka/server/handlers/offset_fetch.cc
@@ -37,10 +37,6 @@ std::ostream& operator<<(std::ostream& os, const offset_fetch_response& r) {
     return os;
 }
 
-void offset_fetch_response::encode(const request_context& ctx, response& resp) {
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 template<>
 ss::future<response_ptr>
 offset_fetch_handler::handle(request_context ctx, ss::smp_service_group) {

--- a/src/v/kafka/server/handlers/sync_group.cc
+++ b/src/v/kafka/server/handlers/sync_group.cc
@@ -21,10 +21,6 @@
 
 namespace kafka {
 
-void sync_group_response::encode(const request_context& ctx, response& resp) {
-    data.encode(resp.writer(), ctx.header().version);
-}
-
 template<>
 ss::future<response_ptr> sync_group_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -131,8 +131,8 @@ public:
     // clang-format off
     template<typename ResponseType>
     CONCEPT(requires requires (
-            ResponseType r, const request_context& ctx, response& resp) {
-        { r.encode(ctx, resp) } -> std::same_as<void>;
+            ResponseType r, response_writer& writer, api_version version) {
+        { r.encode(writer, version) } -> std::same_as<void>;
     })
     // clang-format on
     ss::future<response_ptr> respond(ResponseType r) {
@@ -143,7 +143,7 @@ public:
           ResponseType::api_type::name,
           r);
         auto resp = std::make_unique<response>();
-        r.encode(*this, *resp.get());
+        r.encode(resp->writer(), header().version);
         return ss::make_ready_future<response_ptr>(std::move(resp));
     }
 

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -111,7 +111,7 @@ static iobuf handle_request(kafka::request_context&& ctx) {
     case kafka::join_group_api::key: {
         vlog(rlog.info, "kafka::join_group_api::key");
         kafka::join_group_request r;
-        r.decode(ctx);
+        r.decode(ctx.reader(), ctx.header().version);
         r.encode(writer, ctx.header().version);
         break;
     }

--- a/src/v/pandaproxy/json/requests/test/produce.cc
+++ b/src/v/pandaproxy/json/requests/test/produce.cc
@@ -15,6 +15,7 @@
 #include "pandaproxy/json/exceptions.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "seastarx.h"
+#include "utils/to_string.h"
 
 #include <seastar/testing/thread_test_case.hh>
 


### PR DESCRIPTION
Updates to the on-going process of separating the kafka client and server. In this patch we remove nearly all of the server references in the generic protocol layer. The remaining bits are in `fetch` but waiting on that to avoid a conflict with @mmaslankaprv's fetch performance work.