### PR TITLE
release: fix k8s operator gha workflow

### DIFF
--- a/.github/workflows/k8s-release.yml
+++ b/.github/workflows/k8s-release.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Package helm chart
       working-directory: src/go/k8s/helm-chart/charts
-      run: helm package --version ${{ github.event.release.tag_name }} --app-version ${{ github.event.release.tag_name }} redpanda-operator
+      run: helm package -u --version ${{ github.event.release.tag_name }} --app-version ${{ github.event.release.tag_name }} redpanda-operator
 
     - name: Upload helm package to release
       uses: svenstaro/upload-release-action@2.2.1


### PR DESCRIPTION
add `-u` flag to `helm package` command in order to fetch dependencies prior to packaging

fixes #1404