### PR TITLE
[wip] Schema registry (part2)

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -29,6 +29,46 @@
       }
     },
     "/subjects/{subject}/versions": {
+      "get": {
+        "summary": "Retrieve a list of versions for a subject.",
+        "operationId": "get_subject_versions",
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                  "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Subject not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
       "post": {
         "summary": "Create a new schema for the subject.",
         "operationId": "post_subject_versions",

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -28,6 +28,34 @@
         }
       }
     },
+    "/subjects": {
+      "get": {
+        "summary": "Retrieve a list of subjects.",
+        "operationId": "get_subjects",
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                  "type": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
     "/subjects/{subject}/versions": {
       "get": {
         "summary": "Retrieve a list of versions for a subject.",

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -27,4 +27,87 @@
           }
         }
       }
+    },
+    "/subjects/{subject}/versions": {
+      "post": {
+        "summary": "Create a new schema for the subject.",
+        "operationId": "post_subject_versions",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "schema_def",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "schema": {
+                  "type": "string"
+                },
+                "schemaType": {
+                  "type": "string"
+                },
+                "references": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "subject": {
+                        "type": "string"
+                      },
+                      "version": {
+                          "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Incompatible schema",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "422": {
+            "description": "Invalid schema",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
     }

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -110,4 +110,66 @@
           }
         }
       }
+    },
+    "/subjects/{subject}/versions/{version}": {
+      "get": {
+        "summary": "Retrieve a schema for the subject and version.",
+        "operationId": "get_subject_versions_version",
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "integer"
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Schema not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "422": {
+            "description": "Invalid version",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
     }

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -28,6 +28,51 @@
         }
       }
     },
