### PR TITLE
archival: Extend cloud storage and retry_chain_node api

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -95,7 +95,10 @@ ntp_archiver::download_manifest(retry_chain_node& parent) {
     gate_guard guard{_gate};
     retry_chain_node fib(_manifest_upload_timeout, _initial_backoff, &parent);
     vlog(archival_log.debug, "{} Downloading manifest for {}", fib(), _ntp);
-    co_return co_await _remote.download_manifest(_bucket, _manifest, fib);
+    auto path = _manifest.get_manifest_path();
+    auto key = cloud_storage::remote_manifest_path(
+      std::filesystem::path(std::move(path)));
+    co_return co_await _remote.download_manifest(_bucket, key, _manifest, fib);
 }
 
 ss::future<cloud_storage::upload_result>

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -94,7 +94,8 @@ ss::future<cloud_storage::download_result>
 ntp_archiver::download_manifest(retry_chain_node& parent) {
     gate_guard guard{_gate};
     retry_chain_node fib(_manifest_upload_timeout, _initial_backoff, &parent);
-    vlog(archival_log.debug, "{} Downloading manifest for {}", fib(), _ntp);
+    retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
+    vlog(ctxlog.debug, "Downloading manifest for {}", _ntp);
     auto path = _manifest.get_manifest_path();
     auto key = cloud_storage::remote_manifest_path(
       std::filesystem::path(std::move(path)));
@@ -105,7 +106,8 @@ ss::future<cloud_storage::upload_result>
 ntp_archiver::upload_manifest(retry_chain_node& parent) {
     gate_guard guard{_gate};
     retry_chain_node fib(_manifest_upload_timeout, _initial_backoff, &parent);
-    vlog(archival_log.debug, "{} Uploading manifest for {}", fib(), _ntp);
+    retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
+    vlog(ctxlog.debug, "Uploading manifest for {}", _ntp);
     co_return co_await _remote.upload_manifest(_bucket, _manifest, fib);
 }
 
@@ -113,10 +115,10 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
   upload_candidate candidate, retry_chain_node& parent) {
     gate_guard guard{_gate};
     retry_chain_node fib(_segment_upload_timeout, _initial_backoff, &parent);
+    retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
     vlog(
-      archival_log.debug,
-      "{} Uploading segment for {}, exposed name {} offset {}, length {}",
-      fib(),
+      ctxlog.debug,
+      "Uploading segment for {}, exposed name {} offset {}, length {}",
       _ntp,
       candidate.exposed_name,
       candidate.starting_offset,
@@ -140,13 +142,10 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
   storage::log_manager& lm,
   model::offset high_watermark,
   retry_chain_node& parent) {
+    retry_chain_logger ctxlog(archival_log, parent, _ntp.path());
     gate_guard guard{_gate};
     auto mlock = co_await ss::get_units(_mutex, 1);
-    vlog(
-      archival_log.debug,
-      "{} Uploading next candidates called for {}",
-      parent(),
-      _ntp);
+    vlog(ctxlog.debug, "Uploading next candidates called for {}", _ntp);
     ntp_archiver::batch_result total{};
     // We have to increment last offset to guarantee progress.
     // The manifest's last offset contains dirty_offset of the
@@ -162,19 +161,15 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
     std::vector<model::offset> deltas;
     for (size_t i = 0; i < _concurrency; i++) {
         vlog(
-          archival_log.debug,
-          "{} Uploading next candidates for {}, trying offset {}",
-          parent(),
+          ctxlog.debug,
+          "Uploading next candidates for {}, trying offset {}",
           _ntp,
           last_uploaded_offset);
         auto upload = _policy.get_next_candidate(
           last_uploaded_offset, high_watermark, lm);
         if (upload.source.get() == nullptr) {
             vlog(
-              archival_log.debug,
-              "{} Uploading next candidates for {}, ...skip",
-              parent(),
-              _ntp);
+              ctxlog.debug, "Uploading next candidates for {}, ...skip", _ntp);
             break;
         }
         if (_manifest.contains(upload.exposed_name)) {
@@ -204,20 +199,18 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
             auto dirty_offset = upload.source->offsets().dirty_offset;
             if (meta->committed_offset < dirty_offset) {
                 vlog(
-                  archival_log.info,
-                  "{} Uploading next candidates for {}, attempt to re-upload "
+                  ctxlog.info,
+                  "Uploading next candidates for {}, attempt to re-upload "
                   "{}, manifest committed offset {}, upload dirty offset {}",
-                  parent(),
                   _ntp,
                   upload,
                   meta->committed_offset,
                   dirty_offset);
             } else if (meta->committed_offset >= dirty_offset) {
                 vlog(
-                  archival_log.warn,
-                  "{} Skip upload for {} because it's already in the manifest "
+                  ctxlog.warn,
+                  "Skip upload for {} because it's already in the manifest "
                   "{}, manifest committed offset {}, upload dirty offset {}",
-                  parent(),
                   _ntp,
                   upload,
                   meta->committed_offset,
@@ -243,9 +236,8 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
     }
     if (flist.empty()) {
         vlog(
-          archival_log.debug,
-          "{} Uploading next candidates for {}, no uploads started ...skip",
-          parent(),
+          ctxlog.debug,
+          "Uploading next candidates for {}, no uploads started ...skip",
           _ntp);
         co_return total;
     }
@@ -262,17 +254,12 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
     }
     if (total.num_succeded != 0) {
         vlog(
-          archival_log.debug,
-          "{} Uploading next candidates for {}, re-uploading manifest file",
-          parent(),
+          ctxlog.debug,
+          "Uploading next candidates for {}, re-uploading manifest file",
           _ntp);
         auto res = co_await upload_manifest(parent);
         if (res != cloud_storage::upload_result::success) {
-            vlog(
-              archival_log.debug,
-              "{} Manifest upload for {} failed",
-              parent(),
-              _ntp);
+            vlog(ctxlog.debug, "Manifest upload for {} failed", _ntp);
         }
         _last_upload_time = ss::lowres_clock::now();
     }

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -173,6 +173,7 @@ private:
     ntp_upload_queue _queue;
     simple_time_jitter<ss::lowres_clock> _backoff{100ms};
     retry_chain_node _rtcnode;
+    retry_chain_logger _rtclog;
     service_probe _probe;
     cloud_storage::remote _remote;
     ss::lowres_clock::duration _topic_manifest_upload_timeout;

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -19,6 +19,7 @@
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/loop.hh>
 
 namespace cloud_storage {
 
@@ -41,7 +42,13 @@ public:
     /// On success it should return content_length. On failure it should
     /// allow the exception from the input_stream to propagate.
     using try_consume_stream
-      = std::function<ss::future<uint64_t>(ss::input_stream<char>)>;
+      = std::function<ss::future<uint64_t>(uint64_t, ss::input_stream<char>)>;
+
+    /// Functor that should be provided by user when list_objects api is called.
+    /// It receives every key that matches the query as well as it's modifiation
+    /// time, size in bytes, and etag.
+    using list_objects_consumer = std::function<ss::stop_iteration(
+      ss::sstring, std::chrono::system_clock::time_point, size_t, ss::sstring)>;
 
     /// \brief Initialize 'remote'
     ///
@@ -111,6 +118,13 @@ public:
       const segment_name& name,
       manifest& manifest,
       const try_consume_stream& cons_str,
+      retry_chain_node& parent);
+
+    ss::future<download_result> list_objects(
+      const list_objects_consumer& cons,
+      const s3::bucket_name& bucktet,
+      const std::optional<s3::object_key>& prefix,
+      const std::optional<size_t>& max_keys,
       retry_chain_node& parent);
 
 private:

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -72,10 +72,12 @@ public:
     /// Method downloads the manifest and handles backpressure and
     /// errors. It retries multiple times until timeout excedes.
     /// \param bucket is a bucket name
+    /// \param key is an object key of the manifest
     /// \param manifest is a manifest to download
     /// \return future that returns success code
     ss::future<download_result> download_manifest(
       const s3::bucket_name& bucket,
+      const remote_manifest_path& key,
       base_manifest& manifest,
       retry_chain_node& parent);
 
@@ -116,7 +118,7 @@ public:
     ss::future<download_result> download_segment(
       const s3::bucket_name& bucket,
       const segment_name& name,
-      manifest& manifest,
+      const manifest& manifest,
       const try_consume_stream& cons_str,
       retry_chain_node& parent);
 

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -314,6 +314,8 @@ static client::list_bucket_result iobuf_to_list_bucket_result(iobuf&& buf) {
                     } else if (item_tag == "LastModified") {
                         item.last_modified = parse_timestamp(
                           item_value.get_value<ss::sstring>());
+                    } else if (item_tag == "ETag") {
+                        item.etag = item_value.get_value<ss::sstring>();
                     }
                 }
                 result.contents.push_back(std::move(item));

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -182,6 +182,7 @@ public:
         ss::sstring key;
         std::chrono::system_clock::time_point last_modified;
         size_t size_bytes;
+        ss::sstring etag;
     };
     struct list_bucket_result {
         bool is_truncated;

--- a/src/v/utils/tests/retry_chain_node_test.cc
+++ b/src/v/utils/tests/retry_chain_node_test.cc
@@ -51,6 +51,7 @@ SEASTAR_THREAD_TEST_CASE(check_fmt) {
     }
     retry_chain_node n8(ss::lowres_clock::now() + 100ms, 50ms);
     BOOST_REQUIRE_EQUAL(n8(), "[fiber1|0|100ms]");
+    BOOST_REQUIRE_EQUAL(n8("{} + {}", 1, 2), "[fiber1|0|100ms 1 + 2]");
 }
 
 SEASTAR_THREAD_TEST_CASE(check_retry1) {


### PR DESCRIPTION
## Cover letter

This PR adds logging facility to retry_chain_node.
Also, it extends cloud_storage::remote to
- pass object keys explicitly instead of inferring them from manifests
- support ListObjectsV2 api

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/55dfe49643fe477f2ba6a2015709de1e5df7dcf9..7761f3d231030870c915af379c7c4a36f1673110)
- Fix segfault in archival service unit-test (aarch64, clang, release)

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/7761f3d231030870c915af379c7c4a36f1673110..c42c5496e42075382d095c5d502d2c17ca45359d)
- Rebase branch

## Release notes

N/A