### PR TITLE
archival: Throttling mitigation

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -42,10 +42,14 @@ struct configuration {
     s3::bucket_name bucket_name;
     /// Time interval to run uploads & deletes
     ss::lowres_clock::duration interval;
-    /// Time interval to run GC
-    ss::lowres_clock::duration gc_interval;
     /// Number of simultaneous S3 uploads
     s3_connection_limit connection_limit;
+    /// Initial backoff for uploads
+    ss::lowres_clock::duration initial_backoff;
+    /// Long upload timeout
+    ss::lowres_clock::duration segment_upload_timeout;
+    /// Shor upload timeout
+    ss::lowres_clock::duration manifest_upload_timeout;
     /// Flag that indicates that service level metrics are disabled
     service_metrics_disabled svc_metrics_disabled;
     /// Flag that indicates that ntp-archiver level metrics are disabled
@@ -63,11 +67,6 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg);
 /// generation of per-ntp candidate set. The actual file uploads are
 /// handled by 'archiver_service'.
 class ntp_archiver {
-    /// Timeout value used for manifest uploads and downloads.
-    static constexpr ss::lowres_clock::duration manifest_upload_timeout = 10s;
-    /// Timeout value used for segment uploads.
-    static constexpr ss::lowres_clock::duration segment_upload_timeout = 30s;
-
 public:
     /// Iterator type used to retrieve candidates for upload
     using back_insert_iterator
@@ -150,6 +149,9 @@ private:
     simple_time_jitter<ss::lowres_clock> _backoff{100ms};
     size_t _concurrency{4};
     ss::lowres_clock::time_point _last_upload_time;
+    ss::lowres_clock::duration _initial_backoff;
+    ss::lowres_clock::duration _segment_upload_timeout;
+    ss::lowres_clock::duration _manifest_upload_timeout;
 };
 
 } // namespace archival

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -322,9 +322,13 @@ ss::future<ss::stop_iteration> scheduler_service_impl::add_ntp_archiver(
                 archiver->get_ntp());
               // Start topic manifest upload
               // asynchronously
