### PR TITLE
schema_registry: Introduce store

### DIFF
--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
   SRCS
     configuration.cc
     handlers.cc
+    error.cc
     service.cc
   DEPS
     v::pandaproxy_common

--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -23,3 +23,5 @@ v_cc_library(
   )
 
 add_dependencies(v_pandaproxy_schema_registry schema_registry_swagger)
+
+add_subdirectory(test)

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "error.h"
+
+#include "pandaproxy/error.h"
+#include "pandaproxy/schema_registry/error.h"
+
+namespace pandaproxy::schema_registry {
+
+namespace {
+
+struct error_category final : std::error_category {
+    const char* name() const noexcept override {
+        return "pandaproxy::schema_registry";
+    }
+    std::string message(int ev) const override {
+        switch (static_cast<error_code>(ev)) {
+        case error_code::schema_id_not_found:
+            return "Schema not found";
+        case error_code::schema_invalid:
+            return "Invalid schema";
+        case error_code::subject_not_found:
+            return "Subject not found";
+        case error_code::subject_version_not_found:
+            return "Subject version not found";
+        }
+        return "(unrecognized error)";
+    }
+};
+
+const error_category pps_error_category{};
+
+}; // namespace
+
+std::error_code make_error_code(error_code e) {
+    return {static_cast<int>(e), pps_error_category};
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <system_error>
+
+namespace pandaproxy::schema_registry {
+
+enum class error_code {
+    // 0 is success
+    schema_id_not_found = 1,
+    schema_invalid,
+    subject_not_found,
+    subject_version_not_found,
+};
+
+std::error_code make_error_code(error_code);
+
+} // namespace pandaproxy::schema_registry
+
+namespace std {
+
+template<>
+struct is_error_code_enum<pandaproxy::schema_registry::error_code>
+  : true_type {};
+
+} // namespace std

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -40,6 +40,15 @@ public:
         return {version, id, inserted};
     }
 
+    ///\brief Return a schema by id.
+    result<schema> get_schema(const schema_id& id) const {
+        auto it = _schemas.find(id);
+        if (it == _schemas.end()) {
+            return error_code::schema_id_not_found;
+        }
+        return {it->first, it->second.type, it->second.definition};
+    }
+
 private:
     struct insert_schema_result {
         schema_id id;

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -83,6 +83,23 @@ public:
           .deleted = v_it->deleted};
     }
 