+    "/schemas/ids/{id}": {
+      "get": {
+        "summary": "Get a schema by id.",
+        "operationId": "get_schemas_ids_id",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Schema not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
     "/subjects": {
       "get": {
         "summary": "Retrieve a list of subjects.",

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -26,6 +26,8 @@ struct reply_error_category final : std::error_category {
             return "HTTP 406 Not Acceptable";
         case reply_error_code::unsupported_media_type:
             return "HTTP 415 Unsupported Media Type";
+        case reply_error_code::unprocessable_entity:
+            return "HTTP 422 Unprocesable Entity";
         case reply_error_code::kafka_bad_request:
             return "kafka_bad_request";
         case reply_error_code::kafka_authentication_error:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -27,6 +27,7 @@ namespace pandaproxy {
 enum class reply_error_code : uint16_t {
     not_acceptable = 406,
     unsupported_media_type = 415,
+    unprocessable_entity = 422,
     kafka_bad_request = 40002,
     kafka_authentication_error = 40101,
     kafka_authorization_error = 40301,

--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -25,3 +25,4 @@ v_cc_library(
 add_dependencies(v_pandaproxy_schema_registry schema_registry_swagger)
 
 add_subdirectory(test)
+add_subdirectory(requests)

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -35,6 +35,20 @@ struct error_category final : std::error_category {
         }
         return "(unrecognized error)";
     }
+    std::error_condition
+    default_error_condition(int ec) const noexcept override {
+        switch (static_cast<error_code>(ec)) {
+        case error_code::schema_id_not_found:
+            return reply_error_code::topic_not_found; // hack
+        case error_code::schema_invalid:
+            return reply_error_code::unprocessable_entity;
+        case error_code::subject_not_found:
+            return reply_error_code::topic_not_found; // hack
+        case error_code::subject_version_not_found:
+            return reply_error_code::topic_not_found; // hack
+        }
+        return {};
+    }
 };
 
 const error_category pps_error_category{};

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -27,7 +27,8 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
     auto res_fmt = parse::accept_header(
       *rq.req,
       {ppj::serialization_format::schema_registry_v1_json,
-       ppj::serialization_format::schema_registry_json});
+       ppj::serialization_format::schema_registry_json,
+       ppj::serialization_format::none});
     rq.req.reset();
 
     static const std::vector<std::string_view> schemas_types{"AVRO"};

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -51,6 +51,24 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
 }
 
 ss::future<server::reply_t>
+get_subjects(server::request_t rq, server::reply_t rp) {
+    parse::accept_header(
+      *rq.req,
+      {ppj::serialization_format::schema_registry_v1_json,
+       ppj::serialization_format::schema_registry_json,
+       ppj::serialization_format::none});
+
+    rq.req.reset();
+
+    auto subjects = rq.service().schema_store().get_subjects();
+    auto json_rslt{json::rjson_serialize(subjects)};
+    rp.rep->write_body("json", json_rslt);
+    rp.mime_type = json::serialization_format::schema_registry_v1_json;
+
+    co_return rp;
+}
+
+ss::future<server::reply_t>
 get_subject_versions(server::request_t rq, server::reply_t rp) {
     parse::accept_header(
       *rq.req,

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -9,12 +9,22 @@
 
 #include "handlers.h"
 
+#include "kafka/protocol/exceptions.h"
+#include "kafka/protocol/kafka_batch_adapter.h"
+#include "model/fundamental.h"
 #include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/json/types.h"
 #include "pandaproxy/parsing/httpd.h"
+#include "pandaproxy/reply.h"
+#include "pandaproxy/schema_registry/requests/post_subject_versions.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/server.h"
+#include "storage/record_batch_builder.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/std-coroutine.hh>
 
 namespace ppj = pandaproxy::json;
 
@@ -36,6 +46,57 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
     rp.rep->write_body("json", json_rslt);
     rp.mime_type = res_fmt;
     return ss::make_ready_future<server::reply_t>(std::move(rp));
+}
+
+ss::future<server::reply_t>
+post_subject_versions(server::request_t rq, server::reply_t rp) {
+    // {"keytype":"SCHEMA","subject":"Kafka-key","version":1,"magic":1}
+    // {"subject":"Kafka-key","version":1,"id":1,"schema":"\"string\"","deleted":false}
+    parse::content_type_header(
+      *rq.req,
+      {ppj::serialization_format::schema_registry_v1_json,
+       ppj::serialization_format::schema_registry_json});
+    parse::accept_header(
+      *rq.req,
+      {ppj::serialization_format::schema_registry_v1_json,
+       ppj::serialization_format::schema_registry_json,
+       ppj::serialization_format::none});
+
+    auto req = post_subject_versions_request{
+      .sub = parse::request_param<subject>(*rq.req, "subject"),
+      .payload = ppj::rjson_parse(
+        rq.req->content.data(), post_subject_versions_request_handler{})};
+
+    rq.req.reset();
+
+    auto ins_res = rq.service().schema_store().insert(
+      req.sub, req.payload.schema, req.payload.type);
+
+    if (ins_res.inserted) {
+        storage::record_batch_builder rb{
+          raft::data_batch_type, model::offset{0}};
+        rb.add_raw_kv(
+          make_schema_key(req.sub, ins_res.version),
+          make_schema_value(
+            req.sub, ins_res.version, ins_res.id, req.payload.schema));
+
+        auto res = co_await rq.service().client().local().produce_record_batch(
+          model::topic_partition{
+            model::topic{"_schemas"}, model::partition_id{0}},
+          std::move(rb).build());
+
+        // TODO(Ben): Check the error reporting here
+        if (res.error_code != kafka::error_code::none) {
+            throw kafka::exception(res.error_code, *res.error_message);
+        }
+    }
+
+    auto json_rslt{
+      json::rjson_serialize(post_subject_versions_response{.id{ins_res.id}})};
+    rp.rep->write_body("json", json_rslt);
+    rp.mime_type = json::serialization_format::schema_registry_v1_json;
+
+    co_return rp;
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -22,4 +22,7 @@ namespace pandaproxy::schema_registry {
 ss::future<ctx_server<service>::reply_t> get_schemas_types(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> post_subject_versions(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -25,4 +25,7 @@ ss::future<ctx_server<service>::reply_t> get_schemas_types(
 ss::future<ctx_server<service>::reply_t> post_subject_versions(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -22,6 +22,9 @@ namespace pandaproxy::schema_registry {
 ss::future<ctx_server<service>::reply_t> get_schemas_types(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> get_subject_versions(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> post_subject_versions(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -22,6 +22,9 @@ namespace pandaproxy::schema_registry {
 ss::future<ctx_server<service>::reply_t> get_schemas_types(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> get_subjects(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> get_subject_versions(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -22,6 +22,9 @@ namespace pandaproxy::schema_registry {
 ss::future<ctx_server<service>::reply_t> get_schemas_types(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> get_schemas_ids_id(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> get_subjects(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/requests/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/requests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(test)

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "outcome.h"
+#include "pandaproxy/json/iobuf.h"
+#include "pandaproxy/json/rjson_parse.h"
+#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "seastarx.h"
+#include "utils/string_switch.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <atomic>
+#include <cstdint>
+
+namespace pandaproxy::schema_registry {
+
+struct get_schemas_ids_id_response {
+    schema_definition definition;
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const get_schemas_ids_id_response& res) {
+    w.StartObject();
+    w.Key("schema");
+    ::json::rjson_serialize(w, res.definition);
+    w.EndObject();
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "outcome.h"
+#include "pandaproxy/json/iobuf.h"
+#include "pandaproxy/json/rjson_parse.h"
+#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "seastarx.h"
+#include "utils/string_switch.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <atomic>
+#include <cstdint>
+
+namespace pandaproxy::schema_registry {
+
+struct post_subject_versions_version_response {
+    subject sub;
+    schema_version version;
+    schema_definition definition;
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const post_subject_versions_version_response& res) {
+    w.StartObject();
+    w.Key("name");
+    ::json::rjson_serialize(w, res.sub);
+    w.Key("version");
+    ::json::rjson_serialize(w, res.version);
+    w.Key("schema");
+    ::json::rjson_serialize(w, res.definition);
+    w.EndObject();
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "outcome.h"
+#include "pandaproxy/json/iobuf.h"
+#include "pandaproxy/json/rjson_parse.h"
+#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "seastarx.h"
+#include "utils/string_switch.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sstring.hh>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <atomic>
+#include <cstdint>
+
+namespace pandaproxy::schema_registry {
+
+struct post_subject_versions_request {
+    struct schema_reference {
+        ss::sstring name;
+        subject sub{invalid_subject};
+        schema_version version{invalid_schema_version};
+    };
+
+    struct body {
+        schema_definition schema{invalid_schema_definition};
+        schema_type type{schema_type::avro};
+        std::vector<schema_reference> references;
+    };
+
+    subject sub;
+    body payload;
+};
+
+template<typename Encoding>
+result<schema_definition> make_schema_definition(std::string_view sv) {
+    // Sort and minify
+    rapidjson::GenericDocument<Encoding> doc;
+    doc.Parse(sv.data(), sv.size());
+    if (doc.HasParseError()) {
+        return error_code::schema_invalid;
+    }
+    rapidjson::GenericStringBuffer<Encoding> str_buf;
+    str_buf.Reserve(sv.size());
+    rapidjson::Writer<rapidjson::StringBuffer> w{str_buf};
+    doc.Accept(w);
+    return schema_definition{
+      ss::sstring{str_buf.GetString(), str_buf.GetSize()}};
+}
+
+template<typename Encoding = rapidjson::UTF8<>>
+class post_subject_versions_request_handler
+  : public json::base_handler<Encoding> {
+    enum class state {
+        empty = 0,
+        record,
+        schema,
+        schema_type,
+        references,
+        reference,
+        reference_name,
+        reference_subject,
+        reference_version,
+    };
+    state _state = state::empty;
+
+public:
+    using Ch = typename json::base_handler<Encoding>::Ch;
+    using rjson_parse_result = post_subject_versions_request::body;
+    rjson_parse_result result;
+
+    post_subject_versions_request_handler()
+      : json::base_handler<Encoding>{json::serialization_format::none} {}
+
+    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        switch (_state) {
+        case state::record: {
+            std::optional<state> s{string_switch<std::optional<state>>(sv)
+                                     .match("schema", state::schema)
+                                     .match("schemaType", state::schema_type)
+                                     .match("references", state::references)
+                                     .default_match(std::nullopt)};
+            if (s.has_value()) {
+                _state = *s;
+            }
+            return s.has_value();
+        }
+        case state::reference: {
+            std::optional<state> s{string_switch<std::optional<state>>(sv)
+                                     .match("name", state::reference_name)
+                                     .match("subject", state::reference_subject)
+                                     .match("version", state::reference_version)
+                                     .default_match(std::nullopt)};
+            if (s.has_value()) {
+                _state = *s;
+            }
+            return s.has_value();
+        }
+        case state::empty:
+        case state::schema:
+        case state::schema_type:
+        case state::references:
+        case state::reference_name:
+        case state::reference_subject:
+        case state::reference_version:
+            return false;
+        }
+        return false;
+    }
+
+    bool Uint(int i) {
+        switch (_state) {
+        case state::reference_version:
+            result.references.back().version = schema_version{i};
+            _state = state::reference;
+            return true;
+        case state::empty:
+        case state::record:
+        case state::schema:
+        case state::schema_type:
+        case state::references:
+        case state::reference:
+        case state::reference_name:
+        case state::reference_subject:
+            return false;
+        }
+    }
+
+    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        switch (_state) {
+        case state::schema: {
+            auto def = make_schema_definition<Encoding>(sv);
+            if (!def) {
+                return false;
+            }
+            result.schema = std::move(def).value();
+            _state = state::record;
+            return true;
+        }
+        case state::schema_type: {
+            std::optional<schema_type> type{
+              string_switch<std::optional<schema_type>>(sv)
+                .match(to_string_view(schema_type::avro), schema_type::avro)
+                .match(to_string_view(schema_type::json), schema_type::json)
+                .match(
+                  to_string_view(schema_type::protobuf), schema_type::protobuf)
+                .default_match(std::nullopt)};
+            if (type.has_value()) {
+                result.type = *type;
+                _state = state::record;
+            }
+            return type.has_value();
+        }
+        case state::reference_name:
+            result.references.back().name = ss::sstring{sv};
+            _state = state::reference;
+            return true;
+        case state::reference_subject:
+            result.references.back().sub = subject{ss::sstring{sv}};
+            _state = state::reference;
+            return true;
+        case state::empty:
+        case state::record:
+        case state::references:
+        case state::reference:
+        case state::reference_version:
+            return false;
+        }
+        return false;
+    }
+
+    bool StartObject() {
+        switch (_state) {
+        case state::empty:
+            _state = state::record;
+            return true;
+        case state::references:
+            result.references.emplace_back();
+            _state = state::reference;
+            return true;
+        case state::record:
+        case state::schema:
+        case state::schema_type:
+        case state::reference:
+        case state::reference_name:
+        case state::reference_subject:
+        case state::reference_version:
+            return false;
+        }
+    }
+
+    bool EndObject(rapidjson::SizeType) {
+        switch (_state) {
+        case state::record:
+            _state = state::empty;
+            return !result.schema().empty();
+        case state::reference: {
+            _state = state::references;
+            const auto& reference{result.references.back()};
+            return !reference.name.empty() && reference.sub != invalid_subject
+                   && reference.version != invalid_schema_version;
+        }
+        case state::empty:
+        case state::schema:
+        case state::schema_type:
+        case state::references:
+        case state::reference_name:
+        case state::reference_subject:
+        case state::reference_version:
+            return false;
+        }
+        return false;
+    }
+
+    bool StartArray() { return _state == state::references; }
+
+    bool EndArray(rapidjson::SizeType) {
+        return std::exchange(_state, state::record) == state::references;
+    }
+};
+
+struct post_subject_versions_response {
+    schema_id id;
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const schema_registry::post_subject_versions_response& res) {
+    w.StartObject();
+    w.Key("id");
+    w.Int(res.id());
+    w.EndObject();
+}
+
+struct schema_key {
+    ss::sstring keytype{"SCHEMA"};
+    subject sub;
+    schema_version version;
+    named_type<int32_t, struct magic_tag> magic{1};
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const schema_registry::schema_key& key) {
+    w.StartObject();
+    w.Key("keytype");
+    w.String(key.keytype);
+    w.Key("subject");
+    w.String(key.sub());
+    w.Key("version");
+    w.Int(key.version());
+    w.Key("magic");
+    w.Int(key.magic());
+    w.EndObject();
+}
+
+struct schema_value {
+    subject sub;
+    schema_version version;
+    schema_type type{schema_type::avro};
+    schema_id id;
+    schema_definition schema;
+    bool deleted{false};
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const schema_registry::schema_value& val) {
+    w.StartObject();
+    w.Key("subject");
+    ::json::rjson_serialize(w, val.sub);
+    w.Key("version");
+    w.Int(val.version());
+    if (val.type != schema_type::avro) {
+        w.Key("schemaType");
+        ::json::rjson_serialize(w, to_string_view(val.type));
+    }
+    w.Key("id");
+    ::json::rjson_serialize(w, val.id());
+    w.Key("deleted");
+    ::json::rjson_serialize(w, val.deleted);
+    w.EndObject();
+}
+
+inline iobuf make_schema_key(const subject& sub, schema_version ver) {
+    auto str = json::rjson_serialize(schema_key{.sub{sub}, .version{ver}});
+    iobuf key;
+    key.append(str.data(), str.size());
+    return key;
+}
+
+inline iobuf make_schema_value(
+  subject sub, schema_version ver, schema_id id, schema_definition schema) {
+    auto str = json::rjson_serialize(schema_value{
+      .sub{std::move(sub)},
+      .version{ver},
+      .id{id},
+      .schema{std::move(schema)}});
+    iobuf val;
+    val.append(str.data(), str.size());
+    return val;
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/requests/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/requests/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+rp_test(
+  UNIT_TEST
+  BINARY_NAME pandaproxy_schema_registry_requests_unit
+  SOURCES
+    post_subject_versions.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main v::pandaproxy_schema_registry v::utils
+  LABELS pandaproxy
+)

--- a/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
+++ b/src/v/pandaproxy/schema_registry/requests/test/post_subject_versions.cc
@@ -1,0 +1,56 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/requests/post_subject_versions.h"
+
+#include "seastarx.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <type_traits>
+
+namespace ppj = pandaproxy::json;
+namespace pps = pandaproxy::schema_registry;
+
+SEASTAR_THREAD_TEST_CASE(test_post_subject_versions_parser) {
+    const ss::sstring escaped_schema_def{
+      R"({\n\"type\": \"record\",\n\"name\": \"test\",\n\"fields\":\n  [\n    {\n      \"type\": \"string\",\n      \"name\": \"field1\"\n    },\n    {\n      \"type\": \"com.acme.Referenced\",\n      \"name\": \"int\"\n    }\n  ]\n})"};
+    const ss::sstring expected_schema_def{
+      R"({"type":"record","name":"test","fields":[{"type":"string","name":"field1"},{"type":"com.acme.Referenced","name":"int"}]})"};
+
+    const ss::sstring payload{
+      R"(
+{
+  "schema": ")"
+      + escaped_schema_def + R"(",
+  "schemaType": "AVRO",
+  "references": [
+    {
+       "name": "com.acme.Referenced",
+       "subject":  "childSubject",
+       "version": 1
+    }
+  ]
+})"};
+    const pps::subject sub{"test_subject"};
+    const pps::post_subject_versions_request::body expected{
+      .schema{expected_schema_def},
+      .type = pps::schema_type::avro,
+      .references{{}}};
+
+    auto result{ppj::rjson_parse(
+      payload.data(), pps::post_subject_versions_request_handler{})};
+
+    BOOST_REQUIRE_EQUAL(expected.schema, result.schema);
+    BOOST_REQUIRE(expected.type == result.type);
+    BOOST_REQUIRE(expected.references.size() == result.references.size());
+}

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -30,6 +30,9 @@ server::routes_t get_schema_registry_routes() {
       ss::httpd::schema_registry_json::get_schemas_types, get_schemas_types});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::get_schemas_ids_id, get_schemas_ids_id});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::get_subjects, get_subjects});
 
     routes.routes.emplace_back(server::route_t{

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -29,6 +29,10 @@ server::routes_t get_schema_registry_routes() {
     routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::get_schemas_types, get_schemas_types});
 
+    routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::post_subject_versions,
+      post_subject_versions});
+
     return routes;
 }
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -30,6 +30,9 @@ server::routes_t get_schema_registry_routes() {
       ss::httpd::schema_registry_json::get_schemas_types, get_schemas_types});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::get_subjects, get_subjects});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::get_subject_versions,
       get_subject_versions});
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -33,6 +33,10 @@ server::routes_t get_schema_registry_routes() {
       ss::httpd::schema_registry_json::post_subject_versions,
       post_subject_versions});
 
+    routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::get_subject_versions_version,
+      get_subject_versions_version});
+
     return routes;
 }
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -30,6 +30,10 @@ server::routes_t get_schema_registry_routes() {
       ss::httpd::schema_registry_json::get_schemas_types, get_schemas_types});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::get_subject_versions,
+      get_subject_versions});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::post_subject_versions,
       post_subject_versions});
 

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -13,6 +13,7 @@
 
 #include "kafka/client/client.h"
 #include "pandaproxy/schema_registry/configuration.h"
+#include "pandaproxy/schema_registry/store.h"
 #include "pandaproxy/server.h"
 #include "seastarx.h"
 
@@ -39,6 +40,7 @@ public:
     configuration& config();
     kafka::client::configuration& client_config();
     ss::sharded<kafka::client::client>& client() { return _client; }
+    store& schema_store() { return _store; }
 
 private:
     configuration _config;
@@ -46,6 +48,7 @@ private:
     ss::sharded<kafka::client::client>& _client;
     ctx_server<service>::context_t _ctx;
     ctx_server<service> _server;
+    store _store;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -83,6 +83,18 @@ public:
           .deleted = v_it->deleted};
     }
 
+    ///\brief Return a list of subjects.
+    std::vector<subject> get_subjects() const {
+        std::vector<subject> res;
+        res.reserve(_subjects.size());
+        std::transform(
+          _subjects.begin(),
+          _subjects.end(),
+          std::back_inserter(res),
+          [](const auto& v) { return v.first; });
+        return res;
+    }
+
     ///\brief Return a list of versions and associated schema_id.
     result<std::vector<schema_version>> get_versions(const subject& sub) const {
         auto sub_it = _subjects.find(sub);

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -11,6 +11,7 @@
 
 #include "pandaproxy/schema_registry/util.h"
 
+#include <absl/algorithm/container.h>
 #include <boost/test/unit_test.hpp>
 
 namespace pps = pandaproxy::schema_registry;
@@ -155,4 +156,28 @@ BOOST_AUTO_TEST_CASE(test_store_get_versions) {
     BOOST_REQUIRE_EQUAL(versions.value().size(), 2);
     BOOST_REQUIRE_EQUAL(versions.value().front(), pps::schema_version{1});
     BOOST_REQUIRE_EQUAL(versions.value().back(), pps::schema_version{2});
+}
+
+BOOST_AUTO_TEST_CASE(test_store_get_subjects) {
+    auto is_equal = [](auto lhs) {
+        return [lhs](auto rhs) { return lhs == rhs; };
+    };
+
+    pps::store s;
+
+    auto subjects = s.get_subjects();
+    BOOST_REQUIRE(subjects.empty());
+
+    // First insert
+    s.insert(subject0, string_def0, pps::schema_type::avro);
+    subjects = s.get_subjects();
+    BOOST_REQUIRE_EQUAL(subjects.size(), 1);
+    BOOST_REQUIRE_EQUAL(absl::c_count_if(subjects, is_equal(subject0)), 1);
+
+    // second insert
+    s.insert(subject1, string_def0, pps::schema_type::avro);
+    subjects = s.get_subjects();
+    BOOST_REQUIRE(subjects.size() == 2);
+    BOOST_REQUIRE_EQUAL(absl::c_count_if(subjects, is_equal(subject0)), 1);
+    BOOST_REQUIRE_EQUAL(absl::c_count_if(subjects, is_equal(subject1)), 1);
 }

--- a/src/v/pandaproxy/schema_registry/util.h
+++ b/src/v/pandaproxy/schema_registry/util.h
@@ -32,6 +32,8 @@ namespace pandaproxy::schema_registry {
 template<typename Encoding>
 result<schema_definition> make_schema_definition(std::string_view sv) {
     // Validate and minify
+    // TODO (Ben): Minify. e.g.:
+    // "schema": "{\"type\": \"string\"}" -> "schema": "\"string\""
     rapidjson::GenericDocument<Encoding> doc;
     doc.Parse(sv.data(), sv.size());
     if (doc.HasParseError()) {

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -80,6 +80,10 @@ class SchemaRegistryTest(RedpandaTest):
         return requests.get(f"{self._base_uri()}/schemas/types",
                             headers=headers)
 
+    def _get_schemas_ids_id(self, id, headers=HTTP_GET_HEADERS):
+        return requests.get(f"{self._base_uri()}/schemas/ids/{id}",
+                            headers=headers)
+
     def _get_subjects(self, headers=HTTP_GET_HEADERS):
         return requests.get(f"{self._base_uri()}/subjects", headers=headers)
 
@@ -238,4 +242,17 @@ class SchemaRegistryTest(RedpandaTest):
         result = result_raw.json()
         assert result["name"] == f"{topic}-key"
         assert result["version"] == 1
+        # assert result["schema"] == json.dumps(schema_def)
+
+        self.logger.debug("Get invalid schema version")
+        result_raw = self._get_schemas_ids_id(id=2)
+        assert result_raw.status_code == requests.codes.not_found
+        result = result_raw.json()
+        assert result["error_code"] == 40401
+        assert result["message"] == "Schema not found"
+
+        self.logger.debug("Get schema version 1")
+        result_raw = self._get_schemas_ids_id(id=1)
+        assert result_raw.status_code == requests.codes.ok
+        result = result_raw.json()
         # assert result["schema"] == json.dumps(schema_def)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -80,6 +80,9 @@ class SchemaRegistryTest(RedpandaTest):
         return requests.get(f"{self._base_uri()}/schemas/types",
                             headers=headers)
 
+    def _get_subjects(self, headers=HTTP_GET_HEADERS):
+        return requests.get(f"{self._base_uri()}/subjects", headers=headers)
+
     def _post_subjects_subject_versions(self,
                                         subject,
                                         data,
@@ -154,6 +157,10 @@ class SchemaRegistryTest(RedpandaTest):
 
         schema_1_data = json.dumps({"schema": json.dumps(schema_def)})
 
+        self.logger.debug("Get empty subjects")
+        result_raw = self._get_subjects()
+        assert result_raw.json() == []
+
         self.logger.debug("Posting schema 1 as a subject key")
         result_raw = self._post_subjects_subject_versions(
             subject=f"{topic}-key", data=schema_1_data)
@@ -174,6 +181,10 @@ class SchemaRegistryTest(RedpandaTest):
         self.logger.debug(result_raw)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["id"] == 1
+
+        self.logger.debug("Get subjects")
+        result_raw = self._get_subjects()
+        assert result_raw.json() == [f"{topic}-key", f"{topic}-value"]
 
         self.logger.debug("Get schema versions for invalid subject")
         result_raw = self._get_subjects_subject_versions(

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -74,6 +74,12 @@ class SchemaRegistryTest(RedpandaTest):
         """
         Verify the schema registry returns the supported types
         """
+        
+        self.logger.debug(f"Request schema types with no accept header")
+        result_raw = self._get_schemas_types(headers={})
+        assert result_raw.status_code == requests.codes.ok
+
+        self.logger.debug(f"Request schema types with defautl accept header")
         result_raw = self._get_schemas_types()
         assert result_raw.status_code == requests.codes.ok
         result = result_raw.json()

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -88,6 +88,14 @@ class SchemaRegistryTest(RedpandaTest):
                              headers=headers,
                              data=data)
 
+    def _get_subjects_subject_versions_version(self,
+                                               subject,
+                                               version,
+                                               headers=HTTP_GET_HEADERS):
+        return requests.get(
+            f"{self._base_uri()}/subjects/{subject}/versions/{version}",
+            headers=headers)
+
     @cluster(num_nodes=3)
     def test_schemas_types(self):
         """
@@ -160,3 +168,37 @@ class SchemaRegistryTest(RedpandaTest):
         self.logger.debug(result_raw)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["id"] == 1
+
+        self.logger.debug("Get schema version 1 for invalid subject")
+        result_raw = self._get_subjects_subject_versions_version(
+            subject=f"{topic}-invalid", version=1)
+        assert result_raw.status_code == requests.codes.not_found
+        result = result_raw.json()
+        assert result["error_code"] == 40401
+        assert result["message"] == "Subject not found"
+
+        self.logger.debug("Get invalid schema version for subject")
+        result_raw = self._get_subjects_subject_versions_version(
+            subject=f"{topic}-key", version=2)
+        assert result_raw.status_code == requests.codes.not_found
+        result = result_raw.json()
+        assert result["error_code"] == 40401
+        assert result["message"] == "Subject version not found"
+
+        self.logger.debug("Get schema version 1 for subject key")
+        result_raw = self._get_subjects_subject_versions_version(
+            subject=f"{topic}-key", version=1)
+        assert result_raw.status_code == requests.codes.ok
+        result = result_raw.json()
+        assert result["name"] == f"{topic}-key"
+        assert result["version"] == 1
+        # assert result["schema"] == json.dumps(schema_def)
+
+        self.logger.debug("Get latest schema version for subject key")
+        result_raw = self._get_subjects_subject_versions_version(
+            subject=f"{topic}-key", version="latest")
+        assert result_raw.status_code == requests.codes.ok
+        result = result_raw.json()
+        assert result["name"] == f"{topic}-key"
+        assert result["version"] == 1
+        # assert result["schema"] == json.dumps(schema_def)


### PR DESCRIPTION
# Early work

This is still WIP. Reviews are not necessary, but any review will be much appreciated.

TODO:
 * Testing
   *  Ducktape tests are more of a smoke-test than desired
   * There are no fixture tests
 * Refactoring
   * Error codes and error reply need some attention to detach from pandaproxy

## Cover letter

Support for:
* `GET ​/schemas​/types` # Get the supported schema types.
* `GET ​/schemas​/ids​/{id}` # Get a schema by id.
* `GET ​/subjects` # Retrieve a list of subjects.
* `GET ​/subjects​/{subject}​/versions` # Retrieve a list of versions for a subject.
* `POST ​/subjects​/{subject}​/versions` # Create a new schema for the subject.
* `GET ​/subjects​/{subject}​/versions​/{version}` # Retrive a schema for the subject and version.

## Release notes

Release note: pre-alpha Schema Registry
