### PR TITLE
rpk: Override logrus's defaults to log to STDOUT

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -32,6 +32,8 @@ func Execute() {
 		color.NoColor = true
 	}
 	log.SetFormatter(cli.NewRpkLogFormatter())
+	log.SetOutput(os.Stdout)
+
 	cobra.OnInitialize(func() {
 		// This is only executed when a subcommand (e.g. rpk check) is
 		// specified.

--- a/src/go/rpk/pkg/cli/cmd/root_test.go
+++ b/src/go/rpk/pkg/cli/cmd/root_test.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogOutput(t *testing.T) {
+	Execute()
+	// Execute should have configured logrus's global logger instance to log to
+	// STDOUT.
+	require.Exactly(t, os.Stdout, logrus.StandardLogger().Out)
+}

--- a/src/go/rpk/pkg/cli/cmd/topic_test.go
+++ b/src/go/rpk/pkg/cli/cmd/topic_test.go
@@ -61,19 +61,19 @@ func TestTopicCmd(t *testing.T) {
 			name:           "create should output info about the created topic (custom values)",
 			cmd:            topic.NewCreateCommand,
 			args:           []string{"Seattle", "--partitions", "2", "--replicas", "3", "--compact"},
-			expectedOutput: "Created topic 'Seattle'.\\nYou may check its config with\\n\\nrpk topic describe 'Seattle'\\n\"\n",
+			expectedOutput: "Created topic 'Seattle'.\nYou may check its config with\n\nrpk topic describe 'Seattle'\n\n",
 		},
 		{
 			name:           "create should allow passing arbitrary topic config",
 			cmd:            topic.NewCreateCommand,
 			args:           []string{"San Francisco", "--topic-config", "custom.config:value", "--topic-config", "another.config:anothervalue"},
-			expectedOutput: "Created topic 'San Francisco'.\\nYou may check its config with\\n\\nrpk topic describe 'San Francisco'\\n\"\n",
+			expectedOutput: "Created topic 'San Francisco'.\nYou may check its config with\n\nrpk topic describe 'San Francisco'\n\n",
 		},
 		{
 			name:           "create should allow passing comma-separated config values",
 			cmd:            topic.NewCreateCommand,
 			args:           []string{"San Francisco", "-c", "custom.config:value", "-c", "cleanup.policy:cleanup,compact"},
-			expectedOutput: "Created topic 'San Francisco'.\\nYou may check its config with\\n\\nrpk topic describe 'San Francisco'\\n\"\n",
+			expectedOutput: "Created topic 'San Francisco'.\nYou may check its config with\n\nrpk topic describe 'San Francisco'\n\n",
 		},
 		{
 			name:        "create should fail if no topic is passed",


### PR DESCRIPTION
Logrus defaults to writing to STDERR (https://github.com/sirupsen/logrus/blob/1818363d79cc77045d0724ed85146d5446ae925d/logger.go#L89), which might be confusing for some users, especially if `rpk`'s output is piped to another process or file.

Fix #1385