### PR TITLE
rpk topic describe: Remove ISR column in output

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/describe.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/describe.go
@@ -137,7 +137,7 @@ func NewDescribeCommand(
 			})
 			t.Render()
 			t.ClearRows()
-			partitionHeaders := []string{"Partition", "Leader", "Replicas", "In-Sync Replicas"}
+			partitionHeaders := []string{"Partition", "Leader", "Replicas"}
 			if includeWatermarks {
 				partitionHeaders = append(partitionHeaders, "High Watermark")
 			}
@@ -159,16 +159,10 @@ func NewDescribeCommand(
 				sort.Slice(sortedReplicas, func(i, j int) bool {
 					return sortedReplicas[i] < sortedReplicas[j]
 				})
-
-				sortedISR := partition.Isr
-				sort.Slice(sortedISR, func(i, j int) bool {
-					return sortedISR[i] < sortedISR[j]
-				})
 				row := []string{
 					strconv.Itoa(int(partition.ID)),
 					strconv.Itoa(int(partition.Leader)),
 					fmt.Sprintf("%v", sortedReplicas),
-					fmt.Sprintf("%v", sortedISR),
 				}
 				if includeWatermarks {
 					row = append(

--- a/src/go/rpk/pkg/cli/cmd/topic_test.go
+++ b/src/go/rpk/pkg/cli/cmd/topic_test.go
@@ -299,17 +299,17 @@ func TestDescribeTopic(t *testing.T) {
   Name            Value     Read-only  Sensitive  
   key             value     false      false      
   Partitions      1 - 10 out of 10  
-  Partition       Leader            Replicas   In-Sync Replicas  
-  0               1                 [1]        [1]               
-  1               1                 [1]        [1]               
-  2               1                 [1]        [1]               
-  3               1                 [1]        [1]               
-  4               1                 [1]        [1]               
-  5               1                 [1]        [1]               
-  6               1                 [1]        [1]               
-  7               1                 [1]        [1]               
-  8               1                 [1]        [1]               
-  9               1                 [1]        [1]               
+  Partition       Leader            Replicas   
+  0               1                 [1]        
+  1               1                 [1]        
+  2               1                 [1]        
+  3               1                 [1]        
+  4               1                 [1]        
+  5               1                 [1]        
+  6               1                 [1]        
+  7               1                 [1]        
+  8               1                 [1]        
+  9               1                 [1]        
 `,
 		},
 		{
@@ -338,8 +338,8 @@ func TestDescribeTopic(t *testing.T) {
   Internal        false     
   Cleanup policy  delete    
   Partitions      1 - 1 out of 1  
-  Partition       Leader          Replicas  In-Sync Replicas  
-  0               1               [1]       [1]               
+  Partition       Leader          Replicas  
+  0               1               [1]       
 `,
 		},
 		{
@@ -362,13 +362,13 @@ func TestDescribeTopic(t *testing.T) {
   Name            Value    Read-only  Sensitive  
   key             value    false      false      
   Partitions      7 - 12 out of 12  
-  Partition       Leader            Replicas   In-Sync Replicas  
-  6               1                 [1]        [1]               
-  7               1                 [1]        [1]               
-  8               1                 [1]        [1]               
-  9               1                 [1]        [1]               
-  10              1                 [1]        [1]               
-  11              1                 [1]        [1]               
+  Partition       Leader            Replicas   
+  6               1                 [1]        
+  7               1                 [1]        
+  8               1                 [1]        
+  9               1                 [1]        
+  10              1                 [1]        
+  11              1                 [1]        
 `,
 		},
 		{
@@ -391,10 +391,10 @@ func TestDescribeTopic(t *testing.T) {
   Name            Value    Read-only  Sensitive  
   key             value    false      false      
   Partitions      10 - 12 out of 12  
-  Partition       Leader             Replicas   In-Sync Replicas  
-  9               1                  [1]        [1]               
-  10              1                  [1]        [1]               
-  11              1                  [1]        [1]               
+  Partition       Leader             Replicas   
+  9               1                  [1]        
+  10              1                  [1]        
+  11              1                  [1]        
 `,
 		},
 		{
@@ -417,19 +417,19 @@ func TestDescribeTopic(t *testing.T) {
   Name            Value    Read-only  Sensitive  
   key             value    false      false      
   Partitions      1 - 12 out of 12  
-  Partition       Leader            Replicas   In-Sync Replicas  
-  0               1                 [1]        [1]               
-  1               1                 [1]        [1]               
-  2               1                 [1]        [1]               
-  3               1                 [1]        [1]               
-  4               1                 [1]        [1]               
-  5               1                 [1]        [1]               
-  6               1                 [1]        [1]               
-  7               1                 [1]        [1]               
-  8               1                 [1]        [1]               
-  9               1                 [1]        [1]               
-  10              1                 [1]        [1]               
-  11              1                 [1]        [1]               
+  Partition       Leader            Replicas   
+  0               1                 [1]        
+  1               1                 [1]        
+  2               1                 [1]        
+  3               1                 [1]        
+  4               1                 [1]        
+  5               1                 [1]        
+  6               1                 [1]        
+  7               1                 [1]        
+  8               1                 [1]        
+  9               1                 [1]        
+  10              1                 [1]        
+  11              1                 [1]        
 `,
 		},
 		{
@@ -452,12 +452,12 @@ func TestDescribeTopic(t *testing.T) {
   Name            Value    Read-only  Sensitive  
   key             value    false      false      
   Partitions      1 - 5 out of 5  
-  Partition       Leader          Replicas   In-Sync Replicas  
-  0               1               [1]        [1]               
-  1               1               [1]        [1]               
-  2               1               [1]        [1]               
-  3               1               [1]        [1]               
-  4               1               [1]        [1]               
+  Partition       Leader          Replicas   
+  0               1               [1]        
+  1               1               [1]        
+  2               1               [1]        
+  3               1               [1]        
+  4               1               [1]        
 `,
 		},
 	}


### PR DESCRIPTION
The ISR list in Redpanda's TopicDescribe response is just the replicas. Until this is fixed, remove the In-sync replicas from the output.

Fix #1664
