### PR TITLE
redpanda: improve consumer group logging

### DIFF
--- a/src/v/bytes/bytes.cc
+++ b/src/v/bytes/bytes.cc
@@ -24,7 +24,7 @@ ss::sstring to_hex(bytes_view b) {
 ss::sstring to_hex(const bytes& b) { return to_hex(bytes_view(b)); }
 
 std::ostream& operator<<(std::ostream& os, const bytes& b) {
-    return os << to_hex(b);
+    return os << bytes_view(b);
 }
 
 std::ostream& operator<<(std::ostream& os, const bytes_opt& b) {
@@ -36,6 +36,7 @@ std::ostream& operator<<(std::ostream& os, const bytes_opt& b) {
 
 namespace std {
 std::ostream& operator<<(std::ostream& os, const bytes_view& b) {
-    return os << to_hex(b);
+    fmt::print(os, "{{bytes:{}}}", b.size());
+    return os;
 }
 } // namespace std

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -107,9 +107,9 @@ bool group::valid_previous_state(group_state s) const {
         return _state == g::completing_rebalance;
     case g::dead:
         return true;
-    default:
-        std::terminate(); // make gcc happy
     }
+
+    __builtin_unreachable();
 }
 
 template<typename T>
@@ -572,10 +572,9 @@ group::join_group_known_member(join_group_request&& r) {
         klog.trace(
           "member {} rejoin in unexpected state {}", r.data.member_id, state());
         return make_join_error(r.data.member_id, error_code::unknown_member_id);
-
-    default:
-        std::terminate(); // make gcc happy
     }
+
+    __builtin_unreachable();
 }
 
 ss::future<join_group_response> group::add_member_and_rebalance(
@@ -995,12 +994,11 @@ group::handle_sync_group(sync_group_request&& r) {
     }
 
     case group_state::dead:
-        // checked above
-        [[fallthrough]];
-
-    default:
-        std::terminate(); // make gcc happy
+        // checked above on method entry
+        break;
     }
+
+    __builtin_unreachable();
 }
 
 model::record_batch group::checkpoint(const assignments_type& assignments) {
@@ -1140,12 +1138,11 @@ ss::future<heartbeat_response> group::handle_heartbeat(heartbeat_request&& r) {
     }
 
     case group_state::dead:
-        // checked above
-        [[fallthrough]];
-
-    default:
-        std::terminate(); // mame gcc happy
+        // checked above on method entry
+        break;
     }
