### PR TITLE
operator: Add init container resources

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -332,6 +332,10 @@ func (r *StatefulSetResource) obj() (k8sclient.Object, error) {
 								RunAsUser:  pointer.Int64Ptr(userID),
 								RunAsGroup: pointer.Int64Ptr(groupID),
 							},
+							Resources: corev1.ResourceRequirements{
+								Limits:   r.pandaCluster.Spec.Resources.Limits,
+								Requests: r.pandaCluster.Spec.Resources.Requests,
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "config-dir",


### PR DESCRIPTION
## Cover letter

This commit moves towards CPU static policy management. This will allow users
to assign containers to CPUs cores exclusively.

User needs to understand that in order to run Redpanda on exclusive CPUs cores
the cluster custom resource needs to have integer value for CPU requests and
whole requests needs to equal limits (including memory and cpu).

REF:
https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed
https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy

Fixes #1549

## Release notes

Release note: Users can create Redpanda containers in Guaranteed QoS class.
