### PR TITLE
storage: fix offset overflow in index for large segments

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -56,7 +56,8 @@ disk_log_impl::disk_log_impl(
   , _kvstore(kvstore)
   , _start_offset(read_start_offset())
   , _lock_mngr(_segs)
-  , _max_segment_size(internal::jitter_segment_size(max_segment_size()))
+  , _max_segment_size(internal::jitter_segment_size(
+      std::min(max_segment_size(), segment_size_hard_limit)))
   , _readers_cache(std::make_unique<readers_cache>(
       config().ntp(), _manager.config().readers_cache_eviction_timeout)) {
     const bool is_compacted = config().is_compacted();

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -101,7 +101,6 @@ std::optional<index_state> index_state::hydrate_from_buffer(iobuf b) {
     iobuf_parser parser(std::move(b));
     index_state retval;
 
-    size_t expected_size_adjustment = 0;
     auto version = reflection::adl<int8_t>{}.from(parser);
     switch (version) {
     case index_state::ondisk_version:
@@ -133,13 +132,12 @@ std::optional<index_state> index_state::hydrate_from_buffer(iobuf b) {
     }
 
     retval.size = reflection::adl<uint32_t>{}.from(parser);
-    const auto expected_size = retval.size + expected_size_adjustment;
-    if (unlikely(parser.bytes_left() != expected_size)) {
+    if (unlikely(parser.bytes_left() != retval.size)) {
         vlog(
           stlog.debug,
           "Index size does not match header size. Got:{}, expected:{}",
           parser.bytes_left(),
-          expected_size);
+          retval.size);
         return std::nullopt;
     }
 

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -34,7 +34,7 @@ namespace storage {
    [] position_index
  */
 struct index_state {
-    static constexpr int8_t ondisk_version = 2;
+    static constexpr int8_t ondisk_version = 3;
 
     index_state() = default;
     index_state(index_state&&) noexcept = default;
@@ -61,12 +61,12 @@ struct index_state {
     /// breaking indexes into their own has a 6x latency reduction
     std::vector<uint32_t> relative_offset_index;
     std::vector<uint32_t> relative_time_index;
-    std::vector<uint32_t> position_index;
+    std::vector<uint64_t> position_index;
 
     bool empty() const { return relative_offset_index.empty(); }
 
     void
-    add_entry(uint32_t relative_offset, uint32_t relative_time, uint32_t pos) {
+    add_entry(uint32_t relative_offset, uint32_t relative_time, uint64_t pos) {
         relative_offset_index.push_back(relative_offset);
         relative_time_index.push_back(relative_time);
         position_index.push_back(pos);
@@ -76,7 +76,7 @@ struct index_state {
         relative_time_index.pop_back();
         position_index.pop_back();
     }
-    std::tuple<uint32_t, uint32_t, uint32_t> get_entry(size_t i) {
+    std::tuple<uint32_t, uint32_t, uint64_t> get_entry(size_t i) {
         return {
           relative_offset_index[i], relative_time_index[i], position_index[i]};
     }

--- a/src/v/storage/log_replayer.cc
+++ b/src/v/storage/log_replayer.cc
@@ -26,8 +26,6 @@
 namespace storage {
 class checksumming_consumer final : public batch_consumer {
 public:
-    static constexpr size_t max_segment_size = static_cast<size_t>(
-      std::numeric_limits<uint32_t>::max());
     checksumming_consumer(segment* s, log_replayer::checkpoint& c)
       : _seg(s)
       , _cfg(c) {

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -25,7 +25,7 @@
 namespace storage {
 
 static inline segment_index::entry translate_index_entry(
-  const index_state& s, std::tuple<uint32_t, uint32_t, uint32_t> entry) {
+  const index_state& s, std::tuple<uint32_t, uint32_t, uint64_t> entry) {
     auto [relative_offset, relative_time, filepos] = entry;
     return segment_index::entry{
       .offset = model::offset(relative_offset + s.base_offset()),

--- a/src/v/storage/tests/index_state_test.cc
+++ b/src/v/storage/tests/index_state_test.cc
@@ -73,9 +73,19 @@ BOOST_AUTO_TEST_CASE(encode_decode_v1) {
     set_version(src_buf, 1);
     set_size(src_buf, src.size - 4);
 
-    // version 1 is still supported
+    // version 1 is fully deprecated
     auto dst = storage::index_state::hydrate_from_buffer(src_buf.copy());
-    BOOST_REQUIRE(dst);
+    BOOST_REQUIRE(!dst);
+}
+
+BOOST_AUTO_TEST_CASE(encode_decode_v2) {
+    auto src = make_random_index_state();
+    auto src_buf = src.checksum_and_serialize();
+    set_version(src_buf, 2);
+
+    // version 2 is fully deprecated
+    auto dst = storage::index_state::hydrate_from_buffer(src_buf.copy());
+    BOOST_REQUIRE(!dst);
 }
 
 BOOST_AUTO_TEST_CASE(encode_decode_future_version) {


### PR DESCRIPTION
A hard segment size limit was not enforced and some users created
segments larger than 4gb resulting in an overflow of the 32-bit physical
offset entry in the segment offset index.

The result of this was that readers would eventually seek backwards in a
segment to a non-aligned location and experience a checksum failure on
the header.

This PR switches to a 64-bit representation for the physical offset,
bumps the on-disk file format version for the index, and forces a
rebuild for older versions. This allows us to also remove code for
supporting the older formats.

## Release notes

Release note: Offset indices will be rebuilt on upgrade leading to a delay in boot-up time.
