### PR TITLE
rpk start: Fix parsing of additional flags

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -788,7 +788,9 @@ func parseFlags(flags []string) map[string]string {
 		}
 
 		// Check if it's in name=value format
-		parts := strings.Split(trimmed, "=")
+		// Split only into 2 tokens, since some flags can have multiple '='
+		// in them, like --logger-log-level=archival=debug:cloud_storage=debug
+		parts := strings.SplitN(trimmed, "=", 2)
 		if len(parts) >= 2 {
 			name := strings.Trim(parts[0], " ")
 			value := strings.Trim(parts[1], " ")

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -1333,6 +1333,26 @@ func TestStartCommand(t *testing.T) {
 			require.Equal(st, "55", rpArgs.SeastarFlags["smp"])
 		},
 	}, {
+		name: "it should allow setting flags with multiple key=values in rpk.additional_start_flags",
+		args: []string{
+			"--install-dir", "/var/lib/redpanda",
+		},
+		before: func(fs afero.Fs) error {
+			mgr := config.NewManager(fs)
+			conf := config.Default()
+			conf.Rpk.AdditionalStartFlags = []string{
+				"--logger-log-level=archival=debug:cloud_storage=debug",
+			}
+			return mgr.Write(conf)
+		},
+		postCheck: func(
+			_ afero.Fs,
+			rpArgs *rp.RedpandaArgs,
+			st *testing.T,
+		) {
+			require.Equal(st, "archival=debug:cloud_storage=debug", rpArgs.SeastarFlags["logger-log-level"])
+		},
+	}, {
 		name: "it should pass the last instance of a duplicate flag passed to rpk start",
 		args: []string{
 			"--install-dir", "/var/lib/redpanda",


### PR DESCRIPTION
Split flags only by the first '=', so if there's a string in 'rpk.additional_start_flags' which contains multiple key=value pairs, such as '--logger-log-level archival=debug:cloud_storage=debug', it's passed correctly.
