### PR TITLE
c/members_manager: using table to check if broker is cluster member

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -78,6 +78,10 @@ ss::future<> members_manager::start() {
     return start_config_changes_watcher();
 }
 
+bool members_manager::is_already_member() const {
+    return _members_table.local().get_broker(_self.id()).has_value();
+}
+
 ss::future<> members_manager::start_config_changes_watcher() {
     // handle initial configuration
     auto offset = _raft0->get_latest_configuration_offset();

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -85,9 +85,7 @@ private:
     using seed_iterator = std::vector<config::seed_server>::const_iterator;
     // Cluster join
     void join_raft0();
-    bool is_already_member() const {
-        return _raft0->config().contains_broker(_self.id());
-    }
+    bool is_already_member() const;
 
     ss::future<result<join_reply>>
     dispatch_join_to_seed_server(seed_iterator it);


### PR DESCRIPTION
Raft 0 configuration is updated before the updates are applied to
members table. This may lead to race condition in which we try to access
broker information that is not yet available in members table

Signed-off-by: Michal Maslanka <michal@vectorized.io>

Fixes: #1921 #1867
