### PR TITLE
operator: Add default topic replication

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_types.go
@@ -62,8 +62,12 @@ type ClusterSpec struct {
 	// Notes:
 	// 1. versioning is not supported for map keys
 	// 2. key names not supported by Redpanda will lead to failure on start up
-	// 3. updating this map requires a manual restart of the Redpanda pods
+	// 3. updating this map requires a manual restart of the Redpanda pods. Please be aware of
+	// sync period when one Redpandais POD is restarted
 	// 4. cannot have keys that conflict with existing struct fields - it leads to panic
+	//
+	// By default if Replicas is 3 or more and redpanda.default_topic_partitions is not set
+	// default webhook is setting redpanda.default_topic_partitions to 3.
 	AdditionalConfiguration map[string]string `json:"additionalConfiguration,omitempty"`
 	// DNSTrailingDotDisabled gives ability to turn off the fully-qualified
 	// DNS name.

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -10,6 +10,8 @@
 package v1alpha1
 
 import (
+	"strconv"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,6 +25,11 @@ const (
 	kb = 1024
 	mb = 1024 * kb
 	gb = 1024 * mb
+
+	defaultTopicReplicationNumber = 3
+	minimumReplicas               = 3
+
+	defaultTopicReplicationKey = "redpanda.default_topic_replication"
 )
 
 // log is for logging in this package.
@@ -43,6 +50,16 @@ var _ webhook.Defaulter = &Cluster{}
 // TODO(user): fill in your defaulting logic.
 func (r *Cluster) Default() {
 	log.Info("default", "name", r.Name)
+
+	if *r.Spec.Replicas >= minimumReplicas {
+		if r.Spec.AdditionalConfiguration == nil {
+			r.Spec.AdditionalConfiguration = make(map[string]string)
+		}
+		_, ok := r.Spec.AdditionalConfiguration[defaultTopicReplicationKey]
+		if !ok {
+			r.Spec.AdditionalConfiguration[defaultTopicReplicationKey] = strconv.Itoa(defaultTopicReplicationNumber)
+		}
+	}
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -23,6 +23,56 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+func TestDefault(t *testing.T) {
+	type test struct {
+		name                           string
+		replicas                       int32
+		additionalConfigurationPresent bool
+	}
+	tests := []test{
+		{
+			name:                           "do not set default topic replication when there is less than 3 replicas",
+			replicas:                       0,
+			additionalConfigurationPresent: false,
+		},
+		{
+			name:                           "do not set default topic replication when there is less than 3 replicas",
+			replicas:                       1,
+			additionalConfigurationPresent: false,
+		},
+		{
+			name:                           "do not set default topic replication when there is less than 3 replicas",
+			replicas:                       2,
+			additionalConfigurationPresent: false,
+		},
+		{
+			name:                           "do not set default topic replication when there is less than 3 replicas",
+			replicas:                       3,
+			additionalConfigurationPresent: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redpandaCluster := &v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "",
+				},
+				Spec: v1alpha1.ClusterSpec{
+					Replicas:      pointer.Int32Ptr(tt.replicas),
+					Configuration: v1alpha1.RedpandaConfig{},
+				},
+			}
+
+			redpandaCluster.Default()
+			_, exist := redpandaCluster.Spec.AdditionalConfiguration["redpanda.default_topic_replication"]
+			if exist != tt.additionalConfigurationPresent {
+				t.Fail()
+			}
+		})
+	}
+}
+
 func TestValidateUpdate(t *testing.T) {
 	var replicas1 int32 = 1
 	var replicas2 int32 = 2

--- a/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
+++ b/src/go/k8s/config/crd/bases/redpanda.vectorized.io_clusters.yaml
@@ -46,9 +46,12 @@ spec:
                   \"3\"   pandaproxy_client.produce_batch_size_bytes: \"2097152\"
                   \n Notes: 1. versioning is not supported for map keys 2. key names
                   not supported by Redpanda will lead to failure on start up 3. updating
-                  this map requires a manual restart of the Redpanda pods 4. cannot
-                  have keys that conflict with existing struct fields - it leads to
-                  panic"
+                  this map requires a manual restart of the Redpanda pods. Please
+                  be aware of sync period when one Redpandais POD is restarted 4.
+                  cannot have keys that conflict with existing struct fields - it
+                  leads to panic \n By default if Replicas is 3 or more and redpanda.default_topic_partitions
+                  is not set default webhook is setting redpanda.default_topic_partitions
+                  to 3."
                 type: object
               annotations:
                 additionalProperties:


### PR DESCRIPTION
## Cover letter

This PR intercedes additional configuration in the clusters with more or equal 3 nodes.

Fixes: #1909 

## Release notes

Release note: The default topic replication will be set to 3 if there is enough nodes declared in cluster CR. 
