### PR TITLE
rpk: Get the SASL settings from the config file

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -74,7 +74,7 @@ func NewACLCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&adminAPITruststoreFile,
 		configClosure,
 	)
-	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
+	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism, configClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, kafkaTlsClosure, kAuthClosure)
 
 	command.AddCommand(acl.NewCreateACLsCommand(adminClosure))

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -68,7 +68,7 @@ func NewClusterCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		configClosure,
 		&brokers,
 	)
-	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
+	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism, configClosure)
 	tlsClosure := common.BuildKafkaTLSConfig(fs, &enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	command.AddCommand(cluster.NewInfoCommand(adminClosure))

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -58,7 +58,7 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&brokers,
 	)
 	tlsClosure := common.BuildKafkaTLSConfig(fs, &enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
-	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
+	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism, configClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	clientClosure := common.CreateClient(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure, tlsClosure, kAuthClosure)

--- a/src/go/rpk/pkg/cli/cmd/wasm.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm.go
@@ -56,7 +56,7 @@ func NewWasmCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 		&brokers,
 	)
 	tlsClosure := common.BuildKafkaTLSConfig(fs, &enableTLS, &certFile, &keyFile, &truststoreFile, configClosure)
-	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism)
+	kAuthClosure := common.KafkaAuthConfig(&user, &password, &mechanism, configClosure)
 	producerClosure := common.CreateProducer(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 	adminClosure := common.CreateAdmin(brokersClosure, configClosure, tlsClosure, kAuthClosure)
 


### PR DESCRIPTION
The config sources are now evaluated in this order:

1. Flags
2. Environment variables
3. The rpk.kafka_api.sasl fields in the config file
4. The deprecated rpk.sasl fields in the config file