### PR TITLE
Rpk: Use the Admin API addresses provided in the config file

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -80,6 +80,6 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 	command.AddCommand(acl.NewCreateACLsCommand(adminClosure))
 	command.AddCommand(acl.NewListACLsCommand(adminClosure))
 	command.AddCommand(acl.NewDeleteACLsCommand(adminClosure))
-	command.AddCommand(acl.NewUserCommand(adminTlsClosure))
+	command.AddCommand(acl.NewUserCommand(configClosure, adminTlsClosure))
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -211,6 +211,53 @@ func DeduceBrokers(
 	}
 }
 
+func DeduceAdminApiAddrs(
+	configuration func() (*config.Config, error), addresses *[]string,
+) []string {
+	defaultAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(config.DefaultAdminPort))
+	defaultAddrs := []string{defaultAddr}
+	as := *addresses
+	// Prioritize addresses passed through the flag
+	if len(as) != 0 {
+		log.Debugf("Using Admin API addresses: %s", strings.Join(as, ", "))
+		return as
+	}
+	// If no values were passed directly, look for the env vars.
+	envVar := "REDPANDA_API_ADMIN_ADDRS"
+	envAddrs := os.Getenv(envVar)
+	if envAddrs != "" {
+		log.Debugf("Using %s: %s", envVar, envAddrs)
+		return strings.Split(envAddrs, ",")
+	}
+
+	// Otherwise, try to find an existing config file.
+	conf, err := configuration()
+	if err != nil {
+		log.Debugf(
+			"Couldn't read the config file."+
+				" Assuming Admin API address %s.", defaultAddr,
+		)
+		log.Debug(err)
+		return defaultAddrs
+	}
+
+	// Check rpk.admin_api.addresses
+	if len(conf.Rpk.AdminApi.Addresses) == 0 {
+		// If empty, return the default address
+		log.Debugf(
+			"Empty rpk.admin_api.addresses. Assuming  %s.",
+			defaultAddr,
+		)
+		return defaultAddrs
+	}
+
+	log.Debugf(
+		"Using rpk.admin_api.addresses: %s",
+		strings.Join(conf.Rpk.AdminApi.Addresses, ", "),
+	)
+	return conf.Rpk.AdminApi.Addresses
+}
+
 func CreateProducer(
 	brokers func() []string,
 	configuration func() (*config.Config, error),

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -187,6 +187,91 @@ func TestDeduceBrokers(t *testing.T) {
 	}
 }
 
+func TestDeduceAdminApiAddrs(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   func() (*config.Config, error)
+		addrs    []string
+		before   func()
+		cleanup  func()
+		expected []string
+	}{
+		{
+			name: "it should prioritize the flag value over the env vars & config",
+			config: func() (*config.Config, error) {
+				conf := config.Default()
+				conf.Redpanda.AdminApi = []config.NamedSocketAddress{{
+					SocketAddress: config.SocketAddress{"192.168.76.54", 33146},
+				}}
+				return conf, nil
+			},
+			before: func() {
+				os.Setenv("REDPANDA_API_ADMIN_ADDRS", "192.168.34.12:33145,123.4.5.78:33145")
+			},
+			cleanup: func() {
+				os.Unsetenv("REDPANDA_API_ADMIN_ADDRS")
+			},
+			addrs:    []string{"192.168.34.12:33145"},
+			expected: []string{"192.168.34.12:33145"},
+		}, {
+			name: "it should prioritize the env var over the config",
+			config: func() (*config.Config, error) {
+				conf := config.Default()
+				conf.Redpanda.AdminApi = []config.NamedSocketAddress{{
+					SocketAddress: config.SocketAddress{"192.168.76.54", 9466},
+				}}
+				return conf, nil
+			},
+			before: func() {
+				os.Setenv("REDPANDA_API_ADMIN_ADDRS", "192.168.34.12:33145,123.4.5.78:33145")
+			},
+			cleanup: func() {
+				os.Unsetenv("REDPANDA_API_ADMIN_ADDRS")
+			},
+			expected: []string{"192.168.34.12:33145", "123.4.5.78:33145"},
+		}, {
+			name: "it should prioritize rpk.admin_api.addresses over redpanda.admin_api",
+			config: func() (*config.Config, error) {
+				conf := config.Default()
+				conf.Rpk.AdminApi.Addresses = []string{
+					"192.168.67.54:9644",
+					"192.168.67.55:9644",
+					"192.168.67.56:9644",
+				}
+				return conf, nil
+			},
+			expected: []string{
+				"192.168.67.54:9644",
+				"192.168.67.55:9644",
+				"192.168.67.56:9644",
+			},
+		}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			if tt.before != nil {
+				tt.before()
+			}
+			if tt.cleanup != nil {
+				defer tt.cleanup()
+			}
+			conf := func() (*config.Config, error) {
+				return config.Default(), nil
+			}
+			if tt.config != nil {
+				conf = tt.config
+			}
+
+			addrs := &[]string{}
+
+			if tt.addrs != nil {
+				addrs = &tt.addrs
+			}
+			as := DeduceAdminApiAddrs(conf, addrs)
+			require.Exactly(st, tt.expected, as)
+		})
+	}
+}
+
 func TestAddKafkaFlags(t *testing.T) {
 	var (
 		brokers        []string

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1949,7 +1949,7 @@ func TestSetMode(t *testing.T) {
 			startingConf: func() *Config {
 				conf := Default()
 				conf.Rpk.AdminApi = RpkAdminApi{
-					Addresses: []SocketAddress{{Address: "some.addr.com", Port: 33145}},
+					Addresses: []string{"some.addr.com:33145"},
 				}
 				conf.Rpk.KafkaApi = RpkKafkaApi{
 					Brokers: []string{"192.168.76.54:9092"},
@@ -1965,7 +1965,7 @@ func TestSetMode(t *testing.T) {
 			expectedConfig: func() *Config {
 				conf := fillRpkConfig(ModeProd)()
 				conf.Rpk.AdminApi = RpkAdminApi{
-					Addresses: []SocketAddress{{Address: "some.addr.com", Port: 33145}},
+					Addresses: []string{"some.addr.com:33145"},
 				}
 				conf.Rpk.KafkaApi = RpkKafkaApi{
 					Brokers: []string{"192.168.76.54:9092"},

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -142,8 +142,8 @@ type RpkKafkaApi struct {
 }
 
 type RpkAdminApi struct {
-	Addresses []SocketAddress `yaml:"addresses,omitempty" mapstructure:"addresses,omitempty" json:"addresses"`
-	TLS       *TLS            `yaml:"tls,omitempty" mapstructure:"tls,omitempty" json:"tls"`
+	Addresses []string `yaml:"addresses,omitempty" mapstructure:"addresses,omitempty" json:"addresses"`
+	TLS       *TLS     `yaml:"tls,omitempty" mapstructure:"tls,omitempty" json:"tls"`
 }
 
 type SASL struct {


### PR DESCRIPTION
- Make rpk.admin_api.addresses a list of strings: In the previous changeset that introduced the `rpk.kafka_api` and`rpk.admin_api` config fields, it was agreed that the lists of addresses should be represented as lists of strings instead ofobjects with separate "address" and "port" fields, since it's easier for the users and there's no internal technical requirementor restriction that implies it. `rpk.kafka_api.brokers` was changed but `rpk.admin_api.addresses` was not.
- Check the config for admin API addresses: If the flag wasn't set, check the env vars and the config for the list of Admin API addresses that rpk should use.

