### PR TITLE
Schema registry storage

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -134,6 +134,7 @@ ss::future<> client::update_metadata(wait_or_start::tag) {
 ss::future<> client::apply(metadata_response res) {
     co_await _brokers.apply(std::move(res.data.brokers));
     co_await _topic_cache.apply(std::move(res.data.topics));
+    _controller = res.data.controller_id;
 }
 
 ss::future<> client::mitigate_error(std::exception_ptr ex) {

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -24,6 +24,7 @@
 #include "kafka/client/types.h"
 #include "kafka/protocol/create_topics.h"
 #include "kafka/protocol/fetch.h"
+#include "kafka/protocol/list_offsets.h"
 #include "kafka/types.h"
 #include "utils/retry.h"
 #include "utils/unresolved_address.h"
@@ -109,6 +110,8 @@ public:
 
     ss::future<produce_response>
     produce_records(model::topic topic, std::vector<record_essence> batch);
+
+    ss::future<list_offsets_response> list_offsets(model::topic_partition tp);
 
     ss::future<fetch_response> fetch_partition(
       model::topic_partition tp,

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -183,6 +183,8 @@ private:
     topic_cache _topic_cache;
     /// \brief Broker lookup from topic_partition.
     brokers _brokers;
+    /// \brief The node id of the controller.
+    model::node_id _controller{unknown_node_id};
     /// \brief Update metadata, or wait for an existing one.
     wait_or_start _wait_or_start_update_metadata;
     /// \brief Batching producer.

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -22,6 +22,7 @@
 #include "kafka/client/topic_cache.h"
 #include "kafka/client/transport.h"
 #include "kafka/client/types.h"
+#include "kafka/protocol/create_topics.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/types.h"
 #include "utils/retry.h"
@@ -100,6 +101,8 @@ public:
               });
         });
     }
+
+    ss::future<create_topics_response> create_topic(kafka::creatable_topic req);
 
     ss::future<produce_response::partition> produce_record_batch(
       model::topic_partition tp, model::record_batch&& batch);

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -117,6 +117,8 @@ public:
             return dispatch(std::move(r), api_version(4));
         } else if constexpr (std::is_same_v<type, fetch_request>) {
             return dispatch(std::move(r), api_version(10));
+        } else if constexpr (std::is_same_v<type, list_offsets_request>) {
+            return dispatch(std::move(r), api_version(3));
         } else if constexpr (std::is_same_v<type, produce_request>) {
             return dispatch(std::move(r), api_version(7));
         } else if constexpr (std::is_same_v<type, offset_commit_request>) {

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -56,4 +56,7 @@ inline const model::ntp id_allocator_ntp(
   model::id_allocator_topic,
   model::partition_id(0));
 
+inline const model::topic_partition schema_registry_internal_tp{
+  model::topic{"_schemas"}, model::partition_id{0}};
+
 } // namespace model

