### PR TITLE
Make transaction coordinator support clean up policies

### DIFF
--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -69,7 +69,7 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
-    BOOST_REQUIRE(stm.add_partitions(tx_id, tx1.etag, partitions));
+    BOOST_REQUIRE(stm.add_partitions(tx_id, partitions));
     BOOST_REQUIRE_EQUAL(tx1.partitions.size(), 0);
     auto tx2 = expect_tx(stm.get_tx(tx_id));
     BOOST_REQUIRE_EQUAL(tx2.id, tx_id);
@@ -77,32 +77,26 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE_EQUAL(tx2.status, tx_status::ongoing);
     BOOST_REQUIRE_EQUAL(tx2.tx_seq, tx1.tx_seq);
     BOOST_REQUIRE_EQUAL(tx2.partitions.size(), 2);
-    BOOST_REQUIRE_EQUAL(tx1.etag.log_etag, tx2.etag.log_etag);
-    BOOST_REQUIRE(tx1.etag.mem_etag < tx2.etag.mem_etag);
     auto tx3 = expect_tx(
-      stm.try_change_status(tx_id, tx2.etag, tx_status::preparing).get());
+      stm.try_change_status(tx_id, tx_status::preparing).get());
     BOOST_REQUIRE_EQUAL(tx3.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx3.pid, pid);
     BOOST_REQUIRE_EQUAL(tx3.status, tx_status::preparing);
     BOOST_REQUIRE_EQUAL(tx3.tx_seq, tx1.tx_seq);
     BOOST_REQUIRE_EQUAL(tx3.partitions.size(), 2);
-    BOOST_REQUIRE(tx2.etag.log_etag < tx3.etag.log_etag);
     auto tx4 = expect_tx(
-      stm.try_change_status(tx_id, tx3.etag, tx_status::prepared).get());
+      stm.try_change_status(tx_id, tx_status::prepared).get());
     BOOST_REQUIRE_EQUAL(tx4.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx4.pid, pid);
     BOOST_REQUIRE_EQUAL(tx4.status, tx_status::prepared);
     BOOST_REQUIRE_EQUAL(tx4.tx_seq, tx1.tx_seq);
     BOOST_REQUIRE_EQUAL(tx4.partitions.size(), 2);
-    BOOST_REQUIRE(tx3.etag.log_etag < tx4.etag.log_etag);
-    auto tx5 = expect_tx(stm.mark_tx_finished(tx_id, tx4.etag));
+    auto tx5 = expect_tx(stm.mark_tx_finished(tx_id));
     BOOST_REQUIRE_EQUAL(tx5.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx5.pid, pid);
     BOOST_REQUIRE_EQUAL(tx5.status, tx_status::finished);
     BOOST_REQUIRE_EQUAL(tx5.tx_seq, tx1.tx_seq);
     BOOST_REQUIRE_EQUAL(tx5.partitions.size(), 0);
-    BOOST_REQUIRE_EQUAL(tx4.etag.log_etag, tx5.etag.log_etag);
-    BOOST_REQUIRE(tx4.etag.mem_etag < tx5.etag.mem_etag);
 }
 
 FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
@@ -127,21 +121,19 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
-    BOOST_REQUIRE(stm.add_partitions(tx_id, tx1.etag, partitions));
+    BOOST_REQUIRE(stm.add_partitions(tx_id, partitions));
     auto tx2 = expect_tx(stm.get_tx(tx_id));
     auto tx3 = expect_tx(
-      stm.try_change_status(tx_id, tx2.etag, tx_status::preparing).get());
+      stm.try_change_status(tx_id, tx_status::preparing).get());
     auto tx4 = expect_tx(
-      stm.try_change_status(tx_id, tx3.etag, tx_status::prepared).get());
-    auto tx5 = expect_tx(stm.mark_tx_finished(tx_id, tx4.etag));
+      stm.try_change_status(tx_id, tx_status::prepared).get());
+    auto tx5 = expect_tx(stm.mark_tx_finished(tx_id));
 
-    auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id, tx5.etag));
+    auto tx6 = expect_tx(stm.mark_tx_ongoing(tx_id));
     BOOST_REQUIRE_EQUAL(tx6.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx6.pid, pid);
     BOOST_REQUIRE_EQUAL(tx6.status, tx_status::ongoing);
     BOOST_REQUIRE_EQUAL(tx6.partitions.size(), 0);
-    BOOST_REQUIRE_EQUAL(tx5.etag.log_etag, tx6.etag.log_etag);
-    BOOST_REQUIRE_LT(tx5.etag.mem_etag, tx6.etag.mem_etag);
     BOOST_REQUIRE_NE(tx6.tx_seq, tx1.tx_seq);
 }
 
