### PR TITLE
rpk: Use net.JoinHostPort to support IPv6

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -13,7 +13,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/Shopify/sarama"
@@ -187,19 +189,17 @@ func DeduceBrokers(
 		}
 		// Add the seed servers' Kafka addrs.
 		for _, b := range conf.Redpanda.SeedServers {
-			addr := fmt.Sprintf(
-				"%s:%d",
+			addr := net.JoinHostPort(
 				b.Host.Address,
-				b.Host.Port,
+				strconv.Itoa(b.Host.Port),
 			)
 			bs = append(bs, addr)
 		}
 		if len(conf.Redpanda.KafkaApi) > 0 {
 			// Add the current node's 1st Kafka listener.
-			selfAddr := fmt.Sprintf(
-				"%s:%d",
+			selfAddr := net.JoinHostPort(
 				conf.Redpanda.KafkaApi[0].Address,
-				conf.Redpanda.KafkaApi[0].Port,
+				strconv.Itoa(conf.Redpanda.KafkaApi[0].Port),
 			)
 			bs = append(bs, selfAddr)
 		}

--- a/src/go/rpk/pkg/cli/cmd/container/start.go
+++ b/src/go/rpk/pkg/cli/cmd/container/start.go
@@ -13,7 +13,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -25,7 +27,7 @@ import (
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/ui"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
-	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/net"
+	vnet "github.com/vectorizedio/redpanda/src/go/rpk/pkg/net"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -173,23 +175,23 @@ func startCluster(
 
 	// Start a seed node.
 	seedID := uint(0)
-	seedKafkaPort, err := net.GetFreePort()
+	seedKafkaPort, err := vnet.GetFreePort()
 	if err != nil {
 		return err
 	}
-	seedProxyPort, err := net.GetFreePort()
+	seedProxyPort, err := vnet.GetFreePort()
 	if err != nil {
 		return err
 	}
-	seedSchemaRegPort, err := net.GetFreePort()
+	seedSchemaRegPort, err := vnet.GetFreePort()
 	if err != nil {
 		return err
 	}
-	seedRPCPort, err := net.GetFreePort()
+	seedRPCPort, err := vnet.GetFreePort()
 	if err != nil {
 		return err
 	}
-	seedMetricsPort, err := net.GetFreePort()
+	seedMetricsPort, err := vnet.GetFreePort()
 	if err != nil {
 		return err
 	}
@@ -232,32 +234,31 @@ func startCluster(
 	for nodeID := uint(1); nodeID < n; nodeID++ {
 		id := nodeID
 		grp.Go(func() error {
-			kafkaPort, err := net.GetFreePort()
+			kafkaPort, err := vnet.GetFreePort()
 			if err != nil {
 				return err
 			}
-			proxyPort, err := net.GetFreePort()
+			proxyPort, err := vnet.GetFreePort()
 			if err != nil {
 				return err
 			}
-			schemaRegPort, err := net.GetFreePort()
+			schemaRegPort, err := vnet.GetFreePort()
 			if err != nil {
 				return err
 			}
-			rpcPort, err := net.GetFreePort()
+			rpcPort, err := vnet.GetFreePort()
 			if err != nil {
 				return err
 			}
-			metricsPort, err := net.GetFreePort()
+			metricsPort, err := vnet.GetFreePort()
 			if err != nil {
 				return err
 			}
 			args := []string{
 				"--seeds",
-				fmt.Sprintf(
-					"%s:%d",
+				net.JoinHostPort(
 					seedState.ContainerIP,
-					config.Default().Redpanda.RPCServer.Port,
+					strconv.Itoa(config.Default().Redpanda.RPCServer.Port),
 				),
 			}
 			state, err := common.CreateNode(

--- a/src/go/rpk/pkg/cli/cmd/debug/info.go
+++ b/src/go/rpk/pkg/cli/cmd/debug/info.go
@@ -12,6 +12,7 @@ package debug
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -275,10 +276,9 @@ func getKafkaInfo(
 		kafkaInfoCh <- kInfo
 		return nil
 	}
-	addr := fmt.Sprintf(
-		"%s:%d",
+	addr := net.JoinHostPort(
 		conf.Redpanda.KafkaApi[0].Address,
-		conf.Redpanda.KafkaApi[0].Port,
+		strconv.Itoa(conf.Redpanda.KafkaApi[0].Port),
 	)
 	var tlsConfig *tls.Config
 	var t *config.TLS

--- a/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
@@ -11,6 +11,7 @@ package generate
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -148,7 +149,7 @@ func renderConfig(jobName string, targets []string) ([]byte, error) {
 
 func discoverHosts(url string, port int) ([]string, error) {
 	hosts := []string{}
-	addr := fmt.Sprintf("%s:%d", url, port)
+	addr := net.JoinHostPort(url, strconv.Itoa(port))
 	client, err := kafka.InitClient(addr)
 	if err != nil {
 		return hosts, err
@@ -159,7 +160,10 @@ func discoverHosts(url string, port int) ([]string, error) {
 		if err != nil {
 			return hosts, err
 		}
-		hosts = append(hosts, fmt.Sprintf("%s:%d", host, 9644))
+		hosts = append(
+			hosts,
+			net.JoinHostPort(host, strconv.Itoa(config.DefaultAdminPort)),
+		)
 	}
 	return hosts, nil
 }

--- a/src/go/rpk/pkg/config/manager.go
+++ b/src/go/rpk/pkg/config/manager.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	fp "path/filepath"
@@ -171,10 +172,9 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 			}
 			for i, s := range *seeds {
 				key := fmt.Sprintf("%s.%d", k, i)
-				flatMap[key] = fmt.Sprintf(
-					"%s:%d",
+				flatMap[key] = net.JoinHostPort(
 					s.Host.Address,
-					s.Host.Port,
+					strconv.Itoa(s.Host.Port),
 				)
 			}
 			continue
@@ -187,10 +187,9 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 			}
 			for i, a := range addrs {
 				key := fmt.Sprintf("%s.%d", k, i)
-				str := fmt.Sprintf(
-					"%s:%d",
+				str := net.JoinHostPort(
 					a.Address,
-					a.Port,
+					strconv.Itoa(a.Port),
 				)
 				if a.Name != "" {
 					str = fmt.Sprintf("%s://%s", a.Name, str)
@@ -231,7 +230,7 @@ func (m *manager) ReadFlat(path string) (map[string]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		flatMap[k] = fmt.Sprintf("%s:%d", sa.Address, sa.Port)
+		flatMap[k] = net.JoinHostPort(sa.Address, strconv.Itoa(sa.Port))
 	}
 	return flatMap, nil
 }


### PR DESCRIPTION
`fmt.Sprintf("%s:%d", host, port)` doesn't work for IPv6, so use `net.JoinHostPort` instead.