### PR TITLE
archival: Stability fixes

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -136,6 +136,9 @@ scheduler_service_impl::get_archival_service_config() {
         overrides.trust_file = s3::ca_trust_file(std::filesystem::path(*cert));
     }
     overrides.port = config::shard_local_cfg().cloud_storage_api_endpoint_port;
+    overrides.max_idle_time
+      = config::shard_local_cfg()
+          .cloud_storage_max_connection_idle_time_ms.value();
 
     auto s3_conf = co_await s3::configuration::make_configuration(
       access_key, secret_key, region, overrides, disable_metrics);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -729,6 +729,12 @@ configuration::configuration()
       "Manifest upload timeout (ms)",
       required::no,
       10s)
+  , cloud_storage_max_connection_idle_time_ms(
+      *this,
+      "cloud_storage_max_connection_idle_time_ms",
+      "Max https connection idle time (ms)",
+      required::no,
+      5s)
   , superusers(
       *this, "superusers", "List of superuser usernames", required::no, {})
   , kafka_qdc_latency_alpha(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -176,6 +176,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> cloud_storage_segment_upload_timeout_ms;
     property<std::chrono::milliseconds>
       cloud_storage_manifest_upload_timeout_ms;
+    property<std::chrono::milliseconds>
+      cloud_storage_max_connection_idle_time_ms;
 
     one_or_many_property<ss::sstring> superusers;
 

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -87,7 +87,8 @@ public:
     client(
       const rpc::base_transport::configuration& cfg,
       const ss::abort_source* as,
-      ss::shared_ptr<client_probe> probe);
+      ss::shared_ptr<client_probe> probe,
+      ss::lowres_clock::duration max_idle_time = {});
 
     ss::future<> stop();
     using rpc::base_transport::shutdown;
@@ -237,6 +238,11 @@ private:
     ss::gate _connect_gate;
     const ss::abort_source* _as;
     ss::shared_ptr<http::client_probe> _probe;
+    // Stores point in time when the last response was received
+    // from the server.
+    ss::lowres_clock::time_point _last_response{
+      ss::lowres_clock::time_point::min()};
+    ss::lowres_clock::duration _max_idle_time;
 };
 
 template<class BufferSeq>

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -144,7 +144,6 @@ result<http::client::request_header> request_creator::make_get_object_request(
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::content_length, "0");
     header.insert(aws_header_names::x_amz_content_sha256, emptysig);
-    _sign.update_credentials_if_outdated();
     auto ec = _sign.sign_header(header, emptysig);
     if (ec) {
         return ec;
@@ -189,7 +188,6 @@ request_creator::make_unsigned_put_object_request(
         }
         header.insert(aws_header_names::x_amz_tagging, tstr.str().substr(1));
     }
