### PR TITLE
operator: set smp based on resource request

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -309,6 +309,11 @@ type SocketAddress struct {
 	Port int `json:"port,omitempty"`
 }
 
+const (
+	// MinimumMemoryPerCore the minimum amount of memory needed per core
+	MinimumMemoryPerCore = 2 * gb
+)
+
 func init() {
 	SchemeBuilder.Register(&Cluster{}, &ClusterList{})
 }

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -36,7 +36,7 @@ func TestValidateUpdate(t *testing.T) {
 			Replicas:      pointer.Int32Ptr(replicas2),
 			Configuration: v1alpha1.RedpandaConfig{},
 			Resources: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
+				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("1Gi"),
 				},
 			},
@@ -72,7 +72,7 @@ func TestValidateUpdate(t *testing.T) {
 	statusError := err.(*apierrors.StatusError)
 	expectedFields := []string{
 		field.NewPath("spec").Child("replicas").String(),
-		field.NewPath("spec").Child("resources").Child("limits").Child("memory").String(),
+		field.NewPath("spec").Child("resources").Child("requests").Child("memory").String(),
 		field.NewPath("spec").Child("configuration").Child("kafkaApi").Index(0).Child("tls").Child("requireclientauth").String(),
 		field.NewPath("spec").Child("configuration").Child("kafkaApi").Index(0).Child("tls").Child("nodeSecretRef").String(),
 	}
@@ -108,8 +108,9 @@ func TestValidateUpdate_NoError(t *testing.T) {
 				RPCServer: v1alpha1.SocketAddress{Port: 126},
 			},
 			Resources: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
+				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourceCPU:    resource.MustParse("1"),
 				},
 			},
 		},
@@ -345,8 +346,9 @@ func TestCreation(t *testing.T) {
 				RPCServer: v1alpha1.SocketAddress{Port: 126},
 			},
 			Resources: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("2G"),
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourceCPU:    resource.MustParse("1"),
 				},
 			},
 		},
@@ -418,8 +420,9 @@ func TestCreation(t *testing.T) {
 	t.Run("incorrect memory", func(t *testing.T) {
 		memory := redpandaCluster.DeepCopy()
 		memory.Spec.Resources = corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
+			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
 			},
 		}
 

--- a/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
@@ -32,9 +32,9 @@ spec:
             - --advertise-rpc-addr=$(POD_NAME).external-connectivity.$(POD_NAMESPACE).svc.cluster.local.:33145
             - --overprovisioned
             - --reserve-memory 1M
-            - --smp=1
             - --kernel-page-cache=true
             - --default-log-level=debug
+            - --smp=1
 status:
   readyReplicas: 1
 ---

--- a/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
@@ -32,9 +32,9 @@ spec:
             - --advertise-rpc-addr=$(POD_NAME).cluster-sample.$(POD_NAMESPACE).svc.cluster.local.:33145
             - --overprovisioned
             - --reserve-memory 1M
-            - --smp=1
             - --kernel-page-cache=true
             - --default-log-level=debug
+            - --smp=1
 status:
   readyReplicas: 1
 ---


### PR DESCRIPTION
## Cover letter

Currently, the operator reads the CPU limit from the Cluster CR but the only way to affect the `smp` redpanda argument is through `developerMode`: if set to true `smp` is set to 1, otherwise it's empty (consuming all cores).

This change
- sets the `smp` depending on the resources *requested* in the CR.
- uses the *requested* memory instead of *limit* to set `--memory`, such that the provided amount is guaranteed on the node
- continues passing the resources/limits to the StatefulSet resource configuration (cgroup resources) as provided in the Cluster CR

**Developer mode : true** 
As before, but `smp` is computed based on the _requested_ cores (instead of always being set to 1). If the CPU request is empty, `smp` remains empty, and Redpanda uses all cores.

**Developer mode : false**
- Given the _requested_ memory, we compute the maximum number of cores - we want at least 2GB per core. The `smp` is then set to the minimum of that and the requested number of cores.
- We use `request` instead of `limit` because we have to guarantee the resources are available when providing the arguments to Redpanda.

Fixes https://github.com/vectorizedio/redpanda/issues/1378

Example
```yaml
  resources:
    requests:
      cpu: 100m
      memory: 2Gi [4Gi]
...
    developerMode: false
```
Gives

```
    Args:
      redpanda
      start
      --check=false
      --advertise-rpc-addr=..
      --default-log-level=info
      --reserve-memory 0M
      --smp=1
      --memory=2147483648 [4294967296]
    Requests:
      cpu:     100m
      memory:  2Gi [4Gi]
```

Setting cpu to 2 (or 2000m), sets `smp` to 2.


## Release notes

Provided resource requests in CR determine Redpanda's `smp` value