### PR TITLE
Rpk arm64 workflows

### DIFF
--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -21,7 +21,7 @@ jobs:
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
-    - name: Update the homebrew tap
+    - name: Update the amd64 homebrew tap
       if: contains(steps.get_version.outputs.VERSION, '-beta') == false
       uses: mislav/bump-homebrew-formula-action@v1.8
       with:
@@ -29,5 +29,16 @@ jobs:
         homebrew-tap: vectorizedio/homebrew-tap
         base-branch: main
         download-url: https://github.com/vectorizedio/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-amd64.zip
+      env:
+        COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+
+    - name: Update the arm64 homebrew tap
+      if: contains(steps.get_version.outputs.VERSION, '-beta') == false
+      uses: mislav/bump-homebrew-formula-action@v1.8
+      with:
+        formula-name: redpanda
+        homebrew-tap: vectorizedio/homebrew-tap
+        base-branch: main
+        download-url: https://github.com/vectorizedio/redpanda/releases/download/${{ steps.get_version.outputs.VERSION }}/rpk-darwin-arm64.zip
       env:
         COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [linux, darwin]
+        arch: [amd64, arm64]
     runs-on: ubuntu-latest
     steps:
 
@@ -52,12 +53,12 @@ jobs:
         pkg='vectorized/pkg/cli/cmd/version'
         tag=$(echo ${{ github.ref }} | sed 's;refs/tags/;;g')
 
-        GOOS=${{ matrix.os }} GOARCH=amd64 ./build.sh $tag ${{ github.sha }}
+        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} ./build.sh $tag ${{ github.sha }}
 
     - name: Package
       working-directory: src/go/rpk/
       run: |
-        zip -j rpk-${{ matrix.os }}-amd64.zip ./${{ matrix.os }}-amd64/rpk
+        zip -j rpk-${{ matrix.os }}-${{ matrix.arch }}.zip ./${{ matrix.os }}-${{ matrix.arch }}/rpk
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2
@@ -71,6 +72,9 @@ jobs:
     name: Sign and notarize the darwin release_name
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     runs-on: macos-10.15
     steps:
       - name: Checkout
@@ -85,8 +89,8 @@ jobs:
       - name: Unzip darwin build
         working-directory: zip/
         run: |
-          unzip rpk-darwin-amd64.zip
-          rm rpk-darwin-amd64.zip
+          unzip rpk-darwin-${{ matrix.arch }}.zip
+          rm rpk-darwin-${{ matrix.arch }}.zip
 
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v1
@@ -111,7 +115,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: rpk-archives
-          path: zip/rpk-darwin-amd64.zip
+          path: zip/rpk-darwin-${{ matrix.arch }}.zip
 
   create-release:
     name: Create release
@@ -138,6 +142,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
+        arch: [amd64, arm64]
         os: [linux, darwin]
     runs-on: ubuntu-latest
     steps:
@@ -150,6 +155,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create-release.outputs.upload_url }}
-        asset_path: rpk-archives/rpk-${{ matrix.os }}-amd64.zip
-        asset_name: rpk-${{ matrix.os }}-amd64.zip
+        asset_path: rpk-archives/rpk-${{ matrix.os }}-${{ matrix.arch }}.zip
+        asset_name: rpk-${{ matrix.os }}-${{ matrix.arch }}.zip
         asset_content_type: application/zip


### PR DESCRIPTION
Adds `arch` dimension to RPK (build, publishing, homebrew) github actions workflows to produce `arm64` builds in addition to `amd64`.