### PR TITLE
Processing requests in order in Kafka layer

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -856,13 +856,12 @@ group_manager::abort_tx(cluster::abort_group_tx_request&& r) {
       });
 }
 
-ss::future<offset_commit_response>
+group::offset_commit_stages
 group_manager::offset_commit(offset_commit_request&& r) {
     auto error = validate_group_status(
       r.ntp, r.data.group_id, offset_commit_api::key);
     if (error != error_code::none) {
-        return ss::make_ready_future<offset_commit_response>(
-          offset_commit_response(r, error));
+        return group::offset_commit_stages(offset_commit_response(r, error));
     }
 
     auto group = get_group(r.data.group_id);
@@ -878,7 +877,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
         } else {
             // <kafka>or this is a request coming from an older generation.
             // either way, reject the commit</kafka>
-            return ss::make_ready_future<offset_commit_response>(
+            return group::offset_commit_stages(
               offset_commit_response(r, error_code::illegal_generation));
         }
     }

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -135,8 +135,7 @@ public:
     ss::future<leave_group_response> leave_group(leave_group_request&& request);
 
     /// \brief Handle a OffsetCommit request
-    ss::future<offset_commit_response>
-    offset_commit(offset_commit_request&& request);
+    group::offset_commit_stages offset_commit(offset_commit_request&& request);
 
     ss::future<txn_offset_commit_response>
     txn_offset_commit(txn_offset_commit_request&& request);

--- a/src/v/kafka/server/group_router.h
+++ b/src/v/kafka/server/group_router.h
@@ -29,7 +29,9 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/smp.hh>
 
+#include <exception>
 #include <type_traits>
 
 namespace kafka {
@@ -129,8 +131,59 @@ public:
         return route(std::move(request), &group_manager::leave_group);
     }
 
-    auto offset_commit(offset_commit_request&& request) {
-        return route(std::move(request), &group_manager::offset_commit);
+    group::offset_commit_stages offset_commit(offset_commit_request&& request) {
+        auto m = shard_for(request.data.group_id);
+        if (!m) {
+            return group::offset_commit_stages(
+              offset_commit_response(request, error_code::not_coordinator));
+        }
+        request.ntp = std::move(m->first);
+        auto dispatched = std::make_unique<ss::promise<>>();
+        auto dispatched_f = dispatched->get_future();
+        auto f = with_scheduling_group(
+          _sg,
+          [this,
+           shard = m->second,
+           request = std::move(request),
+           dispatched = std::move(dispatched)]() mutable {
+              return _group_manager.invoke_on(
+                shard,
+                _ssg,
+                [request = std::move(request),
+                 dispatched = std::move(dispatched),
+                 source_shard = ss::this_shard_id()](
+                  group_manager& mgr) mutable {
+                    auto stages = mgr.offset_commit(std::move(request));
+                    /**
+                     * dispatched future is always ready before committed one,
+                     * we do not have to use gate in here
+                     */
+                    return stages.dispatched
+                      .then_wrapped([source_shard, d = std::move(dispatched)](
+                                      ss::future<> f) mutable {
+                          if (f.failed()) {
+                              (void)ss::smp::submit_to(
+                                source_shard,
+                                [d = std::move(d),
+                                 e = f.get_exception()]() mutable {
+                                    d->set_exception(e);
+                                    d.reset();
+                                });
+                              return;
+                          }
+                          (void)ss::smp::submit_to(
+                            source_shard, [d = std::move(d)]() mutable {
+                                d->set_value();
+                                d.reset();
+                            });
+                      })
+                      .then([f = std::move(stages.committed)]() mutable {
+                          return std::move(f);
+                      });
+                });
+          });
+        return group::offset_commit_stages(
+          std::move(dispatched_f), std::move(f));
     }
 
     auto txn_offset_commit(txn_offset_commit_request&& request) {

--- a/src/v/kafka/server/handlers/handler.h
+++ b/src/v/kafka/server/handlers/handler.h
@@ -41,6 +41,15 @@ concept KafkaApiHandler = requires (T h, request_context&& ctx, ss::smp_service_
     { T::handle(std::move(ctx), g) } -> std::same_as<ss::future<response_ptr>>;
 };
 )
+CONCEPT(
+template<typename T>
+concept KafkaApiTwoPhaseHandler = requires (T h, request_context&& ctx, ss::smp_service_group g) {
+    KafkaApi<typename T::api>;
+    { T::min_supported } -> std::convertible_to<const api_version&>;
+    { T::max_supported } -> std::convertible_to<const api_version&>;
+    { T::handle(std::move(ctx), g) } -> std::same_as<process_result_stages>;
+};
+)
 // clang-format on
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/offset_commit.cc
+++ b/src/v/kafka/server/handlers/offset_commit.cc
@@ -53,16 +53,15 @@ struct offset_commit_ctx {
       , ssg(ssg) {}
 };
 
-template<>
-ss::future<response_ptr>
+process_result_stages
 offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     offset_commit_request request;
     request.decode(ctx.reader(), ctx.header().version);
     klog.trace("Handling request {}", request);
 
     if (request.data.group_instance_id) {
-        return ctx.respond(
-          offset_commit_response(request, error_code::unsupported_version));
+        return process_result_stages::single_stage(ctx.respond(
+          offset_commit_response(request, error_code::unsupported_version)));
     }
 
     // check authorization for this group
@@ -186,13 +185,18 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
               .partitions = std::move(topic.second),
             });
         }
