### PR TITLE
operator: Make configurator image configurable

### DIFF
--- a/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/README.md
@@ -63,6 +63,9 @@ Other instruction will be visible after installation.
 | config.leaderElection.resourceName | string | `"aa9fc693.vectorized.io"` |  |
 | config.metrics.bindAddress | string | `"127.0.0.1:8080"` |  |
 | config.webhook.port | int | `9443` |  |
+| configurator.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Redpanda configurator image |
+| configurator.repository | string | `"vectorized/configurator"` | Repository that Redpanda configurator image is available |
+| configurator.tag | string | `"{{ .Chart.AppVersion }}"` | Define the Redpanda configurator container tag |
 | fullnameOverride | string | `""` | Override the fully qualified app name |
 | image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Redpanda Operator image |
 | image.repository | string | `"vectorized/redpanda-operator"` | Repository that Redpanda Operator image is available |

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/deployment.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/deployment.yaml
@@ -57,7 +57,9 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        - --configurator-tag={{ tpl .Values.image.tag . }}
+        - --configurator-tag={{ tpl .Values.configurator.tag . }}
+        - --configurator-base-image={{ .Values.configurator.repository }}
+        - --configurator-image-pull-policy={{ .Values.configurator.pullPolicy }}
         {{- if .Values.webhook.enabled }}
         - --webhook-enabled=true
         {{- else }}

--- a/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/values.yaml
@@ -20,6 +20,15 @@ image:
   # image.pullPolicy -- Define the pullPolicy for Redpanda Operator image
   pullPolicy: IfNotPresent
 
+configurator:
+  # configurator.repository -- Repository that Redpanda configurator image is available
+  repository: vectorized/configurator
+  # configurator.tag -- Define the Redpanda configurator container tag
+  tag: |-
+    {{ .Chart.AppVersion }}
+  # configurator.pullPolicy -- Define the pullPolicy for Redpanda configurator image
+  pullPolicy: IfNotPresent
+
 config:
   apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
   kind: ControllerManagerConfig

--- a/src/go/k8s/pkg/resources/resource_integration_test.go
+++ b/src/go/k8s/pkg/resources/resource_integration_test.go
@@ -78,7 +78,11 @@ func TestEnsure_StatefulSet(t *testing.T) {
 		types.NamespacedName{},
 		types.NamespacedName{},
 		"",
-		"latest",
+		res.ConfiguratorSettings{
+			ConfiguratorBaseImage: "vectorized/configurator",
+			ConfiguratorTag:       "latest",
+			ImagePullPolicy:       "Always",
+		},
 		ctrl.Log.WithName("test"))
 
 	err := sts.Ensure(context.Background())

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -88,7 +88,11 @@ func TestEnsure(t *testing.T) {
 			types.NamespacedName{},
 			types.NamespacedName{},
 			"",
-			"latest",
+			res.ConfiguratorSettings{
+				ConfiguratorBaseImage: "vectorized/configurator",
+				ConfiguratorTag:       "latest",
+				ImagePullPolicy:       "Always",
+			},
 			ctrl.Log.WithName("test"))
 
 		err = sts.Ensure(context.Background())


### PR DESCRIPTION
## Cover letter

Users would like to use our operator in closed environments where
public docker hub is not available. This change give a way to change
image, tag and imagePullPolicy via flags.

Fixes: #1553

## Release notes

Release note: End user can now change the configurator image, tag and imagePullPolicy via manager flags.
