### PR TITLE
docs: Add consume & produce to list of rpk cmds

### DIFF
--- a/docs/www/rpk-commands.md
+++ b/docs/www/rpk-commands.md
@@ -173,6 +173,39 @@ Flags:
       --watermarks      If enabled, will display the topic's partitions' high watermarks (default: true)
 ```
 
+### topic produce
+
+Produce a record from data entered in stdin.
+
+```cmd
+Usage:
+  rpk topic produce <topic> [flags]
+
+Flags:
+  -H, --header stringArray   Header in format <key>:<value>. May be used multiple times to add more headers.
+  -j, --jvm-partitioner      Use a JVM-compatible partitioner. If --partition is passed with a positive value, this will be overridden and a manual partitioner will be used.
+  -k, --key string           Key for the record. Currently only strings are supported.
+  -n, --num int              Number of records to send. (default 1)
+  -p, --partition int32      Partition to produce to. (default -1)
+  -t, --timestamp string     RFC3339-compliant timestamp for the record. If the value passed can't be parsed, the current time will be used.
+```
+
+### topic consume
+
+Consume (read) records from a topic.
+
+```cmd
+Usage:
+  rpk topic consume <topic> [flags]
+
+Flags:
+      --commit                  Commit group offset after receiving messages (Only when consuming as Consumer Group)
+  -g, --group string            Consumer Group to use for consuming
+      --offset string           Offset to start consuming. Supported values: oldest, newest (default "oldest")
+  -p, --partitions int32Slice   Partitions to consume from (default [])
+      --pretty-print            Pretty-print the consumed messages. (default true)
+```
+
 ### topic list
 
 List topics.

--- a/src/go/rpk/pkg/cli/cmd/topic/consume.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/consume.go
@@ -68,7 +68,7 @@ func NewConsumeCommand(client func() (sarama.Client, error)) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "consume <topic>",
-		Short: "Consume records from a topic",
+		Short: "Consume (read) records from a topic",
 		Args:  common.ExactArgs(1, "topic's name is missing."),
 		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
 		SilenceUsage: true,
@@ -135,8 +135,8 @@ func NewConsumeCommand(client func() (sarama.Client, error)) *cobra.Command {
 		&groupCommit,
 		"commit",
 		false,
-		"Commit group offset after receiving messages."+
-			" Works only if consuming as Consumer Group",
+		"Commit group offset after receiving messages"+
+			" (Only when consuming as Consumer Group)",
 	)
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/produce.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/produce.go
@@ -35,7 +35,7 @@ func NewProduceCommand(
 	)
 	cmd := &cobra.Command{
 		Use:   "produce <topic>",
-		Short: "Produce a record. Reads data from stdin.",
+		Short: "Produce a record from data entered in stdin.",
 		Args:  common.ExactArgs(1, "topic's name is missing."),
 		// We don't want Cobra printing CLI usage help if the error isn't about CLI usage.
 		SilenceUsage: true,


### PR DESCRIPTION
Add consume & produce to the rpk command reference documentation page.