-        return octx.rctx.respond(std::move(resp));
+        return process_result_stages::single_stage(
+          octx.rctx.respond(std::move(resp)));
     }
-
-    return ss::do_with(std::move(octx), [](offset_commit_ctx& octx) {
-        return octx.rctx.groups()
-          .offset_commit(std::move(octx.request))
-          .then([&octx](offset_commit_response resp) {
+    ss::promise<> dispatch;
+    auto dispatch_f = dispatch.get_future();
+    auto f = ss::do_with(
+      std::move(octx),
+      [dispatch = std::move(dispatch)](offset_commit_ctx& octx) mutable {
+          auto stages = octx.rctx.groups().offset_commit(
+            std::move(octx.request));
+          stages.dispatched.forward_to(std::move(dispatch));
+          return stages.committed.then([&octx](offset_commit_response resp) {
               if (unlikely(!octx.nonexistent_tps.empty())) {
                   /*
                    * copy over partitions for topics that had some partitions
@@ -229,7 +233,9 @@ offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
               }
               return octx.rctx.respond(std::move(resp));
           });
-    });
+      });
+
+    return process_result_stages(std::move(dispatch_f), std::move(f));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/offset_commit.h
+++ b/src/v/kafka/server/handlers/offset_commit.h
@@ -17,6 +17,10 @@ namespace kafka {
 // in version 0 kafka stores offsets in zookeeper. if we ever need to
 // support version 0 then we need to do some code review to see if this has
 // any implications on semantics.
-using offset_commit_handler = handler<offset_commit_api, 1, 7>;
-
+struct offset_commit_handler {
+    using api = offset_commit_api;
+    static constexpr api_version min_supported = api_version(1);
+    static constexpr api_version max_supported = api_version(7);
+    static process_result_stages handle(request_context, ss::smp_service_group);
+};
 } // namespace kafka

--- a/src/v/kafka/server/handlers/produce.h
+++ b/src/v/kafka/server/handlers/produce.h
@@ -14,6 +14,11 @@
 
 namespace kafka {
 
-using produce_handler = handler<produce_api, 0, 7>;
+struct produce_handler {
+    using api = produce_api;
+    static constexpr api_version min_supported = api_version(0);
+    static constexpr api_version max_supported = api_version(7);
+    static process_result_stages handle(request_context, ss::smp_service_group);
+};
 
-}
+} // namespace kafka

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -49,7 +49,7 @@ public:
     ss::future<result<model::offset>>
       replicate(model::record_batch_reader, raft::replicate_options);
 
-    ss::future<result<model::offset>> replicate(
+    raft::replicate_stages replicate(
       model::batch_identity,
       model::record_batch_reader&&,
       raft::replicate_options);

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -184,7 +184,6 @@ private:
 };
 
 // Executes the API call identified by the specified request_context.
-ss::future<response_ptr>
-process_request(request_context&&, ss::smp_service_group);
+process_result_stages process_request(request_context&&, ss::smp_service_group);
 
 } // namespace kafka

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -56,13 +56,21 @@ struct process_dispatch<api_versions_handler> {
     }
 };
 /**
- * Produce request is currently the only one leveraging two stage processing
+ * Requests processed in two stages
  */
 template<>
 struct process_dispatch<produce_handler> {
     static process_result_stages
     process(request_context&& ctx, ss::smp_service_group g) {
         return produce_handler::handle(std::move(ctx), g);
+    }
+};
+
+template<>
+struct process_dispatch<offset_commit_handler> {
+    static process_result_stages
+    process(request_context&& ctx, ss::smp_service_group g) {
+        return offset_commit_handler::handle(std::move(ctx), g);
     }
 };
 

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -24,18 +24,18 @@ namespace kafka {
 template<typename Request>
 CONCEPT(requires(KafkaApiHandler<Request>))
 struct process_dispatch {
-    static ss::future<response_ptr>
+    static process_result_stages
     process(request_context&& ctx, ss::smp_service_group g) {
         if (
           ctx.header().version < Request::min_supported
           || ctx.header().version > Request::max_supported) {
-            return ss::make_exception_future<response_ptr>(
-              std::runtime_error(fmt::format(
-                "Unsupported version {} for {} API",
-                ctx.header().version,
-                Request::api::name)));
+            throw std::runtime_error(fmt::format(
+              "Unsupported version {} for {} API",
+              ctx.header().version,
+              Request::api::name));
         }
-        return Request::handle(std::move(ctx), g);
+        return process_result_stages::single_stage(
+          Request::handle(std::move(ctx), g));
     }
 };
 
@@ -48,16 +48,17 @@ struct process_dispatch {
  */
 template<>
 struct process_dispatch<api_versions_handler> {
-    static ss::future<response_ptr>
+    static process_result_stages
     process(request_context&& ctx, ss::smp_service_group g) {
-        return api_versions_handler::handle(std::move(ctx), g);
+        return process_result_stages::single_stage(
+          api_versions_handler::handle(std::move(ctx), g));
     }
 };
 
 template<typename Request>
 CONCEPT(requires(KafkaApiHandler<Request>))
-ss::future<response_ptr> do_process(
-  request_context&& ctx, ss::smp_service_group g) {
+process_result_stages
+  do_process(request_context&& ctx, ss::smp_service_group g) {
     vlog(
       klog.trace,
       "Processing name:{}, key:{}, version:{} for {}",
@@ -85,7 +86,7 @@ handle_auth_handshake(request_context&& ctx, ss::smp_service_group g) {
         conn->sasl().set_handshake_v0();
     }
     return do_process<sasl_handshake_handler>(std::move(ctx), g)
-      .then([conn = std::move(conn)](response_ptr r) {
+      .response.then([conn = std::move(conn)](response_ptr r) {
           if (conn->sasl().has_mechanism()) {
               conn->sasl().set_state(
                 security::sasl_server::sasl_state::authenticate);
@@ -146,7 +147,7 @@ handle_auth(request_context&& ctx, ss::smp_service_group g) {
         }
         auto conn = ctx.connection();
         return do_process<sasl_authenticate_handler>(std::move(ctx), g)
-          .then([conn = std::move(conn)](response_ptr r) {
+          .response.then([conn = std::move(conn)](response_ptr r) {
               /*
                * there may be multiple authentication round-trips so it is fine
                * to return without entering an end state like complete/failed.
@@ -179,7 +180,7 @@ handle_auth(request_context&& ctx, ss::smp_service_group g) {
     }
 }
 
-ss::future<response_ptr>
+process_result_stages
 process_request(request_context&& ctx, ss::smp_service_group g) {
     /*
      * requests are handled as normal when auth is disabled. otherwise no
@@ -187,14 +188,15 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
      */
     if (unlikely(!ctx.sasl().complete())) {
         auto conn = ctx.connection();
-        return handle_auth(std::move(ctx), g)
-          .then_wrapped([conn](ss::future<response_ptr> f) {
-              if (f.failed()) {
-                  conn->sasl().set_state(
-                    security::sasl_server::sasl_state::failed);
-              }
-              return f;
-          });
+        return process_result_stages::single_stage(
+          handle_auth(std::move(ctx), g)
+            .then_wrapped([conn](ss::future<response_ptr> f) {
+                if (f.failed()) {
+                    conn->sasl().set_state(
+                      security::sasl_server::sasl_state::failed);
+                }
+                return f;
+            }));
     }
 
     switch (ctx.header().key) {
@@ -235,14 +237,15 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
     case describe_groups_handler::api::key:
         return do_process<describe_groups_handler>(std::move(ctx), g);
     case sasl_handshake_handler::api::key:
-        return ctx.respond(
-          sasl_handshake_response(error_code::illegal_sasl_state, {}));
+        return process_result_stages::single_stage(ctx.respond(
+          sasl_handshake_response(error_code::illegal_sasl_state, {})));
     case sasl_authenticate_handler::api::key: {
         sasl_authenticate_response_data data{
           .error_code = error_code::illegal_sasl_state,
           .error_message = "Authentication process already completed",
         };
-        return ctx.respond(sasl_authenticate_response(std::move(data)));
+        return process_result_stages::single_stage(
+          ctx.respond(sasl_authenticate_response(std::move(data))));
     }
     case init_producer_id_handler::api::key:
         return do_process<init_producer_id_handler>(std::move(ctx), g);
@@ -267,8 +270,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
     case end_txn_handler::api::key:
         return do_process<end_txn_handler>(std::move(ctx), g);
     };
-    return ss::make_exception_future<response_ptr>(
-      std::runtime_error(fmt::format("Unsupported API {}", ctx.header().key)));
+    throw std::runtime_error(
+      fmt::format("Unsupported API {}", ctx.header().key));
 }
 
 std::ostream& operator<<(std::ostream& os, const request_header& header) {


### PR DESCRIPTION
## Cover letter

Changed the way how we process requests in Redpanda Kafka protocol implementation. Previously we processed requests in background, this allowed us to process multiple requests at a time but it may cause issues since requests were not guaranteed to be processed in the same order as they were received. Implemented handling Kafka requests in foreground, this way we normally process one request at a time per connection in exactly the same order as the requests were received. 

Produce and commit offsets requests are treated differently as they leverage two phase processing. We process request dispatch in foreground, after this first phase request processing order is guaranteed. Then the second phase is processed in background. This approach allow us to process multiple produce & offset commit requests at a time without compromising ordering. 

Fixes: N/A

## Release notes

- Full compatibility with Kafka with regards to requests ordering.
