### PR TITLE
Explicit metrics for produce and fetch request latency

### DIFF
--- a/src/v/kafka/latency_probe.h
+++ b/src/v/kafka/latency_probe.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+#include "utils/hdr_hist.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace kafka {
+class latency_probe {
+public:
+    void setup_metrics() {
+        namespace sm = ss::metrics;
+
+        if (config::shard_local_cfg().disable_metrics()) {
+            return;
+        }
+        std::vector<sm::label_instance> labels{
+          sm::label("latency_metric")("microseconds")};
+        _metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka:latency"),
+          {sm::make_histogram(
+             "fetch_latency_us",
+             sm::description("Fetch Latency"),
+             labels,
+             [this] { return _fetch_latency.seastar_histogram_logform(); }),
+           sm::make_histogram(
+             "produce_latency_us",
+             sm::description("Produce Latency"),
+             labels,
+             [this] { return _produce_latency.seastar_histogram_logform(); })});
+    }
+
+    std::unique_ptr<hdr_hist::measurement> auto_produce_measurement() {
+        return _produce_latency.auto_measure();
+    }
+    std::unique_ptr<hdr_hist::measurement> auto_fetch_measurement() {
+        return _fetch_latency.auto_measure();
+    }
+
+private:
+    hdr_hist _produce_latency;
+    hdr_hist _fetch_latency;
+    ss::metrics::metric_groups _metrics;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -251,9 +251,13 @@ struct read_result {
 // struct aggregating fetch requests and corresponding response iterators for
 // the same shard
 struct shard_fetch {
-    void push_back(ntp_fetch_config config, op_context::response_iterator it) {
+    void push_back(
+      ntp_fetch_config config,
+      op_context::response_iterator it,
+      std::unique_ptr<hdr_hist::measurement> m) {
         requests.push_back(std::move(config));
         responses.push_back(it);
+        metrics.push_back(std::move(m));
     }
 
     bool empty() const {
@@ -269,6 +273,7 @@ struct shard_fetch {
     ss::shard_id shard;
     std::vector<ntp_fetch_config> requests;
     std::vector<op_context::response_iterator> responses;
+    std::vector<std::unique_ptr<hdr_hist::measurement>> metrics;
 
     friend std::ostream& operator<<(std::ostream& o, const shard_fetch& sf) {
         fmt::print(o, "{}", sf.requests);

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -72,6 +72,7 @@ protocol::protocol(
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);
     }
+    _probe.setup_metrics();
 }
 
 ss::future<> protocol::apply(rpc::server::resources rs) {

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -13,6 +13,7 @@
 
 #include "cluster/fwd.h"
 #include "config/configuration.h"
+#include "kafka/latency_probe.h"
 #include "kafka/server/fetch_metadata_cache.hh"
 #include "kafka/server/fwd.h"
 #include "kafka/server/queue_depth_monitor.h"
@@ -116,6 +117,8 @@ public:
         return _fetch_metadata_cache;
     }
 
+    latency_probe& probe() { return _probe; }
+
 private:
     ss::smp_service_group _smp_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
@@ -136,6 +139,8 @@ private:
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
     std::optional<qdc_monitor> _qdc_mon;
     kafka::fetch_metadata_cache _fetch_metadata_cache;
+
+    latency_probe _probe;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -82,6 +82,8 @@ public:
 
     request_reader& reader() { return _reader; }
 
+    latency_probe& probe() { return _conn->server().probe(); }
+
     const cluster::metadata_cache& metadata_cache() const {
         return _conn->server().metadata_cache();
     }

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -199,29 +199,14 @@ handle_auth(request_context&& ctx, ss::smp_service_group g) {
     }
 }
 
-// do not track latency for admin apis
+// only track latency for push and fetch requests
 bool track_latency(api_key key) {
     switch (key) {
-    case metadata_handler::api::key:
-    case list_offsets_handler::api::key:
-    case list_groups_handler::api::key:
-    case api_versions_handler::api::key:
-    case create_topics_handler::api::key:
-    case describe_configs_handler::api::key:
-    case alter_configs_handler::api::key:
-    case delete_topics_handler::api::key:
-    case describe_groups_handler::api::key:
-    case sasl_handshake_handler::api::key:
-    case sasl_authenticate_handler::api::key:
-    case incremental_alter_configs_handler::api::key:
-    case delete_groups_handler::api::key:
-    case describe_acls_handler::api::key:
-    case describe_log_dirs_handler::api::key:
-    case create_acls_handler::api::key:
-    case delete_acls_handler::api::key:
-        return false;
-    default:
+    case fetch_handler::api::key:
+    case produce_handler::api::key:
         return true;
+    default:
+        return false;
     }
 }
 

--- a/src/v/utils/hdr_hist.h
+++ b/src/v/utils/hdr_hist.h
@@ -42,7 +42,7 @@ inline hdr_histogram_ptr make_unique_hdr_histogram(
 }
 } // namespace hist_internal
 
-// VERY Expensive object. At default granularity is about 185KB
+// Potentially VERY expensive object. At default granularity is about 4k bytes
 class hdr_hist {
 public:
     using clock_type = std::chrono::high_resolution_clock;
@@ -107,7 +107,7 @@ public:
     hdr_hist(
       int64_t max_value = 3600000000,
       int64_t min = 1,
-      int32_t significant_figures = 3)
+      int32_t significant_figures = 1)
       : _hist(hist_internal::make_unique_hdr_histogram(
         max_value, min, significant_figures)) {}
     hdr_hist(hdr_hist&& o) noexcept


### PR DESCRIPTION
This pull request fixes an open support [ticket](https://github.com/vectorizedio/support/issues/73) which requests we add a feature for measuring produce and latency fetch metrics within the Prometheus UI.

Currently we expose a metric called `kafka_rpc` which measures these two events requests, however when taking into consideration the sometimes long amount of time clients may wait when processing a fetch request (maybe its already up to late with the latest offset) the metric loses its usefulness, having large values make the metric show a large value for a long duration of time.

Fixes: https://github.com/vectorizedio/support/issues/73

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/2469a093d9ce3099d7d2e537a23acd68afe387a1..28bee2b6fac3179713ebe62d1adb490e02bb86b2)
- Updated metric labels to better reflect what they are.
- Had hdr_hist's only used in the latency_probe use a max value of 5 minutes and a granularity value of 2.
- Re-added `track_latency` so the existing `kafka_rpc` metric is now used for tracking latency of kafka admin requests.
 
Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/28bee2b6fac3179713ebe62d1adb490e02bb86b2..a8279a8fefe5db0e5b97ecae796ac5fff434a539)
- Changed default parameters of hdr_hist to a max value of 5 minutes and a granularity value of 1, this change affects all histograms globally. 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/a8279a8fefe5db0e5b97ecae796ac5fff434a539..0b5d02d626f11abd686767d9615fcf037784fc97)
- Modified default parameters in hdr_hist to measure a max value of 1hr, but with a granularity value of 1
- Updated commit comments detailing what these new mesasurements actually measure
- Updated a comment in `track_latency` method