+    ///\brief Return a list of versions and associated schema_id.
+    result<std::vector<schema_version>> get_versions(const subject& sub) const {
+        auto sub_it = _subjects.find(sub);
+        if (sub_it == _subjects.end()) {
+            return error_code::subject_not_found;
+        }
+        const auto& versions = sub_it->second;
+        std::vector<schema_version> res;
+        res.reserve(versions.size());
+        std::transform(
+          versions.begin(),
+          versions.end(),
+          std::back_inserter(res),
+          [](const auto& v) { return v.version; });
+        return res;
+    }
+
 private:
     struct insert_schema_result {
         schema_id id;

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+rp_test(
+  UNIT_TEST
+  BINARY_NAME pandaproxy_schema_registry_unit
+  SOURCES
+    util.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES Boost::unit_test_framework v_pandaproxy_schema_registry
+  LABELS pandaproxy
+)

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -3,6 +3,7 @@ rp_test(
   BINARY_NAME pandaproxy_schema_registry_unit
   SOURCES
     util.cc
+    store.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v_pandaproxy_schema_registry
   LABELS pandaproxy

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -1,0 +1,62 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/store.h"
+
+#include "pandaproxy/schema_registry/util.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace pps = pandaproxy::schema_registry;
+
+constexpr std::string_view sv_string_def0{R"({"type":"string"})"};
+constexpr std::string_view sv_string_def1{R"({"type": "string"})"};
+constexpr std::string_view sv_int_def0{R"({"type": "int"})"};
+const pps::schema_definition string_def0{
+  pps::make_schema_definition<rapidjson::UTF8<>>(sv_string_def0).value()};
+const pps::schema_definition string_def1{
+  pps::make_schema_definition<rapidjson::UTF8<>>(sv_string_def1).value()};
+const pps::schema_definition int_def0{
+  pps::make_schema_definition<rapidjson::UTF8<>>(sv_int_def0).value()};
+const pps::subject subject0{"subject0"};
+const pps::subject subject1{"subject1"};
+
+BOOST_AUTO_TEST_CASE(test_store_insert) {
+    pps::store s;
+
+    // First insert, expect id{1}, version{1}
+    auto ins_res = s.insert(subject0, string_def0, pps::schema_type::avro);
+    BOOST_REQUIRE(ins_res.inserted);
+    BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
+    BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
+
+    // Insert duplicate, expect id{1}, versions{1}
+    ins_res = s.insert(subject0, string_def0, pps::schema_type::avro);
+    BOOST_REQUIRE(!ins_res.inserted);
+    BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
+    BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
+
+    // Insert duplicate, with spaces, expect id{1}, versions{1}
+    ins_res = s.insert(subject0, string_def1, pps::schema_type::avro);
+    BOOST_REQUIRE(!ins_res.inserted);
+    BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
+    BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
+
+    // Insert on different subject, expect id{1}, version{1}
+    ins_res = s.insert(subject1, string_def0, pps::schema_type::avro);
+    BOOST_REQUIRE(ins_res.inserted);
+    BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
+    BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
+
+    // Insert different schema, expect id{2}, version{2}
+    ins_res = s.insert(subject0, int_def0, pps::schema_type::avro);
+    BOOST_REQUIRE(ins_res.inserted);
+    BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{2});
+    BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{2});
+}

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -60,3 +60,26 @@ BOOST_AUTO_TEST_CASE(test_store_insert) {
     BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{2});
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{2});
 }
+
+BOOST_AUTO_TEST_CASE(test_store_get_schema) {
+    pps::store s;
+
+    auto res = s.get_schema(pps::schema_id{1});
+    BOOST_REQUIRE(res.has_error());
+    auto err = std::move(res).assume_error();
+    BOOST_REQUIRE(err == pps::error_code::schema_id_not_found);
+
+    // First insert, expect id{1}
+    auto ins_res = s.insert(subject0, string_def0, pps::schema_type::avro);
+    BOOST_REQUIRE(ins_res.inserted);
+    BOOST_REQUIRE_EQUAL(ins_res.id, pps::schema_id{1});
+    BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{1});
+
+    res = s.get_schema(ins_res.id);
+    BOOST_REQUIRE(res.has_value());
+
+    auto val = std::move(res).assume_value();
+    BOOST_REQUIRE_EQUAL(val.id, ins_res.id);
+    BOOST_REQUIRE_EQUAL(val.definition(), string_def0());
+    BOOST_REQUIRE(val.type == pps::schema_type::avro);
+}

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -127,3 +127,32 @@ BOOST_AUTO_TEST_CASE(test_store_get_subject_schema) {
     err = std::move(res).assume_error();
     BOOST_REQUIRE(err == pps::error_code::subject_version_not_found);
 }
+
+BOOST_AUTO_TEST_CASE(test_store_get_versions) {
+    pps::store s;
+
+    // First insert, expect id{1}, version{1}
+    s.insert(subject0, string_def0, pps::schema_type::avro);
+
+    auto versions = s.get_versions(subject0);
+    BOOST_REQUIRE(versions.has_value());
+    BOOST_REQUIRE_EQUAL(versions.value().size(), 1);
+    BOOST_REQUIRE_EQUAL(versions.value().front(), pps::schema_version{1});
+
+    // Insert duplicate, expect id{1}, versions{1}
+    s.insert(subject0, string_def0, pps::schema_type::avro);
+
+    versions = s.get_versions(subject0);
+    BOOST_REQUIRE(versions.has_value());
+    BOOST_REQUIRE_EQUAL(versions.value().size(), 1);
+    BOOST_REQUIRE_EQUAL(versions.value().front(), pps::schema_version{1});
+
+    // Insert different schema, expect id{2}, version{2}
+    s.insert(subject0, int_def0, pps::schema_type::avro);
+
+    versions = s.get_versions(subject0);
+    BOOST_REQUIRE(versions.has_value());
+    BOOST_REQUIRE_EQUAL(versions.value().size(), 2);
+    BOOST_REQUIRE_EQUAL(versions.value().front(), pps::schema_version{1});
+    BOOST_REQUIRE_EQUAL(versions.value().back(), pps::schema_version{2});
+}

