### PR TITLE
Fix the namespace

### DIFF
--- a/docs/www/quick-start-kubernetes.md
+++ b/docs/www/quick-start-kubernetes.md
@@ -133,7 +133,7 @@ to verify that cert-manager is working correcly.
     ```
     helm install \
     --namespace redpanda-system \
-    --create-namespace redpanda-operator \
+    --create-namespace redpanda-system \
     --version $VERSION \
     redpanda/redpanda-operator
     ```


### PR DESCRIPTION
The Kubernetes quick start guide had wrong namespace provided in one of the argument. This PR aligns it.