### PR TITLE
docs: Updating dates and config options

### DIFF
--- a/docs/www/data-archiving.md
+++ b/docs/www/data-archiving.md
@@ -17,7 +17,7 @@ your data is safe in the cloud for you to recover to your cluster.
 
 > **_Notes:_**
 > - Archiving to Amazon AWS S3 and Google Cloud Storage is tested and supported.
-> - The ability to rehydrate data to a cluster is in development, targeted for April 2021.
+> - The ability to rehydrate data to a cluster is in development, targeted for second half of 2021.
 
 ## How it works
 
@@ -65,14 +65,16 @@ We recommend that you keep topic manifests in order to recover the corresponding
         - (Optional) Specify expiration rules for the files that are based on the `rp-type` file tags.
         - Use the IAM service to create a user to access S3.
             - Grant this user permission to read and create objects.
-            - Copy the access key and secret key to the Redpanda configuration options `archival_storage_s3_access_key` and `archival_storage_s3_secret_key`, respectively.
+            - Copy the access key and secret key to the Redpanda configuration options `cloud_storage_s3_access_key` and `cloud_storage_s3_secret_key`, respectively.
 
     - Google Cloud Storage
         - Choose a uniform access control when you create the bucket.
             - Use bucket level permissions for all objects.
             - Use a Google managed encryption key.
-        - Create a service user with HMAC keys
-            and copy the keys to the Redpanda configuration options `archival_storage_s3_access_key` and `archival_storage_s3_secret_key`, respectively. 
+            - Set a [default project](https://cloud.google.com/storage/docs/migrating#defaultproj).
+        - [Create a service user with HMAC keys](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
+            and copy the keys to the Redpanda configuration options `cloud_storage_s3_access_key` and `cloud_storage_s3_secret_key`, respectively. 
+        - Set `cloud_storage_api_endpoint` to `storage.googleapis.com`
     - MinIO (for local testing)
         - Use the `MINIO_ROOT_PASSWORD` and `MINIO_ROOT_USER` environment variables for the access key (`cloud_storage_access_key`) and secret key (`cloud_storage_secret_key`), respectively.
         - Use the `MINIO_REGION_NAME` environment variable for region name (`cloud_storage_region`).
@@ -87,10 +89,10 @@ We recommend that you keep topic manifests in order to recover the corresponding
     | Parameter name                                | Type         | Descripion                                              |
     |-----------------------------------------------|--------------|---------------------------------------------------------|
     | `cloud_storage_enabled`                       | boolean      | Enables archival storage feature                        |
-    | `cloud_storage_access_key`                    | string       | S3 access key                                           |
-    | `cloud_storage_secret_key`                    | string       | S3 secret key                                           |
-    | `cloud_storage_region`                        | string       | AWS region                                              |
-    | `cloud_storage_bucket`                        | string       | S3 bucket                                               |
+    | `cloud_storage_access_key`                    | string       | Access key                                           |
+    | `cloud_storage_secret_key`                    | string       | Secret key                                           |
+    | `cloud_storage_region`                        | string       | Cloud region                                              |
+    | `cloud_storage_bucket`                        | string       | Bucket name                                              |
     | `cloud_storage_api_endpoint`                  | string       | Cloud storage api endpoint (Default: S3)     |
     | `cloud_storage_api_endpoint_port`             | string       | Cloud storage api endpoint port number (Default: 443)    |
     | `cloud_storage_trust_file`                    | string       | Alternative location of the CA certificate (Default: /etc/pki/tls/cert.pem) |


### PR DESCRIPTION
- Corrected the config names for aws and gcp.
- Updated the timeline for when restore will be available.
- Updated the config names to not be S3 specific