### PR TITLE
pandaproxy/rest: Introduce GET /brokers

### DIFF
--- a/src/v/pandaproxy/api/api-doc/rest.json
+++ b/src/v/pandaproxy/api/api-doc/rest.json
@@ -1,4 +1,21 @@
-"/consumers/{group_name}": {
+"/brokers": {
+        "get": {
+          "summary": "Get a list of brokers.",
+          "operationId": "get_brokers",
+          "responses": {
+            "200": {
+              "description": "Array of topic names",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      },
+      "/consumers/{group_name}": {
         "post": {
           "summary": "Create a consumer for the group",
           "operationId": "create_consumer",

--- a/src/v/pandaproxy/json/requests/brokers.h
+++ b/src/v/pandaproxy/json/requests/brokers.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "json/json.h"
+#include "model/metadata.h"
+
+namespace pandaproxy::json {
+
+struct get_brokers_res {
+    std::vector<model::node_id> ids;
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const get_brokers_res& brokers) {
+    w.StartObject();
+    w.Key("brokers");
+    ::json::rjson_serialize(w, brokers.ids);
+    w.EndObject();
+}
+
+} // namespace pandaproxy::json

--- a/src/v/pandaproxy/rest/handlers.h
+++ b/src/v/pandaproxy/rest/handlers.h
@@ -19,6 +19,9 @@
 
 namespace pandaproxy::rest {
 
+ss::future<ctx_server<proxy>::reply_t>
+get_brokers(ctx_server<proxy>::request_t rq, ctx_server<proxy>::reply_t rp);
+
 ss::future<ctx_server<proxy>::reply_t> get_topics_names(
   ctx_server<proxy>::request_t rq, ctx_server<proxy>::reply_t rp);
 

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -26,6 +26,9 @@ server::routes_t get_proxy_routes() {
     server::routes_t routes;
     routes.api = ss::httpd::rest_json::name;
 
+    routes.routes.emplace_back(
+      server::route_t{ss::httpd::rest_json::get_brokers, get_brokers});
+
     routes.routes.emplace_back(server::route_t{
       ss::httpd::rest_json::get_topics_names, get_topics_names});
 

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -25,6 +25,11 @@ def create_topic_names(count):
     return list(f"pandaproxy-topic-{uuid.uuid4()}" for _ in range(count))
 
 
+HTTP_GET_BROKERS_HEADERS = {
+    "Accept": "application/vnd.kafka.v2+json",
+    "Content-Type": "application/vnd.kafka.v2+json"
+}
+
 HTTP_GET_TOPICS_HEADERS = {
     "Accept": "application/vnd.kafka.v2+json",
     "Content-Type": "application/vnd.kafka.v2+json"
@@ -136,6 +141,9 @@ class PandaProxyTest(RedpandaTest):
     def _base_uri(self):
         return f"http://{self.redpanda.nodes[0].account.hostname}:8082"
 
+    def _get_brokers(self, headers=HTTP_GET_BROKERS_HEADERS):
+        return requests.get(f"{self._base_uri()}/brokers", headers=headers)
+
     def _create_topics(self,
                        names=create_topic_names(1),
                        partitions=1,
@@ -184,6 +192,19 @@ class PandaProxyTest(RedpandaTest):
             }''',
                             headers=headers)
         return res
+
+    @cluster(num_nodes=3)
+    def test_get_brokers(self):
+        """
+        Test get_brokers returns the set of node_ids
+        """
+        brokers_raw = self._get_brokers()
+        brokers = brokers_raw.json()["brokers"]
+
+        nodes = enumerate(self.redpanda.nodes, 1)
+        node_idxs = [node[0] for node in nodes]
+
+        assert sorted(brokers) == sorted(node_idxs)
 
     @cluster(num_nodes=3)
     def test_list_topics_validation(self):


### PR DESCRIPTION
## Cover letter

Introduce the get_brokers endpoint.

This endpoint seems to be used by the karapace REST tests as a status check, this is the first step to integrating those tests for our rest proxy.

## Release notes

Pandaproxy: Introduce `GET /brokers`
