### PR TITLE
Fix decode of null std::optional configuration options

### DIFF
--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -115,4 +115,25 @@ struct convert<ss::sstring> {
         return true;
     }
 };
+
+template<typename T>
+struct convert<std::optional<T>> {
+    using type = std::optional<T>;
+
+    static Node encode(const type& rhs) {
+        if (rhs) {
+            return Node(*rhs);
+        }
+    }
+
+    static bool decode(const Node& node, type& rhs) {
+        if (node && !node.IsNull()) {
+            rhs = std::make_optional<T>(node.as<T>());
+        } else {
+            rhs = std::nullopt;
+        }
+        return true;
+    }
+};
+
 }; // namespace YAML

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -485,7 +485,7 @@ struct convert<std::optional<T>> {
     }
 
     static bool decode(const Node& node, type& rhs) {
-        if (node) {
+        if (node && !node.IsNull()) {
             rhs = std::make_optional<T>(node.as<T>());
         } else {
             rhs = std::nullopt;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -474,26 +474,6 @@ struct convert<config::tls_config> {
     }
 };
 
-template<typename T>
-struct convert<std::optional<T>> {
-    using type = std::optional<T>;
-
-    static Node encode(const type& rhs) {
-        if (rhs) {
-            return Node(*rhs);
-        }
-    }
-
-    static bool decode(const Node& node, type& rhs) {
-        if (node && !node.IsNull()) {
-            rhs = std::make_optional<T>(node.as<T>());
-        } else {
-            rhs = std::nullopt;
-        }
-        return true;
-    }
-};
-
 template<typename T, typename Tag>
 struct convert<named_type<T, Tag>> {
     using type = named_type<T, Tag>;

--- a/src/v/pandaproxy/schema_registry/configuration.cc
+++ b/src/v/pandaproxy/schema_registry/configuration.cc
@@ -36,7 +36,7 @@ configuration::configuration()
       "Replication factor for internal _schemas topic.  If unset, defaults to "
       "`default_topic_replication`",
       config::required::no,
-      -1)
+      std::nullopt)
   , api_doc_dir(
       *this,
       "api_doc_dir",

--- a/src/v/pandaproxy/schema_registry/configuration.h
+++ b/src/v/pandaproxy/schema_registry/configuration.h
@@ -26,7 +26,7 @@ struct configuration final : public config::config_store {
     config::one_or_many_property<model::broker_endpoint> schema_registry_api;
     config::one_or_many_property<config::endpoint_tls_config>
       schema_registry_api_tls;
-    config::property<int16_t> schema_registry_replication_factor;
+    config::property<std::optional<int16_t>> schema_registry_replication_factor;
     config::property<ss::sstring> api_doc_dir;
 };
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -123,11 +123,9 @@ ss::future<> service::do_start() {
 ss::future<> service::create_internal_topic() {
     // Use the default topic replica count, unless our specific setting
     // for the schema registry chooses to override it.
-    int16_t replication_factor = _config.schema_registry_replication_factor();
-    if (replication_factor == -1) {
-        replication_factor
-          = config::shard_local_cfg().default_topic_replication();
-    }
+    int16_t replication_factor
+      = _config.schema_registry_replication_factor().value_or(
+        config::shard_local_cfg().default_topic_replication());
 
     vlog(
       plog.debug,

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -183,7 +183,8 @@ public:
         cfg.get("schema_registry_api")
           .set_value(std::vector<model::broker_endpoint>{model::broker_endpoint(
             unresolved_address("127.0.0.1", listen_port))});
-        cfg.get("schema_registry_replication_factor").set_value(int16_t{1});
+        cfg.get("schema_registry_replication_factor")
+          .set_value(std::make_optional<int16_t>(1));
         return to_yaml(cfg);
     }
 


### PR DESCRIPTION
## Cover letter

This was noticed when adding `schema_registry_replication_factor` setting -- it didn't work as a std::optional because of a decode error during startup.

Turns out std::optional settings were only working when absent, or present with value.  When present with an explicit null value, we would throw a decode exception.

Fixes: https://github.com/vectorizedio/redpanda/issues/1914

## Release notes

No user visible change.
