### PR TITLE
redpanda/configuration: Allow cluster_id to be configurable

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -188,6 +188,10 @@ redpanda:
   # Default: 2GiB
   target_quota_byte_rate: 2147483648
   
+  # Cluster identifier.
+  # Default: null
+  cluster_id: "cluster-id"
+
   # Rack identifier.
   # Default: null
   rack: "rack-id"

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -192,6 +192,8 @@ configuration::configuration()
       "Target quota byte rate (bytes per second) - 2GB default",
       required::no,
       2_GiB)
+  , cluster_id(
+      *this, "cluster_id", "Cluster identifier", required::no, std::nullopt)
   , rack(*this, "rack", "Rack identifier", required::no, std::nullopt)
   , dashboard_dir(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -76,6 +76,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> default_window_sec;
     property<std::chrono::milliseconds> quota_manager_gc_sec;
     property<uint32_t> target_quota_byte_rate;
+    property<std::optional<ss::sstring>> cluster_id;
     property<std::optional<ss::sstring>> rack;
     property<std::optional<ss::sstring>> dashboard_dir;
     property<bool> disable_metrics;

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -232,8 +232,7 @@ ss::future<response_ptr> metadata_handler::handle(
         }
     }
 
-    // FIXME:  #95 Cluster Id
-    reply.data.cluster_id = std::nullopt;
+    reply.data.cluster_id = config::shard_local_cfg().cluster_id;
 
     auto leader_id = ctx.metadata_cache().get_controller_leader_id();
     reply.data.controller_id = leader_id.value_or(model::node_id(-1));


### PR DESCRIPTION
## Cover letter

Allow a `cluster_id` to be configured for Metadata Response v2

Fixes: #1559

## Release notes

Release note: Redpanda: Allow a `cluster_id` to be configured for Metadata Response v2
