### PR TITLE
rpk/container: Listen on internal and external addresses

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -56,6 +56,14 @@ func HostAddr(port uint) string {
 	return fmt.Sprintf("127.0.0.1:%d", port)
 }
 
+func ListenAddresses(ip string, internalPort, externalPort uint) string {
+	return fmt.Sprintf("internal://0.0.0.0:%d,external://%s:%d", internalPort, ip, externalPort)
+}
+
+func AdvertiseAddresses(ip string, internalPort, externalPort uint) string {
+	return fmt.Sprintf("internal://%s:%d,external://127.0.0.1:%d", ip, internalPort, externalPort)
+}
+
 // Returns the container name for the given node ID.
 func Name(nodeID uint) string {
 	return fmt.Sprintf("rp-node-%d", nodeID)
@@ -245,15 +253,15 @@ func CreateNode(
 		"--node-id",
 		fmt.Sprintf("%d", nodeID),
 		"--kafka-addr",
-		fmt.Sprintf("%s:%d", ip, config.DefaultKafkaPort),
+		ListenAddresses(ip, config.DefaultKafkaPort, kafkaPort),
 		"--pandaproxy-addr",
-		fmt.Sprintf("%s:%d", ip, config.DefaultProxyPort),
+		ListenAddresses(ip, config.DefaultProxyPort, proxyPort),
 		"--rpc-addr",
 		fmt.Sprintf("%s:%d", ip, config.Default().Redpanda.RPCServer.Port),
 		"--advertise-kafka-addr",
-		HostAddr(kafkaPort),
+		AdvertiseAddresses(ip, config.DefaultKafkaPort, kafkaPort),
 		"--advertise-pandaproxy-addr",
-		HostAddr(proxyPort),
+		AdvertiseAddresses(ip, config.DefaultProxyPort, proxyPort),
 		"--advertise-rpc-addr",
 		fmt.Sprintf("%s:%d", ip, config.Default().Redpanda.RPCServer.Port),
 		"--smp 1 --memory 1G --reserve-memory 0M",

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -36,7 +36,8 @@ var (
 )
 
 const (
-	redpandaNetwork = "redpanda"
+	redpandaNetwork   = "redpanda"
+	externalKafkaPort = 9093
 
 	defaultDockerClientTimeout = 60 * time.Second
 )
@@ -134,7 +135,7 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 		return nil, err
 	}
 	hostKafkaPort, err := getHostPort(
-		config.DefaultKafkaPort,
+		externalKafkaPort,
 		containerJSON,
 	)
 	if err != nil {
@@ -224,7 +225,7 @@ func CreateNode(
 	}
 	kPort, err := nat.NewPort(
 		"tcp",
-		strconv.Itoa(config.DefaultKafkaPort),
+		strconv.Itoa(int(externalKafkaPort)),
 	)
 	if err != nil {
 		return nil, err
@@ -253,7 +254,7 @@ func CreateNode(
 		"--node-id",
 		fmt.Sprintf("%d", nodeID),
 		"--kafka-addr",
-		ListenAddresses(ip, config.DefaultKafkaPort, kafkaPort),
+		ListenAddresses(ip, config.DefaultKafkaPort, externalKafkaPort),
 		"--pandaproxy-addr",
 		ListenAddresses(ip, config.DefaultProxyPort, proxyPort),
 		"--rpc-addr",

--- a/src/go/rpk/pkg/cli/cmd/container/common/test.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/test.go
@@ -243,7 +243,7 @@ func (c *MockClient) IsErrConnectionFailed(err error) bool {
 func MockContainerInspect(
 	_ context.Context, _ string,
 ) (types.ContainerJSON, error) {
-	kafkaNatPort := nat.Port("9092/tcp")
+	kafkaNatPort := nat.Port("9093/tcp")
 	rpcNatPort := nat.Port("33145/tcp")
 	return types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{


### PR DESCRIPTION
## Cover letter

Fixes #1486

The configuration is now:
```yaml
pandaproxy:
  advertised_pandaproxy_api:
    - address: 172.24.1.2
      name: internal
      port: 8082
    - address: 127.0.0.1
      name: external
      port: 41247
  pandaproxy_api:
    - address: 0.0.0.0
      name: internal
      port: 8082
    - address: 172.24.1.2
      name: external
      port: 41247
redpanda:
  admin:
    - address: 0.0.0.0
      port: 9644
  advertised_kafka_api:
    - address: 172.24.1.2
      name: internal
      port: 9092
    - address: 127.0.0.1
      name: external
      port: 40257
  advertised_rpc_api:
    address: 172.24.1.2
    port: 33145
  auto_create_topics_enabled: true
  data_directory: /var/lib/redpanda/data
  developer_mode: true
  kafka_api:
    - address: 0.0.0.0
      name: internal
      port: 9092
    - address: 172.24.1.2
      name: external
      port: 40257
  node_id: 0
  rpc_server:
    address: 172.24.1.2
    port: 33145
  seed_servers: []
```

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: Improvements to rpk container
