### PR TITLE
storage: fix zstd oom when memory is fragemented

### DIFF
--- a/src/v/compression/stream_zstd.h
+++ b/src/v/compression/stream_zstd.h
@@ -23,27 +23,23 @@ public:
       ZSTD_CCtx,
       // wrap ZSTD C API
       static_sized_deleter_fn<ZSTD_CCtx, &ZSTD_freeCCtx>>;
-    using zstd_decompress_ctx = std::unique_ptr<
-      ZSTD_DCtx,
-      // wrap ZSTD C API
-      static_sized_deleter_fn<ZSTD_DCtx, &ZSTD_freeDCtx>>;
 
     iobuf compress(const iobuf& b) { return do_compress(b); }
     iobuf uncompress(const iobuf& b) { return do_uncompress(b); }
     iobuf compress(iobuf&& b) { return do_compress(b); }
     iobuf uncompress(iobuf&& b) { return do_uncompress(b); }
 
+    static void init_workspace(size_t);
+
 private:
     iobuf do_compress(const iobuf&);
     iobuf do_uncompress(const iobuf&);
 
     void reset_compressor();
-    void reset_decompressor();
     zstd_compress_ctx& compressor();
-    zstd_decompress_ctx& decompressor();
+    ZSTD_DCtx* decompressor();
 
     zstd_compress_ctx _compress{nullptr};
-    zstd_decompress_ctx _decompress{nullptr};
 };
 
 } // namespace compression

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -779,6 +779,12 @@ configuration::configuration()
       "Update frequency for kafka queue depth control.",
       required::no,
       7s)
+  , zstd_decompress_workspace_bytes(
+      *this,
+      "zstd_decompress_workspace_bytes",
+      "Size of the zstd decompression workspace",
+      required::no,
+      8_MiB)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -190,6 +190,7 @@ struct configuration final : public config_store {
     property<size_t> kafka_qdc_min_depth;
     property<size_t> kafka_qdc_max_depth;
     property<std::chrono::milliseconds> kafka_qdc_depth_update_ms;
+    property<size_t> zstd_decompress_workspace_bytes;
 
     configuration();
 


### PR DESCRIPTION
Generally speaking when using stream decompression a window will be
required whose size is determiend by parameters of the compression
process. It looks like the default comrpession settings in something
like librdkafka result in a window size need of 2 MB. This gets larger
the more extreme paramters are used during compression.

In this PR we allocate a fixed size workspace at early bootup when
fragmentation isn't an issue and then re-use this for the lifetime of
the process.

This ticket is tracking future improvements: #1802

Fixes: https://github.com/vectorizedio/redpanda/issues/1726
Fixes: https://github.com/vectorizedio/redpanda/issues/1776
Closes: https://github.com/vectorizedio/redpanda/issues/1729