--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -8,6 +8,7 @@ seastar_generate_swagger(
 v_cc_library(
   NAME pandaproxy_schema_registry
   SRCS
+    client_fetch_batch_reader.cc
     configuration.cc
     handlers.cc
     error.cc

--- a/src/v/pandaproxy/schema_registry/client_fetch_batch_reader.cc
+++ b/src/v/pandaproxy/schema_registry/client_fetch_batch_reader.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/schema_registry/client_fetch_batch_reader.h"
+
+#include "kafka/protocol/exceptions.h"
+#include "kafka/protocol/kafka_batch_adapter.h"
+#include "pandaproxy/logger.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/std-coroutine.hh>
+
+namespace pandaproxy::schema_registry {
+
+class client_fetcher final : public model::record_batch_reader::impl {
+    using storage_t = model::record_batch_reader::storage_t;
+
+public:
+    client_fetcher(
+      kafka::client::client& client,
+      model::topic_partition tp,
+      model::offset first,
+      model::offset last)
+      : _client{client}
+      , _tp{std::move(tp)}
+      , _next_offset{first}
+      , _last_offset{last}
+      , _batch_reader{} {}
+
+    // Implements model::record_batch_reader::impl
+    bool is_end_of_stream() const final { return _next_offset >= _last_offset; }
+
+    // Implements model::record_batch_reader::impl
+    ss::future<storage_t>
+    do_load_slice(model::timeout_clock::time_point t) final {
+        if (!_batch_reader || _batch_reader->is_end_of_stream()) {
+            vlog(plog.debug, "Schema registry: fetch offset: {}", _next_offset);
+            auto res = co_await _client.fetch_partition(
+              _tp, _next_offset, 1_MiB, t - model::timeout_clock::now());
+            vlog(plog.debug, "Schema registry: fetch result: {}", res);
+            vassert(
+              res.begin() != res.end() && ++res.begin() == res.end(),
+              "Expected exactly one response from client::fetch_partition");
+            _batch_reader = std::move(res.begin()->partition_response->records);
+        }
+        auto ret = co_await _batch_reader->do_load_slice(t);
+        using data_t = model::record_batch_reader::data_t;
+        vassert(
+          std::holds_alternative<data_t>(ret),
+          "Expected kafka::batch_reader to hold "
+          "model::record_batch_reader::data_t");
+        auto& data = std::get<data_t>(ret);
+        if (data.empty()) {
+            throw kafka::exception(
+              kafka::error_code::unknown_server_error, "No records returned");
+        }
+        _next_offset = ++data.back().last_offset();
+        vlog(plog.debug, "Schema registry: next_offset: {}", _next_offset);
+        co_return ret;
+    }
+
+    // Implements model::record_batch_reader::impl
+    void print(std::ostream& os) final {
+        os << "{pandaproxy::schema_registry::client_fetcher}";
+    }
+
+private:
+    kafka::client::client& _client;
+    model::topic_partition _tp;
+    model::offset _next_offset;
+    model::offset _last_offset;
+    std::optional<kafka::batch_reader> _batch_reader;
+};
+
+model::record_batch_reader make_client_fetch_batch_reader(
+  kafka::client::client& client,
+  model::topic_partition tp,
+  model::offset first,
+  model::offset last) {
+    return model::make_record_batch_reader<client_fetcher>(
+      client, std::move(tp), first, last);
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/client_fetch_batch_reader.h
+++ b/src/v/pandaproxy/schema_registry/client_fetch_batch_reader.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/client/client.h"
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+
+namespace pandaproxy::schema_registry {
+
+///\brief Adapt a kafka::client to fetch from a tp as a
+/// kafka::record_batch_reader.
+model::record_batch_reader make_client_fetch_batch_reader(
+  kafka::client::client& client,
+  model::topic_partition tp,
+  model::offset first,
+  model::offset last);
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -45,6 +45,7 @@ public:
 
 private:
     ss::future<> do_start();
+    ss::future<> create_internal_topic();
     configuration _config;
     ss::semaphore _mem_sem;
     ss::gate _gate;

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -45,6 +45,7 @@ public:
 private:
     configuration _config;
     ss::semaphore _mem_sem;
+    ss::gate _gate;
     ss::sharded<kafka::client::client>& _client;
     ctx_server<service>::context_t _ctx;
     ctx_server<service> _server;

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -46,6 +46,7 @@ public:
 private:
     ss::future<> do_start();
     ss::future<> create_internal_topic();
+    ss::future<> fetch_internal_topic();
     configuration _config;
     ss::semaphore _mem_sem;
     ss::gate _gate;

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -14,6 +14,7 @@
 #include "kafka/client/client.h"
 #include "pandaproxy/schema_registry/configuration.h"
 #include "pandaproxy/schema_registry/store.h"
+#include "pandaproxy/schema_registry/util.h"
 #include "pandaproxy/server.h"
 #include "seastarx.h"
 
@@ -43,6 +44,7 @@ public:
     store& schema_store() { return _store; }
 
 private:
+    ss::future<> do_start();
     configuration _config;
     ss::semaphore _mem_sem;
     ss::gate _gate;
@@ -50,6 +52,7 @@ private:
     ctx_server<service>::context_t _ctx;
     ctx_server<service> _server;
     store _store;
+    one_shot _ensure_started;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -11,8 +11,11 @@
 
 #pragma once
 
+#include "pandaproxy/json/rjson_parse.h"
+#include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "utils/string_switch.h"
 
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
@@ -21,5 +24,124 @@ namespace pandaproxy::schema_registry {
 
 using topic_key_magic = named_type<int32_t, struct topic_key_magic_tag>;
 using topic_key_type = named_type<ss::sstring, struct topic_key_type_tag>;
+
+struct schema_key {
+    topic_key_type keytype{"SCHEMA"};
+    subject sub;
+    schema_version version;
+    topic_key_magic magic{1};
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const schema_registry::schema_key& key) {
+    w.StartObject();
+    w.Key("keytype");
+    ::json::rjson_serialize(w, key.keytype);
+    w.Key("subject");
+    ::json::rjson_serialize(w, key.sub());
+    w.Key("version");
+    ::json::rjson_serialize(w, key.version);
+    w.Key("magic");
+    ::json::rjson_serialize(w, key.magic);
+    w.EndObject();
+}
+
+template<typename Encoding = rapidjson::UTF8<>>
+class schema_key_handler : public json::base_handler<Encoding> {
+    enum class state {
+        empty = 0,
+        object,
+        keytype,
+        subject,
+        version,
+        magic,
+    };
+    state _state = state::empty;
+
+public:
+    using Ch = typename json::base_handler<Encoding>::Ch;
+    using rjson_parse_result = schema_key;
+    rjson_parse_result result;
+
+    schema_key_handler()
+      : json::base_handler<Encoding>{json::serialization_format::none} {}
+
+    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        switch (_state) {
+        case state::object: {
+            std::optional<state> s{string_switch<std::optional<state>>(sv)
+                                     .match("keytype", state::keytype)
+                                     .match("subject", state::subject)
+                                     .match("version", state::version)
+                                     .match("magic", state::magic)
+                                     .default_match(std::nullopt)};
+            if (s.has_value()) {
+                _state = *s;
+            }
+            return s.has_value();
+        }
+        case state::empty:
+        case state::keytype:
+        case state::subject:
+        case state::version:
+        case state::magic:
+            return false;
+        }
+        return false;
+    }
+
+    bool Uint(int i) {
+        switch (_state) {
+        case state::version: {
+            result.version = schema_version{i};
+            _state = state::object;
+            return true;
+        }
+        case state::magic: {
+            result.magic = topic_key_magic{i};
+            _state = state::object;
+            return true;
+        }
+        case state::empty:
+        case state::object:
+        case state::keytype:
+        case state::subject:
+            return false;
+        }
+        return false;
+    }
+
+    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        switch (_state) {
+        case state::keytype: {
+            result.keytype = topic_key_type{ss::sstring{sv}};
+            _state = state::object;
+            return true;
+        }
+        case state::subject: {
+            result.sub = subject{ss::sstring{sv}};
+            _state = state::object;
+            return true;
+        }
+        case state::empty:
+        case state::object:
+        case state::version:
+        case state::magic:
+            return false;
+        }
+        return false;
+    }
+
+    bool StartObject() {
+        return std::exchange(_state, state::object) == state::empty;
+    }
+
+    bool EndObject(rapidjson::SizeType) {
+        return std::exchange(_state, state::empty) == state::object;
+    }
+};
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -327,4 +327,29 @@ public:
     }
 };
 
+inline schema_value schema_value_from_iobuf(iobuf&& iobuf) {
+    auto p = iobuf_parser(std::move(iobuf));
+    auto str = p.read_string(p.bytes_left());
+    return json::rjson_parse(str.data(), schema_value_handler<>{});
+}
+
+inline iobuf schema_value_to_iobuf(
+  subject sub,
+  schema_version ver,
+  schema_id id,
+  schema_definition schema,
+  schema_type type,
+  bool deleted) {
+    auto str = json::rjson_serialize(schema_value{
+      .sub{std::move(sub)},
+      .version{ver},
+      .type = type,
+      .id{id},
+      .schema{std::move(schema)},
+      .deleted = deleted});
+    iobuf val;
+    val.append(str.data(), str.size());
+    return val;
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "bytes/iobuf_parser.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/rjson_util.h"
 #include "pandaproxy/schema_registry/error.h"
@@ -143,5 +144,18 @@ public:
         return std::exchange(_state, state::empty) == state::object;
     }
 };
+
+inline schema_key schema_key_from_iobuf(iobuf&& iobuf) {
+    auto p = iobuf_parser(std::move(iobuf));
+    auto str = p.read_string(p.bytes_left());
+    return json::rjson_parse(str.data(), schema_key_handler<>{});
+}
+
+inline iobuf schema_key_to_iobuf(const schema_key& key) {
+    auto str = json::rjson_serialize(key);
+    iobuf buf;
+    buf.append(str.data(), str.size());
+    return buf;
+}
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+namespace pandaproxy::schema_registry {
+
+using topic_key_magic = named_type<int32_t, struct topic_key_magic_tag>;
+using topic_key_type = named_type<ss::sstring, struct topic_key_type_tag>;
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -11,6 +11,17 @@ rp_test(
 
 rp_test(
   UNIT_TEST
+  BINARY_NAME pandaproxy_schema_registry_single_thread
+  SOURCES
+    one_shot.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main
+  ARGS "-- -c 1"
+  LABELS pandaproxy
+)
+
+rp_test(
+  UNIT_TEST
   BINARY_NAME pandaproxy_schema_registry_fixture
   SOURCES
     get_schema_types.cc

--- a/src/v/pandaproxy/schema_registry/test/one_shot.cc
+++ b/src/v/pandaproxy/schema_registry/test/one_shot.cc
@@ -1,0 +1,83 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/util.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/std-coroutine.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/later.hh>
+
+#include <boost/range/irange.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <stdexcept>
+
+namespace psr = pandaproxy::schema_registry;
+using namespace std::chrono_literals;
+
+SEASTAR_THREAD_TEST_CASE(test_one_shot_simple) {
+    size_t count{0};
+    psr::one_shot one{[&count]() {
+        ++count;
+        return ss::now();
+    }};
+    BOOST_CHECK_EQUAL(count, 0);
+    one().get();
+    BOOST_CHECK_EQUAL(count, 1);
+    one().get();
+    BOOST_CHECK_EQUAL(count, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_one_shot_fail) {
+    size_t count{0};
+    psr::one_shot one{[&count]() {
+        ++count;
+        return ss::make_exception_future<>(std::runtime_error("failed"));
+    }};
+    BOOST_CHECK_THROW(one().get(), std::runtime_error);
+    BOOST_CHECK_EQUAL(count, 1);
+    BOOST_CHECK_THROW(one().get(), std::runtime_error);
+    BOOST_CHECK_EQUAL(count, 2);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_one_shot_multi) {
+    size_t count{0};
+    size_t ex_count{0};
+    psr::one_shot one{[&count]() -> ss::future<> {
+        ++count;
+        co_await ss::sleep(10ms);
+        throw std::runtime_error("failed");
+    }};
+    ss::parallel_for_each(boost::irange(10), [&](auto) {
+        return one().discard_result().handle_exception(
+          [&](auto) { ++ex_count; });
+    }).get();
+    BOOST_CHECK_EQUAL(count, 1);
+    BOOST_CHECK_EQUAL(ex_count, 10);
+    ss::parallel_for_each(boost::irange(10), [&](auto) {
+        return one().discard_result().handle_exception(
+          [&](auto) { ++ex_count; });
+    }).get();
+    BOOST_CHECK_EQUAL(count, 2);
+    BOOST_CHECK_EQUAL(ex_count, 20);
+}

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -74,7 +74,7 @@ pandaproxy_client:
 {% if enable_sr %}
 schema_registry:
   schema_registry_api:
-    address: "0.0.0.0"
+    address: "{{node.account.hostname}}"
     port: 8081
 
   api_doc_dir: {{root}}/usr/share/redpanda/proxy-api-doc

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -128,12 +128,6 @@ class SchemaRegistryTest(RedpandaTest):
         Verify posting a schema
         """
 
-        self.logger.debug("Creating _schemas topic")
-        self._create_topics(names=["_schemas"],
-                            partitions=1,
-                            replicas=1,
-                            cleanup_policy=TopicSpec.CLEANUP_COMPACT)
-
         topic = create_topic_names(1)[0]
 
         self.logger.debug(f"Register a schema against a subject")


### PR DESCRIPTION
## Cover letter

The schema registry now stores the schema in the `_schemas` topic, and populates the store from the topic on startup.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/cdc03e7eed2f3fba74a725a330c3949e9c041dd9..033831a7ebe99ced8b6707c20431b99fa592233f)
 * Fix some Pandaproxy tests that were overstrict on their topic checks.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/033831a7ebe99ced8b6707c20431b99fa592233f..60e99cabd7cfa23589b489382d8e745264a2778a)
 * Implemented `create_topics` in `kafka::client` so that controller can be found
 * Implemented `list_offsets` in `kafka::client` so that broker can be found
 * `client_fetcher`
   * Moved to own file
   * Properly implemented `record_batch_reader` (vs. just the impl)
   * Various improvements to error handling / reduced asserts
   * *forgot to reduce the header includes.*
* Introduced `one_shot` for lazy startup
* Moved the internal tp to `model/namespace`
* *first commit rewording seems to have been lost*

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/60e99cabd7cfa23589b489382d8e745264a2778a..0efabe16afece5f72a0a1671a7b6d2f80f6ed94e)
* Fixed the first commit message
* Cleanup up includes for client_fetcher
* Reworded the commit message for client_fetch
* Improved one_shot (it now works in release without segfaulting)

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/0efabe16afece5f72a0a1671a7b6d2f80f6ed94e..13fa264eecd6076932afe2b6afe2778171e085b4)
* Reworked one_shot with a semaphore
* Make topic_key_type a named_type

## Release notes

Release note: Initial Schema Registry: Supports a useful subset of endpoints.
