### PR TITLE
redpanda: dynamic log level control

### DIFF
--- a/src/v/redpanda/admin/api-doc/config.json
+++ b/src/v/redpanda/admin/api-doc/config.json
@@ -11,4 +11,44 @@
       }
     }
   }
+},
+"/v1/config/log_level/{name}": {
+  "put": {
+    "summary": "Set log level",
+    "operationId": "set_log_level",
+    "parameters": [
+        {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+        },
+        {
+            "name": "level",
+            "in": "query",
+            "required": true,
+            "allowMultiple": false,
+            "type": "string",
+            "enum": [
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ]
+        },
+        {
+            "name": "expires",
+            "in": "query",
+            "required": false,
+            "allowMultiple": false,
+            "type": "long"
+        }
+    ],
+    "responses": {
+      "200": {
+        "description": "Log level"
+      }
+    }
+  }
 }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -113,13 +113,7 @@ void admin_server::configure_admin_routes() {
     rb->register_function(_server._routes, insert_comma);
     rb->register_api_file(_server._routes, "hbadger");
 
-    ss::httpd::config_json::get_config.set(
-      _server._routes, []([[maybe_unused]] ss::const_req req) {
-          rapidjson::StringBuffer buf;
-          rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
-          config::shard_local_cfg().to_json(writer);
-          return ss::json::json_return_type(buf.GetString());
-      });
+    register_config_routes();
     register_raft_routes();
     register_kafka_routes();
     register_security_routes();
@@ -175,6 +169,16 @@ ss::future<> admin_server::configure_listeners() {
             return _server.listen(resolved, cred);
         });
     }
+}
+
+void admin_server::register_config_routes() {
+    ss::httpd::config_json::get_config.set(
+      _server._routes, []([[maybe_unused]] ss::const_req req) {
+          rapidjson::StringBuffer buf;
+          rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+          config::shard_local_cfg().to_json(writer);
+          return ss::json::json_return_type(buf.GetString());
+      });
 }
 
 void admin_server::register_raft_routes() {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -51,11 +51,13 @@
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/lexical_cast/bad_lexical_cast.hpp>
 #include <rapidjson/document.h>
 #include <rapidjson/schema.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include <stdexcept>
 #include <unordered_map>
 
 using namespace std::chrono_literals;
@@ -68,7 +70,8 @@ admin_server::admin_server(
   cluster::controller* controller,
   ss::sharded<cluster::shard_table>& st,
   ss::sharded<cluster::metadata_cache>& metadata_cache)
-  : _server("admin")
+  : _log_level_timer([this] { log_level_timer_handler(); })
+  , _server("admin")
   , _cfg(std::move(cfg))
   , _partition_manager(pm)
   , _controller(controller)
@@ -171,6 +174,39 @@ ss::future<> admin_server::configure_listeners() {
     }
 }
 
+void admin_server::rearm_log_level_timer() {
+    _log_level_timer.cancel();
+
+    auto next = std::min_element(
+      _log_level_resets.begin(),
+      _log_level_resets.end(),
+      [](const auto& a, const auto& b) {
+          return a.second.expires < b.second.expires;
+      });
+
+    if (next != _log_level_resets.end()) {
+        _log_level_timer.arm(next->second.expires);
+    }
+}
+
+void admin_server::log_level_timer_handler() {
+    for (auto it = _log_level_resets.begin(); it != _log_level_resets.end();) {
+        if (it->second.expires <= ss::timer<>::clock::now()) {
+            vlog(
+              logger.info,
+              "Expiring log level for {{{}}} to {}",
+              it->first,
+              it->second.level);
+            ss::global_logger_registry().set_logger_level(
+              it->first, it->second.level);
+            _log_level_resets.erase(it++);
+        } else {
+            ++it;
+        }
+    }
+    rearm_log_level_timer();
+}
+
 void admin_server::register_config_routes() {
     ss::httpd::config_json::get_config.set(
       _server._routes, []([[maybe_unused]] ss::const_req req) {
@@ -178,6 +214,79 @@ void admin_server::register_config_routes() {
           rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
           config::shard_local_cfg().to_json(writer);
           return ss::json::json_return_type(buf.GetString());
+      });
+
+    ss::httpd::config_json::set_log_level.set(
+      _server._routes, [this](ss::const_req req) {
+          auto name = req.param["name"];
+
+          // current level: will be used revert after a timeout (optional)
+          ss::log_level cur_level;
+          try {
+              cur_level = ss::global_logger_registry().get_logger_level(name);
+          } catch (std::out_of_range&) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Cannot set log level: unknown logger {{{}}}", name));
+          }
+
+          // decode new level
+          ss::log_level new_level;
+          try {
+              new_level = boost::lexical_cast<ss::log_level>(
+                req.get_query_param("level"));
+          } catch (const boost::bad_lexical_cast& e) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Cannot set log level for {{{}}}: unknown level {{{}}}",
+                name,
+                req.get_query_param("level")));
+          }
+
+          // how long should the new log level be active
+          std::optional<std::chrono::seconds> expires;
+          if (auto e = req.get_query_param("expires"); !e.empty()) {
+              try {
+                  expires = std::chrono::seconds(
+                    boost::lexical_cast<unsigned int>(e));
+              } catch (const boost::bad_lexical_cast& e) {
+                  throw ss::httpd::bad_param_exception(fmt::format(
+                    "Cannot set log level for {{{}}}: invalid expires value "
+                    "{{{}}}",
+                    name,
+                    e));
+              }
+          }
+
+          vlog(
+            logger.info,
+            "Set log level for {{{}}}: {} -> {}",
+            name,
+            cur_level,
+            new_level);
+
+          ss::global_logger_registry().set_logger_level(name, new_level);
+
+          if (!expires) {
+              // if no expiration was given, then use some reasonable default
+              // that will prevent the system from remaining in a non-optimal
+              // state (e.g. trace logging) indefinitely.
+              expires = std::chrono::minutes(10);
+          }
+
+          // expires=0 is same as not specifying it at all
+          if (expires->count() > 0) {
+              auto when = ss::timer<>::clock::now() + expires.value();
+              auto res = _log_level_resets.try_emplace(name, cur_level, when);
+              if (!res.second) {
+                  res.first->second.expires = when;
+              }
+          } else {
+              // perm change. no need to store prev level
+              _log_level_resets.erase(name);
+          }
+
+          rearm_log_level_timer();
+
+          return ss::json::json_return_type(ss::json::json_void());
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -69,6 +69,7 @@ private:
     void configure_dashboard();
     void configure_metrics_route();
     void configure_admin_routes();
