### PR TITLE
Fix updating committed index on leader

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1893,6 +1893,11 @@ void consensus::maybe_update_leader_commit_idx() {
     (void)with_gate(_bg, [this] {
         return _op_lock.get_units().then(
           [this](ss::semaphore_units<> u) mutable {
+              // do not update committed index if not the leader, this check has
+              // to be done under the semaphore
+              if (!is_leader()) {
+                  return ss::now();
+              }
               return do_maybe_update_leader_commit_idx(std::move(u));
           });
     }).handle_exception([this](const std::exception_ptr& e) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1415,7 +1415,9 @@ consensus::do_append_entries(append_entries_request&& r) {
             vlog(
               _ctxlog.info,
               "Stale append entries request processed, entry is already "
-              "present");
+              "present, request: {}, current state: {}",
+              r.meta,
+              meta());
             return ss::make_ready_future<append_entries_reply>(
               std::move(reply));
         }


### PR DESCRIPTION
## Cover letter

New way of processing log flushes may cause the situation in which `log::flush()` will execute after new leader was elected. After flushing leader log we try to update committed index (the same way as leader does after receiving successful append entries reply). Whole process reply fiber may be scheduled after a node will stop being a leader. This is incorrect since it may lead to the situation in which follower will stop making progress as it will commit entries different from one being committed by the leader. 

Fixed the issue by explicit check if node is a leader before updating committed index. 


## Release notes
