### PR TITLE
Metadata only consume flag for rpk

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/consume_test.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/consume_test.go
@@ -65,7 +65,7 @@ func TestConsumeMessages(t *testing.T) {
 				errs <- tt.err
 			}
 
-			consumeMessages(msgs, errs, &sync.Mutex{}, ctx, false)
+			consumeMessages(msgs, errs, &sync.Mutex{}, ctx, false, false)
 
 			if tt.err != nil {
 				errMsg := fmt.Sprintf(


### PR DESCRIPTION
## Cover letter
Add `--meta-only` flag to only print metadata of consumed records in rpk

As as a user, I like to only print the metadata of the consumed records and skip the payload. And I also like to print the size of the payload of each record in raw bytes for troubleshooting etc reasons.

## Release notes

End users now can only print metadata of consumed records in rpk by specifying `--meta-only` flag. By default, this flag is false which means payload and metadata will be both printed.  

For example, the following command will print metadata of records only.

```
./rpk topic consume my-topic --brokers local:9092 --meta-only
```
