### PR TITLE
redpanda/admin: /v1/brokers should return membership_status

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -601,6 +601,8 @@ void admin_server::register_broker_routes() {
               auto& b = res.emplace_back();
               b.node_id = broker->id();
               b.num_cores = broker->properties().cores;
+              b.membership_status = fmt::format(
+                "{}", broker->get_membership_state());
           }
           return ss::make_ready_future<ss::json::json_return_type>(
             std::move(res));


### PR DESCRIPTION
## Cover letter

Fix #1922

E.g.:
```
curl -s localhost:36885/v1/brokers | jq
[
  {
    "node_id": 1,
    "num_cores": 1,
    "membership_status": "active"
  },
  {
    "node_id": 0,
    "num_cores": 1,
    "membership_status": "active"
  },
  {
    "node_id": 2,
    "num_cores": 1,
    "membership_status": "active"
  }
]
```

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: Redpanda admin API `:9644/v1/brokers` now includes `membership_status`
