### PR TITLE
Adds pre-prepare auto abort for data partitions

### DIFF
--- a/src/v/cluster/rm_partition_frontend.h
+++ b/src/v/cluster/rm_partition_frontend.h
@@ -38,6 +38,7 @@ public:
       model::ntp,
       model::producer_identity,
       model::tx_seq,
+      std::chrono::milliseconds,
       model::timeout_clock::duration);
     ss::future<prepare_tx_reply> prepare_tx(
       model::ntp,
@@ -75,9 +76,13 @@ private:
       model::ntp,
       model::producer_identity,
       model::tx_seq,
+      std::chrono::milliseconds,
       model::timeout_clock::duration);
-    ss::future<begin_tx_reply>
-      do_begin_tx(model::ntp, model::producer_identity, model::tx_seq);
+    ss::future<begin_tx_reply> do_begin_tx(
+      model::ntp,
+      model::producer_identity,
+      model::tx_seq,
+      std::chrono::milliseconds);
     ss::future<prepare_tx_reply> dispatch_prepare_tx(
       model::node_id,
       model::ntp,

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -523,6 +523,10 @@ ss::future<tx_errc> rm_stm::do_abort_tx(
         co_return tx_errc::stale;
     }
 
+    if (!is_known_session(pid)) {
+        co_return tx_errc::none;
+    }
+
     auto origin = get_abort_origin(pid, tx_seq);
     if (origin == abort_origin::past) {
         // rejecting a delayed abort command to prevent aborting

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -173,15 +173,20 @@ rm_stm::rm_stm(ss::logger& logger, raft::consensus* c)
     }
 }
 
-ss::future<checked<model::term_id, tx_errc>>
-rm_stm::begin_tx(model::producer_identity pid, model::tx_seq tx_seq) {
-    return get_tx_lock(pid.get_id())->with([this, pid, tx_seq]() {
-        return do_begin_tx(pid, tx_seq);
-    });
+ss::future<checked<model::term_id, tx_errc>> rm_stm::begin_tx(
+  model::producer_identity pid,
+  model::tx_seq tx_seq,
+  std::chrono::milliseconds transaction_timeout_ms) {
+    return get_tx_lock(pid.get_id())
+      ->with([this, pid, tx_seq, transaction_timeout_ms]() {
+          return do_begin_tx(pid, tx_seq, transaction_timeout_ms);
+      });
 }
 
-ss::future<checked<model::term_id, tx_errc>>
-rm_stm::do_begin_tx(model::producer_identity pid, model::tx_seq tx_seq) {
+ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
+  model::producer_identity pid,
+  model::tx_seq tx_seq,
+  std::chrono::milliseconds transaction_timeout_ms) {
     if (!co_await sync(_sync_timeout)) {
         co_return tx_errc::stale;
     }

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -80,8 +80,8 @@ public:
 
     explicit rm_stm(ss::logger&, raft::consensus*);
 
-    ss::future<checked<model::term_id, tx_errc>>
-      begin_tx(model::producer_identity, model::tx_seq);
+    ss::future<checked<model::term_id, tx_errc>> begin_tx(
+      model::producer_identity, model::tx_seq, std::chrono::milliseconds);
     ss::future<tx_errc> prepare_tx(
       model::term_id,
       model::partition_id,
@@ -103,8 +103,8 @@ public:
       raft::replicate_options);
 
 private:
-    ss::future<checked<model::term_id, tx_errc>>
-      do_begin_tx(model::producer_identity, model::tx_seq);
+    ss::future<checked<model::term_id, tx_errc>> do_begin_tx(
+      model::producer_identity, model::tx_seq, std::chrono::milliseconds);
     ss::future<tx_errc> do_prepare_tx(
       model::term_id,
       model::partition_id,

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -130,6 +130,8 @@ private:
 
     void compact_snapshot();
 
+    ss::future<bool> sync(model::timeout_clock::duration);
+
     abort_origin
     get_abort_origin(const model::producer_identity&, model::tx_seq) const;
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -137,6 +137,8 @@ private:
     void compact_snapshot();
 
     ss::future<bool> sync(model::timeout_clock::duration);
+    void became_leader();
+    void lost_leadership();
 
     void track_tx(model::producer_identity, std::chrono::milliseconds);
     void abort_old_txes();
@@ -258,6 +260,7 @@ private:
     std::chrono::milliseconds _sync_timeout;
     model::violation_recovery_policy _recovery_policy;
     std::chrono::milliseconds _transactional_id_expiration;
+    bool _is_leader{false};
 };
 
 } // namespace cluster

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -92,7 +92,13 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
 
     auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid2, tx_seq).get0();
