### PR TITLE
task/rpk: fix go mod cache rw

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
-	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/opencontainers/image-spec v1.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1

--- a/taskfiles/rpk.yml
+++ b/taskfiles/rpk.yml
@@ -16,6 +16,7 @@ tasks:
       ver_pkg='github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/version'
       cont_pkg='github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/container/common'
       go build \
+        -modcacherw \
         -ldflags \
           "-X ${ver_pkg}.version={{.RPK_VERSION}} \
            -X ${ver_pkg}.rev={{.SHORT_SHA}} \


### PR DESCRIPTION
Adds `-modcacherw` to `go build` to avoid issues in CI that present when reusing (cleaning up) the workspace.