### PR TITLE
Give feature toggle that removes trailing dot from advertised kafka api 

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -252,6 +252,10 @@ type PandaproxyAPI struct {
 // retrieved from the Secret named '<redpanda-cluster-name>-user-client'.
 //
 // All TLS secrets are stored in the same namespace as the Redpanda cluster.
+//
+// Additionally all mentioned certificates beside PEM version will have JKS
+// and PKCS#12 certificate. Both stores are protected with the password that
+// is the same as the name of the Cluster custom resource.
 type KafkaAPITLS struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// References cert-manager Issuer or ClusterIssuer. When provided, this
@@ -285,6 +289,10 @@ type KafkaAPITLS struct {
 // the Secret named '<redpanda-cluster-name>-admin-api-client'.
 //
 // All TLS secrets are stored in the same namespace as the Redpanda cluster.
+//
+// Additionally all mentioned certificates beside PEM version will have JKS
+// and PKCS#12 certificate. Both stores are protected with the password that
+// is the same as the name of the Cluster custom resource.
 type AdminAPITLS struct {
 	Enabled           bool `json:"enabled,omitempty"`
 	RequireClientAuth bool `json:"requireClientAuth,omitempty"`
@@ -303,6 +311,10 @@ type AdminAPITLS struct {
 // the Secret named '<redpanda-cluster-name>-proxy-api-client'.
 //
 // All TLS secrets are stored in the same namespace as the Redpanda cluster.
+//
+// Additionally all mentioned certificates beside PEM version will have JKS
+// and PKCS#12 certificate. Both stores are protected with the password that
+// is the same as the name of the Cluster custom resource.
 type PandaproxyAPITLS struct {
 	Enabled           bool `json:"enabled,omitempty"`
 	RequireClientAuth bool `json:"requireClientAuth,omitempty"`

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -65,6 +65,10 @@ type ClusterSpec struct {
 	// 3. updating this map requires a manual restart of the Redpanda pods
 	// 4. cannot have keys that conflict with existing struct fields - it leads to panic
 	AdditionalConfiguration map[string]string `json:"additionalConfiguration,omitempty"`
+	// DNSTrailingDotDisabled gives ability to turn off the fully-qualified
+	// DNS name.
+	// http://www.dns-sd.org/trailingdotsindomainnames.html
+	DNSTrailingDotDisabled bool `json:"dnsTrailingDotDisabled,omitempty"`
 }
 
 // Superuser has full access to the Redpanda cluster

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -329,6 +329,10 @@ spec:
                         type: integer
                     type: object
                 type: object
+              dnsTrailingDotDisabled:
+                description: DNSTrailingDotDisabled gives ability to turn off the
+                  fully-qualified DNS name. http://www.dns-sd.org/trailingdotsindomainnames.html
+                type: boolean
               enableSasl:
                 description: SASL enablement flag
                 type: boolean

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -128,7 +128,7 @@ func (r *ClusterReconciler) Reconcile(
 	nodeportSvc := resources.NewNodePortService(r.Client, &redpandaCluster, r.Scheme, nodeports, log)
 
 	clusterPorts := []resources.NamedServicePort{}
-	if proxyAPIExternal != nil {
+	if proxyAPIExternal != nil && proxyAPIInternal != nil {
 		clusterPorts = append(clusterPorts, resources.NamedServicePort{Name: resources.PandaproxyPortExternalName, Port: proxyAPIInternal.Port + 1})
 	}
 	clusterSvc := resources.NewClusterService(r.Client, &redpandaCluster, r.Scheme, clusterPorts, log)

--- a/src/go/k8s/pkg/resources/certmanager/admin_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/admin_api.go
@@ -36,7 +36,7 @@ func (r *PkiReconciler) AdminAPIClientCert() types.NamespacedName {
 }
 
 func (r *PkiReconciler) prepareAdminAPI(
-	issuerRef *cmmeta.ObjectReference,
+	issuerRef *cmmeta.ObjectReference, keystoreSecret *types.NamespacedName,
 ) []resources.Resource {
 	toApply := []resources.Resource{}
 
@@ -50,14 +50,14 @@ func (r *PkiReconciler) prepareAdminAPI(
 		dnsName = externalListener.External.Subdomain
 	}
 
-	nodeCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, issuerRef, dnsName, cn, false, r.logger)
+	nodeCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, issuerRef, dnsName, cn, false, keystoreSecret, r.logger)
 	toApply = append(toApply, nodeCert)
 
 	if r.pandaCluster.AdminAPITLS() != nil && r.pandaCluster.AdminAPITLS().TLS.RequireClientAuth {
 		// Certificate for calling the Admin API on any broker
 		cn := NewCommonName(r.pandaCluster.Name, AdminAPIClientCert)
 		clientCertsKey := types.NamespacedName{Name: string(cn), Namespace: r.pandaCluster.Namespace}
-		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, clientCertsKey, issuerRef, cn, false, r.logger)
+		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, clientCertsKey, issuerRef, cn, false, keystoreSecret, r.logger)
 
 		toApply = append(toApply, adminClientCert)
 	}

--- a/src/go/k8s/pkg/resources/certmanager/certificate.go
+++ b/src/go/k8s/pkg/resources/certmanager/certificate.go
@@ -31,8 +31,6 @@ import (
 var _ resources.Resource = &CertificateResource{}
 
 const (
-	// CAKey filename for root certificate
-	CAKey = cmetav1.TLSCAKey
 	// DefaultCertificateDuration default certification duration - 5 years
 	DefaultCertificateDuration = 5 * 365 * 24 * time.Hour
 	// DefaultRenewBefore default time length prior to expiration to attempt renewal - 90 days

--- a/src/go/k8s/pkg/resources/certmanager/kafka_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/kafka_api.go
@@ -59,6 +59,7 @@ func (r *PkiReconciler) prepareKafkaAPI(
 	ctx context.Context,
 	issuerRef *cmmetav1.ObjectReference,
 	tlsListener *v1alpha1.KafkaAPITLS,
+	keystoreSecret *types.NamespacedName,
 ) ([]resources.Resource, error) {
 	toApply := []resources.Resource{}
 
@@ -81,7 +82,7 @@ func (r *PkiReconciler) prepareKafkaAPI(
 			dnsName = externalListener.External.Subdomain
 		}
 
-		redpandaCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, nodeIssuerRef, dnsName, cn, false, r.logger)
+		redpandaCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, nodeIssuerRef, dnsName, cn, false, keystoreSecret, r.logger)
 
 		toApply = append(toApply, redpandaCert)
 	}
@@ -96,17 +97,17 @@ func (r *PkiReconciler) prepareKafkaAPI(
 		// Certificate for external clients to call the Kafka API on any broker in this Redpanda cluster
 		userClientCn := NewCommonName(r.pandaCluster.Name, UserClientCert)
 		userClientKey := types.NamespacedName{Name: string(userClientCn), Namespace: r.pandaCluster.Namespace}
-		externalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, userClientKey, issuerRef, userClientCn, false, r.logger)
+		externalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, userClientKey, issuerRef, userClientCn, false, keystoreSecret, r.logger)
 
 		// Certificate for operator to call the Kafka API on any broker in this Redpanda cluster
 		operatorClientCn := NewCommonName(r.pandaCluster.Name, OperatorClientCert)
 		operatorClientKey := types.NamespacedName{Name: string(operatorClientCn), Namespace: r.pandaCluster.Namespace}
-		internalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, operatorClientKey, issuerRef, operatorClientCn, false, r.logger)
+		internalClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, operatorClientKey, issuerRef, operatorClientCn, false, keystoreSecret, r.logger)
 
 		// Certificate for admin to call the Kafka API on any broker in this Redpanda cluster
 		adminClientCn := NewCommonName(r.pandaCluster.Name, AdminClientCert)
 		adminClientKey := types.NamespacedName{Name: string(adminClientCn), Namespace: r.pandaCluster.Namespace}
-		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, adminClientKey, issuerRef, adminClientCn, false, r.logger)
+		adminClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, adminClientKey, issuerRef, adminClientCn, false, keystoreSecret, r.logger)
 
 		toApply = append(toApply, externalClientCert, internalClientCert, adminClientCert)
 	}

