### PR TITLE
Throttling recovery of Raft learners 

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -43,7 +43,7 @@ consensus::consensus(
   group_configuration initial_cfg,
   timeout_jitter jit,
   storage::log l,
-  ss::io_priority_class io_priority,
+  scheduling_config scheduling_config,
   model::timeout_clock::duration disk_timeout,
   consensus_client_protocol client,
   consensus::leader_cb_t cb,
@@ -52,7 +52,7 @@ consensus::consensus(
   , _group(group)
   , _jit(std::move(jit))
   , _log(l)
-  , _io_priority(io_priority)
+  , _scheduling(scheduling_config)
   , _disk_timeout(disk_timeout)
   , _client_protocol(client)
   , _leader_notification(std::move(cb))
@@ -68,7 +68,7 @@ consensus::consensus(
   , _snapshot_mgr(
       std::filesystem::path(_log.config().work_directory()),
       storage::snapshot_manager::default_snapshot_filename,
-      _io_priority)
+      _scheduling.default_iopc)
   , _configuration_manager(std::move(initial_cfg), _group, _storage, _ctxlog)
   , _append_requests_buffer(*this, 256) {
     setup_metrics();
@@ -415,7 +415,7 @@ void consensus::dispatch_recovery(follower_index_metadata& idx) {
     // background
     (void)with_gate(_bg, [this, node_id = idx.node_id] {
         auto recovery = std::make_unique<recovery_stm>(
-          this, node_id, _io_priority);
+          this, node_id, _scheduling);
         auto ptr = recovery.get();
         return ptr->apply()
           .handle_exception([this, node_id](const std::exception_ptr& e) {
@@ -1429,7 +1429,8 @@ consensus::do_append_entries(append_entries_request&& r) {
           truncate_at);
         _probe.log_truncated();
         return _log
-          .truncate(storage::truncate_config(truncate_at, _io_priority))
+          .truncate(
+            storage::truncate_config(truncate_at, _scheduling.default_iopc))
           .then([this, truncate_at] {
               _last_quorum_replicated_index = std::min(
                 details::prev_offset(truncate_at),
@@ -1524,7 +1525,8 @@ ss::future<> consensus::truncate_to_latest_snapshot() {
     return _configuration_manager.prefix_truncate(_last_snapshot_index)
       .then([this] {
           return _log.truncate_prefix(storage::truncate_prefix_config(
-            details::next_offset(_last_snapshot_index), _io_priority));
+            details::next_offset(_last_snapshot_index),
+            _scheduling.default_iopc));
       });
 }
 
@@ -1791,7 +1793,7 @@ ss::future<storage::append_result> consensus::disk_append(
       // no fsync explicit on a per write, we verify at the end to
       // batch fsync
       storage::log_append_config::fsync::no,
-      _io_priority,
+      _scheduling.default_iopc,
       model::timeout_clock::now() + _disk_timeout};
     return details::for_each_ref_extract_configuration(
              _log.offsets().dirty_offset,

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -84,7 +84,7 @@ public:
       group_configuration,
       timeout_jitter,
       storage::log,
-      ss::io_priority_class io_priority,
+      scheduling_config,
       model::timeout_clock::duration disk_timeout,
       consensus_client_protocol,
       leader_cb_t,
@@ -487,7 +487,7 @@ private:
     raft::group_id _group;
     timeout_jitter _jit;
     storage::log _log;
-    ss::io_priority_class _io_priority;
+    scheduling_config _scheduling;
     model::timeout_clock::duration _disk_timeout;
     consensus_client_protocol _client_protocol;
     leader_cb_t _leader_notification;

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -19,6 +19,7 @@
 #include "storage/fwd.h"
 
 #include <seastar/core/metrics_registration.hh>
+#include <seastar/core/scheduling.hh>
 
 #include <absl/container/flat_hash_map.h>
 
@@ -37,6 +38,7 @@ public:
     group_manager(
       model::node_id self,
       model::timeout_clock::duration disk_timeout,
+      ss::scheduling_group raft_scheduling_group,
       std::chrono::milliseconds heartbeat_interval,
       std::chrono::milliseconds heartbeat_timeout,
       ss::sharded<rpc::connection_cache>& clients,
@@ -81,6 +83,7 @@ private:
 
     model::node_id _self;
     model::timeout_clock::duration _disk_timeout;
+    ss::scheduling_group _raft_sg;
     raft::consensus_client_protocol _client;
     raft::heartbeat_manager _heartbeats;
     ss::gate _gate;

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -152,7 +152,9 @@ private:
           raft::timeout_jitter(
             config::shard_local_cfg().raft_election_timeout_ms()),
           log,
-          ss::default_priority_class(),
+          raft::scheduling_config(
+            seastar::default_scheduling_group(),
+            seastar::default_priority_class()),
           std::chrono::seconds(1),
           _consensus_client_protocol,
           [this](raft::leadership_status st) {

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -26,11 +26,11 @@ namespace raft {
 using namespace std::chrono_literals;
 
 recovery_stm::recovery_stm(
-  consensus* p, vnode node_id, ss::io_priority_class prio)
+  consensus* p, vnode node_id, scheduling_config scheduling)
   : _ptr(p)
   , _node_id(node_id)
   , _term(_ptr->term())
-  , _prio(prio)
+  , _scheduling(scheduling)
   , _ctxlog(_ptr->_ctxlog) {}
 
 ss::future<> recovery_stm::do_recover() {
@@ -173,7 +173,7 @@ ss::future<> recovery_stm::read_range_for_recovery(
       // time and all drawing from memory. If this setting proves difficult,
       // we'll need to throttle with a core-local semaphore
       32 * 1024,
-      _prio,
+      _scheduling.default_iopc,
       std::nullopt,
       std::nullopt,
       _ptr->_as);

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -19,6 +19,8 @@
 #include "raft/raftgen_service.h"
 
 #include <seastar/core/future-util.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/with_scheduling_group.hh>
 
 #include <chrono>
 
@@ -33,7 +35,23 @@ recovery_stm::recovery_stm(
   , _scheduling(scheduling)
   , _ctxlog(_ptr->_ctxlog) {}
 
-ss::future<> recovery_stm::do_recover() {
+ss::future<> recovery_stm::recover() {
+    auto meta = get_follower_meta();
+    if (!meta) {
+        // stop recovery when node was removed
+        _stop_requested = true;
+        return ss::now();
+    }
+    auto sg = meta.value()->is_learner ? _scheduling.learner_recovery_sg
+                                       : _scheduling.default_sg;
+    auto iopc = meta.value()->is_learner ? _scheduling.learner_recovery_iopc
+                                         : _scheduling.default_iopc;
+
+    return ss::with_scheduling_group(
+      sg, [this, iopc] { return do_recover(iopc); });
+}
+
+ss::future<> recovery_stm::do_recover(ss::io_priority_class iopc) {
     // We have to send all the records that leader have, event those that are
     // beyond commit index, thanks to that after majority have recovered
     // leader can update its commit index
@@ -99,11 +117,12 @@ ss::future<> recovery_stm::do_recover() {
 
     // read & replicate log entries
     return f
-      .then([this, follower_next_offset, follower_committed_match_index] {
+      .then([this, follower_next_offset, follower_committed_match_index, iopc] {
           return read_range_for_recovery(
             follower_next_offset,
             _ptr->_log.offsets().dirty_offset,
-            follower_committed_match_index);
+            follower_committed_match_index,
+            iopc);
       })
       .then([this] {
           auto meta = get_follower_meta();
@@ -163,7 +182,8 @@ recovery_stm::should_flush(model::offset follower_committed_match_index) const {
 ss::future<> recovery_stm::read_range_for_recovery(
   model::offset start_offset,
   model::offset end_offset,
-  model::offset follower_committed_match_index) {
+  model::offset follower_committed_match_index,
+  ss::io_priority_class iopc) {
     storage::log_reader_config cfg(
       start_offset,
       end_offset,
@@ -173,7 +193,7 @@ ss::future<> recovery_stm::read_range_for_recovery(
       // time and all drawing from memory. If this setting proves difficult,
       // we'll need to throttle with a core-local semaphore
       32 * 1024,
-      _scheduling.default_iopc,
+      iopc,
       std::nullopt,
       std::nullopt,
       _ptr->_as);
@@ -466,10 +486,10 @@ ss::future<> recovery_stm::apply() {
     return ss::with_gate(
              _ptr->_bg,
              [this] {
-                 return do_recover().then([this] {
+                 return recover().then([this] {
                      return ss::do_until(
                        [this] { return is_recovery_finished(); },
-                       [this] { return do_recover(); });
+                       [this] { return recover(); });
                  });
              })
       .finally([this] {

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -20,7 +20,7 @@ namespace raft {
 
 class recovery_stm {
 public:
-    recovery_stm(consensus*, vnode, ss::io_priority_class);
+    recovery_stm(consensus*, vnode, scheduling_config);
     ss::future<> apply();
 
 private:
@@ -49,7 +49,7 @@ private:
     model::offset _last_batch_offset;
     model::offset _committed_offset;
     model::term_id _term;
-    ss::io_priority_class _prio;
+    scheduling_config _scheduling;
     ctx_log _ctxlog;
     // tracking follower snapshot delivery
     std::unique_ptr<storage::snapshot_reader> _snapshot_reader;

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -24,9 +24,10 @@ public:
     ss::future<> apply();
 
 private:
-    ss::future<> do_recover();
-    ss::future<>
-      read_range_for_recovery(model::offset, model::offset, model::offset);
+    ss::future<> recover();
+    ss::future<> do_recover(ss::io_priority_class);
+    ss::future<> read_range_for_recovery(
+      model::offset, model::offset, model::offset, ss::io_priority_class);
     ss::future<> replicate(
       model::record_batch_reader&&, append_entries_request::flush_after_append);
     ss::future<result<append_entries_reply>>

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -53,6 +53,7 @@ struct mux_state_machine_fixture {
           .start(
             _self,
             30s,
+            ss::default_scheduling_group(),
             std::chrono::milliseconds(100),
             std::chrono::milliseconds(2000),
             std::ref(_connections),

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -35,6 +35,7 @@
 #include "storage/types.h"
 #include "test_utils/fixture.h"
 
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/net/socket_defs.hh>
@@ -127,7 +128,9 @@ struct raft_node {
           std::move(cfg),
           std::move(jit),
           *log,
-          seastar::default_priority_class(),
+          raft::scheduling_config(
+            seastar::default_scheduling_group(),
+            seastar::default_priority_class()),
           std::chrono::seconds(10),
           raft::make_rpc_client_protocol(self_id, cache),
           [this](raft::leadership_status st) { leader_callback(st); },

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -119,7 +119,9 @@ public:
                         raft::timeout_jitter(
                           config::shard_local_cfg().raft_election_timeout_ms()),
                         log,
-                        ss::default_priority_class(),
+                        raft::scheduling_config(
+                          seastar::default_scheduling_group(),
+                          seastar::default_priority_class()),
                         std::chrono::seconds(1),
                         _consensus_client_protocol,
                         [this](raft::leadership_status st) {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -484,12 +484,23 @@ static constexpr voter_priority min_voter_priority = voter_priority{1};
  */
 struct scheduling_config {
     scheduling_config(
-      ss::scheduling_group default_sg, ss::io_priority_class default_iopc)
+      ss::scheduling_group default_sg,
+      ss::io_priority_class default_iopc,
+      ss::scheduling_group learner_recovery_sg,
+      ss::io_priority_class learner_recovery_iopc)
       : default_sg(default_sg)
-      , default_iopc(default_iopc) {}
+      , default_iopc(default_iopc)
+      , learner_recovery_sg(learner_recovery_sg)
+      , learner_recovery_iopc(learner_recovery_iopc) {}
+
+    scheduling_config(
+      ss::scheduling_group default_sg, ss::io_priority_class default_iopc)
+      : scheduling_config(default_sg, default_iopc, default_sg, default_iopc) {}
 
     ss::scheduling_group default_sg;
     ss::io_priority_class default_iopc;
+    ss::scheduling_group learner_recovery_sg;
+    ss::io_priority_class learner_recovery_iopc;
 };
 
 std::ostream& operator<<(std::ostream& o, const vnode& r);

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -25,6 +25,8 @@
 #include "utils/named_type.h"
 
 #include <seastar/core/condition-variable.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/util/bool_class.hh>
 
@@ -475,6 +477,20 @@ using voter_priority = named_type<uint32_t, struct voter_priority_tag>;
 static constexpr voter_priority zero_voter_priority = voter_priority{0};
 // 1 is smallest possible priority allowing node to become a leader
 static constexpr voter_priority min_voter_priority = voter_priority{1};
+
+/**
+ * Raft scheduling_config contains Seastar scheduling and IO priority
+ * controlling primitives.
+ */
+struct scheduling_config {
+    scheduling_config(
+      ss::scheduling_group default_sg, ss::io_priority_class default_iopc)
+      : default_sg(default_sg)
+      , default_iopc(default_iopc) {}
+
+    ss::scheduling_group default_sg;
+    ss::io_priority_class default_iopc;
+};
 
 std::ostream& operator<<(std::ostream& o, const vnode& r);
 std::ostream& operator<<(std::ostream& o, const consistency_level& l);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -503,6 +503,7 @@ void application::wire_up_redpanda_services() {
       raft_group_manager,
       model::node_id(config::shard_local_cfg().node_id()),
       config::shard_local_cfg().raft_io_timeout_ms(),
+      _scheduling_groups.raft_sg(),
       config::shard_local_cfg().raft_heartbeat_interval_ms(),
       config::shard_local_cfg().raft_heartbeat_timeout_ms(),
       std::ref(_raft_connection_cache),

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -32,6 +32,8 @@ public:
           "cache_background_reclaim", 200);
         _compaction = co_await ss::create_scheduling_group(
           "log_compaction", 100);
+        _raft_learner_recovery = co_await ss::create_scheduling_group(
+          "raft_learner_recovery", 50);
     }
 
     ss::future<> destroy_groups() {
@@ -42,6 +44,7 @@ public:
         co_await destroy_scheduling_group(_coproc);
         co_await destroy_scheduling_group(_cache_background_reclaim);
         co_await destroy_scheduling_group(_compaction);
+        co_await destroy_scheduling_group(_raft_learner_recovery);
         co_return;
     }
 
@@ -54,6 +57,9 @@ public:
         return _cache_background_reclaim;
     }
     ss::scheduling_group compaction_sg() { return _compaction; }
+    ss::scheduling_group raft_learner_recovery_sg() {
+        return _raft_learner_recovery;
+    }
 
 private:
     ss::scheduling_group _admin;
@@ -63,4 +69,5 @@ private:
     ss::scheduling_group _coproc;
     ss::scheduling_group _cache_background_reclaim;
     ss::scheduling_group _compaction;
+    ss::scheduling_group _raft_learner_recovery;
 };

--- a/src/v/resource_mgmt/io_priority.h
+++ b/src/v/resource_mgmt/io_priority.h
@@ -23,6 +23,9 @@ public:
     ss::io_priority_class controller_priority() { return _controller_priority; }
     ss::io_priority_class kafka_read_priority() { return _kafka_read_priority; }
     ss::io_priority_class compaction_priority() { return _compaction_priority; }
+    ss::io_priority_class raft_learner_recovery_priority() {
+        return _raft_learner_recovery_priority;
+    }
 
     static priority_manager& local() {
         static thread_local priority_manager pm = priority_manager();
@@ -37,12 +40,16 @@ private:
       , _kafka_read_priority(
           ss::engine().register_one_priority_class("kafka_read", 1000))
       , _compaction_priority(
-          ss::engine().register_one_priority_class("compaction", 200)) {}
+          ss::engine().register_one_priority_class("compaction", 200))
+      , _raft_learner_recovery_priority(
+          ss::engine().register_one_priority_class(
+            "raft-learner-recovery", 100)) {}
 
     ss::io_priority_class _raft_priority;
     ss::io_priority_class _controller_priority;
     ss::io_priority_class _kafka_read_priority;
     ss::io_priority_class _compaction_priority;
+    ss::io_priority_class _raft_learner_recovery_priority;
 };
 
 inline ss::io_priority_class raft_priority() {
@@ -59,4 +66,8 @@ inline ss::io_priority_class kafka_read_priority() {
 
 inline ss::io_priority_class compaction_priority() {
     return priority_manager::local().compaction_priority();
+}
+
+inline ss::io_priority_class raft_learner_recovery_priority() {
+    return priority_manager::local().raft_learner_recovery_priority();
 }


### PR DESCRIPTION
## Cover letter

When partitions are being moved a lot of data have to be transferred between nodes. 
In order to make sure that the partition moving and replicas rebalancing will not influence main workload we introduced throttling. 

Current PR implements throttling for recovery of raft protocol members being learners. When new node joins the cluster or replica is being moved to another node it always starts as a learner. When node is fully caught up with the leader it is promoted to voter. 

Fixes: #NNN, #NNN, ...

## Release notes
