### PR TITLE
r/consensus: fixed updating follower `is_learner` flag

### DIFF
--- a/src/v/raft/follower_stats.cc
+++ b/src/v/raft/follower_stats.cc
@@ -19,6 +19,19 @@ void follower_stats::update_with_configuration(const group_configuration& cfg) {
         }
         _followers.emplace(rni, follower_index_metadata(rni));
     });
+    // update learner state
+    cfg.for_each_voter([this](const vnode& rni) {
+        if (rni == _self) {
+            return;
+        }
+
+        auto it = _followers.find(rni);
+        vassert(
+          it != _followers.end(),
+          "voter {} have to exists in follower stats",
+          rni);
+        it->second.is_learner = false;
+    });
 
     absl::erase_if(_followers, [&cfg](const container_t::value_type& p) {
         return !cfg.contains(p.first);

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -129,7 +129,7 @@ struct follower_index_metadata {
 
     follower_req_seq last_sent_seq{0};
     follower_req_seq last_received_seq{0};
-    bool is_learner = false;
+    bool is_learner = true;
     bool is_recovering = false;
 
     /*


### PR DESCRIPTION
Fixed updating follower state `is_learner` flag. Follower state is
always created as a learner. `is_learner` flag is updated after the
follower is moved to voters list in raft group configuration.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
