### PR TITLE
Introduce a --name flag to rpk deploy

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/common.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/common.go
@@ -71,9 +71,6 @@ func CreateDeployMsg(
 			Key:   []byte("description"),
 			Value: []byte(description),
 		}, {
-			Key:   []byte("file_name"),
-			Value: []byte(name),
-		}, {
 			Key:   []byte("sha256"),
 			Value: shaValue[:],
 		},
@@ -94,9 +91,6 @@ func CreateRemoveMsg(name string) sarama.ProducerMessage {
 		{
 			Key:   []byte("action"),
 			Value: []byte("remove"),
-		}, {
-			Key:   []byte("file_name"),
-			Value: []byte(name),
 		},
 	}
 	id := xxhash.Sum64([]byte(name))

--- a/src/go/rpk/pkg/cli/cmd/wasm/deploy_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/deploy_test.go
@@ -32,7 +32,7 @@ func TestNewDeployCommand(t *testing.T) {
 	}{
 		{
 			name: "it should publish a message with correct format",
-			args: []string{"--description", "coprocessor description"},
+			args: []string{"--description", "coprocessor description", "--name", "foo"},
 			fileInformation: fileInfo{
 				name:    "fileName.js",
 				content: "let s = 'text'",
@@ -42,18 +42,21 @@ func TestNewDeployCommand(t *testing.T) {
 			},
 		}, {
 			name: "it should fail if the file extension isn't js",
+			args: []string{"--name", "foo"},
 			fileInformation: fileInfo{
 				name: "fileName.html",
 			},
 			expectedErr: "can't deploy 'fileName.html': only .js files are supported.",
 		}, {
 			name: "it should fail if the file doesn't exist",
+			args: []string{"--name", "foo"},
 			fileInformation: fileInfo{
 				name: "fileName.js",
 			},
 			expectedErr: "open fileName.js: file does not exist",
 		}, {
 			name: "it should show an error if there is a error on send message",
+			args: []string{"--name", "foo"},
 			fileInformation: fileInfo{
 				name: "fileName.js",
 			},
@@ -76,6 +79,7 @@ func TestNewDeployCommand(t *testing.T) {
 			},
 		}, {
 			name: "it should create a coprocessor_internal_topic if it doesn't exist",
+			args: []string{"--name", "foo"},
 			fileInformation: fileInfo{
 				name: "fileName.js",
 			},
@@ -95,6 +99,7 @@ func TestNewDeployCommand(t *testing.T) {
 			},
 		}, {
 			name: "it shouldn't create a coprocessor_internal_topic if it exist",
+			args: []string{"--name", "foo"},
 			fileInformation: fileInfo{
 				name: "fileName.js",
 			},
@@ -114,7 +119,7 @@ func TestNewDeployCommand(t *testing.T) {
 			},
 		}, {
 			name: "it should publish a message with correct format with correct header",
-			args: []string{"--description", "coprocessor description"},
+			args: []string{"--description", "coprocessor description", "--name", "bar"},
 			fileInformation: fileInfo{
 				name:    "fileName.js",
 				content: "let s = 'text'",
@@ -133,9 +138,6 @@ func TestNewDeployCommand(t *testing.T) {
 						}, {
 							Key:   []byte("description"),
 							Value: []byte("coprocessor description"),
-						}, {
-							Key:   []byte("file_name"),
-							Value: []byte("fileName.js"),
 						}, {
 							Key:   []byte("sha256"),
 							Value: hashContent[:],

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove.go
@@ -49,7 +49,7 @@ func NewRemoveCommand(
 this function create and publish message for removing coprocessor
 message format:
 {
-	key: <file name>,
+	key: <name>,
 	header: {
 		action: "remove"
 	}

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove_test.go
@@ -15,7 +15,6 @@ func TestNewRemoveCommand(t *testing.T) {
 	tests := []struct {
 		name           string
 		producer       kafkaMocks.MockProducer
-		filename       string
 		args           []string
 		expectedOutput []string
 		expectedErr    string
@@ -23,14 +22,14 @@ func TestNewRemoveCommand(t *testing.T) {
 	}{
 		{
 			name: "it should publish a message with correct format",
-			args: []string{"filename.js"},
+			args: []string{"bar"},
 		}, {
-			name:        "it should a error if the name arg doesn't set",
+			name:        "it should a error if the name arg isn't set",
 			args:        []string{},
 			expectedErr: "no wasm script name specified",
 		}, {
 			name: "it should publish a message with correct format with valid headers",
-			args: []string{"filename.js"},
+			args: []string{"foo"},
 			producer: kafkaMocks.MockProducer{
 				MockSendMessage: func(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
 					require.Equal(t, msg.Topic, kafka.CoprocessorTopic)
@@ -38,9 +37,6 @@ func TestNewRemoveCommand(t *testing.T) {
 						{
 							Key:   []byte("action"),
 							Value: []byte("remove"),
-						}, {
-							Key:   []byte("file_name"),
-							Value: []byte("filename.js"),
 						},
 					}
 					require.Equal(t, expectHeader, msg.Headers)

--- a/src/go/rpk/pkg/cli/cmd/wasm/template/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/template/wasm.go
@@ -16,7 +16,7 @@ const wasmJs = `const {
 } = require("@vectorizedio/wasm-api");
 const transform = new SimpleTransform();
 /* Topics that fire the transform function */
-transform.subscribe(["test-topic", PolicyInjection.Stored]);
+transform.subscribe([["test-topic", PolicyInjection.Stored]]);
 /* The strategy the transform engine will use when handling errors */
 transform.errorHandler(PolicyError.SkipOnFailure);
 /* Auxiliar transform function for records */

--- a/src/v/coproc/script_dispatcher.cc
+++ b/src/v/coproc/script_dispatcher.cc
@@ -335,7 +335,9 @@ script_dispatcher::heartbeat(int8_t connect_attempts) {
           coproclog.error,
           "Failed to connect wasm engine, reason {}",
           transport.error());
-        if (transport.error() == rpc::errc::disconnected_endpoint) {
+        if (
+          transport.error() == rpc::errc::disconnected_endpoint
+          || transport.error() == rpc::errc::exponential_backoff) {
             /// The expected 1s timeout didn't occur
             co_await ss::sleep(1s);
         }

--- a/src/v/coproc/tests/utils/wasm_event_generator.cc
+++ b/src/v/coproc/tests/utils/wasm_event_generator.cc
@@ -27,7 +27,7 @@ event::event(uint64_t id)
 
 event::event(uint64_t id, cpp_enable_payload ep)
   : id(id)
-  , desc(random_generators::gen_alphanum_string(15))
+  , desc(random_generators::get_bytes(64))
   , action(event_action::deploy) {
     iobuf payload;
     reflection::serialize(payload, ep.tid, std::move(ep.topics));
@@ -114,7 +114,7 @@ model::record_batch_reader make_random_event_record_batch_reader(
             if (random_generators::get_int(0, 1) == 0) {
                 e.action = event_action::deploy;
                 e.script = random_generators::get_bytes();
-                e.desc = random_generators::gen_alphanum_string(15);
+                e.desc = random_generators::get_bytes(64);
                 e.checksum = calculate_checksum(e);
             }
             serialize_event(rbb, e);

--- a/src/v/coproc/tests/utils/wasm_event_generator.h
+++ b/src/v/coproc/tests/utils/wasm_event_generator.h
@@ -35,7 +35,7 @@ struct cpp_enable_payload {
 /// skipped during serialization, useful for testing failure cases
 struct event {
     std::optional<uint64_t> id;
-    std::optional<ss::sstring> desc;
+    std::optional<bytes> desc;
     std::optional<bytes> script;
     std::optional<bytes> checksum;
     std::optional<event_action> action;

--- a/src/v/coproc/tests/wasm_event_tests.cc
+++ b/src/v/coproc/tests/wasm_event_tests.cc
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(verify_make_event_failures) {
         /// Erroneous checksum
         coproc::wasm::event e;
         e.id = random_generators::get_int<uint64_t>(55555);
-        e.desc = random_generators::gen_alphanum_string(15);
+        e.desc = random_generators::get_bytes(64);
         e.script = random_generators::get_bytes(15);
         e.checksum = random_generators::get_bytes(32);
         e.action = coproc::wasm::event_action::deploy;

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -88,18 +88,16 @@ class RpkTool:
 
         return filter(lambda p: p != None, map(partition_line, lines))
 
-    def wasm_deploy(self, script, description):
+    def wasm_deploy(self, script, name, description):
         cmd = [
             self._rpk_binary(), 'wasm', 'deploy', script, '--brokers',
-            self._redpanda.brokers(), '--description', description
+            self._redpanda.brokers(), '--name', name, '--description',
+            description
         ]
         return self._execute(cmd)
 
-    def wasm_remove(self, unique_id):
-        cmd = [
-            'wasm', 'remove', unique_id, '--brokers',
-            self._redpanda.brokers()
-        ]
+    def wasm_remove(self, name):
+        cmd = ['wasm', 'remove', name, '--brokers', self._redpanda.brokers()]
         return self._execute(cmd)
 
     def wasm_gen(self, directory):

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -9,6 +9,8 @@
 
 import os
 import uuid
+import random
+import string
 
 from kafka import TopicPartition
 
@@ -33,8 +35,15 @@ def flat_map(fn, ll):
     return reduce(lambda acc, x: acc + fn(x), ll, [])
 
 
+def random_string(N):
+    return ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for _ in range(N))
+
+
 class WasmScript:
     def __init__(self, inputs=[], outputs=[], script=None):
+        self.name = random_string(10)
         self.inputs = inputs
         self.outputs = outputs
         self.script = script
@@ -73,7 +82,8 @@ class WasmTest(RedpandaTest):
 
         # Deploy coprocessor
         self._rpk_tool.wasm_deploy(
-            script.get_artifact(self._build_tool.work_dir), "ducktape")
+            script.get_artifact(self._build_tool.work_dir), script.name,
+            "ducktape")
 
     def restart_wasm_engine(self, node):
         self.logger.info(


### PR DESCRIPTION
Modify rpk deploy to expect a `--name` flag which the hash of this will become the unique id to refer to the deployed copro as