### PR TITLE
rpk container start: add --set to override config values

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start_test.go
@@ -495,7 +495,14 @@ Please check your internet connection and try again.`,
 				check = tt.check
 			}
 			retries := uint(10)
-			err = startCluster(c, tt.nodes, check, retries, common.DefaultImage())
+			err = startCluster(
+				c,
+				tt.nodes,
+				check,
+				retries,
+				common.DefaultImage(),
+				nil,
+			)
 			if tt.expectedErrMsg != "" {
 				require.EqualError(st, err, tt.expectedErrMsg)
 			} else {
@@ -505,6 +512,42 @@ Please check your internet connection and try again.`,
 					require.Contains(st, out.String(), tt.expectedOutput)
 				}
 			}
+		})
+	}
+}
+
+func TestCollectFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{{
+		name: "it should collect the --set flags and values",
+		input: []string{
+			"arg1",
+			"--flag",
+			"--set", "k1=v1",
+			"--other-flag", "value",
+			"--set", `path.to.field={"field":"this is a json obj","arr":[]}`,
+		},
+		expected: []string{
+			"--set", "k1=v1",
+			"--set", `path.to.field={"field":"this is a json obj","arr":[]}`,
+		},
+	}, {
+		name: "it should return an empty list if there are no values",
+		input: []string{
+			"arg1",
+			"--flag",
+			"--other-flag", "value",
+		},
+		expected: []string{},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			res := collectFlags(tt.input, "--set")
+			require.Exactly(st, tt.expected, res)
 		})
 	}
 }


### PR DESCRIPTION
Recently, a `--set` flag was added to `rpk redpanda start`, which allows setting config values at startup. This changeset introduces a similar `--set` flag to `rpk container start`, but instead of parsing the values, both the flags and the values are passed through to the containers' entrypoint (`rpk redpanda start`).