### PR TITLE
Introduce "plugin" command

### DIFF
--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/prometheus/client_golang v1.10.0
-	github.com/spf13/afero v1.2.2
+	github.com/spf13/afero v1.6.0
 	github.com/stretchr/testify v1.7.0
 	github.com/vectorizedio/redpanda/src/go/rpk v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -444,6 +444,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -583,6 +584,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -652,8 +654,9 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
-github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
+github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -754,6 +757,7 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -895,16 +899,13 @@ golang.org/x/sys v0.0.0-20201029080932-201ba4db2418/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 h1:46ULzRKLh1CwgRq2dC5SlBzEqqNCi8rreOZnNrbqcIY=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 h1:siQdpVirKtzPhKl3lZWozZraCFObP8S1v6PRp0bLrtU=
-golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20191110171634-ad39bd3f0407/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56 h1:b8jxX3zqjpqb2LklXPzKSGJhzyxCOZSz8ncv8Nv+y7w=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
-golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
-golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/prometheus/common v0.9.1
 	github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8
 	github.com/sirupsen/logrus v1.4.2
-	github.com/spf13/afero v1.2.2
+	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
@@ -49,8 +49,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/mod v0.4.1 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069
-	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
+	golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -231,6 +231,7 @@ github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -307,6 +308,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -353,8 +355,8 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
-github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
-github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
+github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
@@ -404,6 +406,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -491,16 +494,13 @@ golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201029080932-201ba4db2418/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc h1:y0Og6AYdwus7SIAnKnDxjc4gJetRiYEWOx4AKbOeyEI=
 golang.org/x/sys v0.0.0-20210112091331-59c308dcf3cc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 h1:siQdpVirKtzPhKl3lZWozZraCFObP8S1v6PRp0bLrtU=
-golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20191110171634-ad39bd3f0407/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56 h1:b8jxX3zqjpqb2LklXPzKSGJhzyxCOZSz8ncv8Nv+y7w=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
-golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
-golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/go/rpk/pkg/cli/cmd/plugin/plugin.go
+++ b/src/go/rpk/pkg/cli/cmd/plugin/plugin.go
@@ -1,0 +1,297 @@
+// Package plugin contains the plugin command.
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/out"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/plugin"
+)
+
+const urlBase = "https://vectorized-public.s3.us-west-2.amazonaws.com/rpk-plugins"
+
+func NewCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "List, download, update, and remove rpk plugins.",
+		Long: `List, download, update, and remove rpk plugins.
+	
+Plugins augment rpk with new commands.
+
+For a plugin to be used, it must be somewhere discoverable by rpk in your
+$PATH. All plugins follow a defined naming scheme:
+
+  rpk-<name>
+  rpk.ac-<name>
+
+All plugins are prefixed with either rpk- or rpk.ac-. When rpk starts up, it
+searches all directories in your $PATH for any executable binary that begins
+with either of those prefixes. For any binary it finds, rpk adds a command for
+that name to the rpk command space itself.
+
+No plugin name can shadow an existing rpk command, and only one plugin can
+exist under a given name at once. Plugins are added to the rpk command space on
+a first-seen basis. If you have two plugins rpk-foo, and the second is
+discovered later on in the $PATH directories, then only the first will be used.
+The second will be ignored.
+
+Plugins that have an rpk.ac- prefix indicate that they support the
+--help-autocomplete flag. If rpk sees this, rpk will exec the plugin with that
+flag when rpk starts up, and the plugin will return all commands it supports as
+well as short and long help test for each command. Rpk uses this return to
+build a shadow command space within rpk itself so that it looks as if the
+plugin exists within rpk. This is particularly useful if you enable
+autocompletion.
+
+The expected return for plugins from --help-autocomplete is an array of the
+following:
+
+  type pluginHelp struct {
+          Path    string   ` + "`json:\"path,omitempty\"`" + `
+          Short   string   ` + "`json:\"short,omitempty\"`" + `
+          Long    string   ` + "`json:\"long,omitempty\"`" + `
+          Example string   ` + "`json:\"example,omitempty\"`" + `
+          Args    []string ` + "`json:\"args,omitempty\"`" + `
+  }
+
+where "path" is an underscore delimited argument path to a command. For
+example, "foo_bar_baz" corresponds to the command "rpk foo bar baz".
+`,
+		Args: cobra.ExactArgs(0),
+	}
+	cmd.AddCommand(
+		newListCommand(fs),
+		newInstallCommand(fs),
+		newUninstallCommand(fs),
+	)
+	return cmd
+}
+
+func newListCommand(fs afero.Fs) *cobra.Command {
+	var local bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all available plugins.",
+		Long: `List all available plugins.
+
+By default, this command fetches the remote manifest and prints plugins
+available for download. Any plugin that is already downloaded is prefixed with
+an asterisk. If a locally installed plugin has a different sha256sum as the one
+specified in the manifest, or if the sha256sum could not be calculated for the
+local plugin, an additional message is printed.
+
+You can specify --local to print all locally installed plugins, as well as
+whether you have "shadowed" plugins (the same plugin specified multiple times).
+`,
+
+		Args: cobra.ExactArgs(0),
+		Run: func(*cobra.Command, []string) {
+			installed := plugin.ListPlugins(fs, plugin.UserPaths())
+
+			if local {
+				installed.Sort()
+
+				tw := out.NewTable("NAME", "PATH", "SHADOWS")
+				defer tw.Flush()
+
+				for _, p := range installed {
+					var shadowed string
+					if len(p.ShadowedPaths) > 0 {
+						shadowed = p.ShadowedPaths[0]
+					}
+					tw.Print(p.Name(), p.Path, shadowed)
+
+					if len(p.ShadowedPaths) < 1 {
+						continue
+					}
+					for _, shadowed = range p.ShadowedPaths[1:] {
+						tw.Print("", "", shadowed)
+					}
+				}
+
+				return
+			}
+
+			m, err := getManifest()
+			out.MaybeDieErr(err)
+
+			tw := out.NewTable("NAME", "DESCRIPTION", "MESSAGE")
+			defer tw.Flush()
+			for _, entry := range m.Plugins {
+				name := entry.Name
+				_, entrySha, _ := entry.PathShaForUser()
+
+				var message string
+
+				p, exists := installed.Find(name)
+				if exists {
+					name = "*" + name
+
+					sha, err := plugin.Sha256Path(fs, p.Path)
+					if err != nil {
+						message = fmt.Sprintf("unable to calculate local binary sha256: %v", err)
+					} else if sha != entrySha {
+						message = "local binary sha256 differs from manifest sha256"
+					}
+				}
+
+				tw.Print(name, entry.Description, message)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVarP(&local, "local", "l", false, "list locally installed plugins and shadowed plugins")
+
+	return cmd
+}
+
+func newInstallCommand(fs afero.Fs) *cobra.Command {
+	var dir string
+	var update bool
+	cmd := &cobra.Command{
+		Use:     "install [PLUGIN]",
+		Aliases: []string{"download"},
+		Short:   "Install an rpk plugin.",
+		Long: `Install an rpk plugin.
+
+An rpk plugin must be saved in a directory that is in your $PATH. By default,
+this command installs plugins to the first directory in your $PATH. This can
+be overridden by specifying the --bin-dir flag.
+`,
+		Args: cobra.ExactArgs(1),
+		Run: func(_ *cobra.Command, args []string) {
+			name := args[0]
+
+			fmt.Printf("Searching plugin manifest for %q...\n", name)
+			m, err := getManifest()
+			out.MaybeDieErr(err)
+
+			p, err := m.FindEntry(name)
+			out.MaybeDieErr(err)
+
+			_, remoteSha, err := p.PathShaForUser()
+			out.MaybeDieErr(err)
+
+			var userAlreadyHas bool
+			installed := plugin.ListPlugins(fs, plugin.UserPaths())
+			for _, p := range installed {
+				if name == p.Name() {
+					sha, err := plugin.Sha256Path(fs, p.Path)
+					out.MaybeDieErr(err)
+
+					if sha == remoteSha {
+						out.Exit("Plugin %q is already installed and up to date!", name)
+					}
+
+					msg := fmt.Sprintf(`Plugin %q is already installed, but is different from the remote plugin!
+
+ Local sha256: %s
+Remote sha256: %s
+
+`, name, sha, remoteSha)
+					if !update {
+						out.Exit(msg + "--update was not requested, exiting!")
+					}
+					fmt.Println(msg + "Downloading and validating updated plugin...")
+					userAlreadyHas = true
+
+				}
+			}
+			if !userAlreadyHas {
+				fmt.Println("Found! Downloading and validating plugin...")
+			}
+
+			body, err := p.DownloadForUser(urlBase)
+			out.MaybeDieErr(err)
+
+			fmt.Println("Downloaded! Writing plugin to disk...")
+			dst, err := plugin.WriteBinary(fs, p.Name, dir, body, p.HelpAutoComplete)
+			out.MaybeDieErr(err)
+
+			fmt.Printf("Success! Plugin %q has been saved to %q and is now ready to use!\n", p.Name, dst)
+
+			if p.HelpAutoComplete {
+				fmt.Printf(`
+This plugin supports autocompletion through rpk.
+
+If you enable rpk autocompletion, start a new terminal to tab complete your new
+command %q!
+`, p.Name)
+			} else {
+				fmt.Printf(`
+
+If you enable rpk autocompletion, start a new terminal to tab complete your new
+command %q!
+`, p.Name)
+			}
+		},
+	}
+
+	var err error
+	dir, err = determineBinDir()
+	out.MaybeDieErr(err)
+
+	cmd.Flags().StringVar(&dir, "dir", dir, "destination directory to save the installed plugin (defaults to the first dir in $PATH)")
+	cmd.Flags().BoolVarP(&update, "update", "u", false, "update a locally installed plugin if it differs from the current remote version")
+
+	return cmd
+}
+
+func newUninstallCommand(fs afero.Fs) *cobra.Command {
+	var includeShadowed bool
+	cmd := &cobra.Command{
+		Use:     "uninstall [NAME]",
+		Aliases: []string{"rm"},
+		Short:   "Uninstall / remove an existing local plugin.",
+		Long: `Uninstall / remove an existing local plugin.
+
+This command lists locally installed plugins and removes the first plugin that
+matches the requested removal. If --include-shadowed is specified, this command
+also removes all shadowed plugins of the same name.
+`,
+
+		Args: cobra.ExactArgs(1),
+
+		Run: func(_ *cobra.Command, args []string) {
+			name := args[0]
+			installed := plugin.ListPlugins(fs, plugin.UserPaths())
+
+			p, ok := installed.Find(name)
+			if !ok {
+				out.Exit("Plugin %q does not appear to be installed, exiting!", name)
+			}
+
+			err := os.Remove(p.Path)
+			out.MaybeDie(err, "unable to remove %q: %v", p.Path, err)
+			fmt.Printf("Removed %q.\n", p.Path)
+
+			if !includeShadowed {
+				return
+			}
+			for _, shadowed := range p.ShadowedPaths {
+				err = os.Remove(shadowed)
+				out.MaybeDie(err, "unable to remove shadowed at %q: %v", shadowed, err)
+				fmt.Printf("Removed shadowed at %q.\n", shadowed)
+			}
+		},
+	}
+	cmd.Flags().BoolVar(&includeShadowed, "include-shadowed", false, "also remove shadowed plugins that have the same name")
+	return cmd
+}
+
+func getManifest() (*plugin.Manifest, error) {
+	return plugin.DownloadManifest(urlBase + "/manifest.yaml")
+}
+
+func determineBinDir() (string, error) {
+	paths := plugin.UserPaths()
+	if len(paths) == 0 {
+		return "", errors.New("unable to determine where to save plugin: PATH list is empty")
+	}
+	return paths[0], nil
+}

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/common"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/plugin"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -100,9 +101,9 @@ func Execute() {
 	// is ensured by the return from listPlugins, but we can also ensure
 	// that here by only adding a plugin with exec if a command does not
 	// exist yet.
-	for _, plugin := range listPlugins(fs, filepath.SplitList(os.Getenv("PATH"))) {
-		if _, _, err := rootCmd.Find(plugin.pieces); err != nil {
-			addPluginWithExec(rootCmd, plugin.pieces, plugin.path)
+	for _, plugin := range plugin.ListPlugins(fs, filepath.SplitList(os.Getenv("PATH"))) {
+		if _, _, err := rootCmd.Find(plugin.Arguments); err != nil {
+			addPluginWithExec(rootCmd, plugin.Arguments, plugin.Path)
 		}
 	}
 
@@ -174,11 +175,11 @@ func tryExecPlugin(h pluginHandler, args []string) (string, error) {
 	foundPath := ""
 	for len(pieces) > 0 {
 		joined := strings.Join(pieces, "_")
-		if path, ok := h.lookPath(pluginPrefix + joined); ok {
+		if path, ok := h.lookPath(plugin.NamePrefix + joined); ok {
 			foundPath = path
 			break
 		}
-		if path, ok := h.lookPath(pluginPrefixAutoComplete + joined); ok {
+		if path, ok := h.lookPath(plugin.NamePrefixAutoComplete + joined); ok {
 			foundPath = path
 			break
 		}
@@ -189,113 +190,6 @@ func tryExecPlugin(h pluginHandler, args []string) (string, error) {
 	}
 
 	return foundPath, h.exec(foundPath, args[len(pieces):])
-}
-
-const (
-	pluginPrefix             = "rpk-"    // does not support --help-autocomplete
-	pluginPrefixAutoComplete = "rpk.ac-" // supports --help-autocomplete
-)
-
-// A plugin is made up of the "pieces" that are used to call it, and the binary
-// path for the plugin on disk. Reversing the documentation on tryExecPlugin,
-// if a plugin filepath is /foo/bar/rpk.ac-baz-boz_biz, then the pieces will be
-// baz-boz biz.
-type plugin struct {
-	pieces []string
-	path   string
-}
-
-// listPlugins returns all plugins found in fs across the given search
-// directories.
-//
-// Unlike kubectl, we do not allow plugins to be tacked on paths within other
-// plugins. That is, we do not allow rpk_foo_bar to be an additional plugin on
-// top of rpk_foo.
-//
-// We do support plugins defining themselves as "rpk-foo_bar", even though that
-// reserves the "foo" plugin namespace.
-func listPlugins(fs afero.Fs, searchDirs []string) []plugin {
-	searchDirs = uniqueTrimmedStrs(searchDirs)
-
-	uniquePlugins := make(map[string]int) // plugin name (e.g., mm3 or cloud) => index into plugins
-	var plugins []plugin
-	for _, searchDir := range searchDirs {
-		infos, err := afero.ReadDir(fs, searchDir)
-		if err != nil {
-			log.Debugf("unable to read dir %s from PATH: %v", searchDir, err)
-			continue
-		}
-		for _, info := range infos {
-			if info.IsDir() {
-				continue
-			}
-
-			name := info.Name()
-			if !strings.HasPrefix(name, pluginPrefix) && !strings.HasPrefix(name, pluginPrefixAutoComplete) {
-				continue
-			}
-
-			fullPath := filepath.Join(searchDir, name)
-
-			if info.Mode()&0111 == 0 {
-				log.Debugf("matching plugin path %s is not executable, skipping", fullPath)
-				continue
-			}
-
-			// Reverse our args-to-plugin-binary logic to get the
-			// "pieces" that are used to call this plugin.
-			if strings.HasPrefix(name, pluginPrefix) {
-				name = strings.TrimPrefix(name, pluginPrefix)
-			} else {
-				name = strings.TrimPrefix(name, pluginPrefixAutoComplete)
-			}
-			if len(name) == 0 { // e.g., "rpk-"
-				log.Debugf("invalid empty plugin name at path %s", fullPath)
-				continue
-			}
-
-			pieces := toPieces(name)
-			pluginName := pieces[0]
-
-			if priorAt, exists := uniquePlugins[pluginName]; exists {
-				log.Debugf("skipping duplicate plugin %s at path %s, because it is previously overshadowed by path %s", pluginName, fullPath, plugins[priorAt].path)
-				continue
-			}
-
-			uniquePlugins[pluginName] = len(plugins)
-			plugins = append(plugins, plugin{
-				pieces: pieces,
-				path:   fullPath,
-			})
-
-		}
-	}
-
-	return plugins
-}
-
-// Converts a command name to its argument pieces.
-func toPieces(command string) []string {
-	return strings.Split(command, "_")
-}
-
-// Returns the unique strings in `in`, preserving order.
-//
-// Order preservation is important for search paths: a higher priority plugin
-// (path search wise) will shadow a lower priority one.
-func uniqueTrimmedStrs(in []string) []string {
-	seen := make(map[string]bool)
-	keep := in[:0]
-	for i := 0; i < len(in); i++ {
-		path := in[i]
-		path = strings.TrimSpace(path)
-		if seen[path] || len(path) == 0 {
-			continue
-		}
-		seen[path] = true
-		keep = append(keep, path)
-	}
-	return keep
 }
 
 // This recursive function recursively adds commands to parent commands,
@@ -338,26 +232,26 @@ func addPluginWithExec(
 	// If the exec command has the rpk.ac- prefix, then the plugin
 	// signifies that it supports --help-autocomplete, and we can exec it
 	// quickly to get useful fields for the command.
-	if !strings.HasPrefix(filepath.Base(execPath), pluginPrefixAutoComplete) {
+	if !strings.HasPrefix(filepath.Base(execPath), plugin.NamePrefixAutoComplete) {
 		return
 	}
 
 	out, err := (&exec.Cmd{
 		Path: execPath,
-		Args: append([]string{execPath, flagHelpAutocomplete}),
+		Args: append([]string{execPath, plugin.FlagAutoComplete}),
 		Env:  os.Environ(),
 	}).Output()
 	if err != nil {
-		log.Debugf("unable to run %s: %v", flagHelpAutocomplete, err)
+		log.Debugf("unable to run %s: %v", plugin.FlagAutoComplete, err)
 		return
 	}
 	var helps []pluginHelp
 	if err = json.Unmarshal(out, &helps); err != nil {
-		log.Debugf("unable to parse %s return: %v", flagHelpAutocomplete, err)
+		log.Debugf("unable to parse %s return: %v", plugin.FlagAutoComplete, err)
 		return
 	}
 	if len(helps) == 0 {
-		log.Debugf("plugin that supports %s did not return any help", flagHelpAutocomplete)
+		log.Debugf("plugin that supports %s did not return any help", plugin.FlagAutoComplete)
 		return
 	}
 
@@ -376,8 +270,6 @@ var (
 	rePluginString = "^[A-Za-z0-9_-]+$"
 	rePlugin       = regexp.MustCompile(rePluginString)
 )
-
-const flagHelpAutocomplete = "--help-autocomplete"
 
 // If a plugin supports --help-autocomplete, we exec it and add its commands to
 // rpk itself. This allows autocompletion to work across plugins.
@@ -422,7 +314,7 @@ func addPluginHelp(
 	for path, help := range uniques {
 		trackHelp(
 			&subcommands,
-			toPieces(path),
+			plugin.NameToArgs(path), // path here is the argument path (foo_bar_baz)
 			help,
 		)
 	}

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	plugincmd "github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/plugin"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/plugin"
 	"golang.org/x/crypto/ssh/terminal"
@@ -82,6 +83,8 @@ func Execute() {
 	rootCmd.AddCommand(NewClusterCommand(fs, mgr))
 	rootCmd.AddCommand(NewACLCommand(fs, mgr))
 
+	rootCmd.AddCommand(plugincmd.NewCommand(fs))
+
 	addPlatformDependentCmds(fs, mgr, rootCmd)
 
 	// To support autocompletion even for plugins, we list all plugins now
@@ -101,7 +104,7 @@ func Execute() {
 	// is ensured by the return from listPlugins, but we can also ensure
 	// that here by only adding a plugin with exec if a command does not
 	// exist yet.
-	for _, plugin := range plugin.ListPlugins(fs, filepath.SplitList(os.Getenv("PATH"))) {
+	for _, plugin := range plugin.ListPlugins(fs, plugin.UserPaths()) {
 		if _, _, err := rootCmd.Find(plugin.Arguments); err != nil {
 			addPluginWithExec(rootCmd, plugin.Arguments, plugin.Path)
 		}

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -66,16 +66,16 @@ func NewGenerateCommand(fs afero.Fs) *cobra.Command {
 	return command
 }
 
-func createIfNotExist(fs afero.Fs, path string) (afero.File, error) {
+func checkIfExists(fs afero.Fs, path string) error {
 	exist, err := afero.Exists(fs, path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if exist {
 		folderPath, filePath := filepath.Split(path)
-		return nil, fmt.Errorf("The directory %s contains files that could conflict: \n %s", folderPath, filePath)
+		return fmt.Errorf("The directory %s contains files that could conflict: \n %s", folderPath, filePath)
 	}
-	return fs.Create(path)
+	return nil
 }
 
 func GetLatestClientApiVersion() string {
@@ -114,7 +114,7 @@ func executeGenerate(fs afero.Fs, path string) error {
 		}
 		for _, templateFile := range templates {
 			filePath := filepath.Join(folderPath, templateFile.name)
-			_, err := createIfNotExist(fs, filePath)
+			err := checkIfExists(fs, filePath)
 			if err != nil {
 				return err
 			}
@@ -122,6 +122,7 @@ func executeGenerate(fs afero.Fs, path string) error {
 			if err != nil {
 				return err
 			}
+
 			if templateFile.permission > 0 {
 				err = fs.Chmod(filePath, templateFile.permission)
 				if err != nil {

--- a/src/go/rpk/pkg/plugin/manifest.go
+++ b/src/go/rpk/pkg/plugin/manifest.go
@@ -1,0 +1,142 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"sort"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Manifest represents a plugin manifest, which is essentially a list of
+// plugins available for install.
+type Manifest struct {
+	// Version is a YYYY-MM-DD version of the manifest. We use this to
+	// determine how to parse the manifest. We currently only understand
+	// one version; if the version does not match what we expect, then we
+	// know that rpk needs to be updated.
+	Version string `yaml:"api_version"`
+
+	// Plugins contains all plugins available for downloading.
+	Plugins []ManifestPlugin `yaml:"plugins"`
+}
+
+// FindEntry looks for a plugin with the given name and returns it.
+func (m *Manifest) FindEntry(name string) (ManifestPlugin, error) {
+	for _, p := range m.Plugins {
+		if p.Name == name {
+			return p, nil
+		}
+	}
+	return ManifestPlugin{}, fmt.Errorf("unable to find plugin %q", name)
+}
+
+// The client we use for downloading plugin manifests and plugins. At most, we
+// may increase the timeout or make it configurable later.
+var client = &http.Client{Timeout: 30 * time.Second}
+
+// DownloadManifest downloads a plugin manifest at the given URL and returns
+// its parsed form.
+//
+// This returns an error if the download fails at all or if we do not know how
+// to parse the manifest. For the latter, the user's rpk must be out of date,
+// and the returned error indicates they should update.
+func DownloadManifest(url string) (*Manifest, error) {
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		url,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create manifest request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to request manifest: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read manifest body: %v", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("unsuccessful manifest response %s: %q", http.StatusText(resp.StatusCode), body)
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(body, &m); err != nil {
+		return nil, fmt.Errorf("unable to decode manifest body: %v", err)
+	}
+
+	const understand = "2021-07-27"
+	if m.Version != understand {
+		return nil, fmt.Errorf("Plugin manifest indicates version %q, and we can only understand %q! Please update rpk!", m.Version, understand)
+	}
+
+	sort.Slice(m.Plugins, func(i, j int) bool {
+		return m.Plugins[i].Name < m.Plugins[j].Name
+	})
+
+	return &m, nil
+}
+
+// ManifestPlugin is an entry of a plugin available to install.
+type ManifestPlugin struct {
+	// Name is the name of a plugin.
+	Name string `yaml:"name"`
+
+	// Description is a short one-liner description of the plugin suitable
+	// for output to a console.
+	Description string `yaml:"description"`
+
+	// Path is the base request path of the plugin, such as
+	// plugins/vectorized/cloud.
+	Path string `yaml:"path"`
+
+	// Compression indicates what type of compression is used on the plugin
+	// binary. We currently only understand either no compression ("") or
+	// "gzip".
+	Compression string `yaml:"compression"`
+
+	// HelpAutoComplete indicates whether the plugin supports the
+	// --help-autocomplete flag.
+	HelpAutoComplete bool `yaml:"help_autocomplete"`
+
+	// OSArchShas contains the binaries that are supported per
+	// ${os}_${arch}, and their sha256 sums if we download and decompressed
+	// the binary.
+	OSArchShas map[string]string `yaml:"os_arch_shas"`
+}
+
+// PathShaForUser is a shortcut for PathSha for the current user's os / arch.
+func (p *ManifestPlugin) PathShaForUser() (path, sha string, err error) {
+	return p.PathSha(runtime.GOOS, runtime.GOARCH)
+}
+
+// PathSha returns the download path and the sha256 sum of the binary for the
+// given OS and arch. If the path does not exist (i.e. the os / arch is
+// unsupported), this returns an error.
+func (p *ManifestPlugin) PathSha(
+	os, arch string,
+) (path, sha string, err error) {
+	if p.Name == "" {
+		return "", "", errors.New("invalid plugin has no name")
+	}
+	if p.Path == "" {
+		return "", "", fmt.Errorf("plugin %s is missing a download path", p.Name)
+	}
+	if p.OSArchShas == nil {
+		return "", "", fmt.Errorf("plugin %s has no os / arch's to evaluate for downloading", p.Name)
+	}
+
+	need := fmt.Sprintf("%s_%s", os, arch)
+	sha, ok := p.OSArchShas[need]
+	if !ok {
+		return "", "", fmt.Errorf("plugin %s: unable to find binary to download for os / arch %s", p.Name, need)
+	}
+
+	return fmt.Sprintf("/%s/%s/%s/%s", p.Path, need, sha, p.Name), sha, nil
+}

--- a/src/go/rpk/pkg/plugin/manifest_test.go
+++ b/src/go/rpk/pkg/plugin/manifest_test.go
@@ -1,0 +1,117 @@
+package plugin
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadManifest(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name  string
+		serve string
+
+		exp    *Manifest
+		expErr bool
+	}{
+
+		// This first test is our golden test; we ensure we can decode
+		// every field properly, invalid fields are ignored, and things
+		// are returned in alphabetical order.
+		{
+			name: "valid 2021-07-27",
+			serve: `
+api_version: 2021-07-27
+
+plugins:
+  - name: test
+    description: Description
+    path: path/to/plugin/test
+    compression: gzip
+    help_autocomplete: true
+    os_arch_shas:
+      darwin_amd64: foo
+      darwin_arm64: bar
+      linux_amd64: biz
+      linux_arm64: baz
+
+  - name: alphabeticallyfirst
+`,
+
+			exp: &Manifest{
+				Version: "2021-07-27",
+				Plugins: []ManifestPlugin{
+					{
+						Name: "alphabeticallyfirst",
+					},
+
+					{
+						Name:             "test",
+						Description:      "Description",
+						Path:             "path/to/plugin/test",
+						Compression:      "gzip",
+						HelpAutoComplete: true,
+						OSArchShas: map[string]string{
+							"darwin_amd64": "foo",
+							"darwin_arm64": "bar",
+							"linux_amd64":  "biz",
+							"linux_arm64":  "baz",
+						},
+					},
+				},
+			},
+		},
+
+		// The second test shows that a manifest with just a version is
+		// valid, which in our next test allows us to how that changing
+		// just the version breaks things.
+		{
+			name:  "valid 2021-07-27 empty",
+			serve: `api_version: 2021-07-27`,
+
+			exp: &Manifest{
+				Version: "2021-07-27",
+			},
+		},
+
+		// We now ensure that unknown versions are detected.
+		{
+			name:   "unknown version",
+			serve:  `api_version: 2021-06-27`,
+			expErr: true,
+		},
+
+		// The rest of the download code is just standard request
+		// issuing and downloading.
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			const path = "/path"
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != path {
+					t.Errorf("invalid request path %s != exp %s", r.URL.Path, path)
+				}
+				io.WriteString(w, test.serve)
+			}))
+			defer svr.Close()
+
+			m, err := DownloadManifest(svr.URL + path)
+
+			if gotErr := err != nil; gotErr != test.expErr {
+				t.Errorf("got err? %v != exp err? %v", gotErr, test.expErr)
+				return
+			}
+			if test.expErr {
+				return
+			}
+
+			require.Equal(t, test.exp, m, "received manifest is not equal to expected manifest")
+		})
+	}
+}

--- a/src/go/rpk/pkg/plugin/plugin.go
+++ b/src/go/rpk/pkg/plugin/plugin.go
@@ -1,0 +1,136 @@
+// Package plugin contains functions to load plugin information from a
+// filesystem.
+package plugin
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+const (
+	// NamePrefix is the expected prefix of the basename of plugins that do
+	// not support the --help-autocomplete flag.
+	NamePrefix = "rpk-"
+
+	// NamePrefixAutoComplete is the expected prefix of the basename of
+	// plugins that support the --help-autocomplete flag.
+	NamePrefixAutoComplete = "rpk.ac-"
+
+	// FlagAutoComplete is the expected flag if a plugin has the rpk.ac-
+	// name prefix.
+	FlagAutoComplete = "--help-autocomplete"
+)
+
+// Plugin groups information about a plugin's location on disk with the
+// arguments to call the plugin.
+//
+// Plugins are searched in path order, and any unique name that comes first
+// shadows any duplicate names.
+//
+// If a plugin filepath is /foo/bar/rpk.ac-baz-boz_biz, then the arguments will
+// be baz-boz biz.
+type Plugin struct {
+	// Path is the path to the plugin binary on disk.
+	Path string
+
+	// Arguments is the set of arguments that should be used to call this
+	// plugin.
+	Arguments []string
+
+	// ShadowedPaths are other plugin filepaths that are shadowed by this
+	// plugin.
+	ShadowedPaths []string
+}
+
+// NameToArgs converts a plugin command name into its arguments.
+func NameToArgs(command string) []string {
+	return strings.Split(command, "_")
+}
+
+// ListPlugins returns all plugins found in fs across the given search
+// directories.
+//
+// Unlike kubectl, we do not allow plugins to be tacked on paths within other
+// plugins. That is, we do not allow rpk_foo_bar to be an additional plugin on
+// top of rpk_foo.
+//
+// We do support plugins defining themselves as "rpk-foo_bar", even though that
+// reserves the "foo" plugin namespace.
+func ListPlugins(fs afero.Fs, searchDirs []string) []Plugin {
+	searchDirs = uniqueTrimmedStrs(searchDirs)
+
+	uniquePlugins := make(map[string]int) // plugin name (e.g., mm3 or cloud) => index into plugins
+	var plugins []Plugin
+	for _, searchDir := range searchDirs {
+		infos, err := afero.ReadDir(fs, searchDir)
+		if err != nil {
+			continue // unable to read dir; skip
+		}
+		for _, info := range infos {
+			if info.IsDir() {
+				continue
+			}
+
+			name := info.Name()
+			if !strings.HasPrefix(name, NamePrefix) &&
+				!strings.HasPrefix(name, NamePrefixAutoComplete) {
+				continue // missing required name prefix; skip
+			}
+
+			fullPath := filepath.Join(searchDir, name)
+
+			if info.Mode()&0111 == 0 {
+				continue // not executable; skip
+			}
+
+			if strings.HasPrefix(name, NamePrefix) {
+				name = strings.TrimPrefix(name, NamePrefix)
+			} else {
+				name = strings.TrimPrefix(name, NamePrefixAutoComplete)
+			}
+			if len(name) == 0 { // e.g., "rpk-"
+				continue
+			}
+
+			arguments := NameToArgs(name)
+			pluginName := arguments[0]
+
+			priorAt, exists := uniquePlugins[pluginName]
+			if exists {
+				prior := &plugins[priorAt]
+				prior.ShadowedPaths = append(prior.ShadowedPaths, fullPath)
+				continue
+			}
+
+			uniquePlugins[pluginName] = len(plugins)
+			plugins = append(plugins, Plugin{
+				Path:      fullPath,
+				Arguments: arguments,
+			})
+
+		}
+	}
+
+	return plugins
+}
+
+// Returns the unique strings in `in`, preserving order.
+//
+// Order preservation is important for search paths: a higher priority plugin
+// (path search wise) will shadow a lower priority one.
+func uniqueTrimmedStrs(in []string) []string {
+	seen := make(map[string]bool)
+	keep := in[:0]
+	for i := 0; i < len(in); i++ {
+		path := in[i]
+		path = strings.TrimSpace(path)
+		if seen[path] || len(path) == 0 {
+			continue
+		}
+		seen[path] = true
+		keep = append(keep, path)
+	}
+	return keep
+}

--- a/src/go/rpk/pkg/plugin/plugin_test.go
+++ b/src/go/rpk/pkg/plugin/plugin_test.go
@@ -28,7 +28,7 @@ func TestListPlugins(t *testing.T) {
 		"/bin",
 	})
 
-	exp := []Plugin{
+	exp := Plugins{
 		{
 			Path:      "/usr/local/sbin/rpk-barely_executable",
 			Arguments: []string{"barely", "executable"},

--- a/src/go/rpk/pkg/plugin/plugin_test.go
+++ b/src/go/rpk/pkg/plugin/plugin_test.go
@@ -1,0 +1,78 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/testfs"
+)
+
+func TestListPlugins(t *testing.T) {
+	fs := testfs.FromMap(map[string]testfs.Fmode{
+		"/usr/local/sbin/rpk-non_executable":    {0666, ""},
+		"/usr/local/sbin/rpk-barely_executable": {0100, ""},
+		"/bin/rpk-barely_executable":            {0100, "shadowed!"},
+		"/bin/rpk.ac-barely_executable":         {0100, "also shadowed!"},
+		"/bin/rpk.ac-auto_completed":            {0777, ""},
+		"/bin/has/dir/":                         {0777, ""},
+		"/bin/rpk.ac-":                          {0777, "empty name ignored"},
+		"/bin/rpk-":                             {0777, "empty name ignored"},
+		"/bin/rpkunrelated":                     {0777, ""},
+		"/unsearched/rpk-valid_unused":          {0777, ""},
+	})
+
+	got := ListPlugins(fs, []string{
+		"   /usr/local/sbin   ", // space trimmed
+		"",                      // empty path, ignored
+		"/usr/local/sbin",       // dup ignored
+		"/bin",
+	})
+
+	exp := []Plugin{
+		{
+			Path:      "/usr/local/sbin/rpk-barely_executable",
+			Arguments: []string{"barely", "executable"},
+			ShadowedPaths: []string{
+				"/bin/rpk-barely_executable",
+				"/bin/rpk.ac-barely_executable",
+			},
+		},
+		{
+			Path:      "/bin/rpk.ac-auto_completed",
+			Arguments: []string{"auto", "completed"},
+		},
+	}
+
+	require.Equal(t, exp, got, "got plugins != expected")
+}
+
+func TestUniqueTrimmedStrs(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   []string
+		exp  []string
+	}{
+		{
+			"empty",
+			[]string{},
+			[]string{},
+		},
+
+		{
+			"duplicated",
+			[]string{"foo", "bar", "foo", "biz", "baz"},
+			[]string{"foo", "bar", "biz", "baz"},
+		},
+
+		{
+			"trimmed and empty dropped",
+			[]string{"", "    bar ", "foo", "biz", "baz", "foo   "},
+			[]string{"bar", "foo", "biz", "baz"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := uniqueTrimmedStrs(test.in)
+			require.Equal(t, test.exp, got, "got unique trimmed strs != expected")
+		})
+	}
+}

--- a/src/go/rpk/pkg/tuners/executors/script_rendering.go
+++ b/src/go/rpk/pkg/tuners/executors/script_rendering.go
@@ -12,6 +12,7 @@ package executors
 import (
 	"bufio"
 	"fmt"
+	"os"
 
 	"github.com/spf13/afero"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/tuners/executors/commands"
@@ -25,14 +26,7 @@ type scriptRenderingExecutor struct {
 // FIXME: @david
 // This should also return an error.
 func NewScriptRenderingExecutor(fs afero.Fs, filename string) Executor {
-	file, err := fs.Create(filename)
-	if err != nil {
-		return &scriptRenderingExecutor{
-			deffered: err,
-			writer:   nil,
-		}
-	}
-	err = fs.Chmod(filename, 0755)
+	file, err := fs.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
 	if err != nil {
 		return &scriptRenderingExecutor{
 			deffered: err,

--- a/src/go/rpk/pkg/utils/files.go
+++ b/src/go/rpk/pkg/utils/files.go
@@ -74,29 +74,11 @@ func CopyFile(fs afero.Fs, src string, dst string) error {
 }
 
 func WriteFileLines(fs afero.Fs, lines []string, path string) error {
-	file, err := fs.Create(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	w := bufio.NewWriter(file)
-	for _, line := range lines {
-		_, err := fmt.Fprintln(w, line)
-		if err != nil {
-			return err
-		}
-	}
-	return w.Flush()
+	return afero.WriteFile(fs, path, []byte(strings.Join(lines, "\n")+"\n"), 0o600)
 }
 
 func WriteBytes(fs afero.Fs, bs []byte, path string) (int, error) {
-	file, err := fs.Create(path)
-	if err != nil {
-		return 0, err
-	}
-	defer file.Close()
-	return file.Write(bs)
+	return len(bs), afero.WriteFile(fs, path, bs, 0o600)
 }
 
 func FileMd5(fs afero.Fs, filePath string) (string, error) {

--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -53,6 +53,23 @@ tasks:
     status:
     - test -f '{{.GO_BUILD_ROOT}}/bin/go'
 
+  install-crlfmt:
+    desc: install crlfmt go formater
+    summary: |
+      Install crlfmt go formater tool in the build directory ($BUILD_ROOT/bin/go),
+      only if it does not exist on the host already. Checking whether is
+      available on the host is done so that this task can also run in
+      containerized environments.
+    cmds:
+    - |
+      TMP_DIR=$(mktemp -d)
+      cd $TMP_DIR
+      go mod init tmp
+      GOBIN={{ .BUILD_ROOT }}/bin/go go install github.com/cockroachdb/crlfmt@latest
+      rm -rf $TMP_DIR
+    status:
+    - "[ -f '{{ .BUILD_ROOT }}/bin/go' ] || command -v {{ .BUILD_ROOT }}/bin/go/crlfmt >/dev/null 2>&1"
+
   install-kubectl:
     desc: install kubectl
     vars:

--- a/taskfiles/rpk.yml
+++ b/taskfiles/rpk.yml
@@ -28,6 +28,15 @@ tasks:
            -X ${cont_pkg}.tag={{.RPK_VERSION}}" \
         -o "{{.BUILD_ROOT}}/go/$GOOS/bin" ./...
 
+  fmt:
+    desc: run formater on the go code
+    dir: "{{.SRC_DIR}}/src/go"
+    deps:
+    - :dev:install-crlfmt
+    cmds:
+    - find . -name *.go -type f | xargs -n1 {{ .BUILD_ROOT }}/bin/go/crlfmt -wrap=80 -ignore '_generated.deepcopy.go$$' -w
+    - git diff --exit-code
+
   tidy:
     desc: mod tidy rpk
     env:


### PR DESCRIPTION
This introduces the plugin command, which builds on autocompletion work previously introduced, as well as the plugin manifest scheme proposed in a separate (internal) issue.

We will start with three commands: list, install, and uninstall. Listing by default lists plugins that are available, but we can also list local plugins with `--local`. Local listing also prints whether there are shadowed binaries.

The listPlugins code that was previously in root.go is moved to a new plugin package, which is expanded to include logic for the manifest, as well as downloading the manifest / plugin and writing plugin binaries. A good bit of logic remains in root.go, basically anything related to modifying cobra commands.