--- a/src/v/pandaproxy/schema_registry/test/util.cc
+++ b/src/v/pandaproxy/schema_registry/test/util.cc
@@ -1,0 +1,57 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#define BOOST_TEST_MODULE pandaproxy_schema_registry_unit
+
+#include "pandaproxy/schema_registry/util.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace pps = pandaproxy::schema_registry;
+
+constexpr std::string_view example_avro_schema{R"({
+  "namespace": "com.acme",
+  "protocol": "HelloWorld",
+  "doc": "Protocol Greetings",
+
+  "types": [
+    {"name": "Greeting", "type": "record", "fields": [
+      {"name": "message", "type": "string"}]},
+    {"name": "Curse", "type": "error", "fields": [
+      {"name": "message", "type": "string"}]}
+  ],
+
+  "messages": {
+    "hello": {
+      "doc": "Say hello.",
+      "request": [{"name": "greeting", "type": "Greeting" }],
+      "response": "Greeting",
+      "errors": ["Curse"]
+    }
+  }
+})"};
+
+constexpr std::string_view minified_avro_schema{
+  R"({"namespace":"com.acme","protocol":"HelloWorld","doc":"Protocol Greetings","types":[{"name":"Greeting","type":"record","fields":[{"name":"message","type":"string"}]},{"name":"Curse","type":"error","fields":[{"name":"message","type":"string"}]}],"messages":{"hello":{"doc":"Say hello.","request":[{"name":"greeting","type":"Greeting"}],"response":"Greeting","errors":["Curse"]}}})"};
+
+BOOST_AUTO_TEST_CASE(test_make_schema_definition) {
+    auto res = pps::make_schema_definition<rapidjson::UTF8<>>(
+      example_avro_schema);
+
+    BOOST_REQUIRE(res);
+    BOOST_REQUIRE_EQUAL(res.value()(), minified_avro_schema);
+}
+
+BOOST_AUTO_TEST_CASE(test_make_schema_definition_failure) {
+    auto res = pps::make_schema_definition<rapidjson::UTF8<>>(
+      "this should fail to parse");
+
+    BOOST_REQUIRE(res.has_error());
+    BOOST_REQUIRE_EQUAL(res.error(), pps::error_code::schema_invalid);
+}

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+namespace pandaproxy::schema_registry {
+
+enum class schema_type { avro = 0, json, protobuf };
+
+inline constexpr std::string_view to_string_view(schema_type e) {
+    switch (e) {
+    case schema_type::avro:
+        return "AVRO";
+    case schema_type::json:
+        return "JSON";
+    case schema_type::protobuf:
+        return "PROTOBUF";
+    }
+}
+
+///\brief A subject is the name under which a schema is registered.
+///
+/// Typically it will be "<topic>-key" or "<topic>-value".
+using subject = named_type<ss::sstring, struct subject_tag>;
+static const subject invalid_subject{};
+
+///\brief The definition of the schema.
+///
+/// TODO(Ben): Make this cheap to copy
+using schema_definition = named_type<ss::sstring, struct schema_definition_tag>;
+static const schema_definition invalid_schema_definition{};
+
+///\brief The version of the schema registered with a subject.
+///
+/// A subject may evolve its schema over time. Each version is associated with a
+/// schema_id.
+using schema_version = named_type<int32_t, struct schema_version_tag>;
+static constexpr schema_version invalid_schema_version{-1};
+
+///\brief Globally unique identifier for a schema.
+using schema_id = named_type<int32_t, struct schema_id_tag>;
+static constexpr schema_id invalid_schema_id{-1};
+
+///\brief Complete description of a schema.
+struct schema {
+    schema(schema_id id, schema_type type, schema_definition definition)
+      : id{id}
+      , type{type}
+      , definition{std::move(definition)} {}
+
+    schema_id id;
+    schema_type type;
+    schema_definition definition;
+};
+
+///\brief A mapping of version and schema id for a subject.
+struct subject_version_id {
+    subject_version_id(schema_version version, schema_id id)
+      : version{version}
+      , id{id} {}
+
+    schema_version version;
+    schema_id id;
+    bool deleted{false};
+};
+
+///\brief All schema versions for a subject.
+using subject_versions = std::vector<subject_version_id>;
+
+///\brief Complete description of a subject and schema for a version.
+struct subject_schema {
+    subject sub{invalid_subject};
+    schema_version version{invalid_schema_version};
+    schema_id id{invalid_schema_id};
+    schema_type type{schema_type::avro};
+    schema_definition definition{invalid_schema_definition};
+    bool deleted{false};
+};
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/util.h
+++ b/src/v/pandaproxy/schema_registry/util.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "outcome.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+namespace pandaproxy::schema_registry {
+
+///\brief Create a schema definition from raw input.
+///
+/// Validates the JSON and minify it.
+/// TODO(Ben): Validate that it's a valid schema
+///
+/// Returns error_code::schema_invalid on failure
+template<typename Encoding>
+result<schema_definition> make_schema_definition(std::string_view sv) {
+    // Validate and minify
+    rapidjson::GenericDocument<Encoding> doc;
+    doc.Parse(sv.data(), sv.size());
+    if (doc.HasParseError()) {
+        return error_code::schema_invalid;
+    }
+    rapidjson::GenericStringBuffer<Encoding> str_buf;
+    str_buf.Reserve(sv.size());
+    rapidjson::Writer<rapidjson::StringBuffer> w{str_buf};
+    doc.Accept(w);
+    return schema_definition{
+      ss::sstring{str_buf.GetString(), str_buf.GetSize()}};
+}
+
+} // namespace pandaproxy::schema_registry


