### PR TITLE
Add materialized topic support to list offsets API

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -56,6 +56,7 @@ v_cc_library(
     server/quota_manager.cc
     server/fetch_session_cache.cc
     server/replicated_partition.cc
+    server/partition_proxy.cc
  DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -200,7 +200,7 @@ static ss::future<read_result> do_read_from_ntp(
           error_code::unknown_topic_or_partition);
     }
 
-    auto high_watermark = partition->high_watermark();
+    auto high_watermark = kafka_partition->high_watermark();
 
     auto max_offset = high_watermark < model::offset(0) ? model::offset(0)
                                                         : high_watermark;
@@ -209,13 +209,13 @@ static ss::future<read_result> do_read_from_ntp(
         if (
           ntp_config.cfg.isolation_level
           == model::isolation_level::read_committed) {
-            ntp_config.cfg.max_offset = partition->last_stable_offset();
-            max_offset = partition->last_stable_offset();
+            ntp_config.cfg.max_offset = kafka_partition->last_stable_offset();
+            max_offset = kafka_partition->last_stable_offset();
         }
     }
 
     if (
-      ntp_config.cfg.start_offset < partition->start_offset()
+      ntp_config.cfg.start_offset < kafka_partition->start_offset()
       || ntp_config.cfg.start_offset > max_offset) {
         return ss::make_ready_future<read_result>(
           error_code::offset_out_of_range);

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -161,22 +161,17 @@ struct fetch_config {
 };
 
 struct ntp_fetch_config {
-    ntp_fetch_config(
-      model::ntp ntp,
-      fetch_config cfg,
-      std::optional<model::ntp> materialized_ntp = std::nullopt)
-      : ntp(std::move(ntp))
-      , cfg(cfg)
-      , materialized_ntp(std::move(materialized_ntp)) {}
-    model::ntp ntp;
+    ntp_fetch_config(const model::materialized_ntp& ntp, fetch_config cfg)
+      : materialized_ntp(std::move(ntp))
+      , cfg(cfg) {}
+    model::materialized_ntp materialized_ntp;
     fetch_config cfg;
-    std::optional<model::ntp> materialized_ntp;
 
-    bool is_materialized() const { return materialized_ntp.has_value(); }
+    const model::ntp& ntp() const { return materialized_ntp.source_ntp(); }
 
     friend std::ostream&
     operator<<(std::ostream& o, const ntp_fetch_config& ntp_fetch) {
-        fmt::print(o, R"({{"{}": {}}})", ntp_fetch.ntp, ntp_fetch.cfg);
+        fmt::print(o, R"({{"{}": {}}})", ntp_fetch.ntp(), ntp_fetch.cfg);
         return o;
     }
 };

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -13,6 +13,7 @@
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
 #include "kafka/protocol/errors.h"
+#include "kafka/server/materialized_partition.h"
 #include "kafka/server/partition_proxy.h"
 #include "kafka/server/replicated_partition.h"
 #include "kafka/server/request_context.h"
@@ -63,16 +64,15 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
   model::timestamp timestamp,
   list_offset_topic& topic,
   list_offset_partition& part) {
-    auto ntp = model::ntp(
-      model::kafka_namespace,
-      model::get_source_topic(topic.name),
-      part.partition_index);
+    auto ntp = model::materialized_ntp(
+      model::ntp(model::kafka_namespace, topic.name, part.partition_index));
 
-    auto shard = octx.rctx.shards().shard_for(ntp);
+    auto shard = octx.rctx.shards().shard_for(ntp.source_ntp());
     if (!shard) {
         return ss::make_ready_future<list_offset_partition_response>(
           list_offsets_response::make_partition(
-            ntp.tp.partition, error_code::unknown_topic_or_partition));
+            ntp.input_ntp().tp.partition,
+            error_code::unknown_topic_or_partition));
     }
 
     return octx.rctx.partition_manager().invoke_on(
@@ -82,20 +82,28 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
        ntp = std::move(ntp),
        isolation_lvl = model::isolation_level(
          octx.request.data.isolation_level)](cluster::partition_manager& mgr) {
-          auto partition = mgr.get(ntp);
+          auto partition = mgr.get(ntp.source_ntp());
           if (!partition) {
               return ss::make_ready_future<list_offset_partition_response>(
                 list_offsets_response::make_partition(
-                  ntp.tp.partition, error_code::unknown_topic_or_partition));
+                  ntp.input_ntp().tp.partition,
+                  error_code::unknown_topic_or_partition));
           }
 
           if (!partition->is_leader()) {
               return ss::make_ready_future<list_offset_partition_response>(
                 list_offsets_response::make_partition(
-                  ntp.tp.partition, error_code::not_leader_for_partition));
+                  ntp.input_ntp().tp.partition,
+                  error_code::not_leader_for_partition));
           }
