### PR TITLE
rpk/admin: do not modify input urls slice

### DIFF
--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -51,13 +51,15 @@ type newUser struct {
 }
 
 func NewAdminAPI(urls []string, tlsConfig *tls.Config) (AdminAPI, error) {
+	adminUrls := make([]string, len(urls))
 	for i := 0; i < len(urls); i++ {
+		prefix := ""
 		url := urls[i]
 		// Go's http library requires that the URL have a protocol.
 		if !(strings.HasPrefix(url, httpPrefix) ||
 			strings.HasPrefix(url, httpsPrefix)) {
 
-			prefix := httpPrefix
+			prefix = httpPrefix
 
 			if tlsConfig != nil {
 				// If TLS will be enabled, use HTTPS as the protocol
@@ -65,8 +67,8 @@ func NewAdminAPI(urls []string, tlsConfig *tls.Config) (AdminAPI, error) {
 			}
 
 			url = strings.TrimRight(url, "/")
-			urls[i] = fmt.Sprintf("%s%s", prefix, url)
 		}
+		adminUrls[i] = fmt.Sprintf("%s%s", prefix, url)
 	}
 
 	tr := &http.Transport{
@@ -74,7 +76,7 @@ func NewAdminAPI(urls []string, tlsConfig *tls.Config) (AdminAPI, error) {
 	}
 
 	client := &http.Client{Transport: tr}
-	return &adminAPI{urls: urls, client: client}, nil
+	return &adminAPI{urls: adminUrls, client: client}, nil
 }
 
 func (a *adminAPI) CreateUser(username, password string) error {
@@ -89,10 +91,11 @@ func (a *adminAPI) CreateUser(username, password string) error {
 		Password:  password,
 		Algorithm: sarama.SASLTypeSCRAMSHA256,
 	}
+	urls := make([]string, len(a.urls))
 	for i := 0; i < len(a.urls); i++ {
-		a.urls[i] = fmt.Sprintf("%s%s", a.urls[i], usersEndpoint)
+		urls[i] = fmt.Sprintf("%s%s", a.urls[i], usersEndpoint)
 	}
-	_, err := sendToMultiple(a.urls, http.MethodPost, u, a.client)
+	_, err := sendToMultiple(urls, http.MethodPost, u, a.client)
 	return err
 }
 
@@ -101,18 +104,20 @@ func (a *adminAPI) DeleteUser(username string) error {
 		return errors.New("empty username")
 	}
 
+	urls := make([]string, len(a.urls))
 	for i := 0; i < len(a.urls); i++ {
-		a.urls[i] = fmt.Sprintf("%s%s/%s", a.urls[i], usersEndpoint, username)
+		urls[i] = fmt.Sprintf("%s%s/%s", a.urls[i], usersEndpoint, username)
 	}
-	_, err := sendToMultiple(a.urls, http.MethodDelete, nil, a.client)
+	_, err := sendToMultiple(urls, http.MethodDelete, nil, a.client)
 	return err
 }
 
 func (a *adminAPI) ListUsers() ([]string, error) {
+	urls := make([]string, len(a.urls))
 	for i := 0; i < len(a.urls); i++ {
-		a.urls[i] = fmt.Sprintf("%s%s", a.urls[i], usersEndpoint)
+		urls[i] = fmt.Sprintf("%s%s", a.urls[i], usersEndpoint)
 	}
-	res, err := sendToMultiple(a.urls, http.MethodGet, nil, a.client)
+	res, err := sendToMultiple(urls, http.MethodGet, nil, a.client)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Cover letter

Multiple Admin API functions take as input the broker urls and end up "modifying" them, e.g.,

```
a.urls[i] = fmt.Sprintf("%s%s", a.urls[i], usersEndpoint)
```

This leads to addresses becoming invalid in consecutive calls, e.g.,

```
http://redpanda:9644/v1/security/users
http://redpanda:9644/v1/security/users/v1/security/users
http://redpanda:9644/v1/security/users/v1/security/users/v1/security/users
```

Fixing this here by copying the input addresses.