--- a/src/go/k8s/pkg/resources/certmanager/keystore_password.go
+++ b/src/go/k8s/pkg/resources/certmanager/keystore_password.go
@@ -1,0 +1,99 @@
+package certmanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	redpandav1alpha1 "github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/labels"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	passwordKey = "password"
+
+	keystoreSuffix = "keystore"
+	separator      = "-"
+)
+
+// KeystoreSecretResource is part of the reconciliation of redpanda.vectorized.io CRD
+// creating secrets for pkcs#12 and jks password
+type KeystoreSecretResource struct {
+	k8sclient.Client
+	scheme       *runtime.Scheme
+	pandaCluster *redpandav1alpha1.Cluster
+	key          types.NamespacedName
+	logger       logr.Logger
+}
+
+// NewKeystoreSecretResource creates KeystoreSecretResource instance
+func NewKeystoreSecretResource(
+	client k8sclient.Client,
+	scheme *runtime.Scheme,
+	pandaCluster *redpandav1alpha1.Cluster,
+	key types.NamespacedName,
+	logger logr.Logger,
+) *KeystoreSecretResource {
+	return &KeystoreSecretResource{
+		client,
+		scheme,
+		pandaCluster,
+		key,
+		logger,
+	}
+}
+
+// Ensure will manage pkcs#12 and jks password for KafkaAPI certificate
+func (r *KeystoreSecretResource) Ensure(ctx context.Context) error {
+	obj, err := r.obj()
+	if err != nil {
+		return fmt.Errorf("unable to construct object: %w", err)
+	}
+
+	_, err = resources.CreateIfNotExists(ctx, r, obj, r.logger)
+	return err
+}
+
+// obj returns secret that consist password for jks and pkcs#12 keystores
+func (r *KeystoreSecretResource) obj() (k8sclient.Object, error) {
+	objLabels := labels.ForCluster(r.pandaCluster)
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.Key().Name,
+			Namespace: r.Key().Namespace,
+			Labels:    objLabels,
+		},
+		StringData: map[string]string{
+			passwordKey: r.pandaCluster.Name,
+		},
+	}
+	err := controllerutil.SetControllerReference(r.pandaCluster, secret, r.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+// Key returns namespace/name object that is used to identify object.
+// For reference please visit types.NamespacedName docs in k8s.io/apimachinery
+func (r *KeystoreSecretResource) Key() types.NamespacedName {
+	return r.key
+}
+
+func keystoreName(clusterName string) string {
+	suffixLength := len(keystoreSuffix)
+	maxClusterNameLength := validation.DNS1123SubdomainMaxLength - suffixLength - len(separator)
+	if len(clusterName) > maxClusterNameLength {
+		clusterName = clusterName[:maxClusterNameLength]
+	}
+	return fmt.Sprintf("%s%s%s", clusterName, separator, keystoreSuffix)
+}

--- a/src/go/k8s/pkg/resources/certmanager/pandaproxy_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/pandaproxy_api.go
@@ -36,7 +36,7 @@ func (r *PkiReconciler) PandaproxyAPIClientCert() types.NamespacedName {
 }
 
 func (r *PkiReconciler) preparePandaproxyAPI(
-	issuerRef *cmmeta.ObjectReference,
+	issuerRef *cmmeta.ObjectReference, keystoreSecret *types.NamespacedName,
 ) []resources.Resource {
 	toApply := []resources.Resource{}
 
@@ -50,14 +50,14 @@ func (r *PkiReconciler) preparePandaproxyAPI(
 		dnsName = externalListener.External.Subdomain
 	}
 
-	nodeCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, issuerRef, dnsName, cn, false, r.logger)
+	nodeCert := NewNodeCertificate(r.Client, r.scheme, r.pandaCluster, certsKey, issuerRef, dnsName, cn, false, keystoreSecret, r.logger)
 	toApply = append(toApply, nodeCert)
 
 	if r.pandaCluster.PandaproxyAPITLS() != nil && r.pandaCluster.PandaproxyAPITLS().TLS.RequireClientAuth {
 		// Certificate for calling the Pandaproxy API on any broker
 		cn := NewCommonName(r.pandaCluster.Name, PandaproxyAPIClientCert)
 		clientCertsKey := types.NamespacedName{Name: string(cn), Namespace: r.pandaCluster.Namespace}
-		proxyClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, clientCertsKey, issuerRef, cn, false, r.logger)
+		proxyClientCert := NewCertificate(r.Client, r.scheme, r.pandaCluster, clientCertsKey, issuerRef, cn, false, keystoreSecret, r.logger)
 
 		toApply = append(toApply, proxyClientCert)
 	}

