### PR TITLE
Updating config after join

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -129,7 +129,7 @@ ss::future<> maybe_create_tcp_client(
                     .disable_metrics = rpc::metrics_disabled(
                       config::shard_local_cfg().disable_metrics)},
                   rpc::make_exponential_backoff_policy<rpc::clock_type>(
-                    std::chrono::seconds(1), std::chrono::seconds(60)));
+                    std::chrono::seconds(1), std::chrono::seconds(15)));
             });
     });
 }

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -358,6 +358,18 @@ void members_manager::join_raft0() {
                            _join_retry_jitter.next_duration(), _as.local())
                     .then([] { return ss::stop_iteration::no; });
               });
+        })
+        .then([this] {
+            if (is_already_member()) {
+                return maybe_update_current_node_configuration();
+            }
+            return ss::now();
+        })
+        .handle_exception_type([](const ss::gate_closed_exception& e) {
+            vlog(
+              clusterlog.debug,
+              "unable to update node configuration, gate closed - {}",
+              e);
         });
     });
 }


### PR DESCRIPTION
## Cover letter

When node tries to join the cluster it may happen that it was already part of it but the node data folder was wiped out. In this scenario node with removed data will try to join the cluster until it will receive updates from rest of the nodes. After this update is received node that is trying to join the cluster will stop joining procedure since it is already a cluster member. After that joining node must check if configuration update is require since its configuration might have been changed.

Fixes: #1834 

## Release notes

Release note: [1-2 sentences of what this PR changes]
