### PR TITLE
rpk topic set-config: Don't parse negative nums. as flags

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/config.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/config.go
@@ -24,7 +24,8 @@ func NewSetConfigCommand(
 		Short: "Set the topic's config key/value pairs",
 		Args:  common.ExactArgs(3, "topic's name, config key or value are missing."),
 		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
-		SilenceUsage: true,
+		SilenceUsage:       true,
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			adm, err := admin()
 			if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/topic_test.go
+++ b/src/go/rpk/pkg/cli/cmd/topic_test.go
@@ -122,6 +122,12 @@ func TestTopicCmd(t *testing.T) {
 			expectedOutput: "Added config 'somekey'='somevalue' to topic 'Panama'.",
 		},
 		{
+			name:           "set-config should allow passing negative numbers and not parse them as flags",
+			cmd:            topic.NewSetConfigCommand,
+			args:           []string{"Panama", "retention.ms", "-1"},
+			expectedOutput: "Added config 'retention.ms'='-1' to topic 'Panama'.",
+		},
+		{
 			name: "set-config should fail if the req fails",
 			cmd:  topic.NewSetConfigCommand,
 			args: []string{"Chiriqui", "k", "v"},


### PR DESCRIPTION
Some configuration keys, like `retention.ms`, allow negative numbers as values, which Cobra parses as flags by default. Disable flag parsing for `rpk topic set-config`

Fix #1415