### PR TITLE
r/replicate_batcher: fixed handling large batches in replicate batcher

### DIFF
--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -68,7 +68,7 @@ private:
 
     consensus* _ptr;
     ss::semaphore _max_batch_size_sem;
-
+    size_t _max_batch_size;
     std::vector<item_ptr> _item_cache;
     mutex _lock;
 };


### PR DESCRIPTION
Fixed incorrect handling of big batches in replicate batcher leading to
partition being not usable.

Limiting amount of units that may be acquire when processing batch to
max allowed cache size. This way large batches will be processed without
additional batching in replicate batcher.

Fixes: #1503

Signed-off-by: Michal Maslanka <michal@vectorized.io>
