### PR TITLE
Rpk ballast tuner

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -625,6 +625,20 @@ rpk:
   # Default: ''
   coredump_dir: "/var/lib/redpanda/coredump"
 
+  # Creates a "ballast" file so that, if a Redpanda node runs out of space,
+  # you can delete the ballast file to allow the node to resume operations and then
+  # delete a topic or records to reduce the space used by Redpanda.
+  # Default: false
+  tune_ballast_file: false
+
+  # The path where the ballast file will be created.
+  # Default: "/var/lib/redpanda/data/ballast"
+  ballast_file_path: "/var/lib/redpanda/data/ballast"
+
+  # The ballast file size.
+  # Default: "1GiB"
+  ballast_file_size: "1GiB"
+
   # (Optional) The vendor, VM type and storage device type that redpanda will run on, in
   # the format <vendor>:<vm>:<storage>. This hints to rpk which configuration values it
   # should use for the redpanda IO scheduler.

--- a/src/go/rpk/pkg/cli/cmd/check.go
+++ b/src/go/rpk/pkg/cli/cmd/check.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Vectorized, Inc.
+// Copyright 2021 Vectorized, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -6,6 +6,8 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
+
+// +build linux
 
 package cmd
 

--- a/src/go/rpk/pkg/cli/cmd/config.go
+++ b/src/go/rpk/pkg/cli/cmd/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Vectorized, Inc.
+// Copyright 2021 Vectorized, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -6,6 +6,8 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
+
+// +build linux
 
 package cmd
 

--- a/src/go/rpk/pkg/cli/cmd/mode.go
+++ b/src/go/rpk/pkg/cli/cmd/mode.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Vectorized, Inc.
+// Copyright 2021 Vectorized, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -6,6 +6,8 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
+
+// +build linux
 
 package cmd
 

--- a/src/go/rpk/pkg/cli/cmd/redpanda.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package cmd
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/check.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/check.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda_test
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -75,6 +75,7 @@ func TestSetCmd(t *testing.T) {
 				"enable_memory_locking":      false,
 				"tune_fstrim":                false,
 				"tune_coredump":              false,
+				"tune_ballast_file":          false,
 				"coredump_dir":               "/var/lib/redpanda/coredump",
 			},
 		},

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -40,6 +40,7 @@ func fillRpkConfig(path, mode string) *config.Config {
 		TuneSwappiness:     val,
 		CoredumpDir:        path,
 		Overprovisioned:    !val,
+		TuneBallastFile:    val,
 	}
 	return conf
 }