--- a/src/go/k8s/pkg/resources/headless_service.go
+++ b/src/go/k8s/pkg/resources/headless_service.go
@@ -138,6 +138,12 @@ func serviceKind() string {
 // allows it.
 func (r *HeadlessServiceResource) HeadlessServiceFQDN() string {
 	// TODO Retrieve cluster domain dynamically and remove hardcoded cluster.local
+	if r.pandaCluster.Spec.DNSTrailingDotDisabled {
+		return fmt.Sprintf("%s%c%s.svc.cluster.local",
+			r.Key().Name,
+			'.',
+			r.Key().Namespace)
+	}
 	return fmt.Sprintf("%s%c%s.svc.cluster.local.",
 		r.Key().Name,
 		'.',

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: schema-registry-test
+status:
+  readyReplicas: 1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/00-redpanda-cluster.yaml
@@ -1,0 +1,27 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: schema-registry-test
+spec:
+  image: "vectorized/redpanda"
+  version: "latest"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+      tls:
+        enabled: true
+    adminApi:
+    - port: 9644
+    developerMode: true
+    autoCreateTopics: true
+  dnsTrailingDotDisabled: true

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cp-schema-registry
+status:
+  readyReplicas: 1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/01-create-schema-registry.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/01-create-schema-registry.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cp-schema-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cp-schema-registry
+  template:
+    metadata:
+      labels:
+        app: cp-schema-registry
+    spec:
+      containers:
+      - name: cp-schema-registry-server
+        image: "confluentinc/cp-schema-registry:6.0.1"
+        imagePullPolicy: "IfNotPresent"
+        command:
+        - /bin/bash
+        - -c
+        args:
+        - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=schema-registry-test-0.schema-registry-test.$POD_NAMESPACE.svc.cluster.local:9092 /etc/confluent/docker/run
+        ports:
+        - name: schema-registry
+          containerPort: 8081
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 600m
+            memory: 1Gi
+          limits:
+            cpu: 600m
+            memory: 1Gi
+        env:
+        - name: SCHEMA_REGISTRY_HOST_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SCHEMA_REGISTRY_LISTENERS
+          value: http://0.0.0.0:8081
+        - name: SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION
+          value: /redpanda/tls/truststore.jks
+        - name: SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: schema-registry-test-keystore
+              key: password
+        - name: SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL
+          value: SSL
+        - name: SCHEMA_REGISTRY_HEAP_OPTS
+          value: "-Xms512M -Xmx512M"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - mountPath: /redpanda/tls
+          name: redpanda-tls
+          readOnly: true
+      volumes:
+      - name: redpanda-tls
+        secret:
+          secretName: schema-registry-test-redpanda
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cp-schema-registry
+spec:
+  ports:
+    - name: schema-registry
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: cp-schema-registry
+  type: ClusterIP

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/02-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/02-create-schema.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/02-create-schema.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema
+spec:
+  template:
+    spec:
+      containers:
+      - name: rpk
+        image: vectorized/redpanda:latest
+        command:
+        - curl
+        args:
+        - -v
+        - --silent
+        - -X
+        - POST
+        - -H
+        - "Content-Type: application/vnd.schemaregistry.v1+json"
+        - --data
+        - '{"schema": "{\"type\": \"string\"}" }'
+        - http://cp-schema-registry:8081/subjects/Kafka-value/versions
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/03-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: retrive-schema
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/03-retrieve-schema.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/03-retrieve-schema.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: retrive-schema
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: vectorized/redpanda:latest
+          command:
+            - curl
+          args:
+            - -v
+            - --silent
+            - -X
+            - GET
+            - http://cp-schema-registry:8081/schemas/ids/1
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1


### PR DESCRIPTION
## Cover letter

This PR gives user feature toggle that removes trailing dot from advertised kafka api.

This RP also introduces keystore and truststore in the format of jks and pkcs#12 in all but root certificate. 

REF: https://cert-manager.io/docs/release-notes/release-notes-0.15/#general-availability-of-jks-and-pkcs-12-keystores

Fixes: #1640 #1661

## Release notes

Release note: Schema registry can talk to Redpanda with server side TLS enabled.