### PR TITLE
Generic adl implementations for map-like and vector-like types

### DIFF
--- a/src/v/coproc/offset_storage_utils.cc
+++ b/src/v/coproc/offset_storage_utils.cc
@@ -15,7 +15,8 @@
 #include "coproc/logger.h"
 #include "coproc/ntp_context.h"
 #include "model/fundamental.h"
-#include "reflection/adl.h"
+#include "reflection/absl/btree_map.h"
+#include "reflection/absl/flat_hash_map.h"
 #include "storage/log_manager.h"
 #include "storage/snapshot.h"
 #include "vlog.h"
@@ -27,75 +28,10 @@
 
 #include <optional>
 
-namespace reflection {
-
-template<>
-struct adl<coproc::ntp_context::offset_tracker> {
-    void to(iobuf& out, coproc::ntp_context::offset_tracker&& offsets) {
-        reflection::serialize(out, static_cast<int32_t>(offsets.size()));
-        for (const auto& e : offsets) {
-            reflection::serialize(
-              out, e.first, e.second.last_read, e.second.last_acked);
-        }
-    }
-
-    coproc::ntp_context::offset_tracker from(iobuf_parser& in) {
-        coproc::ntp_context::offset_tracker offsets;
-        auto size = reflection::adl<int32_t>{}.from(in);
-        for (auto i = 0; i < size; ++i) {
-            auto id = reflection::adl<coproc::script_id>{}.from(in);
-            auto last_read = reflection::adl<model::offset>{}.from(in);
-            auto last_acked = reflection::adl<model::offset>{}.from(in);
-            offsets.emplace(
-              id,
-              coproc::ntp_context::offset_pair{
-                .last_read = last_read, .last_acked = last_acked});
-        }
-        return offsets;
-    }
-};
-
-} // namespace reflection
-
 namespace coproc {
 
 using iresults_map
   = absl::flat_hash_map<model::ntp, ntp_context::offset_tracker>;
-
-ss::future<iresults_map> deserialize_data_field(iobuf data) {
-    return ss::do_with(
-      iresults_map(),
-      iobuf_parser(std::move(data)),
-      [](iresults_map& irm, iobuf_parser& p) {
-          const int32_t n_elements = reflection::adl<int32_t>{}.from(p);
-          auto range = boost::irange<int32_t>(0, n_elements);
-          return ss::do_for_each(
-                   range,
-                   [&irm, &p](int32_t) {
-                       model::ntp key = reflection::adl<model::ntp>{}.from(p);
-                       ntp_context::offset_tracker offsets
-                         = reflection::adl<ntp_context::offset_tracker>{}.from(
-                           p);
-                       irm.emplace(std::move(key), std::move(offsets));
-                   })
-            .then([&irm] { return std::move(irm); });
-      });
-}
-
-ss::future<iobuf> serialize_data_field(const ntp_context_cache& ntp_cache) {
-    return ss::do_with(iobuf(), [&ntp_cache](iobuf& data) {
-        reflection::serialize(data, static_cast<int32_t>(ntp_cache.size()));
-        return ss::do_for_each(
-                 ntp_cache,
-                 [&data](const ntp_context_cache::value_type& p) {
-                     reflection::serialize(
-                       data,
-                       model::ntp(p.first),
-                       ntp_context::offset_tracker(p.second->offsets));
-                 })
-          .then([&data] { return std::move(data); });
-    });
-}
 
 ss::future<ntp_context_cache> recover_offsets(
   storage::snapshot_manager& snap, storage::log_manager& log_mgr) {
@@ -116,9 +52,11 @@ ss::future<ntp_context_cache> recover_offsets(
     /// Query the total size, and read the rest of the data
     const size_t size = co_await reader.get_snapshot_size();
     iobuf data = co_await read_iobuf_exactly(reader.input(), size);
+    iobuf_parser iobuf_p(std::move(data));
     co_await reader.close();
     /// Deserialize the data
-    iresults_map irm = co_await deserialize_data_field(std::move(data));
+    iresults_map irm = co_await reflection::async_adl<iresults_map>{}.from(
+      iobuf_p);
     vlog(coproclog.info, "Recovered {} coprocessor offsets....", irm.size());
     /// Match the offsets map with the corresponding storage::log queried from
     /// the log_manager, building the completed ntp_context_cache
@@ -132,7 +70,7 @@ ss::future<ntp_context_cache> recover_offsets(
               key);
         } else {
             auto [itr, _] = recovered.emplace(
-              std::move(key), ss::make_lw_shared<ntp_context>(std::move(*log)));
+              key, ss::make_lw_shared<ntp_context>(std::move(*log)));
             itr->second->offsets = std::move(offsets);
         }
     }
