### PR TITLE
rpk/start: Fix the flags' priority

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -152,6 +152,13 @@ func NewStartCommand(
 				return err
 			}
 
+			if len(configKvs) > 0 {
+				conf, err = setConfig(mgr, configKvs)
+				if err != nil {
+					return err
+				}
+			}
+
 			updateConfigWithFlags(conf, ccmd.Flags())
 
 			env := api.EnvironmentPayload{}
@@ -292,12 +299,6 @@ func NewStartCommand(
 			if err != nil {
 				sendEnv(fs, mgr, env, conf, !prestartCfg.checkEnabled, err)
 				return err
-			}
-			if len(configKvs) > 0 {
-				conf, err = setConfig(mgr, configKvs)
-				if err != nil {
-					return err
-				}
 			}
 			rpArgs, err := buildRedpandaFlags(
 				fs,


### PR DESCRIPTION
Edit the config fields set with `--set` first, so that field-specific flags such as `--node-id` or `--kafka-addr` don't get ignored.

The current priority is as follows (from more to less):
1. Specific flags, such as `--node-id` or `--advertised-kafka-address`
2. Environment variables, where applicable
3. Config values passed through `--set`
4. The values in the config file

Fix #1417, #1411
