### PR TITLE
rpk config: Support different TLS configurations for the Kafka API & the Admin API

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -516,16 +516,48 @@ rpk:
     - "--memory=4G"
     - "--default-log-level=info"
 
-  # TLS configuration to allow rpk to make requests to the redpanda API.
-  tls:
-    # The path to the root CA certificate (PEM).
-    truststore_file: ""
-    # The path to the client certificate (PEM). Only required if client authentication is
-    # enabled in the broker.
-    cert_file: ""
-    # The path to the client certificate key (PEM). Only required if client authentication is
-    # enabled in the broker.
-    key_file: ""
+  # The Kafka API configuration
+  kafka_api:
+    # A list of broker addresses that rpk will use
+    brokers:
+    - 192.168.72.34:9092
+    - 192.168.72.35:9092
+
+    # The TLS configuration to be used when interacting with the Kafka API.
+    # If present, TLS will be enabled. If missing or null, TLS will be disabled.
+    tls:
+      # The path to the client certificate (PEM). Only required if client authentication is
+      # enabled in the broker.
+      cert_file: ~/certs/cert.pem
+      # The path to the client certificate key (PEM). Only required if client authentication is
+      # enabled in the broker.
+      key_file: ~/certs/key.pem
+      # The path to the root CA certificate (PEM).
+      truststore_file: ~/certs/ca.pem
+
+    # The SASL config, if enabled in the brokers.
+    sasl:
+      user: user
+      password: pass
+      method: scram-sha256
+
+  # The Admin API configuration
+  admin_api:
+    # A list of the nodes' admin API addresses that rpk will use.
+    addresses:
+    - 192.168.72.34:9644
+    - 192.168.72.35:9644
+    # The TLS configuration to be used when with the Admin API.
+    # If present, TLS will be enabled. If missing or null, TLS will be disabled.
+    tls:
+      # The path to the client certificate (PEM). Only required if client authentication is
+      # enabled in the broker.
+      cert_file: ~/certs/admin-cert.pem
+      # The path to the client certificate key (PEM). Only required if client authentication is
+      # enabled in the broker.
+      key_file: ~/certs/admin-key.pem
+      # The path to the root CA certificate (PEM).
+      truststore_file: ~/certs/admin-ca.pem
 
   # Available tuners. Set to true to enable, false to disable.
 

--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -24,9 +24,11 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		user                   string
 		password               string
 		mechanism              string
+		enableTLS              bool
 		certFile               string
 		keyFile                string
 		truststoreFile         string
+		adminAPIEnableTLS      bool
 		adminAPICertFile       string
 		adminAPIKeyFile        string
 		adminAPITruststoreFile string
@@ -43,6 +45,7 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&user,
 		&password,
 		&mechanism,
+		&enableTLS,
 		&certFile,
 		&keyFile,
 		&truststoreFile,
