### PR TITLE
rpk container: Increase timeout & update client lib

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containerd/containerd v1.4.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
+	github.com/docker/docker v20.10.6+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
 	github.com/fatih/color v1.7.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -64,6 +64,8 @@ github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BU
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible h1:SiUATuP//KecDjpOK2tvZJgeScYAklvyjfK8JZlU6fo=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.6+incompatible h1:oXI3Vas8TI8Eu/EjH4srKHJBVqraSzJybhxY7Om9faQ=
+github.com/docker/docker v20.10.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=

--- a/src/go/rpk/pkg/cli/cmd/container/common/client.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Defines an interface with the functions from Docker's *client.Client that are
@@ -35,12 +36,12 @@ type Client interface {
 		ctx context.Context,
 		options types.ImageListOptions,
 	) ([]types.ImageSummary, error)
-
 	ContainerCreate(
 		ctx context.Context,
 		config *container.Config,
 		hostConfig *container.HostConfig,
 		networkingConfig *network.NetworkingConfig,
+		platform *specs.Platform,
 		containerName string,
 	) (container.ContainerCreateCreatedBody, error)
 
@@ -101,7 +102,7 @@ type dockerClient struct {
 }
 
 func NewDockerClient() (Client, error) {
-	c, err := client.NewEnvClient()
+	c, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -305,6 +305,7 @@ func CreateNode(
 		&containerConfig,
 		&hostConfig,
 		&networkConfig,
+		nil,
 		hostname,
 	)
 	if err != nil {

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -38,7 +38,7 @@ var (
 const (
 	redpandaNetwork = "redpanda"
 
-	defaultDockerClientTimeout = 10 * time.Second
+	defaultDockerClientTimeout = 60 * time.Second
 )
 
 type NodeState struct {

--- a/src/go/rpk/pkg/cli/cmd/container/common/test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type MockClient struct {
@@ -39,6 +40,7 @@ type MockClient struct {
 		config *container.Config,
 		hostConfig *container.HostConfig,
 		networkingConfig *network.NetworkingConfig,
+		platform *specs.Platform,
 		containerName string,
 	) (container.ContainerCreateCreatedBody, error)
 
@@ -109,6 +111,7 @@ func (c *MockClient) ContainerCreate(
 	config *container.Config,
 	hostConfig *container.HostConfig,
 	networkingConfig *network.NetworkingConfig,
+	platform *specs.Platform,
 	containerName string,
 ) (container.ContainerCreateCreatedBody, error) {
 	if c.MockContainerCreate != nil {
@@ -117,6 +120,7 @@ func (c *MockClient) ContainerCreate(
 			config,
 			hostConfig,
 			networkingConfig,
+			platform,
 			containerName,
 		)
 	}

--- a/src/go/rpk/pkg/cli/cmd/container/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/container/common"
@@ -241,6 +242,7 @@ Please check your internet connection and try again.`,
 						_ *container.Config,
 						_ *container.HostConfig,
 						_ *network.NetworkingConfig,
+						_ *specs.Platform,
 						_ string,
 					) (container.ContainerCreateCreatedBody, error) {
 						body := container.ContainerCreateCreatedBody{}
@@ -285,6 +287,7 @@ Please check your internet connection and try again.`,
 						_ *container.Config,
 						_ *container.HostConfig,
 						_ *network.NetworkingConfig,
+						_ *specs.Platform,
 						_ string,
 					) (container.ContainerCreateCreatedBody, error) {
 						body := container.ContainerCreateCreatedBody{
@@ -329,6 +332,7 @@ Please check your internet connection and try again.`,
 						_ *container.Config,
 						_ *container.HostConfig,
 						_ *network.NetworkingConfig,
+						_ *specs.Platform,
 						_ string,
 					) (container.ContainerCreateCreatedBody, error) {
 						body := container.ContainerCreateCreatedBody{
@@ -407,6 +411,7 @@ Please check your internet connection and try again.`,
 						_ *container.Config,
 						_ *container.HostConfig,
 						_ *network.NetworkingConfig,
+						_ *specs.Platform,
 						_ string,
 					) (container.ContainerCreateCreatedBody, error) {
 						body := container.ContainerCreateCreatedBody{
@@ -456,6 +461,7 @@ Please check your internet connection and try again.`,
 						cc *container.Config,
 						_ *container.HostConfig,
 						_ *network.NetworkingConfig,
+						_ *specs.Platform,
 						_ string,
 					) (container.ContainerCreateCreatedBody, error) {
 						// If the node is not the seed, check


### PR DESCRIPTION
Increase the timeout used for requests with the docker demon, since for some MacOS machines 10 seconds is sill too little.

Update the docker client library.

Fix #1471 
