### PR TITLE
treewide: replaced record_batch_type with an enum

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -27,18 +27,6 @@
 
 namespace cluster {
 
-// cluster batch types
-// we do not have to add it to well_known_batch_types as we will never use it to
-// filter the batches out
-static constexpr model::record_batch_type topic_batch_type
-  = model::record_batch_type(6);
-
-static constexpr model::record_batch_type user_batch_type
-  = model::record_batch_type(12);
-
-static constexpr model::record_batch_type acl_batch_type
-  = model::record_batch_type(13);
-
 using command_type = named_type<int8_t, struct command_type_tag>;
 // Controller state updates are represented in terms of commands. Each
 // command represent different type of action that is going to be executed
@@ -49,7 +37,7 @@ using command_type = named_type<int8_t, struct command_type_tag>;
 // handling.
 //
 // Generic controller command, this type is base for all commands
-template<typename K, typename V, int8_t tp, model::record_batch_type::type bt>
+template<typename K, typename V, int8_t tp, model::record_batch_type bt>
 struct controller_command {
     using key_t = K;
     using value_t = V;
@@ -81,61 +69,61 @@ using create_topic_cmd = controller_command<
   model::topic_namespace,
   topic_configuration_assignment,
   create_topic_cmd_type,
-  topic_batch_type()>;
+  model::record_batch_type::topic_management_cmd>;
 
 using delete_topic_cmd = controller_command<
   model::topic_namespace,
   model::topic_namespace,
   delete_topic_cmd_type,
-  topic_batch_type()>;
+  model::record_batch_type::topic_management_cmd>;
 
 using move_partition_replicas_cmd = controller_command<
   model::ntp,
   std::vector<model::broker_shard>,
   move_partition_replicas_cmd_type,
-  topic_batch_type()>;
+  model::record_batch_type::topic_management_cmd>;
 
 using finish_moving_partition_replicas_cmd = controller_command<
   model::ntp,
   std::vector<model::broker_shard>,
   finish_moving_partition_replicas_cmd_type,
-  topic_batch_type()>;
+  model::record_batch_type::topic_management_cmd>;
 
 using update_topic_properties_cmd = controller_command<
   model::topic_namespace,
   incremental_topic_updates,
   update_topic_properties_cmd_type,
-  topic_batch_type()>;
+  model::record_batch_type::topic_management_cmd>;
 
 using create_user_cmd = controller_command<
   security::credential_user,
   security::scram_credential,
   create_user_cmd_type,
-  user_batch_type()>;
+  model::record_batch_type::user_management_cmd>;
 
 using delete_user_cmd = controller_command<
   security::credential_user,
   int8_t, // unused
   delete_user_cmd_type,
-  user_batch_type()>;
+  model::record_batch_type::user_management_cmd>;
 
 using update_user_cmd = controller_command<
   security::credential_user,
   security::scram_credential,
   update_user_cmd_type,
-  user_batch_type()>;
+  model::record_batch_type::user_management_cmd>;
 
 using create_acls_cmd = controller_command<
   create_acls_cmd_data,
   int8_t, // unused
   create_acls_cmd_type,
-  acl_batch_type()>;
+  model::record_batch_type::acl_management_cmd>;
 
 using delete_acls_cmd = controller_command<
   delete_acls_cmd_data,
   int8_t, // unused
   delete_acls_cmd_type,
-  acl_batch_type()>;
+  model::record_batch_type::acl_management_cmd>;
 
 // typelist utils
 // clang-format off

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -64,7 +64,7 @@ id_allocator_stm::allocate_id_and_wait(
                                     return replicate(serialize_cmd(
                                       execute_truncation_cmd{
                                         _prepare_offset, _prepare_state},
-                                      cluster::id_allocator_stm_batch_type));
+                                      model::record_batch_type::id_allocator));
                                 });
                             } catch (const ss::gate_closed_exception&) {
                                 // it's ok to ignore the expection because
@@ -78,7 +78,7 @@ id_allocator_stm::allocate_id_and_wait(
             (void)ss::with_gate(_gate, [this] {
                 return replicate(serialize_cmd(
                   execute_truncation_cmd{_prepare_offset, _prepare_state},
-                  cluster::id_allocator_stm_batch_type));
+                  model::record_batch_type::id_allocator));
             });
         } catch (const ss::gate_closed_exception&) {
             // it's ok to ignore the expection because
@@ -101,7 +101,7 @@ id_allocator_stm::allocate_id_and_wait(
 }
 
 ss::future<> id_allocator_stm::apply(model::record_batch b) {
-    if (b.header().type == cluster::id_allocator_stm_batch_type) {
+    if (b.header().type == model::record_batch_type::id_allocator) {
         return process(std::move(b));
     }
 
@@ -188,7 +188,7 @@ id_allocator_stm::replicate_and_wait(
   sequence_id seq) {
     using ret_t = id_allocator_stm::log_allocation_result;
 
-    auto b = serialize_cmd(cmd, cluster::id_allocator_stm_batch_type);
+    auto b = serialize_cmd(cmd, model::record_batch_type::id_allocator);
     _promises.emplace(seq, expiring_promise<ret_t>{});
 
     return replicate(std::move(b))
@@ -231,7 +231,7 @@ ss::future<bool> id_allocator_stm::replicate_and_wait(
   prepare_truncation_cmd cmd,
   model::timeout_clock::time_point timeout,
   sequence_id seq) {
-    auto b = serialize_cmd(cmd, cluster::id_allocator_stm_batch_type);
+    auto b = serialize_cmd(cmd, model::record_batch_type::id_allocator);
     _prepare_promises.emplace(seq, expiring_promise<bool>{});
 
     return replicate(std::move(b))

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -52,7 +52,7 @@ public:
       handle_configuration_update_request(configuration_update_request);
 
     bool is_batch_applicable(const model::record_batch& b) {
-        return b.header().type == raft::configuration_batch_type;
+        return b.header().type == model::record_batch_type::raft_configuration;
     }
 
 private:

--- a/src/v/cluster/security_manager.h
+++ b/src/v/cluster/security_manager.h
@@ -35,8 +35,10 @@ public:
     ss::future<std::error_code> apply_update(model::record_batch);
 
     bool is_batch_applicable(const model::record_batch& batch) const {
-        return batch.header().type == user_batch_type
-               || batch.header().type == acl_batch_type;
+        return batch.header().type
+                 == model::record_batch_type::user_management_cmd
+               || batch.header().type
+                    == model::record_batch_type::acl_management_cmd;
     }
 
 private:

--- a/src/v/cluster/tests/simple_batch_builder_test.cc
+++ b/src/v/cluster/tests/simple_batch_builder_test.cc
@@ -44,15 +44,16 @@ cluster::partition_assignment create_test_assignment(uint32_t p, uint16_t rf) {
 SEASTAR_THREAD_TEST_CASE(simple_batch_builder_batch_test) {
     auto pa_key = log_record_key{log_record_key::type::partition_assignment};
     auto batch
-      = std::move(cluster::simple_batch_builder(
-                    model::record_batch_type(3), model::offset(0))
-                    .add_kv(
-                      log_record_key{log_record_key::type::topic_configuration},
-                      cluster::topic_configuration(
-                        model::ns("test"), model::topic{"a_topic"}, 3, 1))
-                    .add_kv(pa_key, create_test_assignment(0, 1))
-                    .add_kv(pa_key, create_test_assignment(1, 1))
-                    .add_kv(pa_key, create_test_assignment(2, 1)))
+      = std::move(
+          cluster::simple_batch_builder(
+            model::record_batch_type::topic_management_cmd, model::offset(0))
+            .add_kv(
+              log_record_key{log_record_key::type::topic_configuration},
+              cluster::topic_configuration(
+                model::ns("test"), model::topic{"a_topic"}, 3, 1))
+            .add_kv(pa_key, create_test_assignment(0, 1))
+            .add_kv(pa_key, create_test_assignment(1, 1))
+            .add_kv(pa_key, create_test_assignment(2, 1)))
           .build();
 
     BOOST_REQUIRE_EQUAL(batch.record_count(), 4);
@@ -63,15 +64,16 @@ SEASTAR_THREAD_TEST_CASE(simple_batch_builder_batch_test) {
 SEASTAR_THREAD_TEST_CASE(round_trip_test) {
     auto pa_key = log_record_key{log_record_key::type::partition_assignment};
     auto batch
-      = std::move(cluster::simple_batch_builder(
-                    model::record_batch_type(3), model::offset(0))
-                    .add_kv(
-                      log_record_key{log_record_key::type::topic_configuration},
-                      cluster::topic_configuration(
-                        model::ns("test"), model::topic{"a_topic"}, 3, 1))
-                    .add_kv(pa_key, create_test_assignment(0, 1))
-                    .add_kv(pa_key, create_test_assignment(1, 1))
-                    .add_kv(pa_key, create_test_assignment(2, 1)))
+      = std::move(
+          cluster::simple_batch_builder(
+            model::record_batch_type::topic_management_cmd, model::offset(0))
+            .add_kv(
+              log_record_key{log_record_key::type::topic_configuration},
+              cluster::topic_configuration(
+                model::ns("test"), model::topic{"a_topic"}, 3, 1))
+            .add_kv(pa_key, create_test_assignment(0, 1))
+            .add_kv(pa_key, create_test_assignment(1, 1))
+            .add_kv(pa_key, create_test_assignment(2, 1)))
           .build();
     int32_t current_crc = batch.header().crc;
     ss::sstring base_dir = "test.dir_"

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -54,7 +54,8 @@ public:
     }
 
     bool is_batch_applicable(const model::record_batch& b) const {
-        return b.header().type == topic_batch_type;
+        return b.header().type
+               == model::record_batch_type::topic_management_cmd;
     }
 
     // list of commands that this table is able to apply, the list is used to

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -61,7 +61,8 @@ public:
       update_topic_properties_cmd>();
 
     bool is_batch_applicable(const model::record_batch& batch) const {
-        return batch.header().type == topic_batch_type;
+        return batch.header().type
+               == model::record_batch_type::topic_management_cmd;
     }
 
 private:

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -28,16 +28,6 @@
 #include <fmt/format.h>
 
 namespace cluster {
-
-static constexpr model::record_batch_type controller_record_batch_type{3};
-static constexpr model::record_batch_type id_allocator_stm_batch_type{8};
-static constexpr model::record_batch_type tx_prepare_batch_type{9};
-static constexpr model::record_batch_type tx_fence_batch_type{10};
-static constexpr model::record_batch_type tm_update_batch_type{11};
-static constexpr model::record_batch_type group_prepare_tx_batch_type{14};
-static constexpr model::record_batch_type group_commit_tx_batch_type{15};
-static constexpr model::record_batch_type group_abort_tx_batch_type{16};
-
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
 using broker_ptr = ss::lw_shared_ptr<model::broker>;
 

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -196,7 +196,7 @@ script_context::get_reader(const ss::lw_shared_ptr<ntp_context>& ntp_ctx) {
       1,
       max_batch_size(),
       ss::default_priority_class(),
-      raft::data_batch_type,
+      model::record_batch_type::raft_data,
       std::nullopt,
       _abort_source);
 }

--- a/src/v/coproc/tests/utils/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/utils/coproc_test_fixture.cc
@@ -45,7 +45,7 @@ static storage::log_reader_config log_rdr_cfg(const model::offset& min_offset) {
       0,
       std::numeric_limits<size_t>::max(),
       ss::default_priority_class(),
-      raft::data_batch_type,
+      model::record_batch_type::raft_data,
       std::nullopt,
       std::nullopt);
 }

--- a/src/v/coproc/tests/utils/wasm_event_generator.cc
+++ b/src/v/coproc/tests/utils/wasm_event_generator.cc
@@ -93,7 +93,8 @@ bytes calculate_checksum(const event& e) {
 /// 'make_wasm_batch'. This method is only useful for situations where a single
 /// model::record with exact fields must be serialized
 model::record make_record(const event& e) {
-    storage::record_batch_builder rbb(raft::data_batch_type, model::offset(0));
+    storage::record_batch_builder rbb(
+      model::record_batch_type::raft_data, model::offset(0));
     serialize_event(rbb, e);
     auto record_batch = std::move(rbb).build();
     vassert(
@@ -106,7 +107,8 @@ model::record_batch_reader make_random_event_record_batch_reader(
     model::record_batch_reader::data_t batches;
     model::offset o{offset};
     for (auto i = 0; i < n_batches; ++i) {
-        storage::record_batch_builder rbb(raft::data_batch_type, o);
+        storage::record_batch_builder rbb(
+          model::record_batch_type::raft_data, o);
         for (int j = 0; j < batch_size; ++j) {
             event e(random_generators::get_int<uint64_t>(82827));
             if (random_generators::get_int(0, 1) == 0) {
@@ -128,7 +130,8 @@ make_event_record_batch_reader(std::vector<std::vector<event>> event_batches) {
     model::record_batch_reader::data_t batches;
     model::offset o{0};
     for (auto& events : event_batches) {
-        storage::record_batch_builder rbb(raft::data_batch_type, o);
+        storage::record_batch_builder rbb(
+          model::record_batch_type::raft_data, o);
         for (event& e : events) {
             e.checksum = calculate_checksum(e);
             serialize_event(rbb, e);

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -208,7 +208,7 @@ ss::future<produce_response> client::produce_records(
                    .emplace(
                      *p_id,
                      storage::record_batch_builder(
-                       raft::data_batch_type, model::offset(0)))
+                       model::record_batch_type::raft_data, model::offset(0)))
                    .first;
         }
         it->second.add_raw_kw(

--- a/src/v/kafka/client/produce_batcher.h
+++ b/src/v/kafka/client/produce_batcher.h
@@ -112,7 +112,7 @@ public:
 
 private:
     storage::record_batch_builder make_builder() {
-        return {raft::data_batch_type, model::offset(0)};
+        return {model::record_batch_type::raft_data, model::offset(0)};
     }
 
     storage::record_batch_builder _builder;

--- a/src/v/kafka/client/test/utils.h
+++ b/src/v/kafka/client/test/utils.h
@@ -15,7 +15,8 @@
 #include "storage/record_batch_builder.h"
 
 inline model::record_batch make_batch(model::offset offset, size_t count) {
-    storage::record_batch_builder builder(raft::data_batch_type, offset);
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, offset);
     for (size_t i = 0; i < count; ++i) {
         builder.add_raw_kv(reflection::to_iobuf(i + offset), iobuf());
     }

--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -66,7 +66,7 @@ model::record_batch_header kafka_batch_adapter::read_header(iobuf_parser& in) {
     auto header = model::record_batch_header{
       .size_bytes = size_bytes,
       .base_offset = base_offset,
-      .type = raft::data_batch_type,
+      .type = model::record_batch_type::raft_data,
       .crc = crc,
       .attrs = attrs,
       .last_offset_delta = last_offset_delta,
@@ -272,7 +272,7 @@ void kafka_batch_adapter::adapt_with_version(
 
     // accumulates records from legacy message set
     storage::record_batch_builder builder(
-      raft::data_batch_type, model::offset(0));
+      model::record_batch_type::raft_data, model::offset(0));
 
     convert_message_set(builder, std::move(kbatch), false);
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -88,7 +88,7 @@ iobuf make_control_record_batch_key() {
  */
 model::record_batch adapt_fetch_batch(model::record_batch&& batch) {
     // pass through data batches
-    if (likely(batch.header().type == raft::data_batch_type)) {
+    if (likely(batch.header().type == model::record_batch_type::raft_data)) {
         return std::move(batch);
     }
     /**

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -32,7 +32,7 @@ ss::future<model::record_batch_reader> replicated_partition::make_reader(
   std::optional<model::timeout_clock::time_point> deadline) {
     cfg.start_offset = _translator->from_kafka_offset(cfg.start_offset);
     cfg.max_offset = _translator->from_kafka_offset(cfg.max_offset);
-    cfg.type_filter = {raft::data_batch_type};
+    cfg.type_filter = {model::record_batch_type::raft_data};
 
     class reader : public model::record_batch_reader::impl {
     public:

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -48,7 +48,7 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
 
     std::vector<kafka::produce_request::partition> small_batches(size_t count) {
         storage::record_batch_builder builder(
-          model::well_known_record_batch_types[1], model::offset(0));
+          model::record_batch_type::raft_data, model::offset(0));
 
         for (int i = 0; i < count; ++i) {
             iobuf v{};

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -12,6 +12,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
+#include "model/record_batch_types.h"
 #include "model/timestamp.h"
 #include "model/validation.h"
 #include "utils/string_switch.h"
@@ -179,7 +180,7 @@ operator<<(std::ostream& o, const record_batch_attributes& attrs) {
 
 std::ostream& operator<<(std::ostream& o, const record_batch_header& h) {
     o << "{header_crc:" << h.header_crc << ", size_bytes:" << h.size_bytes
-      << ", base_offset:" << h.base_offset << ", type:" << (int)h.type()
+      << ", base_offset:" << h.base_offset << ", type:" << h.type
       << ", crc:" << h.crc << ", attrs:" << h.attrs
       << ", last_offset_delta:" << h.last_offset_delta
       << ", first_timestamp:" << h.first_timestamp
@@ -355,6 +356,45 @@ std::istream& operator>>(std::istream& i, cleanup_policy_bitflags& cp) {
 std::ostream& operator<<(std::ostream& os, const model::broker_endpoint& ep) {
     fmt::print(os, "{{{}:{}}}", ep.name, ep.address);
     return os;
+}
+
+std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
+    switch (bt) {
+    case record_batch_type::raft_data:
+        return o << "batch_type::raft_data";
+    case record_batch_type::raft_configuration:
+        return o << "batch_type::raft_configuration";
+    case record_batch_type::controller:
+        return o << "batch_type::controller";
+    case record_batch_type::kvstore:
+        return o << "batch_type::kvstore";
+    case record_batch_type::checkpoint:
+        return o << "batch_type::checkpoint";
+    case record_batch_type::topic_management_cmd:
+        return o << "batch_type::topic_management_cmd";
+    case record_batch_type::ghost_batch:
+        return o << "batch_type::ghost_batch";
+    case record_batch_type::id_allocator:
+        return o << "batch_type::id_allocator";
+    case record_batch_type::tx_prepare:
+        return o << "batch_type::tx_prepare";
+    case record_batch_type::tx_fence:
+        return o << "batch_type::tx_fence";
+    case record_batch_type::tm_update:
+        return o << "batch_type::tm_update";
+    case record_batch_type::user_management_cmd:
+        return o << "batch_type::user_management_cmd";
+    case record_batch_type::acl_management_cmd:
+        return o << "batch_type::acl_management_cmd";
+    case record_batch_type::group_prepare_tx:
+        return o << "batch_type::group_prepare_tx";
+    case record_batch_type::group_commit_tx:
+        return o << "batch_type::group_commit_tx";
+    case record_batch_type::group_abort_tx:
+        return o << "batch_type::group_abort_tx";
+    }
+
+    return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";
 }
 
 } // namespace model

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -475,7 +475,7 @@ constexpr uint32_t packed_record_batch_header_size
   = sizeof(model::record_batch_header::header_crc)          // 4
     + sizeof(model::record_batch_header::size_bytes)        // 4
     + sizeof(model::record_batch_header::base_offset)       // 8
-    + sizeof(model::record_batch_type::type)                // 1
+    + sizeof(model::record_batch_type)                      // 1
     + sizeof(model::record_batch_header::crc)               // 4
     + sizeof(model::record_batch_attributes::type)          // 2
     + sizeof(model::record_batch_header::last_offset_delta) // 4

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -13,27 +13,29 @@
 
 #include "utils/named_type.h"
 
+#include <cstdint>
+#include <ostream>
+
 namespace model {
-
-using record_batch_type = named_type<int8_t, struct model_record_batch_type>;
-
-constexpr std::array<record_batch_type, 17> well_known_record_batch_types{
-  record_batch_type(),   // unknown - used for debugging
-  record_batch_type(1),  // raft::data
-  record_batch_type(2),  // raft::configuration
-  record_batch_type(3),  // controller::*
-  record_batch_type(4),  // kvstore::*
-  record_batch_type(5),  // checkpoint - used to achieve linearizable reads
-  record_batch_type(6),  // controller topic command batch type
-  record_batch_type(7),  // ghost - used to fill gaps in raft recovery
-  record_batch_type(8),  // id_allocator_stm::*
-  record_batch_type(9),  // tx_prepare_batch_type
-  record_batch_type(10), // tx_fence_batch_type
-  record_batch_type(11), // tm_update_batch_type
-  record_batch_type(12), // controller user management command batch type
-  record_batch_type(13), // controller acl management command batch type
-  record_batch_type(14), // group_prepare_tx_batch_type
-  record_batch_type(15), // group_commit_tx_batch_type
-  record_batch_type(16), // group_abort_tx_batch_type
+enum class record_batch_type : int8_t {
+    raft_data = 1,            // raft::data
+    raft_configuration = 2,   // raft::configuration
+    controller = 3,           // controller::*
+    kvstore = 4,              // kvstore::*
+    checkpoint = 5,           // checkpoint - used to achieve linearizable reads
+    topic_management_cmd = 6, // controller topic command batch type
+    ghost_batch = 7,          // ghost - used to fill gaps in raft recovery
+    id_allocator = 8,         // id_allocator_stm::*
+    tx_prepare = 9,           // tx_prepare_batch_type
+    tx_fence = 10,            // tx_fence_batch_type
+    tm_update = 11,           // tm_update_batch_type
+    user_management_cmd = 12, // controller user management command batch type
+    acl_management_cmd = 13,  // controller acl management command batch type
+    group_prepare_tx = 14,    // group_prepare_tx_batch_type
+    group_commit_tx = 15,     // group_commit_tx_batch_type
+    group_abort_tx = 16,      // group_abort_tx_batch_type
 };
+
+std::ostream& operator<<(std::ostream& o, record_batch_type bt);
+
 } // namespace model

--- a/src/v/model/record_utils.cc
+++ b/src/v/model/record_utils.cc
@@ -14,6 +14,8 @@
 #include "reflection/adl.h"
 #include "utils/vint.h"
 
+#include <type_traits>
+
 namespace model {
 
 template<typename T, typename = std::enable_if_t<std::is_integral_v<T>, T>>
@@ -36,7 +38,7 @@ uint32_t internal_header_only_crc(const record_batch_header& header) {
       /*Additional fields*/
       header.size_bytes,
       header.base_offset(),
-      header.type(),
+      static_cast<std::underlying_type_t<record_batch_type>>(header.type),
       header.crc,
 
       /*Below are same fields as kafka - but at no cost on x86 since they are

--- a/src/v/raft/configuration_bootstrap_state.cc
+++ b/src/v/raft/configuration_bootstrap_state.cc
@@ -19,7 +19,8 @@
 namespace raft {
 void configuration_bootstrap_state::process_configuration(
   model::record_batch b) {
-    if (unlikely(b.header().type != configuration_batch_type)) {
+    if (unlikely(
+          b.header().type != model::record_batch_type::raft_configuration)) {
         throw std::runtime_error(fmt::format(
           "Logic error. Asked a configuration tracker to process an unknown "
           "record_batch_type: {}",
@@ -43,7 +44,8 @@ void configuration_bootstrap_state::process_configuration(
 void configuration_bootstrap_state::process_data_offsets(
   model::record_batch b) {
     _data_batches_seen++;
-    if (unlikely(b.header().type == configuration_batch_type)) {
+    if (unlikely(
+          b.header().type == model::record_batch_type::raft_configuration)) {
         throw std::runtime_error(fmt::format(
           "Logic error. Asked a data tracker to process "
           "configuration_batch_type "
@@ -75,7 +77,7 @@ void configuration_bootstrap_state::process_offsets(
 
 void configuration_bootstrap_state::process_batch(model::record_batch b) {
     switch (b.header().type) {
-    case configuration_batch_type:
+    case model::record_batch_type::raft_configuration:
         process_configuration(std::move(b));
         break;
     default:

--- a/src/v/raft/kvelldb/kvrsm.cc
+++ b/src/v/raft/kvelldb/kvrsm.cc
@@ -42,7 +42,8 @@ ss::future<kvrsm::cmd_result> kvrsm::set_and_wait(
   model::timeout_clock::time_point timeout) {
     sequence_id seq = ++_last_generated_seq;
     return replicate_and_wait(
-      serialize_cmd(set_cmd{seq, key, value, write_id}, kvrsm_batch_type),
+      serialize_cmd(
+        set_cmd{seq, key, value, write_id}, model::record_batch_type::kvstore),
       timeout,
       seq);
 }
@@ -56,7 +57,8 @@ ss::future<kvrsm::cmd_result> kvrsm::cas_and_wait(
     sequence_id seq = ++_last_generated_seq;
     return replicate_and_wait(
       serialize_cmd(
-        cas_cmd{seq, key, prev_write_id, value, write_id}, kvrsm_batch_type),
+        cas_cmd{seq, key, prev_write_id, value, write_id},
+        model::record_batch_type::kvstore),
       timeout,
       seq);
 }
@@ -65,11 +67,13 @@ ss::future<kvrsm::cmd_result>
 kvrsm::get_and_wait(ss::sstring key, model::timeout_clock::time_point timeout) {
     sequence_id seq = ++_last_generated_seq;
     return replicate_and_wait(
-      serialize_cmd(get_cmd{seq, key}, kvrsm_batch_type), timeout, seq);
+      serialize_cmd(get_cmd{seq, key}, model::record_batch_type::kvstore),
+      timeout,
+      seq);
 }
 
 ss::future<> kvrsm::apply(model::record_batch b) {
-    if (b.header().type == kvrsm::kvrsm_batch_type) {
+    if (b.header().type == model::record_batch_type::kvstore) {
         auto last_offset = b.last_offset();
         auto result = process(std::move(b));
         result.offset = last_offset;

--- a/src/v/raft/kvelldb/kvrsm.h
+++ b/src/v/raft/kvelldb/kvrsm.h
@@ -135,9 +135,6 @@ private:
     consensus* _c;
     absl::flat_hash_map<sequence_id, expiring_promise<cmd_result>> _promises;
     absl::flat_hash_map<ss::sstring, kvrsm::record> kv_map;
-
-    static inline constexpr model::record_batch_type kvrsm_batch_type
-      = model::record_batch_type(10);
 };
 
 } // namespace raft::kvelldb

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -264,8 +264,9 @@ ss::future<> mux_state_machine<T...>::apply(model::record_batch b) {
         // applicable state not found
         if (!state) {
             vassert(
-              b.header().type == state_machine::checkpoint_batch_type
-                || b.header().type == raft::configuration_batch_type,
+              b.header().type == model::record_batch_type::checkpoint
+                || b.header().type
+                     == model::record_batch_type::raft_configuration,
               "State handler for batch of type: {} not found",
               b.header().type);
             return ss::now();

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -75,7 +75,7 @@ bool state_machine::stop_batch_applicator() { return _gate.is_closed(); }
 
 model::record_batch_reader make_checkpoint() {
     storage::record_batch_builder builder(
-      state_machine::checkpoint_batch_type, model::offset(0));
+      model::record_batch_type::checkpoint, model::offset(0));
     builder.add_raw_kv(iobuf(), iobuf());
     return model::make_memory_record_batch_reader(std::move(builder).build());
 }

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -56,7 +56,6 @@ class consensus;
  */
 class state_machine {
 public:
-    static constexpr model::record_batch_type checkpoint_batch_type{5};
     state_machine(consensus*, ss::logger& log, ss::io_priority_class io_prio);
 
     // start after ready to receive batches through apply upcall.

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -773,7 +773,7 @@ FIXTURE_TEST(test_big_batches_replication, raft_test_fixture) {
     bool success
       = retry_with_leader(gr, 5, 2s, [](raft_node& leader_node) mutable {
             storage::record_batch_builder builder(
-              raft::data_batch_type, model::offset(0));
+              model::record_batch_type::raft_data, model::offset(0));
 
             auto value = bytes_to_iobuf(random_generators::get_bytes(3_MiB));
             builder.add_raw_kv({}, std::move(value));
@@ -799,7 +799,7 @@ FIXTURE_TEST(test_big_batches_replication, raft_test_fixture) {
 struct request_ordering_test_fixture : public raft_test_fixture {
     model::record_batch_reader make_indexed_batch_reader(int32_t idx) {
         storage::record_batch_builder builder(
-          raft::data_batch_type, model::offset(0));
+          model::record_batch_type::raft_data, model::offset(0));
 
         iobuf buf;
         reflection::serialize(buf, idx);
@@ -830,7 +830,7 @@ struct request_ordering_test_fixture : public raft_test_fixture {
             int32_t idx = 0;
             BOOST_REQUIRE_GE(batches.size(), count);
             for (auto& b : batches) {
-                if (b.header().type == raft::data_batch_type) {
+                if (b.header().type == model::record_batch_type::raft_data) {
                     BOOST_REQUIRE_EQUAL(
                       idx,
                       reflection::from_iobuf<int32_t>(

--- a/src/v/raft/tests/configuration_serialization_test.cc
+++ b/src/v/raft/tests/configuration_serialization_test.cc
@@ -84,7 +84,7 @@ struct test_consumer {
     ss::future<ss::stop_iteration> operator()(model::record_batch& b) {
         if (
           !b.compressed()
-          && b.header().type == raft::configuration_batch_type) {
+          && b.header().type == model::record_batch_type::raft_configuration) {
             _config_offsets.push_back(_next_offset);
         }
         _next_offset += model::offset(b.header().last_offset_delta)

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -90,14 +90,15 @@ struct foreign_entry_fixture {
         return reader_gen(n, [this] { return data_batch(); });
     }
     model::record_batch data_batch() {
-        storage::record_batch_builder bldr(raft::data_batch_type, _base_offset);
+        storage::record_batch_builder bldr(
+          model::record_batch_type::raft_data, _base_offset);
         bldr.add_raw_kv(rand_iobuf(), rand_iobuf());
         ++_base_offset;
         return std::move(bldr).build();
     }
     model::record_batch config_batch() {
         storage::record_batch_builder bldr(
-          raft::configuration_batch_type, _base_offset);
+          model::record_batch_type::raft_configuration, _base_offset);
         bldr.add_raw_kv(rand_iobuf(), reflection::to_iobuf(rand_config()));
         ++_base_offset;
         return std::move(bldr).build();

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -751,7 +751,7 @@ make_compactible_batches(int keys, size_t batches, model::timestamp ts) {
     for (size_t b = 0; b < batches; b++) {
         int k = random_generators::get_int(0, keys);
         storage::record_batch_builder builder(
-          raft::data_batch_type, model::offset(0));
+          model::record_batch_type::raft_data, model::offset(0));
         iobuf k_buf;
         iobuf v_buf;
         ss::sstring k_str = ssx::sformat("key-{}", k);

--- a/src/v/raft/tests/simple_record_fixture.h
+++ b/src/v/raft/tests/simple_record_fixture.h
@@ -36,14 +36,15 @@ struct simple_record_fixture {
         return reader_gen(n, [this] { return data_batch(); });
     }
     model::record_batch data_batch() {
-        storage::record_batch_builder bldr(raft::data_batch_type, _base_offset);
+        storage::record_batch_builder bldr(
+          model::record_batch_type::raft_data, _base_offset);
         bldr.add_raw_kv(rand_iobuf(), rand_iobuf());
         ++_base_offset;
         return std::move(bldr).build();
     }
     model::record_batch config_batch() {
         storage::record_batch_builder bldr(
-          raft::configuration_batch_type, _base_offset);
+          model::record_batch_type::raft_configuration, _base_offset);
         bldr.add_raw_kv(rand_iobuf(), reflection::to_iobuf(rand_config()));
         ++_base_offset;
         return std::move(bldr).build();

--- a/src/v/raft/tron/client.cc
+++ b/src/v/raft/tron/client.cc
@@ -129,7 +129,7 @@ private:
     }
     model::record_batch data_batch() {
         storage::record_batch_builder bldr(
-          raft::data_batch_type, _offset_index);
+          model::record_batch_type::raft_data, _offset_index);
         bldr.add_raw_kv(rand_iobuf(_cfg.key_size), rand_iobuf(_cfg.value_size));
         ++_offset_index;
         return std::move(bldr).build();

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -42,10 +42,6 @@ static constexpr clock_type::time_point no_timeout
   = clock_type::time_point::max();
 
 using group_id = named_type<int64_t, struct raft_group_id_type>;
-
-static constexpr const model::record_batch_type configuration_batch_type{2};
-static constexpr const model::record_batch_type data_batch_type{1};
-
 struct protocol_metadata {
     group_id group;
     model::offset commit_index;

--- a/src/v/storage/disk_log_appender.cc
+++ b/src/v/storage/disk_log_appender.cc
@@ -108,7 +108,8 @@ disk_log_appender::operator()(model::record_batch& batch) {
 ss::future<ss::stop_iteration>
 disk_log_appender::append_batch_to_segment(const model::record_batch& batch) {
     // ghost batch handling, it doesn't happen often so we can use unlikely
-    if (unlikely(batch.header().type == storage::ghost_record_batch_type)) {
+    if (unlikely(
+          batch.header().type == model::record_batch_type::ghost_batch)) {
         _idx = batch.last_offset() + model::offset(1); // next base offset
         _last_offset = batch.last_offset();
         return ss::make_ready_future<ss::stop_iteration>(

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -218,7 +218,8 @@ ss::future<> kvstore::flush_and_apply_ops() {
     auto ops = std::exchange(_ops, {});
 
     // build the operation batch to be logged
-    storage::record_batch_builder builder(kvstore_batch_type, _next_offset);
+    storage::record_batch_builder builder(
+      model::record_batch_type::kvstore, _next_offset);
     for (auto& op : ops) {
         std::optional<iobuf> value;
         if (op.value) {
@@ -324,7 +325,8 @@ ss::future<> kvstore::save_snapshot() {
       _next_offset - model::offset(1));
 
     // package up the db into a batch
-    storage::record_batch_builder builder(kvstore_batch_type, model::offset(0));
+    storage::record_batch_builder builder(
+      model::record_batch_type::kvstore, model::offset(0));
     for (auto& entry : _db) {
         builder.add_raw_kv(
           bytes_to_iobuf(entry.first),

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -71,8 +71,6 @@ namespace storage {
  * the set of unique keys and queue depth of at most a few bytes *
  * O(#-partitions-per-core).
  */
-static constexpr const model::record_batch_type kvstore_batch_type(4);
-
 struct kvstore_config {
     size_t max_segment_size;
     std::chrono::milliseconds commit_interval;

--- a/src/v/storage/segment_appender_utils.cc
+++ b/src/v/storage/segment_appender_utils.cc
@@ -35,7 +35,7 @@ static iobuf disk_header_to_iobuf(const model::record_batch_header& h) {
       h.header_crc,
       h.size_bytes,
       h.base_offset(),
-      h.type(),
+      h.type,
       h.crc,
       h.attrs.value(),
       h.last_offset_delta,

--- a/src/v/storage/tests/batch_cache_reclaim_test.cc
+++ b/src/v/storage/tests/batch_cache_reclaim_test.cc
@@ -32,7 +32,8 @@ model::record_batch make_batch(size_t size) {
     static model::offset base_offset{0};
     iobuf value;
     value.append(ss::temporary_buffer<char>(size));
-    cluster::simple_batch_builder builder(raft::data_batch_type, base_offset);
+    cluster::simple_batch_builder builder(
+      model::record_batch_type::raft_data, base_offset);
     builder.add_kv(iobuf{}, std::move(value));
     auto batch = std::move(builder).build();
     base_offset += model::offset(batch.record_count());

--- a/src/v/storage/tests/disk_log_builder_test.cc
+++ b/src/v/storage/tests/disk_log_builder_test.cc
@@ -88,8 +88,9 @@ FIXTURE_TEST(test_valid_segment_name_with_zeroes_data, log_builder_fixture) {
 FIXTURE_TEST(iterator_invalidation, log_builder_fixture) {
     using namespace storage; // NOLINT
     constexpr const model::record_batch_type configuration
-      = model::record_batch_type(2);
-    constexpr const model::record_batch_type data = model::record_batch_type(1);
+      = model::record_batch_type::raft_configuration;
+    constexpr const model::record_batch_type data
+      = model::record_batch_type::raft_data;
 
     b | start() | add_segment(0)
       | add_random_batch(0, 1, maybe_compress_batches::yes, configuration)

--- a/src/v/storage/tests/half_page_concurrent_dispatch.cc
+++ b/src/v/storage/tests/half_page_concurrent_dispatch.cc
@@ -36,7 +36,7 @@ FIXTURE_TEST(half_next_page, fixture) {
     value.append(data.share());
     key.append(data.share());
     auto batchbldr = record_batch_builder(
-      model::record_batch_type{1}, model::offset(0));
+      model::record_batch_type::raft_data, model::offset(0));
     auto batch = std::move(
                    batchbldr.add_raw_kv(std::move(key), std::move(value)))
                    .build();

--- a/src/v/storage/tests/log_segment_reader_test.cc
+++ b/src/v/storage/tests/log_segment_reader_test.cc
@@ -248,7 +248,7 @@ SEASTAR_THREAD_TEST_CASE(test_batch_type_filter) {
 
         std::set<int> types;
         for (auto& batch : res) {
-            types.insert(batch.header().type);
+            types.insert(static_cast<int>(batch.header().type));
         }
         return {types.begin(), types.end()};
     };

--- a/src/v/storage/tests/record_batch_builder_test.cc
+++ b/src/v/storage/tests/record_batch_builder_test.cc
@@ -86,7 +86,7 @@ sample_type deserialize_sample_type(model::record& r) {
 
 SEASTAR_THREAD_TEST_CASE(empty_builder) {
     storage::record_batch_builder rbb(
-      model::record_batch_type(), model::offset(0));
+      model::record_batch_type::raft_data, model::offset(0));
     auto rb = std::move(rbb).build();
     BOOST_CHECK(rb.empty());
     BOOST_CHECK_EQUAL(rb.record_count(), 0);
@@ -113,7 +113,7 @@ SEASTAR_THREAD_TEST_CASE(serialize_deserialize_then_cmp) {
 
     /// 2. Serialize to record_batch
     storage::record_batch_builder rbb(
-      model::record_batch_type(), model::offset(0));
+      model::record_batch_type::raft_data, model::offset(0));
     for (const auto& st : sample_data) {
         detail::serialize_sample_type(rbb, st);
     }

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -498,7 +498,7 @@ ss::future<storage::append_result> append_exactly(
 
     for (int i = 0; i < batch_count; ++i) {
         storage::record_batch_builder builder(
-          model::record_batch_type(1), model::offset{});
+          model::record_batch_type::raft_data, model::offset{});
         iobuf value = bytes_to_iobuf(random_generators::get_bytes(val_sz));
         builder.add_raw_kv(key_buf.copy(), std::move(value));
 
@@ -593,7 +593,7 @@ FIXTURE_TEST(empty_segment_recovery, storage_test_fixture) {
      */
 
     storage::disk_log_builder builder(cfg);
-    model::record_batch_type bt = model::record_batch_type(1);
+    model::record_batch_type bt = model::record_batch_type::raft_data;
     using should_flush_t = storage::disk_log_builder::should_flush_after;
     storage::log_append_config appender_cfg{
       .should_fsync = storage::log_append_config::fsync::no,
@@ -687,7 +687,7 @@ FIXTURE_TEST(test_compation_preserve_state, storage_test_fixture) {
     ss::abort_source as;
 
     storage::disk_log_builder builder(cfg);
-    model::record_batch_type bt = model::record_batch_type(2);
+    model::record_batch_type bt = model::record_batch_type::raft_configuration;
     using should_flush_t = storage::disk_log_builder::should_flush_after;
     storage::log_append_config appender_cfg{
       .should_fsync = storage::log_append_config::fsync::no,
@@ -777,7 +777,7 @@ void append_single_record_batch(
         }
         iobuf value = bytes_to_iobuf(val_bytes);
         storage::record_batch_builder builder(
-          model::record_batch_type(1), model::offset(0));
+          model::record_batch_type::raft_data, model::offset(0));
         builder.add_raw_kv(std::move(key), std::move(value));
         auto batch = std::move(builder).build();
         batch.set_term(term);

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -253,7 +253,7 @@ public:
       model::offset offset,
       int num_records,
       maybe_compress_batches comp = maybe_compress_batches::yes,
-      model::record_batch_type bt = model::record_batch_type(1), // data
+      model::record_batch_type bt = model::record_batch_type::raft_data, // data
       log_append_config config = append_config(),
       should_flush_after flush = should_flush_after::yes);
     ss::future<> add_random_batches(

--- a/src/v/storage/tests/utils/random_batch.cc
+++ b/src/v/storage/tests/utils/random_batch.cc
@@ -92,7 +92,7 @@ model::record_batch make_random_batch(
 model::record_batch
 make_random_batch(model::offset o, int num_records, bool allow_compression) {
     return make_random_batch(
-      o, num_records, allow_compression, model::record_batch_type(1));
+      o, num_records, allow_compression, model::record_batch_type::raft_data);
 }
 
 model::record_batch make_random_batch(record_batch_spec spec) {
@@ -156,7 +156,7 @@ model::record_batch make_random_batch(record_batch_spec spec) {
 model::record_batch make_random_batch(model::offset o, bool allow_compression) {
     auto num_records = get_int(2, 30);
     return make_random_batch(
-      o, num_records, allow_compression, model::record_batch_type(1));
+      o, num_records, allow_compression, model::record_batch_type::raft_data);
 }
 
 ss::circular_buffer<model::record_batch>

--- a/src/v/storage/tests/utils/random_batch.h
+++ b/src/v/storage/tests/utils/random_batch.h
@@ -22,7 +22,7 @@ struct record_batch_spec {
     model::offset offset{0};
     bool allow_compression{true};
     int count{0};
-    model::record_batch_type bt{1};
+    model::record_batch_type bt{model::record_batch_type::raft_data};
     bool enable_idempotence{false};
     int64_t producer_id{0};
     int16_t producer_epoch{0};

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -28,13 +28,6 @@
 #include <vector>
 
 namespace storage {
-/**
- * ghost record batch type, used by raft recovery to deliver gapless stream of
- * batches to follower, ghost batches aren't appended to the log
- */
-constexpr model::record_batch_type ghost_record_batch_type
-  = model::well_known_record_batch_types[7];
-
 using log_clock = ss::lowres_clock;
 using debug_sanitize_files = ss::bool_class<struct debug_sanitize_files_tag>;
 


### PR DESCRIPTION
Replaced `model::record_batch_type` with `enum class`. This way we have
single source of truth for all record_batch_types used in whole system.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
