### PR TITLE
docs: add missing line continuator

### DIFF
--- a/docs/www/kubernetes-external-connect.md
+++ b/docs/www/kubernetes-external-connect.md
@@ -92,7 +92,7 @@ We'll use Helm to install cert-manager:
   VERSION=v21.4.15
   kubectl apply -k 'https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$VERSION'
   helm repo add redpanda https://charts.vectorized.io/ && \
-  helm repo update \
+  helm repo update && \
   helm install \
     --namespace redpanda-system \
     --create-namespace redpanda-operator \


### PR DESCRIPTION
The sample bash script to install the redpanda operator is missing one
'&&' to continue a line. This commit adds the '&&'.

## Cover letter

This PR fixes a small typo in a sample script from the documentation for external access to Kubernetes clusters.

## Release notes

The user-visible change is that the script now works.

Release note: [1-2 sentences of what this PR changes]

[No need to describe in release notes.]
