### PR TITLE
Retruning at least one message even if it exceeds max_bytes limit.

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -296,7 +296,13 @@ static void fill_fetch_responses(
         resp.high_watermark = res.high_watermark;
         resp.last_stable_offset = res.last_stable_offset;
 
-        if (res.has_data() && octx.bytes_left >= res.data_size_bytes()) {
+        /**
+         * According to KIP-74 we have to return first batch even if it would
+         * violate max_bytes fetch parameter
+         */
+        if (
+          res.has_data()
+          && (octx.bytes_left >= res.data_size_bytes() || octx.response_size == 0)) {
             /**
              * set aborted transactions if present
              */


### PR DESCRIPTION
## Cover letter 
According to [KiP-74](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65864887) fetch API should always return at least one message even if its size exceed the `max_bytes` limit.


KiPs: [KiP-74](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65864887)

Fixes: #NNN, #NNN, ...

## Release notes
N/A