### PR TITLE
task: Fix rpk build command

### DIFF
--- a/taskfiles/rpk.yml
+++ b/taskfiles/rpk.yml
@@ -55,6 +55,6 @@ tasks:
         cmd="$cmd -count=1"
       fi
       if [ '{{.FILTER}}' != '' ]; then
-        cmd="$cmd: -run {{.FILTER}}"
+        cmd="$cmd -run {{.FILTER}}"
       fi
       $cmd


### PR DESCRIPTION
Remove a colon that was making the `rpk:build` task fail when `FILTER` was provided.