### PR TITLE
storage: use a fragmented vector for segment index

### DIFF
--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -158,9 +158,6 @@ std::optional<index_state> index_state::hydrate_from_buffer(iobuf b) {
 
     const uint32_t vsize = ss::le_to_cpu(
       reflection::adl<uint32_t>{}.from(parser));
-    retval.relative_offset_index.reserve(vsize);
-    retval.relative_time_index.reserve(vsize);
-    retval.position_index.reserve(vsize);
     for (auto i = 0U; i < vsize; ++i) {
         retval.relative_offset_index.push_back(
           reflection::adl<uint32_t>{}.from(parser));
@@ -173,6 +170,9 @@ std::optional<index_state> index_state::hydrate_from_buffer(iobuf b) {
         retval.position_index.push_back(
           reflection::adl<uint64_t>{}.from(parser));
     }
+    retval.relative_offset_index.shrink_to_fit();
+    retval.relative_time_index.shrink_to_fit();
+    retval.position_index.shrink_to_fit();
     const auto computed_checksum = storage::index_state::checksum_state(retval);
     if (unlikely(retval.checksum != computed_checksum)) {
         vlog(

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -14,6 +14,7 @@
 #include "bytes/iobuf.h"
 #include "model/fundamental.h"
 #include "model/timestamp.h"
+#include "utils/fragmented_vector.h"
 
 #include <cstdint>
 #include <optional>
@@ -59,9 +60,9 @@ struct index_state {
     model::timestamp max_timestamp{0};
 
     /// breaking indexes into their own has a 6x latency reduction
-    std::vector<uint32_t> relative_offset_index;
-    std::vector<uint32_t> relative_time_index;
-    std::vector<uint64_t> position_index;
+    fragmented_vector<uint32_t> relative_offset_index;
+    fragmented_vector<uint32_t> relative_time_index;
+    fragmented_vector<uint64_t> position_index;
 
     bool empty() const { return relative_offset_index.empty(); }
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "vassert.h"
+
+#include <cstddef>
+#include <vector>
+
+/**
+ * A very very simple fragmented vector that provides random access like a
+ * vector, but does not store its data in contiguous memory.
+ *
+ * There is no reserve method because we allocate a full fragment at a time.
+ * However, after you populate a vector you might want to call shrink to fit if
+ * your fragment is large. A more advanced strategy could allocate capacity up
+ * front which just requires a bit more accounting.
+ *
+ * The iterator implementation works for a few things like std::lower_bound,
+ * upper_bound, distance, etc... see fragmented_vector_test.
+ *
+ * Note that the decision to allocate a full fragment at a time isn't
+ * necessarily an optimization, but rather a restriction that simplifies the
+ * implementation. If expand fragmented_vector to be more general purpose, we
+ * should indeed make it more flexible. If we add a reserve method to allocate
+ * all of the space at once we might benefit from the allocator helping with
+ * giving us contiguous memory.
+ */
+template<typename T, size_t fragment_size = 8192>
+class fragmented_vector {
+    static_assert(
+      (fragment_size & fragment_size - 1) == 0,
+      "fragment size must be a power of 2");
+    static_assert(fragment_size % sizeof(T) == 0);
+    static constexpr size_t elems_per_frag = fragment_size / sizeof(T);
+    static_assert(elems_per_frag >= 1);
+
+public:
+    fragmented_vector() noexcept = default;
+    fragmented_vector(const fragmented_vector&) noexcept = delete;
+    fragmented_vector& operator=(const fragmented_vector&) noexcept = delete;
+    fragmented_vector(fragmented_vector&&) noexcept = default;
+    fragmented_vector& operator=(fragmented_vector&&) noexcept = default;
+    ~fragmented_vector() noexcept = default;
+
+    void push_back(T elem) {
+        if (_size == _capacity) {
+            std::vector<T> frag;
+            frag.reserve(elems_per_frag);
+            _frags.push_back(std::move(frag));
+            _capacity += elems_per_frag;
+        }
+        _frags.back().push_back(elem);
+        ++_size;
+    }
+
+    void pop_back() {
+        vassert(_size > 0, "Cannot pop from empty container");
+        _frags.back().pop_back();
+        --_size;
+        if (_frags.back().empty()) {
+            _frags.pop_back();
+            _capacity -= elems_per_frag;
+        }
+    }
+
+    const T& operator[](size_t index) const {
+        vassert(index < _size, "Index out of range {}/{}", index, _size);
+        auto& frag = _frags.at(index / elems_per_frag);
+        return frag.at(index % elems_per_frag);
+    }
+
+    const T& back() const { return _frags.back().back(); }
+    bool empty() const noexcept { return _size == 0; }
+    size_t size() const noexcept { return _size; }
+
+    void shrink_to_fit() {
+        if (!_frags.empty()) {
+            _frags.back().shrink_to_fit();
+        }
+    }
+
+    bool operator==(const fragmented_vector& o) const noexcept {
+        return o._frags == _frags;
+    }
+
+    class const_iterator {
+    public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = const T;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const T*;
+        using reference = const T&;
+
+        reference operator*() const { return _vec->operator[](_index); }
+
+        const_iterator& operator+=(ssize_t n) {
+            _index += n;
+            return *this;
+        }
+
+        const_iterator& operator++() {
+            ++_index;
+            return *this;
+        }
+
+        bool operator==(const const_iterator&) const = default;
+
+        friend ssize_t
+        operator-(const const_iterator& a, const const_iterator& b) {
+            return a._index - b._index;
+        }
+
+    private:
+        friend class fragmented_vector;
+
+        const_iterator(
+          const fragmented_vector<T, fragment_size>* vec, size_t index)
+          : _index(index)
+          , _vec(vec) {}
+
+        size_t _index;
+        const fragmented_vector<T, fragment_size>* _vec;
+    };
+
+    const_iterator begin() const { return const_iterator(this, 0); }
+    const_iterator end() const { return const_iterator(this, _size); }
+
+private:
+    size_t _size{0};
+    size_t _capacity{0};
+    std::vector<std::vector<T>> _frags;
+};

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ rp_test(
     tristate_test.cc
     moving_average_test.cc
     human_test.cc
+    fragmented_vector_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::utils
   LABELS utils

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "random/generators.h"
+#include "utils/fragmented_vector.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+template<typename T>
+static void
+test_equal(std::vector<T>& truth, fragmented_vector<T, 1024>& other) {
+    BOOST_REQUIRE(!truth.empty());
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      truth.begin(), truth.end(), other.begin(), other.end());
+    BOOST_REQUIRE_EQUAL(truth.empty(), other.empty());
+    BOOST_REQUIRE_EQUAL(truth.size(), other.size());
+    BOOST_REQUIRE_EQUAL(truth.back(), other.back());
+}
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_test) {
+    std::vector<int64_t> truth;
+    fragmented_vector<int64_t, 1024> other;
+
+    for (int64_t i = 0; i < 2500; i++) {
+        truth.push_back(i);
+        other.push_back(i);
+        test_equal(truth, other);
+    }
+
+    for (int64_t i = 0; i < 1234; i++) {
+        truth.pop_back();
+        other.pop_back();
+        test_equal(truth, other);
+    }
+
+    for (int64_t i = 0; i < 123; i++) {
+        truth.push_back(i);
+        other.push_back(i);
+        test_equal(truth, other);
+    }
+
+    for (int64_t i = 0; i < 1389; i++) {
+        test_equal(truth, other);
+        truth.pop_back();
+        other.pop_back();
+    }
+
+    BOOST_REQUIRE_EQUAL(truth.size(), other.size());
+    BOOST_REQUIRE_EQUAL(truth.empty(), other.empty());
+
+    for (int i = 0; i < 2000; i++) {
+        truth.push_back(random_generators::get_int<int64_t>(1000, 3000));
+        other.push_back(truth.back());
+    }
+    BOOST_REQUIRE_EQUAL(truth.size(), 2000);
+    test_equal(truth, other);
+
+    BOOST_REQUIRE_EQUAL(
+      truth, std::vector<int64_t>(other.begin(), other.end()));
+
+    for (int i = 0; i < 6000; i++) {
+        auto val = random_generators::get_int<int64_t>(0, 4000);
+
+        auto it = std::lower_bound(truth.begin(), truth.end(), val);
+        auto it2 = std::lower_bound(other.begin(), other.end(), val);
+        BOOST_REQUIRE_EQUAL(it == truth.end(), it2 == other.end());
+        BOOST_REQUIRE_EQUAL(
+          std::distance(truth.begin(), it), std::distance(other.begin(), it2));
+        BOOST_REQUIRE_EQUAL(
+          std::distance(it, truth.end()), std::distance(it2, other.end()));
+
+        it = std::upper_bound(truth.begin(), truth.end(), val);
+        it2 = std::upper_bound(other.begin(), other.end(), val);
+        BOOST_REQUIRE_EQUAL(it == truth.end(), it2 == other.end());
+        BOOST_REQUIRE_EQUAL(
+          std::distance(truth.begin(), it), std::distance(other.begin(), it2));
+        BOOST_REQUIRE_EQUAL(
+          std::distance(it, truth.end()), std::distance(it2, other.end()));
+
+        it = std::find(truth.begin(), truth.end(), val);
+        it2 = std::find(other.begin(), other.end(), val);
+        BOOST_REQUIRE_EQUAL(it == truth.end(), it2 == other.end());
+        BOOST_REQUIRE_EQUAL(
+          std::distance(truth.begin(), it), std::distance(other.begin(), it2));
+        BOOST_REQUIRE_EQUAL(
+          std::distance(it, truth.end()), std::distance(it2, other.end()));
+    }
+}


### PR DESCRIPTION
We've noticed several cases where segment index makes large allocations. In response, this PR adds a simple fragmented vector implementation and updates the segment index to use this instead of making making potentially large contiguous memory allocations.

Some information about memory usage and why contiguous memory is problematic: https://github.com/vectorizedio/redpanda/discussions/1956