@@ -147,7 +85,17 @@ ss::future<> save_offsets(
       ntp_cache.size());
     /// Create the metadata, and data iobuffers
     iobuf metadata = reflection::to_iobuf(static_cast<int8_t>(1));
-    iobuf data = co_await serialize_data_field(ntp_cache);
+    iresults_map irm_map;
+    irm_map.reserve(ntp_cache.size());
+    std::transform(
+      ntp_cache.cbegin(),
+      ntp_cache.end(),
+      std::inserter(irm_map, irm_map.end()),
+      [](const ntp_context_cache::value_type& p) {
+          return std::make_pair<>(p.first, p.second->offsets);
+      });
+    iobuf data;
+    co_await reflection::async_adl<iresults_map>{}.to(data, std::move(irm_map));
 
     /// Serialize this to disk via the snapshot_manager
     storage::snapshot_writer writer = co_await snap.start_snapshot();

--- a/src/v/coproc/pacemaker.cc
+++ b/src/v/coproc/pacemaker.cc
@@ -240,9 +240,4 @@ bool pacemaker::local_script_id_exists(script_id id) {
     return _scripts.find(id) != _scripts.end();
 }
 
-bool pacemaker::ntp_is_registered(const model::ntp& ntp) {
-    auto found = _ntps.find(ntp);
-    return found != _ntps.end() && found->second;
-}
-
 } // namespace coproc

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -89,11 +89,6 @@ public:
      */
     bool local_script_id_exists(script_id);
 
-    /**
-     * @returns true if a matching ntp exists on 'this' shard
-     */
-    bool ntp_is_registered(const model::ntp&);
-
     /// returns the number of running / registered fibers
     size_t n_registered_scripts() const { return _scripts.size(); }
 

--- a/src/v/coproc/types.cc
+++ b/src/v/coproc/types.cc
@@ -10,6 +10,7 @@
 
 #include "coproc/errc.h"
 #include "model/async_adl_serde.h"
+#include "reflection/std/vector.h"
 
 #include <boost/range/irange.hpp>
 

--- a/src/v/model/async_adl_serde.cc
+++ b/src/v/model/async_adl_serde.cc
@@ -11,40 +11,24 @@
 
 #include "model/adl_serde.h"
 #include "model/record_batch_reader.h"
