### PR TITLE
k/replicated_partition: forwarding finally to underlying reader

### DIFF
--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -73,6 +73,8 @@ ss::future<model::record_batch_reader> replicated_partition::make_reader(
             });
         }
 
+        ss::future<> finally() noexcept final { return _underlying->finally(); }
+
     private:
         std::unique_ptr<model::record_batch_reader::impl> _underlying;
         ss::lw_shared_ptr<offset_translator> _translator;


### PR DESCRIPTION
The `log_reader::impl::finally()` have to be forwarded to underlying
reader since when reader life cycle isn't managed by
`storage::log_readers_cache` we have to close underlying reader.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
