### PR TITLE
operator/config: enable idempotent producers and transactions by default

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -261,6 +261,8 @@ func (r *ConfigMapResource) createConfiguration(
 		cr.Other = make(map[string]interface{})
 	}
 	cr.Other["auto_create_topics_enabled"] = r.pandaCluster.Spec.Configuration.AutoCreateTopics
+	cr.Other["enable_idempotence"] = true
+	cr.Other["enable_transactions"] = true
 
 	segmentSize := logSegmentSize
 	cr.LogSegmentSize = &segmentSize

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -124,6 +124,12 @@ func TestEnsure_ConfigMap(t *testing.T) {
 	if !strings.Contains(data, "auto_create_topics_enabled: false") {
 		t.Fatalf("expecting configmap containing 'auto_create_topics_enabled: false' but got %v", data)
 	}
+	if !strings.Contains(data, "enable_idempotence: true") {
+		t.Fatalf("expecting configmap containing 'enable_idempotence: true' but got %v", data)
+	}
+	if !strings.Contains(data, "enable_transactions: true") {
+		t.Fatalf("expecting configmap containing 'enable_transactions: true' but got %v", data)
+	}
 
 	// calling ensure for second time to see the resource does not get updated
 	err = cm.Ensure(context.Background())

--- a/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
+++ b/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
@@ -34,6 +34,7 @@ redpanda:
   default_topic_partitions: 3
   developer_mode: true
   enable_idempotence: true
+  enable_transactions: true
   kafka_api:
   - address: 0.0.0.0
     name: kafka


### PR DESCRIPTION
## Cover letter

This PR enables idempotent producers and transactions by default when using the operator. The generated `redpanda.yaml` (shown at startup) now includes:
```
redpanda:
...
  enable_idempotence: true
  enable_transactions: true
```

If necessary to disable, that is possible by adding `additionalConfiguration` in the CR:
```
spec:
..
  additionalConfiguration:
    redpanda.enable_idempotence: "false"
    redpanda.enable_transactions: "false"
```

Fixes: #1602 

## Release notes

Idempotence and transactions are enabled by default when using the operator.
