### PR TITLE
ducktape: Increase timeout for flaky rpk test

### DIFF
--- a/tests/rptest/tests/rpk_topic_test.py
+++ b/tests/rptest/tests/rpk_topic_test.py
@@ -201,6 +201,6 @@ class RpkToolTest(RedpandaTest):
             return True
 
         wait_until(cond,
-                   timeout_sec=15,
+                   timeout_sec=25,
                    backoff_sec=5,
                    err_msg="Message didn't appear.")


### PR DESCRIPTION
When changing the platform where the tests are run (local machine vs dedicated machines vs containers), the tests execution time may change, so increase the timeout for a test that fails intermittently.