+#include "reflection/seastar/circular_buffer.h"
 
 namespace reflection {
-/**
- * My moving the individual record_batches into a std::vector, we can take
- * advantage of the async_adl<std::vector<T>> template specializtion.
- */
+
 ss::future<> async_adl<model::record_batch_reader>::to(
   iobuf& out, model::record_batch_reader&& reader) {
     return model::consume_reader_to_memory(std::move(reader), model::no_timeout)
       .then([&out](ss::circular_buffer<model::record_batch> data) {
-          std::vector<model::record_batch> batches;
-          batches.reserve(data.size());
-          std::transform(
-            std::make_move_iterator(data.begin()),
-            std::make_move_iterator(data.end()),
-            std::back_inserter(batches),
-            [](model::record_batch&& rb) { return std::move(rb); });
-          return async_adl<std::vector<model::record_batch>>{}.to(
-            out, std::move(batches));
+          return async_adl<ss::circular_buffer<model::record_batch>>{}.to(
+            out, std::move(data));
       });
 }
 
 ss::future<model::record_batch_reader>
 async_adl<model::record_batch_reader>::from(iobuf_parser& in) {
-    return async_adl<std::vector<model::record_batch>>{}.from(in).then(
-      [](std::vector<model::record_batch> batches) {
-          ss::circular_buffer<model::record_batch> cbuffer;
-          cbuffer.reserve(batches.size());
-          std::transform(
-            std::make_move_iterator(batches.begin()),
-            std::make_move_iterator(batches.end()),
-            std::back_inserter(cbuffer),
-            [](model::record_batch&& rb) { return std::move(rb); });
-          return model::make_memory_record_batch_reader(std::move(cbuffer));
+    return async_adl<ss::circular_buffer<model::record_batch>>{}.from(in).then(
+      [](ss::circular_buffer<model::record_batch> batches) {
+          return model::make_memory_record_batch_reader(std::move(batches));
       });
 }
 

--- a/src/v/reflection/absl/btree_map.h
+++ b/src/v/reflection/absl/btree_map.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "reflection/async_adl.h"
+
+#include <absl/container/btree_map.h>
+
+namespace reflection {
+
+template<typename... Args>
+struct async_adl<absl::btree_map<Args...>>
+  : public detail::async_adl_map<absl::btree_map<Args...>> {};
+
+} // namespace reflection

--- a/src/v/reflection/absl/flat_hash_map.h
+++ b/src/v/reflection/absl/flat_hash_map.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "reflection/async_adl.h"
+
+#include <absl/container/flat_hash_map.h>
+
+namespace reflection {
+
+template<typename... Args>
+struct async_adl<absl::flat_hash_map<Args...>>
+  : public detail::async_adl_map<absl::flat_hash_map<Args...>> {};
+
+} // namespace reflection

--- a/src/v/reflection/absl/node_hash_map.h
+++ b/src/v/reflection/absl/node_hash_map.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "reflection/async_adl.h"
+
+#include <absl/container/node_hash_map.h>
+
+namespace reflection {
+
+template<typename... Args>
+struct async_adl<absl::node_hash_map<Args...>>
+  : public detail::async_adl_map<absl::node_hash_map<Args...>> {};
+
+} // namespace reflection

--- a/src/v/reflection/seastar/circular_buffer.h
+++ b/src/v/reflection/seastar/circular_buffer.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "reflection/async_adl.h"
+
+#include <seastar/core/circular_buffer.hh>
+
+namespace reflection {
+
+template<typename... Args>
+struct async_adl<ss::circular_buffer<Args...>>
+  : public detail::async_adl_list<ss::circular_buffer<Args...>> {};
+
+} // namespace reflection

--- a/src/v/reflection/std/map.h
+++ b/src/v/reflection/std/map.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "reflection/async_adl.h"
+
+#include <map>
+
+namespace reflection {
+
+template<typename... Args>
+struct async_adl<std::map<Args...>>
+  : public detail::async_adl_map<std::map<Args...>> {};
+
+} // namespace reflection

--- a/src/v/reflection/std/unordered_map.h
+++ b/src/v/reflection/std/unordered_map.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "reflection/async_adl.h"
+
+#include <unordered_map>
+
+namespace reflection {
+
+template<typename... Args>
+struct async_adl<std::unordered_map<Args...>>
+  : public detail::async_adl_map<std::unordered_map<Args...>> {};
+
+} // namespace reflection

--- a/src/v/reflection/std/vector.h
+++ b/src/v/reflection/std/vector.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "reflection/async_adl.h"
+
+#include <vector>
+
+namespace reflection {
+
+template<typename... Args>
+struct async_adl<std::vector<Args...>>
+  : public detail::async_adl_list<std::vector<Args...>> {};
+
+} // namespace reflection

--- a/src/v/reflection/test/CMakeLists.txt
+++ b/src/v/reflection/test/CMakeLists.txt
@@ -11,6 +11,6 @@ rp_test(
   UNIT_TEST
   BINARY_NAME reflection_async_adl_test
   SOURCES async_adl_test.cc
-  LIBRARIES v::seastar_testing_main v::reflection v::bytes v::model
+  LIBRARIES v::seastar_testing_main absl::flat_hash_map v::reflection v::bytes v::model
   LABELS reflection
 )

--- a/src/v/reflection/test/async_adl_test.cc
+++ b/src/v/reflection/test/async_adl_test.cc
@@ -12,7 +12,7 @@
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "random/generators.h"
-#include "reflection/async_adl.h"
+#include "reflection/std/vector.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
@@ -43,13 +43,14 @@ SEASTAR_THREAD_TEST_CASE(test_async_adl_collection) {
     // Serialize
     iobuf out;
     auto original_vec = make_random_collection();
-    reflection::async_adl<ntp_vec>{}.to(out, original_vec).get();
+    auto ovec_copy = original_vec;
+    reflection::async_adl<ntp_vec>{}.to(out, std::move(original_vec)).get();
     const auto originals_hash = std::hash<iobuf>{}(out);
 
     // Deserialize
     iobuf_parser in(std::move(out));
     auto result = reflection::async_adl<ntp_vec>{}.from(in).get0();
-    BOOST_REQUIRE_EQUAL(original_vec, result);
+    BOOST_REQUIRE_EQUAL(ovec_copy, result);
 
     // Reserialize
     iobuf second_out;

--- a/src/v/reflection/test/async_adl_test.cc
+++ b/src/v/reflection/test/async_adl_test.cc
@@ -12,49 +12,121 @@
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "random/generators.h"
+#include "reflection/absl/btree_map.h"
+#include "reflection/absl/flat_hash_map.h"
+#include "reflection/absl/node_hash_map.h"
+#include "reflection/seastar/circular_buffer.h"
+#include "reflection/std/map.h"
 #include "reflection/std/vector.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <map>
+#include <vector>
+
 namespace rand_gen = random_generators;
 
-model::ntp make_random_ntp() {
-    auto ns = rand_gen::gen_alphanum_string(5);
-    auto topic = rand_gen::gen_alphanum_string(10);
-    auto partition_id = rand_gen::get_int(0, 20);
-    return model::ntp(ns, topic, partition_id);
-}
+template<typename T>
+struct random_type {
+    T gen() { return T(); }
+};
 
-std::vector<model::ntp> make_random_collection() {
-    const auto size = rand_gen::get_int(0, 5);
-    std::vector<model::ntp> ntps;
-    ntps.reserve(size);
-    for (auto i = 0; i < size; ++i) {
-        ntps.emplace_back(make_random_ntp());
+template<>
+struct random_type<int32_t> {
+    int32_t gen() { return random_generators::get_int<int32_t>(); }
+};
+
+template<>
+struct random_type<model::ntp> {
+    model::ntp gen() {
+        auto ns = rand_gen::gen_alphanum_string(5);
+        auto topic = rand_gen::gen_alphanum_string(10);
+        auto partition_id = rand_gen::get_int(0, 20);
+        return model::ntp(ns, topic, partition_id);
     }
-    return ntps;
+};
+
+template<typename T>
+T make_random_collection_vec() {
+    const auto size = rand_gen::get_int(0, 5);
+    T collection;
+    collection.reserve(size);
+    for (auto i = 0; i < size; ++i) {
+        collection.emplace_back(random_type<typename T::value_type>{}.gen());
+    }
+    return collection;
 }
 
-SEASTAR_THREAD_TEST_CASE(test_async_adl_collection) {
-    using ntp_vec = std::vector<model::ntp>;
+template<typename T>
+T make_random_collection_map() {
+    T collection;
+    for (auto i = 0; i < rand_gen::get_int(0, 5); ++i) {
+        collection.emplace(
+          random_type<typename T::key_type>{}.gen(),
+          random_type<typename T::mapped_type>{}.gen());
+    }
+    return collection;
+}
+
+template<typename T>
+bool ser_deser_verify_hash(T&& type) {
     // Serialize
     iobuf out;
-    auto original_vec = make_random_collection();
-    auto ovec_copy = original_vec;
-    reflection::async_adl<ntp_vec>{}.to(out, std::move(original_vec)).get();
+    reflection::async_adl<T>{}.to(out, std::forward<T>(type)).get();
     const auto originals_hash = std::hash<iobuf>{}(out);
 
     // Deserialize
     iobuf_parser in(std::move(out));
-    auto result = reflection::async_adl<ntp_vec>{}.from(in).get0();
-    BOOST_REQUIRE_EQUAL(ovec_copy, result);
+    auto result = reflection::async_adl<T>{}.from(in).get0();
 
     // Reserialize
     iobuf second_out;
-    reflection::async_adl<ntp_vec>{}.to(second_out, std::move(result)).get();
+    reflection::async_adl<T>{}.to(second_out, std::move(result)).get();
     const auto seconds_hash = std::hash<iobuf>{}(second_out);
-    BOOST_REQUIRE_EQUAL(originals_hash, seconds_hash);
+    return originals_hash == seconds_hash;
+}
+
+template<typename T>
+bool ser_deser_verify(T type) {
+    // Serialize
+    iobuf out;
+    reflection::async_adl<T>{}.to(out, type).get();
+    const auto originals_hash = std::hash<iobuf>{}(out);
+
+    // Deserialize
+    iobuf_parser in(std::move(out));
+    auto result = reflection::async_adl<T>{}.from(in).get0();
+    return result == type;
+}
+
+SEASTAR_THREAD_TEST_CASE(test_async_adl_collection_vec) {
+    BOOST_REQUIRE_EQUAL(
+      true,
+      ser_deser_verify_hash(
+        make_random_collection_vec<std::vector<model::ntp>>()));
+    BOOST_REQUIRE_EQUAL(
+      true,
+      ser_deser_verify_hash(
+        make_random_collection_vec<ss::circular_buffer<model::ntp>>()));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_async_adl_collection_map) {
+    bool v = ser_deser_verify_hash(
+      make_random_collection_map<std::map<int32_t, model::ntp>>());
+    bool w = ser_deser_verify_hash(
+      make_random_collection_map<absl::btree_map<int32_t, model::ntp>>());
+    bool x = ser_deser_verify(
+      make_random_collection_map<absl::flat_hash_map<int32_t, model::ntp>>());
+    bool y = ser_deser_verify(
+      make_random_collection_map<absl::node_hash_map<int32_t, model::ntp>>());
+
+    BOOST_REQUIRE(v);
+    BOOST_REQUIRE(w);
+    BOOST_REQUIRE(x);
+    BOOST_REQUIRE(y);
 }


### PR DESCRIPTION
Addressing some technical debt. There is a fair bit of code that performs the same type of logic to serialize a map-like or vector-like type. Now this can be done automatically with `async_adl<map<k, v>>{}.to/from` or `async_adl<list<T>{}.to/from`