### PR TITLE
rpk: override viper's default SupportedExts to avoid picking up non-yaml

### DIFF
--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -36,6 +36,13 @@ func InitViper(fs afero.Fs) *viper.Viper {
 	v.SetFs(fs)
 	v.SetConfigName("redpanda")
 	v.SetConfigType("yaml")
+
+	// Viper does not take into account our explicit SetConfigType when
+	// calling ReadInConfig, instead it internally uses SupportedExts.
+	// Since we only ever want to load yaml, setting this global disables
+	// ReadInConfig from using any existing json files.
+	viper.SupportedExts = []string{"yaml"}
+
 	setDefaults(v)
 	return v
 }


### PR DESCRIPTION
viper does not use our explicit `SetConfigType("yaml")` when it searches
for configs with ReadInConfig. Instead, it uses SupportedExts. Since
that variable is global, we can just override it to be our list of (1)
extension that we want to search for.

This is a small fix, the real one is that we will be removing viper from
rpk soon enough.

I've manually tested the worklow that exists in #1637, we no longer have
mentions of trying to use json.

Fixes #1637.