### PR TITLE
test: add verifiable client test with partition movement

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -41,3 +41,5 @@ services:
   n2: *node
   n3: *node
   n4: *node
+  n5: *node
+  n6: *node

--- a/tests/docker/ducktape_cluster.json
+++ b/tests/docker/ducktape_cluster.json
@@ -43,6 +43,28 @@
                 "port": 22,
                 "user": "root"
             }
+        },
+        {
+            "externally_routable_ip": "n5",
+            "ssh_config": {
+                "host": "n5",
+                "hostname": "n5",
+                "identityfile": "/root/.ssh/id_rsa",
+                "password": "UNUSED",
+                "port": 22,
+                "user": "root"
+            }
+        },
+        {
+            "externally_routable_ip": "n6",
+            "ssh_config": {
+                "host": "n6",
+                "hostname": "n6",
+                "identityfile": "/root/.ssh/id_rsa",
+                "password": "UNUSED",
+                "port": 22,
+                "user": "root"
+            }
         }
     ]
 }

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -72,7 +72,7 @@ class RedpandaService(Service):
         self._context = context
         self._client_type = client_type
         self._enable_rp = enable_rp
-        self._extra_rp_conf = extra_rp_conf
+        self._extra_rp_conf = extra_rp_conf or dict()
         self._enable_pp = enable_pp
         self._enable_sr = enable_sr
         self._log_level = self._context.globals.get(self.LOG_LEVEL_KEY,

--- a/tests/rptest/services/templates/producer.properties
+++ b/tests/rptest/services/templates/producer.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# see kafka.producer.ProducerConfig for more details
+
+request.timeout.ms={{ request_timeout_ms }}

--- a/tests/rptest/services/templates/tools_log4j.properties
+++ b/tests/rptest/services/templates/tools_log4j.properties
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define the root logger with appender file
+log4j.rootLogger = {{ log_level|default("INFO") }}, FILE
+
+{% if loggers is defined %}
+{% for logger, log_level in loggers.items() %}
+log4j.logger.{{ logger }}={{ log_level }}
+{% endfor %}
+{% endif %}
+
+log4j.appender.FILE=org.apache.log4j.FileAppender
+log4j.appender.FILE.File={{ log_file }}
+log4j.appender.FILE.ImmediateFlush=true
+# Set the append to true
+log4j.appender.FILE.Append=true
+log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.FILE.layout.conversionPattern=[%d] %p %m (%c)%n

--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -1,0 +1,466 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+from ducktape.services.background_thread import BackgroundThreadService
+
+from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
+from kafkatest.services.kafka import TopicPartition
+from kafkatest.services.verifiable_client import VerifiableClientMixin
+from kafkatest.version import DEV_BRANCH, V_2_3_0, V_2_3_1, V_0_10_0_0
+
+
+class ConsumerState:
+    Started = 1
+    Dead = 2
+    Rebalancing = 3
+    Joined = 4
+
+
+class ConsumerEventHandler(object):
+    def __init__(self, node, verify_offsets, idx):
+        self.node = node
+        self.idx = idx
+        self.state = ConsumerState.Dead
+        self.revoked_count = 0
+        self.assigned_count = 0
+        self.assignment = []
+        self.position = {}
+        self.committed = {}
+        self.total_consumed = 0
+        self.verify_offsets = verify_offsets
+
+    def handle_shutdown_complete(self):
+        self.state = ConsumerState.Dead
+        self.assignment = []
+        self.position = {}
+
+    def handle_startup_complete(self):
+        self.state = ConsumerState.Started
+
+    def handle_offsets_committed(self, event, node, logger):
+        if event["success"]:
+            for offset_commit in event["offsets"]:
+                if offset_commit.get("error", "") != "":
+                    logger.debug("%s: Offset commit failed for: %s" %
+                                 (str(node.account), offset_commit))
+                    continue
+
+                topic = offset_commit["topic"]
+                partition = offset_commit["partition"]
+                tp = TopicPartition(topic, partition)
+                offset = offset_commit["offset"]
+                assert tp in self.assignment, \
+                    "Committed offsets for partition %s not assigned (current assignment: %s)" % \
+                    (str(tp), str(self.assignment))
+                assert tp in self.position, "No previous position for %s: %s" % (
+                    str(tp), event)
+                assert self.position[tp] >= offset, \
+                    "The committed offset %d was greater than the current position %d for partition %s" % \
+                    (offset, self.position[tp], str(tp))
+                self.committed[tp] = offset
+
+    def handle_records_consumed(self, event, logger):
+        assert self.state == ConsumerState.Joined, \
+            "Consumed records should only be received when joined (current state: %s)" % str(self.state)
+
+        for record_batch in event["partitions"]:
+            tp = TopicPartition(topic=record_batch["topic"],
+                                partition=record_batch["partition"])
+            min_offset = record_batch["minOffset"]
+            max_offset = record_batch["maxOffset"]
+
+            assert tp in self.assignment, \
+                "Consumed records for partition %s which is not assigned (current assignment: %s)" % \
+                (str(tp), str(self.assignment))
+            if tp not in self.position or self.position[tp] == min_offset:
+                self.position[tp] = max_offset + 1
+            else:
+                msg = "Consumed from an unexpected offset (%d, %d) for partition %s" % \
+                      (self.position.get(tp), min_offset, str(tp))
+                if self.verify_offsets:
+                    raise AssertionError(msg)
+                else:
+                    if tp in self.position:
+                        self.position[tp] = max_offset + 1
+                    logger.warn(msg)
+        self.total_consumed += event["count"]
+
+    def handle_partitions_revoked(self, event):
+        self.revoked_count += 1
+        self.state = ConsumerState.Rebalancing
+        self.position = {}
+
+    def handle_partitions_assigned(self, event):
+        self.assigned_count += 1
+        self.state = ConsumerState.Joined
+        assignment = []
+        for topic_partition in event["partitions"]:
+            topic = topic_partition["topic"]
+            partition = topic_partition["partition"]
+            assignment.append(TopicPartition(topic, partition))
+        self.assignment = assignment
+
+    def handle_kill_process(self, clean_shutdown):
+        # if the shutdown was clean, then we expect the explicit
+        # shutdown event from the consumer
+        if not clean_shutdown:
+            self.handle_shutdown_complete()
+
+    def current_assignment(self):
+        return list(self.assignment)
+
+    def current_position(self, tp):
+        if tp in self.position:
+            return self.position[tp]
+        else:
+            return None
+
+    def last_commit(self, tp):
+        if tp in self.committed:
+            return self.committed[tp]
+        else:
+            return None
+
+
+class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin,
+                         BackgroundThreadService):
+    """This service wraps org.apache.kafka.tools.VerifiableConsumer for use in
+    system testing. 
+    
+    NOTE: this class should be treated as a PUBLIC API. Downstream users use
+    this service both directly and through class extension, so care must be 
+    taken to ensure compatibility.
+    """
+
+    PERSISTENT_ROOT = "/mnt/verifiable_consumer"
+    STDOUT_CAPTURE = os.path.join(PERSISTENT_ROOT,
+                                  "verifiable_consumer.stdout")
+    STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT,
+                                  "verifiable_consumer.stderr")
+    LOG_DIR = os.path.join(PERSISTENT_ROOT, "logs")
+    LOG_FILE = os.path.join(LOG_DIR, "verifiable_consumer.log")
+    LOG4J_CONFIG = os.path.join(PERSISTENT_ROOT, "tools-log4j.properties")
+    CONFIG_FILE = os.path.join(PERSISTENT_ROOT,
+                               "verifiable_consumer.properties")
+
+    logs = {
+        "verifiable_consumer_stdout": {
+            "path": STDOUT_CAPTURE,
+            "collect_default": False
+        },
+        "verifiable_consumer_stderr": {
+            "path": STDERR_CAPTURE,
+            "collect_default": False
+        },
+        "verifiable_consumer_log": {
+            "path": LOG_FILE,
+            "collect_default": True
+        }
+    }
+
+    def __init__(self,
+                 context,
+                 num_nodes,
+                 kafka,
+                 topic,
+                 group_id,
+                 static_membership=False,
+                 max_messages=-1,
+                 session_timeout_sec=30,
+                 enable_autocommit=False,
+                 assignment_strategy=None,
+                 version=DEV_BRANCH,
+                 stop_timeout_sec=30,
+                 log_level="INFO",
+                 jaas_override_variables=None,
+                 on_record_consumed=None,
+                 reset_policy="earliest",
+                 verify_offsets=True):
+        """
+        :param jaas_override_variables: A dict of variables to be used in the jaas.conf template file
+        """
+        super(VerifiableConsumer, self).__init__(context, num_nodes)
+        self.log_level = log_level
+        self.kafka = kafka
+        self.topic = topic
+        self.group_id = group_id
+        self.reset_policy = reset_policy
+        self.static_membership = static_membership
+        self.max_messages = max_messages
+        self.session_timeout_sec = session_timeout_sec
+        self.enable_autocommit = enable_autocommit
+        self.assignment_strategy = assignment_strategy
+        self.prop_file = ""
+        self.stop_timeout_sec = stop_timeout_sec
+        self.on_record_consumed = on_record_consumed
+        self.verify_offsets = verify_offsets
+
+        self.event_handlers = {}
+        self.global_position = {}
+        self.global_committed = {}
+        self.jaas_override_variables = jaas_override_variables or {}
+
+        for node in self.nodes:
+            node.version = version
+
+    def java_class_name(self):
+        return "VerifiableConsumer"
+
+    def _worker(self, idx, node):
+        with self.lock:
+            if node not in self.event_handlers:
+                self.event_handlers[node] = ConsumerEventHandler(
+                    node, self.verify_offsets, idx)
+            handler = self.event_handlers[node]
+
+        node.account.ssh("mkdir -p %s" % VerifiableConsumer.PERSISTENT_ROOT,
+                         allow_fail=False)
+
+        # Create and upload log properties
+        log_config = self.render('tools_log4j.properties',
+                                 log_file=VerifiableConsumer.LOG_FILE)
+        node.account.create_file(VerifiableConsumer.LOG4J_CONFIG, log_config)
+
+        # Create and upload config file
+        self.security_config = self.kafka.security_config.client_config(
+            self.prop_file, node, self.jaas_override_variables)
+        self.security_config.setup_node(node)
+        self.prop_file += str(self.security_config)
+        self.logger.info("verifiable_consumer.properties:")
+        self.logger.info(self.prop_file)
+        node.account.create_file(VerifiableConsumer.CONFIG_FILE,
+                                 self.prop_file)
+        self.security_config.setup_node(node)
+        # apply group.instance.id to the node for static membership validation
+        node.group_instance_id = None
+        if self.static_membership:
+            assert node.version >= V_2_3_0, \
+                "Version %s does not support static membership (must be 2.3 or higher)" % str(node.version)
+            node.group_instance_id = self.group_id + "-instance-" + str(idx)
+
+        if self.assignment_strategy:
+            assert node.version >= V_0_10_0_0, \
+                "Version %s does not setting an assignment strategy (must be 0.10.0 or higher)" % str(node.version)
+
+        cmd = self.start_cmd(node)
+        self.logger.debug("VerifiableConsumer %d command: %s" % (idx, cmd))
+
+        for line in node.account.ssh_capture(cmd):
+            event = self.try_parse_json(node, line.strip())
+            if event is not None:
+                with self.lock:
+                    name = event["name"]
+                    if name == "shutdown_complete":
+                        handler.handle_shutdown_complete()
+                    elif name == "startup_complete":
+                        handler.handle_startup_complete()
+                    elif name == "offsets_committed":
+                        handler.handle_offsets_committed(
+                            event, node, self.logger)
+                        self._update_global_committed(event)
+                    elif name == "records_consumed":
+                        handler.handle_records_consumed(event, self.logger)
+                        self._update_global_position(event, node)
+                    elif name == "record_data" and self.on_record_consumed:
+                        self.on_record_consumed(event, node)
+                    elif name == "partitions_revoked":
+                        handler.handle_partitions_revoked(event)
+                    elif name == "partitions_assigned":
+                        handler.handle_partitions_assigned(event)
+                    else:
+                        self.logger.debug("%s: ignoring unknown event: %s" %
+                                          (str(node.account), event))
+
+    def _update_global_position(self, consumed_event, node):
+        for consumed_partition in consumed_event["partitions"]:
+            tp = TopicPartition(consumed_partition["topic"],
+                                consumed_partition["partition"])
+            if tp in self.global_committed:
+                # verify that the position never gets behind the current commit.
+                if self.global_committed[tp] > consumed_partition["minOffset"]:
+                    msg = "Consumed position %d is behind the current committed offset %d for partition %s" % \
+                          (consumed_partition["minOffset"], self.global_committed[tp], str(tp))
+                    if self.verify_offsets:
+                        raise AssertionError(msg)
+                    else:
+                        self.logger.warn(msg)
+
+            # the consumer cannot generally guarantee that the position increases monotonically
+            # without gaps in the face of hard failures, so we only log a warning when this happens
+            if tp in self.global_position and self.global_position[
+                    tp] != consumed_partition["minOffset"]:
+                self.logger.warn(
+                    "%s: Expected next consumed offset of %d for partition %s, but instead saw %d"
+                    % (str(node.account), self.global_position[tp], str(tp),
+                       consumed_partition["minOffset"]))
+
+            self.global_position[tp] = consumed_partition["maxOffset"] + 1
+
+    def _update_global_committed(self, commit_event):
+        if commit_event["success"]:
+            for offset_commit in commit_event["offsets"]:
+                tp = TopicPartition(offset_commit["topic"],
+                                    offset_commit["partition"])
+                offset = offset_commit["offset"]
+                assert self.global_position[tp] >= offset, \
+                    "Committed offset %d for partition %s is ahead of the current position %d" % \
+                    (offset, str(tp), self.global_position[tp])
+                self.global_committed[tp] = offset
+
+    def start_cmd(self, node):
+        cmd = ""
+        cmd += "export LOG_DIR=%s;" % VerifiableConsumer.LOG_DIR
+        cmd += " export KAFKA_OPTS=%s;" % self.security_config.kafka_opts
+        cmd += " export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % VerifiableConsumer.LOG4J_CONFIG
+        cmd += self.impl.exec_cmd(node)
+        if self.on_record_consumed:
+            cmd += " --verbose"
+
+        if node.group_instance_id:
+            cmd += " --group-instance-id %s" % node.group_instance_id
+        elif node.version == V_2_3_0 or node.version == V_2_3_1:
+            # In 2.3, --group-instance-id was required, but would be left empty
+            # if `None` is passed as the argument value
+            cmd += " --group-instance-id None"
+
+        if self.assignment_strategy:
+            cmd += " --assignment-strategy %s" % self.assignment_strategy
+
+        if self.enable_autocommit:
+            cmd += " --enable-autocommit "
+
+        cmd += " --reset-policy %s --group-id %s --topic %s --broker-list %s --session-timeout %s" % \
+               (self.reset_policy, self.group_id, self.topic,
+                self.kafka.bootstrap_servers(self.security_config.security_protocol),
+                self.session_timeout_sec*1000)
+
+        if self.max_messages > 0:
+            cmd += " --max-messages %s" % str(self.max_messages)
+
+        cmd += " --consumer.config %s" % VerifiableConsumer.CONFIG_FILE
+        cmd += " 2>> %s | tee -a %s &" % (VerifiableConsumer.STDOUT_CAPTURE,
+                                          VerifiableConsumer.STDOUT_CAPTURE)
+        return cmd
+
+    def pids(self, node):
+        return self.impl.pids(node)
+
+    def try_parse_json(self, node, string):
+        """Try to parse a string as json. Return None if not parseable."""
+        try:
+            return json.loads(string)
+        except ValueError:
+            self.logger.debug("%s: Could not parse as json: %s" %
+                              (str(node.account), str(string)))
+            return None
+
+    def stop_all(self):
+        for node in self.nodes:
+            self.stop_node(node)
+
+    def kill_node(self, node, clean_shutdown=True, allow_fail=False):
+        sig = self.impl.kill_signal(clean_shutdown)
+        for pid in self.pids(node):
+            node.account.signal(pid, sig, allow_fail)
+
+        with self.lock:
+            self.event_handlers[node].handle_kill_process(clean_shutdown)
+
+    def stop_node(self, node, clean_shutdown=True):
+        self.kill_node(node, clean_shutdown=clean_shutdown)
+
+        stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
+        assert stopped, "Node %s: did not stop within the specified timeout of %s seconds" % \
+                        (str(node.account), str(self.stop_timeout_sec))
+
+    def clean_node(self, node):
+        self.kill_node(node, clean_shutdown=False)
+        node.account.ssh("rm -rf " + self.PERSISTENT_ROOT, allow_fail=False)
+        self.security_config.clean_node(node)
+
+    def current_assignment(self):
+        with self.lock:
+            return {
+                handler.node: handler.current_assignment()
+                for handler in self.event_handlers.values()
+            }
+
+    def current_position(self, tp):
+        with self.lock:
+            if tp in self.global_position:
+                return self.global_position[tp]
+            else:
+                return None
+
+    def owner(self, tp):
+        with self.lock:
+            for handler in self.event_handlers.values():
+                if tp in handler.current_assignment():
+                    return handler.node
+            return None
+
+    def last_commit(self, tp):
+        with self.lock:
+            if tp in self.global_committed:
+                return self.global_committed[tp]
+            else:
+                return None
+
+    def total_consumed(self):
+        with self.lock:
+            return sum(handler.total_consumed
+                       for handler in self.event_handlers.values())
+
+    def num_rebalances(self):
+        with self.lock:
+            return max(handler.assigned_count
+                       for handler in self.event_handlers.values())
+
+    def num_revokes_for_alive(self, keep_alive=1):
+        with self.lock:
+            return max(handler.revoked_count
+                       for handler in self.event_handlers.values()
+                       if handler.idx <= keep_alive)
+
+    def joined_nodes(self):
+        with self.lock:
+            return [
+                handler.node for handler in self.event_handlers.values()
+                if handler.state == ConsumerState.Joined
+            ]
+
+    def rebalancing_nodes(self):
+        with self.lock:
+            return [
+                handler.node for handler in self.event_handlers.values()
+                if handler.state == ConsumerState.Rebalancing
+            ]
+
+    def dead_nodes(self):
+        with self.lock:
+            return [
+                handler.node for handler in self.event_handlers.values()
+                if handler.state == ConsumerState.Dead
+            ]
+
+    def alive_nodes(self):
+        with self.lock:
+            return [
+                handler.node for handler in self.event_handlers.values()
+                if handler.state != ConsumerState.Dead
+            ]

