### PR TITLE
Enable Schema Registry by default

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -49,6 +49,9 @@ redpanda:
 # Enable Pandaproxy
 pandaproxy:
 
+# Enable Schema Registry
+schema_registry:
+
 rpk:
   # TLS configuration.
   tls:

--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -465,6 +465,41 @@ pandaproxy_client:
   # Default: ""
   scram_password: ""
 
+# The Schema Registry provides a RESTful interface for Schema storage, retrieval, and compatibility.
+# To disable the Schema Registry, remove this top-level config node
+schema_registry:
+  # A list of address and port to listen for Schema Registry API requests.
+  # Default: 0.0.0.0:8082
+  schema_registry_api: 
+  - address: "0.0.0.0"
+    name: internal
+    port: 8081
+  - address: "0.0.0.0"
+    name: external
+    port: 18081
+
+  # A list of TLS configurations for the Schema Registry API.
+  # Default: null
+  schema_registry_api_tls:
+  - name: external
+    # Whether to enable TLS.
+    enabled: false
+    # Require client authentication
+    require_client_auth: false
+    # The path to the server certificate PEM file.
+    cert_file: ""
+    # The path to the server key PEM file
+    key_file: ""
+    # The path to the truststore PEM file. Only required if client
+    # authentication is enabled.
+    truststore_file: ""
+  - name: internal
+    enabled: false
+
+# The Schema Registry client config
+# See pandaproxy_client for a list of options
+schema_registry_client:
+
 rpk:
   # TLS configuration to allow rpk to make requests to the redpanda API.
   tls:

