### PR TITLE
rpk wasm list: displays the status of coprocessors cluster wide

### DIFF
--- a/docs/rfcs/20210628_rpk_wasm_list.md
+++ b/docs/rfcs/20210628_rpk_wasm_list.md
@@ -1,0 +1,58 @@
+- Feature Name: rpk wasm list
+- Status: draft
+- Start Date: 2021-06-28
+- Authors: Rob Blafford
+- Issue:
+
+# Summary
+
+To provide insights into the current state of all coprocessors across the cluster.
+
+Currently the way to dispatch a coprocessor is to use `rpk wasm deploy`. This bundles up the request into a kafka record and writes it into a predefined topic `coprocessor_internal_topic`. Redpanda itself listens for updates on this topic, and starts up the coprocessors that were produced onto the topic. However during and after this process, the only way to know anything about a coprocessor is to look at redpanda or wasm engine logs, or to take a look and see if any coprocessors had created any expected stateful effects.
+
+This proposal increases visibility into the current state of the system by listing all of the available coprocessors, their input topics, and on which nodes they are currently deployed onto.
+
+# Motivation
+
+There is currently no supported way to know about the state of deployed/removed coprocessors within redpanda.
+
+# Guide-level explaination
+
+The way this will be achieved is to have redpanda post all status updates to another predefined topic called `coprocessor_status_topic`. This will be a compacted topic, where the keys for all records will be the node_id of a given redpanda instance.
+
+Each redpanda instance will produce onto this topic once any state change in coprocessors has been detected. The value of the record payload will be in JSON and it will provide information such as registered coprocessors, node_id, and current wasm engine status. A sample JSON payload is provided below:
+
+```
+{
+    "node_id" : 5,
+    "status" : "up",
+    "coprocessors" : {
+        "name_a" : {
+           "input_topics": ["foo", "bar", "baz"],
+           "description": "This copro is interesting!"
+        },
+        "name_b" : {
+           "input_topics": ["dd"],
+           "description" : "Strips sensitive info from topic"
+        }
+    }
+}
+```
+
+With this implementation any tool can consume from the topic, interpret the JSON value and recieve the status. `rpk` does exactly this, and just prints a pretty version of the provided JSON to stdout. If desired the raw JSON can also be printed.
+
+```
+  COPROCESSOR NAME  NODE ID  INPUT TOPICS   DESCRIPTION
+  name_a            2        [foo,bar,baz]  This copro is interesting!
+  name_b            2        [dd]           Strings sensitive info from topic
+  name_a            3        [foo,bar,baz]  This copro is interesting!
+  name_b            3        [dd]           Strings sensitive info from topic
+  name_b            1        [dd]           Strings sensitive info from topic
+  name_a            1        [foo,bar,baz]  This copro is interesting!
+```
+
+## Drawbacks
+
+Why shouldn't we do this?
+
+There are no drawbacks to providing this feature. In it's implementation the cost of this feature is the cost of maintining another compacted kafka topic (w/ 1 partition, replication factor of 3).

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -10,6 +10,7 @@
 package cmd
 
 import (
+	"github.com/Shopify/sarama"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/common"
@@ -56,10 +57,12 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	tlsClosure := common.BuildTLSConfig(&certFile, &keyFile, &truststoreFile)
 	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure, tlsClosure, kAuthClosure)
+	clientClosure := common.CreateClient(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
+	consumerClosure := sarama.NewConsumerFromClient
 
 	command.AddCommand(wasm.NewDeployCommand(fs, producerClosure, adminClosure))
-
+	command.AddCommand(wasm.NewListCommand(clientClosure, consumerClosure))
 	command.AddCommand(wasm.NewRemoveCommand(producerClosure, adminClosure))
 
 	return command

--- a/src/go/rpk/pkg/cli/cmd/wasm/common.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/common.go
@@ -1,3 +1,12 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package wasm
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/wasm/common.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/common.go
@@ -82,6 +82,9 @@ func CreateDeployMsg(
 		}, {
 			Key:   []byte("sha256"),
 			Value: shaValue[:],
+		}, {
+			Key:   []byte("name"),
+			Value: []byte(name),
 		},
 	}
 	id := xxhash.Sum64([]byte(name))

--- a/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/deploy.go
@@ -1,3 +1,12 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package wasm
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/wasm/deploy_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/deploy_test.go
@@ -1,3 +1,12 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package wasm
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/wasm/deploy_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/deploy_test.go
@@ -150,6 +150,9 @@ func TestNewDeployCommand(t *testing.T) {
 						}, {
 							Key:   []byte("sha256"),
 							Value: hashContent[:],
+						}, {
+							Key:   []byte("name"),
+							Value: []byte("bar"),
 						},
 					}
 					require.Equal(t, expectHeader, msg.Headers)