+    auto term_op = stm
+                     .begin_tx(
+                       pid2,
+                       tx_seq,
+                       std::chrono::milliseconds(
+                         std::numeric_limits<int32_t>::max()))
+                     .get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid2, 0, 5, true);
@@ -156,7 +162,13 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
 
     auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid2, tx_seq).get0();
+    auto term_op = stm
+                     .begin_tx(
+                       pid2,
+                       tx_seq,
+                       std::chrono::milliseconds(
+                         std::numeric_limits<int32_t>::max()))
+                     .get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid2, 0, 5, true);
@@ -222,7 +234,13 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     BOOST_REQUIRE_LT(first_offset, stm.last_stable_offset());
 
     auto pid2 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid2, tx_seq).get0();
+    auto term_op = stm
+                     .begin_tx(
+                       pid2,
+                       tx_seq,
+                       std::chrono::milliseconds(
+                         std::numeric_limits<int32_t>::max()))
+                     .get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid2, 0, 5, true);
@@ -319,11 +337,23 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid20, tx_seq).get0();
+    auto term_op = stm
+                     .begin_tx(
+                       pid20,
+                       tx_seq,
+                       std::chrono::milliseconds(
+                         std::numeric_limits<int32_t>::max()))
+                     .get0();
     BOOST_REQUIRE((bool)term_op);
 
     auto pid21 = model::producer_identity{.id = 2, .epoch = 1};
-    term_op = stm.begin_tx(pid21, tx_seq).get0();
+    term_op = stm
+                .begin_tx(
+                  pid21,
+                  tx_seq,
+                  std::chrono::milliseconds(
+                    std::numeric_limits<int32_t>::max()))
+                .get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid20, 0, 5, true);
@@ -361,7 +391,13 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
     BOOST_REQUIRE((bool)offset_r);
 
     auto pid20 = model::producer_identity{.id = 2, .epoch = 0};
-    auto term_op = stm.begin_tx(pid20, tx_seq).get0();
+    auto term_op = stm
+                     .begin_tx(
+                       pid20,
+                       tx_seq,
+                       std::chrono::milliseconds(
+                         std::numeric_limits<int32_t>::max()))
+                     .get0();
     BOOST_REQUIRE((bool)term_op);
 
     rreader = make_rreader(pid20, 0, 5, true);