@@ -167,21 +159,20 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
-    BOOST_REQUIRE(stm.add_partitions(tx_id, tx1.etag, partitions));
+    BOOST_REQUIRE(stm.add_partitions(tx_id, partitions));
     auto tx2 = expect_tx(stm.get_tx(tx_id));
     auto tx3 = expect_tx(
-      stm.try_change_status(tx_id, tx2.etag, tx_status::preparing).get());
+      stm.try_change_status(tx_id, tx_status::preparing).get());
     auto tx4 = expect_tx(
-      stm.try_change_status(tx_id, tx3.etag, tx_status::prepared).get());
-    auto tx5 = expect_tx(stm.mark_tx_finished(tx_id, tx4.etag));
+      stm.try_change_status(tx_id, tx_status::prepared).get());
+    auto tx5 = expect_tx(stm.mark_tx_finished(tx_id));
 
     auto pid2 = model::producer_identity{.id = 1, .epoch = 1};
-    op_code = stm.re_register_producer(tx_id, tx5.etag, pid2).get0();
+    op_code = stm.re_register_producer(tx_id, pid2).get0();
     BOOST_REQUIRE_EQUAL(op_code, op_status::success);
     auto tx6 = expect_tx(stm.get_tx(tx_id));
     BOOST_REQUIRE_EQUAL(tx6.id, tx_id);
     BOOST_REQUIRE_EQUAL(tx6.pid, pid2);
     BOOST_REQUIRE_EQUAL(tx6.status, tx_status::ongoing);
     BOOST_REQUIRE_EQUAL(tx6.partitions.size(), 0);
