### PR TITLE
wasm: use correct lower bound on default wasm template

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/template/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/template/wasm.go
@@ -23,7 +23,7 @@ const uppercase = (record) => {
   const newRecord = {
     ...record,
     value: record.value.map((char) => {
-      if (char > 97 && char < 122) {
+      if (char >= 97 && char <= 122) {
         return char - 32;
       } else {
         return char;


### PR DESCRIPTION
## Cover letter

fixes wasm template for correct ascii lower bound. 