### PR TITLE
rpk: Don't use seed_servers addresses to connect to the Kafka API

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/common/common.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common.go
@@ -187,14 +187,6 @@ func DeduceBrokers(
 			)
 			return defaultAddrs
 		}
-		// Add the seed servers' Kafka addrs.
-		for _, b := range conf.Redpanda.SeedServers {
-			addr := net.JoinHostPort(
-				b.Host.Address,
-				strconv.Itoa(b.Host.Port),
-			)
-			bs = append(bs, addr)
-		}
 		if len(conf.Redpanda.KafkaApi) > 0 {
 			// Add the current node's 1st Kafka listener.
 			selfAddr := net.JoinHostPort(

--- a/src/go/rpk/pkg/cli/cmd/common/common_test.go
+++ b/src/go/rpk/pkg/cli/cmd/common/common_test.go
@@ -135,15 +135,12 @@ func TestDeduceBrokers(t *testing.T) {
 		name: "it should take the local broker's cluster addresses if rpk.kafka_api.brokers is empty",
 		config: func() (*config.Config, error) {
 			conf := config.Default()
-			conf.Redpanda.SeedServers = []config.SeedServer{{
-				Host: config.SocketAddress{"somedomain.co", 1234},
-			}}
 			conf.Redpanda.KafkaApi = []config.NamedSocketAddress{{
 				SocketAddress: config.SocketAddress{"anotherhost", 4321},
 			}}
 			return conf, nil
 		},
-		expected: []string{"somedomain.co:1234", "anotherhost:4321"},
+		expected: []string{"anotherhost:4321"},
 	}, {
 		name: "it should return 127.0.0.1:9092 if no config sources yield a brokers list",
 		config: func() (*config.Config, error) {


### PR DESCRIPTION
The redpanda.seed_servers list contains addresses for the brokers' RPC API, which can't be used to initialize the Kafka client.
Fix #1904
