### PR TITLE
k8s: bring back parallelism to e2e tests

### DIFF
--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -17,4 +17,4 @@ commands:
 artifactsDir: tests/_e2e_artifacts
 timeout: 300
 reportFormat: xml
-parallel: 1
+parallel: 3


### PR DESCRIPTION
## Cover letter

The tests are currently so incredibly slow. Let's try bumping the parallelism again since we're not running in github actions anymore.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
