### PR TITLE
gcb/config: increase timeout to 3hrs

### DIFF
--- a/tests/ci/cloudbuild.yaml
+++ b/tests/ci/cloudbuild.yaml
@@ -41,7 +41,7 @@ steps:
     mkdir build/
     bin/task $_TASK_ARGS
 
-timeout: 7200s
+timeout: 10800s
 
 options:
   machineType: 'N1_HIGHCPU_32'


### PR DESCRIPTION
2hrs is not enough anymore on GCB