### PR TITLE
archival: Use high watermark instead of committed offset of the segment

### DIFF
--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -42,14 +42,17 @@ public:
     /// \brief regurn next upload candidate
     ///
     /// \param last_offset is a last uploaded offset
+    /// \param high_watermark is current high_watermark offset for the partition
     /// \param lm is a log manager
     /// \return initializd struct on success, empty struct on failure
     /// \note returned upload candidate can have offset which is smaller than
     ///       last_offset because index is sparse and don't have all possible
     ///       offsets. If index is not materialized we will upload log starting
     ///       from the begining.
-    upload_candidate
-    get_next_candidate(model::offset last_offset, storage::log_manager& lm);
+    upload_candidate get_next_candidate(
+      model::offset last_offset,
+      model::offset high_watermark,
+      storage::log_manager& lm);
 
 private:
     struct lookup_result {
@@ -57,8 +60,10 @@ private:
         const storage::ntp_config* ntp_conf;
     };
 
-    lookup_result
-    find_segment(model::offset last_offset, storage::log_manager& lm);
+    lookup_result find_segment(
+      model::offset last_offset,
+      model::offset high_watermark,
+      storage::log_manager& lm);
 
     model::ntp _ntp;
     service_probe& _svc_probe;

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -122,9 +122,13 @@ public:
     /// uploading them.
     ///
     /// \param lm is a log manager instance
+    /// \param high_watermark is a high watermark offset of the partition
+    /// \param parent is a retry chain node of the caller
     /// \return future that returns number of uploaded/failed segments
-    ss::future<batch_result>
-    upload_next_candidates(storage::log_manager& lm, retry_chain_node& parent);
+    ss::future<batch_result> upload_next_candidates(
+      storage::log_manager& lm,
+      model::offset high_watermark,
+      retry_chain_node& parent);
 
 private:
     /// Upload individual segment to S3.

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -157,6 +157,9 @@ private:
     /// Adds archiver to the reconciliation loop after fetching its manifest.
     ss::future<ss::stop_iteration>
     add_ntp_archiver(ss::lw_shared_ptr<ntp_archiver> archiver);
+    /// Returns high watermark for the partition
+    std::optional<model::offset>
+    get_high_watermark(const model::ntp& ntp) const;
 
     configuration _conf;
     ss::sharded<cluster::partition_manager>& _partition_manager;

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -126,6 +126,37 @@ compare_json_objects(const std::string_view& lhs, const std::string_view& rhs) {
     return lhsd == rhsd;
 }
 
+static void log_segment(const storage::segment& s) {
+    vlog(
+      test_log.info,
+      "Log segment {}. Offsets: {} {}. Is compacted: {}. Is sealed: {}.",
+      s.reader().filename(),
+      s.offsets().base_offset,
+      s.offsets().dirty_offset,
+      s.is_compacted_segment(),
+      !s.has_appender());
+}
+
+static void log_segment_set(storage::log_manager& lm) {
+    auto log = lm.get(manifest_ntp);
+    auto plog = dynamic_cast<const storage::disk_log_impl*>(log->get_impl());
+    BOOST_REQUIRE(plog != nullptr);
+    const auto& sset = plog->segments();
+    for (const auto& s : sset) {
+        log_segment(*s);
+    }
+}
+
+void log_upload_candidate(const archival::upload_candidate& up) {
+    vlog(
+      test_log.info,
+      "Upload candidate, exposed name: {} "
+      "real offsets: {} {}",
+      up.exposed_name,
+      up.source->offsets().base_offset,
+      up.source->offsets().dirty_offset);
+}
+
 FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
     set_expectations_and_listen(default_expectations);
     auto conf = get_configuration();
@@ -188,6 +219,7 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
       get_ntp_conf(), get_configuration(), remote, probe);
     auto action = ss::defer([&archiver] { archiver.stop().get(); });
 
