### PR TITLE
rpk acls delete: Sort the acls list

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/acl/delete.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/delete.go
@@ -12,6 +12,7 @@ package acl
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Shopify/sarama"
@@ -201,6 +202,12 @@ func executeDeleteACLs(
 	for matchingACLs := range aclsChan {
 		acls = append(acls, matchingACLs...)
 	}
+
+	sort.Slice(acls, func(i, j int) bool {
+		a := acls[i]
+		b := acls[j]
+		return strings.Compare(a.ResourceName, b.ResourceName) < 0
+	})
 
 	printMatchingACLs(acls)
 

--- a/src/go/rpk/pkg/cli/cmd/acl/delete_test.go
+++ b/src/go/rpk/pkg/cli/cmd/acl/delete_test.go
@@ -122,8 +122,8 @@ func TestNewDeleteACLsCommand(t *testing.T) {
 		},
 		expectedOut: `  DELETED  PRINCIPAL    HOST       OPERATION  PERMISSION TYPE  RESOURCE TYPE  RESOURCE NAME      ERROR MESSAGE  
            
-  yes      User:user-2  127.0.0.1  Alter      Deny             Topic          some-cool-topic-2  None           
   yes      User:user-1  *          Read       Allow            Topic          some-cool-topic    None           
+  yes      User:user-2  127.0.0.1  Alter      Deny             Topic          some-cool-topic-2  None           
            
 `,
 	}, {


### PR DESCRIPTION
Sort the ACLs list so that the output is always the same in the
tests, fixing flaky test cases.
