### PR TITLE
ducktape: Rename docker network used in tests

### DIFF
--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -146,7 +146,7 @@ tasks:
     - mkdir -p '{{.BUILD_ROOT}}/ducktape/config/metadata'
     - docker run --rm --privileged
         --name ducktape
-        --network redpanda
+        --network redpanda-test
         --volume '{{.BUILD_ROOT}}/ducktape/config/:/root/.ducktape/'
         --volume '{{.BUILD_ROOT}}/ducktape/:/build/tests/'
         --volume '{{.BUILD_ROOT}}:{{.BUILD_ROOT}}'

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 
 networks:
-  redpanda:
-    name: redpanda
+  redpanda-test:
+    name: redpanda-test
     driver: bridge
 
 services:
@@ -27,7 +27,7 @@ services:
       timeout: 20s
     image: minio/minio:RELEASE.2021-03-26T00-00-41Z
     networks:
-    - redpanda
+    - redpanda-test
 
   n1: &node
     image: vectorized/redpanda-test-node
@@ -37,7 +37,7 @@ services:
     volumes:
     - '${BUILD_ROOT}:${BUILD_ROOT}'
     networks:
-    - redpanda
+    - redpanda-test
   n2: *node
   n3: *node
   n4: *node


### PR DESCRIPTION
Rename the docker network used in tests from "redpanda" to "redpanda-tests" to prevent it from colliding with `rpk container`.