+
+    __builtin_unreachable();
 }
 
 ss::future<leave_group_response>

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -635,7 +635,8 @@ ss::future<join_group_response> group::add_member_and_rebalance(
 
 ss::future<join_group_response>
 group::update_member_and_rebalance(member_ptr member, join_group_request&& r) {
-    auto response = update_member(member, r.native_member_protocols());
+    auto response = update_member(
+      std::move(member), r.native_member_protocols());
     try_prepare_rebalance();
     return response;
 }

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -147,7 +147,7 @@ group_state group::set_state(group_state s) {
     return std::exchange(_state, s);
 }
 
-bool group::supports_protocols(const join_group_request& r) {
+bool group::supports_protocols(const join_group_request& r) const {
     // first member decides so make sure its defined
     if (in_state(group_state::empty)) {
         return !r.data.protocol_type().empty() && !r.data.protocols.empty();

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -64,7 +64,8 @@ group::group(
   , _conf(conf)
   , _partition(std::move(partition))
   , _recovery_policy(
-      config::shard_local_cfg().rm_violation_recovery_policy.value()) {}
+      config::shard_local_cfg().rm_violation_recovery_policy.value())
+  , _ctxlog(*this) {}
 
 group::group(
   kafka::group_id id,
@@ -77,7 +78,8 @@ group::group(
   , _conf(conf)
   , _partition(std::move(partition))
   , _recovery_policy(
-      config::shard_local_cfg().rm_violation_recovery_policy.value()) {
+      config::shard_local_cfg().rm_violation_recovery_policy.value())
+  , _ctxlog(*this) {
     _state = md.members.empty() ? group_state::empty : group_state::stable;
     _generation = md.generation;
     _protocol_type = md.protocol_type;

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -136,10 +136,13 @@ static model::record_batch make_tx_batch(
 }
 
 group_state group::set_state(group_state s) {
-    klog.trace("group state transition {} -> {}", _state, s);
-    if (!valid_previous_state(s)) {
-        std::terminate();
-    }
+    vassert(
+      valid_previous_state(s),
+      "Group {} invalid state transition from {} to {}",
+      _id,
+      _state,
+      s);
+    vlog(_ctxlog.trace, "Changing state from {} to {}", _state, s);
     _state_timestamp = clock_type::now();
     return std::exchange(_state, s);
 }

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -34,6 +34,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <fmt/core.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
 #include <algorithm>
 #include <chrono>
@@ -148,6 +149,16 @@ group_state group::set_state(group_state s) {
 }
 
 bool group::supports_protocols(const join_group_request& r) const {
+    vlog(
+      _ctxlog.trace,
+      "Check protocol support type {} members {} req.type {} req.protos {} "
+      "supported {}",
+      _protocol_type,
+      _members.size(),
+      r.data.protocol_type,
+      r.data.protocols,
+      fmt::join(_supported_protocols, ", "));
+
     // first member decides so make sure its defined
     if (in_state(group_state::empty)) {
         return !r.data.protocol_type().empty() && !r.data.protocols.empty();
@@ -1892,7 +1903,7 @@ kafka::member_id group::generate_member_id(const join_group_request& r) {
     auto cid = r.client_id ? *r.client_id : kafka::client_id("");
     auto id = r.data.group_instance_id ? (*r.data.group_instance_id)() : cid();
     boost::uuids::uuid uuid = boost::uuids::random_generator()();
-    return kafka::member_id(ssx::sformat("{}-{}", id, uuid));
+    return kafka::member_id(ssx::sformat("{}-{}", id, to_string(uuid)));
 }
 
 described_group group::describe() const {

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -252,7 +252,7 @@ public:
      * specifies at least one protocol that is supported by all members of
      * the group.
      */
-    bool supports_protocols(const join_group_request& r);
+    bool supports_protocols(const join_group_request& r) const;
 
     /**
      * \brief Add a member to the group.

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -511,6 +511,44 @@ private:
 
     friend std::ostream& operator<<(std::ostream&, const group&);
 
+    class ctx_log {
+    public:
+        explicit ctx_log(const group& group)
+          : _group(group) {}
+
+        template<typename... Args>
+        void info(const char* format, Args&&... args) const {
+            log(ss::log_level::info, format, std::forward<Args>(args)...);
+        }
+
+        template<typename... Args>
+        void debug(const char* format, Args&&... args) const {
+            log(ss::log_level::debug, format, std::forward<Args>(args)...);
+        }
+
+        template<typename... Args>
+        void trace(const char* format, Args&&... args) const {
+            log(ss::log_level::trace, format, std::forward<Args>(args)...);
+        }
+
+        template<typename... Args>
+        void log(ss::log_level lvl, const char* format, Args&&... args) const {
+            if (unlikely(klog.is_enabled(lvl))) {
+                auto line_fmt = ss::sstring("[N:{} S:{} G:{}] ") + format;
+                klog.log(
+                  lvl,
+                  line_fmt.c_str(),
+                  _group.id()(),
+                  _group.state(),
+                  _group.generation(),
+                  std::forward<Args>(args)...);
+            }
+        }
+
+    private:
+        const group& _group;
+    };
+
     model::record_batch checkpoint(const assignments_type& assignments);
 
     cluster::abort_origin
@@ -533,6 +571,7 @@ private:
     ss::lw_shared_ptr<cluster::partition> _partition;
     absl::node_hash_map<model::topic_partition, offset_metadata> _offsets;
     model::violation_recovery_policy _recovery_policy;
+    ctx_log _ctxlog;
 
     mutex _tx_mutex;
     model::term_id _term;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -631,17 +631,14 @@ group_manager::sync_group(sync_group_request&& r) {
 }
 
 ss::future<heartbeat_response> group_manager::heartbeat(heartbeat_request&& r) {
-    klog.trace("heartbeat request {}", r);
-
     if (r.data.group_instance_id) {
-        klog.trace("static group membership is unsupported");
+        vlog(klog.trace, "Static group membership is not supported");
         return make_heartbeat_error(error_code::unsupported_version);
     }
 
     auto error = validate_group_status(
       r.ntp, r.data.group_id, heartbeat_api::key);
     if (error != error_code::none) {
-        klog.trace("invalid group status {}", error);
         if (error == error_code::coordinator_load_in_progress) {
             // <kafka>the group is still loading, so respond just
             // blindly</kafka>
@@ -655,7 +652,11 @@ ss::future<heartbeat_response> group_manager::heartbeat(heartbeat_request&& r) {
         return group->handle_heartbeat(std::move(r));
     }
 
-    klog.trace("group not found");
+    vlog(
+      klog.trace,
+      "Cannot handle heartbeat request for unknown group {}",
+      r.data.group_id);
+
     return make_heartbeat_error(error_code::unknown_member_id);
 }
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -662,12 +662,9 @@ ss::future<heartbeat_response> group_manager::heartbeat(heartbeat_request&& r) {
 
 ss::future<leave_group_response>
 group_manager::leave_group(leave_group_request&& r) {
-    klog.trace("leave request {}", r);
-
     auto error = validate_group_status(
       r.ntp, r.data.group_id, leave_group_api::key);
     if (error != error_code::none) {
-        klog.trace("invalid group status error={}", error);
         return make_leave_error(error);
     }
 
@@ -675,7 +672,10 @@ group_manager::leave_group(leave_group_request&& r) {
     if (group) {
         return group->handle_leave_group(std::move(r));
     } else {
-        klog.trace("group does not exist");
+        vlog(
+          klog.trace,
+          "Cannot handle leave group request for unknown group {}",
+          r.data.group_id);
         return make_leave_error(error_code::unknown_member_id);
     }
 }

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -1009,17 +1009,29 @@ bool group_manager::valid_group_id(const group_id& group, api_key api) {
 error_code group_manager::validate_group_status(
   const model::ntp& ntp, const group_id& group, api_key api) {
     if (!valid_group_id(group, api)) {
+        vlog(
+          klog.trace, "Group name {} is invalid for operation {}", group, api);
         return error_code::invalid_group_id;
     }
 
     if (const auto it = _partitions.find(ntp); it != _partitions.end()) {
         if (!it->second->partition->is_leader()) {
-            klog.trace("group partition is not leader {}/{}", group, ntp);
+            vlog(
+              klog.trace,
+              "Group {} operation {} sent to non-leader coordinator {}",
+              group,
+              api,
+              ntp);
             return error_code::not_coordinator;
         }
 
         if (it->second->loading) {
-            klog.trace("group is loading {}/{}", group, ntp);
+            vlog(
+              klog.trace,
+              "Group {} operation {} sent to loading coordinator {}",
+              group,
+              api,
+              ntp);
             return error_code::not_coordinator;
             /*
              * returning `load in progress` is the correct error code for this
@@ -1039,7 +1051,12 @@ error_code group_manager::validate_group_status(
         return error_code::none;
     }
 
-    klog.trace("group operation misdirected {}/{}", group, ntp);
+    vlog(
+      klog.trace,
+      "Group {} operation {} misdirected to non-coordinator {}",
+      group,
+      api,
+      ntp);
     return error_code::not_coordinator;
 }
 


### PR DESCRIPTION
Recent consumer group issues have been difficult to debug because the logging in the consumer group sub-system contained very little context. This PR significantly improves the situation by attaching group state to every log message. In addition, some auditing has shown that richer log messages in well-placed locations could supplant other more verbose log points.