--- a/docs/www/rpk-commands.md
+++ b/docs/www/rpk-commands.md
@@ -67,6 +67,7 @@ Flags:
       --node-id int                    The node ID. Must be an integer and must be unique within a cluster
       --pandaproxy-addr                A comma-separated list of Pandaproxy listener addresses to bind to (<name>://<host>:<port>)
       --rpc-addr string                The RPC address to bind to (<host>:<port>)
+      --schema-registry-addr           A comma-separated list of Schema Registry listener addresses to bind to (<name>://<host>:<port>)
   -s, --seeds strings                  A comma-separated list of seed node addresses (<host>[:<port>]) to connect to
       --timeout duration               The maximum time to wait for the checks and tune processes to complete. The value passed is a sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5s' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h' (default: 10s)
       --tune                           When present will enable tuning before starting redpanda

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -377,7 +377,7 @@ func (r *ConfigMapResource) preparePandaproxyClient(
 	}
 
 	replicas := *r.pandaCluster.Spec.Replicas
-	cfgRpk.PandaproxyClient = &config.PandaproxyClient{}
+	cfgRpk.PandaproxyClient = &config.KafkaClient{}
 	for i := int32(0); i < replicas; i++ {
 		cfgRpk.PandaproxyClient.Brokers = append(cfgRpk.PandaproxyClient.Brokers, config.SocketAddress{
 			Address: fmt.Sprintf("%s-%d.%s", r.pandaCluster.Name, i, r.serviceFQDN),

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -257,6 +257,7 @@ func CreateNode(
 	}
 	hostname := Name(nodeID)
 	cmd := []string{
+		"redpanda",
 		"start",
 		"--node-id",
 		fmt.Sprintf("%d", nodeID),

--- a/src/go/rpk/pkg/cli/cmd/container/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/container/common/common.go
@@ -212,7 +212,7 @@ func RemoveNetwork(c Client) error {
 
 func CreateNode(
 	c Client,
-	nodeID, kafkaPort, proxyPort, rpcPort, metricsPort uint,
+	nodeID, kafkaPort, proxyPort, schemaRegPort, rpcPort, metricsPort uint,
 	netID, image string,
 	args ...string,
 ) (*NodeState, error) {
@@ -237,6 +237,13 @@ func CreateNode(
 	if err != nil {
 		return nil, err
 	}
+	sPort, err := nat.NewPort(
+		"tcp",
+		strconv.Itoa(config.DefaultSchemaRegPort),
+	)
+	if err != nil {
+		return nil, err
+	}
 	metPort, err := nat.NewPort(
 		"tcp",
 		strconv.Itoa(config.DefaultAdminPort),
@@ -257,6 +264,8 @@ func CreateNode(
 		ListenAddresses(ip, config.DefaultKafkaPort, externalKafkaPort),
 		"--pandaproxy-addr",
 		ListenAddresses(ip, config.DefaultProxyPort, proxyPort),
+		"--schema-registry-addr",
+		fmt.Sprintf("%s:%d", ip, config.DefaultSchemaRegPort),
 		"--rpc-addr",
 		fmt.Sprintf("%s:%d", ip, config.Default().Redpanda.RPCServer.Port),
 		"--advertise-kafka-addr",
@@ -274,6 +283,7 @@ func CreateNode(
 		ExposedPorts: nat.PortSet{
 			rPort: {},
 			pPort: {},
+			sPort: {},
 			kPort: {},
 		},
 		Labels: map[string]string{
@@ -291,6 +301,9 @@ func CreateNode(
 			}},
 			pPort: []nat.PortBinding{{
 				HostPort: fmt.Sprint(proxyPort),
+			}},
+			pPort: []nat.PortBinding{{
+				HostPort: fmt.Sprint(schemaRegPort),
 			}},
 			metPort: []nat.PortBinding{{
 				HostPort: fmt.Sprint(metricsPort),

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -181,6 +181,10 @@ func startCluster(
 	if err != nil {
 		return err
 	}
+	seedSchemaRegPort, err := net.GetFreePort()
+	if err != nil {
+		return err
+	}
 	seedRPCPort, err := net.GetFreePort()
 	if err != nil {
 		return err
@@ -194,6 +198,7 @@ func startCluster(
 		seedID,
 		seedKafkaPort,
 		seedProxyPort,
+		seedSchemaRegPort,
 		seedRPCPort,
 		seedMetricsPort,
 		netID,
@@ -235,6 +240,10 @@ func startCluster(
 			if err != nil {
 				return err
 			}
+			schemaRegPort, err := net.GetFreePort()
+			if err != nil {
+				return err
+			}
 			rpcPort, err := net.GetFreePort()
 			if err != nil {
 				return err
@@ -256,6 +265,7 @@ func startCluster(
 				id,
 				kafkaPort,
 				proxyPort,
+				schemaRegPort,
 				rpcPort,
 				metricsPort,
 				netID,

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -122,6 +122,7 @@ func NewStartCommand(
 		seeds           []string
 		kafkaAddr       []string
 		proxyAddr       []string
+		schemaRegAddr   []string
 		rpcAddr         string
 		advertisedKafka []string
 		advertisedProxy []string
@@ -221,6 +222,28 @@ func NewStartCommand(
 					conf.Pandaproxy = config.Default().Pandaproxy
 				}
 				conf.Pandaproxy.PandaproxyAPI = proxyApi
+			}
+
+			schemaRegAddr = stringSliceOr(
+				schemaRegAddr,
+				strings.Split(
+					os.Getenv("REDPANDA_SCHEMA_REGISTRY_ADDRESS"),
+					",",
+				),
+			)
+			schemaRegApi, err := parseNamedAddresses(
+				schemaRegAddr,
+				config.DefaultSchemaRegPort,
+			)
+			if err != nil {
+				sendEnv(fs, mgr, env, conf, !prestartCfg.checkEnabled, err)
+				return err
+			}
+			if schemaRegApi != nil && len(schemaRegApi) > 0 {
+				if conf.SchemaRegistry == nil {
+					conf.SchemaRegistry = config.Default().SchemaRegistry
+				}
+				conf.SchemaRegistry.SchemaRegistryAPI = schemaRegApi
 			}
 
 			rpcAddr = stringOr(
@@ -372,6 +395,12 @@ func NewStartCommand(
 		"pandaproxy-addr",
 		[]string{},
 		"A comma-separated list of Pandaproxy listener addresses to bind to (<name>://<host>:<port>)",
+	)
+	command.Flags().StringSliceVar(
+		&schemaRegAddr,
+		"schema-registry-addr",
+		[]string{},
+		"A comma-separated list of Schema Registry listener addresses to bind to (<name>://<host>:<port>)",
 	)
 	command.Flags().StringVar(
 		&rpcAddr,

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -91,8 +91,9 @@ func defaultMap() map[string]interface{} {
 	}
 	var defaultAdminListeners []interface{} = []interface{}{defaultAdminListener}
 	return map[string]interface{}{
-		"config_file": "/etc/redpanda/redpanda.yaml",
-		"pandaproxy":  Pandaproxy{},
+		"config_file":     "/etc/redpanda/redpanda.yaml",
+		"pandaproxy":      Pandaproxy{},
+		"schema_registry": SchemaRegistry{},
 		"redpanda": map[string]interface{}{
 			"data_directory": "/var/lib/redpanda/data",
 			"rpc_server": map[string]interface{}{

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -26,9 +26,10 @@ const (
 	ModeDev  = "dev"
 	ModeProd = "prod"
 
-	DefaultKafkaPort = 9092
-	DefaultProxyPort = 8082
-	DefaultAdminPort = 9644
+	DefaultKafkaPort     = 9092
+	DefaultSchemaRegPort = 8081
+	DefaultProxyPort     = 8082
+	DefaultAdminPort     = 9644
 )
 
 func InitViper(fs afero.Fs) *viper.Viper {

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -357,8 +357,9 @@ func TestMerge(t *testing.T) {
 func TestDefault(t *testing.T) {
 	defaultConfig := Default()
 	expected := &Config{
-		ConfigFile: "/etc/redpanda/redpanda.yaml",
-		Pandaproxy: &Pandaproxy{},
+		ConfigFile:     "/etc/redpanda/redpanda.yaml",
+		Pandaproxy:     &Pandaproxy{},
+		SchemaRegistry: &SchemaRegistry{},
 		Redpanda: RedpandaConfig{
 			Directory: "/var/lib/redpanda/data",
 			RPCServer: SocketAddress{"0.0.0.0", 33145},
@@ -487,6 +488,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -533,6 +535,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -589,6 +592,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -647,6 +651,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -696,6 +701,7 @@ rpk:
   tune_network: false
   tune_swappiness: false
   tune_transparent_hugepages: false
+schema_registry: {}
 `,
 		},
 		{
@@ -751,6 +757,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -829,6 +836,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 unrecognized_top_field:
   child: true
 `,
@@ -899,6 +907,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -965,6 +974,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1027,6 +1037,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1079,6 +1090,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1169,6 +1181,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1233,6 +1246,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1307,6 +1321,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1359,6 +1374,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1411,6 +1427,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1472,6 +1489,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1554,6 +1572,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1610,6 +1629,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1666,6 +1686,7 @@ rpk:
   tune_swappiness: true
   tune_transparent_hugepages: true
   well_known_io: vendor:vm:storage
+schema_registry: {}
 `,
 		},
 		{
@@ -1734,6 +1755,7 @@ rpk:
   tune_network: false
   tune_swappiness: false
   tune_transparent_hugepages: false
+schema_registry: {}
 `,
 		},
 	}
@@ -2077,7 +2099,7 @@ func TestReadAsJSON(t *testing.T) {
 				return mgr.Write(conf)
 			},
 			path:     Default().ConfigFile,
-			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","pandaproxy":{},"redpanda":{"admin":[{"address":"0.0.0.0","port":9644}],"data_directory":"/var/lib/redpanda/data","developer_mode":true,"kafka_api":[{"address":"0.0.0.0","name":"internal","port":9092}],"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_disk_write_cache":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false}}`,
+			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","pandaproxy":{},"redpanda":{"admin":[{"address":"0.0.0.0","port":9644}],"data_directory":"/var/lib/redpanda/data","developer_mode":true,"kafka_api":[{"address":"0.0.0.0","name":"internal","port":9092}],"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_disk_write_cache":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false},"schema_registry":{}}`,
 		},
 		{
 			name:           "it should fail if the the config isn't found",
@@ -2153,6 +2175,7 @@ func TestReadFlat(t *testing.T) {
 		"rpk.tune_network":                             "false",
 		"rpk.tune_swappiness":                          "false",
 		"rpk.tune_transparent_hugepages":               "false",
+		"schema_registry":                              "",
 	}
 	fs := afero.NewMemMapFs()
 	mgr := NewManager(fs)

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1239,7 +1239,7 @@ rpk:
 			name: "shall write config with pandaproxy client configuration",
 			conf: func() *Config {
 				c := getValidConfig()
-				c.PandaproxyClient = &PandaproxyClient{
+				c.PandaproxyClient = &KafkaClient{
 					Brokers: []SocketAddress{
 						{
 							Address: "1.2.3.4",
@@ -1420,7 +1420,7 @@ rpk:
 				mechanism := "abc"
 				username := "user"
 				password := "pass"
-				c.PandaproxyClient = &PandaproxyClient{
+				c.PandaproxyClient = &KafkaClient{
 					SASLMechanism: &mechanism,
 					SCRAMUsername: &username,
 					SCRAMPassword: &password,

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -12,16 +12,18 @@ package config
 import "path"
 
 type Config struct {
-	NodeUuid         string                 `yaml:"node_uuid,omitempty" mapstructure:"node_uuid,omitempty" json:"nodeUuid"`
-	Organization     string                 `yaml:"organization,omitempty" mapstructure:"organization,omitempty" json:"organization"`
-	LicenseKey       string                 `yaml:"license_key,omitempty" mapstructure:"license_key,omitempty" json:"licenseKey"`
-	ClusterId        string                 `yaml:"cluster_id,omitempty" mapstructure:"cluster_id,omitempty" json:"clusterId"`
-	ConfigFile       string                 `yaml:"config_file" mapstructure:"config_file" json:"configFile"`
-	Redpanda         RedpandaConfig         `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
-	Rpk              RpkConfig              `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
-	Pandaproxy       *Pandaproxy            `yaml:"pandaproxy,omitempty" mapstructure:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`
-	PandaproxyClient *KafkaClient           `yaml:"pandaproxy_client,omitempty" mapstructure:"pandaproxy_client,omitempty" json:"pandaproxyClient,omitempty"`
-	Other            map[string]interface{} `yaml:",inline" mapstructure:",remain"`
+	NodeUuid             string                 `yaml:"node_uuid,omitempty" mapstructure:"node_uuid,omitempty" json:"nodeUuid"`
+	Organization         string                 `yaml:"organization,omitempty" mapstructure:"organization,omitempty" json:"organization"`
+	LicenseKey           string                 `yaml:"license_key,omitempty" mapstructure:"license_key,omitempty" json:"licenseKey"`
+	ClusterId            string                 `yaml:"cluster_id,omitempty" mapstructure:"cluster_id,omitempty" json:"clusterId"`
+	ConfigFile           string                 `yaml:"config_file" mapstructure:"config_file" json:"configFile"`
+	Redpanda             RedpandaConfig         `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
+	Rpk                  RpkConfig              `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
+	Pandaproxy           *Pandaproxy            `yaml:"pandaproxy,omitempty" mapstructure:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`
+	PandaproxyClient     *KafkaClient           `yaml:"pandaproxy_client,omitempty" mapstructure:"pandaproxy_client,omitempty" json:"pandaproxyClient,omitempty"`
+	SchemaRegistry       *SchemaRegistry        `yaml:"schema_registry,omitempty" mapstructure:"schema_registry,omitempty" json:"schemaRegistry,omitempty"`
+	SchemaRegistryClient *KafkaClient           `yaml:"schema_registry_client,omitempty" mapstructure:"schema_registry_client,omitempty" json:"schemaRegistryClient,omitempty"`
+	Other                map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 
 type RedpandaConfig struct {
@@ -59,6 +61,11 @@ type Pandaproxy struct {
 	PandaproxyAPITLS        []ServerTLS            `yaml:"pandaproxy_api_tls,omitempty" mapstructure:"pandaproxy_api_tls,omitempty" json:"pandaproxyApiTls,omitempty"`
 	AdvertisedPandaproxyAPI []NamedSocketAddress   `yaml:"advertised_pandaproxy_api,omitempty" mapstructure:"advertised_pandaproxy_api,omitempty" json:"advertisedPandaproxyApi,omitempty"`
 	Other                   map[string]interface{} `yaml:",inline" mapstructure:",remain"`
+}
+
+type SchemaRegistry struct {
+	SchemaRegistryAPI    []NamedSocketAddress `yaml:"schema_registry_api,omitempty" mapstructure:"schema_registry_api,omitempty" json:"schemaRegistryApi,omitempty"`
+	SchemaRegistryAPITLS []ServerTLS          `yaml:"schema_registry_api_tls,omitempty" mapstructure:"schema_registry_api_tls,omitempty" json:"schemaRegistryApiTls,omitempty"`
 }
 
 type KafkaClient struct {

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -20,7 +20,7 @@ type Config struct {
 	Redpanda         RedpandaConfig         `yaml:"redpanda" mapstructure:"redpanda" json:"redpanda"`
 	Rpk              RpkConfig              `yaml:"rpk" mapstructure:"rpk" json:"rpk"`
 	Pandaproxy       *Pandaproxy            `yaml:"pandaproxy,omitempty" mapstructure:"pandaproxy,omitempty" json:"pandaproxy,omitempty"`
-	PandaproxyClient *PandaproxyClient      `yaml:"pandaproxy_client,omitempty" mapstructure:"pandaproxy_client,omitempty" json:"pandaproxyClient,omitempty"`
+	PandaproxyClient *KafkaClient           `yaml:"pandaproxy_client,omitempty" mapstructure:"pandaproxy_client,omitempty" json:"pandaproxyClient,omitempty"`
 	Other            map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 
@@ -61,7 +61,7 @@ type Pandaproxy struct {
 	Other                   map[string]interface{} `yaml:",inline" mapstructure:",remain"`
 }
 
-type PandaproxyClient struct {
+type KafkaClient struct {
 	Brokers       []SocketAddress        `yaml:"brokers,omitempty" mapstructure:"brokers,omitempty" json:"brokers,omitempty"`
 	BrokerTLS     ServerTLS              `yaml:"broker_tls,omitempty" mapstructure:"broker_tls,omitempty" json:"brokerTls,omitempty"`
 	SASLMechanism *string                `yaml:"sasl_mechanism,omitempty" mapstructure:"sasl_mechanism,omitempty" json:"saslMechanism,omitempty"`


### PR DESCRIPTION
## Cover letter

* Add configuration for `schema_registry` and `schema_registry_client`
* support for `--schema-registry-addr` argument to `rpk redpanda start`
* Port bindings in `rpk container`
* Switch `rpk container` to use `redpanda start`

## Release notes

Release note: Enable Schema Registry by default