### PR DESCRIPTION
## Cover letter

Introduce the core types for schema registry and a store for the schemas and subjects

Schemas are stored in a compacted topic, `_schemas`.

The key is `(keytype,subject,version,magic)` the value is `(subject,version,id,schema,deleted[,schemaType])` e.g.:
```
{"keytype":"SCHEMA","subject":"Kafka1-value","version":1,"magic":1} {"subject":"Kafka1-value","version":1,"id":1,"schema":"\"string\"","deleted":false}
{"keytype":"SCHEMA","subject":"Kafka1-value","version":2,"magic":1} {"subject":"Kafka1-value","version":2,"id":2,"schema":"\"int\"","deleted":false}
{"keytype":"SCHEMA","subject":"Kafka2-value","version":1,"magic":1} {"subject":"Kafka2-value","version":1,"id":1,"schema":"\"string\"","deleted":false}
{"keytype":"SCHEMA","subject":"Kafka1-value","version":1,"magic":1} {"subject":"Kafka1-value","version":1,"id":1,"schema":"\"string\"","deleted":true}
{"keytype":"SCHEMA","subject":"Kafka3-value","version":1,"magic":1} {"subject":"Kafka3-value","version":1,"id":3,"schema":"{\"type\":\"string\"}","deleted":false,"schemaType":"JSON"}
```

The schemas are listed in full for each subject.

The `schemaType` field is omitted if it's `AVRO`.

Duplicate schemas `(schema, type)` are detected and given the same schema id.

Duplicate subjects `(subject,schema,schemaType)` are detected and the matching version is returned.

A future PR will wire-up handlers and storage to & retrieval from the `_schemas` topic.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/d7e84010075b392844be6be7fc4e7369642b97cd..ecdfe8813bbb28fa6cbe805e08919aaf764b664c)
* store members are const where appropriate
* `subject_schema` now contains `schema_type`
* `store::insert` has a specific return type
* More code docs
* Remove unused headers

## Release notes

Release note: [none]
