### PR TITLE
Schema registry high availability

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -485,6 +485,9 @@ schema_registry:
     name: external
     port: 18081
 
+  # The replication factor of Schema Registry's internal storage topic
+  schema_registry_replication_factor: 3
+
   # A list of TLS configurations for the Schema Registry API.
   # Default: null
   schema_registry_api_tls:

--- a/src/go/rpk/pkg/config/schema.go
+++ b/src/go/rpk/pkg/config/schema.go
@@ -64,8 +64,9 @@ type Pandaproxy struct {
 }
 
 type SchemaRegistry struct {
-	SchemaRegistryAPI    []NamedSocketAddress `yaml:"schema_registry_api,omitempty" mapstructure:"schema_registry_api,omitempty" json:"schemaRegistryApi,omitempty"`
-	SchemaRegistryAPITLS []ServerTLS          `yaml:"schema_registry_api_tls,omitempty" mapstructure:"schema_registry_api_tls,omitempty" json:"schemaRegistryApiTls,omitempty"`
+	SchemaRegistryAPI               []NamedSocketAddress `yaml:"schema_registry_api,omitempty" mapstructure:"schema_registry_api,omitempty" json:"schemaRegistryApi,omitempty"`
+	SchemaRegistryAPITLS            []ServerTLS          `yaml:"schema_registry_api_tls,omitempty" mapstructure:"schema_registry_api_tls,omitempty" json:"schemaRegistryApiTls,omitempty"`
+	SchemaRegistryReplicationFactor *int                 `yaml:"schema_registry_replication_factor,omitempty" mapstructure:"schema_registry_replication_factor,omitempty" json:"schemaRegistryReplicationFactor,omitempty"`
 }
 
 type KafkaClient struct {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -57,7 +57,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> coproc_offset_flush_interval_ms;
 
     // Raft
-    property<int32_t> node_id;
+    property<model::node_id> node_id;
     property<int32_t> seed_server_meta_topic_partitions;
     property<std::chrono::milliseconds> raft_heartbeat_interval_ms;
     property<std::chrono::milliseconds> raft_heartbeat_timeout_ms;

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -48,6 +48,8 @@ struct reply_error_category final : std::error_category {
             return "subject_version_soft_deleted";
         case reply_error_code::subject_version_not_deleted:
             return "subject_version_not_deleted";
+        case reply_error_code::write_collision:
+            return "write_collision";
         case reply_error_code::zookeeper_error:
             return "zookeeper_error";
         case reply_error_code::kafka_error:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -38,6 +38,7 @@ enum class reply_error_code : uint16_t {
     subject_not_deleted = 40405,
     subject_version_soft_deleted = 40406,
     subject_version_not_deleted = 40407,
+    write_collision = 50301,
     zookeeper_error = 50001,
     kafka_error = 50002,
     kafka_retriable_error = 50003,

--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -13,6 +13,7 @@ v_cc_library(
     handlers.cc
     error.cc
     service.cc
+    seq_writer.cc
     sharded_store.cc
     avro.cc
   DEPS

--- a/src/v/pandaproxy/schema_registry/README.md
+++ b/src/v/pandaproxy/schema_registry/README.md
@@ -1,0 +1,174 @@
+# Schema Registry
+
+## References
+
+- REST API: https://docs.confluent.io/platform/current/schema-registry/develop/api.html
+- Alternative implementation: https://github.com/aiven/karapace
+
+## High level design
+
+Schema registry is built in to `pandaproxy`.
+
+A single-partition topic `_schemas` is used as a backend store.
+
+Each node maintains an in-memory copy of all schema data, lazily updated from the topic.
+
+Active/Active HA: any node can serve reads and writes.
+
+User-facing REST API is compatible with other products' schema registry implementations, but internal storage format is
+not intended to be compatible.
+
+*Future: we should apply a sanity limit on the number of schemas, as we hold them all in memory.*
+
+## Writer synchronisation
+
+**tldr; Optimistic writes, first writer wins**
+
+Each write includes a sequence number in the key. This sequence number increases monotonically, and any write with an
+out-of-order sequence number is ignored by readers. Writers set the sequence number for their next write as the most
+recent message sequence they've seen, plus one.
+
+While the sequence number is logically independent of the offset, it is very convenient to simply use the offset as the
+sequence number:
+that way, message validity can be checked by simply comparing the sequence number to the actual offset where the message
+was written.
+
+Under contention, writers know whether their write was successful by comparing the offset returned by their write
+against the offset where they expected to write. If not equal, writer retries until they succeed.
+
+Using the offset as the effective sequence number comes with a downside: concurrent writes from different nodes are more
+expensive, as otherwise-valid writes can be rendered invalid by another /invalid/ write arriving before and knocking
+them out of their intended offset. However, schemas are likely to be written at comparatively low rates, and usually by
+a single API client (e.g. a CI system deploying new schemas for a new software build). This can be improved in future by
+switching to a true sequence number (such that for a given sequence number under contended writes, at least one writer
+is guaranteed to win).
+
+Allocation of schema IDs and version IDs is done locally by writers based on the contents of their `ShardedStore`. If
+this turns out to be out of date, then their write will retry (allocation is re-done on retry). Changes to the
+`ShardedStore`, including advancing the next ID to allocate, are only applied once the write persists successfully.
+
+To avoid compaction incorrectly preserving the last contended write (contended meaning same seq number) rather than
+first write to a particular subject-version, the writer's node ID is also included in the key.
+
+For permanent deletion of subjects or versions (i.e. writing tombstones), writers must remember the sequence number and
+node ID that originally wrote to the subject, in order to regenerate the original write's key. These permanent deletion
+writes are not subject to any sequence-ordering logic, and if multiple nodes perma-delete the same thing concurrently,
+they will both succeed.
+
+Q: Why is the sequence number global rather than per-subject?
+
+- A: Because different subjects refer to the same schema IDs: if we treated subjects as independent, they might both
+  grab the same schema ID for different schema definitions.
+
+See worked examples further down that include sequence numbers.
+
+## I/O
+
+### Reads
+
+Reads are served symmetrically from any node.
+
+High traffic read endpoints are usually served from memory, falling back to read from the topic only if the requested ID
+is not found locally (i.e. the local ShardedStore is out of date).
+
+These fast-read endpoints are:
+
+- `GET /schemas/ids/{int: id}`
+- `GET /subjects/(string: subject)/versions/(versionId: version)`
+- `GET /subjects/(string: subject)/versions/(versionId: version)/schema`
+
+Endpoints that generate lists require a read from the topic to ensure that the list they are returning is complete.
+These are:
+GET /schemas/ids/{int: id}/versions
+(because while we might have the schema in memory, it may have new subject-version associations we haven't seen yet)
+
+- `GET /subjects`
+- `GET /subjects/(string: subject)/version`
+- `POST /subjects/(string: subject)`
+- `GET /subjects/(string: subject)/versions/{versionId: version}/referencedby`
+
+Within a single node, only one read to the topic is in flight at at time (enforced by a semaphore) -- this serialization
+of reads reflects the serial layout of the underlying store.
+
+*Future: use a queue-of-waiters synchronisation mechanism to reduce number of topic reads when many readers hit slow
+endpoints concurrently within the same node*
+
+*Future: if these endpoints turn out to be higher traffic than expected, introduce a config setting to make them
+eventually consistent*
+
+### Writes & deletes
+
+As well as being subject to inter-node serialization via sequence numbers, writes are serialized within a node using a
+semaphore. This simplifies the code, to avoid having rollback logic for projecting schema+version handle cases where
+multiple writes are in flight & only some succeed.
+
+*Future: if we find it necessary to
+
+Writes are served symmetrically from any node, **but** it is advisable to send writes to the same node (doesn't matter
+which)
+as much as possible, to reduce the cost of synchronisation.
+
+- `POST /subjects/(string: subject)/versions`
+
+Soft deletions (without `permanent` parameter) are normal writes, which create new sequenced keys and include a flag in
+the value to indicate that the named subject or version should be marked deleted.
+
+- `DELETE /subjects/(string: subject)`
+- `DELETE /subjects/(string: subject)/versions/(versionId: version)`
+
+Permanent deletions render schemas unreadable, and are expected to free underlying storage. For us, that means emitting
+tombstones to the keys used when writing the subject/version.
+
+- `DELETE /subjects/(string: subject)?permanent=true`
+- `DELETE /subjects/(string: subject)/versions/(versionId: version)?permanent=true`
+
+### Examples
+
+*Using shorthand key format of sequence-node-subject-version, where nodes are like A, B, C...*
+
+#### Uncontended create & delete lifecycle
+
+    # POST /subjects/foo
+    1-A-foo-1 {schema}
+    # POST /subjects/foo
+    2-A-foo-2 {schema}
+    # DELETE /subjects/foo
+    3-A-foo-1 {deleted=true}
+    4-A-foo-2 {deleted=true}
+    # DELETE /subjects/foo?permanent=true
+    1-A-foo-1 NULL
+    1-A-foo-2 NULL
+    3-A-foo-1 NULL
+    4-A-foo-1 NULL
+
+#### Contended writes (same subject+value)
+
+    # POST A/subjects/foo
+    1-A-foo-1 {schema}
+    # Node A discovers they succeeded, returns schema=1 to caller
+
+    # POST B/subjects/foo
+    1-B-foo-1 {schema}
+    # Node B re-reads, sees A's write, realizes value was already applied, returns schema=1 to caller
+
+#### Contended writes (different subject)
+
+    # POST A/subjects/foo
+    1-A-foo-1 {schema}
+    # Node A succeeds at offset 1.
+
+    # POST B/subjects/bar
+    1-B-foo-1 {schema}
+    # Node B sees that its write landed at 'wrong' offset.  Re-reads.  Retries write.
+    2-B-foo-1 {schema}
+    # Node B succeeds at offset 2.
+
+#### Contended hard deletes
+
+    # DELETE A/subjects/foo?permanent=true
+    1-A-foo-1 NULL
+
+    # DELETE A/subjects/foo?permanent=true
+    1-A-foo-1 NULL
+
+    # Both nodes 'win'.

--- a/src/v/pandaproxy/schema_registry/configuration.cc
+++ b/src/v/pandaproxy/schema_registry/configuration.cc
@@ -30,6 +30,13 @@ configuration::configuration()
       config::required::no,
       {},
       config::endpoint_tls_config::validate_many)
+  , schema_registry_replication_factor(
+      *this,
+      "schema_registry_replication_factor",
+      "Replication factor for internal _schemas topic.  If unset, defaults to "
+      "`default_topic_replication`",
+      config::required::no,
+      -1)
   , api_doc_dir(
       *this,
       "api_doc_dir",

--- a/src/v/pandaproxy/schema_registry/configuration.h
+++ b/src/v/pandaproxy/schema_registry/configuration.h
@@ -26,6 +26,7 @@ struct configuration final : public config::config_store {
     config::one_or_many_property<model::broker_endpoint> schema_registry_api;
     config::one_or_many_property<config::endpoint_tls_config>
       schema_registry_api_tls;
+    config::property<int16_t> schema_registry_replication_factor;
     config::property<ss::sstring> api_doc_dir;
 };
 

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -42,6 +42,8 @@ struct error_category final : std::error_category {
                    "permanently";
         case error_code::subject_version_not_deleted:
             return "Version not deleted before being permanently deleted";
+        case error_code::write_collision:
+            return "Too many retries on write collision";
         case error_code::topic_parse_error:
             return "Unexpected data found in topic";
         }
@@ -64,6 +66,8 @@ struct error_category final : std::error_category {
             return reply_error_code::subject_version_soft_deleted; // 40406
         case error_code::subject_version_not_deleted:
             return reply_error_code::subject_version_not_deleted; // 40407
+        case error_code::write_collision:
+            return reply_error_code::write_collision; // 50301
         case error_code::schema_invalid:
             return reply_error_code::unprocessable_entity;
         case error_code::topic_parse_error:

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -33,12 +33,12 @@ struct error_category final : std::error_category {
         case error_code::subject_version_not_found:
             return "Subject version not found";
         case error_code::subject_soft_deleted:
-            return "Subject was soft deleted. Set permanent=true to delete "
+            return "Subject was soft deleted.Set permanent=true to delete "
                    "permanently";
         case error_code::subject_not_deleted:
             return "Subject not deleted before being permanently deleted";
         case error_code::subject_version_soft_deleted:
-            return "Version was soft deleted. Set permanent=true to delete "
+            return "Version was soft deleted.Set permanent=true to delete "
                    "permanently";
         case error_code::subject_version_not_deleted:
             return "Version not deleted before being permanently deleted";

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -25,6 +25,7 @@ enum class error_code {
     subject_not_deleted,
     subject_version_soft_deleted,
     subject_version_not_deleted,
+    write_collision,
     topic_parse_error,
 };
 

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -76,7 +76,7 @@ inline error_info soft_deleted(const subject& sub) {
     return error_info{
       error_code::subject_soft_deleted,
       fmt::format(
-        "Subject '{}' was soft deleted. Set permanent=true to delete "
+        "Subject '{}' was soft deleted.Set permanent=true to delete "
         "permanently",
         sub())};
 }
@@ -93,7 +93,7 @@ inline error_info soft_deleted(const subject& sub, schema_version version) {
     return error_info{
       error_code::subject_version_soft_deleted,
       fmt::format(
-        "Subject '{}' Version {} was soft deleted. Set permanent=true to "
+        "Subject '{}' Version {} was soft deleted.Set permanent=true to "
         "delete permanently",
         sub(),
         version())};

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -230,19 +230,11 @@ delete_subject(server::request_t rq, server::reply_t rp) {
         .value_or(permanent_delete::no)};
     rq.req.reset();
 
-    auto versions = co_await rq.service().schema_store().delete_subject(
-      sub, permanent);
-
-    auto batch = permanent
-                   ? make_delete_subject_permanently_batch(sub, versions)
-                   : make_delete_subject_batch(sub, versions.back());
-
-    auto res = co_await rq.service().client().local().produce_record_batch(
-      model::schema_registry_internal_tp, std::move(batch));
-
-    if (res.error_code != kafka::error_code::none) {
-        throw kafka::exception(res.error_code, *res.error_message);
-    }
+    auto versions
+      = permanent
+          ? co_await rq.service().writer().delete_subject_permanent(
+            sub, std::nullopt)
+          : co_await rq.service().writer().delete_subject_impermanent(sub);
 
     auto json_rslt{json::rjson_serialize(versions)};
     rp.rep->write_body("json", json_rslt);
@@ -259,38 +251,38 @@ delete_subject_version(server::request_t rq, server::reply_t rp) {
         .value_or(permanent_delete::no)};
     rq.req.reset();
 
+    // Must see latest data to know whether what we're deleting is the last
+    // version
+    co_await rq.service().writer().read_sync();
+
     auto version = invalid_schema_version;
+    bool final_version = false;
     if (ver == "latest") {
+        // Requests for 'latest' mean the latest which is not marked deleted
+        // (Clearly this will never succeed for permanent=true -- calling
+        //  with latest+permanent is a bad request per API docs)
         auto versions = co_await rq.service().schema_store().get_versions(
-          sub, include_deleted::yes);
+          sub, include_deleted::no);
         if (versions.empty()) {
             throw as_exception(not_found(sub, version));
         }
         version = versions.back();
     } else {
+        auto versions = co_await rq.service().schema_store().get_versions(
+          sub, include_deleted::yes);
+        if (versions.size() == 1) {
+            final_version = true;
+        }
         version = parse::from_chars<schema_version>{}(ver).value();
     }
 
-    auto d_res = co_await rq.service().schema_store().delete_subject_version(
-      sub, version, permanent, include_deleted::no);
-
-    if (d_res) {
-        std::optional<model::record_batch> batch;
-        if (permanent) {
-            batch.emplace(
-              make_delete_subject_version_permanently_batch(sub, version));
-        } else {
-            auto s_res
-              = co_await rq.service().schema_store().get_subject_schema(
-                sub, version, include_deleted::yes);
-            batch.emplace(make_delete_subject_version_batch(std::move(s_res)));
-        }
-        auto res = co_await rq.service().client().local().produce_record_batch(
-          model::schema_registry_internal_tp, std::move(batch).value());
-
-        if (res.error_code != kafka::error_code::none) {
-            throw kafka::exception(res.error_code, *res.error_message);
-        }
+    // A permanent deletion emits tombstones for prior schema_key messages
+    if (permanent) {
+        co_await rq.service().writer().delete_subject_permanent(
+          sub, final_version ? std::nullopt : std::make_optional(version));
+    } else {
+        // Upsert the version with is_deleted=1
+        co_await rq.service().writer().delete_subject_version(sub, version);
     }
 
     auto json_rslt{json::rjson_serialize(version)};

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -254,6 +254,7 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
 
     auto json_rslt{json::rjson_serialize(post_subject_versions_version_response{
       .sub = sub,
+      .id = get_res.id,
       .version = version,
       .definition = std::move(get_res.definition)})};
     rp.rep->write_body("json", json_rslt);

--- a/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_subject_versions_version.h
@@ -27,7 +27,7 @@ inline void rjson_serialize(
   rapidjson::Writer<rapidjson::StringBuffer>& w,
   const post_subject_versions_version_response& res) {
     w.StartObject();
-    w.Key("name");
+    w.Key("subject");
     ::json::rjson_serialize(w, res.sub);
     w.Key("id");
     ::json::rjson_serialize(w, res.id);

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -366,6 +366,9 @@ seq_writer::delete_subject_permanent_inner(
         }
     }
 
+    // Stash the list of versions to return at end
+    auto versions = co_await _store.get_versions(sub, include_deleted::yes);
+
     // Produce tombstones.  We do not need to check where they landed,
     // because these can arrive in any order and be safely repeated.
     auto batch = std::move(rb).build();
@@ -400,7 +403,7 @@ seq_writer::delete_subject_permanent_inner(
         advance_offset_inner(offset);
         offset++;
     }
-    co_return std::vector<schema_version>();
+    co_return versions;
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -1,0 +1,131 @@
+//// Copyright 2021 Vectorized, Inc.
+////
+//// Use of this software is governed by the Business Source License
+//// included in the file licenses/BSL.md
+////
+//// As of the Change Date specified in that file, in accordance with
+//// the Business Source License, use of this software will be governed
+//// by the Apache License, Version 2.
+
+#include "pandaproxy/schema_registry/seq_writer.h"
+
+#include "pandaproxy/error.h"
+#include "pandaproxy/logger.h"
+#include "pandaproxy/schema_registry/client_fetch_batch_reader.h"
+#include "pandaproxy/schema_registry/storage.h"
+#include "random/simple_time_jitter.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+
+using namespace std::chrono_literals;
+
+namespace pandaproxy::schema_registry {
+
+/// Call this before reading from the store, if servicing
+/// a REST API endpoint that requires global knowledge of latest
+/// data (i.e. any listings)
+ss::future<> seq_writer::read_sync() {
+    auto offsets = co_await _client.local().list_offsets(
+      model::schema_registry_internal_tp);
+
+    const auto& topics = offsets.data.topics;
+    if (topics.size() != 1 || topics.front().partitions.size() != 1) {
+        auto ec = kafka::error_code::unknown_topic_or_partition;
+        throw kafka::exception(ec, make_error_code(ec).message());
+    }
+
+    const auto& partition = topics.front().partitions.front();
+    if (partition.error_code != kafka::error_code::none) {
+        auto ec = partition.error_code;
+        throw kafka::exception(ec, make_error_code(ec).message());
+    }
+
+    co_await wait_for(partition.offset - model::offset{1});
+}
+
+ss::future<> seq_writer::wait_for(model::offset offset) {
+    return container().invoke_on(0, _smp_opts, [offset](seq_writer& seq) {
+        return ss::with_semaphore(seq._wait_for_sem, 1, [&seq, offset]() {
+            if (offset > seq._loaded_offset) {
+                vlog(
+                  plog.debug,
+                  "wait_for dirty!  Reading {}..{}",
+                  seq._loaded_offset,
+                  offset);
+
+                return make_client_fetch_batch_reader(
+                         seq._client.local(),
+                         model::schema_registry_internal_tp,
+                         seq._loaded_offset + model::offset{1},
+                         offset + model::offset{1})
+                  .consume(
+                    consume_to_store{seq._store, seq}, model::no_timeout);
+            } else {
+                vlog(plog.debug, "wait_for clean (offset  {})", offset);
+                return ss::make_ready_future<>();
+            }
+        });
+    });
+}
+
+/// Helper for write methods that need to check + retry if their
+/// write landed where they expected it to.
+///
+/// \param write_at Offset at which caller expects their write to land
+/// \param batch Message to write
+/// \return true if the write landed at `write_at`, else false
+ss::future<bool> seq_writer::produce_and_check(
+  model::offset write_at, model::record_batch batch) {
+    // Because we rely on checking exactly where our message (singular) landed,
+    // only use this function with batches of a single message.
+    vassert(batch.record_count() == 1, "Only single-message batches allowed");
+
+    kafka::partition_produce_response res
+      = co_await _client.local().produce_record_batch(
+        model::schema_registry_internal_tp, std::move(batch));
+
+    // TODO(Ben): Check the error reporting here
+    if (res.error_code != kafka::error_code::none) {
+        throw kafka::exception(res.error_code, *res.error_message);
+    }
+
+    auto wrote_at = res.base_offset;
+    if (wrote_at == write_at) {
+        vlog(plog.debug, "seq_writer: Successful write at {}", wrote_at);
+
+        co_return true;
+    } else {
+        vlog(
+          plog.debug,
+          "seq_writer: Failed write at {} (wrote at {})",
+          write_at,
+          wrote_at);
+        co_return false;
+    }
+};
+
+ss::future<> seq_writer::advance_offset(model::offset offset) {
+    auto remote = [offset](seq_writer& s) { s.advance_offset_inner(offset); };
+
+    return container().invoke_on(0, _smp_opts, remote);
+}
+
+void seq_writer::advance_offset_inner(model::offset offset) {
+    if (_loaded_offset < offset) {
+        vlog(
+          plog.debug,
+          "seq_writer::advance_offset {}->{}",
+          _loaded_offset,
+          offset);
+        _loaded_offset = offset;
+    } else {
+        vlog(
+          plog.debug,
+          "seq_writer::advance_offset ignoring {} (have {})",
+          offset,
+          _loaded_offset);
+    }
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -40,6 +40,9 @@ public:
     // API for readers: notify us when they have read and applied an offset
     ss::future<> advance_offset(model::offset offset);
 
+    ss::future<schema_id>
+    write_subject_version(subject sub, schema_definition def, schema_type type);
+
 private:
     ss::smp_submit_to_options _smp_opts;
 
@@ -71,6 +74,8 @@ private:
         return container().invoke_on(0, _smp_opts, remote);
     }
 
+    /// The part of sequenced_write that runs on shard zero
+    ///
     /// This is declared as a separate member function rather than
     /// inline in sequenced_write, to avoid compiler issues (and resulting
     /// crashes) seen when passing in a coroutine lambda.

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -46,6 +46,15 @@ public:
     ss::future<bool>
     write_config(std::optional<subject> sub, compatibility_level compat);
 
+    ss::future<bool>
+    delete_subject_version(subject sub, schema_version version);
+
+    ss::future<std::vector<schema_version>>
+    delete_subject_impermanent(subject sub);
+
+    ss::future<std::vector<schema_version>> delete_subject_permanent(
+      subject sub, std::optional<schema_version> version);
+
 private:
     ss::smp_submit_to_options _smp_opts;
 
@@ -55,6 +64,9 @@ private:
     model::node_id _node_id;
 
     void advance_offset_inner(model::offset offset);
+
+    ss::future<std::vector<schema_version>> delete_subject_permanent_inner(
+      subject sub, std::optional<schema_version> version);
 
     simple_time_jitter<ss::lowres_clock> _jitter{
       std::chrono::milliseconds{100}};

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -1,0 +1,120 @@
+//// Copyright 2021 Vectorized, Inc.
+////
+//// Use of this software is governed by the Business Source License
+//// included in the file licenses/BSL.md
+////
+//// As of the Change Date specified in that file, in accordance with
+//// the Business Source License, use of this software will be governed
+//// by the Apache License, Version 2.
+
+#pragma once
+
+#include "kafka/client/client.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "random/simple_time_jitter.h"
+#include "utils/retry.h"
+
+namespace pandaproxy::schema_registry {
+
+using namespace std::chrono_literals;
+
+static const int max_retries = 32;
+
+class seq_writer final : public ss::peering_sharded_service<seq_writer> {
+public:
+    seq_writer(
+      model::node_id node_id,
+      ss::smp_service_group smp_group,
+      ss::sharded<kafka::client::client>& client,
+      sharded_store& store)
+      : _smp_opts(ss::smp_submit_to_options{smp_group})
+      , _client(client)
+      , _store(store)
+      , _node_id(node_id) {}
+
+    ss::future<> read_sync();
+
+    // API for readers: notify us when they have read and applied an offset
+    ss::future<> advance_offset(model::offset offset);
+
+private:
+    ss::smp_submit_to_options _smp_opts;
+
+    ss::sharded<kafka::client::client>& _client;
+    sharded_store& _store;
+
+    model::node_id _node_id;
+
+    void advance_offset_inner(model::offset offset);
+
+    simple_time_jitter<ss::lowres_clock> _jitter{
+      std::chrono::milliseconds{100}};
+
+    /// Helper for write paths that use sequence+retry logic to synchronize
+    /// multiple writing nodes.
+    template<typename F>
+    auto sequenced_write(F f) {
+        auto base_backoff = _jitter.next_duration();
+        auto remote = [base_backoff, f](seq_writer& seq) {
+            return ss::with_semaphore(
+              seq._write_sem, 1, [&seq, f, base_backoff]() {
+                  return retry_with_backoff(
+                    max_retries,
+                    [f, &seq]() { return seq.sequenced_write_inner(f); },
+                    base_backoff);
+              });
+        };
+
+        return container().invoke_on(0, _smp_opts, remote);
+    }
+
+    /// This is declared as a separate member function rather than
+    /// inline in sequenced_write, to avoid compiler issues (and resulting
+    /// crashes) seen when passing in a coroutine lambda.
+    template<typename F>
+    ss::future<typename std::invoke_result_t<F, model::offset, seq_writer&>::
+                 value_type::value_type>
+    sequenced_write_inner(F f) {
+        // If we run concurrently with them, redundant replays to the store
+        // will be safely dropped based on offset.
+        co_await read_sync();
+
+        auto next_offset = _loaded_offset + model::offset{1};
+        auto r = co_await f(next_offset, *this);
+
+        if (r.has_value()) {
+            co_return r.value();
+        } else {
+            throw exception(
+              error_code::write_collision,
+              fmt::format("Write collision at offset {}", next_offset));
+        }
+    }
+
+    ss::future<bool>
+    produce_and_check(model::offset write_at, model::record_batch batch);
+
+    /// Block until this offset is available, fetching if necessary
+    ss::future<> wait_for(model::offset offset);
+
+    // Global (Shard 0) State
+    // ======================
+
+    /// Serialize wait_for operations, to avoid issuing
+    /// gratuitous number of reads to the topic on concurrent GETs.
+    ss::semaphore _wait_for_sem{1};
+
+    /// Shard 0 only: Reads have progressed as far as this offset
+    model::offset _loaded_offset{-1};
+
+    /// Shard 0 only: Serialize write operations.
+    ss::semaphore _write_sem{1};
+
+    // ======================
+    // End of Shard 0 state
+};
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -43,6 +43,9 @@ public:
     ss::future<schema_id>
     write_subject_version(subject sub, schema_definition def, schema_type type);
 
+    ss::future<bool>
+    write_config(std::optional<subject> sub, compatibility_level compat);
+
 private:
     ss::smp_submit_to_options _smp_opts;
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -21,7 +21,7 @@ namespace pandaproxy::schema_registry {
 
 using namespace std::chrono_literals;
 
-static const int max_retries = 32;
+static const int max_retries = 4;
 
 class seq_writer final : public ss::peering_sharded_service<seq_writer> {
 public:
@@ -68,8 +68,7 @@ private:
     ss::future<std::vector<schema_version>> delete_subject_permanent_inner(
       subject sub, std::optional<schema_version> version);
 
-    simple_time_jitter<ss::lowres_clock> _jitter{
-      std::chrono::milliseconds{100}};
+    simple_time_jitter<ss::lowres_clock> _jitter{std::chrono::milliseconds{50}};
 
     /// Helper for write paths that use sequence+retry logic to synchronize
     /// multiple writing nodes.

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -117,12 +117,24 @@ ss::future<> service::do_start() {
 }
 
 ss::future<> service::create_internal_topic() {
-    vlog(plog.debug, "Schema registry: attempting to create internal topic");
-    static constexpr auto make_internal_topic = []() {
+    // Use the default topic replica count, unless our specific setting
+    // for the schema registry chooses to override it.
+    int16_t replication_factor = _config.schema_registry_replication_factor();
+    if (replication_factor == -1) {
+        replication_factor
+          = config::shard_local_cfg().default_topic_replication();
+    }
+
+    vlog(
+      plog.debug,
+      "Schema registry: attempting to create internal topic (replication={})",
+      replication_factor);
+
+    auto make_internal_topic = [replication_factor]() {
         return kafka::creatable_topic{
           .name{model::schema_registry_internal_tp.topic},
           .num_partitions = 1,
-          .replication_factor = 1, // TODO(Ben): Make configurable
+          .replication_factor = replication_factor,
           .assignments{},
           .configs{
             {.name{ss::sstring{kafka::topic_property_cleanup_policy}},
@@ -151,6 +163,11 @@ ss::future<> service::create_internal_topic() {
 }
 
 ss::future<> service::fetch_internal_topic() {
+    vlog(plog.debug, "Schema registry: loading internal topic");
+
+    // TODO: should check the replication_factor of the topic is
+    // what our config calls for
+
     auto offset_res = co_await _client.local().list_offsets(
       model::schema_registry_internal_tp);
     const auto& topics = offset_res.data.topics;

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -13,6 +13,7 @@
 
 #include "kafka/client/client.h"
 #include "pandaproxy/schema_registry/configuration.h"
+#include "pandaproxy/schema_registry/seq_writer.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/util.h"
 #include "pandaproxy/server.h"
@@ -34,7 +35,8 @@ public:
       ss::smp_service_group smp_sg,
       size_t max_memory,
       ss::sharded<kafka::client::client>& client,
-      sharded_store& store);
+      sharded_store& store,
+      ss::sharded<seq_writer>& sequencer);
 
     ss::future<> start();
     ss::future<> stop();
@@ -42,6 +44,7 @@ public:
     configuration& config();
     kafka::client::configuration& client_config();
     ss::sharded<kafka::client::client>& client() { return _client; }
+    seq_writer& writer() { return _writer.local(); }
     sharded_store& schema_store() { return _store; }
 
 private:
@@ -55,6 +58,8 @@ private:
     ctx_server<service>::context_t _ctx;
     ctx_server<service> _server;
     sharded_store& _store;
+    ss::sharded<seq_writer>& _writer;
+
     one_shot _ensure_started;
 };
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -72,6 +72,7 @@ ss::future<sharded_store::insert_result> sharded_store::project_ids(
 }
 
 ss::future<bool> sharded_store::upsert(
+  seq_marker marker,
   subject sub,
   schema_definition def,
   schema_type type,
@@ -79,7 +80,7 @@ ss::future<bool> sharded_store::upsert(
   schema_version version,
   is_deleted deleted) {
     co_await upsert_schema(id, std::move(def), type);
-    co_return co_await upsert_subject(sub, version, id, deleted);
+    co_return co_await upsert_subject(marker, sub, version, id, deleted);
 }
 
 ss::future<schema> sharded_store::get_schema(const schema_id& id) {
@@ -129,26 +130,50 @@ sharded_store::get_versions(const subject& sub, include_deleted inc_del) {
     co_return std::move(versions).value();
 }
 
-ss::future<std::vector<schema_version>>
-sharded_store::delete_subject(const subject& sub, permanent_delete permanent) {
+ss::future<std::vector<schema_version>> sharded_store::delete_subject(
+  seq_marker marker, const subject& sub, permanent_delete permanent) {
     auto versions = co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, &store::delete_subject, sub, permanent);
+      shard_for(sub),
+      _smp_opts,
+      &store::delete_subject,
+      marker,
+      sub,
+      permanent);
     co_return std::move(versions).value();
 }
 
-ss::future<bool> sharded_store::delete_subject_version(
-  const subject& sub,
-  schema_version version,
-  permanent_delete permanent,
-  include_deleted inc_del) {
+ss::future<is_deleted> sharded_store::is_subject_deleted(const subject& sub) {
     auto deleted = co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, &store::is_subject_deleted, sub);
+
+    co_return std::move(deleted).value();
+}
+
+ss::future<std::vector<seq_marker>>
+sharded_store::get_subject_written_at(const subject& sub) {
+    auto history = co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, &store::get_subject_written_at, sub);
+
+    co_return std::move(history).value();
+}
+
+ss::future<std::vector<seq_marker>>
+sharded_store::get_subject_version_written_at(
+  const subject& sub, schema_version version) {
+    auto history = co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
-      &store::delete_subject_version,
+      &store::get_subject_version_written_at,
       sub,
-      version,
-      permanent,
-      inc_del);
+      version);
+
+    co_return std::move(history).value();
+}
+
+ss::future<bool> sharded_store::delete_subject_version(
+  const subject& sub, schema_version version) {
+    auto deleted = co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, &store::delete_subject_version, sub, version);
     co_return deleted.value();
 }
 
@@ -178,13 +203,14 @@ sharded_store::set_compatibility(compatibility_level compatibility) {
 }
 
 ss::future<bool> sharded_store::set_compatibility(
-  const subject& sub, compatibility_level compatibility) {
+  seq_marker marker, const subject& sub, compatibility_level compatibility) {
     using overload_t = result<bool> (store::*)(
-      const subject&, compatibility_level);
+      seq_marker, const subject&, compatibility_level);
     auto set = co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
       static_cast<overload_t>(&store::set_compatibility),
+      marker,
       sub,
       compatibility);
     co_return set.value();
@@ -216,11 +242,16 @@ sharded_store::insert_subject(subject sub, schema_id id) {
 }
 
 ss::future<bool> sharded_store::upsert_subject(
-  subject sub, schema_version version, schema_id id, is_deleted deleted) {
+  seq_marker marker,
+  subject sub,
+  schema_version version,
+  schema_id id,
+  is_deleted deleted) {
     co_return co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
       &store::upsert_subject,
+      marker,
       sub,
       version,
       id,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -149,6 +149,18 @@ ss::future<is_deleted> sharded_store::is_subject_deleted(const subject& sub) {
     co_return std::move(deleted).value();
 }
 
+ss::future<is_deleted> sharded_store::is_subject_version_deleted(
+  const subject& sub, const schema_version version) {
+    auto deleted = co_await _store.invoke_on(
+      shard_for(sub),
+      _smp_opts,
+      &store::is_subject_version_deleted,
+      sub,
+      version);
+
+    co_return std::move(deleted).value();
+}
+
 ss::future<std::vector<seq_marker>>
 sharded_store::get_subject_written_at(const subject& sub) {
     auto history = co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -36,6 +36,7 @@ public:
     project_ids(subject sub, schema_definition def, schema_type type);
 
     ss::future<bool> upsert(
+      seq_marker marker,
       subject sub,
       schema_definition def,
       schema_type type,
@@ -58,15 +59,22 @@ public:
     get_versions(const subject& sub, include_deleted inc_del);
 
     ///\brief Delete a subject.
-    ss::future<std::vector<schema_version>>
-    delete_subject(const subject& sub, permanent_delete permanent);
+    ss::future<std::vector<schema_version>> delete_subject(
+      seq_marker marker, const subject& sub, permanent_delete permanent);
+
+    ss::future<is_deleted> is_subject_deleted(const subject& sub);
+
+    ///\brief Get sequence number history (errors out if not soft-deleted)
+    ss::future<std::vector<seq_marker>>
+    get_subject_written_at(const subject& sub);
+
+    ///\brief Get sequence number history (errors out if not soft-deleted)
+    ss::future<std::vector<seq_marker>>
+    get_subject_version_written_at(const subject& sub, schema_version version);
 
     ///\brief Delete a subject version
-    ss::future<bool> delete_subject_version(
-      const subject& sub,
-      schema_version version,
-      permanent_delete permanent,
-      include_deleted inc_del);
+    ss::future<bool>
+    delete_subject_version(const subject& sub, schema_version version);
 
     ///\brief Get the global compatibility level.
     ss::future<compatibility_level> get_compatibility();
@@ -78,8 +86,8 @@ public:
     ss::future<bool> set_compatibility(compatibility_level compatibility);
 
     ///\brief Set the compatibility level for a subject.
-    ss::future<bool>
-    set_compatibility(const subject& sub, compatibility_level compatibility);
+    ss::future<bool> set_compatibility(
+      seq_marker marker, const subject& sub, compatibility_level compatibility);
 
     ///\brief Clear the compatibility level for a subject.
     ss::future<bool> clear_compatibility(const subject& sub);
@@ -106,7 +114,11 @@ private:
     ss::future<insert_subject_result> insert_subject(subject sub, schema_id id);
 
     ss::future<bool> upsert_subject(
-      subject sub, schema_version version, schema_id id, is_deleted deleted);
+      seq_marker marker,
+      subject sub,
+      schema_version version,
+      schema_id id,
+      is_deleted deleted);
 
     ss::future<> maybe_update_max_schema_id(schema_id id);
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -31,8 +31,9 @@ public:
         schema_id id;
         bool inserted;
     };
+
     ss::future<insert_result>
-    insert(subject sub, schema_definition def, schema_type type);
+    project_ids(subject sub, schema_definition def, schema_type type);
 
     ss::future<bool> upsert(
       subject sub,
@@ -95,13 +96,6 @@ public:
       schema_type new_schema_type);
 
 private:
-    struct insert_schema_result {
-        schema_id id;
-        bool inserted;
-    };
-    ss::future<insert_schema_result>
-    insert_schema(schema_definition def, schema_type type);
-
     ss::future<bool>
     upsert_schema(schema_id id, schema_definition def, schema_type type);
 
@@ -114,11 +108,13 @@ private:
     ss::future<bool> upsert_subject(
       subject sub, schema_version version, schema_id id, is_deleted deleted);
 
-    ss::future<schema_id> allocate_schema_id();
     ss::future<> maybe_update_max_schema_id(schema_id id);
+
+    ss::future<schema_id> project_schema_id();
 
     ss::smp_submit_to_options _smp_opts;
     ss::sharded<store> _store;
+
     ///\brief Access must occur only on shard 0.
     schema_id _next_schema_id{1};
 };

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -64,6 +64,9 @@ public:
 
     ss::future<is_deleted> is_subject_deleted(const subject& sub);
 
+    ss::future<is_deleted> is_subject_version_deleted(
+      const subject& sub, const schema_version version);
+
     ///\brief Get sequence number history (errors out if not soft-deleted)
     ss::future<std::vector<seq_marker>>
     get_subject_written_at(const subject& sub);

--- a/src/v/pandaproxy/schema_registry/storage.h
+++ b/src/v/pandaproxy/schema_registry/storage.h
@@ -19,6 +19,7 @@
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/seq_writer.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "raft/types.h"
@@ -925,8 +926,9 @@ inline model::record_batch make_delete_subject_version_permanently_batch(
 }
 
 struct consume_to_store {
-    explicit consume_to_store(sharded_store& s)
-      : _store{s} {}
+    explicit consume_to_store(sharded_store& s, seq_writer& seq)
+      : _store{s}
+      , _sequencer(seq) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch b) {
         if (!b.header().attrs.is_control()) {
@@ -1042,6 +1044,7 @@ struct consume_to_store {
 
     void end_of_stream() {}
     sharded_store& _store;
+    seq_writer& _sequencer;
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -142,6 +142,16 @@ public:
         return sub_it->second.deleted;
     }
 
+    ///\brief Return the value of the 'deleted' field on a subject
+    result<is_deleted> is_subject_version_deleted(
+      const subject& sub, const schema_version version) const {
+        auto sub_it = BOOST_OUTCOME_TRYX(
+          get_subject_iter(sub, include_deleted::yes));
+        auto v_it = BOOST_OUTCOME_TRYX(
+          get_version_iter(*sub_it, version, include_deleted::yes));
+        return v_it->deleted;
+    }
+
     /// \brief Return the seq_marker write history of a subject
     ///
     /// \return A vector with at least one element

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -149,6 +149,32 @@ public:
         return res;
     }
 
+    ///\brief If this schema ID isn't already in the version list, return
+    ///       what the version number will be if it is inserted.
+    std::optional<schema_version>
+    project_version(const subject& sub, schema_id sid) const {
+        auto subject_iter = _subjects.find(sub);
+        if (subject_iter == _subjects.end()) {
+            // Subject doesn't exist yet.  First version will be 1.
+            return schema_version{1};
+        }
+
+        auto& versions = subject_iter->second.versions;
+
+        schema_version maxver{0};
+        for (auto v : versions) {
+            if (v.id == sid) {
+                // No version to project, the schema is already
+                // present in this subject.
+                return std::nullopt;
+            } else {
+                maxver = std::max(maxver, v.version);
+            }
+        }
+
+        return maxver + 1;
+    }
+
     ///\brief Return a list of versions and associated schema_id.
     result<std::vector<subject_version_id>>
     get_version_ids(const subject& sub, include_deleted inc_del) const {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/types.h"
 
@@ -54,21 +55,6 @@ public:
         auto id = insert_schema(std::move(def), type).id;
         auto [version, inserted] = insert_subject(std::move(sub), id);
         return {version, id, inserted};
-    }
-
-    ///\brief Update or insert a schema with the given id, and register it with
-    /// the subject for the given version.
-    ///
-    /// return true if a new version was inserted, false if updated.
-    bool upsert(
-      subject sub,
-      schema_definition def,
-      schema_type type,
-      schema_id id,
-      schema_version version,
-      is_deleted deleted) {
-        upsert_schema(id, std::move(def), type);
-        return upsert_subject(std::move(sub), version, id, deleted);
     }
 
     ///\brief Return a schema by id.
@@ -149,6 +135,73 @@ public:
         return res;
     }
 
+    ///\brief Return the value of the 'deleted' field on a subject
+    result<is_deleted> is_subject_deleted(const subject& sub) const {
+        auto sub_it = BOOST_OUTCOME_TRYX(
+          get_subject_iter(sub, include_deleted::yes));
+        return sub_it->second.deleted;
+    }
+
+    /// \brief Return the seq_marker write history of a subject
+    ///
+    /// \return A vector with at least one element
+    result<std::vector<seq_marker>>
+    get_subject_written_at(const subject& sub) const {
+        auto sub_it = BOOST_OUTCOME_TRYX(
+          get_subject_iter(sub, include_deleted::yes));
+
+        if (!sub_it->second.deleted) {
+            // Refuse to yield sequence history for anything that
+            // hasn't been soft-deleted, to prevent a hard-delete
+            // from generating tombstones without a preceding soft-delete
+            return not_deleted(sub);
+        } else {
+            if (sub_it->second.written_at.empty()) {
+                // This should never happen (how can a record get into the
+                // store without an originating sequenced record?), but return
+                // an error instead of vasserting out.
+                return not_found(sub);
+            }
+
+            return sub_it->second.written_at;
+        }
+    }
+
+    /// \brief Return the seq_marker write history of a version.
+    ///
+    /// \return A vector with at least one element
+    result<std::vector<seq_marker>> get_subject_version_written_at(
+      const subject& sub, schema_version version) const {
+        auto sub_it = BOOST_OUTCOME_TRYX(
+          get_subject_iter(sub, include_deleted::yes));
+
+        auto v_it = BOOST_OUTCOME_TRYX(
+          get_version_iter(*sub_it, version, include_deleted::yes));
+
+        if (!v_it->deleted) {
+            // Refuse to yield sequence history for anything that
+            // hasn't been soft-deleted, to prevent a hard-delete
+            // from generating tombstones without a preceding soft-delete
+            return not_deleted(sub, version);
+        }
+
+        std::vector<seq_marker> result;
+        for (auto s : sub_it->second.written_at) {
+            if (s.version == version) {
+                result.push_back(s);
+            }
+        }
+
+        if (result.empty()) {
+            // This should never happen (how can a record get into the
+            // store without an originating sequenced record?), but return
+            // an error instead of vasserting out.
+            return not_found(sub, version);
+        }
+
+        return result;
+    }
+
     ///\brief If this schema ID isn't already in the version list, return
     ///       what the version number will be if it is inserted.
     std::optional<schema_version>
@@ -183,8 +236,8 @@ public:
     }
 
     ///\brief Delete a subject.
-    result<std::vector<schema_version>>
-    delete_subject(const subject& sub, permanent_delete permanent) {
+    result<std::vector<schema_version>> delete_subject(
+      seq_marker marker, const subject& sub, permanent_delete permanent) {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::yes));
 
@@ -196,6 +249,7 @@ public:
             return soft_deleted(sub);
         }
 
+        sub_it->second.written_at.push_back(marker);
         sub_it->second.deleted = is_deleted::yes;
 
         const auto& versions = sub_it->second.versions;
@@ -214,30 +268,38 @@ public:
         return res;
     }
 
-    ///\brief Delete a subject version
-    result<bool> delete_subject_version(
-      const subject& sub,
-      schema_version version,
-      permanent_delete permanent,
-      include_deleted inc_del) {
-        auto sub_it = BOOST_OUTCOME_TRYX(get_subject_iter(sub, inc_del));
+    ///\brief Delete a subject version.
+    result<bool>
+    delete_subject_version(const subject& sub, schema_version version) {
+        auto sub_it = BOOST_OUTCOME_TRYX(
+          get_subject_iter(sub, include_deleted::yes));
         auto& versions = sub_it->second.versions;
         auto v_it = BOOST_OUTCOME_TRYX(
           get_version_iter(*sub_it, version, include_deleted::yes));
 
-        if (!v_it->deleted && permanent && !inc_del) {
+        // A hard delete should always be preceded by a soft delete
+        if (!(v_it->deleted || sub_it->second.deleted)) {
             return not_deleted(sub, version);
         }
 
-        if (v_it->deleted && !permanent && !inc_del) {
-            return soft_deleted(sub, version);
+        versions.erase(v_it);
+
+        // Trim any seq_markers referring to this version, so
+        // that when we later hard-delete the subject, we do not
+        // emit more tombstones for versions already tombstoned
+        auto& markers = sub_it->second.written_at;
+        markers.erase(
+          std::remove_if(
+            markers.begin(),
+            markers.end(),
+            [&version](auto sm) { return sm.version == version; }),
+          markers.end());
+
+        if (versions.empty()) {
+            _subjects.erase(sub_it);
         }
 
-        if (permanent) {
-            versions.erase(v_it);
-            return true;
-        }
-        return std::exchange(v_it->deleted, is_deleted::yes) != is_deleted::yes;
+        return true;
     }
 
     ///\brief Get the global compatibility level.
@@ -258,10 +320,14 @@ public:
     }
 
     ///\brief Set the compatibility level for a subject.
-    result<bool>
-    set_compatibility(const subject& sub, compatibility_level compatibility) {
+    result<bool> set_compatibility(
+      seq_marker marker,
+      const subject& sub,
+      compatibility_level compatibility) {
         auto sub_it = BOOST_OUTCOME_TRYX(
           get_subject_iter(sub, include_deleted::no));
+
+        sub_it->second.written_at.push_back(marker);
 
         // TODO(Ben): Check needs to be made here?
         return std::exchange(sub_it->second.compatibility, compatibility)
@@ -326,11 +392,15 @@ public:
     }
 
     bool upsert_subject(
-      subject sub, schema_version version, schema_id id, is_deleted deleted) {
+      seq_marker marker,
+      subject sub,
+      schema_version version,
+      schema_id id,
+      is_deleted deleted) {
         auto& subject_entry = _subjects[std::move(sub)];
-        // Inserting a version undeletes the subject
-        subject_entry.deleted = is_deleted::no;
         auto& versions = subject_entry.versions;
+        subject_entry.written_at.push_back(marker);
+
         const auto v_it = std::lower_bound(
           versions.begin(),
           versions.end(),
@@ -338,12 +408,26 @@ public:
           [](const subject_version_id& lhs, schema_version rhs) {
               return lhs.version < rhs;
           });
-        if (v_it != versions.end() && v_it->version == version) {
+
+        const bool found = v_it != versions.end() && v_it->version == version;
+        if (found) {
             *v_it = subject_version_id(version, id, deleted);
-            return false;
+        } else {
+            versions.insert(v_it, subject_version_id(version, id, deleted));
         }
-        versions.insert(v_it, subject_version_id(version, id, deleted));
-        return true;
+
+        const auto all_deleted = is_deleted(
+          std::all_of(versions.begin(), versions.end(), [](const auto& v) {
+              return v.deleted;
+          }));
+        if (deleted == all_deleted) {
+            // - If we're deleting and all are deleted, subject is deleted
+            // - If we're not deleting and some are not deleted, the subject
+            //   is not deleted.
+            subject_entry.deleted = deleted;
+        }
+
+        return !found;
     }
 
 private:
@@ -360,6 +444,8 @@ private:
         std::optional<compatibility_level> compatibility;
         std::vector<subject_version_id> versions;
         is_deleted deleted{false};
+
+        std::vector<seq_marker> written_at;
     };
     using schema_map = absl::btree_map<schema_id, schema_entry>;
     using subject_map = absl::node_hash_map<subject, subject_entry>;

--- a/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
@@ -30,13 +30,27 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
     s.set_compatibility(pps::compatibility_level::backward).get();
     auto sub = pps::subject{"sub"};
     auto avro = pps::schema_type::avro;
-    auto res = s.insert(sub, pps::schema_definition{schema1}, avro).get();
+    s.upsert(
+       sub,
+       pps::schema_definition{schema1},
+       avro,
+       pps::schema_id{1},
+       pps::schema_version{1},
+       pps::is_deleted::no)
+      .get();
     // add a defaulted field
     BOOST_REQUIRE(
       s.is_compatible(
          sub, pps::schema_version{1}, pps::schema_definition{schema2}, avro)
         .get());
-    res = s.insert(sub, pps::schema_definition{schema2}, avro).get();
+    s.upsert(
+       sub,
+       pps::schema_definition{schema2},
+       avro,
+       pps::schema_id{2},
+       pps::schema_version{2},
+       pps::is_deleted::no)
+      .get();
 
     // Test non-defaulted field
     BOOST_REQUIRE(
@@ -45,7 +59,14 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
          .get());
 
     // Insert schema with non-defaulted field
-    res = s.insert(sub, pps::schema_definition{schema2}, avro).get();
+    s.upsert(
+       sub,
+       pps::schema_definition{schema2},
+       avro,
+       pps::schema_id{2},
+       pps::schema_version{2},
+       pps::is_deleted::no)
+      .get();
 
     // Test Remove defaulted field to previous
     BOOST_REQUIRE(

--- a/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_store.cc
@@ -27,10 +27,13 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
     s.start(ss::default_smp_service_group()).get();
     auto stop_store = ss::defer([&s]() { s.stop().get(); });
 
+    pps::seq_marker dummy_marker;
+
     s.set_compatibility(pps::compatibility_level::backward).get();
     auto sub = pps::subject{"sub"};
     auto avro = pps::schema_type::avro;
     s.upsert(
+       dummy_marker,
        sub,
        pps::schema_definition{schema1},
        avro,
@@ -44,6 +47,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
          sub, pps::schema_version{1}, pps::schema_definition{schema2}, avro)
         .get());
     s.upsert(
+       dummy_marker,
        sub,
        pps::schema_definition{schema2},
        avro,
@@ -60,6 +64,7 @@ SEASTAR_THREAD_TEST_CASE(test_avro_basic_backwards_store_compat) {
 
     // Insert schema with non-defaulted field
     s.upsert(
+       dummy_marker,
        sub,
        pps::schema_definition{schema2},
        avro,

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -98,7 +98,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
       s.get_compatibility(subject0).get() == pps::compatibility_level::none);
 
     auto good_config = pps::as_record_batch(
-      pps::config_key{subject0, magic0},
+      pps::config_key{sequence, node_id, subject0, magic0},
       pps::config_value{pps::compatibility_level::full});
     BOOST_REQUIRE_NO_THROW(c(std::move(good_config)).get());
 
@@ -106,7 +106,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
       s.get_compatibility(subject0).get() == pps::compatibility_level::full);
 
     auto bad_config_magic = pps::as_record_batch(
-      pps::config_key{subject0, magic1},
+      pps::config_key{sequence, node_id, subject0, magic1},
       pps::config_value{pps::compatibility_level::full});
     BOOST_REQUIRE_THROW(c(std::move(bad_config_magic)).get(), pps::exception);
 

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -16,6 +16,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "model/fundamental.h"
+#include "model/record.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/storage.h"
 #include "pandaproxy/schema_registry/util.h"
@@ -70,8 +72,11 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
 
     auto c = pps::consume_to_store(s, seq.local());
 
+    auto sequence = model::offset{0};
+    const auto node_id = model::node_id{123};
+
     auto good_schema_1 = pps::as_record_batch(
-      pps::schema_key{subject0, version0, magic1},
+      pps::schema_key{sequence, node_id, subject0, version0, magic1},
       pps::schema_value{
         subject0, version0, pps::schema_type::avro, id0, string_def0});
     BOOST_REQUIRE_NO_THROW(c(std::move(good_schema_1)).get());
@@ -82,7 +87,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
     BOOST_REQUIRE_EQUAL(s_res.definition, string_def0);
 
     auto bad_schema_magic = pps::as_record_batch(
-      pps::schema_key{subject0, version0, magic2},
+      pps::schema_key{sequence, node_id, subject0, version0, magic2},
       pps::schema_value{
         subject0, version0, pps::schema_type::avro, id0, string_def0});
     BOOST_REQUIRE_THROW(c(std::move(bad_schema_magic)).get(), pps::exception);
@@ -132,7 +137,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
 
     // Insert a deleted schema
     good_schema_1 = pps::as_record_batch(
-      pps::schema_key{subject0, version0, magic1},
+      pps::schema_key{sequence, node_id, subject0, version0, magic1},
       pps::schema_value{
         subject0,
         version0,

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -27,9 +27,13 @@ constexpr std::string_view avro_schema_key_sv{
   "keytype": "SCHEMA",
   "subject": "my-kafka-value",
   "version": 1,
-  "magic": 1
+  "magic": 1,
+  "seq": 42,
+  "node": 2
 })"};
 const pps::schema_key avro_schema_key{
+  .seq{model::offset{42}},
+  .node{model::node_id{2}},
   .sub{pps::subject{"my-kafka-value"}},
   .version{pps::schema_version{1}},
   .magic{pps::topic_key_magic{1}}};

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -93,9 +93,13 @@ constexpr std::string_view delete_subject_key_sv{
   R"({
   "keytype": "DELETE_SUBJECT",
   "subject": "my-kafka-value",
-  "magic": 0
+  "magic": 0,
+  "seq": 42,
+  "node": 2
 })"};
 const pps::delete_subject_key delete_subject_key{
+  .seq{model::offset{42}},
+  .node{model::node_id{2}},
   .sub{pps::subject{"my-kafka-value"}}};
 
 constexpr std::string_view delete_subject_value_sv{

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -57,19 +57,30 @@ const pps::schema_value avro_schema_value{
 constexpr std::string_view config_key_sv{
   R"({
   "keytype": "CONFIG",
+  "seq": 0,
+  "node": 0,
   "subject": null,
   "magic": 0
 })"};
-const pps::config_key config_key{.sub{}, .magic{pps::topic_key_magic{0}}};
+const pps::config_key config_key{
+  .seq{model::offset{0}},
+  .node{model::node_id{0}},
+  .sub{},
+  .magic{pps::topic_key_magic{0}}};
 
 constexpr std::string_view config_key_sub_sv{
   R"({
   "keytype": "CONFIG",
+  "seq": 0,
+  "node": 0,
   "subject": "my-kafka-value",
   "magic": 0
 })"};
 const pps::config_key config_key_sub{
-  .sub{pps::subject{"my-kafka-value"}}, .magic{pps::topic_key_magic{0}}};
+  .seq{model::offset{0}},
+  .node{model::node_id{0}},
+  .sub{pps::subject{"my-kafka-value"}},
+  .magic{pps::topic_key_magic{0}}};
 
 constexpr std::string_view config_value_sv{
   R"({

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -63,19 +63,35 @@ BOOST_AUTO_TEST_CASE(test_store_insert) {
     BOOST_REQUIRE_EQUAL(ins_res.version, pps::schema_version{2});
 }
 
+/// Emulate how `sharded_store` does upserts on `store`
+bool upsert(
+  pps::store& store,
+  pps::subject sub,
+  pps::schema_definition def,
+  pps::schema_type type,
+  pps::schema_id id,
+  pps::schema_version version,
+  pps::is_deleted deleted) {
+    store.upsert_schema(id, std::move(def), type);
+    return store.upsert_subject(
+      pps::seq_marker{}, std::move(sub), version, id, deleted);
+}
+
 BOOST_AUTO_TEST_CASE(test_store_upsert_in_order) {
     const auto expected = std::vector<pps::schema_version>(
       {pps::schema_version{0}, pps::schema_version{1}});
 
     pps::store s;
-    BOOST_REQUIRE(s.upsert(
+    BOOST_REQUIRE(upsert(
+      s,
       subject0,
       string_def0,
       pps::schema_type::avro,
       pps::schema_id{0},
       pps::schema_version{0},
       pps::is_deleted::no));
-    BOOST_REQUIRE(s.upsert(
+    BOOST_REQUIRE(upsert(
+      s,
       subject0,
       string_def0,
       pps::schema_type::avro,
@@ -97,14 +113,16 @@ BOOST_AUTO_TEST_CASE(test_store_upsert_reverse_order) {
       {pps::schema_version{0}, pps::schema_version{1}});
 
     pps::store s;
-    BOOST_REQUIRE(s.upsert(
+    BOOST_REQUIRE(upsert(
+      s,
       subject0,
       string_def0,
       pps::schema_type::avro,
       pps::schema_id{1},
       pps::schema_version{1},
       pps::is_deleted::no));
-    BOOST_REQUIRE(s.upsert(
+    BOOST_REQUIRE(upsert(
+      s,
       subject0,
       string_def0,
       pps::schema_type::avro,
@@ -126,7 +144,8 @@ BOOST_AUTO_TEST_CASE(test_store_upsert_override) {
       {pps::schema_version{0}});
 
     pps::store s;
-    BOOST_REQUIRE(s.upsert(
+    BOOST_REQUIRE(upsert(
+      s,
       subject0,
       string_def0,
       pps::schema_type::avro,
@@ -134,7 +153,8 @@ BOOST_AUTO_TEST_CASE(test_store_upsert_override) {
       pps::schema_version{0},
       pps::is_deleted::no));
     // override schema and version (should return no insertion)
-    BOOST_REQUIRE(!s.upsert(
+    BOOST_REQUIRE(!upsert(
+      s,
       subject0,
       int_def0,
       pps::schema_type::avro,
@@ -305,22 +325,30 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
     // Setting the retrieving a subject compatibility should be allowed multiple
     // times
 
+    pps::seq_marker dummy_marker;
+
     pps::compatibility_level global_expected{pps::compatibility_level::none};
     pps::store s;
     BOOST_REQUIRE(s.get_compatibility().value() == global_expected);
     s.insert(subject0, string_def0, pps::schema_type::avro);
 
     auto sub_expected = pps::compatibility_level::backward;
-    BOOST_REQUIRE(s.set_compatibility(subject0, sub_expected).value() == true);
+    BOOST_REQUIRE(
+      s.set_compatibility(dummy_marker, subject0, sub_expected).value()
+      == true);
     BOOST_REQUIRE(s.get_compatibility(subject0).value() == sub_expected);
 
     // duplicate should return false
     sub_expected = pps::compatibility_level::backward;
-    BOOST_REQUIRE(s.set_compatibility(subject0, sub_expected).value() == false);
+    BOOST_REQUIRE(
+      s.set_compatibility(dummy_marker, subject0, sub_expected).value()
+      == false);
     BOOST_REQUIRE(s.get_compatibility(subject0).value() == sub_expected);
 
     sub_expected = pps::compatibility_level::full_transitive;
-    BOOST_REQUIRE(s.set_compatibility(subject0, sub_expected).value() == true);
+    BOOST_REQUIRE(
+      s.set_compatibility(dummy_marker, subject0, sub_expected).value()
+      == true);
     BOOST_REQUIRE(s.get_compatibility(subject0).value() == sub_expected);
     BOOST_REQUIRE(s.get_compatibility().value() == global_expected);
 
@@ -346,6 +374,7 @@ BOOST_AUTO_TEST_CASE(test_store_invalid_subject_compat) {
     // Setting and getting a compatibility for a non-existant subject should
     // fail
 
+    pps::seq_marker dummy_marker;
     pps::compatibility_level expected{pps::compatibility_level::none};
     pps::store s;
 
@@ -355,7 +384,7 @@ BOOST_AUTO_TEST_CASE(test_store_invalid_subject_compat) {
 
     expected = pps::compatibility_level::backward;
     BOOST_REQUIRE_EQUAL(
-      s.set_compatibility(subject0, expected).error().code(),
+      s.set_compatibility(dummy_marker, subject0, expected).error().code(),
       pps::error_code::subject_not_found);
 }
 
@@ -366,12 +395,18 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject) {
     pps::store s;
     s.set_compatibility(pps::compatibility_level::none).value();
 
+    pps::seq_marker dummy_marker;
+
     BOOST_REQUIRE_EQUAL(
-      s.delete_subject(subject0, pps::permanent_delete::no).error().code(),
+      s.delete_subject(dummy_marker, subject0, pps::permanent_delete::no)
+        .error()
+        .code(),
       pps::error_code::subject_not_found);
 
     BOOST_REQUIRE_EQUAL(
-      s.delete_subject(subject0, pps::permanent_delete::yes).error().code(),
+      s.delete_subject(dummy_marker, subject0, pps::permanent_delete::yes)
+        .error()
+        .code(),
       pps::error_code::subject_not_found);
 
     // First insert, expect id{1}, version{1}
@@ -387,7 +422,8 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject) {
       expected_vers.cend());
 
     // permanent delete of not soft-deleted should fail
-    auto d_res = s.delete_subject(subject0, pps::permanent_delete::yes);
+    auto d_res = s.delete_subject(
+      dummy_marker, subject0, pps::permanent_delete::yes);
     BOOST_REQUIRE(d_res.has_error());
     BOOST_REQUIRE_EQUAL(
       d_res.error().code(), pps::error_code::subject_not_deleted);
@@ -404,7 +440,7 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject) {
     BOOST_REQUIRE_EQUAL(s.get_subjects(pps::include_deleted::no).size(), 1);
 
     // soft delete should return versions
-    d_res = s.delete_subject(subject0, pps::permanent_delete::no);
+    d_res = s.delete_subject(dummy_marker, subject0, pps::permanent_delete::no);
     BOOST_REQUIRE(d_res.has_value());
     BOOST_REQUIRE_EQUAL_COLLECTIONS(
       d_res.value().cbegin(),
@@ -422,7 +458,7 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject) {
     BOOST_REQUIRE_EQUAL(s.get_subjects(pps::include_deleted::yes).size(), 1);
 
     // Second soft delete should fail
-    d_res = s.delete_subject(subject0, pps::permanent_delete::no);
+    d_res = s.delete_subject(dummy_marker, subject0, pps::permanent_delete::no);
     BOOST_REQUIRE(d_res.has_error());
     BOOST_REQUIRE_EQUAL(
       d_res.error().code(), pps::error_code::subject_soft_deleted);
@@ -439,7 +475,8 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject) {
       expected_vers.cend());
 
     // permanent delete should return versions
-    d_res = s.delete_subject(subject0, pps::permanent_delete::yes);
+    d_res = s.delete_subject(
+      dummy_marker, subject0, pps::permanent_delete::yes);
     BOOST_REQUIRE(d_res.has_value());
     BOOST_REQUIRE_EQUAL_COLLECTIONS(
       d_res.value().cbegin(),
@@ -457,7 +494,8 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject) {
     BOOST_REQUIRE(s.get_subjects(pps::include_deleted::yes).empty());
 
     // Second permanant delete should fail
-    d_res = s.delete_subject(subject0, pps::permanent_delete::yes);
+    d_res = s.delete_subject(
+      dummy_marker, subject0, pps::permanent_delete::yes);
     BOOST_REQUIRE(d_res.has_error());
     BOOST_REQUIRE_EQUAL(
       d_res.error().code(), pps::error_code::subject_not_found);
@@ -472,28 +510,13 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
     const std::vector<pps::schema_version> expected_vers{
       {pps::schema_version{1}, pps::schema_version{2}}};
 
+    pps::seq_marker dummy_marker;
     pps::store s;
     s.set_compatibility(pps::compatibility_level::none).value();
 
     // Test unknown subject
     BOOST_REQUIRE_EQUAL(
-      s.delete_subject_version(
-         subject0,
-         pps::schema_version{0},
-         pps::permanent_delete::no,
-         pps::include_deleted::no)
-        .error()
-        .code(),
-      pps::error_code::subject_not_found);
-
-    BOOST_REQUIRE_EQUAL(
-      s.delete_subject_version(
-         subject0,
-         pps::schema_version{0},
-         pps::permanent_delete::yes,
-         pps::include_deleted::no)
-        .error()
-        .code(),
+      s.delete_subject_version(subject0, pps::schema_version{0}).error().code(),
       pps::error_code::subject_not_found);
 
     // First insert, expect id{1}, version{1}
@@ -510,43 +533,23 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
 
     // Test unknown versions
     BOOST_REQUIRE_EQUAL(
-      s.delete_subject_version(
-         subject0,
-         pps::schema_version{42},
-         pps::permanent_delete::no,
-         pps::include_deleted::no)
-        .error()
-        .code(),
-      pps::error_code::subject_version_not_found);
-
-    BOOST_REQUIRE_EQUAL(
-      s.delete_subject_version(
-         subject0,
-         pps::schema_version{42},
-         pps::permanent_delete::yes,
-         pps::include_deleted::no)
+      s.delete_subject_version(subject0, pps::schema_version{42})
         .error()
         .code(),
       pps::error_code::subject_version_not_found);
 
     // perm-delete before soft-delete should fail
     BOOST_REQUIRE_EQUAL(
-      s.delete_subject_version(
-         subject0,
-         pps::schema_version{1},
-         pps::permanent_delete::yes,
-         pps::include_deleted::no)
-        .error()
-        .code(),
+      s.delete_subject_version(subject0, pps::schema_version{1}).error().code(),
       pps::error_code::subject_version_not_deleted);
 
     // soft-delete version 1
-    BOOST_REQUIRE(s.delete_subject_version(
-                     subject0,
-                     pps::schema_version{1},
-                     pps::permanent_delete::no,
-                     pps::include_deleted::no)
-                    .value());
+    BOOST_REQUIRE_NO_THROW(s.upsert_subject(
+      dummy_marker,
+      subject0,
+      pps::schema_version{1},
+      pps::schema_id{1},
+      pps::is_deleted::yes));
 
     // expect [v2] for include_deleted::no
     v_res = s.get_versions(subject0, pps::include_deleted::no);
@@ -562,24 +565,9 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
       expected_vers.cbegin(),
       expected_vers.cend());
 
-    // soft-delete version 1, second time should fail
-    BOOST_REQUIRE_EQUAL(
-      s.delete_subject_version(
-         subject0,
-         pps::schema_version{1},
-         pps::permanent_delete::no,
-         pps::include_deleted::no)
-        .error()
-        .code(),
-      pps::error_code::subject_version_soft_deleted);
-
     // perm-delete version 1
-    BOOST_REQUIRE(s.delete_subject_version(
-                     subject0,
-                     pps::schema_version{1},
-                     pps::permanent_delete::yes,
-                     pps::include_deleted::no)
-                    .value());
+    BOOST_REQUIRE(
+      s.delete_subject_version(subject0, pps::schema_version{1}).value());
 
     // expect [v2] for include_deleted::no
     v_res = s.get_versions(subject0, pps::include_deleted::no);
@@ -593,12 +581,6 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
 
     // perm-delete version 1, second time should fail
     BOOST_REQUIRE_EQUAL(
-      s.delete_subject_version(
-         subject0,
-         pps::schema_version{1},
-         pps::permanent_delete::yes,
-         pps::include_deleted::no)
-        .error()
-        .code(),
+      s.delete_subject_version(subject0, pps::schema_version{1}).error().code(),
       pps::error_code::subject_version_not_found);
 }

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "model/metadata.h"
 #include "seastarx.h"
 #include "utils/named_type.h"
 #include "utils/string_switch.h"
@@ -84,6 +85,46 @@ static constexpr schema_version invalid_schema_version{-1};
 using schema_id = named_type<int32_t, struct schema_id_tag>;
 static constexpr schema_id invalid_schema_id{-1};
 
+// Very similar to topic_key_type, separate to avoid intermingling storage code
+enum class seq_marker_key_type { invalid = 0, schema, delete_subject, config };
+
+constexpr std::string_view to_string_view(seq_marker_key_type v) {
+    switch (v) {
+    case seq_marker_key_type::schema:
+        return "schema";
+        break;
+    case seq_marker_key_type::delete_subject:
+        return "delete_subject";
+        break;
+    case seq_marker_key_type::config:
+        return "config";
+        break;
+    default:
+        return "invalid";
+    }
+}
+
+// Record the sequence+node where updates were made to a subject,
+// in order to later generate tombstone keys when doing a permanent
+// deletion.
+struct seq_marker {
+    model::offset seq;
+    model::node_id node;
+    schema_version version;
+    seq_marker_key_type key_type{seq_marker_key_type::invalid};
+
+    friend std::ostream& operator<<(std::ostream& os, const seq_marker& v) {
+        fmt::print(
+          os,
+          "seq={} node={} version={} key_type={}",
+          v.seq,
+          v.node,
+          v.version,
+          to_string_view(v.key_type));
+        return os;
+    }
+};
+
 ///\brief Complete description of a schema.
 struct schema {
     schema(schema_id id, schema_type type, schema_definition definition)
@@ -110,6 +151,8 @@ struct subject_version_id {
     schema_version version;
     schema_id id;
     is_deleted deleted{is_deleted::no};
+
+    std::vector<seq_marker> written_at;
 };
 
 ///\brief All schema versions for a subject.

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -471,6 +471,15 @@ void application::wire_up_services() {
         construct_service(
           _schema_registry_client, to_yaml(*_schema_reg_client_config))
           .get();
+
+        construct_service(
+          _schema_registry_sequencer,
+          config::shard_local_cfg().node_id(),
+          smp_service_groups.proxy_smp_sg(),
+          std::reference_wrapper(_schema_registry_client),
+          std::reference_wrapper(_schema_registry_store))
+          .get();
+
         construct_service(
           _schema_registry,
           to_yaml(*_schema_reg_config),
@@ -479,7 +488,8 @@ void application::wire_up_services() {
           // https://github.com/vectorizedio/redpanda/issues/1392
           memory_groups::kafka_total_memory(),
           std::reference_wrapper(_schema_registry_client),
-          std::reference_wrapper(_schema_registry_store))
+          std::reference_wrapper(_schema_registry_store),
+          std::reference_wrapper(_schema_registry_sequencer))
           .get();
     }
 }

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -23,6 +23,7 @@
 #include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/schema_registry/configuration.h"
 #include "pandaproxy/schema_registry/fwd.h"
+#include "pandaproxy/schema_registry/seq_writer.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "raft/group_manager.h"
 #include "raft/recovery_throttle.h"
@@ -143,6 +144,8 @@ private:
     ss::sharded<kafka::client::client> _schema_registry_client;
     pandaproxy::schema_registry::sharded_store _schema_registry_store;
     ss::sharded<pandaproxy::schema_registry::service> _schema_registry;
+    ss::sharded<pandaproxy::schema_registry::seq_writer>
+      _schema_registry_sequencer;
     ss::sharded<storage::compaction_controller> _compaction_controller;
 
     ss::metrics::metric_groups _metrics;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -134,7 +134,7 @@ public:
                                 seed_servers = std::move(seed_servers),
                                 base_path]() mutable {
             auto& config = config::shard_local_cfg();
-            config.get("node_id").set_value(node_id());
+            config.get("node_id").set_value(node_id);
 
             config.get("rpc_server")
               .set_value(unresolved_address("127.0.0.1", rpc_port));

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -183,6 +183,7 @@ public:
         cfg.get("schema_registry_api")
           .set_value(std::vector<model::broker_endpoint>{model::broker_endpoint(
             unresolved_address("127.0.0.1", listen_port))});
+        cfg.get("schema_registry_replication_factor").set_value(int16_t{1});
         return to_yaml(cfg);
     }
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -326,7 +326,7 @@ class SchemaRegistryTest(RedpandaTest):
             subject=f"{topic}-key", version=1)
         assert result_raw.status_code == requests.codes.ok
         result = result_raw.json()
-        assert result["name"] == f"{topic}-key"
+        assert result["subject"] == f"{topic}-key"
         assert result["version"] == 1
         # assert result["schema"] == json.dumps(schema_def)
 
@@ -335,7 +335,7 @@ class SchemaRegistryTest(RedpandaTest):
             subject=f"{topic}-key", version="latest")
         assert result_raw.status_code == requests.codes.ok
         result = result_raw.json()
-        assert result["name"] == f"{topic}-key"
+        assert result["subject"] == f"{topic}-key"
         assert result["version"] == 1
         # assert result["schema"] == json.dumps(schema_def)
 

--- a/tests/rptest/tests/schema_registry_test_helper.py
+++ b/tests/rptest/tests/schema_registry_test_helper.py
@@ -1,0 +1,247 @@
+# This is not a test.  It is a remote script for use by schema_registry_test.py
+
+import threading
+import requests
+import sys
+import logging
+import random
+import time
+import json
+
+log = logging.getLogger("helper")
+log.setLevel(logging.DEBUG)
+log.addHandler(logging.StreamHandler())
+
+# How many errors before a worker gives up?
+max_errs = 1
+
+HTTP_GET_HEADERS = {"Accept": "application/vnd.schemaregistry.v1+json"}
+
+HTTP_POST_HEADERS = {
+    "Accept": "application/vnd.schemaregistry.v1+json",
+    "Content-Type": "application/vnd.schemaregistry.v1+json"
+}
+
+schema_template = '{"type":"record","name":"record_%s","fields":[{"type":"string","name":"f1"}]}'
+
+
+class WriteWorker(threading.Thread):
+    def __init__(self, name, count, node_names):
+        super(WriteWorker, self).__init__()
+        self.name = name
+        self.count = count
+        self.schema_counter = 1
+        self.results = {}
+        self.nodes = node_names
+
+        self.errors = []
+
+    def _request(self, verb, path, hostname=None, **kwargs):
+        """
+
+        :param verb: String, as for first arg to requests.request
+        :param path: URI path without leading slash
+        :param timeout: Optional requests timeout in seconds
+        :return:
+        """
+
+        if hostname is None:
+            # Pick hostname once: we will retry the same place we got an error,
+            # to avoid silently skipping hosts that are persistently broken
+            nodes = [n for n in self.nodes]
+            random.shuffle(nodes)
+            hostname = nodes[0]
+
+        uri = f"http://{hostname}:8081/{path}"
+
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = 60
+
+        # Error codes that may appear during normal API operation, do not
+        # indicate an issue with the service
+        acceptable_errors = {409, 422, 404}
+
+        def accept_response(resp):
+            return 200 <= resp.status_code < 300 or resp.status_code in acceptable_errors
+
+        log.debug(f"{verb} hostname={hostname} {path} {kwargs}")
+
+        # This is not a retry loop: you get *one* retry to handle issues
+        # during startup, after that a failure is a failure.
+        r = requests.request(verb, uri, **kwargs)
+        if not accept_response(r):
+            log.info(
+                f"Retrying for error {r.status_code} on {verb} {path} ({r.text})"
+            )
+            time.sleep(10)
+            r = requests.request(verb, uri, **kwargs)
+            if accept_response(r):
+                log.info(
+                    f"OK after retry {r.status_code} on {verb} {path} ({r.text})"
+                )
+            else:
+                log.info(
+                    f"Error after retry {r.status_code} on {verb} {path} ({r.text})"
+                )
+
+        log.info(f"{r.status_code} {verb} hostname={hostname} {path} {kwargs}")
+
+        return r
+
+    def _post_subjects_subject_versions(self,
+                                        subject,
+                                        data,
+                                        headers=HTTP_POST_HEADERS,
+                                        **kwargs):
+        return self._request("POST",
+                             f"subjects/{subject}/versions",
+                             headers=headers,
+                             data=data,
+                             **kwargs)
+
+    def _get_subjects_subject_versions_version(self,
+                                               subject,
+                                               version,
+                                               headers=HTTP_GET_HEADERS):
+        return self._request("GET",
+                             f"subjects/{subject}/versions/{version}",
+                             headers=headers)
+
+    def _get_schemas_ids_id(self, id, headers=HTTP_GET_HEADERS):
+        return self._request("GET", f"schemas/ids/{id}", headers=headers)
+
+    def create(self):
+        for i in range(0, self.count):
+            subject = f"subject_{self.name}_{i}"
+            version_id = 1
+            schema_def = schema_template % f"{self.name}_{i}"
+
+            log.debug(f"Worker {self.name} writing subject {subject}")
+            try:
+                resp = self._post_subjects_subject_versions(
+                    subject=subject,
+                    data=json.dumps({"schema": schema_def}),
+                    timeout=20)
+            except requests.exceptions.RequestException as e:
+                self._push_err(f"{subject}/{version_id} POST exception: {e}")
+            else:
+                self._check_eq(subject, version_id, "post_ret",
+                               resp.status_code, 200)
+                if resp.status_code == 200:
+                    schema_id = resp.json()["id"]
+                    self.results[(subject, version_id)] = (schema_def,
+                                                           schema_id)
+
+    def _push_err(self, err):
+        log.error(f"push_err[{self.name}]: {err}")
+        self.errors.append(err)
+        if len(self.errors) > max_errs:
+            # On e.g. timeouts, test takes too long if we wait for every request to time out
+            raise RuntimeError("Too many errors on worker {self.name}")
+
+    def _check_eq(self, subject, version, check_name, a, b):
+        if a != b:
+            self._push_err(f"{subject}/{version} failed {check_name} {a}!={b}")
+
+    def verify(self):
+        for (subject, version), (schema_def,
+                                 schema_id) in self.results.items():
+            try:
+                r = self._get_subjects_subject_versions_version(
+                    subject, version)
+            except requests.exceptions.RequestException as e:
+                self._push_err(
+                    f"{subject}/{version} GET version exception: {e}")
+                continue
+
+            self._check_eq(subject, version, "subject_retcode", r.status_code,
+                           200)
+            self._check_eq(subject, version, "name", r.json()['name'], subject)
+            self._check_eq(subject, version, "version",
+                           r.json()['version'], version)
+            self._check_eq(subject, version, "schema",
+                           r.json()['schema'], schema_def)
+
+            try:
+                r = self._get_schemas_ids_id(id=schema_id)
+            except requests.exceptions.RequestException as e:
+                self._push_err(
+                    f"{subject}/{version} GET schema exception: {e}")
+                continue
+            self._check_eq(subject, version, "schema_retcode", r.status_code,
+                           200)
+            self._check_eq(subject, version, "schema_def",
+                           r.json()['schema'], schema_def)
+
+        schema_ids = self.get_schema_ids()
+        if len(set(schema_ids)) != len(schema_ids):
+            self._push_err(f"Schema IDs reused!")
+
+    def run(self):
+        try:
+            t1 = time.time()
+            self.create()
+            create_dur = time.time() - t1
+            log.info(
+                f"[{self.name}] Created {self.count} in {create_dur}s ({self.count / create_dur}/s)"
+            )
+
+            # Drop out early if we already found some errors during write
+            if len(self.errors) == 0:
+                self.verify()
+        except Exception as e:
+            self.errors.append(f"Exception!  {e}")
+            raise
+
+    def get_schema_ids(self):
+        result = []
+        for (subject, version), (schema_def,
+                                 schema_id) in self.results.items():
+            result.append(schema_id)
+
+        return result
+
+
+def stress_test(node_names):
+    # Even this relatively small number of concurrent writers is
+    # more stress than the system will encounter in the field: schemas
+    # are likely to be written occasionally and not from many clients at once.
+    # However, it is enough to push the system to hit its collision/retry path
+    # for writes.
+    subjects_per_worker = 16
+    n_workers = 4
+    workers = []
+    for n in range(0, n_workers):
+        worker = WriteWorker(f"{n}", subjects_per_worker, node_names)
+        workers.append(worker)
+
+    for worker in workers:
+        worker.start()
+
+    for worker in workers:
+        worker.join()
+
+    all_schema_ids = []
+    for worker in workers:
+        if worker.errors:
+            log.error(f"Worker {worker.name} errors:")
+            for e in worker.errors:
+                log.error(f"  Worker {worker.name}: {e}")
+        else:
+            log.info(f"Worker {worker.name} OK")
+
+        all_schema_ids.extend(worker.get_schema_ids())
+
+    assert sum([len(worker.errors) for worker in workers]) == 0
+
+    # Check no schema IDs were duplicated
+    assert len(all_schema_ids) == len(set(all_schema_ids))
+
+
+if __name__ == "__main__":
+    node_names = sys.argv[1:]
+
+    assert len(node_names) > 1
+    stress_test(node_names)
+
+    log.info("All checks passed")

--- a/tests/rptest/tests/schema_registry_test_helper.py
+++ b/tests/rptest/tests/schema_registry_test_helper.py
@@ -156,7 +156,8 @@ class WriteWorker(threading.Thread):
 
             self._check_eq(subject, version, "subject_retcode", r.status_code,
                            200)
-            self._check_eq(subject, version, "name", r.json()['name'], subject)
+            self._check_eq(subject, version, "subject",
+                           r.json()['subject'], subject)
             self._check_eq(subject, version, "version",
                            r.json()['version'], version)
             self._check_eq(subject, version, "schema",


### PR DESCRIPTION
## Cover letter

The Schema Registry code needs to provide active/active HA, such that a k8s service can sit on top of the endpoint and send any read or write to any node.

An optimistic first writer wins approach is used, where the 'winner' is identified by a key's sequence number ('seq' attribute) being equal to the topic offset where the write landed.  Write operations are retried if they lose.

On reads, nodes will use their local store contents if possible (e.g. fetch schema by ID and it's already there), and otherwise fall back to a `read_sync` call to check the latest written offset and load new messages from the _schemas topic if necessary.  There is room for improvement on the read side with better use of continuous loading via consumer groups.

## Release notes

A new configuration setting schema_registry_replication_factor is added.  This controls the replication factor of the internal topic used by the schema registry.  Default is 3 for data safety - for single node dev/debug activity adjust it to 1.

## TODO

* [ ] ~Re-introduce support for reading Confluent's topic format (?)~ out of scope for this PR
* [X] Tombstone config_key records during permanent deletes
* [X] Extra test that actively exercise concurrency
* [x] Doc for testers that defines which endpoints are intentionally left out in phase 1 #1878 