@@ -162,6 +163,7 @@ func TestModeCommand(t *testing.T) {
 			require.NoError(t, err)
 			output := out.String()
 			require.Contains(t, strings.TrimSpace(output), tt.expectedOutput)
+			mgr = config.NewManager(fs)
 			conf, err := mgr.Read(path)
 			require.NoError(t, err)
 			require.Exactly(t, tt.expectedConfig, conf)

--- a/src/go/rpk/pkg/cli/cmd/redpanda/package.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/package.go
@@ -1,0 +1,13 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// This file's purpose is to prevent darwin builds from failing, since
+// all the other files in the "cmd/redpanda" package are excluded.
+
+package redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda_test
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package redpanda
 
 import (

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -74,7 +74,6 @@ func Execute() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose",
 		"v", false, "enable verbose logging (default false)")
 
-	rootCmd.AddCommand(NewModeCommand(mgr))
 	rootCmd.AddCommand(NewGenerateCommand(mgr))
 	rootCmd.AddCommand(NewVersionCommand())
 	rootCmd.AddCommand(NewWasmCommand(fs, mgr))

--- a/src/go/rpk/pkg/cli/cmd/root_linux.go
+++ b/src/go/rpk/pkg/cli/cmd/root_linux.go
@@ -29,4 +29,5 @@ func addPlatformDependentCmds(
 	cmd.AddCommand(NewStopCommand(fs, mgr))
 	cmd.AddCommand(NewConfigCommand(fs, mgr))
 	cmd.AddCommand(NewStatusCommand(fs, mgr))
+	cmd.AddCommand(NewModeCommand(mgr))
 }

--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Vectorized, Inc.
+// Copyright 2021 Vectorized, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -6,6 +6,8 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
+
+// +build linux
 
 package cmd
 

--- a/src/go/rpk/pkg/cli/cmd/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/stop.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Vectorized, Inc.
+// Copyright 2021 Vectorized, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -6,6 +6,8 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
+
+// +build linux
 
 package cmd
 

--- a/src/go/rpk/pkg/cli/cmd/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/tune.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Vectorized, Inc.
+// Copyright 2021 Vectorized, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -6,6 +6,8 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
+
+// +build linux
 
 package cmd
 

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -30,6 +30,9 @@ const (
 	DefaultSchemaRegPort = 8081
 	DefaultProxyPort     = 8082
 	DefaultAdminPort     = 9644
+
+	DefaultBallastFilePath = "/var/lib/redpanda/data/ballast"
+	DefaultBallastFileSize = "1GiB"
 )
 
 func InitViper(fs afero.Fs) *viper.Viper {
@@ -167,6 +170,8 @@ func setDevelopment(conf *Config) *Config {
 		EnableUsageStats:     conf.Rpk.EnableUsageStats,
 		CoredumpDir:          conf.Rpk.CoredumpDir,
 		SMP:                  Default().Rpk.SMP,
+		BallastFilePath:      conf.Rpk.BallastFilePath,
+		BallastFileSize:      conf.Rpk.BallastFileSize,
 		Overprovisioned:      true,
 	}
 	return conf
@@ -185,6 +190,7 @@ func setProduction(conf *Config) *Config {
 	conf.Rpk.TuneSwappiness = true
 	conf.Rpk.Overprovisioned = false
 	conf.Rpk.TuneDiskWriteCache = true
+	conf.Rpk.TuneBallastFile = true
 	return conf
 }
 

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -46,6 +46,7 @@ func getValidConfig() *Config {
 		TuneTransparentHugePages: true,
 		EnableMemoryLocking:      true,
 		TuneCoredump:             true,
+		TuneBallastFile:          true,
 		CoredumpDir:              "/var/lib/redpanda/coredumps",
 		WellKnownIo:              "vendor:vm:storage",
 	}
@@ -476,6 +477,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -523,6 +525,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -580,6 +583,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -639,6 +643,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -690,6 +695,7 @@ rpk:
   enable_usage_stats: false
   overprovisioned: false
   tune_aio_events: false
+  tune_ballast_file: false
   tune_clocksource: false
   tune_coredump: false
   tune_cpu: false
@@ -745,6 +751,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -824,6 +831,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -895,6 +903,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -962,6 +971,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1025,6 +1035,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1078,6 +1089,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1169,6 +1181,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1234,6 +1247,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1309,6 +1323,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1362,6 +1377,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1415,6 +1431,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1477,6 +1494,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1560,6 +1578,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1617,6 +1636,7 @@ rpk:
   enable_usage_stats: true
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1677,6 +1697,7 @@ rpk:
       user: scram_user
   overprovisioned: false
   tune_aio_events: true
+  tune_ballast_file: true
   tune_clocksource: true
   tune_coredump: true
   tune_cpu: true
@@ -1747,6 +1768,7 @@ rpk:
   enable_usage_stats: false
   overprovisioned: false
   tune_aio_events: false
+  tune_ballast_file: false
   tune_clocksource: false
   tune_coredump: false
   tune_cpu: false
@@ -1902,6 +1924,7 @@ func TestSetMode(t *testing.T) {
 				TuneSwappiness:     val,
 				CoredumpDir:        conf.Rpk.CoredumpDir,
 				Overprovisioned:    !val,
+				TuneBallastFile:    val,
 			}
 			return conf
 		}
@@ -2142,7 +2165,7 @@ func TestReadAsJSON(t *testing.T) {
 				return mgr.Write(conf)
 			},
 			path:     Default().ConfigFile,
-			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","pandaproxy":{},"redpanda":{"admin":[{"address":"0.0.0.0","port":9644}],"data_directory":"/var/lib/redpanda/data","developer_mode":true,"kafka_api":[{"address":"0.0.0.0","name":"internal","port":9092}],"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_disk_write_cache":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false},"schema_registry":{}}`,
+			expected: `{"config_file":"/etc/redpanda/redpanda.yaml","pandaproxy":{},"redpanda":{"admin":[{"address":"0.0.0.0","port":9644}],"data_directory":"/var/lib/redpanda/data","developer_mode":true,"kafka_api":[{"address":"0.0.0.0","name":"internal","port":9092}],"node_id":0,"rpc_server":{"address":"0.0.0.0","port":33145},"seed_servers":[]},"rpk":{"coredump_dir":"/var/lib/redpanda/coredump","enable_memory_locking":false,"enable_usage_stats":false,"overprovisioned":false,"tune_aio_events":false,"tune_ballast_file":false,"tune_clocksource":false,"tune_coredump":false,"tune_cpu":false,"tune_disk_irq":false,"tune_disk_nomerges":false,"tune_disk_scheduler":false,"tune_disk_write_cache":false,"tune_fstrim":false,"tune_network":false,"tune_swappiness":false,"tune_transparent_hugepages":false},"schema_registry":{}}`,
 		},
 		{
 			name:           "it should fail if the the config isn't found",
@@ -2207,6 +2230,7 @@ func TestReadFlat(t *testing.T) {
 		"rpk.enable_usage_stats":                       "false",
 		"rpk.overprovisioned":                          "false",
 		"rpk.tune_aio_events":                          "false",
+		"rpk.tune_ballast_file":                        "false",
 		"rpk.tune_clocksource":                         "false",
 		"rpk.tune_coredump":                            "false",
 		"rpk.tune_cpu":                                 "false",

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -131,6 +131,9 @@ type RpkConfig struct {
 	EnableMemoryLocking      bool        `yaml:"enable_memory_locking" mapstructure:"enable_memory_locking" json:"enableMemoryLocking"`
 	TuneCoredump             bool        `yaml:"tune_coredump" mapstructure:"tune_coredump" json:"tuneCoredump"`
 	CoredumpDir              string      `yaml:"coredump_dir,omitempty" mapstructure:"coredump_dir,omitempty" json:"coredumpDir"`
+	TuneBallastFile          bool        `yaml:"tune_ballast_file" mapstructure:"tune_ballast_file" json:"tuneBallastFile"`
+	BallastFilePath          string      `yaml:"ballast_file_path,omitempty" mapstructure:"ballast_file_path,omitempty" json:"ballastFilePath"`
+	BallastFileSize          string      `yaml:"ballast_file_size,omitempty" mapstructure:"ballast_file_size,omitempty" json:"ballastFileSize"`
 	WellKnownIo              string      `yaml:"well_known_io,omitempty" mapstructure:"well_known_io,omitempty" json:"wellKnownIo"`
 	Overprovisioned          bool        `yaml:"overprovisioned" mapstructure:"overprovisioned" json:"overprovisioned"`
 	SMP                      *int        `yaml:"smp,omitempty" mapstructure:"smp,omitempty" json:"smp,omitempty"`

--- a/src/go/rpk/pkg/tuners/ballast/tuner.go
+++ b/src/go/rpk/pkg/tuners/ballast/tuner.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package ballast
 
 import (

--- a/src/go/rpk/pkg/tuners/ballast/tuner.go
+++ b/src/go/rpk/pkg/tuners/ballast/tuner.go
@@ -1,0 +1,70 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package ballast
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/docker/go-units"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners/executors"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners/executors/commands"
+)
+
+type ballastTuner struct {
+	conf     config.Config
+	executor executors.Executor
+}
+
+func NewBallastFileTuner(
+	conf config.Config, executor executors.Executor,
+) tuners.Tunable {
+	return &ballastTuner{conf, executor}
+}
+
+func (t *ballastTuner) Tune() tuners.TuneResult {
+	path := config.DefaultBallastFilePath
+	if t.conf.Rpk.BallastFilePath != "" {
+		path = t.conf.Rpk.BallastFilePath
+	}
+	abspath, err := filepath.Abs(path)
+	if err != nil {
+		return tuners.NewTuneError(fmt.Errorf(
+			"couldn't resolve the absolute file path for %s: %w",
+			path,
+			err,
+		))
+	}
+
+	size := config.DefaultBallastFileSize
+	if t.conf.Rpk.BallastFileSize != "" {
+		size = t.conf.Rpk.BallastFileSize
+	}
+	sizeBytes, err := units.FromHumanSize(size)
+	if err != nil {
+		return tuners.NewTuneError(fmt.Errorf(
+			"'%s' is not a valid size unit.",
+			size,
+		))
+	}
+
+	cmd := commands.NewWriteSizedFileCmd(abspath, sizeBytes)
+	err = t.executor.Execute(cmd)
+	if err != nil {
+		return tuners.NewTuneError(err)
+	}
+	return tuners.NewTuneResult(false)
+}
+
+func (*ballastTuner) CheckIfSupported() (supported bool, reason string) {
+	return true, ""
+}

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
@@ -1,0 +1,83 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+type writeSizedFileCommand struct {
+	path      string
+	sizeBytes int64
+}
+
+// Creates a file of size sizeBytes at the given path.
+// When executed through DirectExecutor, it uses fallocate to create
+// the file. If the file already existed, then it uses ftruncate to shrink it
+// down if needed.
+// The script rendered throug a ScriptRenderingExecutor calls `truncate`,
+// which has the same behavior.
+func NewWriteSizedFileCmd(path string, sizeBytes int64) Command {
+	return &writeSizedFileCommand{path, sizeBytes}
+}
+
+func (c *writeSizedFileCommand) Execute() error {
+	log.Debugf("Creating '%s' (%d B)", c.path, c.sizeBytes)
+
+	// the 'os' package needs to be used instead of 'afero', because the file
+	// handles returned by afero don't have a way to get their file descriptor
+	// (i.e. an Fd() method):
+	// https://github.com/spf13/afero/issues/234
+	f, err := os.OpenFile(c.path, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	err = unix.Fallocate(int(f.Fd()), 0, 0, c.sizeBytes)
+	if err != nil {
+		return fmt.Errorf("could not allocate the requested size while"+
+			" creating the file at '%s': %w",
+			c.path,
+			err,
+		)
+	}
+
+	// If the file already exists, then its current size might be larger than desired.
+	// Use ftruncate to ensure that doesn't happen.
+	err = unix.Ftruncate(int(f.Fd()), c.sizeBytes)
+	if err != nil {
+		return fmt.Errorf("could not resize the file at '%s' to the requested size: %w",
+			c.path,
+			err,
+		)
+	}
+	err = f.Sync()
+	if err != nil {
+		return fmt.Errorf("unable to sync the file at %s: %w", c.path, err)
+	}
+	return nil
+}
+
+func (c *writeSizedFileCommand) RenderScript(w *bufio.Writer) error {
+	// See 'man truncate'.
+	fmt.Fprintf(
+		w,
+		"truncate -s %d %s",
+		c.sizeBytes,
+		c.path,
+	)
+	return w.Flush()
+}

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package commands
 
 import (

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file_test.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package commands_test
 
 import (

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file_test.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file_test.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package commands_test
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners/executors/commands"
+)
+
+func TestWriteSizedFileCmdRender(t *testing.T) {
+	cmd := commands.NewWriteSizedFileCmd(
+		"/some/made/up/filepath.txt",
+		int64(1),
+	)
+
+	expected := "truncate -s 1 /some/made/up/filepath.txt"
+	var buf bytes.Buffer
+
+	w := bufio.NewWriter(&buf)
+	cmd.RenderScript(w)
+	require.NoError(t, w.Flush())
+
+	require.Equal(t, expected, buf.String())
+}

--- a/src/go/rpk/pkg/tuners/factory/factory.go
+++ b/src/go/rpk/pkg/tuners/factory/factory.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package factory
 
 import (

--- a/src/go/rpk/pkg/tuners/factory/factory.go
+++ b/src/go/rpk/pkg/tuners/factory/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Vectorized, Inc.
+// Copyright 2021 Vectorized, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -21,6 +21,7 @@ import (
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/os"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/system"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners/ballast"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners/coredump"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners/cpu"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners/disk"
@@ -44,6 +45,7 @@ var (
 		"swappiness":            (*tunersFactory).newSwappinessTuner,
 		"transparent_hugepages": (*tunersFactory).newTHPTuner,
 		"coredump":              (*tunersFactory).newCoredumpTuner,
+		"ballast_file":          (*tunersFactory).newBallastFileTuner,
 	}
 )
 
@@ -154,6 +156,8 @@ func IsTunerEnabled(tuner string, rpkConfig config.RpkConfig) bool {
 		return rpkConfig.TuneTransparentHugePages
 	case "coredump":
 		return rpkConfig.TuneCoredump
+	case "ballast_file":
+		return rpkConfig.TuneBallastFile
 	}
 	return false
 }
@@ -282,6 +286,12 @@ func (factory *tunersFactory) newCoredumpTuner(
 	params *TunerParams,
 ) tuners.Tunable {
 	return coredump.NewCoredumpTuner(factory.fs, factory.conf, factory.executor)
+}
+
+func (factory *tunersFactory) newBallastFileTuner(
+	params *TunerParams,
+) tuners.Tunable {
+	return ballast.NewBallastFileTuner(factory.conf, factory.executor)
 }
 
 func MergeTunerParamsConfig(

--- a/src/go/rpk/pkg/tuners/factory/factory_test.go
+++ b/src/go/rpk/pkg/tuners/factory/factory_test.go
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+// +build linux
+
 package factory_test
 
 import (

--- a/src/go/rpk/pkg/tuners/redpanda_checkers.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers.go
@@ -59,6 +59,7 @@ const (
 	Swappiness
 	KernelVersion
 	WriteCachePolicyChecker
+	BallastFileChecker
 )
 
 func NewConfigChecker(conf *config.Config) Checker {
@@ -158,6 +159,16 @@ func NewIOConfigFileExistanceChecker(fs afero.Fs, filePath string) Checker {
 		filePath)
 }
 
+func NewBallastFileChecker(fs afero.Fs, conf *config.Config) Checker {
+	return NewFileExistanceChecker(
+		fs,
+		IoConfigFileChecker,
+		"Ballast file present",
+		Warning,
+		conf.Rpk.BallastFilePath,
+	)
+}
+
 func NewNTPSyncChecker(timeout time.Duration, fs afero.Fs) Checker {
 	return NewEqualityChecker(
 		NtpChecker,
@@ -247,6 +258,7 @@ func RedpandaCheckers(
 		ClockSource:                   {NewClockSourceChecker(fs)},
 		Swappiness:                    {NewSwappinessChecker(fs)},
 		KernelVersion:                 {NewKernelVersionChecker(GetKernelVersion)},
+		BallastFileChecker:            {NewBallastFileChecker(fs, config)},
 	}
 
 	v, err := cloud.AvailableVendor()


### PR DESCRIPTION
Add a ballast file tuner, which creates a file (1GiB, in "/var/lib/redpanda/data/ballast.txt" by default) which can be deleted in case the disk gets full, so that the OS can be booted and the root issue troubleshot. It uses `fallocate` which means that even large files will be created quickly.

The tuner can be run by setting `rpk.tune_ballast_file` to `true` in the config file, and the size and path can be changed by setting `rpk.ballast_file_size` and `ballast_file_path`, respectively (the former's values are bytes by default, but it supports multipliers like `3GiB`, `1024MB`, etc). Additionally, when running `rpk redpanda tune` directly, `ballast_file` can be passed along with the list of tuners too.

If `--output-script` is passed when running `rpk redpanda tune`, the tuner will add the following to the script (size and path depend on their corresponding config fields):

```sh
truncate -s 100000000 /var/lib/redpanda/data/ballast
```
