### PR TITLE
schema_registry: Various fixes (part2)

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -25,36 +25,6 @@ namespace {
 
 bool can_promote(avro::Node& writer, avro::Node& reader) {
     switch (writer.type()) {
-    case avro::AVRO_INT: {
-        switch (reader.type()) {
-        case avro::AVRO_LONG:
-        case avro::AVRO_FLOAT:
-        case avro::AVRO_DOUBLE:
-            return true;
-        default:
-            return false;
-        }
-        return false;
-    }
-    case avro::AVRO_LONG: {
-        switch (reader.type()) {
-        case avro::AVRO_FLOAT:
-        case avro::AVRO_DOUBLE:
-            return true;
-        default:
-            return false;
-        }
-        return false;
-    }
-    case avro::AVRO_FLOAT: {
-        switch (reader.type()) {
-        case avro::AVRO_DOUBLE:
-            return true;
-        default:
-            return false;
-        }
-        return false;
-    }
     case avro::AVRO_STRING:
         return reader.type() == avro::AVRO_BYTES;
     case avro::AVRO_BYTES:
@@ -151,7 +121,7 @@ bool check_compatible(avro::Node& reader, avro::Node& writer) {
     } else if (can_promote(writer, reader)) {
         return true;
     }
-    return writer.resolve(reader) == avro::RESOLVE_MATCH;
+    return writer.resolve(reader) != avro::RESOLVE_NO_MATCH;
 }
 
 } // namespace

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -59,8 +59,9 @@ struct error_category final : std::error_category {
         switch (static_cast<error_code>(ec)) {
         case error_code::schema_id_not_found:
         case error_code::subject_not_found:
-        case error_code::subject_version_not_found:
             return reply_error_code::topic_not_found; // 40401
+        case error_code::subject_version_not_found:
+            return reply_error_code::partition_not_found; // 40402
         case error_code::subject_soft_deleted:
             return reply_error_code::subject_soft_deleted; // 40404
         case error_code::subject_not_deleted:

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -57,11 +57,12 @@ struct error_category final : std::error_category {
     std::error_condition
     default_error_condition(int ec) const noexcept override {
         switch (static_cast<error_code>(ec)) {
-        case error_code::schema_id_not_found:
         case error_code::subject_not_found:
             return reply_error_code::topic_not_found; // 40401
         case error_code::subject_version_not_found:
             return reply_error_code::partition_not_found; // 40402
+        case error_code::schema_id_not_found:
+            return reply_error_code::consumer_instance_not_found; // 40403
         case error_code::subject_soft_deleted:
             return reply_error_code::subject_soft_deleted; // 40404
         case error_code::subject_not_deleted:

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -66,10 +66,10 @@ inline error_info not_found(const subject& sub) {
       fmt::format("Subject '{}' not found.", sub())};
 }
 
-inline error_info not_found(const subject& sub, schema_version id) {
+inline error_info not_found(const subject&, schema_version id) {
     return error_info{
       error_code::subject_version_not_found,
-      fmt::format("Subject '{}' Version {} not found.", sub(), id())};
+      fmt::format("Version {} not found.", id())};
 }
 
 inline error_info soft_deleted(const subject& sub) {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -349,13 +349,9 @@ public:
       seq_marker marker,
       const subject& sub,
       compatibility_level compatibility) {
-        auto sub_it = BOOST_OUTCOME_TRYX(
-          get_subject_iter(sub, include_deleted::no));
-
-        sub_it->second.written_at.push_back(marker);
-
-        // TODO(Ben): Check needs to be made here?
-        return std::exchange(sub_it->second.compatibility, compatibility)
+        auto& sub_entry = _subjects[sub];
+        sub_entry.written_at.push_back(marker);
+        return std::exchange(sub_entry.compatibility, compatibility)
                != compatibility;
     }
 

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -530,7 +530,7 @@ private:
 
     schema_map _schemas;
     subject_map _subjects;
-    compatibility_level _compatibility{compatibility_level::none};
+    compatibility_level _compatibility{compatibility_level::backward};
 };
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -49,6 +49,12 @@ BOOST_AUTO_TEST_CASE(test_avro_union) {
     BOOST_REQUIRE(!check_compatible(union1, union0));
 }
 
+BOOST_AUTO_TEST_CASE(test_avro_array) {
+    BOOST_REQUIRE(check_compatible(long_array, int_array));
+
+    BOOST_REQUIRE(!check_compatible(int_array, long_array));
+}
+
 BOOST_AUTO_TEST_CASE(test_avro_basic_backwards_compat) {
     // Backward compatibility: A new schema is backward compatible if it can be
     // used to read the data written in the previous schema.

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -43,6 +43,12 @@ BOOST_AUTO_TEST_CASE(test_avro_enum) {
     // BOOST_REQUIRE(check_compatible(enum3, enum2_def));
 }
 
+BOOST_AUTO_TEST_CASE(test_avro_union) {
+    BOOST_REQUIRE(check_compatible(union2, union0));
+
+    BOOST_REQUIRE(!check_compatible(union1, union0));
+}
+
 BOOST_AUTO_TEST_CASE(test_avro_basic_backwards_compat) {
     // Backward compatibility: A new schema is backward compatible if it can be
     // used to read the data written in the previous schema.

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
@@ -74,6 +74,20 @@ const auto union2 = pps::make_avro_schema_definition(R"({
 })")
                       .value();
 
+const auto int_array = pps::make_avro_schema_definition(R"({
+  "name": "test2",
+  "type": "array",
+  "items": "int"
+})")
+                         .value();
+
+const auto long_array = pps::make_avro_schema_definition(R"({
+  "name": "test2",
+  "type": "array",
+  "items": "long"
+})")
+                          .value();
+
 // Schemas defined in AvroCompatibilityTest.java. Used here to ensure
 // compatibility with the schema-registry
 const auto schema1

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
@@ -37,6 +37,43 @@ const auto enum_2def = pps::make_avro_schema_definition(
 })")
                          .value();
 
+const auto union0 = pps::make_avro_schema_definition(R"({
+    "name": "init",
+    "type": "record",
+    "fields": [{
+        "name": "inner",
+        "type": ["string", "int"]}]
+})")
+                      .value();
+
+const auto union1 = pps::make_avro_schema_definition(R"({
+    "name": "init",
+    "type": "record",
+    "fields": [{
+        "name": "inner",
+        "type": ["null", "string"]}]
+})")
+                      .value();
+
+const auto union2 = pps::make_avro_schema_definition(R"({
+    "name": "init",
+    "type": "record",
+    "fields": [{
+        "name": "inner",
+        "type": [
+            "int", "string", {
+                "type": "record",
+                "name": "foobar_fields",
+                "fields": [{
+                    "name": "foo",
+                    "type": "string"
+                }]
+            }
+        ]
+    }]
+})")
+                      .value();
+
 // Schemas defined in AvroCompatibilityTest.java. Used here to ensure
 // compatibility with the schema-registry
 const auto schema1

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -122,10 +122,10 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
     BOOST_REQUIRE_THROW(c(std::move(bad_schema_magic)).get(), pps::exception);
 
     BOOST_REQUIRE(
-      s.get_compatibility().get() == pps::compatibility_level::none);
+      s.get_compatibility().get() == pps::compatibility_level::backward);
     BOOST_REQUIRE(
       s.get_compatibility(subject0, pps::default_to_global::yes).get()
-      == pps::compatibility_level::none);
+      == pps::compatibility_level::backward);
 
     auto good_config = pps::as_record_batch(
       pps::config_key{sequence, node_id, subject0, magic0},

--- a/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/consume_to_store.cc
@@ -47,15 +47,14 @@ constexpr pps::schema_version version1{1};
 constexpr pps::schema_id id0{0};
 constexpr pps::schema_id id1{1};
 
-inline model::record_batch
-make_delete_subject_batch(pps::subject sub, pps::schema_version version) {
+inline model::record_batch make_delete_subject_batch(pps::subject sub) {
     storage::record_batch_builder rb{
       model::record_batch_type::raft_data, model::offset{0}};
 
     rb.add_raw_kv(
       to_json_iobuf(pps::delete_subject_key{
         .seq{model::offset{0}}, .node{model::node_id{0}}, .sub{sub}}),
-      to_json_iobuf(pps::delete_subject_value{.sub{sub}, .version{version}}));
+      to_json_iobuf(pps::delete_subject_value{.sub{sub}}));
     return std::move(rb).build();
 }
 
@@ -146,7 +145,7 @@ SEASTAR_THREAD_TEST_CASE(test_consume_to_store) {
       s.get_subjects(pps::include_deleted::no).get().size(), 1);
     BOOST_REQUIRE_EQUAL(
       s.get_subjects(pps::include_deleted::yes).get().size(), 1);
-    auto delete_sub = make_delete_subject_batch(subject0, version1);
+    auto delete_sub = make_delete_subject_batch(subject0);
     BOOST_REQUIRE_NO_THROW(c(std::move(delete_sub)).get());
     BOOST_REQUIRE_EQUAL(
       s.get_subjects(pps::include_deleted::no).get().size(), 0);

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -51,6 +51,21 @@ const ss::sstring avro_int_payload{
 })"};
 const ss::sstring expected_avro_int_def{R"({"int"})"};
 
