### PR TITLE
Support concurrent appends and flushes in storage

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -529,9 +529,10 @@ ss::future<> segment_appender::flush() {
 
     vassert(
       file_byte_offset() <= _stable_offset,
-      "No inflight writes but eof {} > stable offset {}",
+      "No inflight writes but eof {} > stable offset {}: {}",
       file_byte_offset(),
-      _stable_offset);
+      _stable_offset,
+      *this);
 
     return _out.flush().handle_exception([this](std::exception_ptr e) {
         vassert(false, "Could not flush: {} - {}", e, *this);

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -109,6 +109,7 @@ private:
     size_t _bytes_flush_pending{0};
     ss::semaphore _concurrent_flushes;
     ss::lw_shared_ptr<chunk> _head;
+    ss::lw_shared_ptr<ss::semaphore> _prev_head_write;
 
     struct inflight_write {
         bool done;

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -111,6 +111,21 @@ private:
     ss::lw_shared_ptr<chunk> _head;
     ss::lw_shared_ptr<ss::semaphore> _prev_head_write;
 
+    struct flush_op {
+        explicit flush_op(size_t offset)
+          : offset(offset) {}
+        size_t offset;
+        ss::promise<> p;
+    };
+
+    std::vector<flush_op> _flush_ops;
+    size_t _flushed_offset{0};
+    size_t _stable_offset{0};
+
+    // like flush, but wait on fibers. used by truncate() and close() which are
+    // still heavy weight operations compared to regular flush()
+    ss::future<> hard_flush();
+
     struct inflight_write {
         bool done;
         size_t offset;
@@ -122,7 +137,9 @@ private:
 
     ss::chunked_fifo<ss::lw_shared_ptr<inflight_write>> _inflight;
     callbacks* _callbacks = nullptr;
-    void maybe_advance_stable_offset(const ss::lw_shared_ptr<inflight_write>&);
+    ss::future<>
+    maybe_advance_stable_offset(const ss::lw_shared_ptr<inflight_write>&);
+    ss::future<> process_flush_ops(size_t);
 
     ss::timer<ss::lowres_clock> _inactive_timer;
     void handle_inactive_timer();

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -126,7 +126,6 @@ private:
 
     ss::timer<ss::lowres_clock> _inactive_timer;
     void handle_inactive_timer();
-    bool _previously_inactive = false;
 
     friend std::ostream& operator<<(std::ostream&, const segment_appender&);
 };

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -601,7 +601,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
       offsets,
       std::move(reader),
       std::move(index),
-      std::nullopt,
+      nullptr,
       std::nullopt,
       std::nullopt);
 }

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -45,14 +45,14 @@ struct context {
         fd = ss::file(ss::make_shared(file_io_sanitizer(std::move(fd))));
         fidx = ss::file(ss::make_shared(file_io_sanitizer(std::move(fidx))));
 
-        auto appender = segment_appender(
+        auto appender = std::make_unique<segment_appender>(
           fd, segment_appender::options(ss::default_priority_class(), 1));
         auto indexer = segment_index(
           base_name + ".index", std::move(fidx), base, 4096);
         auto reader = segment_reader(
           base_name,
           ss::open_file_dma(base_name, ss::open_flags::ro).get0(),
-          appender.file_byte_offset(),
+          appender->file_byte_offset(),
           128);
         _seg = ss::make_lw_shared<segment>(
           segment::offset_tracker(model::term_id(0), base),


### PR DESCRIPTION
Adds support to the segment appender for dispatching appends before previous flushes complete.

Fixes: #1538 