### PR TITLE
test: ignore flaky rpk consumer test

### DIFF
--- a/tests/rptest/tests/rpk_topic_test.py
+++ b/tests/rptest/tests/rpk_topic_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import ignore
 from ducktape.mark.resource import cluster
 
 from rptest.tests.redpanda_test import RedpandaTest
@@ -161,6 +162,7 @@ class RpkToolTest(RedpandaTest):
                    backoff_sec=20,
                    err_msg="Message didn't appear.")
 
+    @ignore
     @cluster(nodes=3)
     def test_consume_from_partition(self):
         topic = 'topic_partition'


### PR DESCRIPTION
Let's disable the rpk consumer test until it more stable.