-    BOOST_REQUIRE_LT(tx5.etag.log_etag, tx6.etag.log_etag);
 }

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -170,17 +170,6 @@ ss::future<tm_stm::op_status> tm_stm::register_new_producer(
     if (ptx != _tx_table.end()) {
         co_return tm_stm::op_status::conflict;
     }
-    co_return co_await register_new_producer(term, tx_id, pid);
-}
-
-ss::future<tm_stm::op_status> tm_stm::register_new_producer(
-  model::term_id term,
-  kafka::transactional_id tx_id,
-  model::producer_identity pid) {
-    auto ptx = _tx_table.find(tx_id);
-    if (ptx != _tx_table.end()) {
-        co_return tm_stm::op_status::conflict;
-    }
 
     auto tx = tm_transaction{
       .id = tx_id,

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -32,25 +32,6 @@
 
 namespace cluster {
 
-struct tm_etag {
-    int64_t log_etag{0};
-    int64_t mem_etag{0};
-
-    tm_etag inc_mem() const {
-        return tm_etag{
-          .log_etag = this->log_etag, .mem_etag = this->mem_etag + 1};
-    }
-
-    tm_etag inc_log() const {
-        // kicking log_etag (major component) resetting minor
-        return tm_etag{.log_etag = this->log_etag + 1, .mem_etag = 0};
-    }
-
-    auto operator<=>(const tm_etag&) const = default;
-
-    friend std::ostream& operator<<(std::ostream&, const tm_etag&);
-};
-
 struct tm_transaction {
     enum tx_status {
         ongoing,
@@ -85,8 +66,6 @@ struct tm_transaction {
     tx_status status;
     std::vector<tx_partition> partitions;
     std::vector<tx_group> groups;
-    // version of tm_tx, used to perform conditional updates
-    tm_etag etag;
 
     friend std::ostream& operator<<(std::ostream&, const tm_transaction&);
 };
@@ -116,22 +95,20 @@ public:
     explicit tm_stm(ss::logger&, raft::consensus*);
 
     std::optional<tm_transaction> get_tx(kafka::transactional_id);
-    ss::future<checked<tm_transaction, tm_stm::op_status>> try_change_status(
-      kafka::transactional_id, tm_etag, tm_transaction::tx_status);
     checked<tm_transaction, tm_stm::op_status>
-      mark_tx_finished(kafka::transactional_id, tm_etag);
+      mark_tx_finished(kafka::transactional_id);
     checked<tm_transaction, tm_stm::op_status>
-      mark_tx_ongoing(kafka::transactional_id, tm_etag);
-    ss::future<tm_stm::op_status> re_register_producer(
-      kafka::transactional_id, tm_etag, model::producer_identity);
+      mark_tx_ongoing(kafka::transactional_id);
+    bool add_partitions(
+      kafka::transactional_id, std::vector<tm_transaction::tx_partition>);
+    bool add_group(kafka::transactional_id, kafka::group_id, model::term_id);
+
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
+      try_change_status(kafka::transactional_id, tm_transaction::tx_status);
+    ss::future<tm_stm::op_status>
+      re_register_producer(kafka::transactional_id, model::producer_identity);
     ss::future<tm_stm::op_status>
       register_new_producer(kafka::transactional_id, model::producer_identity);
-    bool add_partitions(
-      kafka::transactional_id,
-      tm_etag,
-      std::vector<tm_transaction::tx_partition>);
-    bool add_group(
-      kafka::transactional_id, tm_etag, kafka::group_id, model::term_id);
 
     // before calling a tm_stm modifying operation a caller should
     // take get_tx_lock mutex

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -147,7 +147,6 @@ private:
     struct tx_updated_cmd {
         static constexpr uint8_t record_key = 0;
         tm_transaction tx;
-        tm_etag prev_etag;
     };
 
     void load_snapshot(stm_snapshot_header, iobuf&&) override;

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -40,7 +40,7 @@ struct tm_transaction {
         preparing,
         prepared,
         aborting,
-        finished,
+        ready,
     };
 
     struct tx_partition {
@@ -65,6 +65,10 @@ struct tm_transaction {
     // triple (transactional_id, producer_identity, tx_seq) uniquely
     // identidies a transaction
     model::tx_seq tx_seq;
+    // term of a transaction coordinated started a transaction.
+    // transactions can't span cross term to prevent loss of information stored
+    // only in memory (partitions and groups).
+    model::term_id etag;
     tx_status status;
     std::vector<tx_partition> partitions;
     std::vector<tx_group> groups;
@@ -98,13 +102,18 @@ public:
 
     std::optional<tm_transaction> get_tx(kafka::transactional_id);
     checked<tm_transaction, tm_stm::op_status>
-      mark_tx_finished(kafka::transactional_id);
-    checked<tm_transaction, tm_stm::op_status>
       mark_tx_ongoing(kafka::transactional_id);
     bool add_partitions(
       kafka::transactional_id, std::vector<tm_transaction::tx_partition>);
     bool add_group(kafka::transactional_id, kafka::group_id, model::term_id);
+    bool is_actual_term(model::term_id term) { return _insync_term == term; }
 
+    ss::future<std::optional<tm_transaction>>
+      get_actual_tx(kafka::transactional_id);
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
+      mark_tx_ready(kafka::transactional_id);
+    ss::future<checked<tm_transaction, tm_stm::op_status>>
+      mark_tx_ready(kafka::transactional_id, model::term_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       try_change_status(kafka::transactional_id, tm_transaction::tx_status);
     ss::future<tm_stm::op_status>
@@ -136,7 +145,7 @@ private:
     ss::future<> apply(model::record_batch b) override;
 
     ss::future<checked<tm_transaction, tm_stm::op_status>>
-      save_tx(model::term_id, tm_transaction);
+      update_tx(tm_transaction, model::term_id);
     ss::future<result<raft::replicate_result>>
     replicate_quorum_ack(model::term_id term, model::record_batch&& batch) {
         return _c->replicate(

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -33,6 +33,8 @@
 namespace cluster {
 
 struct tm_transaction {
+    static constexpr uint8_t version = 0;
+
     enum tx_status {
         ongoing,
         preparing,
@@ -121,11 +123,6 @@ public:
     }
 
 private:
-    struct tx_updated_cmd {
-        static constexpr uint8_t record_key = 0;
-        tm_transaction tx;
-    };
-
     void load_snapshot(stm_snapshot_header, iobuf&&) override;
     stm_snapshot take_snapshot() override;
 

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -138,8 +138,6 @@ private:
       _tx_locks;
     ss::future<> apply(model::record_batch b) override;
 
-    ss::future<tm_stm::op_status> register_new_producer(
-      model::term_id, kafka::transactional_id, model::producer_identity);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       save_tx(model::term_id, tm_transaction);
     ss::future<result<raft::replicate_result>>

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -139,7 +139,11 @@ public:
     // get_end_lock method returns a mutex used to coordinate start
     // and end of a transaction
     ss::lw_shared_ptr<mutex> get_end_lock(kafka::transactional_id tid) {
-        return _end_locks.find(tid)->second;
+        auto [lock_it, inserted] = _end_locks.try_emplace(tid, nullptr);
+        if (inserted) {
+            lock_it->second = ss::make_lw_shared<mutex>();
+        }
+        return lock_it->second;
     }
 
 private:

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -162,8 +162,6 @@ private:
     model::violation_recovery_policy _recovery_policy;
     absl::flat_hash_map<kafka::transactional_id, tm_transaction> _tx_table;
     absl::flat_hash_map<kafka::transactional_id, ss::lw_shared_ptr<mutex>>
-      _tx_locks;
-    absl::flat_hash_map<kafka::transactional_id, ss::lw_shared_ptr<mutex>>
       _end_locks;
     ss::future<> apply(model::record_batch b) override;
 

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -247,7 +247,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
   ss::shared_ptr<tm_stm> stm,
   kafka::transactional_id tx_id,
   model::timeout_clock::duration timeout) {
-    auto maybe_tx = stm->get_tx(tx_id);
+    auto maybe_tx = co_await stm->get_actual_tx(tx_id);
 
     if (!maybe_tx) {
         allocate_id_reply pid_reply
@@ -283,19 +283,26 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
 
     checked<tm_transaction, tx_errc> r(tx);
 
-    if (tx.status == tm_transaction::tx_status::ongoing) {
+    if (tx.status == tm_transaction::tx_status::ready) {
+        // already in a good state, we don't need to do nothing. even if
+        // tx's etag is old it will be bumped by re_register_producer
+    } else if (tx.status == tm_transaction::tx_status::ongoing) {
         r = co_await do_abort_tm_tx(stm, tx, timeout, ss::promise<tx_errc>());
     } else if (tx.status == tm_transaction::tx_status::preparing) {
         r = co_await do_commit_tm_tx(stm, tx, timeout, ss::promise<tx_errc>());
-    } else if (tx.status == tm_transaction::tx_status::prepared) {
-        r = co_await recommit_tm_tx(tx, timeout);
-    } else if (tx.status == tm_transaction::tx_status::aborting) {
-        r = co_await reabort_tm_tx(tx, timeout);
     } else {
-        vassert(
-          tx.status == tm_transaction::tx_status::finished,
-          "unexpected tx status {}",
-          tx.status);
+        tx_errc ec;
+        if (tx.status == tm_transaction::tx_status::prepared) {
+            ec = co_await recommit_tm_tx(tx, timeout);
+        } else if (tx.status == tm_transaction::tx_status::aborting) {
+            ec = co_await reabort_tm_tx(tx, timeout);
+        } else {
+            vassert(false, "unexpected tx status {}", tx.status);
+        }
+
+        if (ec != tx_errc::none) {
+            r = ec;
+        }
     }
 
     if (!r.has_value()) {
@@ -376,22 +383,17 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
     model::producer_identity pid{
       .id = request.producer_id, .epoch = request.producer_epoch};
 
-    auto f = get_ongoing_tx(stm, pid, request.transactional_id, timeout);
+    auto r = co_await get_ongoing_tx(
+      stm, pid, request.transactional_id, timeout);
 
-    return f.then(
-      [this, request, timeout, stm](checked<tm_transaction, tx_errc> r) {
-          if (!r.has_value()) {
-              return ss::make_ready_future<add_paritions_tx_reply>(
-                make_add_partitions_error_response(
-                  request, tx_errc::unknown_server_error));
-          }
+    if (!r.has_value()) {
+        co_return make_add_partitions_error_response(
+          request, tx_errc::unknown_server_error);
+    }
 
-          add_paritions_tx_reply response;
-
-          auto tx = r.value();
-
-          return do_add_partition_to_tx(std::move(tx), stm, request, timeout);
-      });
+    auto tx = r.value();
+    co_return co_await do_add_partition_to_tx(
+      std::move(tx), stm, request, timeout);
 }
 
 ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
@@ -512,13 +514,6 @@ ss::future<add_offsets_tx_reply> tx_gateway_frontend::add_offsets_to_tx(
                   .error_code = tx_errc::unknown_server_error});
           }
 
-          auto maybe_tx = stm->get_tx(request.transactional_id);
-          if (!maybe_tx) {
-              return ss::make_ready_future<add_offsets_tx_reply>(
-                add_offsets_tx_reply{
-                  .error_code = tx_errc::unknown_server_error});
-          }
-
           return stm->get_tx_lock(request.transactional_id)
             ->with([&self, stm, request, timeout]() {
                 return self.do_add_offsets_to_tx(stm, request, timeout);
@@ -533,13 +528,13 @@ ss::future<add_offsets_tx_reply> tx_gateway_frontend::do_add_offsets_to_tx(
     model::producer_identity pid{
       .id = request.producer_id, .epoch = request.producer_epoch};
 
-    auto tx_opt = co_await get_ongoing_tx(
+    auto r = co_await get_ongoing_tx(
       stm, pid, request.transactional_id, timeout);
-    if (!tx_opt.has_value()) {
+    if (!r.has_value()) {
         co_return add_offsets_tx_reply{
           .error_code = tx_errc::unknown_server_error};
     }
-    auto tx = tx_opt.value();
+    auto tx = r.value();
 
     auto group_info = co_await _rm_group_proxy->begin_group_tx(
       request.group_id, pid, tx.tx_seq, timeout);
@@ -631,20 +626,15 @@ tx_gateway_frontend::do_end_txn(
   ss::shared_ptr<cluster::tm_stm> stm,
   model::timeout_clock::duration timeout,
   ss::promise<tx_errc> outcome) {
-    auto maybe_tx = stm->get_tx(request.transactional_id);
+    auto maybe_tx = co_await stm->get_actual_tx(request.transactional_id);
     if (!maybe_tx) {
-        outcome.set_value(tx_errc::unknown_server_error);
-        co_return tx_errc::timeout;
-    }
-
-    auto tx = maybe_tx.value();
-    if (tx.status != tm_transaction::tx_status::ongoing) {
         outcome.set_value(tx_errc::unknown_server_error);
         co_return tx_errc::timeout;
     }
 
     model::producer_identity pid{
       .id = request.producer_id, .epoch = request.producer_epoch};
+    auto tx = maybe_tx.value();
     if (tx.pid != pid) {
         if (tx.pid.id == pid.id && tx.pid.epoch > pid.epoch) {
             outcome.set_value(tx_errc::fenced);
@@ -655,12 +645,22 @@ tx_gateway_frontend::do_end_txn(
         co_return tx_errc::timeout;
     }
 
+    checked<cluster::tm_transaction, tx_errc> r(tx_errc::timeout);
     if (request.committed) {
-        co_return co_await do_commit_tm_tx(
-          stm, tx, timeout, std::move(outcome));
+        r = co_await do_commit_tm_tx(stm, tx, timeout, std::move(outcome));
     } else {
-        co_return co_await do_abort_tm_tx(stm, tx, timeout, std::move(outcome));
+        r = co_await do_abort_tm_tx(stm, tx, timeout, std::move(outcome));
     }
+    if (!r.has_value()) {
+        co_return r;
+    }
+    tx = r.value();
+
+    auto ongoing_tx = stm->mark_tx_ongoing(tx.id);
+    if (!ongoing_tx.has_value()) {
+        co_return tx_errc::timeout;
+    }
+    co_return ongoing_tx.value();
 }
 
 ss::future<checked<cluster::tm_transaction, tx_errc>>
@@ -669,11 +669,34 @@ tx_gateway_frontend::do_abort_tm_tx(
   cluster::tm_transaction tx,
   model::timeout_clock::duration timeout,
   ss::promise<tx_errc> outcome) {
+    if (tx.status == tm_transaction::tx_status::ready) {
+        if (stm->is_actual_term(tx.etag)) {
+            // client should start a transaction before attempting to
+            // abort it. since tx has actual term we know for sure it
+            // wasn't start on a different leader
+            outcome.set_value(tx_errc::request_rejected);
+            co_return tx_errc::request_rejected;
+        }
+
+        // writing ready status to overwrite an ongoing transaction if
+        // it exists on an older leader
+        auto ready_tx = co_await stm->mark_tx_ready(tx.id);
+        if (!ready_tx.has_value()) {
+            outcome.set_value(tx_errc::unknown_server_error);
+            co_return tx_errc::unknown_server_error;
+        }
+        outcome.set_value(tx_errc::none);
+        co_return ready_tx.value();
+    } else if (tx.status != tm_transaction::tx_status::ongoing) {
+        outcome.set_value(tx_errc::unknown_server_error);
+        co_return tx_errc::unknown_server_error;
+    }
+
     auto changed_tx = co_await stm->try_change_status(
       tx.id, cluster::tm_transaction::tx_status::aborting);
     if (!changed_tx.has_value()) {
-        outcome.set_value(tx_errc::timeout);
-        co_return checked<cluster::tm_transaction, tx_errc>(tx_errc::timeout);
+        outcome.set_value(tx_errc::unknown_server_error);
+        co_return tx_errc::unknown_server_error;
     }
     outcome.set_value(tx_errc::none);
 
@@ -698,14 +721,9 @@ tx_gateway_frontend::do_abort_tm_tx(
         ok = ok && (r.ec == tx_errc::none);
     }
     if (!ok) {
-        co_return checked<cluster::tm_transaction, tx_errc>(tx_errc::timeout);
+        co_return tx_errc::timeout;
     }
-    changed_tx = stm->mark_tx_finished(tx.id);
-    if (!changed_tx.has_value()) {
-        co_return checked<cluster::tm_transaction, tx_errc>(tx_errc::timeout);
-    }
-    tx = changed_tx.value();
-    co_return checked<cluster::tm_transaction, tx_errc>(tx);
+    co_return tx;
 }
 
 ss::future<checked<cluster::tm_transaction, tx_errc>>
@@ -714,6 +732,11 @@ tx_gateway_frontend::do_commit_tm_tx(
   cluster::tm_transaction tx,
   model::timeout_clock::duration timeout,
   ss::promise<tx_errc> outcome) {
+    if (tx.status != tm_transaction::tx_status::ongoing) {
+        outcome.set_value(tx_errc::request_rejected);
+        co_return tx_errc::request_rejected;
+    }
+
     std::vector<ss::future<prepare_tx_reply>> pfs;
     for (auto rm : tx.partitions) {
         pfs.push_back(_rm_partition_frontend.local().prepare_tx(
@@ -784,18 +807,12 @@ tx_gateway_frontend::do_commit_tm_tx(
         ok = ok && (r.ec == tx_errc::none);
     }
     if (!ok) {
-        co_return checked<cluster::tm_transaction, tx_errc>(tx_errc::timeout);
+        co_return tx_errc::timeout;
     }
-    changed_tx = stm->mark_tx_finished(tx.id);
-    if (!changed_tx.has_value()) {
-        co_return checked<cluster::tm_transaction, tx_errc>(tx_errc::timeout);
-    }
-    tx = changed_tx.value();
-    co_return checked<cluster::tm_transaction, tx_errc>(tx);
+    co_return tx;
 }
 
-ss::future<checked<tm_transaction, tx_errc>>
-tx_gateway_frontend::recommit_tm_tx(
+ss::future<tx_errc> tx_gateway_frontend::recommit_tm_tx(
   tm_transaction tx, model::timeout_clock::duration timeout) {
     std::vector<ss::future<commit_group_tx_reply>> gfs;
     for (auto group : tx.groups) {
@@ -817,14 +834,13 @@ tx_gateway_frontend::recommit_tm_tx(
     for (const auto& r : crs) {
         ok = ok && (r.ec == tx_errc::none);
     }
-
-    if (ok) {
-        co_return checked<tm_transaction, tx_errc>(tx);
+    if (!ok) {
+        co_return tx_errc::timeout;
     }
-    co_return checked<tm_transaction, tx_errc>(tx_errc::timeout);
+    co_return tx_errc::none;
 }
 
-ss::future<checked<tm_transaction, tx_errc>> tx_gateway_frontend::reabort_tm_tx(
+ss::future<tx_errc> tx_gateway_frontend::reabort_tm_tx(
   tm_transaction tx, model::timeout_clock::duration timeout) {
     std::vector<ss::future<abort_tx_reply>> pfs;
     for (auto rm : tx.partitions) {
@@ -845,10 +861,10 @@ ss::future<checked<tm_transaction, tx_errc>> tx_gateway_frontend::reabort_tm_tx(
     for (const auto& r : grs) {
         ok = ok && (r.ec == tx_errc::none);
     }
-    if (ok) {
-        co_return checked<tm_transaction, tx_errc>(tx);
+    if (!ok) {
+        co_return tx_errc::timeout;
     }
-    co_return checked<tm_transaction, tx_errc>(tx_errc::timeout);
+    co_return tx_errc::none;
 }
 
 // get_tx must be called under stm->get_tx_lock
@@ -858,49 +874,83 @@ tx_gateway_frontend::get_ongoing_tx(
   model::producer_identity pid,
   kafka::transactional_id transactional_id,
   model::timeout_clock::duration timeout) {
-    auto maybe_tx = stm->get_tx(transactional_id);
+    auto maybe_tx = co_await stm->get_actual_tx(transactional_id);
     if (!maybe_tx) {
-        co_return checked<tm_transaction, tx_errc>(tx_errc::timeout);
+        co_return tx_errc::timeout;
     }
 
     auto tx = maybe_tx.value();
 
     if (tx.pid != pid) {
-        co_return checked<tm_transaction, tx_errc>(tx_errc::timeout);
+        co_return tx_errc::timeout;
     }
 
-    checked<tm_transaction, tx_errc> r(tx);
-
-    if (tx.status != tm_transaction::tx_status::ongoing) {
-        if (tx.status == tm_transaction::tx_status::preparing) {
-            r = co_await do_commit_tm_tx(
-              stm, tx, timeout, ss::promise<tx_errc>());
-        } else if (tx.status == tm_transaction::tx_status::prepared) {
-            r = co_await recommit_tm_tx(tx, timeout);
+    if (tx.status == tm_transaction::tx_status::ready) {
+        if (!stm->is_actual_term(tx.etag)) {
+            // There is a possibility that a transaction was already started on
+            // a previous leader. Failing this request since it has a chance of
+            // being a part of that transaction. We expect client to abort on
+            // error and the abort will bump the tx's term (etag)
+            co_return tx_errc::timeout;
+        }
+    } else if (tx.status == tm_transaction::tx_status::ongoing) {
+        if (!stm->is_actual_term(tx.etag)) {
+            // Intentnally empty body. Leaving it just to comment what's going
+            // on.
+            //
+            // We don't save ongoing state to the log so the only case when it's
+            // possible to observe old ongoing transaction is when the tx was
+            // started on this node. Then an another node became leader, a
+            // client didn't issue any new requests to that node, the current
+            // node became leader again and the client woke up. It's safe to
+            // continue it.
+        }
+        co_return tx;
+    } else if (tx.status == tm_transaction::tx_status::preparing) {
+        // a producer can see a transaction with the same pid and in a
+        // preparing state only if it attempted a commit, the commit
+        // failed and then the producer ignored it and tried to start
+        // another transaction.
+        //
+        // it violates the docs, the producer is expected to call abort
+        // https://kafka.apache.org/23/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html
+        co_return tx_errc::timeout;
+    } else {
+        // A previous transaction has failed after its status has been
+        // decided, rolling it forward.
+        tx_errc ec;
+        if (tx.status == tm_transaction::tx_status::prepared) {
+            ec = co_await recommit_tm_tx(tx, timeout);
         } else if (tx.status == tm_transaction::tx_status::aborting) {
-            r = co_await reabort_tm_tx(tx, timeout);
+            ec = co_await reabort_tm_tx(tx, timeout);
         } else {
-            vassert(
-              tx.status == tm_transaction::tx_status::finished,
-              "unexpected tx status {}",
-              tx.status);
+            vassert(false, "unexpected tx status {}", tx.status);
         }
 
-        if (!r.has_value()) {
-            co_return r;
+        if (ec != tx_errc::none) {
+            co_return ec;
         }
 
-        auto tx = r.value();
-
-        auto changed_tx = stm->mark_tx_ongoing(tx.id);
-        if (!changed_tx.has_value()) {
-            co_return checked<cluster::tm_transaction, tx_errc>(
-              tx_errc::timeout);
+        if (!stm->is_actual_term(tx.etag)) {
+            // The tx has started on the previous term. Even though we rolled it
+            // forward there is a possibility that a previous leader did the
+            // same and already started the current transaction.
+            //
+            // Failing the current request. By the spec a client should abort on
+            // failure, but abort doesn't handle prepared and aborting statuses.
+            // So marking it as ready. We use previous term because aborting a
+            // tx in current ready state with current term means we abort a tx
+            // which wasn't started and it leads to an error.
+            (void)co_await stm->mark_tx_ready(tx.id, tx.etag);
+            co_return tx_errc::timeout;
         }
-        co_return checked<cluster::tm_transaction, tx_errc>(changed_tx.value());
     }
 
-    co_return r;
+    auto ongoing_tx = stm->mark_tx_ongoing(tx.id);
+    if (!ongoing_tx.has_value()) {
+        co_return tx_errc::timeout;
+    }
+    co_return ongoing_tx.value();
 }
 
 ss::future<bool> tx_gateway_frontend::try_create_tx_topic() {

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -362,13 +362,6 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::add_partition_to_tx(
                   request, tx_errc::unknown_server_error));
           }
 
-          auto maybe_tx = stm->get_tx(request.transactional_id);
-          if (!maybe_tx) {
-              return ss::make_ready_future<add_paritions_tx_reply>(
-                make_add_partitions_error_response(
-                  request, tx_errc::unknown_server_error));
-          }
-
           return stm->get_tx_lock(request.transactional_id)
             ->with([&self, stm, request, timeout]() {
                 return self.do_add_partition_to_tx(stm, request, timeout);

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -759,8 +759,7 @@ tx_gateway_frontend::do_commit_tm_tx(
           tx.id, cluster::tm_transaction::tx_status::preparing);
         if (!became_preparing_tx.has_value()) {
             outcome.set_value(tx_errc::timeout);
-            co_return checked<cluster::tm_transaction, tx_errc>(
-              tx_errc::timeout);
+            co_return tx_errc::timeout;
         }
         tx = became_preparing_tx.value();
     }
@@ -776,14 +775,14 @@ tx_gateway_frontend::do_commit_tm_tx(
     }
     if (!ok) {
         outcome.set_value(tx_errc::timeout);
-        co_return checked<cluster::tm_transaction, tx_errc>(tx_errc::timeout);
+        co_return tx_errc::timeout;
     }
     outcome.set_value(tx_errc::none);
 
     auto changed_tx = co_await stm->try_change_status(
       tx.id, cluster::tm_transaction::tx_status::prepared);
     if (!changed_tx.has_value()) {
-        co_return checked<cluster::tm_transaction, tx_errc>(tx_errc::timeout);
+        co_return tx_errc::timeout;
     }
     tx = changed_tx.value();
 

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -70,7 +70,7 @@ private:
 
     ss::future<bool> try_create_tx_topic();
 
-    ss::future<checked<tm_transaction, tx_errc>> get_tx(
+    ss::future<checked<tm_transaction, tx_errc>> get_ongoing_tx(
       ss::shared_ptr<tm_stm>,
       model::producer_identity,
       kafka::transactional_id,

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -85,17 +85,12 @@ private:
       kafka::transactional_id,
       model::timeout_clock::duration);
 
-    ss::future<checked<cluster::tm_transaction, tx_errc>> abort_tm_tx(
-      ss::shared_ptr<cluster::tm_stm>,
-      cluster::tm_transaction,
-      model::timeout_clock::duration,
-      ss::promise<tx_errc>);
+    ss::future<checked<cluster::tm_transaction, tx_errc>> do_end_txn(
+      end_tx_request request,
+      ss::shared_ptr<cluster::tm_stm> stm,
+      model::timeout_clock::duration timeout,
+      ss::promise<tx_errc> outcome);
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_abort_tm_tx(
-      ss::shared_ptr<cluster::tm_stm>,
-      cluster::tm_transaction,
-      model::timeout_clock::duration,
-      ss::promise<tx_errc>);
-    ss::future<checked<cluster::tm_transaction, tx_errc>> commit_tm_tx(
       ss::shared_ptr<cluster::tm_stm>,
       cluster::tm_transaction,
       model::timeout_clock::duration,

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -86,20 +86,20 @@ private:
       model::timeout_clock::duration);
 
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_end_txn(
-      end_tx_request request,
-      ss::shared_ptr<cluster::tm_stm> stm,
-      model::timeout_clock::duration timeout,
-      ss::promise<tx_errc> outcome);
+      end_tx_request,
+      ss::shared_ptr<cluster::tm_stm>,
+      model::timeout_clock::duration,
+      ss::lw_shared_ptr<ss::shared_promise<tx_errc>>);
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_abort_tm_tx(
       ss::shared_ptr<cluster::tm_stm>,
       cluster::tm_transaction,
       model::timeout_clock::duration,
-      ss::promise<tx_errc>);
+      ss::lw_shared_ptr<ss::shared_promise<tx_errc>>);
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_commit_tm_tx(
       ss::shared_ptr<cluster::tm_stm>,
       cluster::tm_transaction,
       model::timeout_clock::duration,
-      ss::promise<tx_errc>);
+      ss::lw_shared_ptr<ss::shared_promise<tx_errc>>);
     ss::future<tx_errc>
       recommit_tm_tx(tm_transaction, model::timeout_clock::duration);
     ss::future<tx_errc>

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -80,8 +80,10 @@ private:
       model::node_id, kafka::transactional_id, model::timeout_clock::duration);
     ss::future<cluster::init_tm_tx_reply> do_init_tm_tx(
       ss::shard_id, kafka::transactional_id, model::timeout_clock::duration);
-    ss::future<cluster::init_tm_tx_reply>
-      do_init_tm_tx(kafka::transactional_id, model::timeout_clock::duration);
+    ss::future<cluster::init_tm_tx_reply> do_init_tm_tx(
+      ss::shared_ptr<tm_stm>,
+      kafka::transactional_id,
+      model::timeout_clock::duration);
 
     ss::future<checked<cluster::tm_transaction, tx_errc>> abort_tm_tx(
       ss::shared_ptr<cluster::tm_stm>,

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -100,9 +100,9 @@ private:
       cluster::tm_transaction,
       model::timeout_clock::duration,
       ss::promise<tx_errc>);
-    ss::future<checked<tm_transaction, tx_errc>>
+    ss::future<tx_errc>
       recommit_tm_tx(tm_transaction, model::timeout_clock::duration);
-    ss::future<checked<tm_transaction, tx_errc>>
+    ss::future<tx_errc>
       reabort_tm_tx(tm_transaction, model::timeout_clock::duration);
 
     ss::future<add_paritions_tx_reply> do_add_partition_to_tx(


### PR DESCRIPTION
The motivation behind this PR is to make transaction coordinator to support garbage collection via compaction and deletion clean up policies.

Supporting deletion clean policy forced us to use last write wins conflict resolution instead of first write wins.

Why do conflicts exist in the first place?

Upon a request a transaction coordinator uses its in-memory state to make a decision, writes a command (the decision) to its partition, waits until a catch up processes reads the command back, replays it to update the in memory state and replies to the client.

When a write fails the transaction coordinator doesn't know if the write has passed or not so it doesn't wait for the catch up process and times out the request. Because the status of the write is unknown the state of the transaction coordinator may become stale. In that case the next command may conflict with the previous one but since the client doesn't get an acknowledgement the coordinator may choose any command to resolve the conflict.

We used to do first write wins conflict resolution but it doesn't work well with deletion clean up policy. Let's look on the following change log where the conflicts are designated by the same letter:

    a, b, c1, c2, d, e

With first write wins policy `c1` takes precedence over `c2` but when we cut the beginning of the log just after `c1`:

    c2, d, e

`c2` becomes first and we resolve the conflict in its favor potentially violating consistency. Using last write wins (lww) policy eliminates this scenario.

With the migration to lww the explicit versioning (etag) became obsolete we switched to pessimistic concurrency control and got rid of etags and excessive short term locks.

The last big change of the PR is fixing a consistency violation. Redpanda keeps ongoing transactions in memory to avoid write/replication latency. When a re-election happens we lose this information. Since the Kafka's protocol initiates a transaction implicitly on the first transactional request then when a request lends on new leader it starts new transaction and a client commits only the second part assuming the whole transaction.

We fix this problem by setting a fencing (with ready status) when a transaction starts on a new leader and failing a transaction if current the leader's term doesn't match the fence. When this happens a client aborts a transaction and the abort refreshes the fence.

[ch2201]