-          auto k_partition = make_partition_proxy<replicated_partition>(
-            partition);
+          auto k_partition = make_partition_proxy(ntp, partition, mgr);
+
+          if (!k_partition) {
+              return ss::make_ready_future<list_offset_partition_response>(
+                list_offsets_response::make_partition(
+                  ntp.input_ntp().tp.partition,
+                  error_code::unknown_topic_or_partition));
+          }
           /*
            * the responses for earliest/latest timestamp queries do not require
            * that the actual timestamp be returned. only the offset is required.
@@ -103,24 +111,24 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
           if (timestamp == list_offsets_request::earliest_timestamp) {
               return ss::make_ready_future<list_offset_partition_response>(
                 list_offsets_response::make_partition(
-                  ntp.tp.partition,
+                  ntp.input_ntp().tp.partition,
                   model::timestamp(-1),
-                  k_partition.start_offset()));
+                  k_partition->start_offset()));
 
           } else if (timestamp == list_offsets_request::latest_timestamp) {
               const auto offset = isolation_lvl
                                       == model::isolation_level::read_committed
-                                    ? k_partition.last_stable_offset()
-                                    : k_partition.high_watermark();
+                                    ? k_partition->last_stable_offset()
+                                    : k_partition->high_watermark();
 
               return ss::make_ready_future<list_offset_partition_response>(
                 list_offsets_response::make_partition(
-                  ntp.tp.partition, model::timestamp(-1), offset));
+                  ntp.input_ntp().tp.partition, model::timestamp(-1), offset));
           }
 
-          return k_partition.timequery(timestamp, kafka_read_priority())
+          return k_partition->timequery(timestamp, kafka_read_priority())
             .then([partition,
-                   id = ntp.tp.partition,
+                   id = ntp.input_ntp().tp.partition,
                    k_partition = std::move(k_partition)](
                     std::optional<storage::timequery_result> res) {
                 if (res) {
@@ -133,7 +141,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
                   list_offsets_response::make_partition(
                     id,
                     model::timestamp(-1),
-                    k_partition.last_stable_offset()));
+                    k_partition->last_stable_offset()));
             });
       });
 }

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -22,15 +22,16 @@ public:
 
     const model::ntp& ntp() const final { return _log.config().ntp(); }
     model::offset start_offset() const final {
-        return _log.offsets().start_offset;
+        model::offset start = _log.offsets().start_offset;
+        return start < model::offset{0} ? model::offset{0} : start;
     }
 
     model::offset high_watermark() const final {
-        return _log.offsets().dirty_offset;
+        return raft::details::next_offset(_log.offsets().dirty_offset);
     }
 
     model::offset last_stable_offset() const final {
-        return _log.offsets().dirty_offset;
+        return raft::details::next_offset(_log.offsets().dirty_offset);
     }
 
     ss::future<model::record_batch_reader> make_reader(
@@ -54,6 +55,10 @@ public:
     cluster::partition_probe& probe() final { return _probe; }
 
 private:
+    static model::offset offset_or_zero(model::offset o) {
+        return o > model::offset(0) ? o : model::offset(0);
+    }
+
     storage::log _log;
     cluster::partition_probe _probe;
 };

--- a/src/v/kafka/server/partition_proxy.cc
+++ b/src/v/kafka/server/partition_proxy.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "partition_proxy.h"
+
+#include "cluster/partition_manager.h"
+#include "kafka/server/materialized_partition.h"
+#include "kafka/server/replicated_partition.h"
+
+namespace kafka {
+
+std::optional<partition_proxy> make_partition_proxy(
+  const model::materialized_ntp& mntp,
+  ss::lw_shared_ptr<cluster::partition> partition,
+  cluster::partition_manager& pm) {
+    if (!mntp.is_materialized()) {
+        return make_partition_proxy<replicated_partition>(partition);
+    }
+    if (auto log = pm.log(mntp.input_ntp()); log) {
+        return make_partition_proxy<materialized_partition>(*log);
+    }
+    return std::nullopt;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -81,4 +81,9 @@ partition_proxy make_partition_proxy(Args&&... args) {
     return partition_proxy(std::make_unique<Impl>(std::forward<Args>(args)...));
 }
 
+std::optional<partition_proxy> make_partition_proxy(
+  const model::materialized_ntp&,
+  ss::lw_shared_ptr<cluster::partition>,
+  cluster::partition_manager&);
+
 } // namespace kafka

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -18,7 +18,6 @@ quick:
   - tests/compacted_term_rolled_recovery_test.py
   - tests/compacted_topic_verifier_test.py
   - tests/compaction_recovery_test.py
-  - tests/wasm_identity_test.py
   - tests/wasm_failure_recovery_test.py
   - tests/wasm_redpanda_failure_recovery_test.py
   - tests/partition_movement_test.py::PartitionMovementTest.test_dynamic

--- a/tests/rptest/wasm/topics_result_set.py
+++ b/tests/rptest/wasm/topics_result_set.py
@@ -55,27 +55,12 @@ class TopicsResultSet:
         return TopicsResultSet(new_rset)
 
     def append(self, r):
-        def filter_control_record(records):
-            # Unfortunately the kafka-python API abstracts away the notion of a
-            # record batch, leaving us unable to check the control attribute
-            # within the record_batch header.
-            # https://github.com/dpkp/kafka-python/issues/1853
-            if len(records) == 0 or records[0].offset != 0:
-                return records
-            r = records[0]
-            if r.checksum is None and r.value is not None and \
-               r.headers == [] and r.serialized_key_size == 4:
-                return records[1:]
-            return records
-
         def to_basic_records(records):
             return list([
                 BasicKafkaRecord(x.topic, x.partition, x.key, x.value,
                                  x.offset) for x in records
             ])
 
-        # Filter out control records and unwanted data
-        r = dict([(kv[0], filter_control_record(kv[1])) for kv in r.items()])
         r = dict([(kv[0], to_basic_records(kv[1])) for kv in r.items()])
         for tp, records in r.items():
             rs = self.rset.get(tp)


### PR DESCRIPTION
If there is an Offset out of range error , kafka clients have the option of restarting from the earliest or latest portion of the log. When this occurred the list topic request was made, however querying the source topic not the materialized topic.