### PR TITLE
Tracking flushed offset directly in Raft

### DIFF
--- a/src/v/raft/append_entries_buffer.cc
+++ b/src/v/raft/append_entries_buffer.cc
@@ -137,14 +137,13 @@ void append_entries_buffer::propagate_results(
       replies.size());
     auto resp_it = response_promises.begin();
     for (auto& reply : replies) {
-        auto lstats = _consensus._log.offsets();
         ss::visit(
           reply,
-          [&resp_it, &lstats](append_entries_reply r) {
+          [&resp_it, this](append_entries_reply r) {
               // this is important, we want to update response committed
               // offset here as we flushed after the response structure was
               // created
-              r.last_committed_log_index = lstats.committed_offset;
+              r.last_committed_log_index = _consensus._flushed_offset;
               resp_it->set_value(r);
           },
           [&resp_it](std::exception_ptr& e) {

--- a/src/v/raft/append_entries_buffer.cc
+++ b/src/v/raft/append_entries_buffer.cc
@@ -143,7 +143,7 @@ void append_entries_buffer::propagate_results(
               // this is important, we want to update response committed
               // offset here as we flushed after the response structure was
               // created
-              r.last_committed_log_index = _consensus._flushed_offset;
+              r.last_flushed_log_index = _consensus._flushed_offset;
               resp_it->set_value(r);
           },
           [&resp_it](std::exception_ptr& e) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -711,20 +711,6 @@ ss::future<result<replicate_result>> consensus::do_append_replicate_relaxed(
       .finally([this, u = std::move(u)] { _probe.replicate_done(); });
 }
 
-void consensus::dispatch_flush_with_lock() {
-    if (!_has_pending_flushes) {
-        return;
-    }
-    (void)ss::with_gate(_bg, [this] {
-        return _op_lock.with([this] {
-            if (!_has_pending_flushes) {
-                return ss::make_ready_future<>();
-            }
-            return flush_log();
-        });
-    });
-}
-
 ss::future<model::record_batch_reader>
 consensus::do_make_reader(storage::log_reader_config config) {
     // limit to last visible index

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -318,9 +318,9 @@ consensus::success_reply consensus::update_follower_index(
           _ctxlog.trace,
           "Updated node {} last committed log index: {}",
           idx.node_id,
-          reply.last_committed_log_index);
+          reply.last_flushed_log_index);
         idx.last_dirty_log_index = reply.last_dirty_log_index;
-        idx.last_committed_log_index = reply.last_committed_log_index;
+        idx.last_flushed_log_index = reply.last_flushed_log_index;
         idx.next_index = details::next_offset(idx.last_dirty_log_index);
     }
 
@@ -336,7 +336,7 @@ consensus::success_reply consensus::update_follower_index(
             // update follower state to allow recovery of follower with
             // missing entries
             idx.last_dirty_log_index = reply.last_dirty_log_index;
-            idx.last_committed_log_index = reply.last_committed_log_index;
+            idx.last_flushed_log_index = reply.last_flushed_log_index;
             idx.next_index = details::next_offset(idx.last_dirty_log_index);
             idx.follower_state_change.broadcast();
         }
@@ -418,7 +418,7 @@ void consensus::successfull_append_entries_reply(
   follower_index_metadata& idx, append_entries_reply reply) {
     // follower and leader logs matches
     idx.last_dirty_log_index = reply.last_dirty_log_index;
-    idx.last_committed_log_index = reply.last_committed_log_index;
+    idx.last_flushed_log_index = reply.last_flushed_log_index;
     idx.match_index = idx.last_dirty_log_index;
     idx.next_index = details::next_offset(idx.last_dirty_log_index);
     vlog(
@@ -1483,7 +1483,7 @@ consensus::do_append_entries(append_entries_request&& r) {
     reply.group = r.meta.group;
     reply.term = _term;
     reply.last_dirty_log_index = lstats.dirty_offset;
-    reply.last_committed_log_index = _flushed_offset;
+    reply.last_flushed_log_index = _flushed_offset;
     reply.result = append_entries_reply::status::failure;
     _probe.append_request();
 
@@ -2013,7 +2013,7 @@ append_entries_reply consensus::make_append_entries_reply(
     reply.group = _group;
     reply.term = _term;
     reply.last_dirty_log_index = disk_results.last_offset;
-    reply.last_committed_log_index = _flushed_offset;
+    reply.last_flushed_log_index = _flushed_offset;
     reply.result = append_entries_reply::status::success;
     return reply;
 }
@@ -2890,7 +2890,7 @@ std::vector<follower_metrics> consensus::get_follower_metrics() const {
         ret.push_back(follower_metrics{
           .id = f.first.id(),
           .is_learner = f.second.is_learner,
-          .committed_log_index = f.second.last_committed_log_index,
+          .committed_log_index = f.second.last_flushed_log_index,
           .dirty_log_index = f.second.last_dirty_log_index,
           .match_index = f.second.match_index,
           .last_heartbeat = last_hbeat,

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -379,7 +379,7 @@ void consensus::maybe_promote_to_voter(vnode id) {
         }
 
         // do not promote to voter, learner is not up to date
-        if (it->second.match_index < _log.offsets().committed_offset) {
+        if (it->second.match_index < _flushed_offset) {
             return ss::now();
         }
 
@@ -1483,7 +1483,7 @@ consensus::do_append_entries(append_entries_request&& r) {
     reply.group = r.meta.group;
     reply.term = _term;
     reply.last_dirty_log_index = lstats.dirty_offset;
-    reply.last_committed_log_index = lstats.committed_offset;
+    reply.last_committed_log_index = _flushed_offset;
     reply.result = append_entries_reply::status::failure;
     _probe.append_request();
 
@@ -2007,14 +2007,13 @@ ss::future<result<replicate_result>> consensus::dispatch_replicate(
 
 append_entries_reply consensus::make_append_entries_reply(
   vnode target_node, storage::append_result disk_results) {
-    auto lstats = _log.offsets();
     append_entries_reply reply;
     reply.node_id = _self;
     reply.target_node_id = target_node;
     reply.group = _group;
     reply.term = _term;
     reply.last_dirty_log_index = disk_results.last_offset;
-    reply.last_committed_log_index = lstats.committed_offset;
+    reply.last_committed_log_index = _flushed_offset;
     reply.result = append_entries_reply::status::success;
     return reply;
 }
@@ -2251,18 +2250,17 @@ consensus::do_maybe_update_leader_commit_idx(ss::semaphore_units<> u) {
     // If there exists an N such that N > commitIndex, a majority
     // of matchIndex[i] ≥ N, and log[N].term == currentTerm:
     // set commitIndex = N (§5.3, §5.4).
-    auto majority_match = config().quorum_match(
-      [this, committed_offset = lstats.committed_offset](vnode id) {
-          // current node - we just return commited offset
-          if (id == _self) {
-              return committed_offset;
-          }
-          if (auto it = _fstats.find(id); it != _fstats.end()) {
-              return it->second.match_committed_index();
-          }
+    auto majority_match = config().quorum_match([this](vnode id) {
+        // current node - we just return commited offset
+        if (id == _self) {
+            return _flushed_offset;
+        }
+        if (auto it = _fstats.find(id); it != _fstats.end()) {
+            return it->second.match_committed_index();
+        }
 
-          return model::offset{};
-      });
+        return model::offset{};
+    });
     /**
      * we have to make sure that we do not advance committed_index beyond the
      * point which is readable in log. Since we are not waiting for flush to
@@ -2274,7 +2272,8 @@ consensus::do_maybe_update_leader_commit_idx(ss::semaphore_units<> u) {
      * batcher aren't readable since some of the writes are still in flight in
      * segment appender.
      */
-    majority_match = std::min(majority_match, lstats.committed_offset);
+    majority_match = std::min(majority_match, _flushed_offset);
+
     if (
       majority_match > _commit_index
       && _log.get_term(majority_match) == _term) {
@@ -2305,14 +2304,12 @@ consensus::do_maybe_update_leader_commit_idx(ss::semaphore_units<> u) {
 }
 ss::future<>
 consensus::maybe_update_follower_commit_idx(model::offset request_commit_idx) {
-    auto lstats = _log.offsets();
     // Raft paper:
     //
     // If leaderCommit > commitIndex, set commitIndex =
     // min(leaderCommit, index of last new entry)
     if (request_commit_idx > _commit_index) {
-        auto new_commit_idx = std::min(
-          request_commit_idx, lstats.committed_offset);
+        auto new_commit_idx = std::min(request_commit_idx, _flushed_offset);
         if (new_commit_idx != _commit_index) {
             _commit_index = new_commit_idx;
             vlog(

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -429,9 +429,6 @@ private:
 
     /// \brief _does not_ hold the lock.
     ss::future<> flush_log();
-    /// \brief called by the vote timer, to dispatch a write under
-    /// the ops semaphore
-    void dispatch_flush_with_lock();
 
     void maybe_step_down();
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -539,6 +539,7 @@ private:
     // consensus state
     model::offset _commit_index;
     model::term_id _term;
+    model::offset _flushed_offset{};
 
     // read at `ss::future<> start()`
     vnode _voted_for;

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -64,7 +64,7 @@ ss::future<result<append_entries_reply>> replicate_entries_stm::flush_log() {
                    reply.term = _ptr->term();
                    // we just flushed offsets are the same
                    reply.last_dirty_log_index = new_committed_offset;
-                   reply.last_committed_log_index = new_committed_offset;
+                   reply.last_flushed_log_index = new_committed_offset;
                    reply.result = append_entries_reply::status::success;
                    return ret_t(reply);
                })

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -221,7 +221,7 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_response_roundtrip) {
           .node_id = raft::vnode(model::node_id(1), model::revision_id(i)),
           .group = raft::group_id(i),
           .term = model::term_id(random_generators::get_int(-1, 1000)),
-          .last_committed_log_index = commited_idx,
+          .last_flushed_log_index = commited_idx,
           .last_dirty_log_index = dirty_idx,
           .result = raft::append_entries_reply::status::success});
     }
@@ -250,8 +250,8 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_response_roundtrip) {
         BOOST_REQUIRE_EQUAL(expected[gr].group, result.meta[i].group);
         BOOST_REQUIRE_EQUAL(expected[gr].term, result.meta[i].term);
         BOOST_REQUIRE_EQUAL(
-          expected[gr].last_committed_log_index,
-          result.meta[i].last_committed_log_index);
+          expected[gr].last_flushed_log_index,
+          result.meta[i].last_flushed_log_index);
         BOOST_REQUIRE_EQUAL(
           expected[gr].last_dirty_log_index,
           result.meta[i].last_dirty_log_index);

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -67,14 +67,14 @@ struct follower_index_metadata {
 
     vnode node_id;
     // index of last known log for this follower
-    model::offset last_committed_log_index;
+    model::offset last_flushed_log_index;
     // index of last not flushed offset
     model::offset last_dirty_log_index;
     // index of log for which leader and follower logs matches
     model::offset match_index;
     // Used to establish index persistently replicated by majority
     constexpr model::offset match_committed_index() const {
-        return std::min(last_committed_log_index, match_index);
+        return std::min(last_flushed_log_index, match_index);
     }
     // next index to send to this follower
     model::offset next_index;
@@ -238,7 +238,7 @@ struct append_entries_reply {
     /// \brief The recipient's last log index after it applied changes to
     /// the log. This is used to speed up finding the correct value for the
     /// nextIndex with a follower that is far behind a leader
-    model::offset last_committed_log_index;
+    model::offset last_flushed_log_index;
     model::offset last_dirty_log_index;
     // the last entry base offset used for the recovery speed up, the value is
     // only valid for not successfull append_entries reply

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -246,7 +246,7 @@ ss::future<> vote_stm::update_vote_state(ss::semaphore_units<> u) {
     // Set last heartbeat timestamp to max as we are the leader
     _ptr->_hbeat = clock_type::time_point::max();
     vlog(_ctxlog.info, "became the leader term:{}", _ptr->term());
-    _ptr->_last_quorum_replicated_index = _ptr->_log.offsets().committed_offset;
+    _ptr->_last_quorum_replicated_index = _ptr->_flushed_offset;
     _ptr->trigger_leadership_notification();
 
     return replicate_config_as_new_leader(std::move(u))


### PR DESCRIPTION
## Cover letter

Implemented tracking flushed log offset in Raft instead of relaying on `log` `committed_offset`. This way Raft is using storage in exactly the same way as file systems are used. This simplify the logic and in the end will allow us to reduce number of offsets that we track in storage layer.

Fixes: #NNN, #NNN, ...

## Release notes
N/A
