### PR TITLE
Pipelining flush and disk appends in raft 

### DIFF
--- a/src/v/raft/append_entries_buffer.cc
+++ b/src/v/raft/append_entries_buffer.cc
@@ -6,6 +6,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/variant_utils.hh>
 
@@ -75,34 +76,44 @@ ss::future<> append_entries_buffer::flush() {
     auto requests = std::exchange(_requests, {});
     auto response_promises = std::exchange(_responses, {});
 
-    return _consensus._op_lock.with(
+    return _consensus._op_lock.get_units().then(
       [this,
        requests = std::move(requests),
-       response_promises = std::move(response_promises)]() mutable {
-          return do_flush(std::move(requests), std::move(response_promises));
+       response_promises = std::move(response_promises)](
+        ss::semaphore_units<> u) mutable {
+          return do_flush(
+            std::move(requests), std::move(response_promises), std::move(u));
       });
 }
 
 ss::future<> append_entries_buffer::do_flush(
-  request_t requests, response_t response_promises) {
+  request_t requests, response_t response_promises, ss::semaphore_units<> u) {
     bool needs_flush = false;
     std::vector<reply_t> replies;
-    replies.reserve(requests.size());
-    for (auto& req : requests) {
-        if (req.flush) {
-            needs_flush = true;
+    auto f = ss::now();
+    {
+        ss::semaphore_units<> op_lock_units = std::move(u);
+        replies.reserve(requests.size());
+        for (auto& req : requests) {
+            if (req.flush) {
+                needs_flush = true;
+            }
+            try {
+                // NOTE: do_append_entries do not flush
+                auto reply = co_await _consensus.do_append_entries(
+                  std::move(req));
+                replies.emplace_back(reply);
+            } catch (...) {
+                replies.emplace_back(std::current_exception());
+            }
         }
-        try {
-            // NOTE: do_append_entries do not flush
-            auto reply = co_await _consensus.do_append_entries(std::move(req));
-            replies.emplace_back(reply);
-        } catch (...) {
-            replies.emplace_back(std::current_exception());
+        if (needs_flush) {
+            f = _consensus.flush_log();
         }
     }
-    if (needs_flush) {
-        co_await _consensus.flush_log();
-    }
+
+    // units were released before flushing log
+    co_await std::move(f);
 
     propagate_results(std::move(replies), std::move(response_promises));
     _flushed.broadcast();

--- a/src/v/raft/append_entries_buffer.h
+++ b/src/v/raft/append_entries_buffer.h
@@ -4,6 +4,7 @@
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/semaphore.hh>
 
 namespace raft {
 
@@ -136,7 +137,7 @@ private:
     using reply_t = std::variant<append_entries_reply, std::exception_ptr>;
 
     ss::future<> flush();
-    ss::future<> do_flush(request_t, response_t);
+    ss::future<> do_flush(request_t, response_t, ss::semaphore_units<>);
 
     void propagate_results(std::vector<reply_t>, response_t);
 

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -49,7 +49,10 @@ replicate_stages replicate_batcher::replicate(
                    }
 
                    enqueued.set_value();
-                   return _lock.with([this] { return flush(); })
+                   return _lock.get_units()
+                     .then([this](ss::semaphore_units<> u) {
+                         return flush(std::move(u));
+                     })
                      .then([i = f.get()] { return i->_promise.get_future(); });
                })
                .finally([this] { _ptr->_probe.replicate_done(); });
@@ -108,7 +111,6 @@ replicate_batcher::do_cache_with_backpressure(
 
     return ss::get_units(_max_batch_size_sem, std::min(bytes, _max_batch_size))
       .then([this, expected_term, batches = std::move(batches)](
-
               ss::semaphore_units<> u) mutable {
           size_t record_count = 0;
           auto i = ss::make_lw_shared<item>();
@@ -128,16 +130,23 @@ replicate_batcher::do_cache_with_backpressure(
       });
 }
 
-ss::future<> replicate_batcher::flush() {
+ss::future<> replicate_batcher::flush(ss::semaphore_units<> u) {
     auto item_cache = std::exchange(_item_cache, {});
     if (item_cache.empty()) {
         return ss::now();
     }
     return ss::with_gate(
-      _ptr->_bg, [this, item_cache = std::move(item_cache)]() mutable {
+      _ptr->_bg,
+      [this,
+       item_cache = std::move(item_cache),
+       batcher_units = std::move(u)]() mutable {
           return _ptr->_op_lock.get_units().then(
-            [this, item_cache = std::move(item_cache)](
+            [this,
+             item_cache = std::move(item_cache),
+             batcher_units = std::move(batcher_units)](
               ss::semaphore_units<> u) mutable {
+                // release batcher replicate batcher lock
+                batcher_units.return_all();
                 // we have to check if we are the leader
                 // it is critical as term could have been updated already by
                 // vote request and entries from current node could be accepted
@@ -155,8 +164,9 @@ ss::future<> replicate_batcher::flush() {
                 auto const term = model::term_id(meta.term);
                 ss::circular_buffer<model::record_batch> data;
                 std::vector<item_ptr> notifications;
-
+                ss::semaphore_units<> item_memory_units(_max_batch_size_sem, 0);
                 for (auto& n : item_cache) {
+                    item_memory_units.adopt(std::move(n->units));
                     if (
                       !n->expected_term.has_value()
                       || n->expected_term.value() == term) {
@@ -179,10 +189,16 @@ ss::future<> replicate_batcher::flush() {
                   _ptr->_self,
                   std::move(meta),
                   model::make_memory_record_batch_reader(std::move(data)));
+                std::vector<ss::semaphore_units<>> units;
+                units.reserve(2);
+                units.push_back(std::move(u));
+                // we will release memory semaphore as soon as append entry
+                // requests will be dispatched
+                units.push_back(std::move(item_memory_units));
                 return do_flush(
                   std::move(notifications),
                   std::move(req),
-                  std::move(u),
+                  std::move(units),
                   std::move(seqs));
             });
       });
@@ -219,7 +235,7 @@ static void propagate_current_exception(
 ss::future<> replicate_batcher::do_flush(
   std::vector<replicate_batcher::item_ptr>&& notifications,
   append_entries_request&& req,
-  ss::semaphore_units<> u,
+  std::vector<ss::semaphore_units<>> u,
   absl::flat_hash_map<vnode, follower_req_seq> seqs) {
     _ptr->_probe.replicate_batch_flushed();
     auto stm = ss::make_lw_shared<replicate_entries_stm>(

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -48,14 +48,14 @@ public:
     replicate_stages
     replicate(std::optional<model::term_id>, model::record_batch_reader&&);
 
-    ss::future<> flush();
+    ss::future<> flush(ss::semaphore_units<> u);
     ss::future<> stop();
 
     // it will lock on behalf of caller to append entries to leader log.
     ss::future<> do_flush(
       std::vector<item_ptr>&&,
       append_entries_request&&,
-      ss::semaphore_units<>,
+      std::vector<ss::semaphore_units<>>,
       absl::flat_hash_map<vnode, follower_req_seq>);
 
 private:

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -40,37 +40,38 @@ ss::future<append_entries_request> replicate_entries_stm::share_request() {
           });
     });
 }
-ss::future<result<append_entries_reply>> replicate_entries_stm::do_dispatch_one(
-  vnode n,
-  append_entries_request req,
-  ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> units) {
+
+ss::future<result<append_entries_reply>> replicate_entries_stm::flush_log() {
     using ret_t = result<append_entries_reply>;
-
-    if (n == _ptr->_self) {
-        auto f = _ptr->flush_log()
-                   .then([this, units]() {
-                       auto lstats = _ptr->_log.offsets();
-                       auto last_idx = lstats.committed_offset;
-                       append_entries_reply reply;
-                       reply.node_id = _ptr->_self;
-                       reply.target_node_id = _ptr->_self;
-                       reply.group = _ptr->group();
-                       reply.term = _ptr->term();
-                       // we just flushed offsets are the same
-                       reply.last_dirty_log_index = last_idx;
-                       reply.last_committed_log_index = last_idx;
-                       reply.result = append_entries_reply::status::success;
-                       return ret_t(std::move(reply));
-                   })
-                   .handle_exception(
-                     []([[maybe_unused]] const std::exception_ptr& ex) {
-                         return ret_t(errc::leader_flush_failed);
-                     });
-
-        _dispatch_sem.signal();
-        return f;
-    }
-    return send_append_entries_request(n, std::move(req));
+    auto f = _ptr->flush_log()
+               .then([this]() {
+                   /**
+                    * Replicate STM _dirty_offset is set to the dirty offset of
+                    * a log after successfull self append. After flush we are
+                    * certain that data to at least `_dirty_offset` were
+                    * flushed. Sampling offset again right before the flush
+                    * isn't necessary since it will not influence result of
+                    * replication process in current `replicate_entries_stm`
+                    * instance.
+                    */
+                   auto new_committed_offset = _dirty_offset;
+                   append_entries_reply reply;
+                   reply.node_id = _ptr->_self;
+                   reply.target_node_id = _ptr->_self;
+                   reply.group = _ptr->group();
+                   reply.term = _ptr->term();
+                   // we just flushed offsets are the same
+                   reply.last_dirty_log_index = new_committed_offset;
+                   reply.last_committed_log_index = new_committed_offset;
+                   reply.result = append_entries_reply::status::success;
+                   return ret_t(reply);
+               })
+               .handle_exception(
+                 []([[maybe_unused]] const std::exception_ptr& ex) {
+                     return ret_t(errc::leader_flush_failed);
+                 });
+    _dispatch_sem.signal();
+    return f;
 }
 
 clock_type::time_point replicate_entries_stm::append_entries_timeout() {
@@ -94,19 +95,24 @@ replicate_entries_stm::send_append_entries_request(
                      "append_entries_replicate", std::move(reply));
                });
     _dispatch_sem.signal();
-    return f.finally([this, n] {
-        _ptr->update_suppress_heartbeats(
-          n, _followers_seq[n], heartbeats_suppressed::no);
-    });
+    return f
+      .handle_exception([this](const std::exception_ptr& e) {
+          vlog(_ctxlog.warn, "Error while replicating entries {}", e);
+          return result<append_entries_reply>(
+            errc::append_entries_dispatch_error);
+      })
+      .finally([this, n] {
+          _ptr->update_suppress_heartbeats(
+            n, _followers_seq[n], heartbeats_suppressed::no);
+      });
 }
 
-ss::future<> replicate_entries_stm::dispatch_one(
-  vnode id, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> units) {
+ss::future<> replicate_entries_stm::dispatch_one(vnode id) {
     return ss::with_gate(
              _req_bg,
-             [this, id, units]() mutable {
-                 return dispatch_single_retry(id, std::move(units))
-                   .then([this, id](result<append_entries_reply> reply) {
+             [this, id]() mutable {
+                 return dispatch_single_retry(id).then(
+                   [this, id](result<append_entries_reply> reply) {
                        auto it = _followers_seq.find(id);
                        auto seq = it == _followers_seq.end()
                                     ? follower_req_seq(0)
@@ -122,17 +128,15 @@ ss::future<> replicate_entries_stm::dispatch_one(
 }
 
 ss::future<result<append_entries_reply>>
-replicate_entries_stm::dispatch_single_retry(
-  vnode id, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> units) {
-    return share_request()
-      .then([this, id, units](append_entries_request r) mutable {
-          return do_dispatch_one(id, std::move(r), units);
-      })
-      .handle_exception([this](const std::exception_ptr& e) {
-          vlog(_ctxlog.warn, "Error while replicating entries {}", e);
-          return result<append_entries_reply>(
-            errc::append_entries_dispatch_error);
-      });
+replicate_entries_stm::dispatch_single_retry(vnode id) {
+    if (id == _ptr->_self) {
+        return flush_log();
+    } else {
+        return share_request().then(
+          [this, id](append_entries_request r) mutable {
+              return send_append_entries_request(id, std::move(r));
+          });
+    }
 }
 
 ss::future<result<storage::append_result>>
@@ -200,30 +204,27 @@ replicate_entries_stm::apply(ss::semaphore_units<> u) {
           }
           _dirty_offset = append_result.value().last_offset;
           // dispatch requests to followers & leader flush
-          std::vector<ss::semaphore_units<>> vec;
-          vec.push_back(std::move(u));
-          auto units = ss::make_lw_shared<std::vector<ss::semaphore_units<>>>(
-            std::move(vec));
           uint16_t requests_count = 0;
-          cfg.for_each_broker_id(
-            [this, &requests_count, units](const vnode& rni) {
-                // We are not dispatching request to followers that are
-                // recovering
-                if (should_skip_follower_request(rni)) {
-                    vlog(
-                      _ctxlog.trace,
-                      "Skipping sending append request to {}",
-                      rni);
-                    _ptr->update_suppress_heartbeats(
-                      rni, _followers_seq[rni], heartbeats_suppressed::no);
-                    return;
-                }
-                ++requests_count;
-                (void)dispatch_one(rni, units); // background
-            });
+          cfg.for_each_broker_id([this, &requests_count](const vnode& rni) {
+              // We are not dispatching request to followers that are
+              // recovering
+              if (should_skip_follower_request(rni)) {
+                  vlog(
+                    _ctxlog.trace,
+                    "Skipping sending append request to {}",
+                    rni);
+                  _ptr->update_suppress_heartbeats(
+                    rni, _followers_seq[rni], heartbeats_suppressed::no);
+                  return;
+              }
+              ++requests_count;
+              (void)dispatch_one(rni); // background
+          });
           // Wait until all RPCs will be dispatched
           return _dispatch_sem.wait(requests_count)
-            .then([append_result, units]() mutable { return append_result; });
+            .then([append_result, u = std::move(u)]() mutable {
+                return append_result;
+            });
       })
       .then([this](result<storage::append_result> append_result) {
           if (!append_result) {

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -193,7 +193,7 @@ inline bool replicate_entries_stm::should_skip_follower_request(vnode id) {
 }
 
 ss::future<result<replicate_result>>
-replicate_entries_stm::apply(ss::semaphore_units<> u) {
+replicate_entries_stm::apply(std::vector<ss::semaphore_units<>> u) {
     // first append lo leader log, no flushing
     auto cfg = _ptr->config();
     cfg.for_each_broker_id([this](const vnode& rni) {

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -87,9 +87,10 @@ public:
       absl::flat_hash_map<vnode, follower_req_seq>);
     ~replicate_entries_stm();
 
-    /// caller have to pass _op_sem semaphore units, the apply call will do the
+    /// caller have to pass semaphore units, the apply call will do the
     /// fine grained locking on behalf of the caller
-    ss::future<result<replicate_result>> apply(ss::semaphore_units<>);
+    ss::future<result<replicate_result>>
+      apply(std::vector<ss::semaphore_units<>>);
 
     /// waits for the remaining background futures
     ss::future<> wait();

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -97,14 +97,9 @@ public:
 private:
     ss::future<append_entries_request> share_request();
 
-    ss::future<> dispatch_one(
-      vnode, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>>);
-    ss::future<result<append_entries_reply>> dispatch_single_retry(
-      vnode, ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>>);
-    ss::future<result<append_entries_reply>> do_dispatch_one(
-      vnode,
-      append_entries_request,
-      ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>>);
+    ss::future<> dispatch_one(vnode);
+    ss::future<result<append_entries_reply>> dispatch_single_retry(vnode);
+    ss::future<result<append_entries_reply>> flush_log();
 
     ss::future<result<append_entries_reply>>
       send_append_entries_request(vnode, append_entries_request);


### PR DESCRIPTION
## Cover letter

Enabled dispatching writes while flush is still in progress this way we pipeline appends and flushes and allow multiple writes to be pending in segment appender.

## Release notes
- acks=-1 performance improvement