### PR TITLE
operator/samples: Enable Pandaproxy

### DIFF
--- a/src/go/k8s/config/samples/external_connectivity.yaml
+++ b/src/go/k8s/config/samples/external_connectivity.yaml
@@ -20,6 +20,10 @@ spec:
      - port: 9092
      - external:
          enabled: true
+    pandaproxyApi:
+     - port: 8082
+     - external:
+         enabled: true
     adminApi:
     - port: 9644
     developerMode: true

--- a/src/go/k8s/config/samples/one_node_cluster.yaml
+++ b/src/go/k8s/config/samples/one_node_cluster.yaml
@@ -18,6 +18,8 @@ spec:
       port: 33145
     kafkaApi:
     - port: 9092
+    pandaproxyApi:
+    - port: 8082
     adminApi:
     - port: 9644
     developerMode: true

--- a/src/go/k8s/config/samples/tls.yaml
+++ b/src/go/k8s/config/samples/tls.yaml
@@ -20,6 +20,10 @@ spec:
      - port: 9092
        tls:
          enabled: true
+    pandaproxyApi:
+     - port: 8082
+     - tls:
+         enabled: true
     adminApi:
     - port: 9644
     developerMode: true


### PR DESCRIPTION
## Cover letter

Enable Pandaproxy by default in the samples.

## Release notes
Release note: Enable Pandaproxy by default in the K8s operator samples
