### PR TITLE
3rdparty: Update abseil to 20210324.1

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -147,7 +147,7 @@ ExternalProject_Add(HdrHistogram
 
 ExternalProject_Add(abseil
   GIT_REPOSITORY https://github.com/vectorizedio/abseil-cpp.git
-  GIT_TAG 1e3d25b2657228bd691ee938cfd37d487f48054b
+  GIT_TAG e1d388e7e74803050423d035e4374131b9b57919
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   DEPENDS ${default_depends}


### PR DESCRIPTION
Abseil LTS 20210324, Patch 1 (#943)
* Add missing `add_subdirectory()` call for "cleanup" (#925)

Since `absl::Cleanup` is now public, it should also be included
in the `absl/CMakeLists.txt` file.

Signed-off-by: Christian Blichmann <cblichmann@google.com>

* Correctly install pkgconfig files under CMAKE_INSTALL_LIBDIR
Fixes #931

PiperOrigin-RevId: 366816645

* AbseilConfigureCopts.cmake: fix AppleClang detection

restore use of MATCHES in comparison with "Clang"; this was lost in:

commit 22771d4
    ...
    24e1f5f72756046f5265abf618e951c341f09b8d by Derek Mauro <dmauro@google.com>:

    Fixes failing CMake string comparisons
    https://cmake.org/cmake/help/latest/policy/CMP0054.html

fixes:
CMake Warning at absl/copts/AbseilConfigureCopts.cmake:61 (message):
    Unknown compiler:
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++.
    Building with no default flags

Fixes #930

PiperOrigin-RevId: 366879337

* Increment SOVERSION to 2103.0.1

Co-authored-by: Christian Blichmann <cblichmann@users.noreply.github.com>
Co-authored-by: Abseil Team <absl-team@google.com>

Apply LTS transformations for 20210324 LTS branch (#920)
* Apply LTS transformations for 20210324 LTS branch

* Change the SOVERSION to make MacOS happy

MacOS expects the first part of the SOVERSION to fit into 16 bits.

Apply LTS transformations for 20210324 LTS branch (#920)
* Apply LTS transformations for 20210324 LTS branch

* Change the SOVERSION to make MacOS happy

MacOS expects the first part of the SOVERSION to fit into 16 bits.

Cherry-picks for LTS 2020_09_23 Patch Release 3 (#888)
* Adds missing <limits> include to fix GCC 11 (prerelease) build
    on 19 Jan  6f9d96a  zip  tar.gz  Notes

Cherry-picks for LTS 2020_09_23 Patch Release 2
* Fixes preprocessor condition for symbols __tsan_mutex_read_lock and
__tsan_mutex_try_lock
* Fixes race in AddressIsReadable file descriptors using stronger memory ordering
* Fixes CMake dependency issues and adds `-Wl,--no-undefined` to avoid
these issues in the future.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
