### PR TITLE
Add admin port to docker containers

### DIFF
--- a/docs/www/quick-start-docker-CN.md
+++ b/docs/www/quick-start-docker-CN.md
@@ -30,6 +30,7 @@ Redpanda是用于任务关键型工作负载的现代[流媒体平台](/blog/int
 ```bash
 docker run -d --pull=always --name=redpanda-1 --rm \
 -p 9092:9092 \
+-p 9644:9644 \
 vectorized/redpanda:latest \
 redpanda start \
 --overprovisioned \
@@ -72,6 +73,7 @@ docker run -d \
 --net=redpandanet \
 -p 8082:8082 \
 -p 9092:9092 \
+-p 9644:9644 \
 -v "redpanda1:/var/lib/redpanda/data" \
 vectorized/redpanda redpanda start \
 --smp 1  \

--- a/docs/www/quick-start-docker.md
+++ b/docs/www/quick-start-docker.md
@@ -31,6 +31,7 @@ With a 1-node cluster you can test out a simple implementation of Redpanda.
 ```bash
 docker run -d --pull=always --name=redpanda-1 --rm \
 -p 9092:9092 \
+-p 9644:9644 \
 docker.vectorized.io/vectorized/redpanda:latest \
 redpanda start \
 --overprovisioned \
@@ -73,6 +74,7 @@ docker run -d \
 --net=redpandanet \
 -p 8082:8082 \
 -p 9092:9092 \
+-p 9644:9644 \
 -v "redpanda1:/var/lib/redpanda/data" \
 docker.vectorized.io/vectorized/redpanda redpanda start \
 --smp 1  \


### PR DESCRIPTION
## Cover letter

Open port 9644 for Docker containers to give access to the admin API.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
