### PR TITLE
Reject join requests if RPC address is already in use by another node

### DIFF
--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -471,6 +471,18 @@ members_manager::handle_join_request(model::broker broker) {
                   return ret_t(r.error());
               });
         }
+
+        if (_raft0->config().contains_address(broker.rpc_address())) {
+            vlog(
+              clusterlog.info,
+              "Broker {} address ({}) conflicts with the address of another "
+              "node",
+              broker.id(),
+              broker.rpc_address());
+            return ss::make_ready_future<result<join_reply>>(
+              ret_t(join_reply{.success = false}));
+        }
+
         // Just update raft0 configuration
         // we do not use revisions in raft0 configuration, it is always revision
         // 0 which is perfectly fine. this will work like revision less raft

--- a/src/v/raft/group_configuration.cc
+++ b/src/v/raft/group_configuration.cc
@@ -119,6 +119,16 @@ bool group_configuration::contains_broker(model::node_id id) const {
     return it != std::cend(_brokers);
 }
 
+bool group_configuration::contains_address(
+  const unresolved_address& address) const {
+    return std::any_of(
+      std::cbegin(_brokers),
+      std::cend(_brokers),
+      [&address](const model::broker& broker) {
+          return address == broker.rpc_address();
+      });
+}
+
 configuration_type group_configuration::type() const {
     if (_old) {
         return configuration_type::joint;

--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -91,6 +91,7 @@ public:
 
     std::optional<model::broker> find_broker(model::node_id id) const;
     bool contains_broker(model::node_id id) const;
+    bool contains_address(const unresolved_address& address) const;
 
     bool contains(vnode) const;
 


### PR DESCRIPTION
## Cover letter

This is an ease of use improvement for handling incorrect configs (I ran into this when first setting up clusters by hand).  Generally people should use `rpk` rather then rolling their own, but we should still validate as well as we can.

One* can run into this if initially starting a single node system, where one might set 0.0.0.0 listen addresses, and then adding a node by copying the config file to another node and just changing IDs.  Currently, that produces a rather confused cluster (the second node is allowed to join, but then the first node sends its AppendEntries to 0.0.0.0 (i.e. itself!).

After this change, we don't let new nodes join the cluster if their RPC address is the same as an existing node.

* ...and by "one" I mean "me" :-)

## Release notes

No user facing changes, just a cleaner behaviour if two nodes' configs have the same RPC address.
