### PR TITLE
rpk/config: Don't clear config objects in rpk's configuration

### DIFF
--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -159,10 +159,15 @@ func setDevelopment(conf *Config) *Config {
 	conf.Redpanda.DeveloperMode = true
 	// Defaults to setting all tuners to false
 	conf.Rpk = RpkConfig{
-		EnableUsageStats: conf.Rpk.EnableUsageStats,
-		CoredumpDir:      conf.Rpk.CoredumpDir,
-		SMP:              Default().Rpk.SMP,
-		Overprovisioned:  true,
+		TLS:                  conf.Rpk.TLS,
+		SASL:                 conf.Rpk.SASL,
+		KafkaApi:             conf.Rpk.KafkaApi,
+		AdminApi:             conf.Rpk.AdminApi,
+		AdditionalStartFlags: conf.Rpk.AdditionalStartFlags,
+		EnableUsageStats:     conf.Rpk.EnableUsageStats,
+		CoredumpDir:          conf.Rpk.CoredumpDir,
+		SMP:                  Default().Rpk.SMP,
+		Overprovisioned:      true,
 	}
 	return conf
 }


### PR DESCRIPTION
As rpk has evolved, some object fields have been added to its section in the config file. Those objects, which contain TLS & SASL configs among others, shouldn't be overwritten when the mode changes.
