### PR TITLE
storage: disable COW for log files when running on btrfs

### DIFF
--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -611,12 +611,11 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
     // build an empty index for the segment
     auto index_name = path;
     index_name.replace_extension("base_index");
-    auto index_fd = co_await ss::open_file_dma(
-      index_name.string(), ss::open_flags::create | ss::open_flags::rw);
-    if (cfg.sanitize) {
-        index_fd = ss::file(
-          ss::make_shared(file_io_sanitizer(std::move(index_fd))));
-    }
+    auto index_fd = co_await make_handle(
+      index_name.string(),
+      ss::open_flags::create | ss::open_flags::rw,
+      {},
+      cfg.sanitize);
     segment_index index(
       index_name.string(),
       index_fd,

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -89,6 +89,11 @@ make_writer_handle(const std::filesystem::path&, storage::debug_sanitize_files);
 /// make file handle with default opts
 ss::future<ss::file>
 make_reader_handle(const std::filesystem::path&, storage::debug_sanitize_files);
+ss::future<ss::file> make_handle(
+  const std::filesystem::path path,
+  ss::open_flags flags,
+  ss::file_open_options opt,
+  debug_sanitize_files debug);
 
 ss::future<compacted_index_writer> make_compacted_index_writer(
   const std::filesystem::path& path,

--- a/src/v/storage/snapshot.cc
+++ b/src/v/storage/snapshot.cc
@@ -14,6 +14,7 @@
 #include "hashing/crc32c.h"
 #include "random/generators.h"
 #include "reflection/adl.h"
+#include "storage/segment_utils.h"
 #include "utils/directory_walker.h"
 
 #include <seastar/core/coroutine.hh>
@@ -60,7 +61,7 @@ snapshot_manager::start_snapshot(ss::sstring target) {
     const auto flags = ss::open_flags::wo | ss::open_flags::create
                        | ss::open_flags::exclusive;
 
-    return ss::open_file_dma(path.string(), flags)
+    return internal::make_handle(path, flags, {}, {})
       .then([this, path](ss::file file) {
           ss::file_output_stream_options options;
           options.io_priority_class = _io_prio;


### PR DESCRIPTION
## Cover letter

Redpanda disk segments do not benefit from COW.  Btrfs enables COW by default, which comes with some overhead and risk of hitting bugs.

Fixes: https://github.com/vectorizedio/redpanda/issues/1880

## Release notes

Log segments written to btrfs filesystems are now set to disable COW.  btrfs remains unsupported as a RedPanda backend, this change is only for the benefit of certain development environments that may use btrfs to back container filesystems.