--- a/tests/rptest/services/verifiable_producer.py
+++ b/tests/rptest/services/verifiable_producer.py
@@ -1,0 +1,368 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+import time
+from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.services.background_thread import BackgroundThreadService
+from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
+from kafkatest.services.kafka import TopicPartition
+from kafkatest.services.verifiable_client import VerifiableClientMixin
+from kafkatest.utils import is_int, is_int_with_prefix
+from kafkatest.version import DEV_BRANCH
+from kafkatest.services.kafka.util import fix_opts_for_new_jvm
+
+
+class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin,
+                         BackgroundThreadService):
+    """This service wraps org.apache.kafka.tools.VerifiableProducer for use in
+    system testing.
+
+    NOTE: this class should be treated as a PUBLIC API. Downstream users use
+    this service both directly and through class extension, so care must be
+    taken to ensure compatibility.
+    """
+
+    PERSISTENT_ROOT = "/mnt/verifiable_producer"
+    STDOUT_CAPTURE = os.path.join(PERSISTENT_ROOT,
+                                  "verifiable_producer.stdout")
+    STDERR_CAPTURE = os.path.join(PERSISTENT_ROOT,
+                                  "verifiable_producer.stderr")
+    LOG_DIR = os.path.join(PERSISTENT_ROOT, "logs")
+    LOG_FILE = os.path.join(LOG_DIR, "verifiable_producer.log")
+    LOG4J_CONFIG = os.path.join(PERSISTENT_ROOT, "tools-log4j.properties")
+    CONFIG_FILE = os.path.join(PERSISTENT_ROOT,
+                               "verifiable_producer.properties")
+
+    logs = {
+        "verifiable_producer_stdout": {
+            "path": STDOUT_CAPTURE,
+            "collect_default": False
+        },
+        "verifiable_producer_stderr": {
+            "path": STDERR_CAPTURE,
+            "collect_default": False
+        },
+        "verifiable_producer_log": {
+            "path": LOG_FILE,
+            "collect_default": True
+        }
+    }
+
+    def __init__(self,
+                 context,
+                 num_nodes,
+                 kafka,
+                 topic,
+                 max_messages=-1,
+                 throughput=100000,
+                 message_validator=is_int,
+                 compression_types=None,
+                 version=DEV_BRANCH,
+                 acks=None,
+                 stop_timeout_sec=150,
+                 request_timeout_sec=30,
+                 log_level="INFO",
+                 enable_idempotence=False,
+                 offline_nodes=[],
+                 create_time=-1,
+                 repeating_keys=None,
+                 jaas_override_variables=None,
+                 kafka_opts_override="",
+                 client_prop_file_override="",
+                 retries=None):
+        """
+        Args:
+            :param max_messages                number of messages to be produced per producer
+            :param message_validator           checks for an expected format of messages produced. There are
+                                               currently two:
+                                               * is_int is an integer format; this is default and expected to be used if
+                                                 num_nodes = 1
+                                               * is_int_with_prefix recommended if num_nodes > 1, because otherwise each producer
+                                                 will produce exactly same messages, and validation may miss missing messages.
+            :param compression_types           If None, all producers will not use compression; or a list of compression types,
+                                               one per producer (could be "none").
+            :param jaas_override_variables     A dict of variables to be used in the jaas.conf template file
+            :param kafka_opts_override         Override parameters of the KAFKA_OPTS environment variable
+            :param client_prop_file_override   Override client.properties file used by the consumer
+        """
+        super(VerifiableProducer, self).__init__(context, num_nodes)
+        self.log_level = log_level
+
+        self.kafka = kafka
+        self.topic = topic
+        self.max_messages = max_messages
+        self.throughput = throughput
+        self.message_validator = message_validator
+        self.compression_types = compression_types
+        if self.compression_types is not None:
+            assert len(self.compression_types
+                       ) == num_nodes, "Specify one compression type per node"
+
+        for node in self.nodes:
+            node.version = version
+        self.acked_values = []
+        self.acked_values_by_partition = {}
+        self._last_acked_offsets = {}
+        self.not_acked_values = []
+        self.produced_count = {}
+        self.clean_shutdown_nodes = set()
+        self.acks = acks
+        self.stop_timeout_sec = stop_timeout_sec
+        self.request_timeout_sec = request_timeout_sec
+        self.enable_idempotence = enable_idempotence
+        self.offline_nodes = offline_nodes
+        self.create_time = create_time
+        self.repeating_keys = repeating_keys
+        self.jaas_override_variables = jaas_override_variables or {}
+        self.kafka_opts_override = kafka_opts_override
+        self.client_prop_file_override = client_prop_file_override
+        self.retries = retries
+
+    def java_class_name(self):
+        return "VerifiableProducer"
+
+    def prop_file(self, node):
+        idx = self.idx(node)
+        prop_file = self.render('producer.properties',
+                                request_timeout_ms=(self.request_timeout_sec *
+                                                    1000))
+        prop_file += "\n{}".format(str(self.security_config))
+        if self.compression_types is not None:
+            compression_index = idx - 1
+            self.logger.info(
+                "VerifiableProducer (index = %d) will use compression type = %s",
+                idx, self.compression_types[compression_index])
+            prop_file += "\ncompression.type=%s\n" % self.compression_types[
+                compression_index]
+        return prop_file
+
+    def _worker(self, idx, node):
+        node.account.ssh("mkdir -p %s" % VerifiableProducer.PERSISTENT_ROOT,
+                         allow_fail=False)
+
+        # Create and upload log properties
+        log_config = self.render('tools_log4j.properties',
+                                 log_file=VerifiableProducer.LOG_FILE)
+        node.account.create_file(VerifiableProducer.LOG4J_CONFIG, log_config)
+
+        # Configure security
+        self.security_config = self.kafka.security_config.client_config(
+            node=node, jaas_override_variables=self.jaas_override_variables)
+        self.security_config.setup_node(node)
+
+        # Create and upload config file
+        if self.client_prop_file_override:
+            producer_prop_file = self.client_prop_file_override
+        else:
+            producer_prop_file = self.prop_file(node)
+
+        if self.acks is not None:
+            self.logger.info(
+                "VerifiableProducer (index = %d) will use acks = %s", idx,
+                self.acks)
+            producer_prop_file += "\nacks=%s\n" % self.acks
+
+        if self.enable_idempotence:
+            self.logger.info("Setting up an idempotent producer")
+            producer_prop_file += "\nmax.in.flight.requests.per.connection=5\n"
+            producer_prop_file += "\nretries=1000000\n"
+            producer_prop_file += "\nenable.idempotence=true\n"
+        elif self.retries is not None:
+            self.logger.info(
+                "VerifiableProducer (index = %d) will use retries = %s", idx,
+                self.retries)
+            producer_prop_file += "\nretries=%s\n" % self.retries
+            producer_prop_file += "\ndelivery.timeout.ms=%s\n" % (
+                self.request_timeout_sec * 1000 * self.retries)
+
+        self.logger.info("verifiable_producer.properties:")
+        self.logger.info(producer_prop_file)
+        node.account.create_file(VerifiableProducer.CONFIG_FILE,
+                                 producer_prop_file)
+
+        cmd = self.start_cmd(node, idx)
+        self.logger.debug("VerifiableProducer %d command: %s" % (idx, cmd))
+
+        self.produced_count[idx] = 0
+        last_produced_time = time.time()
+        prev_msg = None
+
+        for line in node.account.ssh_capture(cmd):
+            line = line.strip()
+
+            data = self.try_parse_json(line)
+            if data is not None:
+
+                with self.lock:
+                    if data["name"] == "producer_send_error":
+                        data["node"] = idx
+                        self.not_acked_values.append(
+                            self.message_validator(data["value"]))
+                        self.produced_count[idx] += 1
+
+                    elif data["name"] == "producer_send_success":
+                        partition = TopicPartition(data["topic"],
+                                                   data["partition"])
+                        value = self.message_validator(data["value"])
+                        self.acked_values.append(value)
+
+                        if partition not in self.acked_values_by_partition:
+                            self.acked_values_by_partition[partition] = []
+                        self.acked_values_by_partition[partition].append(value)
+
+                        self._last_acked_offsets[partition] = data["offset"]
+                        self.produced_count[idx] += 1
+
+                        # Log information if there is a large gap between successively acknowledged messages
+                        t = time.time()
+                        time_delta_sec = t - last_produced_time
+                        if time_delta_sec > 2 and prev_msg is not None:
+                            self.logger.debug(
+                                "Time delta between successively acked messages is large: "
+                                +
+                                "delta_t_sec: %s, prev_message: %s, current_message: %s"
+                                % (str(time_delta_sec), str(prev_msg),
+                                   str(data)))
+
+                        last_produced_time = t
+                        prev_msg = data
+
+                    elif data["name"] == "shutdown_complete":
+                        if node in self.clean_shutdown_nodes:
+                            raise Exception(
+                                "Unexpected shutdown event from producer, already shutdown. Producer index: %d"
+                                % idx)
+                        self.clean_shutdown_nodes.add(node)
+
+    def _has_output(self, node):
+        """Helper used as a proxy to determine whether jmx is running by that jmx_tool_log contains output."""
+        try:
+            node.account.ssh("test -z \"$(cat %s)\"" %
+                             VerifiableProducer.STDOUT_CAPTURE,
+                             allow_fail=False)
+            return False
+        except RemoteCommandError:
+            return True
+
+    def start_cmd(self, node, idx):
+        cmd = "export LOG_DIR=%s;" % VerifiableProducer.LOG_DIR
+        if self.kafka_opts_override:
+            cmd += " export KAFKA_OPTS=\"%s\";" % self.kafka_opts_override
+        else:
+            cmd += " export KAFKA_OPTS=%s;" % self.security_config.kafka_opts
+
+        cmd += fix_opts_for_new_jvm(node)
+        cmd += " export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % VerifiableProducer.LOG4J_CONFIG
+        cmd += self.impl.exec_cmd(node)
+        cmd += " --topic %s --broker-list %s" % (
+            self.topic,
+            self.kafka.bootstrap_servers(
+                self.security_config.security_protocol, True,
+                self.offline_nodes))
+        if self.max_messages > 0:
+            cmd += " --max-messages %s" % str(self.max_messages)
+        if self.throughput > 0:
+            cmd += " --throughput %s" % str(self.throughput)
+        if self.message_validator == is_int_with_prefix:
+            cmd += " --value-prefix %s" % str(idx)
+        if self.acks is not None:
+            cmd += " --acks %s " % str(self.acks)
+        if self.create_time > -1:
+            cmd += " --message-create-time %s " % str(self.create_time)
+        if self.repeating_keys is not None:
+            cmd += " --repeating-keys %s " % str(self.repeating_keys)
+
+        cmd += " --producer.config %s" % VerifiableProducer.CONFIG_FILE
+
+        cmd += " 2>> %s | tee -a %s &" % (VerifiableProducer.STDOUT_CAPTURE,
+                                          VerifiableProducer.STDOUT_CAPTURE)
+        return cmd
+
+    def kill_node(self, node, clean_shutdown=True, allow_fail=False):
+        sig = self.impl.kill_signal(clean_shutdown)
+        for pid in self.pids(node):
+            node.account.signal(pid, sig, allow_fail)
+
+    def pids(self, node):
+        return self.impl.pids(node)
+
+    def alive(self, node):
+        return len(self.pids(node)) > 0
+
+    @property
+    def last_acked_offsets(self):
+        with self.lock:
+            return self._last_acked_offsets
+
+    @property
+    def acked(self):
+        with self.lock:
+            return self.acked_values
+
+    @property
+    def acked_by_partition(self):
+        with self.lock:
+            return self.acked_values_by_partition
+
+    @property
+    def not_acked(self):
+        with self.lock:
+            return self.not_acked_values
+
+    @property
+    def num_acked(self):
+        with self.lock:
+            return len(self.acked_values)
+
+    @property
+    def num_not_acked(self):
+        with self.lock:
+            return len(self.not_acked_values)
+
+    def each_produced_at_least(self, count):
+        with self.lock:
+            for idx in range(1, self.num_nodes + 1):
+                if self.produced_count.get(
+                        idx) is None or self.produced_count[idx] < count:
+                    return False
+            return True
+
+    def stop_node(self, node):
+        # There is a race condition on shutdown if using `max_messages` since the
+        # VerifiableProducer will shutdown automatically when all messages have been
+        # written. In this case, the process will be gone and the signal will fail.
+        allow_fail = self.max_messages > 0
+        self.kill_node(node, clean_shutdown=True, allow_fail=allow_fail)
+
+        stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
+        assert stopped, "Node %s: did not stop within the specified timeout of %s seconds" % \
+                        (str(node.account), str(self.stop_timeout_sec))
+
+    def clean_node(self, node):
+        self.kill_node(node, clean_shutdown=False, allow_fail=False)
+        node.account.ssh("rm -rf " + self.PERSISTENT_ROOT, allow_fail=False)
+        self.security_config.clean_node(node)
+
+    def try_parse_json(self, string):
+        """Try to parse a string as json. Return None if not parseable."""
+        try:
+            record = json.loads(string)
+            return record
+        except ValueError:
+            self.logger.debug("Could not parse as json: %s" % str(string))
+            return None

