### PR TITLE
Update syntax for redpanda subcommand in production

### DIFF
--- a/docs/www/production-deployment.md
+++ b/docs/www/production-deployment.md
@@ -55,14 +55,14 @@ By default Redpanda is installed in **Development** mode, to we next need to
 set Redpanda to run in **Production** mode. This is done with:
 
 ```
-sudo rpk mode production
+sudo rpk redpanda mode production
 ```
 
 We then need to tune the hardware, which can be done by running the following
 on each node:
 
 ```
-sudo rpk tune all
+sudo rpk redpanda tune all
 ```
 
 > **_Optional: Benchmark your SSD_**


### PR DESCRIPTION
From:

```
$ sudo rpk mode
Command "mode" is deprecated, use 'rpk redpanda mode' instead.

sudo rpk tune all
Command "tune" is deprecated, use 'rpk redpanda tune' instead.
```

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