+    model::offset high_watermark = model::offset::max();
     std::vector<segment_desc> segments = {
       {manifest_ntp, model::offset(1), model::term_id(2)},
       {manifest_ntp, model::offset(1000), model::term_id(4)},
@@ -196,7 +228,8 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
 
     retry_chain_node fib;
     auto res = archiver
-                 .upload_next_candidates(get_local_storage_api().log_mgr(), fib)
+                 .upload_next_candidates(
+                   get_local_storage_api().log_mgr(), high_watermark, fib)
                  .get0();
     BOOST_REQUIRE_EQUAL(res.num_succeded, 2);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
@@ -232,13 +265,16 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
 
 // NOLINTNEXTLINE
 FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
+    model::offset high_watermark{9999};
     const auto offset1 = model::offset(1000);
     const auto offset2 = model::offset(2000);
     const auto offset3 = model::offset(3000);
+    const auto offset4 = model::offset(10000);
     std::vector<segment_desc> segments = {
       {manifest_ntp, offset1, model::term_id(1)},
       {manifest_ntp, offset2, model::term_id(1)},
       {manifest_ntp, offset3, model::term_id(1)},
+      {manifest_ntp, offset4, model::term_id(1)},
     };
     init_storage_api_local(segments);
     auto& lm = get_local_storage_api().log_mgr();
@@ -246,46 +282,18 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     service_probe svc_probe(service_metrics_disabled::yes);
     archival::archival_policy policy(manifest_ntp, svc_probe, ntp_probe);
 
-    // Every segment should be returned once as we're calling the
-    // policy to get next candidate.
-    auto log_segment = [](const storage::segment& s) {
-        vlog(
-          test_log.info,
-          "Log segment {}. Offsets: {} {}. Is compacted: {}. Is sealed: {}.",
-          s.reader().filename(),
-          s.offsets().base_offset,
-          s.offsets().committed_offset,
-          s.is_compacted_segment(),
-          !s.has_appender());
-    };
-    auto log_segment_set = [log_segment](storage::log_manager& lm) {
-        auto log = lm.get(manifest_ntp);
-        auto plog = dynamic_cast<const storage::disk_log_impl*>(
-          log->get_impl());
-        BOOST_REQUIRE(plog != nullptr);
-        const auto& sset = plog->segments();
-        for (const auto& s : sset) {
-            log_segment(*s);
-        }
-    };
-    auto log_upload_candidate = [](const archival::upload_candidate& up) {
-        vlog(
-          test_log.info,
-          "Upload candidate, exposed name: {} "
-          "real offsets: {} {}",
-          up.exposed_name,
-          up.source->offsets().base_offset,
-          up.source->offsets().committed_offset);
-    };
     log_segment_set(lm);
     // Starting offset is lower than offset1
-    auto upload1 = policy.get_next_candidate(model::offset(0), lm);
+    auto upload1 = policy.get_next_candidate(
+      model::offset(0), high_watermark, lm);
     log_upload_candidate(upload1);
     BOOST_REQUIRE(upload1.source.get() != nullptr);
     BOOST_REQUIRE(upload1.starting_offset == offset1);
 
     auto upload2 = policy.get_next_candidate(
-      upload1.source->offsets().committed_offset + model::offset(1), lm);
+      upload1.source->offsets().dirty_offset + model::offset(1),
+      high_watermark,
+      lm);
     log_upload_candidate(upload2);
     BOOST_REQUIRE(upload2.source.get() != nullptr);
     BOOST_REQUIRE(upload2.starting_offset() == offset2);
@@ -294,7 +302,9 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload2.source->offsets().base_offset == offset2);
 
     auto upload3 = policy.get_next_candidate(
-      upload2.source->offsets().committed_offset + model::offset(1), lm);
+      upload2.source->offsets().dirty_offset + model::offset(1),
+      high_watermark,
+      lm);
     log_upload_candidate(upload3);
     BOOST_REQUIRE(upload3.source.get() != nullptr);
     BOOST_REQUIRE(upload3.starting_offset() == offset3);
@@ -303,8 +313,14 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload3.source->offsets().base_offset == offset3);
 
     auto upload4 = policy.get_next_candidate(
-      upload3.source->offsets().committed_offset + model::offset(1), lm);
+      upload3.source->offsets().dirty_offset + model::offset(1),
+      high_watermark,
+      lm);
     BOOST_REQUIRE(upload4.source.get() == nullptr);
+
+    auto upload5 = policy.get_next_candidate(
+      high_watermark + model::offset(1), high_watermark, lm);
+    BOOST_REQUIRE(upload5.source.get() == nullptr);
 }
 
 // NOLINTNEXTLINE
@@ -315,6 +331,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     // made.
     // The manifest that this test generates contains a segment definition
     // that clashes with the partial upload.
+    model::offset high_watermark = model::offset::max();
     std::vector<segment_desc> segments = {
       {manifest_ntp, model::offset(1), model::term_id(2)},
       {manifest_ntp, model::offset(1000), model::term_id(4)},
@@ -333,8 +350,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
       .is_compacted = false,
       .size_bytes = 100,
       .base_offset = model::offset(2),
-      .committed_offset = segment1->offsets().committed_offset
-                          - model::offset(1)};
+      .committed_offset = segment1->offsets().dirty_offset - model::offset(1)};
     auto oldname = archival::segment_name("2-2-v1.log");
     old_manifest.add(oldname, old_meta);
     std::stringstream old_str;
@@ -363,7 +379,8 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     archiver.download_manifest(fib).get();
 
     auto res = archiver
-                 .upload_next_candidates(get_local_storage_api().log_mgr(), fib)
+                 .upload_next_candidates(
+                   get_local_storage_api().log_mgr(), high_watermark, fib)
                  .get0();
     BOOST_REQUIRE_EQUAL(res.num_succeded, 2);
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);


### PR DESCRIPTION
## Cover letter

Archival upload algorithm can fail if the dirty offset of the rolled log
segment is greater than committed offset (as described in #1521). The
committed offset is used as a last uploaded offset in the manifest and
the search for the next upload candidate is incrementally started from this offset.
Then the uploaded segment becomes the next upload candidate once again
(this time partial upload is triggered with length 0 which triggers throttling).

This commit makes archival subsystem use dirty offset instead of committed
offset. The dirty offset is always consistent with the actual data layout (the next segment
start with dirty offset of the previous +1. The archival service uses partition manager to read high
watermark offset of the partition. Then it compares the dirty offset
with high watermark and decides if the segment can be uploaded. It never
uploads a segment that contains an offset which is higher than high
watermark.

This change makes archival service tolerant to a situation when the
committed offset is inconsistent (as described in #1800).

This change might introduce the following problem: when the log is
truncated on a leader the already uploaded log segment might be
truncated as well (since we upload by dirty offset). But check against
high watermark should prevent this situation.

Fixes #1800, related to #1521

## Release notes

N/A