-              (void)upload_topic_manifest(
-                model::topic_namespace(ntp.ns, ntp.tp.topic),
-                archiver->get_revision_id());
+              if (ntp.tp.partition == 0) {
+                  // Upload manifest once per topic. GCS has strict
+                  // limits for single object updates.
+                  (void)upload_topic_manifest(
+                    model::topic_namespace(ntp.ns, ntp.tp.topic),
+                    archiver->get_revision_id());
+              }
               _probe.start_archiving_ntp();
               return ss::make_ready_future<ss::stop_iteration>(
                 ss::stop_iteration::yes);

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -148,6 +148,14 @@ scheduler_service_impl::get_archival_service_config() {
       = config::shard_local_cfg().cloud_storage_reconciliation_ms.value(),
       .connection_limit = s3_connection_limit(
         config::shard_local_cfg().cloud_storage_max_connections.value()),
+      .initial_backoff
+      = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value(),
+      .segment_upload_timeout
+      = config::shard_local_cfg()
+          .cloud_storage_segment_upload_timeout_ms.value(),
+      .manifest_upload_timeout
+      = config::shard_local_cfg()
+          .cloud_storage_manifest_upload_timeout_ms.value(),
       .svc_metrics_disabled = service_metrics_disabled(
         static_cast<bool>(disable_metrics)),
       .ntp_metrics_disabled = per_ntp_metrics_disabled(
@@ -170,7 +178,9 @@ scheduler_service_impl::scheduler_service_impl(
   , _stop_limit(conf.connection_limit())
   , _rtcnode(_as)
   , _probe(conf.svc_metrics_disabled)
-  , _remote(conf.connection_limit, conf.client_config, _probe) {}
+  , _remote(conf.connection_limit, conf.client_config, _probe)
+  , _topic_manifest_upload_timeout(conf.manifest_upload_timeout)
+  , _initial_backoff(conf.initial_backoff) {}
 
 scheduler_service_impl::scheduler_service_impl(
   ss::sharded<storage::api>& api,
@@ -241,7 +251,7 @@ ss::future<> scheduler_service_impl::upload_topic_manifest(
         while (!uploaded && !_gate.is_closed()) {
             // This runs asynchronously so we can just retry indefinetly
             retry_chain_node fib(
-              max_topic_manifest_upload_backoff, 100ms, &_rtcnode);
+              _topic_manifest_upload_timeout, _initial_backoff, &_rtcnode);
             vlog(
               archival_log.info,
               "{} Uploading topic manifest {}",

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -94,10 +94,6 @@ void ntp_upload_queue::copy_if(FwdIt out, const Func& pred) const {
 /// - Re-upload manifest(s)
 /// - Reset timer
 class scheduler_service_impl {
-    static constexpr ss::lowres_clock::duration
-      max_topic_manifest_upload_backoff
-      = 60s;
-
 public:
     /// \brief create scheduler service
     ///
@@ -176,6 +172,8 @@ private:
     retry_chain_node _rtcnode;
     service_probe _probe;
     cloud_storage::remote _remote;
+    ss::lowres_clock::duration _topic_manifest_upload_timeout;
+    ss::lowres_clock::duration _initial_backoff;
 };
 
 } // namespace internal

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -88,6 +88,9 @@ archival::configuration get_configuration() {
     conf.connection_limit = archival::s3_connection_limit(2);
     conf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled::yes;
     conf.svc_metrics_disabled = archival::service_metrics_disabled::yes;
+    conf.initial_backoff = 100ms;
+    conf.segment_upload_timeout = 1s;
+    conf.manifest_upload_timeout = 1s;
     return conf;
 }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -693,6 +693,24 @@ configuration::configuration()
       "during TLS handshake",
       required::no,
       std::nullopt)
+  , cloud_storage_initial_backoff_ms(
+      *this,
+      "cloud_storage_initial_backoff_ms",
+      "Initial backoff time for exponetial backoff algorithm (ms)",
+      required::no,
+      100ms)
+  , cloud_storage_segment_upload_timeout_ms(
+      *this,
+      "cloud_storage_segment_upload_timeout_ms",
+      "Log segment upload timeout (ms)",
+      required::no,
+      30s)
+  , cloud_storage_manifest_upload_timeout_ms(
+      *this,
+      "cloud_storage_manifest_upload_timeout_ms",
+      "Manifest upload timeout (ms)",
+      required::no,
+      10s)
   , superusers(
       *this, "superusers", "List of superuser usernames", required::no, {})
   , kafka_qdc_latency_alpha(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -169,6 +169,11 @@ struct configuration final : public config_store {
     property<bool> cloud_storage_disable_tls;
     property<int16_t> cloud_storage_api_endpoint_port;
     property<std::optional<ss::sstring>> cloud_storage_trust_file;
+    property<std::chrono::milliseconds> cloud_storage_initial_backoff_ms;
+    property<std::chrono::milliseconds> cloud_storage_segment_upload_timeout_ms;
+    property<std::chrono::milliseconds>
+      cloud_storage_manifest_upload_timeout_ms;
+
     one_or_many_property<ss::sstring> superusers;
 
     // kakfa queue depth control: latency ewma


### PR DESCRIPTION
## Cover letter

This PR adds new configuration options that can be changed to tweak backoff algorithm used to upload data to the cloud. The default values are set for AWS S3. If the throttling is applied often the initial backoff can be increased.

Also, this PR changes topic_manifest upload algorithm. Previously, topic_manifests were uploaded from every leader node that stores one of the partitions of the topic. After this update it will be uploaded only from the leader that manages partition 0 of the topic. This is good for GCS since it limits single object upload frequency severely.

## Release notes

N/A