### PR TITLE
Adds post-prepare auto abort for data partitions

### DIFF
--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -216,7 +216,7 @@ ss::future<bool> id_allocator_frontend::try_create_id_allocator_topic() {
       model::kafka_internal_namespace,
       model::id_allocator_topic,
       1,
-      config::shard_local_cfg().default_topic_replication()};
+      config::shard_local_cfg().id_allocator_replication()};
 
     topic.properties.cleanup_policy_bitflags
       = model::cleanup_policy_bitflags::none;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -33,7 +33,7 @@ class partition_manager;
 /// all raft logic is proxied transparently
 class partition {
 public:
-    explicit partition(consensus_ptr r);
+    partition(consensus_ptr r, ss::sharded<cluster::tx_gateway_frontend>&);
 
     raft::group_id group() const { return _raft->group(); }
     ss::future<> start();
@@ -194,6 +194,7 @@ private:
     ss::shared_ptr<cluster::tm_stm> _tm_stm;
     ss::abort_source _as;
     partition_probe _probe;
+    ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
 
     friend std::ostream& operator<<(std::ostream& o, const partition& x);
 };

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -29,7 +29,9 @@ public:
       = absl::flat_hash_map<model::ntp, ss::lw_shared_ptr<partition>>;
 
     partition_manager(
-      ss::sharded<storage::api>&, ss::sharded<raft::group_manager>&);
+      ss::sharded<storage::api>&,
+      ss::sharded<raft::group_manager>&,
+      ss::sharded<cluster::tx_gateway_frontend>&);
 
     using manage_cb_t
       = ss::noncopyable_function<void(ss::lw_shared_ptr<partition>)>;
@@ -120,6 +122,7 @@ private:
     ntp_table_container _ntp_table;
     absl::flat_hash_map<raft::group_id, ss::lw_shared_ptr<partition>>
       _raft_table;
+    ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
 
     friend std::ostream& operator<<(std::ostream&, const partition_manager&);
 };

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -160,7 +160,10 @@ static model::control_record_type parse_control_batch(model::record_batch& b) {
     return model::control_record_type(key_reader.read_int16());
 }
 
-rm_stm::rm_stm(ss::logger& logger, raft::consensus* c)
+rm_stm::rm_stm(
+  ss::logger& logger,
+  raft::consensus* c,
+  ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend)
   : persisted_stm("rm", logger, c)
   , _oldest_session(model::timestamp::now())
   , _sync_timeout(config::shard_local_cfg().rm_sync_timeout_ms.value())
@@ -168,7 +171,8 @@ rm_stm::rm_stm(ss::logger& logger, raft::consensus* c)
   , _recovery_policy(
       config::shard_local_cfg().rm_violation_recovery_policy.value())
   , _transactional_id_expiration(
-      config::shard_local_cfg().transactional_id_expiration_ms.value()) {
+      config::shard_local_cfg().transactional_id_expiration_ms.value())
+  , _tx_gateway_frontend(tx_gateway_frontend) {
     if (_recovery_policy != crash && _recovery_policy != best_effort) {
         vassert(false, "Unknown recovery policy: {}", _recovery_policy);
     }

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -798,6 +798,9 @@ void rm_stm::became_leader() {
     if (_gate.is_closed()) {
         return;
     }
+    if (!_is_autoabort_enabled) {
+        return;
+    }
     if (!auto_abort_timer.armed()) {
         abort_old_txes();
     }
@@ -813,6 +816,9 @@ void rm_stm::track_tx(
     }
     _mem_state.expiration[pid] = expiration_info{
       .timeout = transaction_timeout_ms, .last_update = clock_type::now()};
+    if (!_is_autoabort_enabled) {
+        return;
+    }
     auto deadline = _mem_state.expiration[pid].deadline();
     if (auto_abort_timer.armed() && auto_abort_timer.get_timeout() > deadline) {
         auto_abort_timer.cancel();

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -108,6 +108,8 @@ public:
 
     ss::future<> stop() override;
 
+    void testing_only_disable_auto_abort() { _is_autoabort_enabled = false; }
+
 private:
     ss::future<checked<model::term_id, tx_errc>> do_begin_tx(
       model::producer_identity, model::tx_seq, std::chrono::milliseconds);
@@ -261,6 +263,7 @@ private:
     model::violation_recovery_policy _recovery_policy;
     std::chrono::milliseconds _transactional_id_expiration;
     bool _is_leader{false};
+    bool _is_autoabort_enabled{true};
 };
 
 } // namespace cluster

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -82,7 +82,10 @@ public:
     static constexpr int8_t prepare_control_record_version{0};
     static constexpr int8_t fence_control_record_version{0};
 
-    explicit rm_stm(ss::logger&, raft::consensus*);
+    explicit rm_stm(
+      ss::logger&,
+      raft::consensus*,
+      ss::sharded<cluster::tx_gateway_frontend>&);
 
     ss::future<checked<model::term_id, tx_errc>> begin_tx(
       model::producer_identity, model::tx_seq, std::chrono::milliseconds);
@@ -265,6 +268,7 @@ private:
     std::chrono::milliseconds _transactional_id_expiration;
     bool _is_leader{false};
     bool _is_autoabort_enabled{true};
+    ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
 };
 
 } // namespace cluster

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -260,6 +260,7 @@ private:
     ss::timer<clock_type> auto_abort_timer;
     model::timestamp _oldest_session;
     std::chrono::milliseconds _sync_timeout;
