### PR TITLE
redpanda: expose version information via metrics

### DIFF
--- a/src/v/version.h.in
+++ b/src/v/version.h.in
@@ -1,6 +1,14 @@
 #pragma once
 #include <string_view>
 
+static constexpr inline std::string_view redpanda_git_version() {
+    return std::string_view("@GIT_VER@");
+}
+
+static constexpr inline std::string_view redpanda_git_revision() {
+    return std::string_view("@GIT_SHA1@@GIT_CLEAN_DIRTY@");
+}
+
 static constexpr inline std::string_view redpanda_version() {
     return std::string_view("@GIT_VER@ - @GIT_SHA1@@GIT_CLEAN_DIRTY@");
 }


### PR DESCRIPTION
This adds a core-0 metric that exposes version metadata as labels on a
constant guage metric.

fixes: #1429 