### PR TITLE
cluster: add config option to disable auto partition rebalance

### DIFF
--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -181,7 +181,10 @@ std::ostream& operator<<(std::ostream& o, const replicas_to_move& r) {
 };
 
 void members_backend::calculate_reallocations_after_node_added(
-  members_backend::update_meta& meta) {
+  members_backend::update_meta& meta) const {
+    if (!config::shard_local_cfg().enable_auto_rebalance_on_node_add()) {
+        return;
+    }
     auto& topics = _topics.local().topics_map();
     struct node_info {
         size_t replicas_count;

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -70,7 +70,7 @@ private:
     void handle_recommissioned(const members_manager::node_update&);
     void handle_reallocation_finished(model::node_id);
     void reassign_replicas(partition_assignment&, partition_reallocation&);
-    void calculate_reallocations_after_node_added(update_meta&);
+    void calculate_reallocations_after_node_added(update_meta&) const;
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<topic_table>& _topics;
     ss::sharded<partition_allocator>& _allocator;

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -17,8 +17,17 @@
 #include "model/fundamental.h"
 #include "random/fast_prng.h"
 #include "random/generators.h"
+#include "redpanda/application.h"
 
 struct partition_allocator_fixture {
+    partition_allocator_fixture() {
+        ss::smp::invoke_on_all([] {
+            config::shard_local_cfg()
+              .get("enable_auto_rebalance_on_node_add")
+              .set_value(true);
+        }).get0();
+    }
+
     void register_node(int id, int core_count) {
         allocator.register_node(std::make_unique<cluster::allocation_node>(
           model::node_id(id),

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -797,6 +797,12 @@ configuration::configuration()
       "Recovery raft configuration on start for NTPs matching pattern",
       required::no,
       {})
+  , enable_auto_rebalance_on_node_add(
+      *this,
+      "enable_auto_rebalance_on_node_add",
+      "Enable automatic partition rebalancing when new nodes are added",
+      required::no,
+      false)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -193,6 +193,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> kafka_qdc_depth_update_ms;
     property<size_t> zstd_decompress_workspace_bytes;
     one_or_many_property<ss::sstring> full_raft_configuration_recovery_pattern;
+    property<bool> enable_auto_rebalance_on_node_add;
 
     configuration();
 

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -32,6 +32,8 @@ redpanda:
 
   superusers: {{superuser[0]}}
 
+  enable_auto_rebalance_on_node_add: true
+
 {% if node_id > 1 %}
   seed_servers:
     - host:


### PR DESCRIPTION
Adds config to disable auto partition rebalancing on node addition.