@@ -50,6 +53,7 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	)
 	common.AddAdminAPITLSFlags(
 		command,
+		&adminAPIEnableTLS,
 		&adminAPICertFile,
 		&adminAPIKeyFile,
 		&adminAPITruststoreFile,
@@ -61,8 +65,9 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	kafkaTlsClosure := common.BuildKafkaTLSConfig(&certFile, &keyFile, &truststoreFile, configClosure)
+	kafkaTlsClosure := common.BuildKafkaTLSConfig(&enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
 	adminTlsClosure := common.BuildAdminApiTLSConfig(
+		&adminAPIEnableTLS,
 		&adminAPICertFile,
 		&adminAPIKeyFile,
 		&adminAPITruststoreFile,

--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -65,8 +65,9 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	kafkaTlsClosure := common.BuildKafkaTLSConfig(&enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
+	kafkaTlsClosure := common.BuildKafkaTLSConfig(fs, &enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
 	adminTlsClosure := common.BuildAdminApiTLSConfig(
+		fs,
 		&adminAPIEnableTLS,
 		&adminAPICertFile,
 		&adminAPIKeyFile,

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -67,7 +67,7 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&brokers,
 	)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
-	tlsClosure := common.BuildTLSConfig(&certFile, &keyFile, &truststoreFile)
+	tlsClosure := common.BuildKafkaTLSConfig(&certFile, &keyFile, &truststoreFile, configClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	command.AddCommand(cluster.NewInfoCommand(adminClosure))
 

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -25,6 +25,7 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		user           string
 		password       string
 		mechanism      string
+		enableTLS      bool
 		certFile       string
 		keyFile        string
 		truststoreFile string
@@ -39,6 +40,7 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&user,
 		&password,
 		&mechanism,
+		&enableTLS,
 		&certFile,
 		&keyFile,
 		&truststoreFile,
@@ -67,7 +69,7 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&brokers,
 	)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
-	tlsClosure := common.BuildKafkaTLSConfig(&certFile, &keyFile, &truststoreFile, configClosure)
+	tlsClosure := common.BuildKafkaTLSConfig(&enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	command.AddCommand(cluster.NewInfoCommand(adminClosure))
 

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -69,7 +69,7 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&brokers,
 	)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
-	tlsClosure := common.BuildKafkaTLSConfig(&enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
+	tlsClosure := common.BuildKafkaTLSConfig(fs, &enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	command.AddCommand(cluster.NewInfoCommand(adminClosure))
 

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -10,6 +10,7 @@
 package common
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"os"
@@ -22,6 +23,7 @@ import (
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/container/common"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
+	vtls "github.com/vectorizedio/redpanda/src/go/rpk/pkg/tls"
 )
 
 const FeedbackMsg = `We'd love to hear about your experience with redpanda:
@@ -29,9 +31,11 @@ https://vectorized.io/feedback`
 
 const (
 	saslMechanismFlag          = "sasl-mechanism"
+	enableTLSFlag              = "tls-enabled"
 	certFileFlag               = "tls-cert"
 	keyFileFlag                = "tls-key"
 	truststoreFileFlag         = "tls-truststore"
+	adminAPIEnableTLSFlag      = "admin-api-tls-enabled"
 	adminAPICertFileFlag       = "admin-api-tls-cert"
 	adminAPIKeyFileFlag        = "admin-api-tls-key"
 	adminAPITruststoreFileFlag = "admin-api-tls-truststore"
@@ -173,7 +177,7 @@ func DeduceBrokers(
 func CreateProducer(
 	brokers func() []string,
 	configuration func() (*config.Config, error),
-	tlsConfig func() (*config.TLS, error),
+	tlsConfig func() (*tls.Config, error),
 	authConfig func() (*config.SASL, error),
 ) func(bool, int32) (sarama.SyncProducer, error) {
 	return func(jvmPartitioner bool, partition int32) (sarama.SyncProducer, error) {
@@ -185,11 +189,6 @@ func CreateProducer(
 		tls, err := tlsConfig()
 		if err != nil {
 			return nil, err
-		}
-		// If no TLS config was set, try to look for TLS config in the
-		// config file.
-		if tls == nil {
-			tls = conf.Rpk.KafkaApi.TLS
 		}
 
 		sasl, err := authConfig()
@@ -227,7 +226,7 @@ func CreateProducer(
 func CreateClient(
 	brokers func() []string,
 	configuration func() (*config.Config, error),
-	tlsConfig func() (*config.TLS, error),
+	tlsConfig func() (*tls.Config, error),
 	authConfig func() (*config.SASL, error),
 ) func() (sarama.Client, error) {
 	return func() (sarama.Client, error) {
@@ -238,11 +237,6 @@ func CreateClient(
 		tls, err := tlsConfig()
 		if err != nil {
 			return nil, err
-		}
-		// If no TLS config was set, try to look for TLS config in the
-		// config file.
-		if tls == nil {
-			tls = conf.Rpk.KafkaApi.TLS
 		}
 
 		sasl, err := authConfig()
@@ -270,7 +264,7 @@ func CreateClient(
 func CreateAdmin(
 	brokers func() []string,
 	configuration func() (*config.Config, error),
-	tlsConfig func() (*config.TLS, error),
+	tlsConfig func() (*tls.Config, error),
 	authConfig func() (*config.SASL, error),
 ) func() (sarama.ClusterAdmin, error) {
 	return func() (sarama.ClusterAdmin, error) {
@@ -283,11 +277,6 @@ func CreateAdmin(
 		tls, err := tlsConfig()
 		if err != nil {
 			return nil, err
-		}
-		// If no TLS config was set, try to look for TLS config in the
-		// config file.
-		if tls == nil {
-			tls = conf.Rpk.KafkaApi.TLS
 		}
 
 		sasl, err := authConfig()
@@ -363,10 +352,11 @@ func KafkaAuthConfig(
 }
 
 func BuildAdminApiTLSConfig(
+	enableTLS *bool,
 	certFile, keyFile, truststoreFile *string,
 	configuration func() (*config.Config, error),
-) func() (*config.TLS, error) {
-	return func() (*config.TLS, error) {
+) func() (*tls.Config, error) {
+	return func() (*tls.Config, error) {
 		defaultVal := func() (*config.TLS, error) {
 			conf, err := configuration()
 			if err != nil {
@@ -380,6 +370,7 @@ func BuildAdminApiTLSConfig(
 			return conf.Rpk.TLS, nil
 		}
 		return buildTLS(
+			enableTLS,
 			certFile,
 			keyFile,
 			truststoreFile,
@@ -392,10 +383,11 @@ func BuildAdminApiTLSConfig(
 }
 
 func BuildKafkaTLSConfig(
+	enableTLS *bool,
 	certFile, keyFile, truststoreFile *string,
 	configuration func() (*config.Config, error),
-) func() (*config.TLS, error) {
-	return func() (*config.TLS, error) {
+) func() (*tls.Config, error) {
+	return func() (*tls.Config, error) {
 		defaultVal := func() (*config.TLS, error) {
 			conf, err := configuration()
 			if err != nil {
@@ -409,6 +401,7 @@ func BuildKafkaTLSConfig(
 			return conf.Rpk.TLS, nil
 		}
 		return buildTLS(
+			enableTLS,
 			certFile,
 			keyFile,
 			truststoreFile,
@@ -426,12 +419,14 @@ func BuildKafkaTLSConfig(
 // If after that no value is found for any of them, the result of calling
 // defaultVal is returned.
 func buildTLS(
+	enableTLS *bool,
 	certFile, keyFile, truststoreFile *string,
 	certEnvVar, keyEnvVar, truststoreEnvVar string,
 	defaultVal func() (*config.TLS, error),
-) (*config.TLS, error) {
+) (*tls.Config, error) {
 	// Give priority to building the TLS config with args that were passed
 	// directly or as env vars.
+	enable := *enableTLS
 	c := *certFile
 	k := *keyFile
 	t := *truststoreFile
@@ -448,36 +443,22 @@ func buildTLS(
 	if t == "" && c == "" && k == "" {
 		// If the values weren't set with flags nor env vars,
 		// return the TLS config for the Admin API from the config
-		return defaultVal()
+		defaultTLS, err := defaultVal()
+		if err != nil {
+			return nil, err
+		}
+		if defaultTLS != nil {
+			c = defaultTLS.CertFile
+			k = defaultTLS.KeyFile
+			t = defaultTLS.TruststoreFile
+		}
 	}
-	if t == "" && (c != "" || k != "") {
-		return nil, fmt.Errorf(
-			"--%s is required to enable TLS",
-			truststoreFileFlag,
-		)
-	}
-	if c != "" && k == "" {
-		return nil, fmt.Errorf(
-			"if --%s is passed, then --%s must be passed to enable"+
-				" TLS authentication",
-			certFileFlag,
-			keyFileFlag,
-		)
-	}
-	if k != "" && c == "" {
-		return nil, fmt.Errorf(
-			"if --%s is passed, then --%s must be passed to enable"+
-				" TLS authentication",
-			keyFileFlag,
-			certFileFlag,
-		)
-	}
-	tls := &config.TLS{
-		KeyFile:        k,
-		CertFile:       c,
-		TruststoreFile: t,
-	}
-	return tls, nil
+	return vtls.BuildTLSConfig(
+		enable,
+		c,
+		k,
+		t,
+	)
 }
 
 func CreateDockerClient() (common.Client, error) {
@@ -509,7 +490,9 @@ func ContainerBrokers(c common.Client) ([]string, []string) {
 
 func AddKafkaFlags(
 	command *cobra.Command,
-	configFile, user, password, saslMechanism, certFile, keyFile, truststoreFile *string,
+	configFile, user, password, saslMechanism *string,
+	enableTLS *bool,
+	certFile, keyFile, truststoreFile *string,
 	brokers *[]string,
 ) *cobra.Command {
 	command.PersistentFlags().StringSliceVar(
@@ -551,16 +534,22 @@ func AddKafkaFlags(
 		),
 	)
 
-	AddTLSFlags(command, certFile, keyFile, truststoreFile)
+	AddTLSFlags(command, enableTLS, certFile, keyFile, truststoreFile)
 
 	return command
 }
 
 func AddTLSFlags(
-	command *cobra.Command, certFile,
-	keyFile,
-	truststoreFile *string,
+	command *cobra.Command,
+	enableTLS *bool,
+	certFile, keyFile, truststoreFile *string,
 ) *cobra.Command {
+	command.PersistentFlags().BoolVar(
+		enableTLS,
+		enableTLSFlag,
+		false,
+		"Enable TLS for the Kafka API (not necessary if specifying custom certs).",
+	)
 	command.PersistentFlags().StringVar(
 		certFile,
 		certFileFlag,
@@ -584,10 +573,16 @@ func AddTLSFlags(
 }
 
 func AddAdminAPITLSFlags(
-	command *cobra.Command, certFile,
-	keyFile,
-	truststoreFile *string,
+	command *cobra.Command,
+	enableTLS *bool,
+	certFile, keyFile, truststoreFile *string,
 ) *cobra.Command {
+	command.PersistentFlags().BoolVar(
+		enableTLS,
+		adminAPIEnableTLSFlag,
+		false,
+		"Enable TLS for the Admin API (not necessary if specifying custom certs).",
+	)
 	command.PersistentFlags().StringVar(
 		certFile,
 		adminAPICertFileFlag,

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -28,10 +28,13 @@ const FeedbackMsg = `We'd love to hear about your experience with redpanda:
 https://vectorized.io/feedback`
 
 const (
-	saslMechanismFlag  = "sasl-mechanism"
-	certFileFlag       = "tls-cert"
-	keyFileFlag        = "tls-key"
-	truststoreFileFlag = "tls-truststore"
+	saslMechanismFlag          = "sasl-mechanism"
+	certFileFlag               = "tls-cert"
+	keyFileFlag                = "tls-key"
+	truststoreFileFlag         = "tls-truststore"
+	adminAPICertFileFlag       = "admin-api-tls-cert"
+	adminAPIKeyFileFlag        = "admin-api-tls-key"
+	adminAPITruststoreFileFlag = "admin-api-tls-truststore"
 )
 
 var ErrNoCredentials = errors.New("empty username and password")
@@ -529,6 +532,33 @@ func AddTLSFlags(
 		truststoreFileFlag,
 		"",
 		"The truststore to be used for TLS communication with the broker.",
+	)
+
+	return command
+}
+
+func AddAdminAPITLSFlags(
+	command *cobra.Command, certFile,
+	keyFile,
+	truststoreFile *string,
+) *cobra.Command {
+	command.PersistentFlags().StringVar(
+		certFile,
+		adminAPICertFileFlag,
+		"",
+		"The certificate to be used for TLS authentication with the Admin API.",
+	)
+	command.PersistentFlags().StringVar(
+		keyFile,
+		adminAPIKeyFileFlag,
+		"",
+		"The certificate key to be used for TLS authentication with the Admin API.",
+	)
+	command.PersistentFlags().StringVar(
+		truststoreFile,
+		adminAPITruststoreFileFlag,
+		"",
+		"The truststore to be used for TLS communication with the Admin API.",
 	)
 
 	return command

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/burdiyan/kafkautil"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/container/common"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
@@ -352,6 +353,7 @@ func KafkaAuthConfig(
 }
 
 func BuildAdminApiTLSConfig(
+	fs afero.Fs,
 	enableTLS *bool,
 	certFile, keyFile, truststoreFile *string,
 	configuration func() (*config.Config, error),
@@ -370,6 +372,7 @@ func BuildAdminApiTLSConfig(
 			return conf.Rpk.TLS, nil
 		}
 		return buildTLS(
+			fs,
 			enableTLS,
 			certFile,
 			keyFile,
@@ -383,6 +386,7 @@ func BuildAdminApiTLSConfig(
 }
 
 func BuildKafkaTLSConfig(
+	fs afero.Fs,
 	enableTLS *bool,
 	certFile, keyFile, truststoreFile *string,
 	configuration func() (*config.Config, error),
@@ -401,6 +405,7 @@ func BuildKafkaTLSConfig(
 			return conf.Rpk.TLS, nil
 		}
 		return buildTLS(
+			fs,
 			enableTLS,
 			certFile,
 			keyFile,
@@ -419,6 +424,7 @@ func BuildKafkaTLSConfig(
 // If after that no value is found for any of them, the result of calling
 // defaultVal is returned.
 func buildTLS(
+	fs afero.Fs,
 	enableTLS *bool,
 	certFile, keyFile, truststoreFile *string,
 	certEnvVar, keyEnvVar, truststoreEnvVar string,
@@ -454,6 +460,7 @@ func buildTLS(
 		}
 	}
 	return vtls.BuildTLSConfig(
+		fs,
 		enable,
 		c,
 		k,

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -103,12 +103,7 @@ func TestDeduceBrokers(t *testing.T) {
 		},
 		config: func() (*config.Config, error) {
 			conf := config.Default()
-			conf.Redpanda.KafkaApi = []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.25.88",
-					Port:    1235,
-				},
-			}}
+			conf.Rpk.KafkaApi.Brokers = []string{"192.168.25.88:1235"}
 			return conf, nil
 		},
 		expected: []string{"192.168.25.88:1235"},
@@ -123,15 +118,13 @@ func TestDeduceBrokers(t *testing.T) {
 		name: "it should prioritize the config over the default broker addr",
 		config: func() (*config.Config, error) {
 			conf := config.Default()
-			conf.Redpanda.KafkaApi = []config.NamedSocketAddress{{
-				SocketAddress: config.SocketAddress{
-					Address: "192.168.25.87",
-					Port:    1234,
-				},
-			}}
+			conf.Rpk.KafkaApi.Brokers = []string{"192.168.25.87:1234", "192.168.26.98:9092"}
 			return conf, nil
 		},
-		expected: []string{"192.168.25.87:1234"},
+		expected: []string{"192.168.25.87:1234", "192.168.26.98:9092"},
+	}, {
+		name:     "it should return 127.0.0.1:9092 if no config sources yield a brokers list",
+		expected: []string{"127.0.0.1:9092"},
 	}}
 
 	for _, tt := range tests {

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -267,7 +267,7 @@ func TestKafkaAuthConfig(t *testing.T) {
 		mechanism      string
 		before         func()
 		cleanup        func()
-		expected       *config.SCRAM
+		expected       *config.SASL
 		expectedErrMsg string
 	}{{
 		name:           "it should fail if user is empty",
@@ -292,13 +292,13 @@ func TestKafkaAuthConfig(t *testing.T) {
 		user:      "usuario",
 		password:  "contraseño",
 		mechanism: "SCRAM-SHA-256",
-		expected:  &config.SCRAM{User: "usuario", Password: "contraseño", Type: "SCRAM-SHA-256"},
+		expected:  &config.SASL{User: "usuario", Password: "contraseño", Mechanism: "SCRAM-SHA-256"},
 	}, {
 		name:      "it should support SCRAM-SHA-512",
 		user:      "usuario",
 		password:  "contraseño",
 		mechanism: "SCRAM-SHA-512",
-		expected:  &config.SCRAM{User: "usuario", Password: "contraseño", Type: "SCRAM-SHA-512"},
+		expected:  &config.SASL{User: "usuario", Password: "contraseño", Mechanism: "SCRAM-SHA-512"},
 	}, {
 		name: "it should pick up the values from env vars if the vars' values is empty",
 		before: func() {
@@ -311,7 +311,7 @@ func TestKafkaAuthConfig(t *testing.T) {
 			os.Unsetenv("REDPANDA_SASL_PASSWORD")
 			os.Unsetenv("REDPANDA_SASL_MECHANISM")
 		},
-		expected: &config.SCRAM{User: "ringo", Password: "octopussgarden66", Type: "SCRAM-SHA-512"},
+		expected: &config.SASL{User: "ringo", Password: "octopussgarden66", Mechanism: "SCRAM-SHA-512"},
 	}, {
 		name:      "it should give priority to values set through the flags",
 		user:      "usuario",
@@ -328,7 +328,7 @@ func TestKafkaAuthConfig(t *testing.T) {
 			os.Unsetenv("REDPANDA_SASL_MECHANISM")
 		},
 		// Disregards the env vars' values
-		expected: &config.SCRAM{User: "usuario", Password: "contraseño", Type: "SCRAM-SHA-512"},
+		expected: &config.SASL{User: "usuario", Password: "contraseño", Mechanism: "SCRAM-SHA-512"},
 	}}
 
 	for _, tt := range tests {
@@ -461,7 +461,7 @@ func TestCreateAdmin(t *testing.T) {
 		brokers        func() []string
 		configuration  func() (*config.Config, error)
 		tlsConfig      func() (*config.TLS, error)
-		authConfig     func() (*config.SCRAM, error)
+		authConfig     func() (*config.SASL, error)
 		expectedErrMsg string
 	}{{
 		name: "the returned closure should fail if configuration fails",
@@ -477,13 +477,13 @@ func TestCreateAdmin(t *testing.T) {
 		expectedErrMsg: "bad tls conf",
 	}, {
 		name: "the returned closure should fail if authConfig returns an error other than ErrNoCredentials",
-		authConfig: func() (*config.SCRAM, error) {
+		authConfig: func() (*config.SASL, error) {
 			return nil, errors.New("Some bad error")
 		},
 		expectedErrMsg: "Some bad error",
 	}, {
 		name: "the returned closure shouldn't fail due to authConfig returning ErrNoCredentials",
-		authConfig: func() (*config.SCRAM, error) {
+		authConfig: func() (*config.SASL, error) {
 			return nil, common.ErrNoCredentials
 		},
 	}}
@@ -511,7 +511,7 @@ func TestCreateAdmin(t *testing.T) {
 				tlsConfig = tt.tlsConfig
 			}
 
-			authConfig := func() (*config.SCRAM, error) {
+			authConfig := func() (*config.SASL, error) {
 				return nil, nil
 			}
 			if tt.authConfig != nil {
@@ -536,7 +536,7 @@ func TestCreateClient(t *testing.T) {
 		brokers        func() []string
 		configuration  func() (*config.Config, error)
 		tlsConfig      func() (*config.TLS, error)
-		authConfig     func() (*config.SCRAM, error)
+		authConfig     func() (*config.SASL, error)
 		expectedErrMsg string
 	}{{
 		name: "the returned closure should fail if configuration fails",
@@ -552,13 +552,13 @@ func TestCreateClient(t *testing.T) {
 		expectedErrMsg: "bad tls conf",
 	}, {
 		name: "the returned closure should fail if authConfig returns an error other than ErrNoCredentials",
-		authConfig: func() (*config.SCRAM, error) {
+		authConfig: func() (*config.SASL, error) {
 			return nil, errors.New("Some bad error")
 		},
 		expectedErrMsg: "Some bad error",
 	}, {
 		name: "the returned closure shouldn't fail due to authConfig returning ErrNoCredentials",
-		authConfig: func() (*config.SCRAM, error) {
+		authConfig: func() (*config.SASL, error) {
 			return nil, common.ErrNoCredentials
 		},
 	}}
@@ -586,7 +586,7 @@ func TestCreateClient(t *testing.T) {
 				tlsConfig = tt.tlsConfig
 			}
 
-			authConfig := func() (*config.SCRAM, error) {
+			authConfig := func() (*config.SASL, error) {
 				return nil, nil
 			}
 			if tt.authConfig != nil {

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -11,11 +11,13 @@ package common
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"os"
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	ccommon "github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/container/common"
@@ -412,6 +414,74 @@ func TestKafkaAuthConfig(t *testing.T) {
 }
 
 func TestBuildTLSConfig(t *testing.T) {
+	truststoreContents := `-----BEGIN CERTIFICATE-----
+MIIDDjCCAfagAwIBAgIUZHm6D1aJYtmVEV1X23m+oK9EJgcwDQYJKoZIhvcNAQEL
+BQAwLTETMBEGA1UECgwKVmVjdG9yaXplZDEWMBQGA1UEAwwNVmVjdG9yaXplZCBD
+QTAeFw0yMTA0MDYwMjMzMjNaFw0yMjA0MDYwMjMzMjNaMC0xEzARBgNVBAoMClZl
+Y3Rvcml6ZWQxFjAUBgNVBAMMDVZlY3Rvcml6ZWQgQ0EwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDZN7ytDxWGvxprVvydv0hwuD3hGcZFbJaeDXrIInGd
+RGK8zr/zoq3oAgw1ZW0OabID3OKs9tezKGM5wPUvzGfU94qhi1ot040Utw+Jf2tQ
+GA3T1X+VHRTUlqDVVnIvhcAiy21bMUMVuFl4QtJnWx9ZljkCFo8IIh/3Sq88ORDl
+gzfM3cK1kk+60uKzXNvgK8ShrZ0GYsbmxncxhbdr2O7mSdVcO6x0tbmNDLc5Hx+w
+34z2hRHReavw3KDFfaIdHZE2tSQ4xh25F9aZQiPsTaGzPtGozLl7Ck1p9Ew4d+MO
+EXd51gGeIdP6EUD8exOMfRq2B6/p18HyjMsuKQKhjx2NAgMBAAGjJjAkMA4GA1Ud
+DwEB/wQEAwIC5DASBgNVHRMBAf8ECDAGAQH/AgEBMA0GCSqGSIb3DQEBCwUAA4IB
+AQCse+GLdlBi77fOgDgX8dby2PVZiSoW8cE1uRJzaXvw9mrz83RW2SxnW3och6Mm
+cixyv+taomZfYNM2wbOzEpkI0QEcV9CF/9Sx5RQVKsoAQkjkmzpHUeRp5ha/VAYq
+KWVCj9Ej+1y8dE0+AvltyymRbcMKUSk3vXK6HmzCGn2XAVz1WBQHQHXe0vwQGAXu
+Tq7VoNh+LNEud7ro5Hwi5aiDA1B7HZum6u2MvU5KwGY3txDve1Jn0bWOa8J3HjIN
+wHAv/4PAPweXflPAVHkUR4VOslBdZo/tAcSbG/Zr3cneBt7VYnPyO+IAe7S54u9g
+eKlljKHOgHw7gXOzsvWTVQbm
+-----END CERTIFICATE-----`
+
+	certContents := `-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAtMRMwEQYDVQQKDApWZWN0
+b3JpemVkMRYwFAYDVQQDDA1WZWN0b3JpemVkIENBMB4XDTIxMDQwNjAyMzMyM1oX
+DTIyMDQwNjAyMzMyM1owFTETMBEGA1UECgwKVmVjdG9yaXplZDCCASIwDQYJKoZI
+hvcNAQEBBQADggEPADCCAQoCggEBANU4vIalSYOb0Oui2ZaDjDxW075L2erSvpZg
+7QWxp5WTmDWglsy/sXxj0aub1HDu6dyZPFSIOc4TunjM+0aU7aLR7aK7k9sCxqs8
+FdRx4VwAQ/ERuJzzrOtw5qb/Wr345K7VmQqO3nfIixc4mipgssWWAFUOCvz3hAod
+qCDKwrsQS3innG6LUUEDgyeSpjopSue7luHCaHL0KwNP/AlzLNhxTJP8MqKDgFX8
+w8oXwlIcmzOUO2RPq08Odspe5g9sfhiOo0uzRvPix7nrg4e6p+zSAnUp6BTGxSL4
+eHRQDTbtXGsAv1ZonbDpAQwhSgszypyG2YeGkamdH8cS6hOy6ycCAwEAAaNQME4w
+DgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAd
+BgNVHREBAf8EEzARgglsb2NhbGhvc3SHBH8AAAEwDQYJKoZIhvcNAQELBQADggEB
+ABVaMl14UyUPUw8hYtRusEE8Q/jt2LVJyX/0OQQkTJpiGaBfbsT7XHIuIgE7EJgk
+zIBT9FigLvnsyndjC+tR5xXjNaMzK5kzpT29BN+v2wpRUhvldJ4nrVxWlMIS8AKj
+TIUnkfUSHIDn+h2WCF3Kwr6zalDkG1tTLxDtJoZzgqTBORozkGmj5O31QSIKy9Y1
+2DMqvkvvUUrTA4V8aNI6pkUwhR56ln2ilYmoccdyO/Xxwe2Vq4lBlXehhGT7tMd0
+5FWiLjwxu1UzElnCTpay+y4snQpRDf46JMZ3UkW66GNCZulImIU9kalWOuPE3bh4
+bsyMIZfcs4exHOV0g2EenLk=
+-----END CERTIFICATE-----`
+
+	keyContents := `-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEA1Ti8hqVJg5vQ66LZloOMPFbTvkvZ6tK+lmDtBbGnlZOYNaCW
+zL+xfGPRq5vUcO7p3Jk8VIg5zhO6eMz7RpTtotHtoruT2wLGqzwV1HHhXABD8RG4
+nPOs63Dmpv9avfjkrtWZCo7ed8iLFziaKmCyxZYAVQ4K/PeECh2oIMrCuxBLeKec
+botRQQODJ5KmOilK57uW4cJocvQrA0/8CXMs2HFMk/wyooOAVfzDyhfCUhybM5Q7
+ZE+rTw52yl7mD2x+GI6jS7NG8+LHueuDh7qn7NICdSnoFMbFIvh4dFANNu1cawC/
+VmidsOkBDCFKCzPKnIbZh4aRqZ0fxxLqE7LrJwIDAQABAoIBAQDQ3yuPmwtQ6arX
+qkgMsgEGeugiWpu29YvONFT8ZvQMCvHoVtBi8sYjXIVg3t5VYzWk7Fe1V12JCrp4
+7BSbJ/lCrvNjnu1Qdn+37rxTyNtDDN+BoCKBXhPe8FKC9VMnFlKvEn9BYIN+Q+49
+aS1cpi16cV8R8xfAh5fJcRPqS7ZHF/1rhUqkcoV956h5RtQy3k/BIVpJydbrb17U
+xEhiCFyRbCIEEnX2hTRFrRt4hEIwa2YceWMsY8ddCngtS/i4UGLsaYLCMrTgtvwS
+H9uI1q0gL5tcp7qo4MQo9BRtbiazV70MofabF19tapDlbPoqcggN/sTi4VQzFWsx
+YKShZhIBAoGBAPA5ZaH6pg76O+E47kPbugx2V6y8YongvBOe+MXkwXG3samLUhN9
+63th3qhDOqqwUN8FgJYqATbn6lsvVnIhoJ1EK126grVeZme7FCTswjHKd2gaVAaz
+GBJ7ejMMoHzw1IGSXxnZ69XFN4xUSAiCeq58LWl3PJmtpt+vZ2ZZrA+HAoGBAOM5
+YJP7YzGPG/OX4EVttGzcMCigTUTKZwH4aNTzJm2KDHiS3uiW6XMgMsY8H057XZbT
+QjB7QnokRUuVqD/Zugh2bHZcHiJNT9re/TZwqXPXh2B4fY0ZOSAImMpsXWdfJSKK
+anIroNF4v5gw+4zqtEBE8Zc7Ct+gbvfPp9qdbu9hAoGAXkAWyQufdYbmUYJVsVgX
+UeZolcQ/4RrEj+oybupGn4hT81JPPIiOCJWol1nxPaD5ydbN0ZzfZxxszaPwBc19
+x9ZEMX0I5YIJKa+zwp0FwCVQ3g5eY1aHHlFF65uLqBmRNtkn6OugZPoAxlUXAge3
+fJgJ9TQsGZuROngGWJjcMicCgYEAxPd12pFt2QX+6tfalxST9FGihXT/xgPV6wVU
+ilQEGawzR0m5ZNF8qEle+iwfzz5tUFLs623NoGdUkkK2yDKKas+NEcSkcoOmF0p5
+IPnkSgCo311TKD6XIEeTetUY2oTFgf2ObE2ZaDtNijXbuLmzaorZCYkq0dMWnkYp
+cP5LrcECgYEA4+Sk/uND5dDc1TXRKGaiu9t2DscUpQCwk5PVOMMA0iwBJBodt85o
+nDpxxecx1Mh1+0V46bnrYrIrAGurqCbQN8B5EsB9dcLZ3bg86KRwP3ZbQNxKPIqo
+T16cNmHSk5jIiR6odFmV6KPjvXhjFTUYxOIjFIWNItOhXBrBxG3NyVE=
+-----END RSA PRIVATE KEY-----`
+
 	certVarName := "RP_TEST_CERT"
 	keyVarName := "RP_TEST_KEY"
 	truststoreVarName := "RP_TEST_TRUSTSTORE"
@@ -421,10 +491,9 @@ func TestBuildTLSConfig(t *testing.T) {
 		keyFile        string
 		certFile       string
 		truststoreFile string
-		before         func()
+		before         func(afero.Fs)
 		cleanup        func()
 		defaultVal     func() (*config.TLS, error)
-		expected       *config.TLS
 		expectedErrMsg string
 	}{{
 		name: "it should return the default value provided if none are set",
@@ -435,79 +504,63 @@ func TestBuildTLSConfig(t *testing.T) {
 				TruststoreFile: "default-trust.pem",
 			}, nil
 		},
-		expected: &config.TLS{
-			CertFile:       "default-cert.pem",
-			KeyFile:        "default-key.pem",
-			TruststoreFile: "default-trust.pem",
+		before: func(fs afero.Fs) {
+			afero.WriteFile(fs, "default-cert.pem", []byte(certContents), 0755)
+			afero.WriteFile(fs, "default-key.pem", []byte(keyContents), 0755)
+			afero.WriteFile(fs, "default-trust.pem", []byte(truststoreContents), 0755)
 		},
-	}, {
-		name:           "it should fail if truststoreFile is empty",
-		certFile:       "cert.pem",
-		keyFile:        "key.pem",
-		expectedErrMsg: "--tls-truststore is required to enable TLS",
 	}, {
 		name:           "it should fail if certFile is present but keyFile is empty",
 		certFile:       "cert.pem",
 		truststoreFile: "trust.pem",
-		expectedErrMsg: "if --tls-cert is passed, then --tls-key must be passed to enable" +
-			" TLS authentication",
+		expectedErrMsg: "if a TLS client certificate is set, then its key must be passed to enable TLS authentication",
 	}, {
 		name:           "it should fail if keyFile is present but certFile is empty",
 		keyFile:        "key.pem",
 		truststoreFile: "trust.pem",
-		expectedErrMsg: "if --tls-key is passed, then --tls-cert must be passed to enable" +
-			" TLS authentication",
+		expectedErrMsg: "if a TLS client certificate key is set, then its certificate must be passed to enable TLS authentication",
 	}, {
 		name:           "it should build the config with only a truststore",
 		truststoreFile: "trust.pem",
-		expected:       &config.TLS{TruststoreFile: "trust.pem"},
+		before: func(fs afero.Fs) {
+			afero.WriteFile(fs, "trust.pem", []byte(truststoreContents), 0755)
+		},
 	}, {
 		name:           "it should build the config with all fields",
 		certFile:       "cert.pem",
 		keyFile:        "key.pem",
 		truststoreFile: "trust.pem",
-		expected: &config.TLS{
-			CertFile:       "cert.pem",
-			KeyFile:        "key.pem",
-			TruststoreFile: "trust.pem",
+		before: func(fs afero.Fs) {
+			afero.WriteFile(fs, "cert.pem", []byte(certContents), 0755)
+			afero.WriteFile(fs, "key.pem", []byte(keyContents), 0755)
+			afero.WriteFile(fs, "trust.pem", []byte(truststoreContents), 0755)
 		},
 	}, {
 		name: "it should pick up the values from env vars if the vars' values is empty",
-		before: func() {
-			os.Setenv(certVarName, "./node.crt")
-			os.Setenv(keyVarName, "./node.key")
-			os.Setenv(truststoreVarName, "./ca.crt")
+		before: func(fs afero.Fs) {
+			cert, key, truststore := "./node.crt", "./node.key", "./ca.crt"
+			os.Setenv(certVarName, cert)
+			os.Setenv(keyVarName, key)
+			os.Setenv(truststoreVarName, truststore)
+
+			afero.WriteFile(fs, cert, []byte(certContents), 0755)
+			afero.WriteFile(fs, key, []byte(keyContents), 0755)
+			afero.WriteFile(fs, truststore, []byte(truststoreContents), 0755)
 		},
 		cleanup: func() {
 			os.Unsetenv(certVarName)
 			os.Unsetenv(keyVarName)
 			os.Unsetenv(truststoreVarName)
-		},
-		expected: &config.TLS{
-			CertFile:       "./node.crt",
-			KeyFile:        "./node.key",
-			TruststoreFile: "./ca.crt",
 		},
 	}, {
 		name:           "it should give priority to values set through the flags",
 		certFile:       "cert.pem",
 		keyFile:        "key.pem",
 		truststoreFile: "trust.pem",
-		before: func() {
-			os.Setenv(certVarName, "./node.crt")
-			os.Setenv(keyVarName, "./node.key")
-			os.Setenv(truststoreVarName, "./ca.crt")
-		},
-		cleanup: func() {
-			os.Unsetenv(certVarName)
-			os.Unsetenv(keyVarName)
-			os.Unsetenv(truststoreVarName)
-		},
-		// Disregards the env vars' values
-		expected: &config.TLS{
-			CertFile:       "cert.pem",
-			KeyFile:        "key.pem",
-			TruststoreFile: "trust.pem",
+		before: func(fs afero.Fs) {
+			afero.WriteFile(fs, "cert.pem", []byte(certContents), 0755)
+			afero.WriteFile(fs, "key.pem", []byte(keyContents), 0755)
+			afero.WriteFile(fs, "trust.pem", []byte(truststoreContents), 0755)
 		},
 	}, {
 		name: "it should return the given default value if no values are set",
@@ -518,17 +571,19 @@ func TestBuildTLSConfig(t *testing.T) {
 				TruststoreFile: "ca.pem",
 			}, nil
 		},
-		expected: &config.TLS{
-			CertFile:       "certificate.pem",
-			KeyFile:        "cert.key",
-			TruststoreFile: "ca.pem",
+		before: func(fs afero.Fs) {
+			afero.WriteFile(fs, "certificate.pem", []byte(certContents), 0755)
+			afero.WriteFile(fs, "cert.key", []byte(keyContents), 0755)
+			afero.WriteFile(fs, "ca.pem", []byte(truststoreContents), 0755)
 		},
-	}}
+	},
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(st *testing.T) {
+			fs := afero.NewMemMapFs()
 			if tt.before != nil {
-				tt.before()
+				tt.before(fs)
 			}
 			if tt.cleanup != nil {
 				defer tt.cleanup()
@@ -540,7 +595,11 @@ func TestBuildTLSConfig(t *testing.T) {
 				}
 			}
 
-			res, err := buildTLS(
+			enableTLS := false
+
+			_, err := buildTLS(
+				fs,
+				&enableTLS,
 				&tt.certFile,
 				&tt.keyFile,
 				&tt.truststoreFile,
@@ -551,8 +610,9 @@ func TestBuildTLSConfig(t *testing.T) {
 			)
 			if tt.expectedErrMsg != "" {
 				require.EqualError(st, err, tt.expectedErrMsg)
+				return
 			}
-			require.Exactly(st, tt.expected, res)
+			require.NoError(st, err)
 		})
 	}
 }
@@ -562,7 +622,7 @@ func TestCreateAdmin(t *testing.T) {
 		name           string
 		brokers        func() []string
 		configuration  func() (*config.Config, error)
-		tlsConfig      func() (*config.TLS, error)
+		tlsConfig      func() (*tls.Config, error)
 		authConfig     func() (*config.SASL, error)
 		expectedErrMsg string
 	}{{
@@ -573,7 +633,7 @@ func TestCreateAdmin(t *testing.T) {
 		expectedErrMsg: "No config found here",
 	}, {
 		name: "the returned closure should fail if tlsConfig fails",
-		tlsConfig: func() (*config.TLS, error) {
+		tlsConfig: func() (*tls.Config, error) {
 			return nil, errors.New("bad tls conf")
 		},
 		expectedErrMsg: "bad tls conf",
@@ -606,7 +666,7 @@ func TestCreateAdmin(t *testing.T) {
 				configuration = tt.configuration
 			}
 
-			tlsConfig := func() (*config.TLS, error) {
+			tlsConfig := func() (*tls.Config, error) {
 				return nil, nil
 			}
 			if tt.tlsConfig != nil {
@@ -637,7 +697,7 @@ func TestCreateClient(t *testing.T) {
 		name           string
 		brokers        func() []string
 		configuration  func() (*config.Config, error)
-		tlsConfig      func() (*config.TLS, error)
+		tlsConfig      func() (*tls.Config, error)
 		authConfig     func() (*config.SASL, error)
 		expectedErrMsg string
 	}{{
@@ -648,7 +708,7 @@ func TestCreateClient(t *testing.T) {
 		expectedErrMsg: "No config found here",
 	}, {
 		name: "the returned closure should fail if tlsConfig fails",
-		tlsConfig: func() (*config.TLS, error) {
+		tlsConfig: func() (*tls.Config, error) {
 			return nil, errors.New("bad tls conf")
 		},
 		expectedErrMsg: "bad tls conf",
@@ -681,7 +741,7 @@ func TestCreateClient(t *testing.T) {
 				configuration = tt.configuration
 			}
 
-			tlsConfig := func() (*config.TLS, error) {
+			tlsConfig := func() (*tls.Config, error) {
 				return nil, nil
 			}
 			if tt.tlsConfig != nil {

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -185,12 +185,15 @@ func TestAddKafkaFlags(t *testing.T) {
 		}
 		parent.AddCommand(child)
 
+		enableTLS := false
+
 		AddKafkaFlags(
 			parent,
 			&configFile,
 			&user,
 			&password,
 			&mechanism,
+			&enableTLS,
 			&certFile,
 			&keyFile,
 			&truststoreFile,
@@ -253,6 +256,7 @@ func TestAddKafkaFlags(t *testing.T) {
 
 func TestAddAdminAPITLSFlags(t *testing.T) {
 	var (
+		enableTLS      bool
 		certFile       string
 		keyFile        string
 		truststoreFile string
@@ -274,6 +278,7 @@ func TestAddAdminAPITLSFlags(t *testing.T) {
 
 		AddAdminAPITLSFlags(
 			parent,
+			&enableTLS,
 			&certFile,
 			&keyFile,
 			&truststoreFile,
@@ -286,11 +291,13 @@ func TestAddAdminAPITLSFlags(t *testing.T) {
 		"--admin-api-tls-cert", "admin-cert.pem",
 		"--admin-api-tls-key", "admin-key.pem",
 		"--admin-api-tls-truststore", "admin-truststore.pem",
+		"--admin-api-tls-enabled",
 	})
 
 	err := cmd.Execute()
 	require.NoError(t, err)
 
+	require.True(t, enableTLS)
 	require.Exactly(t, "admin-cert.pem", certFile)
 	require.Exactly(t, "admin-key.pem", keyFile)
 	require.Exactly(t, "admin-truststore.pem", truststoreFile)
@@ -307,6 +314,7 @@ func TestAddAdminAPITLSFlags(t *testing.T) {
 	err = cmd.Execute()
 	require.NoError(t, err)
 
+	require.False(t, enableTLS)
 	require.Exactly(t, "admin-cert1.pem", certFile)
 	require.Exactly(t, "admin-key1.pem", keyFile)
 	require.Exactly(t, "admin-truststore1.pem", truststoreFile)

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -276,7 +276,11 @@ func getKafkaInfo(
 		conf.Redpanda.KafkaApi[0].Address,
 		conf.Redpanda.KafkaApi[0].Port,
 	)
-	client, err := kafka.InitClientWithConf(&conf.Rpk.TLS, &conf.Rpk.SASL, addr)
+	client, err := kafka.InitClientWithConf(
+		conf.Rpk.KafkaApi.TLS,
+		conf.Rpk.KafkaApi.SASL,
+		addr,
+	)
 	if err != nil {
 		out <- [][]string{}
 		kafkaInfoCh <- kInfo

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -276,7 +276,7 @@ func getKafkaInfo(
 		conf.Redpanda.KafkaApi[0].Address,
 		conf.Redpanda.KafkaApi[0].Port,
 	)
-	client, err := kafka.InitClientWithConf(&conf.Rpk.TLS, &conf.Rpk.SCRAM, addr)
+	client, err := kafka.InitClientWithConf(&conf.Rpk.TLS, &conf.Rpk.SASL, addr)
 	if err != nil {
 		out <- [][]string{}
 		kafkaInfoCh <- kInfo

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -109,7 +109,7 @@ func executeInfo(
 	metricsRes, err := getMetrics(fs, mgr, timeout, *conf)
 
 	go func() {
-		err := getKafkaInfo(*conf, kafkaRowsCh, kafkaInfoCh, send)
+		err := getKafkaInfo(fs, *conf, kafkaRowsCh, kafkaInfoCh, send)
 		log.Debug(err)
 	}()
 	if err != nil {
@@ -262,6 +262,7 @@ func getConf(
 }
 
 func getKafkaInfo(
+	fs afero.Fs,
 	conf config.Config,
 	out chan<- [][]string,
 	kafkaInfoCh chan<- kafkaInfo,
@@ -287,7 +288,7 @@ func getKafkaInfo(
 		t = conf.Rpk.TLS
 	}
 	if t != nil {
-		tlsConfig, err = vtls.BuildTLSConfig(true, t.CertFile, t.KeyFile, t.TruststoreFile)
+		tlsConfig, err = vtls.BuildTLSConfig(fs, true, t.CertFile, t.KeyFile, t.TruststoreFile)
 		if err != nil {
 			out <- [][]string{}
 			kafkaInfoCh <- kInfo

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -56,7 +56,7 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	tlsClosure := common.BuildTLSConfig(&certFile, &keyFile, &truststoreFile)
+	tlsClosure := common.BuildKafkaTLSConfig(&certFile, &keyFile, &truststoreFile, configClosure)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	clientClosure := common.CreateClient(brokersClosure, configClosure, tlsClosure, kAuthClosure)

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -24,6 +24,7 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		user           string
 		password       string
 		mechanism      string
+		enableTLS      bool
 		certFile       string
 		keyFile        string
 		truststoreFile string
@@ -33,7 +34,7 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		Short: "Create, delete, produce to and consume from Redpanda topics.",
 	}
 
-	common.AddKafkaFlags(command, &configFile, &user, &password, &mechanism, &certFile, &keyFile, &truststoreFile, &brokers)
+	common.AddKafkaFlags(command, &configFile, &user, &password, &mechanism, &enableTLS, &certFile, &keyFile, &truststoreFile, &brokers)
 
 	// The ideal way to pass common (global flags') values would be to
 	// declare PersistentPreRun hooks on each command root (such as rpk
@@ -56,7 +57,7 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	tlsClosure := common.BuildKafkaTLSConfig(&certFile, &keyFile, &truststoreFile, configClosure)
+	tlsClosure := common.BuildKafkaTLSConfig(&enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	clientClosure := common.CreateClient(brokersClosure, configClosure, tlsClosure, kAuthClosure)

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -57,7 +57,7 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	tlsClosure := common.BuildKafkaTLSConfig(&enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
+	tlsClosure := common.BuildKafkaTLSConfig(fs, &enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	clientClosure := common.CreateClient(brokersClosure, configClosure, tlsClosure, kAuthClosure)

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -53,7 +53,7 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	tlsClosure := common.BuildTLSConfig(&certFile, &keyFile, &truststoreFile)
+	tlsClosure := common.BuildKafkaTLSConfig(&certFile, &keyFile, &truststoreFile, configClosure)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -55,7 +55,7 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	tlsClosure := common.BuildKafkaTLSConfig(&enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
+	tlsClosure := common.BuildKafkaTLSConfig(fs, &enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -24,6 +24,7 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		user           string
 		password       string
 		mechanism      string
+		enableTLS      bool
 		certFile       string
 		keyFile        string
 		truststoreFile string
@@ -39,6 +40,7 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&user,
 		&password,
 		&mechanism,
+		&enableTLS,
 		&certFile,
 		&keyFile,
 		&truststoreFile,
@@ -53,7 +55,7 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	tlsClosure := common.BuildKafkaTLSConfig(&certFile, &keyFile, &truststoreFile, configClosure)
+	tlsClosure := common.BuildKafkaTLSConfig(&enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1636,9 +1636,9 @@ schema_registry: {}
 			name: "shall write a valid config file with scram configured",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.Rpk.SCRAM.User = "scram_user"
-				c.Rpk.SCRAM.Password = "scram_password"
-				c.Rpk.SCRAM.Type = "SCRAM-SHA-256"
+				c.Rpk.SASL.User = "scram_user"
+				c.Rpk.SASL.Password = "scram_password"
+				c.Rpk.SASL.Mechanism = "SCRAM-SHA-256"
 				return c
 			},
 			wantErr: false,

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1636,9 +1636,11 @@ schema_registry: {}
 			name: "shall write a valid config file with scram configured",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.Rpk.SASL.User = "scram_user"
-				c.Rpk.SASL.Password = "scram_password"
-				c.Rpk.SASL.Mechanism = "SCRAM-SHA-256"
+				c.Rpk.KafkaApi.SASL = &SASL{
+					User:      "scram_user",
+					Password:  "scram_password",
+					Mechanism: "SCRAM-SHA-256",
+				}
 				return c
 			},
 			wantErr: false,
@@ -1668,11 +1670,12 @@ rpk:
   coredump_dir: /var/lib/redpanda/coredumps
   enable_memory_locking: true
   enable_usage_stats: true
+  kafka_api:
+    sasl:
+      password: scram_password
+      type: SCRAM-SHA-256
+      user: scram_user
   overprovisioned: false
-  scram:
-    password: scram_password
-    type: SCRAM-SHA-256
-    user: scram_user
   tune_aio_events: true
   tune_clocksource: true
   tune_coredump: true

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -107,27 +107,43 @@ type ServerTLS struct {
 }
 
 type RpkConfig struct {
-	TLS                      TLS      `yaml:"tls,omitempty" mapstructure:"tls,omitempty" json:"tls"`
-	AdditionalStartFlags     []string `yaml:"additional_start_flags,omitempty" mapstructure:"additional_start_flags,omitempty" json:"additionalStartFlags"`
-	EnableUsageStats         bool     `yaml:"enable_usage_stats" mapstructure:"enable_usage_stats" json:"enableUsageStats"`
-	TuneNetwork              bool     `yaml:"tune_network" mapstructure:"tune_network" json:"tuneNetwork"`
-	TuneDiskScheduler        bool     `yaml:"tune_disk_scheduler" mapstructure:"tune_disk_scheduler" json:"tuneDiskScheduler"`
-	TuneNomerges             bool     `yaml:"tune_disk_nomerges" mapstructure:"tune_disk_nomerges" json:"tuneNomerges"`
-	TuneDiskWriteCache       bool     `yaml:"tune_disk_write_cache" mapstructure:"tune_disk_write_cache" json:"tuneDiskWriteCache"`
-	TuneDiskIrq              bool     `yaml:"tune_disk_irq" mapstructure:"tune_disk_irq" json:"tuneDiskIrq"`
-	TuneFstrim               bool     `yaml:"tune_fstrim" mapstructure:"tune_fstrim" json:"tuneFstrim"`
-	TuneCpu                  bool     `yaml:"tune_cpu" mapstructure:"tune_cpu" json:"tuneCpu"`
-	TuneAioEvents            bool     `yaml:"tune_aio_events" mapstructure:"tune_aio_events" json:"tuneAioEvents"`
-	TuneClocksource          bool     `yaml:"tune_clocksource" mapstructure:"tune_clocksource" json:"tuneClocksource"`
-	TuneSwappiness           bool     `yaml:"tune_swappiness" mapstructure:"tune_swappiness" json:"tuneSwappiness"`
-	TuneTransparentHugePages bool     `yaml:"tune_transparent_hugepages" mapstructure:"tune_transparent_hugepages" json:"tuneTransparentHugePages"`
-	EnableMemoryLocking      bool     `yaml:"enable_memory_locking" mapstructure:"enable_memory_locking" json:"enableMemoryLocking"`
-	TuneCoredump             bool     `yaml:"tune_coredump" mapstructure:"tune_coredump" json:"tuneCoredump"`
-	CoredumpDir              string   `yaml:"coredump_dir,omitempty" mapstructure:"coredump_dir,omitempty" json:"coredumpDir"`
-	WellKnownIo              string   `yaml:"well_known_io,omitempty" mapstructure:"well_known_io,omitempty" json:"wellKnownIo"`
-	Overprovisioned          bool     `yaml:"overprovisioned" mapstructure:"overprovisioned" json:"overprovisioned"`
-	SMP                      *int     `yaml:"smp,omitempty" mapstructure:"smp,omitempty" json:"smp,omitempty"`
-	SASL                     SASL     `yaml:"scram,omitempty" mapstructure:"scram,omitempty" json:"scram,omitempty"`
+	// Deprecated 2021-07-1
+	TLS *TLS `yaml:"tls,omitempty" mapstructure:"tls,omitempty" json:"tls"`
+	// Deprecated 2021-07-1
+	SASL *SASL `yaml:"sasl,omitempty" mapstructure:"sasl,omitempty" json:"sasl,omitempty"`
+
+	KafkaApi                 RpkKafkaApi `yaml:"kafka_api,omitempty" mapstructure:"kafka_api,omitempty" json:"kafkaApi"`
+	AdminApi                 RpkAdminApi `yaml:"admin_api,omitempty" mapstructure:"admin_api,omitempty" json:"adminApi"`
+	AdditionalStartFlags     []string    `yaml:"additional_start_flags,omitempty" mapstructure:"additional_start_flags,omitempty" json:"additionalStartFlags"`
+	EnableUsageStats         bool        `yaml:"enable_usage_stats" mapstructure:"enable_usage_stats" json:"enableUsageStats"`
+	TuneNetwork              bool        `yaml:"tune_network" mapstructure:"tune_network" json:"tuneNetwork"`
+	TuneDiskScheduler        bool        `yaml:"tune_disk_scheduler" mapstructure:"tune_disk_scheduler" json:"tuneDiskScheduler"`
+	TuneNomerges             bool        `yaml:"tune_disk_nomerges" mapstructure:"tune_disk_nomerges" json:"tuneNomerges"`
+	TuneDiskWriteCache       bool        `yaml:"tune_disk_write_cache" mapstructure:"tune_disk_write_cache" json:"tuneDiskWriteCache"`
+	TuneDiskIrq              bool        `yaml:"tune_disk_irq" mapstructure:"tune_disk_irq" json:"tuneDiskIrq"`
+	TuneFstrim               bool        `yaml:"tune_fstrim" mapstructure:"tune_fstrim" json:"tuneFstrim"`
+	TuneCpu                  bool        `yaml:"tune_cpu" mapstructure:"tune_cpu" json:"tuneCpu"`
+	TuneAioEvents            bool        `yaml:"tune_aio_events" mapstructure:"tune_aio_events" json:"tuneAioEvents"`
+	TuneClocksource          bool        `yaml:"tune_clocksource" mapstructure:"tune_clocksource" json:"tuneClocksource"`
+	TuneSwappiness           bool        `yaml:"tune_swappiness" mapstructure:"tune_swappiness" json:"tuneSwappiness"`
+	TuneTransparentHugePages bool        `yaml:"tune_transparent_hugepages" mapstructure:"tune_transparent_hugepages" json:"tuneTransparentHugePages"`
+	EnableMemoryLocking      bool        `yaml:"enable_memory_locking" mapstructure:"enable_memory_locking" json:"enableMemoryLocking"`
+	TuneCoredump             bool        `yaml:"tune_coredump" mapstructure:"tune_coredump" json:"tuneCoredump"`
+	CoredumpDir              string      `yaml:"coredump_dir,omitempty" mapstructure:"coredump_dir,omitempty" json:"coredumpDir"`
+	WellKnownIo              string      `yaml:"well_known_io,omitempty" mapstructure:"well_known_io,omitempty" json:"wellKnownIo"`
+	Overprovisioned          bool        `yaml:"overprovisioned" mapstructure:"overprovisioned" json:"overprovisioned"`
+	SMP                      *int        `yaml:"smp,omitempty" mapstructure:"smp,omitempty" json:"smp,omitempty"`
+}
+
+type RpkKafkaApi struct {
+	Brokers []string `yaml:"brokers,omitempty" mapstructure:"brokers,omitempty" json:"brokers"`
+	TLS     *TLS     `yaml:"tls,omitempty" mapstructure:"tls,omitempty" json:"tls"`
+	SASL    *SASL    `yaml:"sasl,omitempty" mapstructure:"sasl,omitempty" json:"sasl,omitempty"`
+}
+
+type RpkAdminApi struct {
+	Addresses []SocketAddress `yaml:"addresses,omitempty" mapstructure:"addresses,omitempty" json:"addresses"`
+	TLS       *TLS            `yaml:"tls,omitempty" mapstructure:"tls,omitempty" json:"tls"`
 }
 
 type SASL struct {

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -127,13 +127,13 @@ type RpkConfig struct {
 	WellKnownIo              string   `yaml:"well_known_io,omitempty" mapstructure:"well_known_io,omitempty" json:"wellKnownIo"`
 	Overprovisioned          bool     `yaml:"overprovisioned" mapstructure:"overprovisioned" json:"overprovisioned"`
 	SMP                      *int     `yaml:"smp,omitempty" mapstructure:"smp,omitempty" json:"smp,omitempty"`
-	SCRAM                    SCRAM    `yaml:"scram,omitempty" mapstructure:"scram,omitempty" json:"scram,omitempty"`
+	SASL                     SASL     `yaml:"scram,omitempty" mapstructure:"scram,omitempty" json:"scram,omitempty"`
 }
 
-type SCRAM struct {
-	User     string `yaml:"user,omitempty" mapstructure:"user,omitempty" json:"user,omitempty"`
-	Password string `yaml:"password,omitempty" mapstructure:"password,omitempty" json:"password,omitempty"`
-	Type     string `yaml:"type,omitempty" mapstructure:"type,omitempty" json:"type,omitempty"`
+type SASL struct {
+	User      string `yaml:"user,omitempty" mapstructure:"user,omitempty" json:"user,omitempty"`
+	Password  string `yaml:"password,omitempty" mapstructure:"password,omitempty" json:"password,omitempty"`
+	Mechanism string `yaml:"type,omitempty" mapstructure:"type,omitempty" json:"type,omitempty"`
 }
 
 func (conf *Config) PIDFile() string {

--- a/src/go/rpk/pkg/kafka/client.go
+++ b/src/go/rpk/pkg/kafka/client.go
@@ -44,7 +44,7 @@ func DefaultConfig() *sarama.Config {
 }
 
 // Overrides the default config with the redpanda config values, such as TLS.
-func LoadConfig(tls *config.TLS, scram *config.SCRAM) (*sarama.Config, error) {
+func LoadConfig(tls *config.TLS, sasl *config.SASL) (*sarama.Config, error) {
 	var err error
 	c := DefaultConfig()
 
@@ -55,8 +55,8 @@ func LoadConfig(tls *config.TLS, scram *config.SCRAM) (*sarama.Config, error) {
 		}
 	}
 
-	if scram != nil {
-		return ConfigureSASL(c, scram)
+	if sasl != nil {
+		return ConfigureSASL(c, sasl)
 	}
 	return c, nil
 }
@@ -68,9 +68,9 @@ func InitClient(brokers ...string) (sarama.Client, error) {
 
 // Initializes a client using values from the configuration when possible.
 func InitClientWithConf(
-	tls *config.TLS, scram *config.SCRAM, brokers ...string,
+	tls *config.TLS, sasl *config.SASL, brokers ...string,
 ) (sarama.Client, error) {
-	c, err := LoadConfig(tls, scram)
+	c, err := LoadConfig(tls, sasl)
 	if err != nil {
 		return nil, err
 	}
@@ -182,17 +182,17 @@ func RetrySend(
 }
 
 func ConfigureSASL(
-	saramaConf *sarama.Config, scram *config.SCRAM,
+	saramaConf *sarama.Config, sasl *config.SASL,
 ) (*sarama.Config, error) {
-	if scram.Password == "" || scram.User == "" || scram.Type == "" {
+	if sasl.Password == "" || sasl.User == "" || sasl.Mechanism == "" {
 		return saramaConf, nil
 	}
 
 	saramaConf.Net.SASL.Enable = true
 	saramaConf.Net.SASL.Handshake = true
-	saramaConf.Net.SASL.User = scram.User
-	saramaConf.Net.SASL.Password = scram.Password
-	switch scram.Type {
+	saramaConf.Net.SASL.User = sasl.User
+	saramaConf.Net.SASL.Password = sasl.Password
+	switch sasl.Mechanism {
 	case sarama.SASLTypeSCRAMSHA256:
 		saramaConf.Net.SASL.SCRAMClientGeneratorFunc =
 			func() sarama.SCRAMClient {
@@ -207,7 +207,7 @@ func ConfigureSASL(
 		saramaConf.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
 	default:
 		return nil, fmt.Errorf("unrecongnized Salted Challenge Response "+
-			"Authentication Mechanism (SCRAM): '%s'.", scram.Type)
+			"Authentication Mechanism (SCRAM): '%s'.", sasl.Mechanism)
 	}
 	return saramaConf, nil
 }

--- a/src/go/rpk/pkg/kafka/client_test.go
+++ b/src/go/rpk/pkg/kafka/client_test.go
@@ -1,6 +1,7 @@
 package kafka_test
 
 import (
+	"crypto/tls"
 	"testing"
 
 	"github.com/Shopify/sarama"
@@ -76,7 +77,7 @@ func Test_LoadConfig(t *testing.T) {
 			if tt.conf != nil {
 				conf = tt.conf()
 			}
-			c, err := kafka.LoadConfig(conf.Rpk.KafkaApi.TLS, conf.Rpk.KafkaApi.SASL)
+			c, err := kafka.LoadConfig(&tls.Config{}, conf.Rpk.KafkaApi.SASL)
 			require.NoError(t, err)
 			tt.check(st, conf, c)
 		})

--- a/src/go/rpk/pkg/kafka/client_test.go
+++ b/src/go/rpk/pkg/kafka/client_test.go
@@ -14,9 +14,11 @@ func Test_LoadConfig(t *testing.T) {
 
 	getCfg := func() *config.Config {
 		cfg := config.Default()
-		cfg.Rpk.SASL.User = "some_user"
-		cfg.Rpk.SASL.Password = "some_password"
-		cfg.Rpk.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
+		cfg.Rpk.KafkaApi.SASL = &config.SASL{
+			User:      "some_user",
+			Password:  "some_password",
+			Mechanism: sarama.SASLTypeSCRAMSHA256,
+		}
 		return cfg
 	}
 
@@ -27,45 +29,45 @@ func Test_LoadConfig(t *testing.T) {
 	}{{
 		name: "it should load the SCRAM config",
 		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
-			assert.Equal(t, cfg.Rpk.SASL.User, c.Net.SASL.User)
-			assert.Equal(t, cfg.Rpk.SASL.Password, c.Net.SASL.Password)
-			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.SASL.Mechanism), c.Net.SASL.Mechanism)
+			assert.Equal(t, cfg.Rpk.KafkaApi.SASL.User, c.Net.SASL.User)
+			assert.Equal(t, cfg.Rpk.KafkaApi.SASL.Password, c.Net.SASL.Password)
+			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.KafkaApi.SASL.Mechanism), c.Net.SASL.Mechanism)
 		},
 	}, {
 		name: "it shouldn't load the SCRAM user if it's missing",
 		conf: func() *config.Config {
 			cfg := getCfg()
-			cfg.Rpk.SASL.User = ""
+			cfg.Rpk.KafkaApi.SASL.User = ""
 			return cfg
 		},
 		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
-			assert.Equal(t, cfg.Rpk.SASL.User, c.Net.SASL.User)
-			assert.NotEqual(t, cfg.Rpk.SASL.Password, c.Net.SASL.Password)
-			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.SASL.Mechanism), c.Net.SASL.Mechanism)
+			assert.Equal(t, cfg.Rpk.KafkaApi.SASL.User, c.Net.SASL.User)
+			assert.NotEqual(t, cfg.Rpk.KafkaApi.SASL.Password, c.Net.SASL.Password)
+			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.KafkaApi.SASL.Mechanism), c.Net.SASL.Mechanism)
 		},
 	}, {
 		name: "it shouldn't load the SCRAM password if it's missing",
 		conf: func() *config.Config {
 			cfg := getCfg()
-			cfg.Rpk.SASL.Password = ""
+			cfg.Rpk.KafkaApi.SASL.Password = ""
 			return cfg
 		},
 		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
-			assert.NotEqual(t, cfg.Rpk.SASL.User, c.Net.SASL.User)
-			assert.Equal(t, cfg.Rpk.SASL.Password, c.Net.SASL.Password)
-			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.SASL.Mechanism), c.Net.SASL.Mechanism)
+			assert.NotEqual(t, cfg.Rpk.KafkaApi.SASL.User, c.Net.SASL.User)
+			assert.Equal(t, cfg.Rpk.KafkaApi.SASL.Password, c.Net.SASL.Password)
+			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.KafkaApi.SASL.Mechanism), c.Net.SASL.Mechanism)
 		},
 	}, {
 		name: "it shouldn't load the SCRAM type if it's missing",
 		conf: func() *config.Config {
 			cfg := getCfg()
-			cfg.Rpk.SASL.Mechanism = ""
+			cfg.Rpk.KafkaApi.SASL.Mechanism = ""
 			return cfg
 		},
 		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
-			assert.NotEqual(t, cfg.Rpk.SASL.User, c.Net.SASL.User)
-			assert.NotEqual(t, cfg.Rpk.SASL.Password, c.Net.SASL.Password)
-			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.SASL.Mechanism), c.Net.SASL.Mechanism)
+			assert.NotEqual(t, cfg.Rpk.KafkaApi.SASL.User, c.Net.SASL.User)
+			assert.NotEqual(t, cfg.Rpk.KafkaApi.SASL.Password, c.Net.SASL.Password)
+			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.KafkaApi.SASL.Mechanism), c.Net.SASL.Mechanism)
 		},
 	}}
 	for _, tt := range tests {
@@ -74,7 +76,7 @@ func Test_LoadConfig(t *testing.T) {
 			if tt.conf != nil {
 				conf = tt.conf()
 			}
-			c, err := kafka.LoadConfig(&conf.Rpk.TLS, &conf.Rpk.SASL)
+			c, err := kafka.LoadConfig(conf.Rpk.KafkaApi.TLS, conf.Rpk.KafkaApi.SASL)
 			require.NoError(t, err)
 			tt.check(st, conf, c)
 		})

--- a/src/go/rpk/pkg/kafka/client_test.go
+++ b/src/go/rpk/pkg/kafka/client_test.go
@@ -14,9 +14,9 @@ func Test_LoadConfig(t *testing.T) {
 
 	getCfg := func() *config.Config {
 		cfg := config.Default()
-		cfg.Rpk.SCRAM.User = "some_user"
-		cfg.Rpk.SCRAM.Password = "some_password"
-		cfg.Rpk.SCRAM.Type = sarama.SASLTypeSCRAMSHA256
+		cfg.Rpk.SASL.User = "some_user"
+		cfg.Rpk.SASL.Password = "some_password"
+		cfg.Rpk.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
 		return cfg
 	}
 
@@ -27,45 +27,45 @@ func Test_LoadConfig(t *testing.T) {
 	}{{
 		name: "it should load the SCRAM config",
 		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
-			assert.Equal(t, cfg.Rpk.SCRAM.User, c.Net.SASL.User)
-			assert.Equal(t, cfg.Rpk.SCRAM.Password, c.Net.SASL.Password)
-			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.SCRAM.Type), c.Net.SASL.Mechanism)
+			assert.Equal(t, cfg.Rpk.SASL.User, c.Net.SASL.User)
+			assert.Equal(t, cfg.Rpk.SASL.Password, c.Net.SASL.Password)
+			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.SASL.Mechanism), c.Net.SASL.Mechanism)
 		},
 	}, {
 		name: "it shouldn't load the SCRAM user if it's missing",
 		conf: func() *config.Config {
 			cfg := getCfg()
-			cfg.Rpk.SCRAM.User = ""
+			cfg.Rpk.SASL.User = ""
 			return cfg
 		},
 		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
-			assert.Equal(t, cfg.Rpk.SCRAM.User, c.Net.SASL.User)
-			assert.NotEqual(t, cfg.Rpk.SCRAM.Password, c.Net.SASL.Password)
-			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.SCRAM.Type), c.Net.SASL.Mechanism)
+			assert.Equal(t, cfg.Rpk.SASL.User, c.Net.SASL.User)
+			assert.NotEqual(t, cfg.Rpk.SASL.Password, c.Net.SASL.Password)
+			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.SASL.Mechanism), c.Net.SASL.Mechanism)
 		},
 	}, {
 		name: "it shouldn't load the SCRAM password if it's missing",
 		conf: func() *config.Config {
 			cfg := getCfg()
-			cfg.Rpk.SCRAM.Password = ""
+			cfg.Rpk.SASL.Password = ""
 			return cfg
 		},
 		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
-			assert.NotEqual(t, cfg.Rpk.SCRAM.User, c.Net.SASL.User)
-			assert.Equal(t, cfg.Rpk.SCRAM.Password, c.Net.SASL.Password)
-			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.SCRAM.Type), c.Net.SASL.Mechanism)
+			assert.NotEqual(t, cfg.Rpk.SASL.User, c.Net.SASL.User)
+			assert.Equal(t, cfg.Rpk.SASL.Password, c.Net.SASL.Password)
+			assert.NotEqual(t, sarama.SASLMechanism(cfg.Rpk.SASL.Mechanism), c.Net.SASL.Mechanism)
 		},
 	}, {
 		name: "it shouldn't load the SCRAM type if it's missing",
 		conf: func() *config.Config {
 			cfg := getCfg()
-			cfg.Rpk.SCRAM.Type = ""
+			cfg.Rpk.SASL.Mechanism = ""
 			return cfg
 		},
 		check: func(st *testing.T, cfg *config.Config, c *sarama.Config) {
-			assert.NotEqual(t, cfg.Rpk.SCRAM.User, c.Net.SASL.User)
-			assert.NotEqual(t, cfg.Rpk.SCRAM.Password, c.Net.SASL.Password)
-			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.SCRAM.Type), c.Net.SASL.Mechanism)
+			assert.NotEqual(t, cfg.Rpk.SASL.User, c.Net.SASL.User)
+			assert.NotEqual(t, cfg.Rpk.SASL.Password, c.Net.SASL.Password)
+			assert.Equal(t, sarama.SASLMechanism(cfg.Rpk.SASL.Mechanism), c.Net.SASL.Mechanism)
 		},
 	}}
 	for _, tt := range tests {
@@ -74,7 +74,7 @@ func Test_LoadConfig(t *testing.T) {
 			if tt.conf != nil {
 				conf = tt.conf()
 			}
-			c, err := kafka.LoadConfig(&conf.Rpk.TLS, &conf.Rpk.SCRAM)
+			c, err := kafka.LoadConfig(&conf.Rpk.TLS, &conf.Rpk.SASL)
 			require.NoError(t, err)
 			tt.check(st, conf, c)
 		})
@@ -84,22 +84,22 @@ func Test_LoadConfig(t *testing.T) {
 func TestConfigureSASL(t *testing.T) {
 	tests := []struct {
 		name           string
-		scram          *config.SCRAM
+		sasl           *config.SASL
 		check          func(*testing.T, *sarama.Config)
 		expectedErrMsg string
 	}{{
 		name: "it should fail if the mechanism is not supported",
-		scram: &config.SCRAM{
-			User:     "admin",
-			Password: "admin123",
-			Type:     "unsupported",
+		sasl: &config.SASL{
+			User:      "admin",
+			Password:  "admin123",
+			Mechanism: "unsupported",
 		},
 		expectedErrMsg: "unrecongnized Salted Challenge Response Authentication Mechanism (SCRAM): 'unsupported'.",
 	}, {
 		name: "it shouldn't enable SASL if user is empty",
-		scram: &config.SCRAM{
-			Password: "admin123",
-			Type:     "SCRAM-SHA-256",
+		sasl: &config.SASL{
+			Password:  "admin123",
+			Mechanism: "SCRAM-SHA-256",
 		},
 		check: func(st *testing.T, cfg *sarama.Config) {
 			require.False(st, cfg.Net.SASL.Enable, "cfg.Net.SASL.Enable")
@@ -110,9 +110,9 @@ func TestConfigureSASL(t *testing.T) {
 		},
 	}, {
 		name: "it shouldn't enable SASL if password is empty",
-		scram: &config.SCRAM{
-			User: "user1",
-			Type: "SCRAM-SHA-256",
+		sasl: &config.SASL{
+			User:      "user1",
+			Mechanism: "SCRAM-SHA-256",
 		},
 		check: func(st *testing.T, cfg *sarama.Config) {
 			require.False(st, cfg.Net.SASL.Enable, "cfg.Net.SASL.Enable")
@@ -123,7 +123,7 @@ func TestConfigureSASL(t *testing.T) {
 		},
 	}, {
 		name: "it shouldn't enable SASL if mechanism is empty",
-		scram: &config.SCRAM{
+		sasl: &config.SASL{
 			User:     "user1",
 			Password: "pass",
 		},
@@ -136,20 +136,20 @@ func TestConfigureSASL(t *testing.T) {
 		},
 	}, {
 		name: "it should set the appropriate mechanism for SCRAM-SHA-256",
-		scram: &config.SCRAM{
-			User:     "user1",
-			Password: "pass",
-			Type:     "SCRAM-SHA-256",
+		sasl: &config.SASL{
+			User:      "user1",
+			Password:  "pass",
+			Mechanism: "SCRAM-SHA-256",
 		},
 		check: func(st *testing.T, cfg *sarama.Config) {
 			require.Equal(st, sarama.SASLTypeSCRAMSHA256, string(cfg.Net.SASL.Mechanism))
 		},
 	}, {
 		name: "it should set the appropriate mechanism for SCRAM-SHA-512",
-		scram: &config.SCRAM{
-			User:     "user1",
-			Password: "pass",
-			Type:     "SCRAM-SHA-512",
+		sasl: &config.SASL{
+			User:      "user1",
+			Password:  "pass",
+			Mechanism: "SCRAM-SHA-512",
 		},
 		check: func(st *testing.T, cfg *sarama.Config) {
 			require.Equal(st, sarama.SASLTypeSCRAMSHA512, string(cfg.Net.SASL.Mechanism))
@@ -157,7 +157,7 @@ func TestConfigureSASL(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(st *testing.T) {
-			res, err := kafka.ConfigureSASL(kafka.DefaultConfig(), tt.scram)
+			res, err := kafka.ConfigureSASL(kafka.DefaultConfig(), tt.sasl)
 			if tt.expectedErrMsg != "" {
 				require.EqualError(st, err, tt.expectedErrMsg)
 				return

--- a/src/go/rpk/pkg/tls/tls.go
+++ b/src/go/rpk/pkg/tls/tls.go
@@ -3,19 +3,27 @@ package tls
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"io/ioutil"
 )
 
 func LoadTLSConfig(
 	truststoreFile, certFile, keyFile string,
 ) (*tls.Config, error) {
-	caCertPool, err := LoadRootCACert(truststoreFile)
-	if err != nil {
-		return nil, err
+	var err error
+	var caCertPool *x509.CertPool
+	var certs []tls.Certificate
+	if truststoreFile != "" {
+		caCertPool, err = LoadRootCACert(truststoreFile)
+		if err != nil {
+			return nil, err
+		}
 	}
-	certs, err := LoadCert(certFile, keyFile)
-	if err != nil {
-		return nil, err
+	if certFile != "" && keyFile != "" {
+		certs, err = LoadCert(certFile, keyFile)
+		if err != nil {
+			return nil, err
+		}
 	}
 	tlsConf := &tls.Config{RootCAs: caCertPool, Certificates: certs}
 
@@ -42,15 +50,29 @@ func LoadCert(certFile, keyFile string) ([]tls.Certificate, error) {
 }
 
 func BuildTLSConfig(
+	enableTLS bool,
 	certFile, keyFile, truststoreFile string,
 ) (*tls.Config, error) {
-	var tlsConfig *tls.Config
+	tlsConfig := &tls.Config{}
 	var err error
 
 	switch {
+	case certFile != "" && keyFile == "":
+		return nil, errors.New(
+			"if a TLS client certificate is set, then its key must be passed to" +
+				" enable TLS authentication",
+		)
+	case keyFile != "" && certFile == "":
+		return nil, errors.New(
+			"if a TLS client certificate key is set, then its certificate must be" +
+				" passed to enable TLS authentication",
+		)
 	case certFile == "" &&
 		keyFile == "" &&
 		truststoreFile == "":
+		if enableTLS {
+			return tlsConfig, nil
+		}
 		return nil, nil
 
 	case certFile != "" &&


### PR DESCRIPTION
As rpk has evolved, new features have been added (and will probably be added) which don't require that a local node or cluster be present. Therefore, there should be ways of configuring rpk so that it knows which addresses to use when running any of the `rpk topic` commands, as well as which TLS configuration to use when making requests to the Kafka API or the Redpanda Admin API.

The current config structure does have an `rpk.tls` field, but this doesn't support the case when the Kafka API and the Redpanda Admin API use different sets of TLS certificates (which is the recommended setup). 

Furthermore, currently if the `--brokers` flag isn't passed, `rpk` tries to look for them in the `redpanda.kafka_api` field, which isn't very intuitive for someone who is only using rpk as a client CLI (configuring something in the `redpanda` section even if they're not necessarily running redpanda locally).

The new proposed structure this PR introduces is as follows

```yaml
rpk:
  # The Kafka API configuration
  kafka_api:
    # A list of broker addresses that rpk will use
    brokers:
    - 192.168.72.34:9092
    - 192.168.72.35:9092
    # The TLS configuration to be used when with the Kafka API
    tls:
      cert_file: ~/certs/cert.pem
      key_file: ~/certs/key.pem
      truststore_file: ~/certs/ca.pem
    # The SASL config, if enabled in the brokers.
    sasl:
      user: user
      password: pass
      method: scram-sha256

  # The Admin API configuration
  admin_api:
    # A list of the nodes' admin API addresses that rpk will use.
    # NOTE: This can be reduced to just one address when request forwarding for the admin API lands in redpanda.
    addresses:
    - 192.168.72.34:9644
    - 192.168.72.35:9644
    # The TLS configuration to be used when with the Admin API
    tls:
      cert_file: ~/certs/admin-cert.pem
      key_file: ~/certs/admin-key.pem
      truststore_file: ~/certs/admin-ca.pem
```

**NOTE** this change isn't backwards compatible, since `rpk.scram` is moved to `rpk.kafka_api.scram`, and `rpk.tls` is now at either `rpk.kafka_api.tls` or `rpk.admin_api.tls`. However, it doesn't affect redpanda itself, only rpk, and is solved by updating the config file.

Fix #1099
