### PR TITLE
handling moving not initialized partition cross shards

### DIFF
--- a/src/v/finjector/hbadger.h
+++ b/src/v/finjector/hbadger.h
@@ -65,6 +65,16 @@ public:
     void register_probe(std::string_view, probe* p);
     void deregister_probe(std::string_view);
 
+    static constexpr bool is_enabled() {
+#ifndef NDEBUG
+        // debug
+        return true;
+#else
+        // production
+        return false;
+#endif
+    }
+
     void set_exception(std::string_view module, std::string_view point);
     void set_delay(std::string_view module, std::string_view point);
     void set_termination(std::string_view module, std::string_view point);

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -47,6 +47,13 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/partition.json.h
 )
 
+seastar_generate_swagger(
+  TARGET hbadger_swagger
+  VAR hbadger_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/hbadger.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/hbadger.json.h
+)
+
 v_cc_library(
   NAME application
   SRCS 
@@ -69,7 +76,7 @@ add_executable(redpanda
 target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_dependencies(v_application config_swagger raft_swagger kafka_swagger
-    security_swagger status_swagger broker_swagger partition_swagger)
+    security_swagger status_swagger broker_swagger partition_swagger hbadger_swagger)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)
   include(CheckIPOSupported)

--- a/src/v/redpanda/admin/api-doc/hbadger.json
+++ b/src/v/redpanda/admin/api-doc/hbadger.json
@@ -1,0 +1,127 @@
+{
+    "apiVersion": "0.0.1",
+    "swaggerVersion": "1.2",
+    "basePath": "/v1",
+    "resourcePath": "/failure-probes",
+    "produces": [
+        "application/json"
+    ],
+    "apis": [
+        {
+            "path": "/v1/failure-probes",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get a list of available failure probes",
+                    "type": "failure_injector_status",
+                    "nickname": "get_failure_probes",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
+            "path": "/v1/failure-probes/{module}/{point}",
+            "operations": [
+                {
+                    "method": "DELETE",
+                    "summary": "Delete all failure injectors at given point",
+                    "type": "void",
+                    "nickname": "delete_failure_probe",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "module",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "point",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "/v1/failure-probes/{module}/{point}/{type}",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Enable failure injection of given type",
+                    "type": "void",
+                    "nickname": "set_failure_probe",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "module",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "point",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "type",
+                            "in": "path",
+                            "required": true,
+                            "type": "string",
+                            "enum": [
+                                "exception",
+                                "delay",
+                                "terminate"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "models": {
+        "failure_probes": {
+            "id": "failure_probes",
+            "description": "Group of failure probes related with single resource",
+            "properties": {
+                "module": {
+                    "type": "string",
+                    "description": "failure probes module name"
+                },
+                "points": {
+                    "type": "array",
+                    "description": "list of failure points",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "failure_injector_status": {
+            "id": "failure_injector_status",
+            "description": "Status of failure injector with list of available probes",
+            "properties": {
+                "probes": {
+                    "type": "array",
+                    "items": {
+                        "type": "failure_probes"
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -23,10 +23,12 @@
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
+#include "finjector/hbadger.h"
 #include "model/namespace.h"
 #include "raft/types.h"
 #include "redpanda/admin/api-doc/broker.json.h"
 #include "redpanda/admin/api-doc/config.json.h"
+#include "redpanda/admin/api-doc/hbadger.json.h"
 #include "redpanda/admin/api-doc/kafka.json.h"
 #include "redpanda/admin/api-doc/partition.json.h"
 #include "redpanda/admin/api-doc/raft.json.h"
@@ -108,6 +110,9 @@ void admin_server::configure_admin_routes() {
     rb->register_api_file(_server._routes, "security");
     rb->register_function(_server._routes, insert_comma);
     rb->register_api_file(_server._routes, "status");
+    rb->register_function(_server._routes, insert_comma);
+    rb->register_api_file(_server._routes, "hbadger");
+
     ss::httpd::config_json::get_config.set(
       _server._routes, []([[maybe_unused]] ss::const_req req) {
           rapidjson::StringBuffer buf;
@@ -121,6 +126,7 @@ void admin_server::configure_admin_routes() {
     register_status_routes();
     register_broker_routes();
     register_partition_routes();
+    register_hbadger_routes();
 }
 
 void admin_server::configure_dashboard() {
@@ -664,5 +670,102 @@ void admin_server::register_partition_routes() {
           }
 
           co_return ss::json::json_void();
+      });
+}
+
+void admin_server::register_hbadger_routes() {
+    /**
+     * we always register `v1/failure-probes` route. It will ALWAYS return empty
+     * list of probes in production mode, and flag indicating that honey badger
+     * is disabled
+     */
+
+    if constexpr (!finjector::honey_badger::is_enabled()) {
+        ss::httpd::hbadger_json::get_failure_probes.set(
+          _server._routes, [](std::unique_ptr<ss::httpd::request>) {
+              ss::httpd::hbadger_json::failure_injector_status status;
+              status.enabled = false;
+              return ss::make_ready_future<ss::json::json_return_type>(
+                std::move(status));
+          });
+        return;
+    }
+    ss::httpd::hbadger_json::get_failure_probes.set(
+      _server._routes, [](std::unique_ptr<ss::httpd::request>) {
+          auto modules = finjector::shard_local_badger().points();
+          ss::httpd::hbadger_json::failure_injector_status status;
+          status.enabled = true;
+
+          for (auto& m : modules) {
+              ss::httpd::hbadger_json::failure_probes pr;
+              pr.module = m.first.data();
+              for (auto& p : m.second) {
+                  pr.points.push(p.data());
+              }
+              status.probes.push(pr);
+          }
+
+          return ss::make_ready_future<ss::json::json_return_type>(
+            std::move(status));
+      });
+    /*
+     * Enable failure injector
+     */
+    static constexpr std::string_view delay_type = "delay";
+    static constexpr std::string_view exception_type = "exception";
+    static constexpr std::string_view terminate_type = "terminate";
+
+    ss::httpd::hbadger_json::set_failure_probe.set(
+      _server._routes, [](std::unique_ptr<ss::httpd::request> req) {
+          auto m = req->param["module"];
+          auto p = req->param["point"];
+          auto type = req->param["type"];
+          vlog(
+            logger.info,
+            "Request to set failure probe of type '{}' in  '{}' at point '{}'",
+            type,
+            m,
+            p);
+          auto f = ss::now();
+
+          if (type == delay_type) {
+              f = ss::smp::invoke_on_all(
+                [m, p] { finjector::shard_local_badger().set_delay(m, p); });
+          } else if (type == exception_type) {
+              f = ss::smp::invoke_on_all([m, p] {
+                  finjector::shard_local_badger().set_exception(m, p);
+              });
+          } else if (type == terminate_type) {
+              f = ss::smp::invoke_on_all([m, p] {
+                  finjector::shard_local_badger().set_termination(m, p);
+              });
+          } else {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Type parameter has to be one of "
+                "['{}','{}','{}']",
+                delay_type,
+                exception_type,
+                terminate_type));
+          }
+
+          return f.then(
+            [] { return ss::json::json_return_type(ss::json::json_void()); });
+      });
+    /*
+     * Remove all failure injectors at given point
+     */
+    ss::httpd::hbadger_json::delete_failure_probe.set(
+      _server._routes, [](std::unique_ptr<ss::httpd::request> req) {
+          auto m = req->param["module"];
+          auto p = req->param["point"];
+          vlog(
+            logger.info,
+            "Request to unset failure probe '{}' at point '{}'",
+            m,
+            p);
+          return ss::smp::invoke_on_all(
+                   [m, p] { finjector::shard_local_badger().unset(m, p); })
+            .then(
+              [] { return ss::json::json_return_type(ss::json::json_void()); });
       });
 }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -75,6 +75,7 @@ private:
     void register_status_routes();
     void register_broker_routes();
     void register_partition_routes();
+    void register_hbadger_routes();
 
     ss::http_server _server;
     admin_server_cfg _cfg;

--- a/tests/rptest/services/honey_badger.py
+++ b/tests/rptest/services/honey_badger.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import random
+import requests
+
+from rptest.services.admin import Admin
+
+
+class HoneyBadger:
+    @staticmethod
+    def is_enabled(node):
+        return requests.get(Admin._url(node,
+                                       'failure-probes')).json()['enabled']
+
+    @staticmethod
+    def list_failure_probes(node):
+        return requests.get(Admin._url(node, 'failure-probes')).json()
+
+    @staticmethod
+    def set_delay(node, module, probe):
+        requests.post(
+            Admin._url(node, f'failure-probes/{module}/{probe}/delay'))
+
+    @staticmethod
+    def set_terminate(node, module, probe):
+        requests.post(
+            Admin._url(node, f'failure-probes/{module}/{probe}/terminate'))
+
+    @staticmethod
+    def set_exception(node, module, probe):
+        requests.post(
+            Admin._url(node, f'failure-probes/{module}/{probe}/exception'))
+
+    @staticmethod
+    def unset_failures(node, module, probe):
+        requests.delete(Admin._url(node, f'failure-probes/{module}/{probe}'))


### PR DESCRIPTION
## Cover letter

When partition is being moved cross shards, it is shut down on source core and recreated on target one. X-core move doesn't involve any data movement. When partition is recreated on target core we relay on data in partition underlying log to recover partition state. The bug that was triggered in ducktape tests was caused by moving partition before any data were persisted to disk. This prevented partition on target core from recovering its initial configuration. 

Fixed the problem by initializing partition on target core with its original configuration. This way if there is no data it will start from valid initial state, or if data are in log this initial configuration will be overridden.

Additionally exposed honey badger as an admin API endpoint and added test that reproduce the described issue. 
