### PR TITLE
archival: Disable per-ntp metrics

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -147,8 +147,7 @@ scheduler_service_impl::get_archival_service_config() {
         config::shard_local_cfg().cloud_storage_max_connections.value()),
       .svc_metrics_disabled = service_metrics_disabled(
         static_cast<bool>(disable_metrics)),
-      .ntp_metrics_disabled = per_ntp_metrics_disabled(
-        static_cast<bool>(disable_metrics)),
+      .ntp_metrics_disabled = per_ntp_metrics_disabled::yes,
     };
     vlog(archival_log.debug, "Archival configuration generated: {}", cfg);
     co_return cfg;


### PR DESCRIPTION
## Cover letter

Fix #1449 by disabling the metrics that cause double registration.
I wasn't able to reproduce the issue yet. Disabling the metrics is OK since it's only small part of archival metrics that cause this (only three of them). Will re-enable them when the real fix will be ready.

## Release notes

N/A