### PR TITLE
s/index_state: use first timestamp as a last one when max is not set

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -71,6 +71,10 @@ bool index_state::maybe_index(
     // NOTE: we don't need the 'max()' trick below because we controll the
     // offsets ourselves and it would be a bug otherwise - see assert above
     max_offset = batch_max_offset;
+    // some clients leave max timestamp uninitialized in cases there is a
+    // single record in a batch in this case we use first timestamp as a
+    // last one
+    last_timestamp = std::max(first_timestamp, last_timestamp);
     max_timestamp = std::max(max_timestamp, last_timestamp);
     // always saving the first batch simplifies a lot of book keeping
     if (accumulator >= step || retval) {


### PR DESCRIPTION
Some of the Kafka clients do not set record batch header `max_timestamp`
when record batch contains single record.

Previously our index implementation always used `max_timestamp` to update
`max_timestamp` stored in a segment. This way segment last timestamp was
never updated.

Fixed the issue by using `first_timestamp` to update segment last
timestamp when `max_timestamp` is not set by the client.

Signed-off-by: Michal Maslanka <michal@vectorized.io>