### PR TITLE
utils/human: Fix missing KiB

### DIFF
--- a/src/v/utils/human.cc
+++ b/src/v/utils/human.cc
@@ -30,10 +30,10 @@ std::ostream& operator<<(std::ostream& o, const ::human::latency& l) {
     return o << x << "uknown_units";
 }
 std::ostream& operator<<(std::ostream& o, const ::human::bytes& l) {
-    static const char* units[] = {"bytes", "MiB", "GiB", "TiB", "PiB"};
+    static const char* units[] = {"bytes", "KiB", "MiB", "GiB", "TiB", "PiB"};
     static constexpr double step = 1024;
     auto x = l.value;
-    for (size_t i = 0; i < 5; ++i) {
+    for (size_t i = 0; i < 6; ++i) {
         if (x <= step) {
             return ss::fmt_print(o, "{:03.3f}{}", x, units[i]);
         }

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ rp_test(
     named_type_tests.cc
     tristate_test.cc
     moving_average_test.cc
+    human_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::utils
   LABELS utils

--- a/src/v/utils/tests/human_test.cc
+++ b/src/v/utils/tests/human_test.cc
@@ -1,0 +1,32 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "utils/human.h"
+
+#include <boost/test/unit_test.hpp>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+BOOST_AUTO_TEST_CASE(human_bytes) {
+    BOOST_CHECK_EQUAL(fmt::format("{}", human::bytes(-1)), "-1.000bytes");
+    BOOST_CHECK_EQUAL(fmt::format("{}", human::bytes(0)), "0.000bytes");
+    BOOST_CHECK_EQUAL(fmt::format("{}", human::bytes(1)), "1.000bytes");
+    BOOST_CHECK_EQUAL(fmt::format("{}", human::bytes(1024)), "1024.000bytes");
+    BOOST_CHECK_EQUAL(fmt::format("{}", human::bytes(1025)), "1.001KiB");
+    BOOST_CHECK_EQUAL(
+      fmt::format("{}", human::bytes(1UL << 20U)), "1024.000KiB");
+    BOOST_CHECK_EQUAL(
+      fmt::format("{}", human::bytes(1UL << 30U)), "1024.000MiB");
+    BOOST_CHECK_EQUAL(
+      fmt::format("{}", human::bytes(1UL << 40U)), "1024.000GiB");
+    BOOST_CHECK_EQUAL(
+      fmt::format("{}", human::bytes(1UL << 50U)), "1024.000TiB");
+    BOOST_CHECK_EQUAL(
+      fmt::format("{}", human::bytes(1UL << 60U)), "1024.000PiB");
+}


### PR DESCRIPTION
## Cover letter

Fix the output of `human::bytes`

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: Fix logging of bytes that are > 1024bytes
