### PR TITLE
s3: Pass S3 probe to the http client

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -54,13 +54,13 @@ client::client(
 client::client(
   const rpc::base_transport::configuration& cfg,
   const ss::abort_source* as,
-  ss::lw_shared_ptr<client_probe> probe)
+  ss::shared_ptr<client_probe> probe)
   : rpc::base_transport(cfg)
   , _connect_gate()
   , _as(as)
   , _probe(std::move(probe)) {
     if (!_probe) {
-        _probe = ss::make_lw_shared<client_probe>();
+        _probe = ss::make_shared<client_probe>();
     }
 }
 

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -84,6 +84,10 @@ public:
     client(
       const rpc::base_transport::configuration& cfg,
       const ss::abort_source& as);
+    client(
+      const rpc::base_transport::configuration& cfg,
+      const ss::abort_source* as,
+      ss::shared_ptr<client_probe> probe);
 
     ss::future<> stop();
     using rpc::base_transport::shutdown;
@@ -219,12 +223,6 @@ public:
       ss::lowres_clock::duration timeout = default_connect_timeout);
 
 private:
-    /// Do it all private c-tor
-    client(
-      const rpc::base_transport::configuration& cfg,
-      const ss::abort_source* as,
-      ss::lw_shared_ptr<client_probe> probe);
-
     template<class BufferSeq>
     static ss::future<> forward(client* client, BufferSeq&& seq);
 
@@ -238,7 +236,7 @@ private:
 
     ss::gate _connect_gate;
     const ss::abort_source* _as;
-    ss::lw_shared_ptr<http::client_probe> _probe;
+    ss::shared_ptr<http::client_probe> _probe;
 };
 
 template<class BufferSeq>

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -105,7 +105,7 @@ ss::future<configuration> configuration::make_configuration(
       overrides.port ? *overrides.port : default_port,
       ss::net::inet_address::family::INET);
     client_cfg.disable_metrics = disable_metrics;
-    client_cfg._probe = ss::make_lw_shared<client_probe>(
+    client_cfg._probe = ss::make_shared<client_probe>(
       disable_metrics, region(), endpoint_uri);
     co_return client_cfg;
 }
@@ -367,7 +367,7 @@ client::client(const configuration& conf)
 
 client::client(const configuration& conf, const ss::abort_source& as)
   : _requestor(conf)
-  , _client(conf, as)
+  , _client(conf, &as, conf._probe)
   , _probe(conf._probe) {}
 
 ss::future<> client::stop() { return _client.stop(); }

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -64,7 +64,7 @@ struct configuration : rpc::base_transport::configuration {
     /// AWS region
     aws_region_name region;
     /// Metrics probe (should be created for every aws account on every shard)
-    ss::lw_shared_ptr<client_probe> _probe;
+    ss::shared_ptr<client_probe> _probe;
 
     /// \brief opinionated configuraiton initialization
     /// Generates uri field from region, initializes credentials for the
@@ -196,7 +196,7 @@ public:
 private:
     request_creator _requestor;
     http::client _client;
-    ss::lw_shared_ptr<client_probe> _probe;
+    ss::shared_ptr<client_probe> _probe;
 };
 
 /// Policy that controls behaviour of the client pool

--- a/src/v/s3/client_probe.cc
+++ b/src/v/s3/client_probe.cc
@@ -32,12 +32,9 @@ client_probe::client_probe(
 
     auto endpoint_label = sm::label("endpoint");
     auto region_label = sm::label("region");
-    auto shard_label = sm::label("shard");
 
     const std::vector<sm::label_instance> labels = {
-      endpoint_label(std::move(endpoint)),
-      region_label(std::move(region)),
-      shard_label(ss::this_shard_id())};
+      endpoint_label(std::move(endpoint)), region_label(std::move(region))};
 
     _metrics.add_group(
       prometheus_sanitize::metrics_name("s3:client"),

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -166,7 +166,7 @@ s3::configuration transport_configuration() {
       .region = s3::aws_region_name("us-east-1"),
     };
     conf.server_addr = server_addr;
-    conf._probe = ss::make_lw_shared<s3::client_probe>(
+    conf._probe = ss::make_shared<s3::client_probe>(
       rpc::metrics_disabled::yes, "region", "endpoint");
     return conf;
 }


### PR DESCRIPTION
## Cover letter

Currently, only s3 metrics are upated but http metrics
are ommitted because the probe is not passed to the
http_client correctly.

- change pointer type from lw_shared_ptr to shared_ptr
  since the latter one can use pointer cast
- expose http_client c-tor that is used by the s3 client
  to pass the probe

## Release notes

N/A