### PR TITLE
Replicate stages

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -105,9 +105,8 @@ struct errc_category final : public std::error_category {
             return "Producer sequence ID out of order";
         case errc::generic_tx_error:
             return "Generic error when processing transactional requests";
-        default:
-            return "cluster::errc::unknown";
         }
+        return "cluster::errc::unknown";
     }
 };
 inline const std::error_category& error_category() noexcept {

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -38,6 +38,9 @@ enum class errc : int16_t {
     update_in_progress,
     user_exists,
     user_does_not_exist,
+    invalid_producer_epoch,
+    sequence_out_of_order,
+    generic_tx_error
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -96,6 +99,12 @@ struct errc_category final : public std::error_category {
             return "User already exists";
         case errc::user_does_not_exist:
             return "User does not exist";
+        case errc::invalid_producer_epoch:
+            return "Invalid idempotent producer epoch";
+        case errc::sequence_out_of_order:
+            return "Producer sequence ID out of order";
+        case errc::generic_tx_error:
+            return "Generic error when processing transactional requests";
         default:
             return "cluster::errc::unknown";
         }

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -57,14 +57,14 @@ partition::partition(consensus_ptr r)
 
 ss::future<result<raft::replicate_result>> partition::replicate(
   model::record_batch_reader&& r, raft::replicate_options opts) {
-    return _raft->replicate(std::move(r), std::move(opts));
+    return _raft->replicate(std::move(r), opts);
 }
 
 ss::future<result<raft::replicate_result>> partition::replicate(
   model::term_id term,
   model::record_batch_reader&& r,
   raft::replicate_options opts) {
-    return _raft->replicate(term, std::move(r), std::move(opts));
+    return _raft->replicate(term, std::move(r), opts);
 }
 
 ss::future<checked<raft::replicate_result, kafka::error_code>>
@@ -73,9 +73,9 @@ partition::replicate(
   model::record_batch_reader&& r,
   raft::replicate_options opts) {
     if (bid.is_transactional || bid.has_idempotent()) {
-        return _rm_stm->replicate(bid, std::move(r), std::move(opts));
+        return _rm_stm->replicate(bid, std::move(r), opts);
     } else {
-        return _raft->replicate(std::move(r), std::move(opts))
+        return _raft->replicate(std::move(r), opts)
           .then([](result<raft::replicate_result> result) {
               if (result.has_value()) {
                   return checked<raft::replicate_result, kafka::error_code>(

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -42,6 +42,9 @@ public:
     ss::future<result<raft::replicate_result>>
     replicate(model::record_batch_reader&&, raft::replicate_options);
 
+    raft::replicate_stages
+    replicate_in_stages(model::record_batch_reader&&, raft::replicate_options);
+
     ss::future<result<raft::replicate_result>> replicate(
       model::term_id, model::record_batch_reader&&, raft::replicate_options);
 
@@ -50,6 +53,10 @@ public:
       model::record_batch_reader&&,
       raft::replicate_options);
 
+    raft::replicate_stages replicate_in_stages(
+      model::batch_identity,
+      model::record_batch_reader&&,
+      raft::replicate_options);
     /**
      * The reader is modified such that the max offset is configured to be
      * the minimum of the max offset requested and the committed index of the

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -45,7 +45,7 @@ public:
     ss::future<result<raft::replicate_result>> replicate(
       model::term_id, model::record_batch_reader&&, raft::replicate_options);
 
-    ss::future<checked<raft::replicate_result, kafka::error_code>> replicate(
+    ss::future<result<raft::replicate_result>> replicate(
       model::batch_identity,
       model::record_batch_reader&&,
       raft::replicate_options);

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -15,7 +15,6 @@
 #include "cluster/tx_utils.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
-#include "kafka/protocol/errors.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "raft/consensus.h"
@@ -98,7 +97,7 @@ public:
     ss::future<std::vector<rm_stm::tx_range>>
       aborted_transactions(model::offset, model::offset);
 
-    ss::future<checked<raft::replicate_result, kafka::error_code>> replicate(
+    ss::future<result<raft::replicate_result>> replicate(
       model::batch_identity,
       model::record_batch_reader,
       raft::replicate_options);
@@ -121,14 +120,13 @@ private:
 
     bool check_seq(model::batch_identity);
 
-    ss::future<checked<raft::replicate_result, kafka::error_code>>
+    ss::future<result<raft::replicate_result>>
       replicate_tx(model::batch_identity, model::record_batch_reader);
 
-    ss::future<checked<raft::replicate_result, kafka::error_code>>
-      replicate_seq(
-        model::batch_identity,
-        model::record_batch_reader,
-        raft::replicate_options);
+    ss::future<result<raft::replicate_result>> replicate_seq(
+      model::batch_identity,
+      model::record_batch_reader,
+      raft::replicate_options);
 
     void compact_snapshot();
 

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/errc.h"
 #include "cluster/rm_stm.h"
 #include "finjector/hbadger.h"
 #include "model/fundamental.h"
@@ -177,9 +178,7 @@ FIXTURE_TEST(test_rm_stm_prevents_duplicates, mux_state_machine_fixture) {
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get0();
     BOOST_REQUIRE(
-      r2
-      == failure_type<kafka::error_code>(
-        kafka::error_code::out_of_order_sequence_number));
+      r2 == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
 }
 
 FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
@@ -229,9 +228,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get0();
     BOOST_REQUIRE(
-      r2
-      == failure_type<kafka::error_code>(
-        kafka::error_code::out_of_order_sequence_number));
+      r2 == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
 }
 
 FIXTURE_TEST(
@@ -266,7 +263,5 @@ FIXTURE_TEST(
                  raft::replicate_options(raft::consistency_level::quorum_ack))
                .get0();
     BOOST_REQUIRE(
-      r
-      == failure_type<kafka::error_code>(
-        kafka::error_code::out_of_order_sequence_number));
+      r == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
 }

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/errc.h"
 #include "cluster/rm_stm.h"
 #include "finjector/hbadger.h"
 #include "model/fundamental.h"
@@ -29,8 +30,8 @@
 
 using namespace std::chrono_literals;
 
-static const failure_type<kafka::error_code>
-  invalid_producer_epoch(kafka::error_code::invalid_producer_epoch);
+static const failure_type<cluster::errc>
+  invalid_producer_epoch(cluster::errc::invalid_producer_epoch);
 
 static ss::logger logger{"rm_stm-test"};
 

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -106,14 +106,13 @@ ss::future<result<model::offset>> replicated_partition::replicate(
           return ret_t(_translator->to_kafka_offset(r.value().last_offset));
       });
 }
-ss::future<checked<model::offset, kafka::error_code>>
-replicated_partition::replicate(
+ss::future<result<model::offset>> replicated_partition::replicate(
   model::batch_identity batch_id,
   model::record_batch_reader&& rdr,
   raft::replicate_options opts) {
-    using ret_t = checked<model::offset, kafka::error_code>;
+    using ret_t = result<model::offset>;
     return _partition->replicate(batch_id, std::move(rdr), opts)
-      .then([this](checked<raft::replicate_result, kafka::error_code> r) {
+      .then([this](result<raft::replicate_result> r) {
           if (!r) {
               return ret_t(r.error());
           }

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -49,7 +49,7 @@ public:
     ss::future<result<model::offset>>
       replicate(model::record_batch_reader, raft::replicate_options);
 
-    ss::future<checked<model::offset, kafka::error_code>> replicate(
+    ss::future<result<model::offset>> replicate(
       model::batch_identity,
       model::record_batch_reader&&,
       raft::replicate_options);

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -30,6 +30,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
 
 #include <fmt/ostream.h>
 
@@ -519,35 +520,63 @@ ss::future<result<model::offset>> consensus::linearizable_barrier() {
 
 ss::future<result<replicate_result>>
 consensus::replicate(model::record_batch_reader&& rdr, replicate_options opts) {
-    return ss::with_gate(_bg, [this, rdr = std::move(rdr), opts]() mutable {
-        return do_replicate({}, std::move(rdr), opts);
-    });
+    auto r = do_replicate({}, std::move(rdr), opts);
+    return r.request_enqueued.then(
+      [f = std::move(r.replicate_finished)]() mutable { return std::move(f); });
 }
 
 ss::future<result<replicate_result>> consensus::replicate(
   model::term_id expected_term,
   model::record_batch_reader&& rdr,
   replicate_options opts) {
-    return ss::with_gate(
-      _bg, [this, rdr = std::move(rdr), opts, expected_term]() mutable {
-          return do_replicate(expected_term, std::move(rdr), opts);
-      });
+    auto r = do_replicate(expected_term, std::move(rdr), opts);
+    return r.request_enqueued.then(
+      [f = std::move(r.replicate_finished)]() mutable { return std::move(f); });
 }
 
-ss::future<result<replicate_result>> consensus::do_replicate(
+replicate_stages consensus::replicate_in_stages(
+  model::record_batch_reader&& rdr, replicate_options opts) {
+    return do_replicate({}, std::move(rdr), opts);
+}
+
+replicate_stages consensus::replicate_in_stages(
+  model::term_id expected_term,
+  model::record_batch_reader&& rdr,
+  replicate_options opts) {
+    return do_replicate(expected_term, std::move(rdr), opts);
+}
+
+replicate_stages
+wrap_stages_with_gate(ss::gate& gate, replicate_stages stages) {
+    return replicate_stages(
+      ss::with_gate(
+        gate,
+        [f = std::move(stages.request_enqueued)]() mutable {
+            return std::move(f);
+        }),
+      ss::with_gate(gate, [f = std::move(stages.replicate_finished)]() mutable {
+          return std::move(f);
+      }));
+}
+replicate_stages consensus::do_replicate(
   std::optional<model::term_id> expected_term,
   model::record_batch_reader&& rdr,
   replicate_options opts) {
+    // if gate is closed return fast, after this check we are certain that
+    // `ss::with_gate` will succeed
+    if (unlikely(_bg.is_closed())) {
+        return replicate_stages(errc::shutting_down);
+    }
+
     if (!is_leader() || unlikely(_transferring_leadership)) {
-        return seastar::make_ready_future<result<replicate_result>>(
-          errc::not_leader);
+        return replicate_stages(errc::not_leader);
     }
 
     if (opts.consistency == consistency_level::quorum_ack) {
         _probe.replicate_requests_ack_all();
 
-        return _batcher.replicate(expected_term, std::move(rdr))
-          .finally([this] { _probe.replicate_done(); });
+        return wrap_stages_with_gate(
+          _bg, _batcher.replicate(expected_term, std::move(rdr)));
     }
 
     if (opts.consistency == consistency_level::leader_ack) {
@@ -557,41 +586,61 @@ ss::future<result<replicate_result>> consensus::do_replicate(
     }
     // For relaxed consistency, append data to leader disk without flush
     // asynchronous replication is provided by Raft protocol recovery mechanism.
-    return _op_lock
-      .with([this,
-             expected_term,
-             rdr = std::move(rdr),
-             lvl = opts.consistency]() mutable {
-          if (!is_leader()) {
-              return seastar::make_ready_future<result<replicate_result>>(
-                errc::not_leader);
-          }
 
-          if (expected_term.has_value() && expected_term.value() != _term) {
-              return seastar::make_ready_future<result<replicate_result>>(
-                errc::not_leader);
+    ss::promise<> enqueued;
+    auto enqueued_f = enqueued.get_future();
+    using ret_t = result<replicate_result>;
+
+    auto replicated = _op_lock.get_units().then_wrapped(
+      [this,
+       expected_term,
+       enqueued = std::move(enqueued),
+       lvl = opts.consistency,
+       rdr = std::move(rdr)](ss::future<ss::semaphore_units<>> f) mutable {
+          if (!f.failed()) {
+              enqueued.set_value();
+              return do_append_replicate_relaxed(
+                expected_term, std::move(rdr), lvl, f.get());
           }
-          _last_write_consistency_level = lvl;
-          return disk_append(
-                   model::make_record_batch_reader<
-                     details::term_assigning_reader>(
-                     std::move(rdr), model::term_id(_term)),
-                   update_last_quorum_index::no)
-            .then([this](storage::append_result res) {
-                // only update visibility upper bound if all quorum replicated
-                // entries are committed already
-                if (_commit_index >= _last_quorum_replicated_index) {
-                    // for relaxed consistency mode update visibility upper
-                    // bound with last offset appended to the log
-                    _visibility_upper_bound_index = std::max(
-                      _visibility_upper_bound_index, res.last_offset);
-                    maybe_update_majority_replicated_index();
-                }
-                return result<replicate_result>(
-                  replicate_result{.last_offset = res.last_offset});
-            });
+          enqueued.set_exception(f.get_exception());
+          return ss::make_ready_future<ret_t>(errc::leader_append_failed);
+      });
+
+    return wrap_stages_with_gate(
+      _bg, replicate_stages(std::move(enqueued_f), std::move(replicated)));
+}
+
+ss::future<result<replicate_result>> consensus::do_append_replicate_relaxed(
+  std::optional<model::term_id> expected_term,
+  model::record_batch_reader rdr,
+  consistency_level lvl,
+  ss::semaphore_units<> u) {
+    using ret_t = result<replicate_result>;
+    if (!is_leader()) {
+        return seastar::make_ready_future<ret_t>(errc::not_leader);
+    }
+
+    if (expected_term.has_value() && expected_term.value() != _term) {
+        return seastar::make_ready_future<ret_t>(errc::not_leader);
+    }
+    _last_write_consistency_level = lvl;
+    return disk_append(
+             model::make_record_batch_reader<details::term_assigning_reader>(
+               std::move(rdr), model::term_id(_term)),
+             update_last_quorum_index::no)
+      .then([this](storage::append_result res) {
+          // only update visibility upper bound if all quorum
+          // replicated entries are committed already
+          if (_commit_index >= _last_quorum_replicated_index) {
+              // for relaxed consistency mode update visibility
+              // upper bound with last offset appended to the log
+              _visibility_upper_bound_index = std::max(
+                _visibility_upper_bound_index, res.last_offset);
+              maybe_update_majority_replicated_index();
+          }
+          return ret_t(replicate_result{.last_offset = res.last_offset});
       })
-      .finally([this] { _probe.replicate_done(); });
+      .finally([this, u = std::move(u)] { _probe.replicate_done(); });
 }
 
 void consensus::dispatch_flush_with_lock() {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -172,6 +172,8 @@ public:
 
     ss::future<result<replicate_result>>
     replicate(model::record_batch_reader&&, replicate_options);
+    replicate_stages
+    replicate_in_stages(model::record_batch_reader&&, replicate_options);
 
     /**
      * Replication happens only when expected_term matches the current _term
@@ -198,7 +200,8 @@ public:
      */
     ss::future<result<replicate_result>>
     replicate(model::term_id, model::record_batch_reader&&, replicate_options);
-
+    replicate_stages replicate_in_stages(
+      model::term_id, model::record_batch_reader&&, replicate_options);
     ss::future<model::record_batch_reader> make_reader(
       storage::log_reader_config,
       std::optional<clock_type::time_point> = std::nullopt);
@@ -339,10 +342,15 @@ private:
     append_entries_reply
       make_append_entries_reply(vnode, storage::append_result);
 
-    ss::future<result<replicate_result>> do_replicate(
+    replicate_stages do_replicate(
       std::optional<model::term_id>,
       model::record_batch_reader&&,
       replicate_options);
+    ss::future<result<replicate_result>> do_append_replicate_relaxed(
+      std::optional<model::term_id>,
+      model::record_batch_reader,
+      consistency_level,
+      ss::semaphore_units<>);
 
     ss::future<storage::append_result>
     disk_append(model::record_batch_reader&&, update_last_quorum_index);

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -34,7 +34,8 @@ enum class errc {
     invalid_configuration_update,
     not_voter,
     invalid_target_node,
-    shutting_down
+    shutting_down,
+    replicate_batcher_cache_error,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "raft::errc"; }
@@ -80,6 +81,8 @@ struct errc_category final : public std::error_category {
                    "request was addressed to";
         case errc::shutting_down:
             return "raft protocol shutting down";
+        case errc::replicate_batcher_cache_error:
+            return "unable to append batch to replicate batcher cache";
         default:
             return "raft::errc::unknown";
         }

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -45,7 +45,7 @@ public:
     replicate_batcher& operator=(const replicate_batcher&) = delete;
     ~replicate_batcher() noexcept = default;
 
-    ss::future<result<replicate_result>>
+    replicate_stages
     replicate(std::optional<model::term_id>, model::record_batch_reader&&);
 
     ss::future<> flush();

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -12,6 +12,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/consensus_utils.h"
+#include "raft/errc.h"
 #include "raft/group_configuration.h"
 #include "reflection/adl.h"
 #include "utils/to_string.h"
@@ -23,6 +24,16 @@
 #include <type_traits>
 
 namespace raft {
+
+replicate_stages::replicate_stages(
+  ss::future<> enq, ss::future<result<replicate_result>> offset_future)
+  : request_enqueued(std::move(enq))
+  , replicate_finished(std::move(offset_future)) {}
+
+replicate_stages::replicate_stages(raft::errc ec)
+  : request_enqueued(ss::now())
+  , replicate_finished(
+      ss::make_ready_future<result<replicate_result>>(make_error_code(ec))){};
 
 std::ostream& operator<<(std::ostream& o, const vnode& id) {
     return o << "{id: " << id.id() << ", revision: " << id.revision() << "}";

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -17,6 +17,8 @@
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
+#include "outcome.h"
+#include "raft/errc.h"
 #include "raft/fwd.h"
 #include "raft/group_configuration.h"
 #include "reflection/async_adl.h"
@@ -310,6 +312,16 @@ struct replicate_result {
     /// used by the kafka API to produce a kafka reply to produce request.
     /// see produce_request.cc
     model::offset last_offset;
+};
+struct replicate_stages {
+    replicate_stages(ss::future<>, ss::future<result<replicate_result>>);
+    explicit replicate_stages(raft::errc);
+    // after this future is ready, request in enqueued in raft and it will not
+    // be reorderd
+    ss::future<> request_enqueued;
+    // after this future is ready, request was successfully replicated with
+    // requested consistency level
+    ss::future<result<replicate_result>> replicate_finished;
 };
 
 enum class consistency_level { quorum_ack, leader_ack, no_ack };


### PR DESCRIPTION
## Cover letter

Returning `raft::replicate_stages` from `consensus::replicate`. This way `replicate()` caller can decide to either wait for request to be enqueued in raft internals or to wait for the replication to finish. This PR is part of performance improvements work that we do together with @dotnwat.  

Fixes: N/A

## Release notes

N/A