### PR TITLE
Fixed incorrect update of committed offset when new segment is created

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -319,7 +319,7 @@ segment::do_truncate(model::offset prev_last_offset, size_t physical) {
 
 ss::future<bool> segment::materialize_index() {
     vassert(
-      _tracker.base_offset == _tracker.dirty_offset,
+      _tracker.dirty_offset < model::offset(0),
       "Materializing the index must happen tracking any data. {}",
       *this);
     return _idx.materialize_index().then([this](bool yn) {

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -41,10 +41,7 @@ public:
     struct offset_tracker {
         offset_tracker(model::term_id t, model::offset base)
           : term(t)
-          , base_offset(base)
-          , committed_offset(base)
-          , dirty_offset(base)
-          , stable_offset(base) {}
+          , base_offset(base) {}
         model::term_id term;
         model::offset base_offset;
 


### PR DESCRIPTION
## Cover letter

Log committed offset should only be updated after a flush (and always be set to batch last offset). Fixed incorrect handling of offsets when creating new log segment during roll.

Fixes: #1521 

## Release notes
- this will fix `out_of_range` errors returned when consuming log published with `acks=1` and enable pipelining in raft
