### PR TITLE
ci/buildkite: tweaks to taskfiles for running pipelines on buildkite

### DIFF
--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -26,12 +26,9 @@ tasks:
 
   install-docker-compose:
     desc: install docker-compose
-    vars:
-      SYSTEM_PROCESSOR:
-        sh: 'uname -m'
     cmds:
     - mkdir -p '{{.BUILD_ROOT}}/bin/'
-    - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --output '{{.BUILD_ROOT}}/bin/docker-compose' 'https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.1-ls39/docker-compose-{{if eq .SYSTEM_PROCESSOR "aarch64"}}arm64{{else}}amd64{{end}}'
+    - curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 --output '{{.BUILD_ROOT}}/bin/docker-compose' 'https://github.com/linuxserver/docker-docker-compose/releases/download/1.29.1-ls39/docker-compose-{{if eq ARCH "arm64"}}arm64{{else}}amd64{{end}}'
     - chmod +x '{{.BUILD_ROOT}}/bin/docker-compose'
     status:
     - test -f '{{.BUILD_ROOT}}/bin/docker-compose'

--- a/taskfiles/docker.yml
+++ b/taskfiles/docker.yml
@@ -14,7 +14,7 @@ tasks:
     - download-task
     cmds:
     - |
-      docker run --rm -i --privileged {{.DOCKER_RUN_FLAGS}} \
+      docker run --rm -i {{.DOCKER_RUN_FLAGS}} \
         -e "COMMIT={{.COMMIT}}" \
         -e "CI={{.CI}}" \
         -e "TAG_NAME={{.TAG_NAME}}" \

--- a/taskfiles/docker.yml
+++ b/taskfiles/docker.yml
@@ -13,11 +13,15 @@ tasks:
     deps:
     - download-task
     cmds:
-    - printenv > /tmp/.envfile
-    - sed -i 's/PATH.*//' /tmp/.envfile
     - |
       docker run --rm -i --privileged {{.DOCKER_RUN_FLAGS}} \
-        --env-file /tmp/.envfile \
+        -e "COMMIT={{.COMMIT}}" \
+        -e "CI={{.CI}}" \
+        -e "TAG_NAME={{.TAG_NAME}}" \
+        -e "BRANCH_NAME={{.BRANCH_NAME}}" \
+        -e "COMPILER={{.COMPILER}}" \
+        -e "BUILD_TYPE={{.BUILD_TYPE}}" \
+        -e "PWD={{.PWD}}" \
         --volume '{{.PWD}}:{{.PWD}}' \
         --workdir '{{.PWD}}' \
         --entrypoint=bin/task \

--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -94,11 +94,11 @@ tasks:
       if [ '{{.CI}}' == 'true' ]; then
         chmod 644 '{{.SRC_DIR}}/tests/docker/ssh/'* '{{.SRC_DIR}}/tests/setup.py'
         chmod 755 '{{.SRC_DIR}}/tests/docker/ssh'
-        docker pull docker.io/vectorized/redpanda-test-node:cache || true
+        docker pull docker.io/vectorized/redpanda-test-node:cache-{{ARCH}} || true
         docker build \
           --tag vectorized/redpanda-test-node \
           --file '{{.SRC_DIR}}/tests/docker/Dockerfile' \
-          --cache-from docker.io/vectorized/redpanda-test-node:cache \
+          --cache-from docker.io/vectorized/redpanda-test-node:cache-{{ARCH}} \
           '{{.SRC_DIR}}'
       else
         docker build \
@@ -107,6 +107,13 @@ tasks:
           '{{.SRC_DIR}}'
       fi
     - rm '{{.SRC_DIR}}/.dockerignore'
+    - cmd: "if [ '{{.CI}}' == 'true' ] && [ '{{.BRANCH_NAME}}' = 'dev' ]; then docker login --username {{.DOCKERHUB_USER}} --password {{.DOCKERHUB_TOKEN}}; fi"
+      silent: true
+    - |
+      if [ '{{.CI}}' = 'true' ] && [ '{{.BRANCH_NAME}}' = 'dev' ]; then
+        docker tag vectorized/redpanda-test-node docker.io/vectorized/redpanda-test-node:cache-{{ARCH}}
+        docker push docker.io/vectorized/redpanda-test-node:cache-{{ARCH}}
+      fi
 
   start-compose-cluster:
     desc: deploy a cluster using docker-compose

--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -90,7 +90,7 @@ tasks:
     cmds:
     - cp '{{.SRC_DIR}}/tests/docker/Dockerfile.dockerignore' '{{.SRC_DIR}}/.dockerignore'
     - |
-      if [ '{{.CI}}' == '1' ]; then
+      if [ '{{.CI}}' == 'true' ]; then
         chmod 644 '{{.SRC_DIR}}/tests/docker/ssh/'* '{{.SRC_DIR}}/tests/setup.py'
         chmod 755 '{{.SRC_DIR}}/tests/docker/ssh'
         docker pull docker.io/vectorized/redpanda-test-node:cache || true

--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -69,8 +69,9 @@ tasks:
     desc: set minimum required value for fs.aio-max-nr sysctl option
     vars:
       MIN_REQUIRED_AIO_MAX: 10485760
+      USE_SUDO: '{{default "true" .USE_SUDO}}'
     cmds:
-    - sudo sysctl -w fs.aio-max-nr={{.MIN_REQUIRED_AIO_MAX}}
+    - '{{if eq .USE_SUDO "true"}}sudo {{end}}sysctl -w fs.aio-max-nr={{.MIN_REQUIRED_AIO_MAX}}'
     status:
     - test {{.MIN_REQUIRED_AIO_MAX}} -le $(sysctl -nb fs.aio-max-nr)
 

--- a/tests/ci/cloudbuild.yaml
+++ b/tests/ci/cloudbuild.yaml
@@ -24,9 +24,8 @@ steps:
   name: gcr.io/cloud-builders/docker
   entrypoint: sh
   env:
-  - 'CI=1'
-  - 'COMMIT_SHA=$COMMIT_SHA'
-  - 'SHORT_SHA=$SHORT_SHA'
+  - 'CI=true'
+  - 'COMMIT=$COMMIT_SHA'
   - 'BRANCH_NAME=$BRANCH_NAME'
   - 'TAG_NAME=$TAG_NAME'
   - 'DOCKERHUB_USER=$_DOCKER_USERNAME'


### PR DESCRIPTION
Changes for running the `task:docker` task in non-privileged mode, as well as having an explicit list of environment variables being defined on containers, rather than passing the entire set of environment variables.

Other misc. commits for:
  * add flag for indicating whether or not to use sudo when updating `fs.aio-max-nr` (`sysctl` invocation)
  * add architecture name to the tags assigned to ducktape docker images