+const ss::sstring avro_long_payload{
+  R"(
+{
+  "schema": "\"long\"",
+  "schemaType": "AVRO",
+  "references": [
+    {
+       "name": "com.acme.Referenced",
+       "subject":  "childSubject",
+       "version": 1
+    }
+  ]
+})"};
+const ss::sstring expected_avro_long_def{R"({"long"})"};
+
 iobuf make_body(const ss::sstring& body) {
     iobuf buf;
     buf.append(body.data(), body.size());
@@ -114,7 +129,7 @@ FIXTURE_TEST(
     {
         info("Post a new schema as key (expect schema_id=2)");
         auto res = post_schema(
-          client, pps::subject{"test-key"}, avro_string_payload);
+          client, pps::subject{"test-key"}, avro_long_payload);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
         BOOST_REQUIRE_EQUAL(res.body, R"({"id":2})");

--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -104,11 +104,10 @@ const pps::delete_subject_key delete_subject_key{
 
 constexpr std::string_view delete_subject_value_sv{
   R"({
-  "subject": "my-kafka-value",
-  "version": 2
+  "subject": "my-kafka-value"
 })"};
 const pps::delete_subject_value delete_subject_value{
-  .sub{pps::subject{"my-kafka-value"}}, .version{pps::schema_version{2}}};
+  .sub{pps::subject{"my-kafka-value"}}};
 
 BOOST_AUTO_TEST_CASE(test_storage_serde) {
     {

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -303,16 +303,11 @@ BOOST_AUTO_TEST_CASE(test_store_global_compat) {
     // Setting the retrieving global compatibility should be allowed multiple
     // times
 
-    pps::compatibility_level expected{pps::compatibility_level::none};
+    pps::compatibility_level expected{pps::compatibility_level::backward};
     pps::store s;
     BOOST_REQUIRE(s.get_compatibility().value() == expected);
 
-    expected = pps::compatibility_level::backward;
-    BOOST_REQUIRE(s.set_compatibility(expected).value() == true);
-    BOOST_REQUIRE(s.get_compatibility().value() == expected);
-
     // duplicate should return false
-    expected = pps::compatibility_level::backward;
     BOOST_REQUIRE(s.set_compatibility(expected).value() == false);
     BOOST_REQUIRE(s.get_compatibility().value() == expected);
 
@@ -328,7 +323,8 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat) {
     pps::seq_marker dummy_marker;
     auto fallback = pps::default_to_global::yes;
 
-    pps::compatibility_level global_expected{pps::compatibility_level::none};
+    pps::compatibility_level global_expected{
+      pps::compatibility_level::backward};
     pps::store s;
     BOOST_REQUIRE(s.get_compatibility().value() == global_expected);
     s.insert(subject0, string_def0, pps::schema_type::avro);
@@ -366,12 +362,12 @@ BOOST_AUTO_TEST_CASE(test_store_subject_compat_fallback) {
     // A Subject should fallback to the current global setting
     auto fallback = pps::default_to_global::yes;
 
-    pps::compatibility_level expected{pps::compatibility_level::none};
+    pps::compatibility_level expected{pps::compatibility_level::backward};
     pps::store s;
     s.insert(subject0, string_def0, pps::schema_type::avro);
     BOOST_REQUIRE(s.get_compatibility(subject0, fallback).value() == expected);
 
-    expected = pps::compatibility_level::backward;
+    expected = pps::compatibility_level::forward;
     BOOST_REQUIRE(s.set_compatibility(expected).value() == true);
     BOOST_REQUIRE(s.get_compatibility(subject0, fallback).value() == expected);
 }
@@ -382,7 +378,7 @@ BOOST_AUTO_TEST_CASE(test_store_invalid_subject_compat) {
     auto fallback = pps::default_to_global::yes;
 
     pps::seq_marker dummy_marker;
-    pps::compatibility_level expected{pps::compatibility_level::none};
+    pps::compatibility_level expected{pps::compatibility_level::backward};
     pps::store s;
 
     BOOST_REQUIRE_EQUAL(

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -386,9 +386,8 @@ BOOST_AUTO_TEST_CASE(test_store_invalid_subject_compat) {
       pps::error_code::subject_not_found);
 
     expected = pps::compatibility_level::backward;
-    BOOST_REQUIRE_EQUAL(
-      s.set_compatibility(dummy_marker, subject0, expected).error().code(),
-      pps::error_code::subject_not_found);
+    BOOST_REQUIRE(
+      s.set_compatibility(dummy_marker, subject0, expected).value());
 }
 
 BOOST_AUTO_TEST_CASE(test_store_delete_subject) {

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -589,6 +589,7 @@ class SchemaRegistryTest(RedpandaTest):
                                                   permanent=True)
         self.logger.debug(result_raw)
         assert result_raw.status_code == requests.codes.not_found
+        assert result_raw.json()["error_code"] == 40407
 
         self.logger.debug("Soft delete version 2")
         result_raw = self._delete_subject_version(
@@ -597,6 +598,15 @@ class SchemaRegistryTest(RedpandaTest):
         )
         self.logger.debug(result_raw)
         assert result_raw.status_code == requests.codes.ok
+
+        self.logger.debug("Soft delete version 2 - second time")
+        result_raw = self._delete_subject_version(
+            subject=f"{topic}-key",
+            version=2,
+        )
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.not_found
+        assert result_raw.json()["error_code"] == 40406
 
         self.logger.debug("Get versions")
         result_raw = self._get_subjects_subject_versions(
@@ -611,6 +621,21 @@ class SchemaRegistryTest(RedpandaTest):
         self.logger.debug(result_raw)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json() == [1, 2, 3]
+
+        self.logger.debug("Permanently delete version 2")
+        result_raw = self._delete_subject_version(subject=f"{topic}-key",
+                                                  version=2,
+                                                  permanent=True)
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+
+        self.logger.debug("Permanently delete version 2 - second time")
+        result_raw = self._delete_subject_version(subject=f"{topic}-key",
+                                                  version=2,
+                                                  permanent=True)
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.not_found
+        assert result_raw.json()["error_code"] == 40402
 
     @cluster(num_nodes=3)
     def test_mixed_deletes(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -372,7 +372,7 @@ class SchemaRegistryTest(RedpandaTest):
         """
         self.logger.debug("Get initial global config")
         result_raw = self._get_config()
-        assert result_raw.json()["compatibilityLevel"] == "NONE"
+        assert result_raw.json()["compatibilityLevel"] == "BACKWARD"
 
         self.logger.debug("Set global config")
         result_raw = self._set_config(

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -330,7 +330,7 @@ class SchemaRegistryTest(RedpandaTest):
             subject=f"{topic}-key", version=2)
         assert result_raw.status_code == requests.codes.not_found
         result = result_raw.json()
-        assert result["error_code"] == 40401
+        assert result["error_code"] == 40402
         assert result[
             "message"] == f"Subject '{topic}-key' Version 2 not found."
 

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -331,8 +331,7 @@ class SchemaRegistryTest(RedpandaTest):
         assert result_raw.status_code == requests.codes.not_found
         result = result_raw.json()
         assert result["error_code"] == 40402
-        assert result[
-            "message"] == f"Subject '{topic}-key' Version 2 not found."
+        assert result["message"] == f"Version 2 not found."
 
         self.logger.debug("Get schema version 1 for subject key")
         result_raw = self._get_subjects_subject_versions_version(

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -355,7 +355,7 @@ class SchemaRegistryTest(RedpandaTest):
         result_raw = self._get_schemas_ids_id(id=2)
         assert result_raw.status_code == requests.codes.not_found
         result = result_raw.json()
-        assert result["error_code"] == 40401
+        assert result["error_code"] == 40403
         assert result["message"] == "Schema 2 not found"
 
         self.logger.debug("Get schema version 1")


### PR DESCRIPTION
## Cover letter

Various fixes for compatibility with alternative products:
* Set the default compatibility to `BACKWARDS`
* Allow `set_compatibility` on non-existent subject
* Add tests for union
* Weaken AVRO resolve check to support integer promotion on e.g., arrays
* Fix `error_code` and message for `subject_version_not_found `
* Fix  `error_code` for `schema_id_not_found`
* Remove `delete_subject_value::version` - this is a breaking change, but it hasn't been released yet
* Permanently deleting a `subject_version` twice should return `subject_version_not_found`, instead of `subject_not_found`

## Release notes

schema_registry: Various fixes for compatibility with alternative products.
