### PR TITLE
Use lazy-loading of rm_stm's snapshot to avoid resource leak

### DIFF
--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -106,8 +106,8 @@ public:
     wait_no_throw(model::offset offset, model::timeout_clock::duration);
 
 protected:
-    virtual void load_snapshot(stm_snapshot_header, iobuf&&) = 0;
-    virtual stm_snapshot take_snapshot() = 0;
+    virtual ss::future<> load_snapshot(stm_snapshot_header, iobuf&&) = 0;
+    virtual ss::future<stm_snapshot> take_snapshot() = 0;
     ss::future<> hydrate_snapshot(storage::snapshot_reader&);
     ss::future<> wait_for_snapshot_hydrated();
     ss::future<> persist_snapshot(stm_snapshot&&);

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -123,7 +123,7 @@ protected:
     model::term_id _insync_term;
     model::offset _insync_offset;
     raft::consensus* _c;
-    storage::snapshot_manager _snapshot_mgr;
+    storage::simple_snapshot_manager _snapshot_mgr;
     ss::logger& _log;
     model::violation_recovery_policy _snapshot_recovery_policy;
 };

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -172,11 +172,17 @@ rm_stm::rm_stm(
   , _oldest_session(model::timestamp::now())
   , _sync_timeout(config::shard_local_cfg().rm_sync_timeout_ms.value())
   , _tx_timeout_delay(config::shard_local_cfg().tx_timeout_delay_ms.value())
+  , _abort_index_segment_size(
+      config::shard_local_cfg().abort_index_segment_size.value())
   , _recovery_policy(
       config::shard_local_cfg().rm_violation_recovery_policy.value())
   , _transactional_id_expiration(
       config::shard_local_cfg().transactional_id_expiration_ms.value())
-  , _tx_gateway_frontend(tx_gateway_frontend) {
+  , _tx_gateway_frontend(tx_gateway_frontend)
+  , _abort_snapshot_mgr(
+      "abort.idx",
+      std::filesystem::path(c->log_config().work_directory()),
+      ss::default_priority_class()) {
     if (_recovery_policy != crash && _recovery_policy != best_effort) {
         vassert(false, "Unknown recovery policy: {}", _recovery_policy);
     }
@@ -750,18 +756,46 @@ model::offset rm_stm::last_stable_offset() {
     return raft::details::next_offset(last_visible_index);
 }
 
-ss::future<std::vector<rm_stm::tx_range>>
-rm_stm::aborted_transactions(model::offset from, model::offset to) {
-    std::vector<rm_stm::tx_range> result;
-    for (auto& range : _log_state.aborted) {
+static void filter_intersecting(
+  std::vector<rm_stm::tx_range>& target,
+  const std::vector<rm_stm::tx_range>& source,
+  model::offset from,
+  model::offset to) {
+    for (auto& range : source) {
         if (range.last < from) {
             continue;
         }
         if (range.first > to) {
             continue;
         }
-        result.push_back(range);
+        target.push_back(range);
     }
+}
+
+ss::future<std::vector<rm_stm::tx_range>>
+rm_stm::aborted_transactions(model::offset from, model::offset to) {
+    std::vector<rm_stm::tx_range> result;
+
+    for (auto& idx : _log_state.abort_indexes) {
+        if (idx.last < from) {
+            continue;
+        }
+        if (idx.first > to) {
+            continue;
+        }
+        std::optional<abort_snapshot> opt;
+        if (_log_state.last_abort_snapshot.match(idx)) {
+            opt = _log_state.last_abort_snapshot;
+        } else {
+            opt = co_await load_abort_snapshot(idx);
+        }
+        if (opt) {
+            filter_intersecting(result, opt->aborted, from, to);
+        }
+    }
+
+    filter_intersecting(result, _log_state.aborted, from, to);
+
     co_return result;
 }
 
@@ -1026,7 +1060,7 @@ ss::future<> rm_stm::apply(model::record_batch b) {
     } else if (hdr.type == model::record_batch_type::raft_data) {
         auto bid = model::batch_identity::from(hdr);
         if (hdr.attrs.is_control()) {
-            apply_control(bid.pid, parse_control_batch(b));
+            co_await apply_control(bid.pid, parse_control_batch(b));
         } else {
             apply_data(bid, last_offset);
         }
@@ -1034,7 +1068,6 @@ ss::future<> rm_stm::apply(model::record_batch b) {
 
     compact_snapshot();
     _insync_offset = last_offset;
-    return ss::now();
 }
 
 void rm_stm::apply_prepare(rm_stm::prepare_marker prepare) {
@@ -1044,7 +1077,7 @@ void rm_stm::apply_prepare(rm_stm::prepare_marker prepare) {
     _mem_state.preparing.erase(pid);
 }
 
-void rm_stm::apply_control(
+ss::future<> rm_stm::apply_control(
   model::producer_identity pid, model::control_record_type crt) {
     // either epoch is the same as fencing or it's lesser in the latter
     // case we don't fence off aborts and commits because transactional
@@ -1061,6 +1094,10 @@ void rm_stm::apply_control(
         }
 
         _mem_state.forget(pid);
+
+        if (_log_state.aborted.size() > _abort_index_segment_size) {
+            co_await make_snapshot();
+        }
     } else if (crt == model::control_record_type::tx_commit) {
         _log_state.prepared.erase(pid);
         auto offset_it = _log_state.ongoing_map.find(pid);
@@ -1071,6 +1108,8 @@ void rm_stm::apply_control(
 
         _mem_state.forget(pid);
     }
+
+    co_return;
 }
 
 void rm_stm::apply_data(model::batch_identity bid, model::offset last_offset) {
@@ -1148,6 +1187,10 @@ ss::future<> rm_stm::load_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
       _log_state.aborted.end(),
       std::make_move_iterator(data.aborted.begin()),
       std::make_move_iterator(data.aborted.end()));
+    _log_state.abort_indexes.insert(
+      _log_state.abort_indexes.end(),
+      std::make_move_iterator(data.abort_indexes.begin()),
+      std::make_move_iterator(data.abort_indexes.end()));
     for (auto& entry : data.seqs) {
         auto [seq_it, _] = _log_state.seq_table.try_emplace(entry.pid, entry);
         if (seq_it->second.seq < entry.seq) {
@@ -1155,13 +1198,48 @@ ss::future<> rm_stm::load_snapshot(stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
         }
     }
 
+    abort_index last{.last = model::offset(-1)};
+    for (auto& entry : _log_state.abort_indexes) {
+        if (entry.last > last.last) {
+            last = entry;
+        }
+    }
+    if (last.last > model::offset(0)) {
+        auto snapshot_opt = co_await load_abort_snapshot(last);
+        if (snapshot_opt) {
+            _log_state.last_abort_snapshot = snapshot_opt.value();
+        }
+    }
+
     _last_snapshot_offset = data.offset;
     _insync_offset = data.offset;
-
-    return ss::now();
 }
 
 ss::future<stm_snapshot> rm_stm::take_snapshot() {
+    if (_log_state.aborted.size() > _abort_index_segment_size) {
+        std::sort(
+          std::begin(_log_state.aborted),
+          std::end(_log_state.aborted),
+          [](tx_range a, tx_range b) { return a.first < b.first; });
+
+        abort_snapshot snapshot{
+          .first = model::offset::max(), .last = model::offset::min()};
+        for (auto const& entry : _log_state.aborted) {
+            snapshot.first = std::min(snapshot.first, entry.first);
+            snapshot.last = std::max(snapshot.last, entry.last);
+            snapshot.aborted.push_back(entry);
+            if (snapshot.aborted.size() == _abort_index_segment_size) {
+                auto idx = abort_index{
+                  .first = snapshot.first, .last = snapshot.last};
+                _log_state.abort_indexes.push_back(idx);
+                co_await save_abort_snapshot(snapshot);
+                snapshot = abort_snapshot{
+                  .first = model::offset::max(), .last = model::offset::min()};
+            }
+        }
+        _log_state.aborted = snapshot.aborted;
+    }
+
     tx_snapshot tx_ss;
 
     for (auto const& [k, v] : _log_state.fence_pid_epoch) {
@@ -1176,6 +1254,9 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
     }
     for (auto& entry : _log_state.aborted) {
         tx_ss.aborted.push_back(entry);
+    }
+    for (auto& entry : _log_state.abort_indexes) {
+        tx_ss.abort_indexes.push_back(entry);
     }
     for (auto& entry : _log_state.seq_table) {
         tx_ss.seqs.push_back(entry.second);
@@ -1194,6 +1275,61 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
     stx_ss.offset = _insync_offset;
     stx_ss.data = std::move(tx_ss_buf);
     co_return stx_ss;
+}
+
+ss::future<> rm_stm::save_abort_snapshot(abort_snapshot snapshot) {
+    iobuf snapshot_data;
+    reflection::adl<abort_snapshot>{}.to(snapshot_data, snapshot);
+    int32_t snapshot_size = snapshot_data.size_bytes();
+
+    auto filename = fmt::format(
+      "abort.idx.{}.{}", snapshot.first, snapshot.last);
+    auto writer = co_await _abort_snapshot_mgr.start_snapshot(filename);
+
+    iobuf metadata_buf;
+    reflection::serialize(metadata_buf, abort_snapshot_version, snapshot_size);
+    co_await writer.write_metadata(std::move(metadata_buf));
+    co_await write_iobuf_to_output_stream(
+      std::move(snapshot_data), writer.output());
+    co_await writer.close();
+    co_await _abort_snapshot_mgr.finish_snapshot(writer);
+}
+
+ss::future<std::optional<rm_stm::abort_snapshot>>
+rm_stm::load_abort_snapshot(abort_index index) {
+    auto filename = fmt::format("abort.idx.{}.{}", index.first, index.last);
+
+    auto reader = co_await _abort_snapshot_mgr.open_snapshot(filename);
+    if (!reader) {
+        co_return std::nullopt;
+    }
+
+    auto meta_buf = co_await reader->read_metadata();
+    iobuf_parser meta_parser(std::move(meta_buf));
+
+    auto version = reflection::adl<int8_t>{}.from(meta_parser);
+    vassert(
+      version == abort_snapshot_version,
+      "Only support abort_snapshot_version {} but got {}",
+      abort_snapshot_version,
+      version);
+
+    auto snapshot_size = reflection::adl<int32_t>{}.from(meta_parser);
+    vassert(
+      meta_parser.bytes_left() == 0,
+      "Not all metadata content of {} were consumed, {} bytes left. "
+      "This is an indication of the serialization save/load mismatch",
+      filename,
+      meta_parser.bytes_left());
+
+    auto data_buf = co_await read_iobuf_exactly(reader->input(), snapshot_size);
+    co_await reader->close();
+    co_await _abort_snapshot_mgr.remove_partial_snapshots();
+
+    iobuf_parser data_parser(std::move(data_buf));
+    auto data = reflection::adl<abort_snapshot>{}.from(data_parser);
+
+    co_return data;
 }
 
 } // namespace cluster

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -168,7 +168,7 @@ rm_stm::rm_stm(
   ss::logger& logger,
   raft::consensus* c,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend)
-  : persisted_stm("rm", logger, c)
+  : persisted_stm("tx.snapshot", logger, c)
   , _oldest_session(model::timestamp::now())
   , _sync_timeout(config::shard_local_cfg().rm_sync_timeout_ms.value())
   , _tx_timeout_delay(config::shard_local_cfg().tx_timeout_delay_ms.value())

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -126,8 +126,8 @@ private:
       model::producer_identity, model::tx_seq, model::timeout_clock::duration);
     ss::future<tx_errc> do_abort_tx(
       model::producer_identity, model::tx_seq, model::timeout_clock::duration);
-    void load_snapshot(stm_snapshot_header, iobuf&&) override;
-    stm_snapshot take_snapshot() override;
+    ss::future<> load_snapshot(stm_snapshot_header, iobuf&&) override;
+    ss::future<stm_snapshot> take_snapshot() override;
 
     bool check_seq(model::batch_identity);
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -49,8 +49,14 @@ public:
     using duration_type = clock_type::duration;
 
     static constexpr const int8_t tx_snapshot_version = 0;
+    static constexpr const int8_t abort_snapshot_version = 0;
     struct tx_range {
         model::producer_identity pid;
+        model::offset first;
+        model::offset last;
+    };
+
+    struct abort_index {
         model::offset first;
         model::offset last;
     };
@@ -75,8 +81,19 @@ public:
         std::vector<tx_range> ongoing;
         std::vector<prepare_marker> prepared;
         std::vector<tx_range> aborted;
+        std::vector<abort_index> abort_indexes;
         model::offset offset;
         std::vector<seq_entry> seqs;
+    };
+
+    struct abort_snapshot {
+        model::offset first;
+        model::offset last;
+        std::vector<tx_range> aborted;
+
+        bool match(abort_index idx) {
+            return idx.first == first && idx.last == last;
+        }
     };
 
     static constexpr int8_t prepare_control_record_version{0};
@@ -128,6 +145,8 @@ private:
       model::producer_identity, model::tx_seq, model::timeout_clock::duration);
     ss::future<> load_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
+    ss::future<std::optional<abort_snapshot>> load_abort_snapshot(abort_index);
+    ss::future<> save_abort_snapshot(abort_snapshot);
 
     bool check_seq(model::batch_identity);
 
@@ -165,7 +184,8 @@ private:
     ss::future<> apply(model::record_batch) override;
     void apply_fence(model::record_batch&&);
     void apply_prepare(rm_stm::prepare_marker);
-    void apply_control(model::producer_identity, model::control_record_type);
+    ss::future<>
+      apply_control(model::producer_identity, model::control_record_type);
     void apply_data(model::batch_identity, model::offset);
 
     // The state of this state machine maybe change via two paths
@@ -195,6 +215,8 @@ private:
         absl::btree_set<model::offset> ongoing_set;
         absl::flat_hash_map<model::producer_identity, prepare_marker> prepared;
         std::vector<tx_range> aborted;
+        std::vector<abort_index> abort_indexes;
+        abort_snapshot last_abort_snapshot{.last = model::offset(-1)};
         // the only piece of data which we update on replay and before
         // replicating the command. we use the highest seq number to resolve
         // conflicts. if the replication fails we reject a command but clients
@@ -264,11 +286,13 @@ private:
     model::timestamp _oldest_session;
     std::chrono::milliseconds _sync_timeout;
     std::chrono::milliseconds _tx_timeout_delay;
+    uint32_t _abort_index_segment_size;
     model::violation_recovery_policy _recovery_policy;
     std::chrono::milliseconds _transactional_id_expiration;
     bool _is_leader{false};
     bool _is_autoabort_enabled{true};
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
+    storage::snapshot_manager _abort_snapshot_mgr;
 };
 
 } // namespace cluster

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -149,8 +149,8 @@ public:
     }
 
 private:
-    void load_snapshot(stm_snapshot_header, iobuf&&) override;
-    stm_snapshot take_snapshot() override;
+    ss::future<> load_snapshot(stm_snapshot_header, iobuf&&) override;
+    ss::future<stm_snapshot> take_snapshot() override;
 
     void expire_old_txs();
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -348,6 +348,12 @@ configuration::configuration()
       false)
   , enable_transactions(
       *this, "enable_transactions", "Enable transactions", required::no, false)
+  , abort_index_segment_size(
+      *this,
+      "abort_index_segment_size",
+      "Capacity (in number of txns) of an abort index segment",
+      required::no,
+      50000)
   , delete_retention_ms(
       *this,
       "delete_retention_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -103,6 +103,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> transactional_id_expiration_ms;
     property<bool> enable_idempotence;
     property<bool> enable_transactions;
+    property<uint32_t> abort_index_segment_size;
     // same as log.retention.ms in kafka
     property<std::chrono::milliseconds> delete_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;

--- a/src/v/coproc/offset_storage_utils.cc
+++ b/src/v/coproc/offset_storage_utils.cc
@@ -34,7 +34,7 @@ using iresults_map
   = absl::flat_hash_map<model::ntp, ntp_context::offset_tracker>;
 
 ss::future<ntp_context_cache> recover_offsets(
-  storage::snapshot_manager& snap, storage::log_manager& log_mgr) {
+  storage::simple_snapshot_manager& snap, storage::log_manager& log_mgr) {
     ntp_context_cache recovered;
     auto optional_snap_reader = co_await snap.open_snapshot();
     if (!optional_snap_reader) {
@@ -78,7 +78,7 @@ ss::future<ntp_context_cache> recover_offsets(
 }
 
 ss::future<> save_offsets(
-  storage::snapshot_manager& snap, const ntp_context_cache& ntp_cache) {
+  storage::simple_snapshot_manager& snap, const ntp_context_cache& ntp_cache) {
     vlog(
       coproclog.info,
       "Saving {} coprocessor offsets to disk....",
@@ -97,7 +97,7 @@ ss::future<> save_offsets(
     iobuf data;
     co_await reflection::async_adl<iresults_map>{}.to(data, std::move(irm_map));
 
-    /// Serialize this to disk via the snapshot_manager
+    /// Serialize this to disk via the simple_snapshot_manager
     storage::snapshot_writer writer = co_await snap.start_snapshot();
     co_await writer.write_metadata(std::move(metadata));
     co_await write_iobuf_to_output_stream(std::move(data), writer.output());

--- a/src/v/coproc/offset_storage_utils.h
+++ b/src/v/coproc/offset_storage_utils.h
@@ -25,9 +25,10 @@ inline std::filesystem::path offsets_snapshot_path() {
 /// Reads the snapshot on disk (if one exists) and returns an initialized
 /// ntp_context_cache with all proper storage::logs and stored offsets
 ss::future<ntp_context_cache>
-recover_offsets(storage::snapshot_manager&, storage::log_manager&);
+recover_offsets(storage::simple_snapshot_manager&, storage::log_manager&);
 
 /// Writes all offsets to disk using the snapshot manager
-ss::future<> save_offsets(storage::snapshot_manager&, const ntp_context_cache&);
+ss::future<>
+save_offsets(storage::simple_snapshot_manager&, const ntp_context_cache&);
 
 } // namespace coproc

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -105,12 +105,12 @@ private:
     struct offset_flush_fiber_state {
         ss::timer<ss::lowres_clock> timer;
         model::timeout_clock::duration duration;
-        storage::snapshot_manager snap;
+        storage::simple_snapshot_manager snap;
 
         static ss::sstring snapshot_filename() {
             return fmt::format(
               "{}-{}",
-              storage::snapshot_manager::default_snapshot_filename,
+              storage::simple_snapshot_manager::default_snapshot_filename,
               ss::this_shard_id());
         }
 

--- a/src/v/coproc/tests/offset_storage_utils_tests.cc
+++ b/src/v/coproc/tests/offset_storage_utils_tests.cc
@@ -29,7 +29,7 @@ public:
       , _api(make_api())
       , _snap(
           _base_dir,
-          storage::snapshot_manager::default_snapshot_filename,
+          storage::simple_snapshot_manager::default_snapshot_filename,
           ss::default_priority_class()) {
         _api.start().get();
     }
@@ -68,7 +68,7 @@ public:
     }
 
     storage::log_manager& log_mgr() { return _api.log_mgr(); }
-    storage::snapshot_manager& snapshot_mgr() { return _snap; }
+    storage::simple_snapshot_manager& snapshot_mgr() { return _snap; }
 
 private:
     static std::filesystem::path make_base_dir() {
@@ -90,7 +90,7 @@ private:
 
     std::filesystem::path _base_dir;
     storage::api _api;
-    storage::snapshot_manager _snap;
+    storage::simple_snapshot_manager _snap;
 };
 
 namespace coproc {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -69,7 +69,7 @@ consensus::consensus(
   , _recovery_throttle(recovery_throttle)
   , _snapshot_mgr(
       std::filesystem::path(_log.config().work_directory()),
-      storage::snapshot_manager::default_snapshot_filename,
+      storage::simple_snapshot_manager::default_snapshot_filename,
       _scheduling.default_iopc)
   , _configuration_manager(std::move(initial_cfg), _group, _storage, _ctxlog)
   , _append_requests_buffer(*this, 256) {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -553,7 +553,7 @@ private:
     ss::abort_source _as;
     storage::api& _storage;
     std::optional<std::reference_wrapper<recovery_throttle>> _recovery_throttle;
-    storage::snapshot_manager _snapshot_mgr;
+    storage::simple_snapshot_manager _snapshot_mgr;
     std::optional<storage::snapshot_writer> _snapshot_writer;
     model::offset _last_snapshot_index;
     model::term_id _last_snapshot_term;

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -211,7 +211,7 @@ ss::circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
 }
 
 ss::future<> persist_snapshot(
-  storage::snapshot_manager& snapshot_manager,
+  storage::simple_snapshot_manager& snapshot_manager,
   snapshot_metadata md,
   iobuf&& data) {
     return snapshot_manager.start_snapshot().then(

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -52,7 +52,7 @@ ss::circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
 
 /// writes snapshot with given data to disk
 ss::future<>
-persist_snapshot(storage::snapshot_manager&, snapshot_metadata, iobuf&&);
+persist_snapshot(storage::simple_snapshot_manager&, snapshot_metadata, iobuf&&);
 
 /// looks up for the broker with request id in a vector of brokers
 template<typename Iterator>

--- a/src/v/storage/fwd.h
+++ b/src/v/storage/fwd.h
@@ -19,7 +19,7 @@ class log_manager;
 class ntp_config;
 class segment;
 class simple_snapshot_manager;
-class multi_snapshot_manager;
+class snapshot_manager;
 class readers_cache;
 class compaction_controller;
 

--- a/src/v/storage/fwd.h
+++ b/src/v/storage/fwd.h
@@ -18,7 +18,8 @@ class kvstore;
 class log_manager;
 class ntp_config;
 class segment;
-class snapshot_manager;
+class simple_snapshot_manager;
+class multi_snapshot_manager;
 class readers_cache;
 class compaction_controller;
 

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -35,7 +35,7 @@ kvstore::kvstore(kvstore_config kv_conf)
   , _ntpc(model::kvstore_ntp(ss::this_shard_id()), _conf.base_dir)
   , _snap(
       std::filesystem::path(_ntpc.work_directory()),
-      snapshot_manager::default_snapshot_filename,
+      simple_snapshot_manager::default_snapshot_filename,
       ss::default_priority_class())
   , _timer([this] { _sem.signal(); }) {}
 

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -117,7 +117,7 @@ private:
     ntp_config _ntpc;
     ss::gate _gate;
     ss::abort_source _as;
-    snapshot_manager _snap;
+    simple_snapshot_manager _snap;
     bool _started{false};
 
     /**

--- a/src/v/storage/snapshot.cc
+++ b/src/v/storage/snapshot.cc
@@ -24,7 +24,7 @@
 
 namespace storage {
 
-ss::future<std::optional<snapshot_reader>> snapshot_manager::open_snapshot() {
+ss::future<std::optional<snapshot_reader>> simple_snapshot_manager::open_snapshot() {
     auto path = _dir / _filename.c_str();
     return ss::file_exists(path.string()).then([this, path](bool exists) {
         if (!exists) {
@@ -44,7 +44,7 @@ ss::future<std::optional<snapshot_reader>> snapshot_manager::open_snapshot() {
     });
 }
 
-ss::future<snapshot_writer> snapshot_manager::start_snapshot() {
+ss::future<snapshot_writer> simple_snapshot_manager::start_snapshot() {
     // the random suffix is added because the lowres clock doesn't produce
     // unique file names when tests run fast.
     auto filename = fmt::format(
@@ -69,12 +69,12 @@ ss::future<snapshot_writer> snapshot_manager::start_snapshot() {
       });
 }
 
-ss::future<> snapshot_manager::finish_snapshot(snapshot_writer& writer) {
+ss::future<> simple_snapshot_manager::finish_snapshot(snapshot_writer& writer) {
     return ss::rename_file(writer.path().string(), snapshot_path().string())
       .then([this] { return ss::sync_directory(_dir.string()); });
 }
 
-ss::future<> snapshot_manager::remove_partial_snapshots() {
+ss::future<> simple_snapshot_manager::remove_partial_snapshots() {
     std::regex re(
       fmt::format(R"(^{}\.partial\.(\d+)\.([a-zA-Z0-9]{{4}})$)", _filename));
     return directory_walker::walk(
@@ -91,7 +91,7 @@ ss::future<> snapshot_manager::remove_partial_snapshots() {
       });
 }
 
-ss::future<> snapshot_manager::remove_snapshot() {
+ss::future<> simple_snapshot_manager::remove_snapshot() {
     if (co_await ss::file_exists(snapshot_path().string())) {
         co_await ss::remove_file(snapshot_path().string());
     }

--- a/src/v/storage/snapshot.cc
+++ b/src/v/storage/snapshot.cc
@@ -24,8 +24,9 @@
 
 namespace storage {
 
-ss::future<std::optional<snapshot_reader>> simple_snapshot_manager::open_snapshot() {
-    auto path = _dir / _filename.c_str();
+ss::future<std::optional<snapshot_reader>>
+snapshot_manager::open_snapshot(ss::sstring filename) {
+    auto path = snapshot_path(filename);
     return ss::file_exists(path.string()).then([this, path](bool exists) {
         if (!exists) {
             return ss::make_ready_future<std::optional<snapshot_reader>>(
@@ -44,12 +45,13 @@ ss::future<std::optional<snapshot_reader>> simple_snapshot_manager::open_snapsho
     });
 }
 
-ss::future<snapshot_writer> simple_snapshot_manager::start_snapshot() {
+ss::future<snapshot_writer>
+snapshot_manager::start_snapshot(ss::sstring target) {
     // the random suffix is added because the lowres clock doesn't produce
     // unique file names when tests run fast.
     auto filename = fmt::format(
       "{}.partial.{}.{}",
-      _filename,
+      _partial_prefix,
       ss::lowres_system_clock::now().time_since_epoch().count(),
       random_generators::gen_alphanum_string(4));
 
@@ -64,19 +66,20 @@ ss::future<snapshot_writer> simple_snapshot_manager::start_snapshot() {
           options.io_priority_class = _io_prio;
           return ss::make_file_output_stream(std::move(file), options);
       })
-      .then([path](ss::output_stream<char> output) {
-          return snapshot_writer(std::move(output), path);
+      .then([this, target, path](ss::output_stream<char> output) {
+          return snapshot_writer(
+            std::move(output), path, snapshot_path(target));
       });
 }
 
-ss::future<> simple_snapshot_manager::finish_snapshot(snapshot_writer& writer) {
-    return ss::rename_file(writer.path().string(), snapshot_path().string())
+ss::future<> snapshot_manager::finish_snapshot(snapshot_writer& writer) {
+    return ss::rename_file(writer.path().string(), writer.target().string())
       .then([this] { return ss::sync_directory(_dir.string()); });
 }
 
-ss::future<> simple_snapshot_manager::remove_partial_snapshots() {
-    std::regex re(
-      fmt::format(R"(^{}\.partial\.(\d+)\.([a-zA-Z0-9]{{4}})$)", _filename));
+ss::future<> snapshot_manager::remove_partial_snapshots() {
+    std::regex re(fmt::format(
+      R"(^{}\.partial\.(\d+)\.([a-zA-Z0-9]{{4}})$)", _partial_prefix));
     return directory_walker::walk(
       _dir.string(), [this, re = std::move(re)](ss::directory_entry ent) {
           if (!ent.type || *ent.type != ss::directory_entry_type::regular) {
@@ -91,9 +94,9 @@ ss::future<> simple_snapshot_manager::remove_partial_snapshots() {
       });
 }
 
-ss::future<> simple_snapshot_manager::remove_snapshot() {
-    if (co_await ss::file_exists(snapshot_path().string())) {
-        co_await ss::remove_file(snapshot_path().string());
+ss::future<> snapshot_manager::remove_snapshot(ss::sstring target) {
+    if (co_await ss::file_exists(snapshot_path(target).string())) {
+        co_await ss::remove_file(snapshot_path(target).string());
     }
 
     co_return;
@@ -217,9 +220,18 @@ snapshot_writer::~snapshot_writer() noexcept {
     vassert(_closed, "snapshot writer has to be closed before destruction");
 }
 
+snapshot_writer::snapshot_writer(
+  ss::output_stream<char> output,
+  std::filesystem::path path,
+  std::filesystem::path target) noexcept
+  : _path(std::move(path))
+  , _output(std::move(output))
+  , _target(std::move(target)) {}
+
 snapshot_writer::snapshot_writer(snapshot_writer&& o) noexcept
   : _path(std::move(o._path))
   , _output(std::move(o._output))
+  , _target(std::move(o._target))
   , _closed(o._closed) {
     o._closed = true;
 }

--- a/src/v/storage/snapshot.h
+++ b/src/v/storage/snapshot.h
@@ -33,8 +33,8 @@ class snapshot_writer;
  * raft group. Snapshots are organized into a directory:
  *
  *    <dir>/
- *      - snapshot              <- current snapshot (optional)
- *      - snapshot.partial.ts   <- partially written snapshot
+ *      - snapshot            <- current snapshot (optional)
+ *      - prefix.partial.ts   <- partially written snapshot
  *      - ...
  *
  * Snapshots are initially created as `snapshot.partial.*` files. When a
@@ -63,18 +63,26 @@ class snapshot_writer;
  *
  *    Create a manager instance:
  *
- *       snapshot_manager mgr("/path/to/ntp/", io_priority);
+ *       snapshot_manager mgr(prefix, "/path/to/ntp/", io_priority);
+ *
+ *    Snapshot manager saves snapshots atomicly by writing data to temp files
+ *    and then using atomic `mv` to replace older snapshots. Prefix is a name
+ *    prefix for the temporary files (suffix is unique, mix of time and salt).
+ *    It's needed to avoid collision when several snapshot_managers points to
+ *    the same directory. In this case when one manager does
+ *    remove_partial_snapshots it may accidentally remove a wip snapshot of an
+ *    another manager.
  *
  *    All snapshots will be stored in the provided directory, and snapshot
  *    readers and writers will be created using the given io priority.
  *
  *    Open the current snapshot.
  *
- *       snapshot_reader reader = mgr.open_snapshot();
+ *       snapshot_reader reader = mgr.open_snapshot(file_name);
  *
  *    Snapshots are created by creating a new snapshot writer:
  *
- *       snapshot_writer writer = mgr.start_snapshot();
+ *       snapshot_writer writer = mgr.start_snapshot(file_name);
  *
  *    And once a snapshot has been fully written pass the writer back to the
  *    snapshot manager which will detect if the snapshot should replace the
@@ -88,33 +96,31 @@ class snapshot_writer;
  *
  *       mgr.remove_partial_snapshots();
  */
-class simple_snapshot_manager {
+class snapshot_manager {
 public:
-    static constexpr const char* default_snapshot_filename = "snapshot";
-
-    simple_snapshot_manager(
+    snapshot_manager(
+      ss::sstring partial_prefix,
       std::filesystem::path dir,
-      ss::sstring filename,
       ss::io_priority_class io_prio) noexcept
-      : _filename(std::move(filename))
+      : _partial_prefix(partial_prefix)
       , _dir(std::move(dir))
       , _io_prio(io_prio) {}
 
-    ss::future<std::optional<snapshot_reader>> open_snapshot();
+    ss::future<std::optional<snapshot_reader>> open_snapshot(ss::sstring);
 
-    ss::future<snapshot_writer> start_snapshot();
+    ss::future<snapshot_writer> start_snapshot(ss::sstring);
     ss::future<> finish_snapshot(snapshot_writer&);
 
-    std::filesystem::path snapshot_path() const {
-        return _dir / _filename.c_str();
+    std::filesystem::path snapshot_path(ss::sstring filename) const {
+        return _dir / filename.c_str();
     }
 
     ss::future<> remove_partial_snapshots();
 
-    ss::future<> remove_snapshot();
+    ss::future<> remove_snapshot(ss::sstring);
 
 private:
-    ss::sstring _filename;
+    ss::sstring _partial_prefix;
     std::filesystem::path _dir;
     ss::io_priority_class _io_prio;
 };
@@ -212,9 +218,9 @@ private:
 class snapshot_writer {
 public:
     snapshot_writer(
-      ss::output_stream<char> output, std::filesystem::path path) noexcept
-      : _path(std::move(path))
-      , _output(std::move(output)) {}
+      ss::output_stream<char>,
+      std::filesystem::path,
+      std::filesystem::path) noexcept;
 
     ~snapshot_writer() noexcept;
     snapshot_writer(const snapshot_writer&) = delete;
@@ -228,10 +234,52 @@ public:
 
     const std::filesystem::path& path() const { return _path; }
 
+    const std::filesystem::path& target() const { return _target; }
+
 private:
     std::filesystem::path _path;
     ss::output_stream<char> _output;
+    std::filesystem::path _target;
     bool _closed = false;
+};
+
+class simple_snapshot_manager {
+public:
+    static constexpr const char* default_snapshot_filename = "snapshot";
+
+    simple_snapshot_manager(
+      std::filesystem::path dir,
+      ss::sstring filename,
+      ss::io_priority_class io_prio) noexcept
+      : _filename(filename)
+      , _snapshot(filename, std::move(dir), io_prio) {}
+
+    ss::future<std::optional<snapshot_reader>> open_snapshot() {
+        return _snapshot.open_snapshot(_filename);
+    }
+
+    ss::future<snapshot_writer> start_snapshot() {
+        return _snapshot.start_snapshot(_filename);
+    }
+    ss::future<> finish_snapshot(snapshot_writer& writer) {
+        return _snapshot.finish_snapshot(writer);
+    }
+
+    std::filesystem::path snapshot_path() const {
+        return _snapshot.snapshot_path(_filename);
+    }
+
+    ss::future<> remove_partial_snapshots() {
+        return _snapshot.remove_partial_snapshots();
+    }
+
+    ss::future<> remove_snapshot() {
+        return _snapshot.remove_snapshot(_filename);
+    }
+
+private:
+    ss::sstring _filename;
+    snapshot_manager _snapshot;
 };
 
 } // namespace storage

--- a/src/v/storage/snapshot.h
+++ b/src/v/storage/snapshot.h
@@ -88,11 +88,11 @@ class snapshot_writer;
  *
  *       mgr.remove_partial_snapshots();
  */
-class snapshot_manager {
+class simple_snapshot_manager {
 public:
     static constexpr const char* default_snapshot_filename = "snapshot";
 
-    snapshot_manager(
+    simple_snapshot_manager(
       std::filesystem::path dir,
       ss::sstring filename,
       ss::io_priority_class io_prio) noexcept

--- a/src/v/storage/tests/snapshot_test.cc
+++ b/src/v/storage/tests/snapshot_test.cc
@@ -14,18 +14,18 @@
 #include <seastar/testing/thread_test_case.hh>
 
 SEASTAR_THREAD_TEST_CASE(missing_snapshot_is_not_error) {
-    storage::snapshot_manager mgr(
+    storage::simple_snapshot_manager mgr(
       "d/n/e",
-      storage::snapshot_manager::default_snapshot_filename,
+      storage::simple_snapshot_manager::default_snapshot_filename,
       ss::default_priority_class());
     auto reader = mgr.open_snapshot().get0();
     BOOST_REQUIRE(!reader);
 }
 
 SEASTAR_THREAD_TEST_CASE(reading_from_empty_snapshot_is_error) {
-    storage::snapshot_manager mgr(
+    storage::simple_snapshot_manager mgr(
       ".",
-      storage::snapshot_manager::default_snapshot_filename,
+      storage::simple_snapshot_manager::default_snapshot_filename,
       ss::default_priority_class());
     try {
         ss::remove_file(mgr.snapshot_path().string()).get();
@@ -53,9 +53,9 @@ SEASTAR_THREAD_TEST_CASE(reading_from_empty_snapshot_is_error) {
 }
 
 SEASTAR_THREAD_TEST_CASE(reader_verifies_header_crc) {
-    storage::snapshot_manager mgr(
+    storage::simple_snapshot_manager mgr(
       ".",
-      storage::snapshot_manager::default_snapshot_filename,
+      storage::simple_snapshot_manager::default_snapshot_filename,
       ss::default_priority_class());
     try {
         ss::remove_file(mgr.snapshot_path().string()).get();
@@ -90,9 +90,9 @@ SEASTAR_THREAD_TEST_CASE(reader_verifies_header_crc) {
 }
 
 SEASTAR_THREAD_TEST_CASE(reader_verifies_metadata_crc) {
-    storage::snapshot_manager mgr(
+    storage::simple_snapshot_manager mgr(
       ".",
-      storage::snapshot_manager::default_snapshot_filename,
+      storage::simple_snapshot_manager::default_snapshot_filename,
       ss::default_priority_class());
     try {
         ss::remove_file(mgr.snapshot_path().string()).get();
@@ -129,9 +129,9 @@ SEASTAR_THREAD_TEST_CASE(reader_verifies_metadata_crc) {
 }
 
 SEASTAR_THREAD_TEST_CASE(read_write) {
-    storage::snapshot_manager mgr(
+    storage::simple_snapshot_manager mgr(
       ".",
-      storage::snapshot_manager::default_snapshot_filename,
+      storage::simple_snapshot_manager::default_snapshot_filename,
       ss::default_priority_class());
     try {
         ss::remove_file(mgr.snapshot_path().string()).get();
@@ -159,9 +159,9 @@ SEASTAR_THREAD_TEST_CASE(read_write) {
 }
 
 SEASTAR_THREAD_TEST_CASE(remove_partial_snapshots) {
-    storage::snapshot_manager mgr(
+    storage::simple_snapshot_manager mgr(
       ".",
-      storage::snapshot_manager::default_snapshot_filename,
+      storage::simple_snapshot_manager::default_snapshot_filename,
       ss::default_priority_class());
 
     auto mk_partial = [&] {


### PR DESCRIPTION
## Cover letter

Redpanda needs to store a list of all ever aborted transactions.

We used to do by reading the log and then keeping the list in a snapshot. But over time this leads to a resource leak since the list of aborted transactions just keeps growing.

Now we break the list of the aborted transactions into segments, store each segment in a separate file and keep the index of the segments in memory. When Redpanda needs to get a list of aborted transactions for a given offset range it looks up the index and then load data from disk if data are not in the cache (we keep the newest segment in memory as a cache).

[ch2204]