### PR TITLE
Wasm support compressed topics

### DIFF
--- a/src/v/coproc/reference_window_consumer.hpp
+++ b/src/v/coproc/reference_window_consumer.hpp
@@ -1,3 +1,14 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
 #pragma once
 #include "model/record.h"
 

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -90,6 +90,11 @@ private:
       const model::materialized_ntp&, model::record_batch_reader);
     ss::future<std::variant<write_response, model::term_id>>
       write_checked(storage::log, model::term_id, model::record_batch_reader);
+    std::optional<process_batch_request::data> mark_offset(
+      ss::lw_shared_ptr<ntp_context>,
+      model::offset,
+      std::size_t,
+      model::record_batch_reader);
 
     std::size_t max_batch_size() const {
         return config::shard_local_cfg().coproc_max_batch_size.value();
@@ -102,7 +107,8 @@ private:
     /// Manages async fiber that begins when calling 'start()'
     ss::gate _gate;
 
-    // Reference to resources shared across all script_contexts on 'this' shard
+    // Reference to resources shared across all script_contexts on 'this'
+    // shard
     shared_script_resources& _resources;
 
     /// References to input topics that this script is interested in

--- a/src/v/coproc/tests/utils/wasm_event_generator.cc
+++ b/src/v/coproc/tests/utils/wasm_event_generator.cc
@@ -109,6 +109,7 @@ model::record_batch_reader make_random_event_record_batch_reader(
     for (auto i = 0; i < n_batches; ++i) {
         storage::record_batch_builder rbb(
           model::record_batch_type::raft_data, o);
+        rbb.set_compression(model::compression::zstd);
         for (int j = 0; j < batch_size; ++j) {
             event e(random_generators::get_int<uint64_t>(82827));
             if (random_generators::get_int(0, 1) == 0) {
@@ -132,6 +133,7 @@ make_event_record_batch_reader(std::vector<std::vector<event>> event_batches) {
     for (auto& events : event_batches) {
         storage::record_batch_builder rbb(
           model::record_batch_type::raft_data, o);
+        rbb.set_compression(model::compression::zstd);
         for (event& e : events) {
             e.checksum = calculate_checksum(e);
             serialize_event(rbb, e);

--- a/src/v/storage/parser_utils.h
+++ b/src/v/storage/parser_utils.h
@@ -27,6 +27,19 @@ private:
     model::record_batch_reader::data_t _batches;
 };
 
+/// \brief Apply compressor over a model::record_batch_reader
+class compress_batch_consumer {
+public:
+    compress_batch_consumer(model::compression, std::size_t threshold) noexcept;
+    ss::future<ss::stop_iteration> operator()(model::record_batch&);
+    model::record_batch_reader end_of_stream();
+
+private:
+    model::compression _compression_type{model::compression::none};
+    std::size_t _threshold{0};
+    model::record_batch_reader::data_t _batches;
+};
+
 /// \brief batch decompression
 ss::future<model::record_batch> decompress_batch(model::record_batch&&);
 /// \brief batch decompression

--- a/src/v/storage/parser_utils.h
+++ b/src/v/storage/parser_utils.h
@@ -13,8 +13,19 @@
 
 #include "bytes/iobuf_parser.h"
 #include "model/record.h"
+#include "model/record_batch_reader.h"
 
 namespace storage::internal {
+
+/// \brief Decompress over a model::record_batch_reader
+class decompress_batch_consumer {
+public:
+    ss::future<ss::stop_iteration> operator()(model::record_batch&);
+    model::record_batch_reader end_of_stream();
+
+private:
+    model::record_batch_reader::data_t _batches;
+};
 
 /// \brief batch decompression
 ss::future<model::record_batch> decompress_batch(model::record_batch&&);


### PR DESCRIPTION
This PR adds support for topics that contain compressed data. Data is decompressed if necessary when reading from input topics. Additionally we compress record batches that are > 512 bytes before writing them to their respective materialized logs.