### PR TITLE
archival: Fix upload errors and busy error logging

### DIFF
--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -144,6 +144,7 @@ result<http::client::request_header> request_creator::make_get_object_request(
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::content_length, "0");
     header.insert(aws_header_names::x_amz_content_sha256, emptysig);
+    _sign.update_credentials_if_outdated();
     auto ec = _sign.sign_header(header, emptysig);
     if (ec) {
         return ec;
@@ -188,6 +189,7 @@ request_creator::make_unsigned_put_object_request(
         }
         header.insert(aws_header_names::x_amz_tagging, tstr.str().substr(1));
     }
+    _sign.update_credentials_if_outdated();
     auto ec = _sign.sign_header(header, sig);
     if (ec) {
         return ec;
@@ -226,6 +228,7 @@ request_creator::make_list_objects_v2_request(
     if (max_keys) {
         header.insert(aws_header_names::start_after, std::to_string(*max_keys));
     }
+    _sign.update_credentials_if_outdated();
     auto ec = _sign.sign_header(header, emptysig);
     vlog(s3_log.trace, "ListObjectsV2:\n {}", header);
     if (ec) {
@@ -256,6 +259,7 @@ request_creator::make_delete_object_request(
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::content_length, "0");
     header.insert(aws_header_names::x_amz_content_sha256, emptysig);
+    _sign.update_credentials_if_outdated();
     auto ec = _sign.sign_header(header, emptysig);
     if (ec) {
         return ec;

--- a/src/v/s3/signature.h
+++ b/src/v/s3/signature.h
@@ -100,7 +100,13 @@ public:
       std::string_view region,
       std::string_view service);
 
+    /// Checks if credentials are too old and updates them if this is the case
+    void update_credentials_if_outdated();
+
 private:
+    /// Re-generate credentials used to sign headers
+    void update_credentials();
+
     /// \brief Calculate SHA256 digest
     ///
     /// \param payload is ref to payload of the query
@@ -120,6 +126,8 @@ private:
     ss::sstring _sign_key;
     /// Scope of the key (part of the header digest)
     ss::sstring _cred_scope;
+    /// Time of the last credentials update
+    ss::lowres_clock::time_point _last_update;
 };
 
 template<class Fn>


### PR DESCRIPTION
## Cover letter

This PR fixes fixes excessive logging in archival in case of repeated errors. The upload loop is tuned to apply exponential backoff if no progress was made on a previous iteration. The parameters of the exponential backoff was tuned as well (initial backoff increased from 10ms to 100ms, max backoff duration increased from 5s to 10s).

The exponential backoff inside the upload loop was already implemented before. But it was only used in situation when we don't have any new data to upload. This mechanism was generalized to the situation when we can't make any progress. 

Also, the PR fixes a problem with exceptional futures inside reconciliation loop. Such futures were handled correctly on different level but result wasn't discarded leaded to warnings. 

The problem that caused large number of errors is also fixed. Introduction of the s3::client_pool made s3::client a long living object. The client contains s3 signature which was created on startup. The signature contains a derived key with limited lifetime (up to two days). After this derived key expires all s3 requests made through this client fail with cryptic and ungooglable error message. This PR adds a mechanism that checks the key expiration time and updates it if needed. 

Fixes #1728
Fixes #1727 
Fixes #1706

## Release notes

N/A