### PR TITLE
test: improve rpk ducktape consumer test reliability

### DIFF
--- a/tests/rptest/tests/rpk_topic_test.py
+++ b/tests/rptest/tests/rpk_topic_test.py
@@ -173,7 +173,7 @@ class RpkToolTest(RedpandaTest):
         for i in range(n):
             msgs['key-' + str(i)] = 'message-' + str(i)
 
-        part = random.randint(0, n_parts)
+        part = random.randint(0, n_parts - 1)
         # Produce messages to a random partition
         for k in msgs:
             self._rpk.produce(topic, k, msgs[k], partition=part)


### PR DESCRIPTION
- Fixes a bug where an invalid partition might be chosen
- Adds adaptive timeout that extends timeout if progress is being made

Fixes: #1899 (maybe)