### PR TITLE
archival: Fix double registration

### DIFF
--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -18,9 +18,8 @@
 namespace archival {
 
 ntp_level_probe::ntp_level_probe(
-  per_ntp_metrics_disabled disabled, model::ntp ntp)
-  : _ntp(std::move(ntp))
-  , _uploaded()
+  per_ntp_metrics_disabled disabled, const model::ntp& ntp)
+  : _uploaded()
   , _missing()
   , _pending() {
     if (disabled) {

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -29,7 +29,7 @@ namespace archival {
 /// The unit of measure is offset delta.
 class ntp_level_probe {
 public:
-    ntp_level_probe(per_ntp_metrics_disabled disabled, model::ntp ntp);
+    ntp_level_probe(per_ntp_metrics_disabled disabled, const model::ntp& ntp);
 
     /// Register log-segment upload
     void uploaded(model::offset offset_delta) { _uploaded += offset_delta; }
@@ -41,8 +41,6 @@ public:
     void upload_lag(model::offset offset_delta) { _pending = offset_delta; }
 
 private:
-    /// NTP of the probe
-    model::ntp _ntp;
     /// Uploaded offsets
     int64_t _uploaded;
     /// Missing offsets due to gaps


### PR DESCRIPTION
## Cover letter

The bug that caused double registration was a consequence of the object lifetime issue. The ntp that was used to initialize labels for the probe was moved right before that. That caused two metric labels `namespace` and `topic` to be empty but label `partition` was still intact (since it's integer). Because of that it was only manifested with large number of topics (higher chance that two different ntps with the same partition id will end up on the same shard of the same node).

Fixes #1449.

## Release notes

N/A