### PR TITLE
operator/helm: sync configurator image tag with operator tag

### DIFF
--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/deployment.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/deployment.yaml
@@ -57,6 +57,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
+        - --configurator-tag={{ tpl .Values.image.tag . }}
         {{- if .Values.webhook.enabled }}
         - --webhook-enabled=true
         {{- else }}


### PR DESCRIPTION
## Cover letter

When deployed with the helm chart, the "redpanda/configurator" image was always using the "latest" tag, which is bad for reproducibility.

Ideally, the configurator image and tag would be independently
configurable, but using the same tag version seems like a good
compromise in the meantime.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