--- a/src/go/rpk/pkg/cli/cmd/wasm/list.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/list.go
@@ -1,0 +1,173 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package wasm
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/ui"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
+)
+
+type coprocInfo struct {
+	InputTopics []string `json:"input_topics"`
+	Description string   `json:"description"`
+}
+
+type coprocNodeInfo struct {
+	NodeId       int32                 `json:"node_id"`
+	Status       string                `json:"status"`
+	Coprocessors map[string]coprocInfo `json:"coprocessors"`
+}
+
+func NewListCommand(
+	clientClosure func() (sarama.Client, error),
+	consumerClosure func(sarama.Client) (sarama.Consumer, error),
+) *cobra.Command {
+	var pretty bool
+
+	command := &cobra.Command{
+		Use:   "list",
+		Short: "display the current status of functions within redpanda",
+		RunE: func(_ *cobra.Command, args []string) error {
+			return wasmList(clientClosure, consumerClosure, pretty)
+		},
+	}
+
+	command.Flags().BoolVar(&pretty, "raw", false, "Print the raw json to stdout")
+	return command
+}
+
+func printResults(dataSet *map[int32]coprocNodeInfo, raw bool) {
+	if raw {
+		stringRep, err := json.Marshal(dataSet)
+		if err != nil {
+			fmt.Errorf("Internal error with list command, failed to serialize result into json: %s", err)
+		} else {
+			log.Info(string(stringRep))
+		}
+		return
+	}
+	t := ui.NewRpkTable(log.StandardLogger().Out)
+	t.SetColWidth(80)
+	t.SetAutoWrapText(false)
+	unresponsiveEngines := []int32{}
+	header := []string{"Coprocessor Name", "Node ID", "Input Topics", "Description"}
+	t.SetHeader(header[:])
+	for _, val := range *dataSet {
+		if val.Status != "up" {
+			unresponsiveEngines = append(unresponsiveEngines, val.NodeId)
+		}
+		for name, data := range val.Coprocessors {
+			topics := strings.Join(data.InputTopics, ",")
+			topics = "[" + topics + "]"
+			row := []string{name, strconv.Itoa(int(val.NodeId)), topics, data.Description}
+			t.Append(row)
+		}
+	}
+	t.Render()
+	if len(unresponsiveEngines) > 0 {
+		log.Infof("Unresponsive engines: [%v]", unresponsiveEngines)
+	}
+}
+
+func accrueResults(
+	messages []*sarama.ConsumerMessage,
+) (*map[int32]coprocNodeInfo, error) {
+	allData := make(map[int32]coprocNodeInfo)
+	for _, msg := range messages {
+		msgKey := int32(binary.LittleEndian.Uint32(msg.Key))
+		var info coprocNodeInfo
+		if err := json.Unmarshal(msg.Value, &info); err != nil {
+			return nil, err
+		}
+		if msgKey != info.NodeId {
+			return nil, fmt.Errorf("Mismatched node ids, key: %d reported %d", msgKey, info.NodeId)
+		}
+		allData[msgKey] = info
+	}
+	return &allData, nil
+}
+
+func consumeStatusUpdates(
+	pc sarama.PartitionConsumer, finalOffset int64,
+) ([]*sarama.ConsumerMessage, error) {
+	var messages []*sarama.ConsumerMessage
+	var err error
+	for {
+		select {
+		case msg := <-pc.Messages():
+			messages = append(messages, msg)
+			if msg.Offset >= (finalOffset - 1) {
+				return messages, err
+			}
+		case msgerr := <-pc.Errors():
+			err = msgerr.Err
+			return messages, err
+		}
+	}
+}
+
+func wasmList(
+	clientClosure func() (sarama.Client, error),
+	consumerClosure func(sarama.Client) (sarama.Consumer, error),
+	raw bool,
+) error {
+	client, err := clientClosure()
+	if err != nil {
+		return fmt.Errorf("Failed to make client: %s", err)
+	}
+	finalOffset, err := client.GetOffset(kafka.CoprocessorStatusTopic, 0, sarama.OffsetNewest)
+	if err != nil {
+		if raw {
+			log.Info("{\"status\": \"uninitialized\"}")
+		} else {
+			log.Error("CoprocessorStatusTopic is uninitialized")
+		}
+		return nil
+	}
+	if finalOffset == 0 {
+		if raw {
+			log.Info("{}")
+		} else {
+			log.Info("There are no coprocessor events to list")
+		}
+		return nil
+	}
+
+	consumer, err := consumerClosure(client)
+	if err != nil {
+		return fmt.Errorf("Failed to make consumer: %s", err)
+	}
+
+	pc, err := consumer.ConsumePartition(kafka.CoprocessorStatusTopic, 0, sarama.OffsetOldest)
+	if err != nil {
+		return fmt.Errorf("Failed to consumer from coprocessor status topic: %s", kafka.CoprocessorStatusTopic)
+	}
+
+	messages, err := consumeStatusUpdates(pc, finalOffset)
+	consumer.Close()
+	if err != nil {
+		return fmt.Errorf("Failed to consume from coprocessor status topic without error: %s", err)
+	}
+	results, err := accrueResults(messages)
+	if err != nil {
+		return fmt.Errorf("Failed to parse and compile result set: %s", err)
+	}
+	printResults(results, raw)
+	return nil
+}

