### PR TITLE
kafka: ignore admin api when tracking request latency

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -207,91 +207,87 @@ connection_context::reserve_request_units(size_t size) {
 
 ss::future<>
 connection_context::dispatch_method_once(request_header hdr, size_t size) {
-    return throttle_request(hdr, size)
-      .then([this, hdr = std::move(hdr), size](session_resources sres) mutable {
-          if (_rs.abort_requested()) {
-              // protect against shutdown behavior
-              return ss::make_ready_future<>();
-          }
-          auto remaining = size - sizeof(raw_request_header)
-                           - hdr.client_id_buffer.size();
-          return read_iobuf_exactly(_rs.conn->input(), remaining)
-            .then([this, hdr = std::move(hdr), sres = std::move(sres)](
-                    iobuf buf) mutable {
-                if (_rs.abort_requested()) {
-                    // _proto._cntrl etc might not be alive
-                    return ss::now();
-                }
-                auto self = shared_from_this();
-                auto rctx = request_context(
-                  self,
-                  std::move(hdr),
-                  std::move(buf),
-                  sres.backpressure_delay);
-                /*
-                 * we process requests in order since all subsequent requests
-                 * are dependent on authentication having completed.
-                 *
-                 * the other important reason for disabling pipeling is because
-                 * when a sasl handshake with version=0 is processed, the next
-                 * data on the wire is _not_ another request: it is a
-                 * size-prefixed authentication payload without a request
-                 * envelope, and requires special handling.
-                 *
-                 * a well behaved client should implicitly provide a data stream
-                 * that invokes this behavior in the server: that is, it won't
-                 * send auth data (or any other requests) until handshake or the
-                 * full auth-process completes, etc... but representing these
-                 * nuances of the protocol _explicitly_ in the server makes its
-                 * behavior easier to understand and avoids misbehaving clients
-                 * creating server-side errors that will appear as a corrupted
-                 * stream at best and at worst some odd behavior.
-                 */
+    return throttle_request(hdr, size).then([this, hdr = std::move(hdr), size](
+                                              session_resources sres) mutable {
+        if (_rs.abort_requested()) {
+            // protect against shutdown behavior
+            return ss::make_ready_future<>();
+        }
+        auto remaining = size - sizeof(raw_request_header)
+                         - hdr.client_id_buffer.size();
+        return read_iobuf_exactly(_rs.conn->input(), remaining)
+          .then([this, hdr = std::move(hdr), sres = std::move(sres)](
+                  iobuf buf) mutable {
+              if (_rs.abort_requested()) {
+                  // _proto._cntrl etc might not be alive
+                  return ss::now();
+              }
+              auto self = shared_from_this();
+              auto rctx = request_context(
+                self, std::move(hdr), std::move(buf), sres.backpressure_delay);
+              /*
+               * we process requests in order since all subsequent requests
+               * are dependent on authentication having completed.
+               *
+               * the other important reason for disabling pipeling is because
+               * when a sasl handshake with version=0 is processed, the next
+               * data on the wire is _not_ another request: it is a
+               * size-prefixed authentication payload without a request
+               * envelope, and requires special handling.
+               *
+               * a well behaved client should implicitly provide a data stream
+               * that invokes this behavior in the server: that is, it won't
+               * send auth data (or any other requests) until handshake or the
+               * full auth-process completes, etc... but representing these
+               * nuances of the protocol _explicitly_ in the server makes its
+               * behavior easier to understand and avoids misbehaving clients
+               * creating server-side errors that will appear as a corrupted
+               * stream at best and at worst some odd behavior.
+               */
 
-                const auto correlation = rctx.header().correlation;
-                const sequence_id seq = _seq_idx;
-                _seq_idx = _seq_idx + sequence_id(1);
-                auto res = kafka::process_request(
-                  std::move(rctx), _proto.smp_group());
-                /**
-                 * first stage processed in a foreground.
-                 */
-                return res.dispatched
-                  .then([this,
-                         f = std::move(res.response),
-                         seq,
-                         correlation,
-                         self,
-                         s = std::move(sres)]() mutable {
-                      /**
-                       * second stage processed in background.
-                       */
-                      (void)ss::try_with_gate(
-                        _rs.conn_gate(),
-                        [this, f = std::move(f), seq, correlation]() mutable {
-                            return f.then(
-                              [this, seq, correlation](response_ptr r) mutable {
-                                  r->set_correlation(correlation);
-                                  _responses.insert({seq, std::move(r)});
-                                  return process_next_response();
-                              });
-                        })
-                        .handle_exception([self](std::exception_ptr e) {
-                            vlog(
-                              klog.info,
-                              "Detected error processing request: {}",
-                              e);
-                            self->_rs.conn->shutdown_input();
-                        })
-                        .finally([s = std::move(s), self] {});
-                  })
-                  .handle_exception([self](std::exception_ptr e) {
-                      vlog(
-                        klog.info, "Detected error processing request: {}", e);
-                      self->_rs.conn->shutdown_input();
-                  });
-            });
-      });
+              const auto correlation = rctx.header().correlation;
+              const sequence_id seq = _seq_idx;
+              _seq_idx = _seq_idx + sequence_id(1);
+              auto res = kafka::process_request(
+                std::move(rctx), _proto.smp_group());
+              /**
+               * first stage processed in a foreground.
+               */
+              return res.dispatched
+                .then([this,
+                       f = std::move(res.response),
+                       seq,
+                       correlation,
+                       self,
+                       s = std::move(sres)]() mutable {
+                    /**
+                     * second stage processed in background.
+                     */
+                    (void)ss::try_with_gate(
+                      _rs.conn_gate(),
+                      [this, f = std::move(f), seq, correlation]() mutable {
+                          return f.then(
+                            [this, seq, correlation](response_ptr r) mutable {
+                                r->set_correlation(correlation);
+                                _responses.insert({seq, std::move(r)});
+                                return process_next_response();
+                            });
+                      })
+                      .handle_exception([self](std::exception_ptr e) {
+                          vlog(
+                            klog.info,
+                            "Detected error processing request: {}",
+                            e);
+                          self->_rs.conn->shutdown_input();
+                      })
+                      .finally([s = std::move(s), self] {});
+                })
+                .handle_exception([self](std::exception_ptr e) {
+                    vlog(klog.info, "Detected error processing request: {}", e);
+                    self->_rs.conn->shutdown_input();
+                });
+          });
+    });
 }
 
 ss::future<> connection_context::process_next_response() {

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -90,7 +90,7 @@ private:
 
     /// apply correct backpressure sequence
     ss::future<session_resources>
-    throttle_request(std::optional<std::string_view>, size_t sz);
+    throttle_request(const request_header&, size_t sz);
 
     ss::future<> dispatch_method_once(request_header, size_t sz);
     ss::future<> process_next_response();

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -186,4 +186,6 @@ private:
 // Executes the API call identified by the specified request_context.
 process_result_stages process_request(request_context&&, ss::smp_service_group);
 
+bool track_latency(api_key);
+
 } // namespace kafka

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -199,6 +199,32 @@ handle_auth(request_context&& ctx, ss::smp_service_group g) {
     }
 }
 
+// do not track latency for admin apis
+bool track_latency(api_key key) {
+    switch (key) {
+    case metadata_handler::api::key:
+    case list_offsets_handler::api::key:
+    case list_groups_handler::api::key:
+    case api_versions_handler::api::key:
+    case create_topics_handler::api::key:
+    case describe_configs_handler::api::key:
+    case alter_configs_handler::api::key:
+    case delete_topics_handler::api::key:
+    case describe_groups_handler::api::key:
+    case sasl_handshake_handler::api::key:
+    case sasl_authenticate_handler::api::key:
+    case incremental_alter_configs_handler::api::key:
+    case delete_groups_handler::api::key:
+    case describe_acls_handler::api::key:
+    case describe_log_dirs_handler::api::key:
+    case create_acls_handler::api::key:
+    case delete_acls_handler::api::key:
+        return false;
+    default:
+        return true;
+    }
+}
+
 process_result_stages
 process_request(request_context&& ctx, ss::smp_service_group g) {
     /*


### PR DESCRIPTION
When tracking latency for kafka requests filter out admin APIs like create topic, etc...

Fixes: https://github.com/vectorizedio/redpanda/issues/1835