### PR TITLE
archival: Fix upload loop stall

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -175,11 +175,7 @@ upload_candidate archival_policy::get_next_candidate(
     }
     // Invariant: segment is not compacted (segment->is_compacted_segment() ==
     // false)
-    auto end = segment->offsets().committed_offset;
-    if (end > last_offset) {
-        return create_upload_candidate(last_offset, segment, ntp_conf);
-    }
-    return {};
+    return create_upload_candidate(last_offset, segment, ntp_conf);
 }
 
 } // namespace archival


### PR DESCRIPTION
## Cover letter

The implementation attempts to filter out empty segments. This
prevents the upload loop from doing any progress in some cases.
The filtering logic is removed to fix this.

## Release notes

N/A