--- a/src/go/rpk/pkg/cli/cmd/wasm/list_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/list_test.go
@@ -1,0 +1,134 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package wasm
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
+	kafkaMocks "github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka/mocks"
+)
+
+func newClientMock(offset int64) *kafkaMocks.MockClient {
+	return &kafkaMocks.MockClient{
+		MockGetOffset: func(string, int32, int64) (int64, error) {
+			return offset, nil
+		},
+	}
+}
+
+func parseLogrusOutput(output string) string {
+	plain := strings.TrimLeft(output, "level=info msg=\"")
+	plain = strings.Replace(plain, "\\", "", -1)
+	plain = strings.Replace(plain, "\n", "", -1)
+	plain = strings.TrimSuffix(plain, "\"")
+	return plain
+}
+
+func compareJSONResults(expected string, observed string) bool {
+	expectedParsed := make(map[string]interface{})
+	observedParsed := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(expected), &expectedParsed); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(observed), &observedParsed); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(expectedParsed, observedParsed)
+}
+
+func TestNewListCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		mockClient     kafkaMocks.MockClient
+		expectedOutput string
+		numberOfEvents int64
+		consumer       kafkaMocks.MockConsumer
+		pc             kafkaMocks.MockPartitionConsumer
+	}{
+		{
+			name:           "It should return the actual results",
+			args:           []string{"--raw"},
+			numberOfEvents: 1,
+			expectedOutput: "{\"5\": {\"status\":\"up\",\"node_id\":5,\"coprocessors\":{\"22220-name\":{\"input_topics\":[\"bar\"],\"description\":\"Hello World!\"}, \"77778-name\":{\"input_topics\":[\"baz\",\"foo\"],\"description\":\"Hello world again!\"}}}}",
+			pc: kafkaMocks.MockPartitionConsumer{
+				MockMessages: func() <-chan *sarama.ConsumerMessage {
+					nodeId := uint32(5)
+					binaryNodeId := make([]byte, 4)
+					binary.LittleEndian.PutUint32(binaryNodeId, nodeId)
+					messages := make(chan *sarama.ConsumerMessage, 1)
+					message := &sarama.ConsumerMessage{
+						Key:       binaryNodeId,
+						Value:     []byte("{\"status\":\"up\",\"node_id\":5,\"coprocessors\":{\"22220-name\":{\"input_topics\":[\"bar\"],\"description\":\"Hello World!\"}, \"77778-name\":{\"input_topics\":[\"baz\",\"foo\"],\"description\":\"Hello world again!\"}}}"),
+						Topic:     kafka.CoprocessorStatusTopic,
+						Partition: 0,
+						Offset:    0,
+					}
+					messages <- message
+					return messages
+				},
+				MockErrors: func() <-chan *sarama.ConsumerError {
+					return make(chan *sarama.ConsumerError)
+				},
+				MockHighWaterMarkOffset: func() int64 { return 1 },
+				MockAsyncClose:          func() {},
+				MockClose:               func() error { return nil },
+			},
+		},
+		{
+			name:           "It should not error if there are 0 results",
+			args:           []string{"--raw"},
+			expectedOutput: "{}",
+			numberOfEvents: 0,
+			pc: kafkaMocks.MockPartitionConsumer{
+				MockMessages: func() <-chan *sarama.ConsumerMessage {
+					return make(chan *sarama.ConsumerMessage)
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := func() (sarama.Client, error) {
+				return newClientMock(tt.numberOfEvents), nil
+			}
+			consumer := func(sarama.Client) (sarama.Consumer, error) {
+				return &kafkaMocks.MockConsumer{
+					MockConsumePartition: func(string, int32, int64) (sarama.PartitionConsumer, error) {
+						return tt.pc, nil
+					},
+				}, nil
+			}
+			var out bytes.Buffer
+			logrus.SetOutput(&out)
+			logrus.SetLevel(logrus.InfoLevel)
+			logrus.SetFormatter(&logrus.TextFormatter{
+				DisableTimestamp: true,
+			})
+			cmd := NewListCommand(client, consumer)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			require.NoError(t, err)
+			output := parseLogrusOutput(out.String())
+			t.Log(tt.expectedOutput)
+			t.Log(output)
+			require.Equal(t, compareJSONResults(tt.expectedOutput, output), true)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove.go
@@ -1,3 +1,12 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package wasm
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove_test.go
@@ -1,3 +1,12 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package wasm
 
 import (

--- a/src/go/rpk/pkg/kafka/mocks/consumer.go
+++ b/src/go/rpk/pkg/kafka/mocks/consumer.go
@@ -1,0 +1,90 @@
+package mocks
+
+import "github.com/Shopify/sarama"
+
+type MockPartitionConsumer struct {
+	MockAsyncClose          func()
+	MockClose               func() error
+	MockMessages            func() <-chan *sarama.ConsumerMessage
+	MockErrors              func() <-chan *sarama.ConsumerError
+	MockHighWaterMarkOffset func() int64
+}
+
+type MockConsumer struct {
+	MockTopics           func() ([]string, error)
+	MockPartitions       func(topic string) ([]int32, error)
+	MockHighWaterMarks   func() map[string]map[int32]int64
+	MockConsumePartition func(string, int32, int64) (sarama.PartitionConsumer, error)
+	MockClose            func() error
+}
+
+func (m MockPartitionConsumer) AsyncClose() {
+	if m.MockAsyncClose != nil {
+		m.MockAsyncClose()
+	}
+}
+
+func (m MockPartitionConsumer) Close() error {
+	if m.MockClose != nil {
+		return m.MockClose()
+	}
+	return nil
+}
+
+func (m MockPartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
+	if m.MockMessages != nil {
+		return m.MockMessages()
+	}
+	return nil
+}
+
+func (m MockPartitionConsumer) Errors() <-chan *sarama.ConsumerError {
+	if m.MockErrors != nil {
+		return m.MockErrors()
+	}
+	return nil
+}
+
+func (m MockPartitionConsumer) HighWaterMarkOffset() int64 {
+	if m.MockHighWaterMarkOffset != nil {
+		return m.MockHighWaterMarkOffset()
+	}
+	return -1
+}
+
+func (m MockConsumer) Topics() ([]string, error) {
+	if m.MockTopics != nil {
+		return m.MockTopics()
+	}
+	return []string{}, nil
+}
+
+func (m MockConsumer) Partitions(topic string) ([]int32, error) {
+	if m.MockPartitions != nil {
+		return m.MockPartitions(topic)
+	}
+	return []int32{}, nil
+}
+
+func (m MockConsumer) HighWaterMarks() map[string]map[int32]int64 {
+	if m.MockHighWaterMarks != nil {
+		return m.MockHighWaterMarks()
+	}
+	return map[string]map[int32]int64{}
+}
+
+func (m MockConsumer) ConsumePartition(
+	topic string, beginOffset int32, endOffset int64,
+) (sarama.PartitionConsumer, error) {
+	if m.MockConsumePartition != nil {
+		return m.MockConsumePartition(topic, beginOffset, endOffset)
+	}
+	return nil, nil
+}
+
+func (m MockConsumer) Close() (err error) {
+	if m.MockClose != nil {
+		return m.MockClose()
+	}
+	return nil
+}

--- a/src/go/rpk/pkg/kafka/utils.go
+++ b/src/go/rpk/pkg/kafka/utils.go
@@ -9,6 +9,7 @@ import (
 
 // internal topics
 const CoprocessorTopic = "coprocessor_internal_topic"
+const CoprocessorStatusTopic = "coprocessor_status_topic"
 
 func PublishMessage(
 	producer sarama.SyncProducer, produceMessage *sarama.ProducerMessage,

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -17,6 +17,7 @@ v_cc_library(
     wasm_event.cc
     event_listener.cc
     script_dispatcher.cc
+    api/wasm_list.cc
   DEPS
     v::rpc
     v::model

--- a/src/v/coproc/api/wasm_list.cc
+++ b/src/v/coproc/api/wasm_list.cc
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/api/wasm_list.h"
+
+#include "model/record_batch_types.h"
+#include "rapidjson/document.h"
+#include "reflection/adl.h"
+#include "storage/record_batch_builder.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+namespace coproc::wasm {
+
+struct copro_deploy_info {
+    deploy_attributes attrs;
+    std::set<model::topic> topics;
+};
+
+using layout = absl::flat_hash_map<ss::sstring, copro_deploy_info>;
+
+static model::record_batch_reader
+status(model::node_id nid, layout&& lt, bool is_up) {
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    writer.StartObject();
+    writer.Key("status");
+    writer.String(is_up ? "up" : "down");
+    writer.Key("node_id");
+    writer.Int(nid());
+    writer.Key("coprocessors");
+    writer.StartObject();
+    for (auto& p : lt) {
+        writer.Key(p.first.c_str());
+        writer.StartObject();
+        writer.Key("input_topics");
+        writer.StartArray();
+        for (auto& topic : p.second.topics) {
+            writer.String(topic());
+        }
+        writer.EndArray();
+        writer.Key("description");
+        writer.String(p.second.attrs.description);
+        writer.EndObject();
+    }
+    writer.EndObject();
+    writer.EndObject();
+    ss::sstring str(buffer.GetString());
+    storage::record_batch_builder b(
+      model::record_batch_type::raft_data, model::offset{0});
+    iobuf iob;
+    iob.append(str.data(), str.size());
+    b.add_raw_kv(reflection::to_iobuf(nid()), std::move(iob));
+    return model::make_memory_record_batch_reader(std::move(b).build());
+}
+
+ss::future<model::record_batch_reader> current_status(
+  model::node_id nid,
+  ss::sharded<pacemaker>& pacemaker,
+  const absl::btree_map<script_id, deploy_attributes>& scripts) {
+    if (!pacemaker.local().is_connected()) {
+        co_return status(nid, {}, false);
+    }
+    layout lt;
+    for (const auto& item : scripts) {
+        auto current_topics = co_await pacemaker.map_reduce0(
+          [id = item.first](coproc::pacemaker& p) {
+              return p.registered_ntps(id);
+          },
+          std::set<model::topic>(),
+          [](std::set<model::topic> acc, absl::flat_hash_set<model::ntp> x) {
+              std::set<model::topic> topics;
+              std::transform(
+                x.begin(),
+                x.end(),
+                std::inserter(topics, topics.begin()),
+                [](const model::ntp& ntp) { return ntp.tp.topic; });
+              acc.merge(std::move(topics));
+              return acc;
+          });
+        lt[item.second.name] = copro_deploy_info{
+          .attrs = item.second, .topics = current_topics};
+    }
+    co_return status(nid, std::move(lt), true);
+}
+} // namespace coproc::wasm

--- a/src/v/coproc/api/wasm_list.h
+++ b/src/v/coproc/api/wasm_list.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "coproc/pacemaker.h"
+#include "coproc/wasm_event.h"
+#include "model/record_batch_reader.h"
+
+#include <seastar/core/future.hh>
+
+#include <absl/container/btree_map.h>
+
+namespace coproc::wasm {
+
+/// Example of serialized json format to be stored in the copro staus topic
+/// {
+///     "node_id" : 5,
+///     "status" : "up/down",
+///     "coprocessors" : {
+///         "name_a" : {
+///             "input_topics": ["foo", "bar", "baz"],
+///             "description": "This copro is interesting!"
+///         },
+///         "name_b" : {
+///             "input_topics": ["dd"],
+///             "description" : "Strips sensitive info from topic"
+///         }
+///     }
+/// }
+
+/// Queries each shard for the general status and a layout of what scripts and
+/// topics per script are registered
+///
+/// The result is a single record where the key is node is, value is an
+/// indicator of current wasm_engine status, and the headers are populated with
+/// the script_id/topics of registered scripts
+ss::future<model::record_batch_reader> current_status(
+  model::node_id,
+  ss::sharded<pacemaker>&,
+  const absl::btree_map<script_id, deploy_attributes>&);
+
+} // namespace coproc::wasm

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "coproc/pacemaker.h"
 #include "coproc/script_dispatcher.h"
 #include "coproc/types.h"
 #include "coproc/wasm_event.h"
@@ -57,6 +58,9 @@ private:
     ss::future<>
       persist_actions(absl::btree_map<script_id, log_event>, model::offset);
 
+    ss::future<> boostrap_status_topic();
+    ss::future<> advertise_state_update(std::size_t n = 3);
+
 private:
     /// Kafka client used to poll the internal topic
     kafka::client::client _client;
@@ -70,6 +74,9 @@ private:
 
     /// Set of known script ids to be active
     absl::btree_map<script_id, deploy_attributes> _active_ids;
+
+    /// Managing instance of coprocessor infra
+    ss::sharded<coproc::pacemaker>& _pacemaker;
 
     /// Used to make requests to the wasm engine
     script_dispatcher _dispatcher;

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -12,6 +12,7 @@
 
 #include "coproc/script_dispatcher.h"
 #include "coproc/types.h"
+#include "coproc/wasm_event.h"
 #include "kafka/client/client.h"
 
 #include <seastar/core/abort_source.hh>
@@ -54,7 +55,7 @@ private:
     poll_topic(model::record_batch_reader::data_t&);
 
     ss::future<>
-      persist_actions(absl::btree_map<script_id, iobuf>, model::offset);
+      persist_actions(absl::btree_map<script_id, log_event>, model::offset);
 
 private:
     /// Kafka client used to poll the internal topic
@@ -68,7 +69,7 @@ private:
     model::offset _offset{0};
 
     /// Set of known script ids to be active
-    absl::btree_set<script_id> _active_ids;
+    absl::btree_map<script_id, deploy_attributes> _active_ids;
 
     /// Used to make requests to the wasm engine
     script_dispatcher _dispatcher;

--- a/src/v/coproc/pacemaker.cc
+++ b/src/v/coproc/pacemaker.cc
@@ -232,6 +232,14 @@ ss::future<absl::btree_map<script_id, errc>> pacemaker::remove_all_sources() {
     co_return results_map;
 }
 
+absl::flat_hash_set<model::ntp> pacemaker::registered_ntps(script_id id) const {
+    auto found = _scripts.find(id);
+    if (found != _scripts.end()) {
+        return found->second->registered_ntps();
+    }
+    return {};
+}
+
 bool pacemaker::local_script_id_exists(script_id id) {
     return _scripts.find(id) != _scripts.end();
 }

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -25,6 +25,7 @@
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/socket_defs.hh>
 
+#include <absl/container/flat_hash_set.h>
 #include <absl/container/node_hash_map.h>
 
 namespace coproc {
@@ -85,9 +86,19 @@ public:
     ss::future<absl::btree_map<script_id, errc>> remove_all_sources();
 
     /**
+     * @returns valid registered ntps for a given id
+     */
+    absl::flat_hash_set<model::ntp> registered_ntps(script_id) const;
+
+    /**
      * @returns true if a matching script id exists on 'this' shard
      */
     bool local_script_id_exists(script_id);
+
+    /**
+     * @returns true if there is a valid connection to the wasm engine
+     */
+    bool is_connected() const { return _shared_res.transport.is_valid(); }
 
     /// returns the number of running / registered fibers
     size_t n_registered_scripts() const { return _scripts.size(); }

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -407,4 +407,16 @@ ss::future<script_context::write_response> script_context::write_materialized(
     });
 }
 
+absl::flat_hash_set<model::ntp> script_context::registered_ntps() const {
+    absl::flat_hash_set<model::ntp> ntps;
+    std::transform(
+      _ntp_ctxs.cbegin(),
+      _ntp_ctxs.cend(),
+      std::inserter(ntps, ntps.begin()),
+      [](const std::pair<model::ntp, ss::lw_shared_ptr<ntp_context>>& p) {
+          return p.first;
+      });
+    return ntps;
+}
+
 } // namespace coproc

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -21,6 +21,8 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 
+#include <absl/container/flat_hash_set.h>
+
 namespace coproc {
 
 /**
@@ -67,6 +69,12 @@ public:
      * held by this context are relinquished
      */
     ss::future<> shutdown();
+
+    /**
+     * Query the registered ntps for the part of the coprocessor existing on
+     * 'this' shard.
+     */
+    absl::flat_hash_set<model::ntp> registered_ntps() const;
 
 private:
     enum class write_response { success, crc_failure, term_too_old };

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ rp_test(
     wasm_event_tests.cc
     event_listener_tests.cc
     read_materialized_topic_test.cc
+		api/wasm_list_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main ${fixture_deps}
   LABELS coproc

--- a/src/v/coproc/tests/api/wasm_list_tests.cc
+++ b/src/v/coproc/tests/api/wasm_list_tests.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/api/wasm_list.h"
+#include "coproc/tests/fixtures/coproc_slim_fixture.h"
+#include "coproc/tests/utils/coprocessor.h"
+#include "model/metadata.h"
+#include "reflection/adl.h"
+#include "test_utils/fixture.h"
+#include "utils/type_traits.h"
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <algorithm>
+#include <numeric>
+#include <type_traits>
+
+using copro_typeid = coproc::registry::type_identifier;
+
+template<typename T>
+class rapidjson_value_comparator {
+public:
+    explicit rapidjson_value_comparator(T&& value)
+      : _value(std::forward<T>(value)) {}
+
+    bool operator()(const rapidjson::Value& v) const {
+        if constexpr (std::is_integral_v<T>) {
+            return v.GetInt() == _value;
+        } else if constexpr (
+          std::is_same_v<T, std::string> || std::is_same_v<T, ss::sstring>) {
+            return v.GetString() == _value;
+        } else if constexpr (std::is_same_v<T, bool>) {
+            return v.GetBool() == _value;
+        } else if constexpr (std::is_floating_point_v<T>) {
+            return v.GetDouble() == _value;
+        } else {
+            static_assert(dependent_false<T>::value, "Unsupported type");
+        }
+        return false;
+    }
+
+private:
+    T _value;
+};
+
+FIXTURE_TEST(test_wasm_status_report, coproc_slim_fixture) {
+    model::node_id nid(5);
+    model::topic foo("foo");
+    model::topic bar("bar");
+    model::topic baz("baz");
+    setup({{foo, 2}, {bar, 8}, {baz, 3}}).get();
+    enable_coprocessors(
+      {{.id = 22220,
+        .data{
+          .tid = copro_typeid::null_coprocessor, .topics = {{bar, tp_stored}}}},
+       {.id = 77778,
+        .data{
+          .tid = copro_typeid::null_coprocessor,
+          .topics = {{foo, tp_stored}, {baz, tp_latest}}}}})
+      .get();
+    absl::btree_map<coproc::script_id, coproc::wasm::deploy_attributes> layout;
+    layout[coproc::script_id(22220)] = coproc::wasm::deploy_attributes{
+      .description = "1 hello world!", .name = "22220-name"};
+    layout[coproc::script_id(77778)] = coproc::wasm::deploy_attributes{
+      .description = "2 hello world!", .name = "77778-name"};
+    auto result
+      = coproc::wasm::current_status(nid, get_pacemaker(), layout).get();
+    auto data = model::consume_reader_to_memory(
+                  std::move(result), model::no_timeout)
+                  .get();
+    BOOST_CHECK_EQUAL(data.size(), 1);
+    auto record = std::move(data[0].copy_records()[0]);
+    auto record_key = record.release_key();
+    auto record_iobuf = record.release_value();
+    auto key_node_id
+      = iobuf_const_parser(record_key).consume_type<model::node_id::type>();
+    auto value_as_string
+      = iobuf_const_parser(record_iobuf).read_string(record_iobuf.size_bytes());
+
+    info("Raw Json value: {}", value_as_string);
+    rapidjson::Document doc;
+    doc.Parse(std::move(value_as_string));
+    BOOST_CHECK(!doc.HasParseError() && doc.IsObject());
+    BOOST_CHECK(
+      doc.HasMember("node_id") && doc.HasMember("status")
+      && doc.HasMember("coprocessors"));
+    BOOST_CHECK_EQUAL(std::distance(doc.MemberBegin(), doc.MemberEnd()), 3);
+    BOOST_CHECK_EQUAL(doc["node_id"].GetInt(), nid());
+    BOOST_CHECK_EQUAL(doc["node_id"].GetInt(), key_node_id);
+    BOOST_CHECK_EQUAL(ss::sstring(doc["status"].GetString()), "up");
+    BOOST_CHECK(doc["coprocessors"].IsObject());
+    const auto& copros = doc["coprocessors"];
+    BOOST_CHECK(copros.HasMember("22220-name"));
+    BOOST_CHECK(copros.HasMember("77778-name"));
+    BOOST_CHECK_EQUAL(
+      std::distance(copros.MemberBegin(), copros.MemberEnd()), 2);
+    const auto& two_obj = copros["22220-name"].GetObject();
+    const auto& seven_obj = copros["77778-name"].GetObject();
+    BOOST_CHECK(two_obj.HasMember("input_topics"));
+    BOOST_CHECK(two_obj.HasMember("description"));
+    BOOST_CHECK(seven_obj.HasMember("input_topics"));
+    BOOST_CHECK(seven_obj.HasMember("description"));
+    BOOST_CHECK_EQUAL(seven_obj["description"].GetString(), "2 hello world!");
+    BOOST_CHECK_EQUAL(two_obj["description"].GetString(), "1 hello world!");
+    const auto& two_arr = two_obj["input_topics"].GetArray();
+    const auto& seven_arr = seven_obj["input_topics"].GetArray();
+    BOOST_CHECK_EQUAL(two_arr.Size(), 1);
+    BOOST_CHECK_EQUAL(ss::sstring(two_arr[0].GetString()), "bar");
+    BOOST_CHECK_EQUAL(seven_arr.Size(), 2);
+
+    BOOST_CHECK_NE(
+      std::find_if(
+        seven_arr.Begin(),
+        seven_arr.End(),
+        rapidjson_value_comparator<std::string>("foo")),
+      seven_arr.End());
+    BOOST_CHECK_NE(
+      std::find_if(
+        seven_arr.Begin(),
+        seven_arr.End(),
+        rapidjson_value_comparator<std::string>("baz")),
+      seven_arr.End());
+}

--- a/src/v/coproc/tests/utils/wasm_event_generator.cc
+++ b/src/v/coproc/tests/utils/wasm_event_generator.cc
@@ -28,6 +28,7 @@ event::event(uint64_t id)
 event::event(uint64_t id, cpp_enable_payload ep)
   : id(id)
   , desc(random_generators::get_bytes(64))
+  , name(random_generators::get_bytes(24))
   , action(event_action::deploy) {
     iobuf payload;
     reflection::serialize(payload, ep.tid, std::move(ep.topics));
@@ -67,6 +68,9 @@ void serialize_event(storage::record_batch_builder& rbb, const event& e) {
     }
     if (e.desc) {
         headers.emplace_back(create_header("description", *e.desc));
+    }
+    if (e.name) {
+        headers.emplace_back(create_header("name", *e.name));
     }
     if (e.checksum) {
         headers.emplace_back(create_header("sha256", *e.checksum));
@@ -116,6 +120,7 @@ model::record_batch_reader make_random_event_record_batch_reader(
                 e.action = event_action::deploy;
                 e.script = random_generators::get_bytes();
                 e.desc = random_generators::get_bytes(64);
+                e.name = random_generators::get_bytes(24);
                 e.checksum = calculate_checksum(e);
             }
             serialize_event(rbb, e);

--- a/src/v/coproc/tests/utils/wasm_event_generator.cc
+++ b/src/v/coproc/tests/utils/wasm_event_generator.cc
@@ -21,14 +21,21 @@
 
 namespace coproc::wasm {
 
+static bytes gen_random_string_as_bytes(size_t n) {
+    auto string = random_generators::gen_alphanum_string(n);
+    iobuf buf;
+    buf.append(string.begin(), string.size());
+    return iobuf_to_bytes(buf);
+}
+
 event::event(uint64_t id)
   : id(id)
   , action(event_action::remove) {}
 
 event::event(uint64_t id, cpp_enable_payload ep)
   : id(id)
-  , desc(random_generators::get_bytes(64))
-  , name(random_generators::get_bytes(24))
+  , desc(gen_random_string_as_bytes(64))
+  , name(gen_random_string_as_bytes(24))
   , action(event_action::deploy) {
     iobuf payload;
     reflection::serialize(payload, ep.tid, std::move(ep.topics));
@@ -119,8 +126,8 @@ model::record_batch_reader make_random_event_record_batch_reader(
             if (random_generators::get_int(0, 1) == 0) {
                 e.action = event_action::deploy;
                 e.script = random_generators::get_bytes();
-                e.desc = random_generators::get_bytes(64);
-                e.name = random_generators::get_bytes(24);
+                e.desc = gen_random_string_as_bytes(64);
+                e.name = gen_random_string_as_bytes(24);
                 e.checksum = calculate_checksum(e);
             }
             serialize_event(rbb, e);

--- a/src/v/coproc/tests/utils/wasm_event_generator.h
+++ b/src/v/coproc/tests/utils/wasm_event_generator.h
@@ -37,6 +37,7 @@ struct event {
     std::optional<uint64_t> id;
     std::optional<bytes> desc;
     std::optional<bytes> script;
+    std::optional<bytes> name;
     std::optional<bytes> checksum;
     std::optional<event_action> action;
 

--- a/src/v/coproc/tests/wasm_event_tests.cc
+++ b/src/v/coproc/tests/wasm_event_tests.cc
@@ -75,6 +75,7 @@ BOOST_AUTO_TEST_CASE(verify_make_event_failures) {
         e.id = random_generators::get_int<uint64_t>(55555);
         e.desc = random_generators::get_bytes(64);
         e.script = random_generators::get_bytes(15);
+        e.name = random_generators::get_bytes(15);
         e.checksum = random_generators::get_bytes(32);
         e.action = coproc::wasm::event_action::deploy;
         model::record r = coproc::wasm::make_record(e);
@@ -106,8 +107,8 @@ SEASTAR_THREAD_TEST_CASE(verify_event_reconciliation) {
         std::make_move_iterator(batches.begin()),
         std::make_move_iterator(batches.end())));
     BOOST_CHECK_EQUAL(results.size(), 3);
-    BOOST_CHECK(
-      results.find(coproc::script_id(123))->second.empty()); /// 'remove' event
+    BOOST_CHECK(results.find(coproc::script_id(123))
+                  ->second.source_code.empty()); /// 'remove' event
     BOOST_CHECK(results.find(coproc::script_id(123)) != results.end());
     BOOST_CHECK(results.find(coproc::script_id(456)) != results.end());
     BOOST_CHECK(results.find(coproc::script_id(789)) != results.end());

--- a/src/v/coproc/wasm_event.h
+++ b/src/v/coproc/wasm_event.h
@@ -25,10 +25,19 @@
 namespace coproc::wasm {
 
 /// Enumerations for all possible values for keys within the record headers
-enum class event_header { action, description, checksum };
+enum class event_header { action, name, description, checksum };
 
 /// Enumerations for all possible values for the 'action' key within the headers
 enum class event_action { deploy, remove };
+
+struct deploy_attributes {
+    ss::sstring description;
+    ss::sstring name;
+};
+struct log_event {
+    deploy_attributes attrs;
+    iobuf source_code;
+};
 
 /// \brief returns the id of the event, performs a byte-copy
 std::optional<script_id> get_event_id(const model::record&);
@@ -51,7 +60,7 @@ wasm::errc validate_event(const model::record&);
 
 /// \brief Returns the newest events and their data blobs if the event has
 /// passed all validators
-absl::btree_map<script_id, iobuf>
+absl::btree_map<script_id, log_event>
   reconcile_events(std::vector<model::record_batch>);
 
 } // namespace coproc::wasm

--- a/src/v/kafka/client/publish_batch_consumer.h
+++ b/src/v/kafka/client/publish_batch_consumer.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "kafka/client/client.h"
+#include "kafka/protocol/produce.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace kafka::client {
+
+class publish_batch_consumer {
+public:
+    publish_batch_consumer(client& client, model::topic_partition tp)
+      : _client(client)
+      , _publish_tp(std::move(tp)) {}
+
+    ss::future<ss::stop_iteration> operator()(model::record_batch& rb) {
+        /// TODO: Better error handling
+        _results.push_back(
+          co_await _client.produce_record_batch(_publish_tp, std::move(rb)));
+        co_return ss::stop_iteration::no;
+    }
+
+    std::vector<kafka::produce_response::partition> end_of_stream() {
+        return std::move(_results);
+    }
+
+private:
+    std::vector<kafka::produce_response::partition> _results;
+    client& _client;
+    model::topic_partition _publish_tp;
+};
+
+} // namespace kafka::client

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -38,9 +38,12 @@ inline const model::topic kafka_group_topic("group");
 
 inline const model::topic
   coprocessor_internal_topic("coprocessor_internal_topic");
-
 inline const model::topic_partition coprocessor_internal_tp{
   coprocessor_internal_topic, model::partition_id(0)};
+
+inline const model::topic coprocessor_status_topic("coprocessor_status_topic");
+inline const model::topic_partition coprocessor_status_tp{
+  coprocessor_status_topic, model::partition_id(0)};
 
 inline const model::topic tx_manager_topic("tx");
 inline const model::topic_namespace

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -13,6 +13,7 @@
 #include "model/fundamental.h"
 #include "seastarx.h"
 #include "utils/named_type.h"
+#include "utils/type_traits.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/net/inet_address.hh>
@@ -24,12 +25,6 @@
 #include <variant>
 
 namespace security {
-
-namespace details {
-template<class T>
-struct dependent_false : std::false_type {};
-} // namespace details
-
 // cluster is a resource type and the acl data model requires that resources
 // have names, so this is a fixed name for that resource.
 //
@@ -63,7 +58,7 @@ inline resource_type get_resource_type() {
     } else if constexpr (std::is_same_v<T, kafka::transactional_id>) {
         return resource_type::transactional_id;
     } else {
-        static_assert(details::dependent_false<T>::value, "Unsupported type");
+        static_assert(dependent_false<T>::value, "Unsupported type");
     }
 }
 

--- a/src/v/utils/type_traits.h
+++ b/src/v/utils/type_traits.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include <type_traits>
+
+template<class T>
+struct dependent_false : std::false_type {};

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -77,6 +77,7 @@ COPY --chown=0:0 tests/docker/ssh /root/.ssh
 # passes --force so system pip packages can be updated
 COPY --chown=0:0 tests/setup.py /root/tests/
 RUN python3 -m pip install --upgrade --force pip && \
-    python3 -m pip install --force --no-cache-dir -e /root/tests/
+		python3 -m pip install --force --no-cache-dir -e /root/tests/ && \
+    python3 -m pip install zstandard
 
 CMD service ssh start && tail -f /dev/null

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -110,6 +110,13 @@ class RpkTool:
         cmd = [self._rpk_binary(), 'wasm', 'generate', directory]
         return self._execute(cmd)
 
+    def wasm_list(self):
+        cmd = [
+            self._rpk_binary(), 'wasm', 'list', '--raw', '--brokers',
+            self._redpanda.brokers()
+        ]
+        return self._execute(cmd)
+
     def _run_topic(self, cmd, stdin=None, timeout=30):
         cmd = [
             self._rpk_binary(), "topic", "--brokers",

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -160,7 +160,6 @@ class RpkTool:
                 f.write(stdin)
                 f.seek(0)
 
-            # rpk logs everything on STDERR by default
             p = subprocess.Popen(cmd,
                                  stdout=subprocess.PIPE,
                                  stdin=f,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -359,6 +359,11 @@ class RedpandaService(Service):
         cfg = self.read_configuration(node)
         return f"{node.account.hostname}:{cfg['redpanda']['kafka_api']['port']}"
 
+    def node_id(self, node):
+        assert node in self.nodes
+        cfg = self.read_configuration(node)
+        return int(cfg['redpanda']['node_id'])
+
     def brokers(self, limit=None):
         brokers = ",".join(
             map(lambda n: self.broker_address(n), self.nodes[:limit]))
@@ -366,6 +371,9 @@ class RedpandaService(Service):
 
     def brokers_list(self, limit=None):
         return [self.broker_address(n) for n in self.nodes[:limit]]
+
+    def node_id_list(self, limit=None):
+        return [self.node_id(n) for n in self.nodes[:limit]]
 
     def metrics(self, node):
         assert node in self.nodes

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -11,6 +11,7 @@ import os
 import uuid
 import random
 import string
+import json
 
 from kafka import TopicPartition
 
@@ -72,10 +73,44 @@ class WasmTest(RedpandaTest):
                                        extra_rp_conf=wasm_opts,
                                        num_brokers=num_brokers)
         self._rpk_tool = RpkTool(self.redpanda)
+        self._detected_deployed = False
         self._build_tool = WasmBuildTool(self._rpk_tool)
+        self._scripts = []
         self._input_consumer = None
         self._output_consumer = None
         self._producers = None
+
+    def _verify_list_output(self):
+        output = json.loads(self._rpk_tool.wasm_list())
+        ids = self.redpanda.node_id_list()
+        all_found = set([])
+        if 'status' in output:
+            if output['status'] == 'uninitialized':
+                return
+        elif len(output) == 0:
+            return
+        for node_id, result in output.items():
+            if int(node_id) != result['node_id']:
+                raise Exception("Key should equal advertised node_id")
+            if int(node_id) not in ids:
+                raise Exception("Unknown node_id returned from wasm list cmd")
+            if result['status'] != "up":
+                raise Exception("Wasm engine is down, should be up")
+            if self._detected_deployed is True:
+                copros = result['coprocessors']
+                for name, options in copros.items():
+                    found = [x for x in self._scripts if x.name == name]
+                    assert len(found) < 2
+                    if len(found) > 0:
+                        e = found[0]
+                        all_found.add(e.name)
+                        if options['description'] != e.description:
+                            raise Exception("Mismatch script description")
+                        if set(options['input_topics']) != set(e.inputs):
+                            raise Exception("Mistmatch input topics")
+        if self._detected_deployed and all_found != set(
+            [x.name for x in self._scripts]):
+            raise Exception("Expected copro was missing")
 
     def _build_script(self, script):
         # Build the script itself
@@ -98,6 +133,8 @@ class WasmTest(RedpandaTest):
         self.redpanda.restart_nodes(node)
 
     def start(self, topic_spec, scripts):
+        self._scripts = scripts
+
         def to_output_topic_spec(output_topics):
             """
             Create a list of TopicPartitions for the set of output topics.
@@ -187,7 +224,9 @@ class WasmTest(RedpandaTest):
             self.logger.info("Output: %d" %
                              self._output_consumer.results.num_records())
             batch_total = self._input_consumer.results.num_records()
+            self._verify_list_output()
             if batch_total > 0:
+                self._detected_deployed = True
                 self.records_recieved(batch_total)
 
             return self._input_consumer.is_finished() \

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -44,6 +44,7 @@ def random_string(N):
 class WasmScript:
     def __init__(self, inputs=[], outputs=[], script=None):
         self.name = random_string(10)
+        self.description = random_string(20)
         self.inputs = inputs
         self.outputs = outputs
         self.script = script
@@ -83,7 +84,7 @@ class WasmTest(RedpandaTest):
         # Deploy coprocessor
         self._rpk_tool.wasm_deploy(
             script.get_artifact(self._build_tool.work_dir), script.name,
-            "ducktape")
+            script.description)
 
     def restart_wasm_engine(self, node):
         self.logger.info(


### PR DESCRIPTION
Adding a new command to `rpk wasm` called `list` which will display in a neat table (or json if `--raw` is passed) the status of all registered coprocessors and their input topics in a neat table. 