### PR TITLE
task/rp: rootless podman for ducktape tests

### DIFF
--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -86,14 +86,14 @@ tasks:
     - test -f '{{.BUILD_ROOT}}/bin/docker-compose'
 
   start-podman-socket-service:
-    desc: start podman socket service (requires sudo)
+    desc: start podman.socket service
+    vars:
+      USE_PODMAN_DOCKER: '{{default "" .USE_PODMAN_DOCKER}}'
     cmds:
-    - |
-      if {{empty .USE_PODMAN_DOCKER}}; then
-        exit 0
-      fi
-      sudo systemctl start podman.socket
-      sudo curl -H "Content-Type: application/json" --unix-socket /var/run/docker.sock http://localhost/_ping | grep OK
+    - systemctl --user start podman.socket
+    - "curl -H 'Content-Type: application/json' --unix-socket $XDG_RUNTIME_DIR/podman/podman.sock http://localhost/_ping | grep OK"
+    status:
+    - test -z {{.USE_PODMAN_DOCKER}}
 
   generate-certs:
     desc: use openssl to generate dev certs

--- a/taskfiles/rp.yml
+++ b/taskfiles/rp.yml
@@ -128,6 +128,9 @@ tasks:
     cmds:
     - |
       PATH={{.BUILD_ROOT}}/bin/:$PATH
+      if ! {{empty .USE_PODMAN_DOCKER}}; then
+        export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
+      fi
       docker-compose up --detach
 
   run-ducktape-tests:
@@ -174,4 +177,7 @@ tasks:
     cmds:
     - |
       PATH={{.BUILD_ROOT}}/bin/:$PATH
+      if ! {{empty .USE_PODMAN_DOCKER}}; then
+        export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
+      fi
       docker-compose down


### PR DESCRIPTION
With the release of [podman 3.2](https://github.com/containers/podman/releases/tag/v3.2.0), it is now possible to run docker-compose in rootless mode. This PR tweaks taskfiles so that ducktape tests run in rootless mode when executed on podman, which is done by assigning the `USE_PODMAN_DOCKER` task variable to any non-empty string.