### PR TITLE
rpk tune: Print warning when all tuners are disabled

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
@@ -214,8 +214,10 @@ func tune(
 
 	results := []result{}
 	includeErr := false
+	allDisabled := true
 	for _, tunerName := range tunerNames {
 		enabled := factory.IsTunerEnabled(tunerName, conf.Rpk)
+		allDisabled = allDisabled && !enabled
 		tuner := tunersFactory.CreateTuner(tunerName, params)
 		supported, reason := tuner.CheckIfSupported()
 		if !enabled || !supported {
@@ -232,6 +234,14 @@ func tune(
 			errMsg = res.Error().Error()
 		}
 		results = append(results, result{tunerName, !res.IsFailed(), enabled, supported, errMsg})
+	}
+
+	if allDisabled {
+		log.Warn(
+			"All tuners were disabled, so none were applied. You may run " +
+				" `rpk mode prod` to enable the recommended set of tuners " +
+				" for non-containerized production use.",
+		)
 	}
 
 	printTuneResult(results, includeErr)


### PR DESCRIPTION
It's confusing for a user when `rpk tune all` is run and no tuners are applied. This is usually caused because "development" mode defaults are active, so print a message letting the user know.

Fix #1177