### PR TITLE
raft: bandwidth based recovery throttling

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -451,6 +451,12 @@ configuration::configuration()
       "Max size of requests cached for replication",
       required::no,
       1_MiB)
+  , raft_learner_recovery_rate(
+      *this,
+      "raft_learner_recovery_rate",
+      "Raft learner recovery rate limit in bytes per sec",
+      required::no,
+      100_MiB)
   , reclaim_min_size(
       *this,
       "reclaim_min_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -123,6 +123,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> replicate_append_timeout_ms;
     property<std::chrono::milliseconds> recovery_append_timeout_ms;
     property<size_t> raft_replicate_batch_window_size;
+    property<size_t> raft_learner_recovery_rate;
 
     property<size_t> reclaim_min_size;
     property<size_t> reclaim_max_size;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -47,7 +47,8 @@ consensus::consensus(
   model::timeout_clock::duration disk_timeout,
   consensus_client_protocol client,
   consensus::leader_cb_t cb,
-  storage::api& storage)
+  storage::api& storage,
+  std::optional<std::reference_wrapper<recovery_throttle>> recovery_throttle)
   : _self(nid, initial_cfg.revision_id())
   , _group(group)
   , _jit(std::move(jit))
@@ -65,6 +66,7 @@ consensus::consensus(
   , _recovery_append_timeout(
       config::shard_local_cfg().recovery_append_timeout_ms())
   , _storage(storage)
+  , _recovery_throttle(recovery_throttle)
   , _snapshot_mgr(
       std::filesystem::path(_log.config().work_directory()),
       storage::snapshot_manager::default_snapshot_filename,

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -24,6 +24,7 @@
 #include "raft/mutex_buffer.h"
 #include "raft/prevote_stm.h"
 #include "raft/probe.h"
+#include "raft/recovery_throttle.h"
 #include "raft/replicate_batcher.h"
 #include "raft/timeout_jitter.h"
 #include "raft/types.h"
@@ -88,7 +89,8 @@ public:
       model::timeout_clock::duration disk_timeout,
       consensus_client_protocol,
       leader_cb_t,
-      storage::api&);
+      storage::api&,
+      std::optional<std::reference_wrapper<recovery_throttle>>);
 
     /// Initial call. Allow for internal state recovery
     ss::future<> start();
@@ -546,6 +548,7 @@ private:
     ss::metrics::metric_groups _metrics;
     ss::abort_source _as;
     storage::api& _storage;
+    std::optional<std::reference_wrapper<recovery_throttle>> _recovery_throttle;
     storage::snapshot_manager _snapshot_mgr;
     std::optional<storage::snapshot_writer> _snapshot_writer;
     model::offset _last_snapshot_index;

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -42,7 +42,8 @@ public:
       std::chrono::milliseconds heartbeat_interval,
       std::chrono::milliseconds heartbeat_timeout,
       ss::sharded<rpc::connection_cache>& clients,
-      ss::sharded<storage::api>& storage);
+      ss::sharded<storage::api>& storage,
+      ss::sharded<recovery_throttle>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -93,6 +94,7 @@ private:
       _notifications;
     ss::metrics::metric_groups _metrics;
     storage::api& _storage;
+    recovery_throttle& _recovery_throttle;
 };
 
 } // namespace raft

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -168,7 +168,8 @@ private:
                 st.current_leader.value(),
                 st.group);
           },
-          _storage);
+          _storage,
+          std::nullopt);
         return _consensus->start().then(
           [this] { return _hbeats.register_group(_consensus); });
     }

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -223,7 +223,7 @@ ss::future<> recovery_stm::read_range_for_recovery(
           return model::consume_reader_to_memory(
             std::move(reader), model::no_timeout);
       })
