### PR TITLE
Fix archival GCS connection failure

### DIFF
--- a/src/v/rpc/dns.cc
+++ b/src/v/rpc/dns.cc
@@ -23,7 +23,7 @@ ss::future<ss::socket_address> resolve_dns(unresolved_address address) {
     // lock
     auto units = co_await m.get_units();
     // resolve
-    auto i_a = co_await resolver.resolve_name(address.host(), {});
+    auto i_a = co_await resolver.resolve_name(address.host(), address.family());
 
     co_return ss::socket_address(i_a, address.port());
 };

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -68,15 +68,7 @@ transport::transport(
 ss::future<ss::connected_socket> connect_with_timeout(
   const seastar::socket_address& address, rpc::clock_type::time_point timeout) {
     auto socket = ss::make_lw_shared<ss::socket>(ss::engine().net().socket());
-
-    auto f = socket
-               ->connect(
-                 address,
-                 ss::socket_address(sockaddr_in{AF_INET, INADDR_ANY, {0}}),
-                 ss::transport::TCP)
-               .finally([socket] {
-
-               });
+    auto f = socket->connect(address).finally([socket] {});
     return ss::with_timeout(timeout, std::move(f))
       .handle_exception([socket, address](const std::exception_ptr& e) {
           rpclog.warn("error connecting to {} - {}", address, e);

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -99,7 +99,9 @@ ss::future<configuration> configuration::make_configuration(
     }
     constexpr uint16_t default_port = 443;
     client_cfg.server_addr = unresolved_address(
-      client_cfg.uri(), overrides.port ? *overrides.port : default_port);
+      client_cfg.uri(),
+      overrides.port ? *overrides.port : default_port,
+      ss::net::inet_address::family::INET);
     client_cfg.disable_metrics = disable_metrics;
     client_cfg._probe = ss::make_lw_shared<client_probe>(
       disable_metrics, region(), endpoint_uri);

--- a/src/v/utils/unresolved_address.h
+++ b/src/v/utils/unresolved_address.h
@@ -24,13 +24,20 @@
 /// tuple
 class unresolved_address {
 public:
+    using inet_family = std::optional<ss::net::inet_address::family>;
+
     unresolved_address() = default;
-    unresolved_address(ss::sstring host, uint16_t port)
+    unresolved_address(
+      ss::sstring host,
+      uint16_t port,
+      inet_family family = ss::net::inet_address::family::INET)
       : _host(std::move(host))
-      , _port(port) {}
+      , _port(port)
+      , _family(family) {}
 
     const ss::sstring& host() const { return _host; }
     uint16_t port() const { return _port; }
+    inet_family family() const { return _family; }
 
     bool operator==(const unresolved_address& other) const = default;
 
@@ -39,6 +46,7 @@ private:
 
     ss::sstring _host;
     uint16_t _port{0};
+    inet_family _family;
 };
 
 inline std::ostream& operator<<(std::ostream& o, const unresolved_address& s) {


### PR DESCRIPTION
## Cover letter

Archival storage stopped working with GCS after introduction of the new name resolution in RPC. The problem was caused by the name resolution to ipv6 address. The rpc module failed to establish connection when the remote address was ipv6.

This PR fixes the ipv6 connection issue and modifies `unresolved_address` to provide the ability to specify the desired resolution outcome. 

## Release notes

N/A