### PR TITLE
Improved raft error handling

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -42,7 +42,8 @@ enum class errc : int16_t {
     sequence_out_of_order,
     generic_tx_error,
     node_does_not_exists,
-    invalid_node_opeartion
+    invalid_node_opeartion,
+    invalid_configuration_update
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -111,6 +112,8 @@ struct errc_category final : public std::error_category {
             return "Requested node does not exists";
         case errc::invalid_node_opeartion:
             return "Requested node opeartion is invalid";
+        case errc::invalid_configuration_update:
+            return "Requested configuration update is invalid";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -501,6 +501,37 @@ members_manager::dispatch_configuration_update(model::broker broker) {
     }
 }
 
+bool is_result_configuration_valid(
+  const std::vector<broker_ptr>& current_brokers,
+  const model::broker& to_update) {
+    /**
+     * validate if any two of the brokers would listen on the same addresses
+     * after applying configuration update
+     */
+    for (auto& current : current_brokers) {
+        if (current->id() == to_update.id()) {
+            continue;
+        }
+        // error, nodes would point to the same addresses
+        if (current->rpc_address() == to_update.rpc_address()) {
+            return false;
+        }
+        for (auto& current_ep : current->kafka_advertised_listeners()) {
+            auto any_is_the_same = std::any_of(
+              to_update.kafka_advertised_listeners().begin(),
+              to_update.kafka_advertised_listeners().end(),
+              [&current_ep](const model::broker_endpoint& ep) {
+                  return current_ep == ep;
+              });
+            // error, kafka endpoint would point to the same addresses
+            if (any_is_the_same) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 ss::future<result<configuration_update_reply>>
 members_manager::handle_configuration_update_request(
   configuration_update_request req) {
@@ -516,6 +547,16 @@ members_manager::handle_configuration_update_request(
     }
     vlog(
       clusterlog.trace, "Handling node {} configuration update", req.node.id());
+    auto all_brokers = _members_table.local().all_brokers();
+    if (!is_result_configuration_valid(all_brokers, req.node)) {
+        vlog(
+          clusterlog.warn,
+          "Rejecting invalid configuration update: {}, current brokers list: "
+          "{}",
+          req.node,
+          all_brokers);
+        return ss::make_ready_future<ret_t>(errc::invalid_configuration_update);
+    }
     auto node_ptr = ss::make_lw_shared(std::move(req.node));
     patch<broker_ptr> broker_update_patch{
       .additions = {node_ptr}, .deletions = {}};

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -83,9 +83,8 @@ struct errc_category final : public std::error_category {
             return "raft protocol shutting down";
         case errc::replicate_batcher_cache_error:
             return "unable to append batch to replicate batcher cache";
-        default:
-            return "raft::errc::unknown";
         }
+        return "cluster::errc::unknown";
     }
 };
 inline const std::error_category& error_category() noexcept {

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -36,6 +36,7 @@ enum class errc {
     invalid_target_node,
     shutting_down,
     replicate_batcher_cache_error,
+    group_not_exists
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "raft::errc"; }
@@ -83,6 +84,8 @@ struct errc_category final : public std::error_category {
             return "raft protocol shutting down";
         case errc::replicate_batcher_cache_error:
             return "unable to append batch to replicate batcher cache";
+        case errc::group_not_exists:
+            return "raft group does not exists on target broker";
         }
         return "cluster::errc::unknown";
     }


### PR DESCRIPTION
## Cover letter

Added validation to make sure that configuration update wouldn't cause cluster to be unstable. In some cases (f.e. the same addresses on two nodes), configuration update may lead to the situation in which cluster configuration is invalid and inter-node communication is disrupted. To prevent this from being possible, added validation of possible resulting configuration preventing invalid configuration from being propagated. 


Fixes: N/A

## Release notes
N/A