--- a/tests/rptest/test_suite_quick.yml
+++ b/tests/rptest/test_suite_quick.yml
@@ -21,3 +21,4 @@ quick:
   - tests/wasm_identity_test.py
   - tests/wasm_failure_recovery_test.py
   - tests/wasm_redpanda_failure_recovery_test.py
+  - tests/partition_movement_test.py::PartitionMovementTest.test_dynamic

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -1,0 +1,169 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.kafka import KafkaService, quorum
+from kafkatest.services.kafka import TopicPartition
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.services.verifiable_consumer import VerifiableConsumer
+from kafkatest.services.zookeeper import ZookeeperService
+from kafkatest.utils import validate_delivery
+
+
+class EndToEndTest(Test):
+    """This class provides a shared template for tests which follow the common pattern of:
+
+        - produce to a topic in the background
+        - consume from that topic in the background
+        - run some logic, e.g. fail topic leader etc.
+        - perform validation
+    """
+
+    DEFAULT_TOPIC_CONFIG = {"partitions": 2, "replication-factor": 1}
+
+    def __init__(self,
+                 test_context,
+                 topic="test_topic",
+                 topic_config=DEFAULT_TOPIC_CONFIG):
+        super(EndToEndTest, self).__init__(test_context=test_context)
+        self.topic = topic
+        self.topic_config = topic_config
+        self.records_consumed = []
+        self.last_consumed_offsets = {}
+
+    def create_zookeeper_if_necessary(self, num_nodes=1, **kwargs):
+        self.zk = ZookeeperService(
+            self.test_context, num_nodes=num_nodes, **
+            kwargs) if quorum.for_test(
+                self.test_context) == quorum.zk else None
+
+    def create_kafka(self, num_nodes=1, **kwargs):
+        group_metadata_config = {
+            "partitions": num_nodes,
+            "replication-factor": min(num_nodes, 3),
+            "configs": {
+                "cleanup.policy": "compact"
+            }
+        }
+
+        topics = {
+            self.topic: self.topic_config,
+            "__consumer_offsets": group_metadata_config
+        }
+        self.kafka = KafkaService(self.test_context,
+                                  num_nodes=num_nodes,
+                                  zk=self.zk,
+                                  topics=topics,
+                                  **kwargs)
+
+    def create_consumer(self, num_nodes=1, group_id="test_group", **kwargs):
+        self.consumer = VerifiableConsumer(
+            self.test_context,
+            num_nodes=num_nodes,
+            kafka=self.kafka,
+            topic=self.topic,
+            group_id=group_id,
+            on_record_consumed=self.on_record_consumed,
+            **kwargs)
+
+    def create_producer(self, num_nodes=1, throughput=1000, **kwargs):
+        self.producer = VerifiableProducer(self.test_context,
+                                           num_nodes=num_nodes,
+                                           kafka=self.kafka,
+                                           topic=self.topic,
+                                           throughput=throughput,
+                                           **kwargs)
+
+    def on_record_consumed(self, record, node):
+        partition = TopicPartition(record["topic"], record["partition"])
+        record_id = int(record["value"])
+        offset = record["offset"]
+        self.last_consumed_offsets[partition] = offset
+        self.records_consumed.append(record_id)
+
+    def await_consumed_offsets(self, last_acked_offsets, timeout_sec):
+        def has_finished_consuming():
+            for partition, offset in last_acked_offsets.items():
+                if not partition in self.last_consumed_offsets:
+                    return False
+                last_commit = self.consumer.last_commit(partition)
+                if not last_commit or last_commit < offset:
+                    return False
+            return True
+
+        wait_until(has_finished_consuming,
+                   timeout_sec=timeout_sec,
+                   err_msg="Consumer failed to consume up to offsets %s after waiting %ds." %\
+                   (str(last_acked_offsets), timeout_sec))
+
+    def _collect_all_logs(self):
+        for s in self.test_context.services:
+            self.mark_for_collect(s)
+
+    def await_startup(self, min_records=5, timeout_sec=30):
+        try:
+            wait_until(lambda: self.consumer.total_consumed() >= min_records,
+                       timeout_sec=timeout_sec,
+                       err_msg="Timed out after %ds while awaiting initial record delivery of %d records" %\
+                       (timeout_sec, min_records))
+        except BaseException:
+            self._collect_all_logs()
+            raise
+
+    def run_validation(self,
+                       min_records=5000,
+                       producer_timeout_sec=30,
+                       consumer_timeout_sec=30,
+                       enable_idempotence=False):
+        try:
+            wait_until(lambda: self.producer.num_acked > min_records,
+                       timeout_sec=producer_timeout_sec,
+                       err_msg="Producer failed to produce messages for %ds." %\
+                       producer_timeout_sec)
+
+            self.logger.info("Stopping producer after writing up to offsets %s" %\
+                         str(self.producer.last_acked_offsets))
+            self.producer.stop()
+
+            self.await_consumed_offsets(self.producer.last_acked_offsets,
+                                        consumer_timeout_sec)
+            self.consumer.stop()
+
+            self.validate(enable_idempotence)
+        except BaseException:
+            self._collect_all_logs()
+            raise
+
+    def validate(self, enable_idempotence):
+        self.logger.info("Number of acked records: %d" %
+                         len(self.producer.acked))
+        self.logger.info("Number of consumed records: %d" %
+                         len(self.records_consumed))
+
+        def check_lost_data(missing_records):
+            return self.kafka.search_data_files(self.topic, missing_records)
+
+        succeeded, error_msg = validate_delivery(self.producer.acked,
+                                                 self.records_consumed,
+                                                 enable_idempotence,
+                                                 check_lost_data)
+
+        # Collect all logs if validation fails
+        if not succeeded:
+            self._collect_all_logs()
+
+        assert succeeded, error_msg

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -16,14 +16,14 @@ from rptest.clients.kafka_cat import KafkaCat
 import requests
 
 from rptest.clients.types import TopicSpec
