### PR TITLE
kafka: use resource type to restrict acl prefix searches

### DIFF
--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -138,7 +138,7 @@ private:
      *
      *  1. resource type
      *  2. pattern type
-     *  3. name
+     *  3. name (in reverse order)
      */
     struct resource_pattern_compare {
         bool
@@ -149,7 +149,7 @@ private:
             if (a.pattern() != b.pattern()) {
                 return a.pattern() < b.pattern();
             }
-            return a.name() < b.name();
+            return b.name() < a.name();
         }
     };
 

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -78,6 +78,17 @@ static auto get_acls(authorizer& auth, acl_binding_filter filter) {
 
 BOOST_AUTO_TEST_CASE(resource_type_auto) {
     BOOST_REQUIRE(
+      get_resource_type<model::topic>() == security::resource_type::topic);
+    BOOST_REQUIRE(
+      get_resource_type<kafka::group_id>() == security::resource_type::group);
+    BOOST_REQUIRE(
+      get_resource_type<security::acl_cluster_name>()
+      == security::resource_type::cluster);
+    BOOST_REQUIRE(
+      get_resource_type<kafka::transactional_id>()
+      == security::resource_type::transactional_id);
+
+    BOOST_REQUIRE(
       get_resource_type<model::topic>() == get_resource_type<model::topic>());
     BOOST_REQUIRE(
       get_resource_type<model::topic>()

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -841,4 +841,26 @@ BOOST_AUTO_TEST_CASE(topic_acl) {
       auth.authorized(default_topic, acl_operation::write, user3, host1));
 }
 
+// a bug had allowed a topic with read permissions (prefix) to authorize a group
+// for read permissions when the topic name was a prefix of the group name
+BOOST_AUTO_TEST_CASE(topic_group_same_name) {
+    authorizer auth;
+
+    std::vector<acl_binding> bindings;
+
+    resource_pattern resource(
+      resource_type::topic, "topic-foo", pattern_type::prefixed);
+    bindings.emplace_back(resource, allow_read_acl);
+
+    auth.add_bindings(bindings);
+
+    acl_principal user(principal_type::user, "alice");
+    acl_host host("192.168.0.1");
+
+    BOOST_REQUIRE(!auth.authorized(
+      kafka::group_id("topic-foo"), acl_operation::read, user, host));
+    BOOST_REQUIRE(!auth.authorized(
+      kafka::group_id("topic-foo-xxx"), acl_operation::read, user, host));
+}
+
 } // namespace security


### PR DESCRIPTION
When searching the stored ACLs for resource name prefixes the resource
type was not being taken into account. This allowed, for example, a
prefix rule on a topic to authorize an operation on a group when the
group had a name and the topic was a prefix of the name.

Fixes: #1579