--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -57,7 +57,9 @@ FIXTURE_TEST(test_tm_stm_new_tx, mux_state_machine_fixture) {
     auto tx_id = kafka::transactional_id("app-id-1");
     auto pid = model::producer_identity{.id = 1, .epoch = 0};
 
-    auto op_code = stm.register_new_producer(tx_id, pid).get0();
+    auto op_code
+      = stm.register_new_producer(tx_id, std::chrono::milliseconds(0), pid)
+          .get0();
     BOOST_REQUIRE_EQUAL(op_code, op_status::success);
     auto tx1 = expect_tx(stm.get_tx(tx_id));
     BOOST_REQUIRE_EQUAL(tx1.id, tx_id);
@@ -114,7 +116,9 @@ FIXTURE_TEST(test_tm_stm_seq_tx, mux_state_machine_fixture) {
     auto tx_id = kafka::transactional_id("app-id-1");
     auto pid = model::producer_identity{.id = 1, .epoch = 0};
 
-    auto op_code = stm.register_new_producer(tx_id, pid).get0();
+    auto op_code
+      = stm.register_new_producer(tx_id, std::chrono::milliseconds(0), pid)
+          .get0();
     BOOST_REQUIRE_EQUAL(op_code, op_status::success);
     auto tx1 = expect_tx(stm.get_tx(tx_id));
     std::vector<tm_transaction::tx_partition> partitions = {
@@ -151,7 +155,9 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
     auto tx_id = kafka::transactional_id("app-id-1");
     auto pid1 = model::producer_identity{.id = 1, .epoch = 0};
 
-    auto op_code = stm.register_new_producer(tx_id, pid1).get0();
+    auto op_code
+      = stm.register_new_producer(tx_id, std::chrono::milliseconds(0), pid1)
+          .get0();
     BOOST_REQUIRE(op_code == op_status::success);
     auto tx1 = expect_tx(stm.get_tx(tx_id));
     std::vector<tm_transaction::tx_partition> partitions = {
@@ -168,7 +174,9 @@ FIXTURE_TEST(test_tm_stm_re_tx, mux_state_machine_fixture) {
     auto tx5 = expect_tx(stm.mark_tx_ongoing(tx_id));
 
     auto pid2 = model::producer_identity{.id = 1, .epoch = 1};
-    op_code = stm.re_register_producer(tx_id, pid2).get0();
+    op_code = stm
+                .re_register_producer(tx_id, std::chrono::milliseconds(0), pid2)
+                .get0();
     BOOST_REQUIRE_EQUAL(op_code, op_status::success);
     auto tx6 = expect_tx(stm.get_tx(tx_id));
     BOOST_REQUIRE_EQUAL(tx6.id, tx_id);

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -39,7 +39,8 @@ struct tm_transaction {
         ongoing,
         preparing,
         prepared,
-        aborting,
+        aborting, // abort is initiated by a client
+        killed,   // abort is initiated by a timeout
         ready,
     };
 

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -71,6 +71,7 @@ struct tm_transaction {
     // only in memory (partitions and groups).
     model::term_id etag;
     tx_status status;
+    std::chrono::milliseconds timeout_ms;
     std::vector<tx_partition> partitions;
     std::vector<tx_group> groups;
 
@@ -117,10 +118,14 @@ public:
       mark_tx_ready(kafka::transactional_id, model::term_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       try_change_status(kafka::transactional_id, tm_transaction::tx_status);
-    ss::future<tm_stm::op_status>
-      re_register_producer(kafka::transactional_id, model::producer_identity);
-    ss::future<tm_stm::op_status>
-      register_new_producer(kafka::transactional_id, model::producer_identity);
+    ss::future<tm_stm::op_status> re_register_producer(
+      kafka::transactional_id,
+      std::chrono::milliseconds,
+      model::producer_identity);
+    ss::future<tm_stm::op_status> register_new_producer(
+      kafka::transactional_id,
+      std::chrono::milliseconds,
+      model::producer_identity);
 
     // before calling a tm_stm modifying operation a caller should
     // take get_tx_lock mutex

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -35,13 +35,13 @@ tx_gateway::tx_gateway(
 ss::future<init_tm_tx_reply>
 tx_gateway::init_tm_tx(init_tm_tx_request&& request, rpc::streaming_context&) {
     return _tx_gateway_frontend.local().init_tm_tx_locally(
-      request.tx_id, request.timeout);
+      request.tx_id, request.transaction_timeout_ms, request.timeout);
 }
 
 ss::future<begin_tx_reply>
 tx_gateway::begin_tx(begin_tx_request&& request, rpc::streaming_context&) {
     return _rm_partition_frontend.local().do_begin_tx(
-      request.ntp, request.pid, request.tx_seq);
+      request.ntp, request.pid, request.tx_seq, request.transaction_timeout_ms);
 }
 
 ss::future<prepare_tx_reply>

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -873,7 +873,7 @@ ss::future<tx_errc> tx_gateway_frontend::reabort_tm_tx(
           _rm_group_proxy->abort_group_tx(group.group_id, tx.pid, timeout));
     }
     auto prs = co_await when_all_succeed(pfs.begin(), pfs.end());
-    auto grs = co_await when_all_succeed(pfs.begin(), pfs.end());
+    auto grs = co_await when_all_succeed(gfs.begin(), gfs.end());
     auto ok = true;
     for (const auto& r : prs) {
         ok = ok && (r.ec == tx_errc::none);

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -40,10 +40,14 @@ public:
       ss::sharded<cluster::rm_partition_frontend>&);
 
     ss::future<std::optional<model::node_id>> get_tx_broker();
-    ss::future<init_tm_tx_reply>
-      init_tm_tx(kafka::transactional_id, model::timeout_clock::duration);
+    ss::future<init_tm_tx_reply> init_tm_tx(
+      kafka::transactional_id,
+      std::chrono::milliseconds transaction_timeout_ms,
+      model::timeout_clock::duration);
     ss::future<cluster::init_tm_tx_reply> init_tm_tx_locally(
-      kafka::transactional_id, model::timeout_clock::duration);
+      kafka::transactional_id,
+      std::chrono::milliseconds,
+      model::timeout_clock::duration);
     ss::future<add_paritions_tx_reply> add_partition_to_tx(
       add_paritions_tx_request, model::timeout_clock::duration);
     ss::future<add_offsets_tx_reply>
@@ -77,12 +81,19 @@ private:
       model::timeout_clock::duration);
 
     ss::future<cluster::init_tm_tx_reply> dispatch_init_tm_tx(
-      model::node_id, kafka::transactional_id, model::timeout_clock::duration);
+      model::node_id,
+      kafka::transactional_id,
+      std::chrono::milliseconds,
+      model::timeout_clock::duration);
     ss::future<cluster::init_tm_tx_reply> do_init_tm_tx(
-      ss::shard_id, kafka::transactional_id, model::timeout_clock::duration);
+      ss::shard_id,
+      kafka::transactional_id,
+      std::chrono::milliseconds,
+      model::timeout_clock::duration);
     ss::future<cluster::init_tm_tx_reply> do_init_tm_tx(
       ss::shared_ptr<tm_stm>,
       kafka::transactional_id,
+      std::chrono::milliseconds,
       model::timeout_clock::duration);
 
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_end_txn(

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -21,6 +21,7 @@
 #include "config/configuration.h"
 #include "model/metadata.h"
 #include "seastarx.h"
+#include "utils/available_promise.h"
 
 namespace cluster {
 
@@ -100,17 +101,17 @@ private:
       end_tx_request,
       ss::shared_ptr<cluster::tm_stm>,
       model::timeout_clock::duration,
-      ss::lw_shared_ptr<ss::shared_promise<tx_errc>>);
+      ss::lw_shared_ptr<available_promise<tx_errc>>);
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_abort_tm_tx(
       ss::shared_ptr<cluster::tm_stm>,
       cluster::tm_transaction,
       model::timeout_clock::duration,
-      ss::lw_shared_ptr<ss::shared_promise<tx_errc>>);
+      ss::lw_shared_ptr<available_promise<tx_errc>>);
     ss::future<checked<cluster::tm_transaction, tx_errc>> do_commit_tm_tx(
       ss::shared_ptr<cluster::tm_stm>,
       cluster::tm_transaction,
       model::timeout_clock::duration,
-      ss::lw_shared_ptr<ss::shared_promise<tx_errc>>);
+      ss::lw_shared_ptr<available_promise<tx_errc>>);
     ss::future<tx_errc>
       recommit_tm_tx(tm_transaction, model::timeout_clock::duration);
     ss::future<tx_errc>

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -130,6 +130,7 @@ inline std::error_code make_error_code(tx_errc e) noexcept {
 
 struct init_tm_tx_request {
     kafka::transactional_id tx_id;
+    std::chrono::milliseconds transaction_timeout_ms;
     model::timeout_clock::duration timeout;
 };
 struct init_tm_tx_reply {
@@ -180,6 +181,7 @@ struct begin_tx_request {
     model::ntp ntp;
     model::producer_identity pid;
     model::tx_seq tx_seq;
+    std::chrono::milliseconds transaction_timeout_ms;
 };
 struct begin_tx_reply {
     model::ntp ntp;

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -245,6 +245,9 @@ path_type_map = {
             },
         },
     },
+    "InitProducerIdRequestData": {
+        "TransactionTimeoutMs": ("std::chrono::milliseconds", "int32")
+    },
 }
 
 # a few kafka field types specify an entity type