-from rptest.tests.redpanda_test import RedpandaTest
+from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
 from rptest.services.honey_badger import HoneyBadger
 from kafka import KafkaProducer
 from kafka import KafkaConsumer
 
 
-class PartitionMovementTest(RedpandaTest):
+class PartitionMovementTest(EndToEndTest):
     """
     Basic partition movement tests. Each test builds a number of topics and then
     performs a series of random replica set changes. After each change a
@@ -153,6 +153,8 @@ class PartitionMovementTest(RedpandaTest):
         """
         Move partition before first leader is elected
         """
+        self.start_redpanda(num_nodes=3)
+
         topics = []
         hb = HoneyBadger()
         # if failure injector is not enabled simply skip this test
@@ -213,6 +215,8 @@ class PartitionMovementTest(RedpandaTest):
         """
         Move empty partitions.
         """
+        self.start_redpanda(num_nodes=3)
+
         topics = []
         for partition_count in range(1, 5):
             for replication_factor in (3, 3):
@@ -233,6 +237,8 @@ class PartitionMovementTest(RedpandaTest):
         """
         Move partitions with data, but no active producers or consumers.
         """
+        self.start_redpanda(num_nodes=3)
+
         topics = []
         for partition_count in range(1, 5):
             for replication_factor in (3, 3):

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -155,7 +155,6 @@ class PartitionMovementTest(EndToEndTest):
         """
         self.start_redpanda(num_nodes=3)
 
-        topics = []
         hb = HoneyBadger()
         # if failure injector is not enabled simply skip this test
         if not hb.is_enabled(self.redpanda.nodes[0]):


### PR DESCRIPTION
Imports and adapts the verifiable consumer, verifiable producer, and end-to-end test framework from the upstream kafka ducktape test suite. These utilities make it easy to write tests which have background producer/consumers.

In addition a new test is added which performs partition movement while a live producer and consumer run in the background.

@mmaslankaprv this test is disabled because as I increase the amount of partition movements the test fails to validate all of the offsets produced. But the PR itself can merge. In the test you can comment out the `move_and_verify` and replace it with a sleep or (or do nothing at all) to observe the background consumer/producer operating without error.

@ivotron updated the size of the ducktape cluster to accommodate a new larger test.

