### PR TITLE
ci/gcb: fix missing secrets in GCB environment

### DIFF
--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -107,10 +107,10 @@ tasks:
           '{{.SRC_DIR}}'
       fi
     - rm '{{.SRC_DIR}}/.dockerignore'
-    - cmd: "if [ '{{.CI}}' == 'true' ] && [ '{{.BRANCH_NAME}}' = 'dev' ]; then docker login --username {{.DOCKERHUB_USER}} --password {{.DOCKERHUB_TOKEN}}; fi"
+    - cmd: "if [ '{{.CI}}' == 'true' ] && [ '{{.BRANCH_NAME}}' = 'dev' ] && [ '{{.BUILD_TYPE}}' = 'release' ] && [ '{{.COMPILER}}' = 'clang' ]; then docker login --username {{.DOCKERHUB_USER}} --password {{.DOCKERHUB_TOKEN}}; fi"
       silent: true
     - |
-      if [ '{{.CI}}' = 'true' ] && [ '{{.BRANCH_NAME}}' = 'dev' ]; then
+      if [ '{{.CI}}' = 'true' ] && [ '{{.BRANCH_NAME}}' = 'dev' ] && [ '{{.BUILD_TYPE}}' = 'release' ] && [ '{{.COMPILER}}' = 'clang' ]; then
         docker tag vectorized/redpanda-test-node docker.io/vectorized/redpanda-test-node:cache-{{ARCH}}
         docker push docker.io/vectorized/redpanda-test-node:cache-{{ARCH}}
       fi

--- a/tests/ci/cloudbuild.yaml
+++ b/tests/ci/cloudbuild.yaml
@@ -35,6 +35,9 @@ steps:
   - -euc
   - |
     cp vtools/envs/gcb-$_BUILD_TYPE-$_COMPILER .env
+    echo DOCKERHUB_USER=$$DOCKERHUB_USER >> .env
+    echo DOCKERHUB_TOKEN=$$DOCKERHUB_TOKEN >> .env
+    echo CLOUDSMITH_API_KEY=$$CLOUDSMITH_API_KEY >> .env
     mkdir build/
     bin/task $_TASK_ARGS
 


### PR DESCRIPTION
Adds secrets passed as env variables to the `.env` file that Task loads.