### PR TITLE
Fix removing invalid readers from cache

### DIFF
--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -66,13 +66,12 @@ readers_cache::put(std::unique_ptr<log_reader> reader) {
         return model::record_batch_reader(std::move(reader));
     }
 
-    if (reader->lease_range_base_offset())
-        vlog(
-          stlog.trace,
-          "{} - adding reader [{},{}]",
-          _ntp,
-          reader->lease_range_base_offset(),
-          reader->lease_range_end_offset());
+    vlog(
+      stlog.trace,
+      "{} - adding reader [{},{}]",
+      _ntp,
+      reader->lease_range_base_offset(),
+      reader->lease_range_end_offset());
 
     auto ptr = new entry{.reader = std::move(reader)}; // NOLINT
     _in_use.push_back(*ptr);

--- a/src/v/storage/readers_cache.h
+++ b/src/v/storage/readers_cache.h
@@ -116,7 +116,11 @@ private:
 
         ~entry_guard() noexcept {
             _e->_hook.unlink();
-            if (_e->reader->is_reusable()) {
+            /**
+             * we only return reader to cache if it is reusable and wasn't
+             * requested to be evicted
+             */
+            if (_e->reader->is_reusable() && _e->valid) {
                 _cache->_readers.push_back(*_e);
             } else {
                 _cache->dispose_in_background(_e);


### PR DESCRIPTION
## Cover letter

Fixed bug leading to situation in which caller have to wait for operation requiring log write log until reader where evicted from cache by eviction timer.

The problem was related with the fact that when `cached_reader` `entry_guard` was destroyed it didn't scheduled disposing readers that were marked as invalid but only those which were no longer reusable. This might lead to the situation in which reader that was in use during truncate call might not be disposed immediately after it was destroyed even tho it was marked as invalid by `readers_cache::evict_if` method. The reader was reinserted to the readers cache, preventing truncation to finish. The reader was then removed in the next eviction timer iteration.

Example leading to this bug occurrence:

1) create reader
2) truncate log in a range for which reader holds a lock
3) destroy a reader
4) truncation should finish immediately after reader was destroyed

Fixes: #1426