--- a/src/v/kafka/server/handlers/init_producer_id.cc
+++ b/src/v/kafka/server/handlers/init_producer_id.cc
@@ -45,6 +45,7 @@ ss::future<response_ptr> init_producer_id_handler::handle(
             return ctx.tx_gateway_frontend()
               .init_tm_tx(
                 request.data.transactional_id.value(),
+                request.data.transaction_timeout_ms,
                 config::shard_local_cfg().create_topic_timeout_ms())
               .then([&ctx](cluster::init_tm_tx_reply r) {
                   init_producer_id_response reply;

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -423,9 +423,11 @@ struct producer_identity {
     int64_t id{-1};
     int16_t epoch{0};
 
-    model::producer_id get_id() { return model::producer_id(id); }
+    model::producer_id get_id() const { return model::producer_id(id); }
 
-    model::producer_epoch get_epoch() { return model::producer_epoch(epoch); }
+    model::producer_epoch get_epoch() const {
+        return model::producer_epoch(epoch);
+    }
 
     auto operator<=>(const producer_identity&) const = default;
 

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -62,7 +62,7 @@ public:
     // start after ready to receive batches through apply upcall.
     virtual ss::future<> start();
 
-    ss::future<> stop();
+    virtual ss::future<> stop();
 
     // wait until at least offset is applied to state machine
     ss::future<> wait(model::offset, model::timeout_clock::time_point);

--- a/src/v/utils/available_promise.h
+++ b/src/v/utils/available_promise.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+template<typename T>
+class available_promise {
+public:
+    ss::future<T> get_future() { return _promise.get_future(); }
+
+    void set_value(T&& value) {
+        _available = true;
+        _promise.set_value(std::move(value));
+    }
+
+    bool available() { return _available; }
+
+private:
+    bool _available{false};
+    ss::promise<T> _promise;
+};


### PR DESCRIPTION
Because Kafka transactions don't support preconditions it allows to execute multiple transactions in parallel without the conflicts.

The earliest ongoing transaction defines the last stable offset, a barrier the clients with read committed isolation level can't pass. So when the earliest transaction gets stuck it blocks the readers from making progress even if the later transactions are committed.

Kafka protocol supports `transaction.timeout.ms` to let a transaction to be auto-aborted on the server side when it was idle for the specified period.

The obvious place to put auto abort logic is the txn coordinator. But because Redpanda keeps as much as possible of transient data in memory (to avoid unnecessary disk IO) the txn coordinator may lose information about the ongoing transactions and won't be able to auto abort them.

This PR puts auto abort logic on the data partition. If a data partition decides to abort a transaction before it receives a prepare request from the coordinator it may do it locally without communicating with it. Once a transaction is prepared there is a risk that it is already committed and instead of aborting we need to roll it forward. This will be covered in a separate PR see https://app.clubhouse.io/vectorized/story/2191 for more information.

The most important commits are:

  * "tx coordinator: pass transaction_timeout_ms to rm_stm"
  * "kafka/tx: integrate pre-prepare auto aborts with rm_stm"

The rest are re-factorings and bug fixes in the related area.

[ch2188]