### PR TITLE
kafka/client: Retry create_consumer on failure

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -49,7 +49,7 @@ ss::future<shared_broker_t> make_broker(
               return ss::make_exception_future<shared_broker_t>(
                 broker_error(node_id, error_code::network_exception));
           }
-          vlog(kclog.warn, "std::system_error: ", ex.what());
+          vlog(kclog.warn, "std::system_error: {}", ex.what());
           return ss::make_exception_future<shared_broker_t>(ex);
       })
       .then([&config](shared_broker_t broker) -> ss::future<shared_broker_t> {

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -153,6 +153,15 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
                 return _wait_or_start_update_metadata();
             });
         }
+    } catch (const consumer_error& ex) {
+        switch (ex.error) {
+        case error_code::coordinator_not_available:
+            vlog(kclog.debug, "consumer_error: {}", ex);
+            return _wait_or_start_update_metadata();
+        default:
+            vlog(kclog.warn, "consumer_error: {}", ex);
+            return ss::make_exception_future(ex);
+        }
     } catch (const partition_error& ex) {
         switch (ex.error) {
         case error_code::unknown_topic_or_partition:


### PR DESCRIPTION
## Cover letter

When `create_consumer` fails, convert the error to a `consumer_error`, handle `consumer_error` in `mitigate_error`, so that it's retried.

Address some CI failures which result in:
```
C-Ares: Bad Name
```

## Release notes

Release note: [none]
