### PR TITLE
schema_registry: Various fixes

### DIFF
--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -12,6 +12,7 @@ v_cc_library(
     configuration.cc
     handlers.cc
     error.cc
+    schema_util.cc
     service.cc
     seq_writer.cc
     sharded_store.cc

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -109,4 +109,10 @@ inline error_info not_deleted(const subject& sub, schema_version version) {
         version())};
 }
 
+inline error_info invalid_schema_type(schema_type type) {
+    return {
+      error_code::schema_invalid,
+      fmt::format("Invalid schema type {}", to_string_view(type))};
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/schema_util.cc
+++ b/src/v/pandaproxy/schema_registry/schema_util.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/schema_registry/schema_util.h"
+
+#include "pandaproxy/schema_registry/avro.h"
+
+namespace pandaproxy::schema_registry {
+
+result<void> validate(std::string_view def, schema_type type) {
+    switch (type) {
+    case schema_type::avro: {
+        auto res = make_avro_schema_definition(def);
+        if (res.has_error()) {
+            return res.assume_error();
+        }
+        return outcome::success();
+    }
+    default:
+        return invalid_schema_type(type);
+    }
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/schema_util.h
+++ b/src/v/pandaproxy/schema_registry/schema_util.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/schema_registry/errors.h"
+#include "pandaproxy/schema_registry/types.h"
+
+namespace pandaproxy::schema_registry {
+
+result<void> validate(std::string_view def, schema_type type);
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -110,7 +110,8 @@ ss::future<> service::do_start() {
     try {
         co_await create_internal_topic();
         co_await fetch_internal_topic();
-        vlog(plog.error, "service::ensure_started() - success");
+        vlog(
+          plog.info, "Schema registry successfully initialized internal topic");
     } catch (...) {
         vlog(
           plog.error,

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -359,10 +359,7 @@ ss::future<bool> sharded_store::is_compatible(
 
     // Currently only support AVRO
     if (new_schema_type != schema_type::avro) {
-        throw as_exception(error_info{
-          error_code::schema_invalid,
-          fmt::format(
-            "Invalid schema type {}", to_string_view(new_schema_type))});
+        throw as_exception(invalid_schema_type(new_schema_type));
     }
 
     // if transitive, search all, otherwise seach forwards from version

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -18,6 +18,7 @@
 #include "pandaproxy/schema_registry/avro.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/schema_util.h"
 #include "pandaproxy/schema_registry/store.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "vlog.h"
@@ -50,6 +51,9 @@ ss::future<> sharded_store::stop() { return _store.stop(); }
 
 ss::future<sharded_store::insert_result> sharded_store::project_ids(
   subject sub, schema_definition def, schema_type type) {
+    // Validate the schema (may throw)
+    validate(def(), type).value();
+
     // Check compatibility
     std::vector<schema_version> versions;
     try {

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -38,6 +38,7 @@ HTTP_POST_HEADERS = {
 schema1_def = '{"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]}'
 schema2_def = '{"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2","default":"foo"}]}'
 schema3_def = '{"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"},{"type":"string","name":"f2"}]}'
+invalid_avro = '{"type":"notatype","name":"myrecord","fields":[{"type":"string","name":"f1"}]}'
 
 
 class SchemaRegistryTest(RedpandaTest):
@@ -264,6 +265,12 @@ class SchemaRegistryTest(RedpandaTest):
         if result_raw.json() != []:
             self.logger.error(result_raw.json)
         assert result_raw.json() == []
+
+        self.logger.debug("Posting invalid schema as a subject key")
+        result_raw = self._post_subjects_subject_versions(
+            subject=f"{topic}-key", data=json.dumps({"schema": invalid_avro}))
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.unprocessable_entity
 
         self.logger.debug("Posting schema 1 as a subject key")
         result_raw = self._post_subjects_subject_versions(


### PR DESCRIPTION
## Cover letter

* Improve successful log message
* Factor out an `error_info` constructor
* Validate schema on insert to prevent invalid schemas reaching the topic

## Release notes

Release note: schema_registry: Validate schema on insert to prevent invalid schemas reaching the topic
