### PR TITLE
serde: more upward/downward compatibility

### DIFF
--- a/src/v/bytes/iobuf_parser.h
+++ b/src/v/bytes/iobuf_parser.h
@@ -88,6 +88,11 @@ public:
         return _in.consume(n, std::forward<Consumer>(f));
     }
 
+    template<typename Output>
+    [[gnu::always_inline]] void consume_to(size_t n, Output out) {
+        return _in.template consume_to(n, std::forward<Output>(out));
+    }
+
     iobuf copy(size_t len) { return iobuf_copy(_in, len); }
 
 protected:

--- a/src/v/serde/envelope.h
+++ b/src/v/serde/envelope.h
@@ -39,6 +39,7 @@ template<
   typename Version,
   typename CompatVersion = compat_version<Version::v>>
 struct envelope {
+    bool operator==(envelope const&) const = default;
     using value_t = T;
     static constexpr auto redpanda_serde_version = Version::v;
     static constexpr auto redpanda_serde_compat_version = CompatVersion::v;

--- a/src/v/serde/envelope_for_each_field.h
+++ b/src/v/serde/envelope_for_each_field.h
@@ -183,9 +183,18 @@ inline auto envelope_to_tuple(T& t) {
 }
 
 template<typename T, typename Fn>
-inline void envelope_for_each_field(T& t, Fn&& fn) {
+inline auto envelope_for_each_field(T& t, Fn&& fn) -> std::enable_if_t<
+  !std::is_convertible_v<decltype(fn(std::declval<int&>())), bool>> {
     static_assert(is_envelope_v<std::decay_t<T>>);
     std::apply([&](auto&&... args) { (fn(args), ...); }, envelope_to_tuple(t));
+}
+
+template<typename T, typename Fn>
+inline auto envelope_for_each_field(T& t, Fn&& fn) -> std::enable_if_t<
+  std::is_convertible_v<decltype(fn(std::declval<int&>())), bool>> {
+    static_assert(is_envelope_v<std::decay_t<T>>);
+    std::apply(
+      [&](auto&&... args) { (fn(args) && ...); }, envelope_to_tuple(t));
 }
 
 } // namespace serde


### PR DESCRIPTION
support adding and removing fields while keeping same compat version

- instead of envelope size, use bytes left
- use header struct
- pass bytes_left_limit through parse calls