+    void register_config_routes();
     void register_raft_routes();
     void register_kafka_routes();
     void register_security_routes();

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -24,6 +24,18 @@ class Admin:
     def _url(node, path):
         return f"http://{node.account.hostname}:9644/v1/{path}"
 
+    def set_log_level(self, name, level, expires=None):
+        """
+        Set broker log level
+        """
+        for node in self.redpanda.nodes:
+            path = f"config/log_level/{name}?level={level}"
+            if expires:
+                path = f"{path}&expires={expires}"
+            url = self._url(node, path)
+            ret = requests.put(url)
+            self.redpanda.logger.debug(ret)
+
     def get_brokers(self, node=None):
         """
         Return metadata about brokers.

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -193,6 +193,10 @@ class RedpandaService(Service):
                 f"Wasm engine didn't finish startup in {RedpandaService.READY_TIMEOUT_SEC} seconds",
             )
 
+    def monitor_log(self, node):
+        assert node in self.nodes
+        return node.account.monitor_log(RedpandaService.STDOUT_STDERR_CAPTURE)
+
     def find_wasm_root(self):
         rp_install_path_root = self._context.globals.get(
             "rp_install_path_root", None)

--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -1,0 +1,61 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import ducktape.errors
+from ducktape.utils.util import wait_until
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+
+import time
+import threading
+import random
+
+
+class LogLevelTest(RedpandaTest):
+    def test_log_level_control(self):
+        admin = Admin(self.redpanda)
+        node = self.redpanda.nodes[0]
+
+        # set to warn level. message seen at info
+        with self.redpanda.monitor_log(node) as mon:
+            admin.set_log_level("admin_api_server", "warn")
+            mon.wait_until(
+                "Set log level for {admin_api_server}: info -> warn",
+                timeout_sec=5,
+                backoff_sec=1,
+                err_msg="Never saw message")
+
+        # set to debug. log level at warn, so shouldn't see it
+        try:
+            with self.redpanda.monitor_log(node) as mon:
+                admin.set_log_level("admin_api_server", "debug")
+                mon.wait_until(
+                    "Set log level for {admin_api_server}: warn -> debug",
+                    timeout_sec=10,
+                    backoff_sec=1,
+                    err_msg="Never saw message")
+            assert False, "Should not have seen message"
+        except ducktape.errors.TimeoutError:
+            pass
+
+        # should now see it again
+        with self.redpanda.monitor_log(node) as mon:
+            admin.set_log_level("admin_api_server", "info")
+            mon.wait_until(
+                "Set log level for {admin_api_server}: debug -> info",
+                timeout_sec=5,
+                backoff_sec=1,
+                err_msg="Never saw message")
+
+        with self.redpanda.monitor_log(node) as mon:
+            admin.set_log_level("admin_api_server", "debug", expires=5)
+            mon.wait_until("Expiring log level for {admin_api_server} to info",
+                           timeout_sec=10,
+                           backoff_sec=1,
+                           err_msg="Never saw message")


### PR DESCRIPTION
Adds an admin API for controlling log levels at runtime. The feature
includes an expiration which can be used to revert the log level to
its previous level after a fixed amount of time.

The following request would change Kafka's log level for a default of 10 minutes:

- v1/config/log_level/kafka?level=warn

This would permanently change the log level (until the next reboot or change):

- v1/config/log_level/kafka?level=warn&expires=0

And by specifying an `expires` value > 0 the log level will temporarily
be changed and revert to its previous value after `expires` seconds.

Fixes: #1578