### PR TITLE
task/lint: Improve use of yapf

### DIFF
--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,5 @@
+vbuild/*
+build/*
+vtools/*
+depot_tools/*
+src/v/dashboard/node_modules/*

--- a/taskfiles/lint.yml
+++ b/taskfiles/lint.yml
@@ -14,4 +14,4 @@ tasks:
     deps:
     - :dev:install-yapf
     cmds:
-    - '"{{.BUILD_ROOT}}/venv/yapf/bin/yapf" -i -r -e "{{.BUILD_ROOT}}/*" "{{.SRC_DIR}}"'
+    - '{{.BUILD_ROOT}}/venv/yapf/bin/yapf -ir .'


### PR DESCRIPTION
## Cover letter

yapf seems to ignore `.yapfignore` if passed an absolute path.

But now yapf takes a few seconds, instead of >10mins reading 250GB.

Signed-off-by: Ben Pope <ben@vectorized.io>

