### PR TITLE
Update the vectorized_cluster_partition_records_fetched field

### DIFF
--- a/src/v/coproc/tests/utils/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/utils/coproc_test_fixture.cc
@@ -131,7 +131,7 @@ ss::future<coproc_test_fixture::opt_reader_data_t> coproc_test_fixture::drain(
                 }
                 auto p = ss::make_lw_shared<kafka::partition_proxy>(
                   kafka::make_partition_proxy<kafka::materialized_partition>(
-                    *log));
+                    partition, *log));
                 return do_drain(p, offset, limit, timeout).then([](auto rval) {
                     return opt_reader_data_t(std::move(rval));
                 });

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -192,7 +192,7 @@ std::optional<partition_proxy> make_partition_proxy(
         return make_partition_proxy<replicated_partition>(partition);
     }
     if (auto log = pm.log(mntp.input_ntp()); log) {
-        return make_partition_proxy<materialized_partition>(*log);
+        return make_partition_proxy<materialized_partition>(partition, *log);
     }
     return std::nullopt;
 }

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -37,6 +37,7 @@ public:
           timequery(model::timestamp, ss::io_priority_class) = 0;
         virtual ss::future<std::vector<cluster::rm_stm::tx_range>>
           aborted_transactions(model::offset, model::offset) = 0;
+        virtual cluster::partition_probe& probe() = 0;
         virtual ~impl() noexcept = default;
     };
 
@@ -68,6 +69,8 @@ public:
     timequery(model::timestamp ts, ss::io_priority_class io_pc) {
         return _impl->timequery(ts, io_pc);
     }
+
+    cluster::partition_probe& probe() { return _impl->probe(); }
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -75,7 +75,7 @@ public:
         co_return target;
     }
 
-    cluster::partition_probe& probe() { return _partition->probe(); }
+    cluster::partition_probe& probe() final { return _partition->probe(); }
 
 private:
     ss::lw_shared_ptr<cluster::partition> _partition;


### PR DESCRIPTION
In our metrics dashboard graphs that use this field are left blank. It is because the value is never incremented.