### PR TITLE
pandaproxy/json: Introduce base_handler

### DIFF
--- a/src/v/pandaproxy/json/requests/create_consumer.h
+++ b/src/v/pandaproxy/json/requests/create_consumer.h
@@ -17,6 +17,7 @@
 #include "kafka/protocol/produce.h"
 #include "kafka/types.h"
 #include "pandaproxy/json/iobuf.h"
+#include "pandaproxy/json/rjson_parse.h"
 #include "seastarx.h"
 #include "utils/string_switch.h"
 
@@ -40,7 +41,7 @@ struct create_consumer_request {
 };
 
 template<typename Encoding = rapidjson::UTF8<>>
-class create_consumer_request_handler {
+class create_consumer_request_handler final : public base_handler<Encoding> {
 private:
     enum class state {
         empty = 0,
@@ -58,17 +59,6 @@ public:
     using Ch = typename Encoding::Ch;
     using rjson_parse_result = create_consumer_request;
     rjson_parse_result result;
-
-    bool Null() { return false; }
-    bool Bool(bool) { return false; }
-    bool Int64(int64_t) { return false; }
-    bool Uint64(uint64_t) { return false; }
-    bool Double(double) { return false; }
-    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
-    bool Int(int) { return false; }
-    bool Uint(unsigned) { return false; }
-    bool StartArray() { return false; }
-    bool EndArray(rapidjson::SizeType) { return false; }
 
     bool String(const Ch* str, rapidjson::SizeType len, bool) {
         switch (_state) {
@@ -131,7 +121,7 @@ inline void rjson_serialize(
 }
 
 template<typename Encoding = rapidjson::UTF8<>>
-class create_consumer_response_handler {
+class create_consumer_response_handler final : public base_handler<Encoding> {
 private:
     enum class state { empty = 0, instance_id, base_uri };
 
@@ -141,17 +131,6 @@ public:
     using Ch = typename Encoding::Ch;
     using rjson_parse_result = create_consumer_response;
     rjson_parse_result result;
-
-    bool Null() { return false; }
-    bool Bool(bool) { return false; }
-    bool Int64(int64_t) { return false; }
-    bool Uint64(uint64_t) { return false; }
-    bool Double(double) { return false; }
-    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
-    bool Int(int) { return false; }
-    bool Uint(unsigned) { return false; }
-    bool StartArray() { return false; }
-    bool EndArray(rapidjson::SizeType) { return false; }
 
     bool String(const Ch* str, rapidjson::SizeType len, bool) {
         auto str_view{std::string_view{str, len}};

--- a/src/v/pandaproxy/json/requests/partition_offsets.h
+++ b/src/v/pandaproxy/json/requests/partition_offsets.h
@@ -13,6 +13,7 @@
 
 #include "json/json.h"
 #include "model/fundamental.h"
+#include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/types.h"
 #include "seastarx.h"
 
@@ -33,7 +34,7 @@ struct topic_partition_offset {
 };
 
 template<typename Encoding = rapidjson::UTF8<>>
-class partition_offsets_request_handler {
+class partition_offsets_request_handler final : public base_handler<Encoding> {
 private:
     enum class state {
         empty = 0,
@@ -44,20 +45,12 @@ private:
         offset,
     };
 
-    serialization_format _fmt = serialization_format::none;
     state state = state::empty;
 
 public:
     using Ch = typename Encoding::Ch;
     using rjson_parse_result = std::vector<topic_partition_offset>;
     rjson_parse_result result;
-
-    bool Null() { return false; }
-    bool Bool(bool) { return false; }
-    bool Int64(int64_t) { return false; }
-    bool Uint64(uint64_t) { return false; }
-    bool Double(double) { return false; }
-    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
 
     bool Int(int i) {
         switch (state) {

--- a/src/v/pandaproxy/json/requests/partitions.h
+++ b/src/v/pandaproxy/json/requests/partitions.h
@@ -13,6 +13,7 @@
 
 #include "json/json.h"
 #include "model/fundamental.h"
+#include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/types.h"
 #include "seastarx.h"
 
@@ -23,7 +24,7 @@
 namespace pandaproxy::json {
 
 template<typename Encoding = rapidjson::UTF8<>>
-class partitions_request_handler {
+class partitions_request_handler final : public base_handler<Encoding> {
 private:
     enum class state {
         empty = 0,
@@ -33,20 +34,12 @@ private:
         partition,
     };
 
-    serialization_format _fmt = serialization_format::none;
     state state = state::empty;
 
 public:
     using Ch = typename Encoding::Ch;
     using rjson_parse_result = std::vector<model::topic_partition>;
     rjson_parse_result result;
-
-    bool Null() { return false; }
-    bool Bool(bool) { return false; }
-    bool Int64(int64_t) { return false; }
-    bool Uint64(uint64_t) { return false; }
-    bool Double(double) { return false; }
-    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
 
     bool Int(int i) {
         if (state == state::partition) {

--- a/src/v/pandaproxy/json/requests/subscribe_consumer.h
+++ b/src/v/pandaproxy/json/requests/subscribe_consumer.h
@@ -16,6 +16,7 @@
 #include "kafka/protocol/errors.h"
 #include "kafka/types.h"
 #include "pandaproxy/json/iobuf.h"
+#include "pandaproxy/json/rjson_parse.h"
 #include "seastarx.h"
 #include "utils/string_switch.h"
 
@@ -34,7 +35,7 @@ struct subscribe_consumer_request {
 };
 
 template<typename Encoding = rapidjson::UTF8<>>
-class subscribe_consumer_request_handler {
+class subscribe_consumer_request_handler final : public base_handler<Encoding> {
 private:
     enum class state {
         empty = 0,
@@ -48,15 +49,6 @@ public:
     using Ch = typename Encoding::Ch;
     using rjson_parse_result = subscribe_consumer_request;
     rjson_parse_result result;
-
-    bool Null() { return false; }
-    bool Bool(bool) { return false; }
-    bool Int64(int64_t) { return false; }
-    bool Uint64(uint64_t) { return false; }
-    bool Double(double) { return false; }
-    bool RawNumber(const Ch*, rapidjson::SizeType, bool) { return false; }
-    bool Int(int) { return false; }
-    bool Uint(unsigned) { return false; }
 
     bool String(const Ch* str, rapidjson::SizeType len, bool) {
         if (_state != state::topic_name) {

--- a/src/v/pandaproxy/json/rjson_parse.h
+++ b/src/v/pandaproxy/json/rjson_parse.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/json/types.h"
+
+#include <rapidjson/encodings.h>
+#include <rapidjson/reader.h>
+
+namespace pandaproxy::json {
+
+template<typename encoding = rapidjson::UTF8<>>
+class base_handler
+  : public rapidjson::BaseReaderHandler<encoding, base_handler<encoding>> {
+public:
+    using Ch = typename encoding::Ch;
+
+    explicit base_handler(serialization_format fmt = serialization_format::none)
+      : _fmt{fmt} {}
+
+    bool Default() { return false; }
+    serialization_format format() const { return _fmt; }
+
+private:
+    serialization_format _fmt{serialization_format::none};
+};
+
+} // namespace pandaproxy::json


### PR DESCRIPTION
## Cover letter

`pandaproxy::json::base_handler` is a [rapdjson::Handler](https://rapidjson.org/classrapidjson_1_1_handler.html) base class that returns false by default, and carries the `json::serialization_format`.

## Release notes

Release note: [none]