-    _sign.update_credentials_if_outdated();
     auto ec = _sign.sign_header(header, sig);
     if (ec) {
         return ec;
@@ -228,7 +226,6 @@ request_creator::make_list_objects_v2_request(
     if (max_keys) {
         header.insert(aws_header_names::start_after, std::to_string(*max_keys));
     }
-    _sign.update_credentials_if_outdated();
     auto ec = _sign.sign_header(header, emptysig);
     vlog(s3_log.trace, "ListObjectsV2:\n {}", header);
     if (ec) {
@@ -259,7 +256,6 @@ request_creator::make_delete_object_request(
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::content_length, "0");
     header.insert(aws_header_names::x_amz_content_sha256, emptysig);
-    _sign.update_credentials_if_outdated();
     auto ec = _sign.sign_header(header, emptysig);
     if (ec) {
         return ec;

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -41,6 +41,12 @@
 
 namespace s3 {
 
+// Close all connections that were used more than 5 seconds ago.
+// AWS S3 endpoint has timeout of 10 seconds. But since we're supporting
+// not only AWS S3 it makes sense to set timeout value a bit lower.
+static constexpr ss::lowres_clock::duration default_max_idle_time
+  = std::chrono::seconds(5);
+
 struct aws_header_names {
     static constexpr boost::beast::string_view prefix = "prefix";
     static constexpr boost::beast::string_view start_after = "start-after";
@@ -100,7 +106,9 @@ ss::future<configuration> configuration::make_configuration(
         client_cfg.credentials
           = co_await cred_builder.build_reloadable_certificate_credentials();
     }
+
     constexpr uint16_t default_port = 443;
+
     client_cfg.server_addr = unresolved_address(
       client_cfg.uri(),
       overrides.port ? *overrides.port : default_port,
@@ -108,6 +116,9 @@ ss::future<configuration> configuration::make_configuration(
     client_cfg.disable_metrics = disable_metrics;
     client_cfg._probe = ss::make_shared<client_probe>(
       disable_metrics, region(), endpoint_uri);
+    client_cfg.max_idle_time = overrides.max_idle_time
+                                 ? *overrides.max_idle_time
+                                 : default_max_idle_time;
     co_return client_cfg;
 }
 
@@ -115,7 +126,7 @@ std::ostream& operator<<(std::ostream& o, const configuration& c) {
     o << "{access_key:" << c.access_key << ",region:" << c.region()
       << ",secret_key:****"
       << ",access_point_uri:" << c.uri() << ",server_addr:" << c.server_addr
-      << "}";
+      << ",max_idle_time:" << c.max_idle_time.count() << "}";
     return o;
 }
 
@@ -370,7 +381,7 @@ client::client(const configuration& conf)
 
 client::client(const configuration& conf, const ss::abort_source& as)
   : _requestor(conf)
-  , _client(conf, &as, conf._probe)
+  , _client(conf, &as, conf._probe, conf.max_idle_time)
   , _probe(conf._probe) {}
 
 ss::future<> client::stop() { return _client.stop(); }

--- a/src/v/s3/client.h
+++ b/src/v/s3/client.h
@@ -51,6 +51,7 @@ struct default_overrides {
     std::optional<endpoint_url> endpoint = std::nullopt;
     std::optional<uint16_t> port = std::nullopt;
     std::optional<ca_trust_file> trust_file = std::nullopt;
+    std::optional<ss::lowres_clock::duration> max_idle_time = std::nullopt;
     bool disable_tls = false;
 };
 
@@ -64,6 +65,8 @@ struct configuration : rpc::base_transport::configuration {
     private_key_str secret_key;
     /// AWS region
     aws_region_name region;
+    /// Max time that connection can spend idle
+    ss::lowres_clock::duration max_idle_time;
     /// Metrics probe (should be created for every aws account on every shard)
     ss::shared_ptr<client_probe> _probe;
 

--- a/src/v/s3/signature.h
+++ b/src/v/s3/signature.h
@@ -100,13 +100,7 @@ public:
       std::string_view region,
       std::string_view service);
 
-    /// Checks if credentials are too old and updates them if this is the case
-    void update_credentials_if_outdated();
-
 private:
-    /// Re-generate credentials used to sign headers
-    void update_credentials();
-
     /// \brief Calculate SHA256 digest
     ///
     /// \param payload is ref to payload of the query
@@ -122,12 +116,6 @@ private:
     public_key_str _access_key;
     /// Secret key
     private_key_str _private_key;
-    /// Service specific signing key
-    ss::sstring _sign_key;
-    /// Scope of the key (part of the header digest)
-    ss::sstring _cred_scope;
-    /// Time of the last credentials update
-    ss::lowres_clock::time_point _last_update;
 };
 
 template<class Fn>


### PR DESCRIPTION
## Cover letter

This PR fixes a bunch of problems discovered recently.

* Fix upload of empty files (it's broken when input_stream is used to send data). This PR adds a reproducer and a fix.
* Fix  AWS signature v4 implementation (fixes #1888). The PR disables signature key caching.
* Fix https persistent connections by adding a timestamp to every connection. Implementation checks this timestamp to figure out what connections are stale and should be reconnected. This fixes most of the "broken pipe" and "beast:http:25" errors that we see in the logs.
* Fix 'thundering herd' problem in reconciliation loop described in #1889. The PR switches from parallel_for_each to max_concurrent_for_each with meaningful concurrency level.

Fixes #1888 #1889 

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/a00b5d402f3c5d1c8bc0db93dd3887a59d99b454..0a75892e088d2178f133c35c16062b1ecbc7c176):
- Fix CI failure cause by UBSan (ss::lowres_clock::time_point subtraction caused signed integer overflow).

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/0a75892e088d2178f133c35c16062b1ecbc7c176..4d12ec9f3d344d8e147ab720675d015859612c33)
- Make max idle time for https connections configurable in new commit
- Add extra entry to the s3::configuration since it's logical to have this information on this level
- Add configuration parameter `cloud_storage_connection_max_idle_time` with meaningful default for AWS S3

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/4d12ec9f3d344d8e147ab720675d015859612c33..aa90c9b81634c2d13dccffa451a7d91f6ddf9aaf)
- Update commit message, add information about bug related to cached signature key

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/aa90c9b81634c2d13dccffa451a7d91f6ddf9aaf..c5ae76186357367953859032188e5333a53578be)
- Remove debug output

## Release notes

N/A