### PR TITLE
Fix applying partition update operations

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -235,4 +235,19 @@ bool has_local_replicas(
            != replicas.cend();
 }
 
+bool are_replica_sets_equal(
+  const std::vector<model::broker_shard>& lhs,
+  const std::vector<model::broker_shard>& rhs) {
+    auto l_sorted = lhs;
+    auto r_sorted = rhs;
+    static const auto cmp =
+      [](const model::broker_shard& lhs, const model::broker_shard& rhs) {
+          return lhs.node_id < rhs.node_id;
+      };
+    std::sort(l_sorted.begin(), l_sorted.end(), cmp);
+    std::sort(r_sorted.begin(), r_sorted.end(), cmp);
+
+    return l_sorted == r_sorted;
+}
+
 } // namespace cluster

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -169,4 +169,7 @@ auto do_with_client_one_shot(
 bool has_local_replicas(
   model::node_id, const std::vector<model::broker_shard>&);
 
+bool are_replica_sets_equal(
+  const std::vector<model::broker_shard>&,
+  const std::vector<model::broker_shard>&);
 } // namespace cluster

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -385,6 +385,29 @@ ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
         try {
             auto ec = co_await execute_partitition_op(*it);
             if (ec) {
+                if (it->type == topic_table_delta::op_type::update) {
+                    /**
+                     * check if pending update isn't already finished, if so it
+                     * is safe to proceed to the next step
+                     */
+                    auto fit = std::find_if(
+                      it, deltas.end(), [&it](const topic_table::delta& d) {
+                          return d.type
+                                   == topic_table::delta::op_type::
+                                     update_finished
+                                 && d.new_assignment.replicas
+                                      == it->new_assignment.replicas;
+                      });
+                    vassert(
+                      fit == std::next(it),
+                      "finish operation command, if present have to be the one "
+                      "that follows update operation");
+
+                    if (fit != deltas.end()) {
+                        it = fit;
+                        continue;
+                    }
+                }
                 vlog(
                   clusterlog.info,
                   "partition operation {} result: {}",

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -222,6 +222,15 @@ void members_backend::calculate_reallocations_after_node_added(
         to_move_from_node.emplace_back(id, to_move);
     }
 
+    auto all_empty = std::all_of(
+      to_move_from_node.begin(),
+      to_move_from_node.end(),
+      [](const replicas_to_move& m) { return m.left_to_move == 0; });
+    // nothing to do, exit early
+    if (all_empty) {
+        return;
+    }
+
     vlog(
       clusterlog.info,
       "Targeting to move {} partitions and reallocate them to node {}",

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -642,6 +642,12 @@ bool is_result_configuration_valid(
      */
     for (auto& current : current_brokers) {
         if (current->id() == to_update.id()) {
+            /**
+             * do no allow to decrease node core count
+             */
+            if (current->properties().cores > to_update.properties().cores) {
+                return false;
+            }
             continue;
         }
         // error, nodes would point to the same addresses

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -137,7 +137,7 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
     if (tp == _topics.end()) {
         return ss::make_ready_future<std::error_code>(errc::topic_not_exists);
     }
-    _update_in_progress.erase(cmd.key);
+
     // calculate deleta for backend
     auto current_assignment_it = std::find_if(
       tp->second.configuration.assignments.begin(),
@@ -150,6 +150,14 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
         return ss::make_ready_future<std::error_code>(
           errc::partition_not_exists);
     }
+
+    if (current_assignment_it->replicas != cmd.value) {
+        return ss::make_ready_future<std::error_code>(
+          errc::invalid_node_opeartion);
+    }
+
+    _update_in_progress.erase(cmd.key);
+
     partition_assignment delta_assignment{
       .group = current_assignment_it->group,
       .id = current_assignment_it->id,


### PR DESCRIPTION
## Cover letter

This PR fixes/improves handling of partition update commands in controller backend and also improves handling of `last_applied_offset` in `raft::mux_state_machine`. 

Notable changes:

### Preventing decreasing core count when processing update request
Added validation checking if configuration update would cause node core count to be decreased, if that is true request will be rejected. 

### Using `finish_partition_update` command to reason about current partition update result

When finish update command related with current update is present in the controller log we do not need to wait for current update result since it was already successfully executed in the past. 

### Fixed race condition in controller backend

When controller backend is processing an update it have to execute only the finish command related with previous successfully executed update. It may happen that node after restart will replicate finish update command not related with update currently being applied on other nodes. 
 
### Mux state machine optimization 

Major speed up of redpanda starting time. 
In `mux_state_machine` we persist last applied offset to speed up recovery after restart. This an optimization and does not influence correctness.
Last applied offset is persisted in `storage::kvstore` which introduces 10ms debouncing time. This makes every apply to wait at least 10ms before the next one. Since persisted last applied is just an optimization we may handle it in background. This way more than one write will fall into single debouncing window in `kvstore`.

Fixes: #NNN, #NNN, ...

## Release notes

Release note: [1-2 sentences of what this PR changes]
