### PR TITLE
Schema registry config

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1,4 +1,49 @@
-"/schemas/types": {
+"/config": {
+      "put": {
+        "summary": "Set the global compatibility level.",
+        "operationId": "put_config",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "config",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "compatibility": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "compatibility": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
+    "/schemas/types": {
       "get": {
         "summary": "Get the supported schema types.",
         "operationId": "get_schemas_types",

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1,4 +1,34 @@
 "/config": {
+      "get": {
+        "summary": "Get the global compatibility level.",
+        "operationId": "get_config",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "compatibilityLevel": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
       "put": {
         "summary": "Set the global compatibility level.",
         "operationId": "put_config",

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1,4 +1,41 @@
 "/config/{subject}": {
+      "get": {
+        "summary": "Get the compatibility level for a subject.",
+        "operationId": "get_config_subject",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "compatibilityLevel": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
       "put": {
         "summary": "Set the compatibility level for a subject.",
         "operationId": "put_config_subject",

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1,4 +1,55 @@
-"/config": {
+"/config/{subject}": {
+      "put": {
+        "summary": "Set the compatibility level for a subject.",
+        "operationId": "put_config_subject",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "config",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "compatibility": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "compatibility": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
+    "/config": {
       "get": {
         "summary": "Get the global compatibility level.",
         "operationId": "get_config",

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1,29 +1,29 @@
 "/schemas/types": {
-        "get": {
-          "summary": "Get the supported schema types.",
-          "operationId": "get_schemas_types",
-          "consumes": [
-            "application/vnd.schemaregistry.v1+json",
-            "application/vnd.schemaregistry+json",
-            "application/json"
-          ],
-          "parameters": [],
-          "produces": ["application/vnd.schemaregistry.v1+json"],
-          "responses": {
-            "200": {
-              "description": "OK",
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
+      "get": {
+        "summary": "Get the supported schema types.",
+        "operationId": "get_schemas_types",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
-            },
-            "500": {
-              "description": "Internal Server error",
-              "schema": {
-                "$ref": "#/definitions/error_body"
-              }
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
           }
         }
       }

--- a/src/v/pandaproxy/json/rjson_util.h
+++ b/src/v/pandaproxy/json/rjson_util.h
@@ -17,6 +17,7 @@
 
 #include <seastar/core/sstring.hh>
 
+#include <rapidjson/prettywriter.h>
 #include <rapidjson/reader.h>
 #include <rapidjson/stream.h>
 #include <rapidjson/stringbuffer.h>
@@ -71,6 +72,24 @@ typename Handler::rjson_parse_result
         throw parse_error(reader.GetErrorOffset());
     }
     return std::move(handler.result);
+}
+
+inline ss::sstring minify(std::string_view json) {
+    rapidjson::Reader r;
+    rapidjson::StringStream in(json.data());
+    rapidjson::StringBuffer out;
+    rapidjson::Writer<rapidjson::StringBuffer> w{out};
+    r.Parse(in, w);
+    return ss::sstring(out.GetString(), out.GetSize());
+}
+
+inline ss::sstring prettify(std::string_view json) {
+    rapidjson::Reader r;
+    rapidjson::StringStream in(json.data());
+    rapidjson::StringBuffer out;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> w{out};
+    r.Parse(in, w);
+    return ss::sstring(out.GetString(), out.GetSize());
 }
 
 } // namespace pandaproxy::json

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -32,6 +32,8 @@ struct error_category final : std::error_category {
             return "Subject not found";
         case error_code::subject_version_not_found:
             return "Subject version not found";
+        case error_code::topic_parse_error:
+            return "Unexpected data found in topic";
         }
         return "(unrecognized error)";
     }
@@ -46,6 +48,8 @@ struct error_category final : std::error_category {
             return reply_error_code::topic_not_found; // 40401
         case error_code::schema_invalid:
             return reply_error_code::unprocessable_entity;
+        case error_code::topic_parse_error:
+            return reply_error_code::zookeeper_error; // 50001
         }
         return {};
     }

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -21,6 +21,7 @@ enum class error_code {
     schema_invalid,
     subject_not_found,
     subject_version_not_found,
+    topic_parse_error,
 };
 
 std::error_code make_error_code(error_code);

--- a/src/v/pandaproxy/schema_registry/exceptions.h
+++ b/src/v/pandaproxy/schema_registry/exceptions.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/schema_registry/error.h"
+
+#include <fmt/format.h>
+
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace pandaproxy::schema_registry {
+
+struct exception_base : std::exception {
+    explicit exception_base(std::error_condition err)
+      : std::exception{}
+      , error{err}
+      , msg{err.message()} {}
+    exception_base(std::error_condition err, std::string_view msg)
+      : std::exception{}
+      , error{err}
+      , msg{msg} {}
+    const char* what() const noexcept final { return msg.c_str(); }
+    std::error_condition error;
+    std::string msg;
+};
+
+class exception final : public exception_base {
+public:
+    explicit exception(error_code ec)
+      : exception_base(make_error_code(ec).default_error_condition()) {}
+    exception(error_code ec, std::string_view msg)
+      : exception_base(make_error_code(ec).default_error_condition(), msg) {}
+};
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -103,6 +103,37 @@ put_config(server::request_t rq, server::reply_t rp) {
 }
 
 ss::future<server::reply_t>
+put_config_subject(server::request_t rq, server::reply_t rp) {
+    parse_accept_header(rq, rp);
+    auto sub = parse::request_param<subject>(*rq.req, "subject");
+    auto config = ppj::rjson_parse(
+      rq.req->content.data(), put_config_handler<>{});
+    rq.req.reset();
+
+    auto res = rq.service().schema_store().set_compatibility(
+      sub, config.compat);
+    if (res.has_error()) {
+        rp.rep = make_errored_body(res.error());
+        co_return rp;
+    }
+
+    if (res.value()) {
+        auto res = co_await rq.service().client().local().produce_record_batch(
+          model::schema_registry_internal_tp,
+          make_config_batch(sub, config.compat));
+
+        // TODO(Ben): Check the error reporting here
+        if (res.error_code != kafka::error_code::none) {
+            throw kafka::exception(res.error_code, *res.error_message);
+        }
+    }
+
+    auto json_rslt = ppj::rjson_serialize(config);
+    rp.rep->write_body("json", json_rslt);
+    co_return rp;
+}
+
+ss::future<server::reply_t>
 get_schemas_types(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     rq.req.reset();

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -25,6 +25,9 @@ get_config(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 ss::future<ctx_server<service>::reply_t>
 put_config(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> get_config_subject(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> put_config_subject(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -20,6 +20,9 @@
 namespace pandaproxy::schema_registry {
 
 ss::future<ctx_server<service>::reply_t>
+get_config(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
+ss::future<ctx_server<service>::reply_t>
 put_config(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
 ss::future<ctx_server<service>::reply_t> get_schemas_types(

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -25,6 +25,9 @@ get_config(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 ss::future<ctx_server<service>::reply_t>
 put_config(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> put_config_subject(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> get_schemas_types(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -19,6 +19,9 @@
 
 namespace pandaproxy::schema_registry {
 
+ss::future<ctx_server<service>::reply_t>
+put_config(ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> get_schemas_types(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/requests/config.h
+++ b/src/v/pandaproxy/schema_registry/requests/config.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/json/rjson_parse.h"
+#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/schema_registry/types.h"
+
+namespace pandaproxy::schema_registry {
+
+struct put_config_req_rep {
+    static constexpr std::string_view field_name = "compatibility";
+    compatibility_level compat{compatibility_level::none};
+};
+
+template<typename Encoding = rapidjson::UTF8<>>
+class put_config_handler : public json::base_handler<Encoding> {
+    enum class state {
+        empty = 0,
+        object,
+        compatibility,
+    };
+    state _state = state::empty;
+
+public:
+    using Ch = typename json::base_handler<Encoding>::Ch;
+    using rjson_parse_result = put_config_req_rep;
+    rjson_parse_result result;
+
+    explicit put_config_handler()
+      : json::base_handler<Encoding>{json::serialization_format::none}
+      , result() {}
+
+    bool Key(const Ch* str, rapidjson::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        if (_state == state::object && sv == put_config_req_rep::field_name) {
+            _state = state::compatibility;
+            return true;
+        }
+        return false;
+    }
+
+    bool String(const Ch* str, rapidjson::SizeType len, bool) {
+        auto sv = std::string_view{str, len};
+        if (_state == state::compatibility) {
+            auto s = from_string_view<compatibility_level>(sv);
+            if (s.has_value()) {
+                result.compat = *s;
+                _state = state::object;
+            }
+            return s.has_value();
+        }
+        return false;
+    }
+
+    bool StartObject() {
+        return std::exchange(_state, state::object) == state::empty;
+    }
+
+    bool EndObject(rapidjson::SizeType) {
+        return std::exchange(_state, state::empty) == state::object;
+    }
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const schema_registry::put_config_req_rep& res) {
+    w.StartObject();
+    w.Key(put_config_req_rep::field_name.data());
+    ::json::rjson_serialize(w, to_string_view(res.compat));
+    w.EndObject();
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/requests/config.h
+++ b/src/v/pandaproxy/schema_registry/requests/config.h
@@ -17,6 +17,11 @@
 
 namespace pandaproxy::schema_registry {
 
+struct get_config_req_rep {
+    static constexpr std::string_view field_name = "compatibilityLevel";
+    compatibility_level compat{compatibility_level::none};
+};
+
 struct put_config_req_rep {
     static constexpr std::string_view field_name = "compatibility";
     compatibility_level compat{compatibility_level::none};
@@ -70,6 +75,15 @@ public:
         return std::exchange(_state, state::empty) == state::object;
     }
 };
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const schema_registry::get_config_req_rep& res) {
+    w.StartObject();
+    w.Key(get_config_req_rep::field_name.data());
+    ::json::rjson_serialize(w, to_string_view(res.compat));
+    w.EndObject();
+}
 
 inline void rjson_serialize(
   rapidjson::Writer<rapidjson::StringBuffer>& w,

--- a/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/post_subject_versions.h
@@ -143,13 +143,7 @@ public:
             return true;
         }
         case state::schema_type: {
-            std::optional<schema_type> type{
-              string_switch<std::optional<schema_type>>(sv)
-                .match(to_string_view(schema_type::avro), schema_type::avro)
-                .match(to_string_view(schema_type::json), schema_type::json)
-                .match(
-                  to_string_view(schema_type::protobuf), schema_type::protobuf)
-                .default_match(std::nullopt)};
+            auto type = from_string_view<schema_type>(sv);
             if (type.has_value()) {
                 result.type = *type;
                 _state = state::record;

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -55,6 +55,10 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       ss::httpd::schema_registry_json::put_config, wrap(gate, es, put_config)});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::put_config_subject,
+      wrap(gate, es, put_config_subject)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::get_schemas_types,
       wrap(gate, es, get_schemas_types)});
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -49,6 +49,9 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
     routes.api = ss::httpd::schema_registry_json::name;
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::get_config, wrap(gate, es, get_config)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::put_config, wrap(gate, es, put_config)});
 
     routes.routes.emplace_back(server::route_t{

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -49,6 +49,9 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
     routes.api = ss::httpd::schema_registry_json::name;
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::put_config, wrap(gate, es, put_config)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::get_schemas_types,
       wrap(gate, es, get_schemas_types)});
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -55,6 +55,10 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       ss::httpd::schema_registry_json::put_config, wrap(gate, es, put_config)});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::get_config_subject,
+      wrap(gate, es, get_config_subject)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::put_config_subject,
       wrap(gate, es, put_config_subject)});
 

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -23,6 +23,7 @@
 #include "raft/types.h"
 #include "storage/record_batch_builder.h"
 #include "utils/string_switch.h"
+#include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/std-coroutine.hh>

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -303,13 +303,7 @@ public:
             return true;
         }
         case state::type: {
-            std::optional<schema_type> type{
-              string_switch<std::optional<schema_type>>(sv)
-                .match(to_string_view(schema_type::avro), schema_type::avro)
-                .match(to_string_view(schema_type::json), schema_type::json)
-                .match(
-                  to_string_view(schema_type::protobuf), schema_type::protobuf)
-                .default_match(std::nullopt)};
+            auto type = from_string_view<schema_type>(sv);
             if (type.has_value()) {
                 result.type = *type;
                 _state = state::object;

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -678,7 +678,7 @@ struct consume_to_store {
     }
 
     ss::future<> apply(schema_key key, schema_value val) {
-        if (key.magic != 1) {
+        if (key.magic != 0 && key.magic != 1) {
             throw exception(
               error_code::topic_parse_error,
               fmt::format("key has unexpected magic: {}", key));

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -187,6 +187,21 @@ struct schema_value {
     schema_id id;
     schema_definition schema;
     bool deleted{false};
+
+    friend bool operator==(const schema_value&, const schema_value&) = default;
+
+    friend std::ostream& operator<<(std::ostream& os, const schema_value& v) {
+        fmt::print(
+          os,
+          "subject: {}, version: {}, type: {}, id: {}, schema: {}, deleted: {}",
+          v.sub,
+          v.version,
+          v.type,
+          v.id,
+          v.schema,
+          v.deleted);
+        return os;
+    }
 };
 
 inline void rjson_serialize(

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "bytes/iobuf_parser.h"
+#include "json/json.h"
 #include "model/record_utils.h"
 #include "pandaproxy/json/rjson_parse.h"
 #include "pandaproxy/json/rjson_util.h"
@@ -39,6 +40,19 @@ struct schema_key {
     subject sub;
     schema_version version;
     topic_key_magic magic{1};
+
+    friend bool operator==(const schema_key&, const schema_key&) = default;
+
+    friend std::ostream& operator<<(std::ostream& os, const schema_key& v) {
+        fmt::print(
+          os,
+          "keytype: {}, subject: {}, version: {}, magic: {}",
+          v.keytype,
+          v.sub,
+          v.version,
+          v.magic);
+        return os;
+    }
 };
 
 inline void rjson_serialize(

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -632,6 +632,12 @@ inline model::record_batch make_schema_batch(
         .deleted = deleted});
 }
 
+inline model::record_batch
+make_config_batch(std::optional<subject> sub, compatibility_level compat) {
+    return as_record_batch(
+      config_key{.sub{std::move(sub)}}, config_value{.compat = compat});
+}
+
 struct consume_to_store {
     explicit consume_to_store(store& s)
       : _store{s} {}

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -57,7 +57,7 @@ public:
             return error_code::subject_not_found;
         }
 
-        const auto& versions = sub_it->second;
+        const auto& versions = sub_it->second.versions;
         auto v_it = std::lower_bound(
           versions.begin(),
           versions.end(),
@@ -101,7 +101,7 @@ public:
         if (sub_it == _subjects.end()) {
             return error_code::subject_not_found;
         }
-        const auto& versions = sub_it->second;
+        const auto& versions = sub_it->second.versions;
         std::vector<schema_version> res;
         res.reserve(versions.size());
         std::transform(
@@ -139,7 +139,7 @@ private:
         bool inserted;
     };
     insert_subject_result insert_subject(subject sub, schema_id id) {
-        auto& versions = _subjects[std::move(sub)];
+        auto& versions = _subjects[std::move(sub)].versions;
         const auto v_it = std::find_if(
           versions.cbegin(), versions.cend(), [id](auto v) {
               return v.id == id;
@@ -164,16 +164,11 @@ private:
     };
 
     struct subject_entry {
-        explicit subject_entry(subject sub)
-          : sub{std::move(sub)}
-          , versions{} {}
-
-        subject sub;
         std::vector<subject_version_id> versions;
     };
 
     absl::btree_map<schema_id, schema_entry> _schemas;
-    absl::node_hash_map<subject, subject_versions> _subjects;
+    absl::node_hash_map<subject, subject_entry> _subjects;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -3,6 +3,7 @@ rp_test(
   BINARY_NAME pandaproxy_schema_registry_unit
   SOURCES
     util.cc
+    storage.cc
     store.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v_pandaproxy_schema_registry

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -15,8 +15,9 @@ rp_test(
   BINARY_NAME pandaproxy_schema_registry_single_thread
   SOURCES
     one_shot.cc
+    consume_to_store.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES v::seastar_testing_main
+  LIBRARIES v::seastar_testing_main v_pandaproxy_schema_registry
   ARGS "-- -c 1"
   LABELS pandaproxy
 )

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -38,6 +38,7 @@ const pps::schema_definition int_def0{
 const pps::subject subject0{"subject0"};
 constexpr pps::topic_key_magic magic0{0};
 constexpr pps::topic_key_magic magic1{1};
+constexpr pps::topic_key_magic magic2{2};
 constexpr pps::schema_version version0{0};
 constexpr pps::schema_version version1{1};
 constexpr pps::schema_id id0{0};
@@ -58,7 +59,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
     BOOST_REQUIRE(s_res.value().definition == string_def0);
 
     auto bad_schema_magic = pps::as_record_batch(
-      pps::schema_key{subject0, version0, magic0},
+      pps::schema_key{subject0, version0, magic2},
       pps::schema_value{
         subject0, version0, pps::schema_type::avro, id0, string_def0});
     BOOST_REQUIRE_THROW(c(std::move(bad_schema_magic)).get(), pps::exception);

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -1,0 +1,83 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/storage.h"
+#include "pandaproxy/schema_registry/store.h"
+#include "pandaproxy/schema_registry/util.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <stdexcept>
+
+namespace pps = pandaproxy::schema_registry;
+
+constexpr std::string_view sv_string_def0{R"({"type":"string"})"};
+constexpr std::string_view sv_int_def0{R"({"type": "int"})"};
+const pps::schema_definition string_def0{
+  pps::make_schema_definition<rapidjson::UTF8<>>(sv_string_def0).value()};
+const pps::schema_definition int_def0{
+  pps::make_schema_definition<rapidjson::UTF8<>>(sv_int_def0).value()};
+const pps::subject subject0{"subject0"};
+constexpr pps::topic_key_magic magic0{0};
+constexpr pps::topic_key_magic magic1{1};
+constexpr pps::schema_version version0{0};
+constexpr pps::schema_version version1{1};
+constexpr pps::schema_id id0{0};
+constexpr pps::schema_id id1{1};
+
+SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
+    pps::store s;
+    auto c = pps::consume_to_store(s);
+
+    auto good_schema_1 = pps::as_record_batch(
+      pps::schema_key{subject0, version0, magic1},
+      pps::schema_value{
+        subject0, version0, pps::schema_type::avro, id0, string_def0});
+    BOOST_REQUIRE_NO_THROW(c(std::move(good_schema_1)).get());
+
+    auto s_res = s.get_subject_schema(subject0, version0);
+    BOOST_REQUIRE(s_res.has_value());
+    BOOST_REQUIRE(s_res.value().definition == string_def0);
+
+    auto bad_schema_magic = pps::as_record_batch(
+      pps::schema_key{subject0, version0, magic0},
+      pps::schema_value{
+        subject0, version0, pps::schema_type::avro, id0, string_def0});
+    BOOST_REQUIRE_THROW(c(std::move(bad_schema_magic)).get(), pps::exception);
+
+    BOOST_REQUIRE(
+      s.get_compatibility().value() == pps::compatibility_level::none);
+    BOOST_REQUIRE(
+      s.get_compatibility(subject0).value() == pps::compatibility_level::none);
+
+    auto good_config = pps::as_record_batch(
+      pps::config_key{subject0, magic0},
+      pps::config_value{pps::compatibility_level::full});
+    BOOST_REQUIRE_NO_THROW(c(std::move(good_config)).get());
+
+    BOOST_REQUIRE(
+      s.get_compatibility(subject0).value() == pps::compatibility_level::full);
+
+    auto bad_config_magic = pps::as_record_batch(
+      pps::config_key{subject0, magic1},
+      pps::config_value{pps::compatibility_level::full});
+    BOOST_REQUIRE_THROW(c(std::move(bad_config_magic)).get(), pps::exception);
+}

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -49,6 +49,23 @@ const pps::schema_value avro_schema_value{
   .schema{pps::schema_definition{R"({"type":"string"})"}},
   .deleted = true};
 
+constexpr std::string_view config_key_sv{
+  R"({
+  "keytype": "CONFIG",
+  "subject": null,
+  "magic": 0
+})"};
+const pps::config_key config_key{.sub{}, .magic{pps::topic_key_magic{0}}};
+
+constexpr std::string_view config_key_sub_sv{
+  R"({
+  "keytype": "CONFIG",
+  "subject": "my-kafka-value",
+  "magic": 0
+})"};
+const pps::config_key config_key_sub{
+  .sub{pps::subject{"my-kafka-value"}}, .magic{pps::topic_key_magic{0}}};
+
 BOOST_AUTO_TEST_CASE(test_storage_serde) {
     {
         auto key = ppj::rjson_parse(
@@ -66,5 +83,23 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
 
         auto str = ppj::rjson_serialize(avro_schema_value);
         BOOST_CHECK_EQUAL(str, ppj::minify(avro_schema_value_sv));
+    }
+
+    {
+        auto val = ppj::rjson_parse(
+          config_key_sv.data(), pps::config_key_handler<>{});
+        BOOST_CHECK_EQUAL(config_key, val);
+
+        auto str = ppj::rjson_serialize(config_key);
+        BOOST_CHECK_EQUAL(str, ppj::minify(config_key_sv));
+    }
+
+    {
+        auto val = ppj::rjson_parse(
+          config_key_sub_sv.data(), pps::config_key_handler<>{});
+        BOOST_CHECK_EQUAL(config_key_sub, val);
+
+        auto str = ppj::rjson_serialize(config_key_sub);
+        BOOST_CHECK_EQUAL(str, ppj::minify(config_key_sub_sv));
     }
 }

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -66,6 +66,13 @@ constexpr std::string_view config_key_sub_sv{
 const pps::config_key config_key_sub{
   .sub{pps::subject{"my-kafka-value"}}, .magic{pps::topic_key_magic{0}}};
 
+constexpr std::string_view config_value_sv{
+  R"({
+  "compatibilityLevel": "FORWARD_TRANSITIVE"
+})"};
+const pps::config_value config_value{
+  .compat = pps::compatibility_level::forward_transitive};
+
 BOOST_AUTO_TEST_CASE(test_storage_serde) {
     {
         auto key = ppj::rjson_parse(
@@ -101,5 +108,14 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
 
         auto str = ppj::rjson_serialize(config_key_sub);
         BOOST_CHECK_EQUAL(str, ppj::minify(config_key_sub_sv));
+    }
+
+    {
+        auto val = ppj::rjson_parse(
+          config_value_sv.data(), pps::config_value_handler<>{});
+        BOOST_CHECK_EQUAL(config_value, val);
+
+        auto str = ppj::rjson_serialize(config_value);
+        BOOST_CHECK_EQUAL(str, ppj::minify(config_value_sv));
     }
 }

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -1,0 +1,70 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/storage.h"
+
+#include "pandaproxy/json/rjson_parse.h"
+#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/util.h"
+
+#include <absl/algorithm/container.h>
+#include <boost/test/unit_test.hpp>
+#include <fmt/format.h>
+
+namespace ppj = pandaproxy::json;
+namespace pps = pandaproxy::schema_registry;
+
+constexpr std::string_view avro_schema_key_sv{
+  R"({
+  "keytype": "SCHEMA",
+  "subject": "my-kafka-value",
+  "version": 1,
+  "magic": 1
+})"};
+const pps::schema_key avro_schema_key{
+  .sub{pps::subject{"my-kafka-value"}},
+  .version{pps::schema_version{1}},
+  .magic{pps::topic_key_magic{1}}};
+
+constexpr std::string_view avro_schema_value_sv{
+  R"({
+  "subject": "my-kafka-value",
+  "version": 1,
+  "id": 1,
+  "schema": "{\"type\":\"string\"}",
+  "deleted": true
+})"};
+const pps::schema_value avro_schema_value{
+  .sub{pps::subject{"my-kafka-value"}},
+  .version{pps::schema_version{1}},
+  .type = pps::schema_type::avro,
+  .id{pps::schema_id{1}},
+  .schema{pps::schema_definition{R"({"type":"string"})"}},
+  .deleted = true};
+
+BOOST_AUTO_TEST_CASE(test_storage_serde) {
+    {
+        auto key = ppj::rjson_parse(
+          avro_schema_key_sv.data(), pps::schema_key_handler<>{});
+        BOOST_CHECK_EQUAL(avro_schema_key, key);
+
+        auto str = ppj::rjson_serialize(avro_schema_key);
+        BOOST_CHECK_EQUAL(str, ppj::minify(avro_schema_key_sv));
+    }
+
+    {
+        auto val = ppj::rjson_parse(
+          avro_schema_value_sv.data(), pps::schema_value_handler<>{});
+        BOOST_CHECK_EQUAL(avro_schema_value, val);
+
+        auto str = ppj::rjson_serialize(avro_schema_value);
+        BOOST_CHECK_EQUAL(str, ppj::minify(avro_schema_value_sv));
+    }
+}

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -9,6 +9,7 @@
 
 #include "pandaproxy/schema_registry/store.h"
 
+#include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/util.h"
 
 #include <absl/algorithm/container.h>
@@ -180,4 +181,80 @@ BOOST_AUTO_TEST_CASE(test_store_get_subjects) {
     BOOST_REQUIRE(subjects.size() == 2);
     BOOST_REQUIRE_EQUAL(absl::c_count_if(subjects, is_equal(subject0)), 1);
     BOOST_REQUIRE_EQUAL(absl::c_count_if(subjects, is_equal(subject1)), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_store_global_compat) {
+    // Setting the retrieving global compatibility should be allowed multiple
+    // times
+
+    pps::compatibility_level expected{pps::compatibility_level::none};
+    pps::store s;
+    BOOST_REQUIRE(s.get_compatibility().value() == expected);
+
+    expected = pps::compatibility_level::backward;
+    BOOST_REQUIRE(s.set_compatibility(expected).value() == true);
+    BOOST_REQUIRE(s.get_compatibility().value() == expected);
+
+    // duplicate should return false
+    expected = pps::compatibility_level::backward;
+    BOOST_REQUIRE(s.set_compatibility(expected).value() == false);
+    BOOST_REQUIRE(s.get_compatibility().value() == expected);
+
+    expected = pps::compatibility_level::full_transitive;
+    BOOST_REQUIRE(s.set_compatibility(expected).value() == true);
+    BOOST_REQUIRE(s.get_compatibility().value() == expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
+    // Setting the retrieving a subject compatibility should be allowed multiple
+    // times
+
+    pps::compatibility_level global_expected{pps::compatibility_level::none};
+    pps::store s;
+    BOOST_REQUIRE(s.get_compatibility().value() == global_expected);
+    s.insert(subject0, string_def0, pps::schema_type::avro);
+
+    auto sub_expected = pps::compatibility_level::backward;
+    BOOST_REQUIRE(s.set_compatibility(subject0, sub_expected).value() == true);
+    BOOST_REQUIRE(s.get_compatibility(subject0).value() == sub_expected);
+
+    // duplicate should return false
+    sub_expected = pps::compatibility_level::backward;
+    BOOST_REQUIRE(s.set_compatibility(subject0, sub_expected).value() == false);
+    BOOST_REQUIRE(s.get_compatibility(subject0).value() == sub_expected);
+
+    sub_expected = pps::compatibility_level::full_transitive;
+    BOOST_REQUIRE(s.set_compatibility(subject0, sub_expected).value() == true);
+    BOOST_REQUIRE(s.get_compatibility(subject0).value() == sub_expected);
+    BOOST_REQUIRE(s.get_compatibility().value() == global_expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_store_subject_compat_fallback) {
+    // A Subject should fallback to the current global setting
+
+    pps::compatibility_level expected{pps::compatibility_level::none};
+    pps::store s;
+    s.insert(subject0, string_def0, pps::schema_type::avro);
+    BOOST_REQUIRE(s.get_compatibility(subject0).value() == expected);
+
+    expected = pps::compatibility_level::backward;
+    BOOST_REQUIRE(s.set_compatibility(expected).value() == true);
+    BOOST_REQUIRE(s.get_compatibility(subject0).value() == expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_store_invalid_subject_compat) {
+    // Setting and getting a compatibility for a non-existant subject should
+    // fail
+
+    pps::compatibility_level expected{pps::compatibility_level::none};
+    pps::store s;
+
+    BOOST_REQUIRE_EQUAL(
+      s.get_compatibility(subject0).error(),
+      pps::error_code::subject_not_found);
+
+    expected = pps::compatibility_level::backward;
+    BOOST_REQUIRE_EQUAL(
+      s.set_compatibility(subject0, expected).error(),
+      pps::error_code::subject_not_found);
 }

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -19,6 +19,7 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include <type_traits>
 
@@ -49,6 +50,10 @@ from_string_view<schema_type>(std::string_view sv) {
       .match(to_string_view(schema_type::json), schema_type::json)
       .match(to_string_view(schema_type::protobuf), schema_type::protobuf)
       .default_match(std::nullopt);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const schema_type& v) {
+    return os << to_string_view(v);
 }
 
 ///\brief A subject is the name under which a schema is registered.

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -115,4 +115,59 @@ struct subject_schema {
     bool deleted{false};
 };
 
+enum class compatibility_level {
+    none = 0,
+    backward,
+    backward_transitive,
+    forward,
+    forward_transitive,
+    full,
+    full_transitive,
+};
+
+constexpr std::string_view to_string_view(compatibility_level v) {
+    switch (v) {
+    case compatibility_level::none:
+        return "NONE";
+    case compatibility_level::backward:
+        return "BACKWARD";
+    case compatibility_level::backward_transitive:
+        return "BACKWARD_TRANSITIVE";
+    case compatibility_level::forward:
+        return "FORWARD";
+    case compatibility_level::forward_transitive:
+        return "FORWARD_TRANSITIVE";
+    case compatibility_level::full:
+        return "FULL";
+    case compatibility_level::full_transitive:
+        return "FULL_TRANSITIVE";
+    }
+    return "{invalid}";
+}
+template<>
+constexpr std::optional<compatibility_level>
+from_string_view<compatibility_level>(std::string_view sv) {
+    return string_switch<std::optional<compatibility_level>>(sv)
+      .match(
+        to_string_view(compatibility_level::none), compatibility_level::none)
+      .match(
+        to_string_view(compatibility_level::backward),
+        compatibility_level::backward)
+      .match(
+        to_string_view(compatibility_level::backward_transitive),
+        compatibility_level::backward_transitive)
+      .match(
+        to_string_view(compatibility_level::forward),
+        compatibility_level::forward)
+      .match(
+        to_string_view(compatibility_level::forward_transitive),
+        compatibility_level::forward_transitive)
+      .match(
+        to_string_view(compatibility_level::full), compatibility_level::full)
+      .match(
+        to_string_view(compatibility_level::full_transitive),
+        compatibility_level::full_transitive)
+      .default_match(std::nullopt);
+}
+
 } // namespace pandaproxy::schema_registry


### PR DESCRIPTION
## Cover letter

Introduces support for config endpoints:
* `GET /config`
* `GET /config/{subject}`
* `PUT /config`
* `PUT /config/{subject}`

Swagger updated on [SwaggerHub](https://app.swaggerhub.com/apis/BenPope/pandaproxy-schema-registry/0.0.1)

Includes storage and retrieval of the data in the backing topic.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/1f6169bd65c30b96aadaeadebcbceb5853614629..bb9d26b4eb3da15661d94d1cafcb152624dac92e)
* Added the endpoints
* Added the storage
* Added `minify`, `prettify`
* Refactored some stuff in storage
* Added more tests, including ducktape
* `store::set_compatibility` now returns whether an update occurred

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/bb9d26b4eb3da15661d94d1cafcb152624dac92e..037e99ef34002c2bb38588704149d7db967d87f3)
* Set the config for the subject when setting the config for the subject

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/037e99ef34002c2bb38588704149d7db967d87f3..db6a979c83e0fd74e39f8ba88a0410d0e37ba60d)
* Introduce `from_string_view<>`  - cleanup and reduce code duplication
* `topic_key_type` is now an `enum class`
* Cleaned up `requests/config.h`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/db6a979c83e0fd74e39f8ba88a0410d0e37ba60d..62a0dc16bcb6aba3c1c72c6118174e841f44b159)
* constexpr for `from_string_view`
* Introduce `store::upsert` && tests - new information on the internal topic will now override existing data
* Futurized `consume_to_store` to reports errors via an `ss::future`, now uses `upsert`, and added tests.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/62a0dc16bcb6aba3c1c72c6118174e841f44b159..d2cef901fe207eb798723a3a78783c201576ff05)
* Use default `operator==`
* Simplify comparison with `optional`
* Fixed swagger indentation
* Support `schema_key` magic 0
* Remove optionality from some ducktape test params
* Improve `operator<<` for `schema_type`

## Release notes

Release note: Introduces support for config endpoints and state management (compatibility not checked yet)
