### PR TITLE
ducktape: stability and ease-of-use fixes

### DIFF
--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -8,7 +8,7 @@
 
 from rptest.clients.kafka_cat import KafkaCat
 from ducktape.mark.resource import cluster
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ignore
 from ducktape.utils.util import wait_until
 from ducktape.errors import DucktapeError
 from rptest.tests.redpanda_test import RedpandaTest
@@ -199,6 +199,7 @@ class ArchivalTest(RedpandaTest):
         self.kafka_tools.produce(self.topic, 10000, 1024)
         validate(self._quick_verify, self.logger, 90)
 
+    @ignore
     @cluster(num_nodes=3)
     def test_isolate(self):
         """Verify that our isolate/rejoin facilities actually work"""

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -128,10 +128,7 @@ class PandaProxyTest(RedpandaTest):
             extra_rp_conf={"auto_create_topics_enabled": False})
 
         http.client.HTTPConnection.debuglevel = 1
-        logging.basicConfig()
-        requests_log = logging.getLogger("requests.packages.urllib3")
-        requests_log.setLevel(logging.getLogger().level)
-        requests_log.propagate = True
+        http.client.print = lambda *args: self.logger.debug(" ".join(args))
 
     def _base_uri(self):
         return f"http://{self.redpanda.nodes[0].account.hostname}:8082"
@@ -798,10 +795,7 @@ class PandaProxySASLTest(RedpandaTest):
                                                  extra_rp_conf=extra_rp_conf)
 
         http.client.HTTPConnection.debuglevel = 1
-        logging.basicConfig()
-        requests_log = logging.getLogger("requests.packages.urllib3")
-        requests_log.setLevel(logging.getLogger().level)
-        requests_log.propagate = True
+        http.client.print = lambda *args: self.logger.debug(" ".join(args))
 
     def _get_super_client(self):
         user, password, _ = self.redpanda.SUPERUSER_CREDENTIALS

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -55,10 +55,7 @@ class SchemaRegistryTest(RedpandaTest):
             num_cores=1)
 
         http.client.HTTPConnection.debuglevel = 1
-        logging.basicConfig()
-        requests_log = logging.getLogger("requests.packages.urllib3")
-        requests_log.setLevel(logging.getLogger().level)
-        requests_log.propagate = True
+        http.client.print = lambda *args: self.logger.debug(" ".join(args))
 
         self._ctx = context
 


### PR DESCRIPTION
- Temporarily disables flaky archival test (https://github.com/vectorizedio/redpanda/issues/1977)
- Logging proxy/schema-registry http requests to ducktape log instead of foreground in build kite log