+    std::chrono::milliseconds _tx_timeout_delay;
     model::violation_recovery_policy _recovery_policy;
     std::chrono::milliseconds _transactional_id_expiration;
     bool _is_leader{false};

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -147,7 +147,7 @@ private:
 
     void track_tx(model::producer_identity, std::chrono::milliseconds);
     void abort_old_txes();
-    ss::future<> abort_old_txes(std::vector<model::producer_identity>);
+    ss::future<> abort_old_txes(absl::btree_set<model::producer_identity>);
     ss::future<> try_abort_old_tx(model::producer_identity);
     ss::future<> do_try_abort_old_tx(model::producer_identity);
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -227,7 +227,7 @@ private:
         absl::flat_hash_map<model::producer_identity, model::tx_seq> expected;
         // `preparing` helps to identify failed prepare requests and use them to
         // filter out stale abort requests
-        absl::flat_hash_map<model::producer_identity, model::tx_seq> preparing;
+        absl::flat_hash_map<model::producer_identity, prepare_marker> preparing;
         absl::flat_hash_map<model::producer_identity, expiration_info>
           expiration;
 

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -35,7 +35,8 @@ FIXTURE_TEST(
   mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -86,7 +87,8 @@ FIXTURE_TEST(
   test_rm_stm_passes_monotonic_in_session_messages, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -136,7 +138,8 @@ FIXTURE_TEST(
 FIXTURE_TEST(test_rm_stm_prevents_duplicates, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -187,7 +190,8 @@ FIXTURE_TEST(test_rm_stm_prevents_duplicates, mux_state_machine_fixture) {
 FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -239,7 +243,8 @@ FIXTURE_TEST(
   test_rm_stm_prevents_odd_session_start_off, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -36,6 +36,7 @@ FIXTURE_TEST(
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -86,6 +87,7 @@ FIXTURE_TEST(
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -135,6 +137,7 @@ FIXTURE_TEST(test_rm_stm_prevents_duplicates, mux_state_machine_fixture) {
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -185,6 +188,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -236,6 +240,7 @@ FIXTURE_TEST(
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -65,6 +65,7 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -135,6 +136,7 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -207,6 +209,7 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -283,6 +286,7 @@ FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -317,6 +321,7 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });
@@ -371,6 +376,7 @@ FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
     start_raft();
 
     cluster::rm_stm stm(logger, _raft.get());
+    stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
     auto stop = ss::defer([&stm] { stm.stop().get0(); });

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -64,7 +64,8 @@ static rich_reader make_rreader(
 FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -135,7 +136,8 @@ FIXTURE_TEST(test_tx_happy_tx, mux_state_machine_fixture) {
 FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -208,7 +210,8 @@ FIXTURE_TEST(test_tx_aborted_tx_1, mux_state_machine_fixture) {
 FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -285,7 +288,8 @@ FIXTURE_TEST(test_tx_aborted_tx_2, mux_state_machine_fixture) {
 FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -320,7 +324,8 @@ FIXTURE_TEST(test_tx_unknown_produce, mux_state_machine_fixture) {
 FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();
@@ -375,7 +380,8 @@ FIXTURE_TEST(test_tx_begin_fences_produce, mux_state_machine_fixture) {
 FIXTURE_TEST(test_tx_post_aborted_produce, mux_state_machine_fixture) {
     start_raft();
 
-    cluster::rm_stm stm(logger, _raft.get());
+    ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    cluster::rm_stm stm(logger, _raft.get(), tx_gateway_frontend);
     stm.testing_only_disable_auto_abort();
 
     stm.start().get0();

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -109,6 +109,15 @@ public:
       kafka::transactional_id, std::vector<tm_transaction::tx_partition>);
     bool add_group(kafka::transactional_id, kafka::group_id, model::term_id);
     bool is_actual_term(model::term_id term) { return _insync_term == term; }
+    std::optional<kafka::transactional_id>
+    get_id_by_pid(model::producer_identity pid) {
+        auto tx_it = _pid_tx_id.find(pid);
+        std::optional<kafka::transactional_id> r;
+        if (tx_it != _pid_tx_id.end()) {
+            r = tx_it->second;
+        }
+        return r;
+    }
 
     ss::future<std::optional<tm_transaction>>
       get_actual_tx(kafka::transactional_id);
@@ -146,6 +155,8 @@ private:
     std::chrono::milliseconds _sync_timeout;
     model::violation_recovery_policy _recovery_policy;
     absl::flat_hash_map<kafka::transactional_id, tm_transaction> _tx_table;
+    absl::flat_hash_map<model::producer_identity, kafka::transactional_id>
+      _pid_tx_id;
     absl::flat_hash_map<kafka::transactional_id, ss::lw_shared_ptr<mutex>>
       _tx_locks;
     ss::future<> apply(model::record_batch b) override;

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -119,6 +119,8 @@ public:
         return r;
     }
 
+    ss::future<bool> barrier();
+
     ss::future<std::optional<tm_transaction>>
       get_actual_tx(kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -32,6 +32,12 @@ tx_gateway::tx_gateway(
   , _rm_group_proxy(group_proxy)
   , _rm_partition_frontend(rm_partition_frontend) {}
 
+ss::future<try_abort_reply>
+tx_gateway::try_abort(try_abort_request&& request, rpc::streaming_context&) {
+    return _tx_gateway_frontend.local().try_abort_locally(
+      request.tm, request.pid, request.tx_seq, request.timeout);
+}
+
 ss::future<init_tm_tx_reply>
 tx_gateway::init_tm_tx(init_tm_tx_request&& request, rpc::streaming_context&) {
     return _tx_gateway_frontend.local().init_tm_tx_locally(

--- a/src/v/cluster/tx_gateway.h
+++ b/src/v/cluster/tx_gateway.h
@@ -39,6 +39,9 @@ public:
     ss::future<init_tm_tx_reply>
     init_tm_tx(init_tm_tx_request&&, rpc::streaming_context&) override;
 
+    ss::future<try_abort_reply>
+    try_abort(try_abort_request&&, rpc::streaming_context&) override;
+
     ss::future<begin_tx_reply>
     begin_tx(begin_tx_request&&, rpc::streaming_context&) override;
 

--- a/src/v/cluster/tx_gateway.json
+++ b/src/v/cluster/tx_gateway.json
@@ -11,6 +11,11 @@
             "output_type": "init_tm_tx_reply"
         },
         {
+            "name": "try_abort",
+            "input_type": "try_abort_request",
+            "output_type": "try_abort_reply"
+        },
+        {
             "name": "begin_tx",
             "input_type": "begin_tx_request",
             "output_type": "begin_tx_reply"

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1246,10 +1246,10 @@ ss::future<bool> tx_gateway_frontend::try_create_tx_topic() {
       model::kafka_internal_namespace,
       model::tx_manager_topic,
       1,
-      config::shard_local_cfg().default_topic_replication()};
+      config::shard_local_cfg().transaction_coordinator_replication()};
 
     topic.properties.cleanup_policy_bitflags
-      = model::cleanup_policy_bitflags::none;
+      = config::shard_local_cfg().transaction_coordinator_cleanup_policy();
 
     return _controller->get_topics_frontend()
       .local()

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -103,6 +103,12 @@ private:
       model::producer_identity,
       model::tx_seq,
       model::timeout_clock::duration);
+    ss::future<try_abort_reply> do_try_abort(
+      ss::shared_ptr<tm_stm>,
+      kafka::transactional_id,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration);
 
     ss::future<cluster::init_tm_tx_reply> dispatch_init_tm_tx(
       model::node_id,
@@ -135,6 +141,12 @@ private:
       cluster::tm_transaction,
       model::timeout_clock::duration,
       ss::lw_shared_ptr<available_promise<tx_errc>>);
+    ss::future<checked<cluster::tm_transaction, tx_errc>> do_commit_tm_tx(
+      ss::shared_ptr<cluster::tm_stm>,
+      kafka::transactional_id,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration);
     ss::future<tx_errc>
       recommit_tm_tx(tm_transaction, model::timeout_clock::duration);
     ss::future<tx_errc>

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -41,6 +41,16 @@ public:
       ss::sharded<cluster::rm_partition_frontend>&);
 
     ss::future<std::optional<model::node_id>> get_tx_broker();
+    ss::future<try_abort_reply> try_abort(
+      model::partition_id,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration);
+    ss::future<try_abort_reply> try_abort_locally(
+      model::partition_id,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration);
     ss::future<init_tm_tx_reply> init_tm_tx(
       kafka::transactional_id,
       std::chrono::milliseconds transaction_timeout_ms,
@@ -79,6 +89,19 @@ private:
       ss::shared_ptr<tm_stm>,
       model::producer_identity,
       kafka::transactional_id,
+      model::timeout_clock::duration);
+
+    ss::future<try_abort_reply> dispatch_try_abort(
+      model::node_id,
+      model::partition_id,
+      model::producer_identity,
+      model::tx_seq,
+      model::timeout_clock::duration);
+    ss::future<try_abort_reply> do_try_abort(
+      ss::shard_id,
+      model::partition_id,
+      model::producer_identity,
+      model::tx_seq,
       model::timeout_clock::duration);
 
     ss::future<cluster::init_tm_tx_reply> dispatch_init_tm_tx(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -128,6 +128,17 @@ inline std::error_code make_error_code(tx_errc e) noexcept {
     return std::error_code(static_cast<int>(e), tx_error_category());
 }
 
+struct try_abort_request {
+    model::partition_id tm;
+    model::producer_identity pid;
+    model::tx_seq tx_seq;
+    model::timeout_clock::duration timeout;
+};
+struct try_abort_reply {
+    bool commited{false};
+    bool aborted{false};
+    tx_errc ec;
+};
 struct init_tm_tx_request {
     kafka::transactional_id tx_id;
     std::chrono::milliseconds transaction_timeout_ms;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -378,6 +378,24 @@ configuration::configuration()
       "Default replication factor for new topics",
       required::no,
       1)
+  , transaction_coordinator_replication(
+      *this,
+      "transaction_coordinator_replication",
+      "Replication factor for a transaction coordinator topic",
+      required::no,
+      1)
+  , id_allocator_replication(
+      *this,
+      "id_allocator_replication",
+      "Replication factor for an id allocator topic",
+      required::no,
+      1)
+  , transaction_coordinator_cleanup_policy(
+      *this,
+      "transaction_coordinator_cleanup_policy",
+      "Cleanup policy for a transaction coordinator topic",
+      required::no,
+      model::cleanup_policy_bitflags::compaction)
   , create_topic_timeout_ms(
       *this,
       "create_topic_timeout_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -282,6 +282,12 @@ configuration::configuration()
       "Time to wait state catch up before rejecting a request",
       required::no,
       2000ms)
+  , tx_timeout_delay_ms(
+      *this,
+      "tx_timeout_delay_ms",
+      "Delay before scheduling next check for timed out transactions",
+      required::no,
+      1000ms)
   , rm_violation_recovery_policy(
       *this,
       "rm_violation_recovery_policy",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -91,6 +91,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> tm_sync_timeout_ms;
     property<model::violation_recovery_policy> tm_violation_recovery_policy;
     property<std::chrono::milliseconds> rm_sync_timeout_ms;
+    property<std::chrono::milliseconds> tx_timeout_delay_ms;
     property<model::violation_recovery_policy> rm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
     property<std::chrono::milliseconds> alter_topic_cfg_timeout_ms;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -110,6 +110,10 @@ struct configuration final : public config_store {
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;
     property<int16_t> default_topic_replication;
+    property<int16_t> transaction_coordinator_replication;
+    property<int16_t> id_allocator_replication;
+    property<model::cleanup_policy_bitflags>
+      transaction_coordinator_cleanup_policy;
     property<std::chrono::milliseconds> create_topic_timeout_ms;
     property<std::chrono::milliseconds> wait_for_leader_timeout_ms;
     property<int32_t> default_topic_partitions;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -511,7 +511,10 @@ void application::wire_up_redpanda_services() {
 
     syschecks::systemd_message("Adding partition manager").get();
     construct_service(
-      partition_manager, std::ref(storage), std::ref(raft_group_manager))
+      partition_manager,
+      std::ref(storage),
+      std::ref(raft_group_manager),
+      std::ref(tx_gateway_frontend))
       .get();
     vlog(_log.info, "Partition manager started");
 


### PR DESCRIPTION
The change aborts transactions which timed out after they reached the prepare state. Unlike with the pre-prepare transactions which we are able to abort locally (lack of the prepare request implies nobody tried to commit them) with the post prepare timeouts we must communicate with the transaction coordinator because we consider a transaction committed after all the data partitions are in the prepared state so depending on the status of the other partitions a post prepared timed out transaction may be rolled forward (committed) or backward (aborted). Only the the transaction coordinator knows the outcome.

[ch2191]