### PR TITLE
Fix retention policy for relaxed consistency

### DIFF
--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -308,6 +308,10 @@ public:
         return _configuration_manager;
     }
 
+    offset_monitor& visible_offset_monitor() {
+        return _consumable_offset_monitor;
+    }
+
 private:
     friend replicate_entries_stm;
     friend vote_stm;

--- a/src/v/raft/log_eviction_stm.cc
+++ b/src/v/raft/log_eviction_stm.cc
@@ -63,7 +63,7 @@ log_eviction_stm::handle_deletion_notification(model::offset last_evicted) {
     // in an abort source
     _previous_eviction_offset = last_evicted;
 
-    return _raft->events()
+    return _raft->visible_offset_monitor()
       .wait(last_evicted, model::no_timeout, _as)
       .then([this, last_evicted]() mutable {
           auto f = ss::now();

--- a/tests/rptest/services/storage.py
+++ b/tests/rptest/services/storage.py
@@ -50,8 +50,9 @@ class Segment:
 
 
 class Partition:
-    def __init__(self, num, node, path):
-        self.num = num
+    def __init__(self, idx, rev, node, path):
+        self.num = idx
+        self.rev = rev
         self.node = node
         self.path = path
         self.files = set()
@@ -88,8 +89,8 @@ class Topic:
         self.partitions = dict()
 
     def add_partition(self, num, node_id, path):
-        num = int(num)
-        p = Partition(num, node_id, path)
+        (idx, rev) = num.split("_")
+        p = Partition(int(idx), int(rev), node_id, path)
         self.partitions[num] = p
         return p
 

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -1,0 +1,98 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from ducktape.mark import matrix
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+
+
+class RetentionPolicyTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=1,
+                        replication_factor=3,
+                        cleanup_policy=TopicSpec.CLEANUP_DELETE), )
+
+    def __init__(self, test_context):
+        extra_rp_conf = dict(
+            log_compaction_interval_ms=5000,
+            log_segment_size=1048576,
+        )
+
+        super(RetentionPolicyTest, self).__init__(test_context=test_context,
+                                                  num_brokers=3,
+                                                  extra_rp_conf=extra_rp_conf)
+
+    @cluster(num_nodes=3)
+    @matrix(property=[
+        TopicSpec.PROPERTY_RETENTION_TIME, TopicSpec.PROPERTY_RETENTION_BYTES
+    ],
+            acks=[1, -1])
+    def test_changing_topic_retention(self, property, acks):
+        """
+        Test changing topic retention duration for topics with data produced 
+        with ACKS=1 and ACKS=-1. This test produces data until 10 segments 
+        appear, then it changes retention topic property and waits for 
+        segments to be removed
+        """
+        # operate on a partition. doesn't matter which one
+        partition = self.redpanda.partitions(self.topic)[0]
+
+        # produce until segments have been compacted
+        self._produce_until_segments(self.topic, 0, 10, acks)
+        kafka_tools = KafkaCliTools(self.redpanda)
+        # change retention time
+        kafka_tools.alter_topic_config(self.topic, {
+            property: 10000,
+        })
+        self._wait_for_segments_removal(self.topic, 0, 5)
+
+    def _segments_count(self, topic, partition_idx):
+        storage = self.redpanda.storage()
+        topic_partitions = storage.partitions("kafka", topic)
+
+        return map(lambda p: len(p.segments),
+                   filter(lambda p: p.num == partition_idx, topic_partitions))
+
+    def _produce_until_segments(self, topic, partition_idx, count, acks):
+        """
+        Produce into the topic until given number of segments will appear 
+        """
+        kafka_tools = KafkaCliTools(self.redpanda)
+
+        def done():
+            kafka_tools.produce(topic, 10000, 1024, acks=acks)
+            topic_partitions = self._segments_count(topic, partition_idx)
+            partitions = []
+            for p in topic_partitions:
+                partitions.append(p >= count)
+            return all(partitions)
+
+        wait_until(done,
+                   timeout_sec=60,
+                   backoff_sec=2,
+                   err_msg="Segments were not created")
+
+    def _wait_for_segments_removal(self, topic, partition_idx, count):
+        """
+        Wait until only given number of segments will left in a partitions
+        """
+        def done():
+            topic_partitions = self._segments_count(topic, partition_idx)
+            partitions = []
+            for p in topic_partitions:
+                partitions.append(p <= count)
+            return all(partitions)
+
+        wait_until(done,
+                   timeout_sec=120,
+                   backoff_sec=5,
+                   err_msg="Segments were not removed")


### PR DESCRIPTION
## Cover letter

 In redpanda when log underlying Raft protocol is being evicted by deletion cleanup policy, Raft preserves its state in an empty snapshot. Snapshot in Raft protocol can only be created with offset smaller than `committed_index`. For ACKS=1 we never explicitly flush log in Raft protocol implementation, this prevent the snapshot, necessary for eviction from being created. Changed our snapshot implementation to accept snapshots being created with offsets smaller than last visible offset. This way we preserve replication consistency level during snapshot creation and make eviction policy independent from consistency level.
Fixes: N/A

## Release notes

Release note: 
- after this fix, changing topic retention policy will be correctly applied for all the topics. 
