### PR TITLE
tests/rpk: Fix ducktape tests with schema registry on by default

### DIFF
--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -70,6 +70,7 @@ rpk:
   tune_network: false
   tune_swappiness: false
   tune_transparent_hugepages: false
+schema_registry: {}
 '''
 
                 expected_config = yaml.load(expected_out)


### PR DESCRIPTION
See #1775 

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: [none]
