### PR TITLE
operator: Shrink kind cluster to only 1 worker and master

### DIFF
--- a/src/go/k8s/kind.yaml
+++ b/src/go/k8s/kind.yaml
@@ -3,5 +3,3 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
-- role: worker
-- role: worker

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -9,6 +9,7 @@ testDirs:
 kindConfig: ./kind.yaml
 kindNodeCache: false
 commands:
+  - command: "kubectl taint nodes -l node-role.kubernetes.io/master= node-role.kubernetes.io/master:NoSchedule-"
   - command: "./hack/install-cert-manager.sh"
   - command: "kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml"
   - command: "make deploy"

--- a/src/go/k8s/tests/e2e/node-select-tolerations/00-taint-node.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/00-taint-node.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- command: kubectl taint nodes kind-worker2 redpanda-node=true:NoSchedule
+- command: kubectl taint nodes kind-worker redpanda-node=true:NoSchedule

--- a/src/go/k8s/tests/e2e/node-select-tolerations/01-label-node.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/01-label-node.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- command: kubectl label nodes kind-worker2 redpanda-node=true
+- command: kubectl label nodes kind-worker redpanda-node=true

--- a/src/go/k8s/tests/e2e/node-select-tolerations/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/02-assert.yaml
@@ -15,7 +15,7 @@ spec:
   containers:
     - name: redpanda
       image: "vectorized/redpanda:latest"
-  nodeName: kind-worker2
+  nodeName: kind-worker
   nodeSelector:
     redpanda-node: "true"
 status:

--- a/src/go/k8s/tests/e2e/node-select-tolerations/03-remove-taint.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/03-remove-taint.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- command: kubectl taint nodes kind-worker2 redpanda-node=true:NoSchedule-
+- command: kubectl taint nodes kind-worker redpanda-node=true:NoSchedule-

--- a/src/go/k8s/tests/e2e/node-select-tolerations/04-remove-label.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/04-remove-label.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- command: kubectl label nodes kind-worker2 redpanda-node-
+- command: kubectl label nodes kind-worker redpanda-node-


### PR DESCRIPTION
The GitHub CI run out of space when our end-to-end are executed.
To solve this master node is now used as worker and one tests
is adjusted to work with new setup.

## Release notes

NONE.