-      .then([this, start_offset, follower_committed_match_index](
+      .then([this, start_offset, follower_committed_match_index, is_learner](
               ss::circular_buffer<model::record_batch> batches) {
           vlog(
             _ctxlog.trace,
@@ -239,11 +239,33 @@ ss::future<> recovery_stm::read_range_for_recovery(
           _base_batch_offset = gap_filled_batches.begin()->base_offset();
           _last_batch_offset = gap_filled_batches.back().last_offset();
 
+          auto throttle_f = ss::now();
+          if (is_learner && _ptr->_recovery_throttle) {
+              const auto size = std::accumulate(
+                gap_filled_batches.cbegin(),
+                gap_filled_batches.cend(),
+                size_t{0},
+                [](size_t acc, const auto& batch) {
+                    return acc + batch.size_bytes();
+                });
+              throttle_f
+                = _ptr->_recovery_throttle->get()
+                    .throttle(size)
+                    .handle_exception_type([this](const ss::broken_semaphore&) {
+                        vlog(_ctxlog.info, "Recovery throttling has stopped");
+                    });
+          }
+
           auto f_reader = model::make_foreign_memory_record_batch_reader(
             std::move(gap_filled_batches));
 
-          return replicate(
-            std::move(f_reader), should_flush(follower_committed_match_index));
+          return throttle_f.then([this,
+                                  f_reader = std::move(f_reader),
+                                  follower_committed_match_index]() mutable {
+              return replicate(
+                std::move(f_reader),
+                should_flush(follower_committed_match_index));
+          });
       });
 }
 

--- a/src/v/raft/recovery_stm.h
+++ b/src/v/raft/recovery_stm.h
@@ -27,7 +27,7 @@ private:
     ss::future<> recover();
     ss::future<> do_recover(ss::io_priority_class);
     ss::future<> read_range_for_recovery(
-      model::offset, model::offset, model::offset, ss::io_priority_class);
+      model::offset, model::offset, model::offset, ss::io_priority_class, bool);
     ss::future<> replicate(
       model::record_batch_reader&&, append_entries_request::flush_after_append);
     ss::future<result<append_entries_reply>>

--- a/src/v/raft/recovery_throttle.h
+++ b/src/v/raft/recovery_throttle.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "seastarx.h"
+
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/timer.hh>
+#include <seastar/util/later.hh>
+
+namespace raft {
+
+/*
+ * Token bucket-based raft recovery throttling.
+ *
+ * Improvements
+ *
+ *  - cross-core bandwidth sharing
+ *      https://github.com/vectorizedio/redpanda/issues/1770
+ *
+ *  - cluster-level recovery control
+ *      https://github.com/vectorizedio/redpanda/issues/1771
+ */
+class recovery_throttle {
+    using clock_type = ss::lowres_clock;
+    static constexpr std::chrono::milliseconds refresh_error{5};
+    static constexpr std::chrono::milliseconds refresh_interval{50};
+
+public:
+    explicit recovery_throttle(size_t rate)
+      : _rate(rate)
+      , _sem{_rate}
+      , _last_refresh(clock_type::now())
+      , _refresh_timer([this] { handle_refresh(); }) {}
+
+    ss::future<> throttle(size_t size) {
+        _refresh_timer.cancel();
+        refresh();
+
+        /*
+         * when try_wait succeeds it implies that there are no waiters so there
+         * is no risk in returning without arming the refresh timer.
+         */
+        if (_sem.try_wait(size)) {
+            return ss::now();
+        }
+
+        auto elapsed = clock_type::now() - _last_refresh;
+        if (elapsed >= refresh_interval) {
+            _refresh_timer.arm(refresh_interval);
+        } else {
+            _refresh_timer.arm(refresh_interval - elapsed);
+        }
+
+        return _sem.wait(size);
+    }
+
+    ss::future<> stop() {
+        _refresh_timer.cancel();
+        _sem.broken();
+        return ss::now();
+    }
+
+private:
+    void refresh() {
+        auto now = clock_type::now();
+        auto elapsed = now - _last_refresh;
+        if (elapsed < refresh_interval) {
+            return;
+        }
+        _last_refresh = now;
+
+        /*
+         * subtract out half the lowres clock granularity as an error adjustment
+         * that will be pessimistic and error on the side of lower throughput.
+         */
+        auto refresh = _rate * (elapsed - refresh_error)
+                       / std::chrono::milliseconds(1000);
+
+        _sem.signal(refresh);
+
+        /*
+         * throttling is based on an estimate. if rate is low and a waiter
+         * underestimated we may need to allow the available tokens to exceed
+         * the rate to let a waiter through.
+         */
+        if (_sem.current() > _rate && !_sem.waiters()) {
+            _sem.consume(_sem.current() - _rate);
+        }
+    }
+
+    void handle_refresh() {
+        refresh();
+        /*
+         * if a waiter exists continue refreshing since it is not guaranteed
+         * that throttle will be invoked (e.g. excactly one recovering group).
+         */
+        if (_sem.waiters()) {
+            _refresh_timer.arm(refresh_interval);
+        }
+    }
+
+    size_t _rate;
+    ss::semaphore _sem;
+    clock_type::time_point _last_refresh;
+    ss::timer<> _refresh_timer;
+};
+
+} // namespace raft

--- a/src/v/raft/tests/state_removal_test.cc
+++ b/src/v/raft/tests/state_removal_test.cc
@@ -56,6 +56,7 @@ bool snapshot_exists(raft_node& n) {
 }
 
 void stop_node(raft_node& node) {
+    node.recovery_throttle.stop().get();
     node.server.stop().get0();
     node._as.request_abort();
     if (node._nop_stm != nullptr) {

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -138,7 +138,8 @@ public:
                               st.current_leader.value(),
                               st.group);
                         },
-                        _storage);
+                        _storage,
+                        std::nullopt);
                       return _consensus->start().then(
                         [this] { return _hbeats.register_group(_consensus); });
                   });

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -24,6 +24,7 @@
 #include "pandaproxy/schema_registry/configuration.h"
 #include "pandaproxy/schema_registry/fwd.h"
 #include "raft/group_manager.h"
+#include "raft/recovery_throttle.h"
 #include "redpanda/admin_server.h"
 #include "resource_mgmt/cpu_scheduling.h"
 #include "resource_mgmt/memory_groups.h"
@@ -75,6 +76,7 @@ public:
     ss::sharded<storage::api> storage;
     ss::sharded<coproc::pacemaker> pacemaker;
     ss::sharded<cluster::partition_manager> partition_manager;
+    ss::sharded<raft::recovery_throttle> recovery_throttle;
     ss::sharded<raft::group_manager> raft_group_manager;
     ss::sharded<cluster::metadata_dissemination_service>
       md_dissemination_service;


### PR DESCRIPTION
When partition rebalancing occurs (e.g. node addition / removal) it may mean that there is a large amount of data that needs to be copied to one or more machines. Currently raft runs throttling at a low scheduling and io priority, but absent other higher priority work recovery would still run at an unbounded rate. Since we seek to reduce network contention (globally as well as for local NIC) we want to throttle by limited actual bandwidth.

Fixes: #1733

Release note: Adds bandwidth based raft recovery throttling.
