### PR TITLE
Fixed moving committed offset backward

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -248,8 +248,11 @@ ss::future<> segment::do_flush() {
     auto o = _tracker.dirty_offset;
     auto fsize = _appender->file_byte_offset();
     return _appender->flush().then([this, o, fsize] {
-        _tracker.committed_offset = o;
-        _tracker.stable_offset = o;
+        // never move committed offset backward, there may be multiple
+        // outstanding flushes once the one executed later in terms of offset
+        // finishes we guarantee that all previous flushes finished.
+        _tracker.committed_offset = std::max(o, _tracker.committed_offset);
+        _tracker.stable_offset = _tracker.committed_offset;
         _reader.set_file_size(fsize);
     });
 }


### PR DESCRIPTION
## Cover letter

    Recent changes in segment appender made it possible to have multiple
    concurrent appender flush operations pending. This lead to a race
    condition in which flush with was dispatched earlier in terms of log
    offset was finished after later one and caused committed offset to move
    backward. This led to the situation in which caller after storing offset
    and then executed `log::flush` operation observed committed offset
    smaller than the one which was previously appended to the log.

    Example:   
 ```
    [fiber 1] append -> received offset 10
    [fiber 2] append -> received offset 12
    [fiber 2] dispatch flush
    [fiber 1] dispatch flush
    [fiber 2] flush and update committed offset to 12
    [fiber 1] flush and update committed offset to 10
    [fiber 2] check if committed offset is >= 12 <--- inconsistency
```
Fixes: #NNN, #NNN, ...

## Release notes

- fixed acks=-1 replication error leading to a deadlock
