### PR TITLE
coproc: add logic for storing js scripts in internal coproc topic without deploying it to nodejs

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/deploy_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/deploy_test.go
@@ -32,7 +32,7 @@ func TestNewDeployCommand(t *testing.T) {
 	}{
 		{
 			name: "it should publish a message with correct format",
-			args: []string{"--description", "coprocessor description", "--name", "foo"},
+			args: []string{"--description", "coprocessor description", "--name", "foo", "--type", "data-policy"},
 			fileInformation: fileInfo{
 				name:    "fileName.js",
 				content: "let s = 'text'",
@@ -47,6 +47,17 @@ func TestNewDeployCommand(t *testing.T) {
 				name: "fileName.html",
 			},
 			expectedErr: "can't deploy 'fileName.html': only .js files are supported.",
+		}, {
+			name: "it should fail if the type is not correct",
+			args: []string{"--name", "foo", "--type", "test"},
+			fileInformation: fileInfo{
+				name:    "fileName.js",
+				content: "let s = 'text'",
+			},
+			pre: func(fs afero.Fs, fileInformation fileInfo) error {
+				return createMockFile(fs, fileInformation.name, fileInformation.content)
+			},
+			expectedErr: "Unexpected coproc type: 'test'",
 		}, {
 			name: "it should fail if the file doesn't exist",
 			args: []string{"--name", "foo"},
@@ -141,6 +152,9 @@ func TestNewDeployCommand(t *testing.T) {
 						}, {
 							Key:   []byte("sha256"),
 							Value: hashContent[:],
+						}, {
+							Key:   []byte("type"),
+							Value: []byte("async"),
 						},
 					}
 					require.Equal(t, expectHeader, msg.Headers)

--- a/src/go/rpk/pkg/cli/cmd/wasm/remove_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/remove_test.go
@@ -22,11 +22,15 @@ func TestNewRemoveCommand(t *testing.T) {
 	}{
 		{
 			name: "it should publish a message with correct format",
-			args: []string{"bar"},
+			args: []string{"bar", "--type", "async"},
 		}, {
 			name:        "it should a error if the name arg isn't set",
 			args:        []string{},
 			expectedErr: "no wasm script name specified",
+		}, {
+			name:        "it should fail if the type is not correct",
+			args:        []string{"bar", "--type", "test"},
+			expectedErr: "Unexpected coproc type: 'test'",
 		}, {
 			name: "it should publish a message with correct format with valid headers",
 			args: []string{"foo"},
@@ -37,6 +41,9 @@ func TestNewRemoveCommand(t *testing.T) {
 						{
 							Key:   []byte("action"),
 							Value: []byte("remove"),
+						}, {
+							Key:   []byte("type"),
+							Value: []byte("async"),
 						},
 					}
 					require.Equal(t, expectHeader, msg.Headers)

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -20,6 +20,7 @@ v_cc_library(
     wasm_event.cc
     event_listener.cc
     script_dispatcher.cc
+    event_handler.cc
   DEPS
     v::rpc
     v::model

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -30,7 +30,13 @@ api::~api() = default;
 ss::future<> api::start() {
     co_await _pacemaker.start(_engine_addr, std::ref(_rs));
     co_await _pacemaker.invoke_on_all(&coproc::pacemaker::start);
-    _listener = std::make_unique<wasm::event_listener>(_pacemaker);
+    _listener = std::make_unique<wasm::event_listener>();
+
+    _wasm_async_handler = std::make_unique<coproc::wasm::async_event_handler>(
+      _listener->get_abort_source(), std::ref(_pacemaker));
+    _listener->register_handler(
+      coproc::wasm::event_type::async, _wasm_async_handler.get());
+
     co_await _listener->start();
 }
 

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "coproc/event_handler.h"
 #include "coproc/fwd.h"
 #include "coproc/sys_refs.h"
 #include "utils/unresolved_address.h"
@@ -36,6 +37,9 @@ private:
     sys_refs _rs;
     std::unique_ptr<wasm::event_listener> _listener; /// one instance
     ss::sharded<pacemaker> _pacemaker;               /// one per core
+
+    // Event handlers
+    std::unique_ptr<wasm::async_event_handler> _wasm_async_handler;
 };
 
 } // namespace coproc

--- a/src/v/coproc/errc.h
+++ b/src/v/coproc/errc.h
@@ -21,7 +21,8 @@ enum class errc {
     empty_mandatory_field,
     missing_header_key,
     unexpected_action_type,
-    unexpected_value
+    unexpected_value,
+    unexpected_coproc_type
 };
 
 struct errc_category final : public std::error_category {

--- a/src/v/coproc/event_handler.cc
+++ b/src/v/coproc/event_handler.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/event_handler.h"
+
+#include "coproc/ntp_context.h"
+#include "utils/gate_guard.h"
+#include "vlog.h"
+
+namespace coproc::wasm {
+
+async_event_handler::async_event_handler(
+  ss::abort_source& abort_source, ss::sharded<pacemaker>& pacemaker)
+  : _abort_source(abort_source)
+  , _dispatcher(pacemaker, _abort_source) {}
+
+ss::future<> async_event_handler::start() { co_return; }
+
+ss::future<> async_event_handler::stop() { return _gate.close(); }
+
+ss::future<event_handler::cron_finish_status>
+async_event_handler::preparation_before_process() {
+    gate_guard guard{_gate};
+    auto heartbeat = co_await _dispatcher.heartbeat();
+    if (heartbeat.has_error()) {
+        std::error_code err = heartbeat.error();
+        if (
+          err == rpc::errc::client_request_timeout
+          || err == rpc::errc::disconnected_endpoint) {
+            vlog(
+              coproclog.error,
+              "Wasm engine failed to reply to heartbeat within the "
+              "expected "
+              "interval");
+            co_return cron_finish_status::skip_pull;
+        }
+    } else if (heartbeat.value().data != _active_ids.size()) {
+        /// There is a discrepency between the number of registered coprocs
+        /// according to redpanda and according to the wasm engine.
+        /// Reconcile all state from offset 0.
+        vlog(coproclog.info, "Replaying coprocessor state...");
+        if (co_await _dispatcher.disable_all_coprocessors()) {
+            vlog(
+              coproclog.error,
+              "Failed to reset wasm_engine state, will keep retrying...");
+        } else {
+            _active_ids.clear();
+            co_return cron_finish_status::replay_topic;
+        }
+    }
+    co_return cron_finish_status::none;
+}
+
+ss::future<>
+async_event_handler::process(absl::btree_map<script_id, parsed_event> wsas) {
+    gate_guard guard{_gate};
+    std::vector<enable_copros_request::data> enables;
+    std::vector<script_id> disables;
+    for (auto& [id, event] : wsas) {
+        /// Keeping the active_ids cache up to date solves the issue of
+        /// issuing a bunch of remove commands for scripts that aren't
+        /// deployed (this could occur during bootstrapping)
+        auto found = _active_ids.find(id);
+        if (event.header.action == event_action::remove) {
+            if (found != _active_ids.end()) {
+                disables.emplace_back(id);
+            }
+        } else {
+            /// ... or in the case if deploys are performed using the same
+            /// key. This would normally be resolved if the events came in
+            /// the same record batch by the reconcile events function, but
+            /// not if they arrived in separate batches.
+            if (found == _active_ids.end()) {
+                enables.emplace_back(enable_copros_request::data{
+                  .id = id, .source_code = std::move(event.data)});
+            }
+        }
+    }
+    /// TODO: In the future, maybe it would be cleaner to have a add/remove
+    /// endpoint, instead of two seperate RPC endpoints
+    if (!enables.empty()) {
+        enable_copros_request req{.inputs = std::move(enables)};
+        auto resp = co_await _dispatcher.enable_coprocessors(std::move(req));
+        if (resp.has_error()) {
+            throw async_event_handler_exception(fmt_with_ctx(
+              fmt::format,
+              "Failed to register coprocessors with the wasm engine: {}",
+              resp.error()));
+            co_return;
+        } else {
+            for (script_id id : resp.value()) {
+                vlog(
+                  coproclog.info,
+                  "Successfully registered script with id: {}",
+                  id);
+                _active_ids.insert(id);
+            }
+        }
+    }
+    if (!disables.empty()) {
+        disable_copros_request req{.ids = std::move(disables)};
+        auto resp = co_await _dispatcher.disable_coprocessors(std::move(req));
+        if (resp.has_error()) {
+            /// In this case the code will follow a path that re-enters this
+            /// method with the same inputs, and the call to enable_copros
+            /// above succeeded but the call to disable_coprocessors failed,
+            /// double registrations will be avoided because the ids have
+            /// entered the \ref active_ids cache and will not be queued for
+            /// re-registration
+            throw async_event_handler_exception(fmt_with_ctx(
+              fmt::format,
+              "Failed to make disable request to the wasm engine: {}",
+              resp.error()));
+        } else {
+            for (script_id id : resp.value()) {
+                _active_ids.erase(id);
+            }
+        }
+    }
+}
+
+ss::future<> data_policy_event_handler::start() { return _scripts.start(); }
+
+ss::future<> data_policy_event_handler::stop() { return _scripts.stop(); }
+
+// event_listener run this method from 0-core
+ss::future<> data_policy_event_handler::process(
+  absl::btree_map<script_id, parsed_event> wsas) {
+    for (auto& [id, event] : wsas) {
+        co_await _scripts.invoke_on_all(
+          [id = id, &event = event](
+            absl::btree_map<script_id, iobuf>& _local_scripts) mutable {
+              if (event.header.action == event_action::deploy) {
+                  _local_scripts.insert_or_assign(id, event.data.copy());
+              } else {
+                  _local_scripts.erase(id);
+              }
+          });
+    }
+    co_return;
+}
+
+std::optional<iobuf>
+data_policy_event_handler::get_code(std::string_view name) {
+    // rpk use xxhash_64 for create script_is from script name
+    script_id id(xxhash_64(name.data(), name.size()));
+    auto code = _scripts.local().find(id);
+    if (code == _scripts.local().end()) {
+        return std::nullopt;
+    }
+
+    return code->second.copy();
+}
+
+} // namespace coproc::wasm

--- a/src/v/coproc/event_handler.h
+++ b/src/v/coproc/event_handler.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "coproc/logger.h"
+#include "coproc/script_dispatcher.h"
+#include "coproc/wasm_event.h"
+#include "seastarx.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
+#include <absl/container/btree_map.h>
+#include <absl/container/btree_set.h>
+
+namespace coproc::wasm {
+
+class event_handler_exception : public std::exception {
+public:
+    explicit event_handler_exception(ss::sstring msg) noexcept
+      : _msg(std::move(msg)) {}
+
+    const char* what() const noexcept final { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
+
+/// This class implements logic for handling events from internal coproc topic.
+/// There are 2 methods: for process event for specifix type and cron
+/// events(like heartbeats) We need store this handler to application, and pass
+/// it to register method of event_listener.
+class event_handler {
+public:
+    virtual ~event_handler() {}
+
+    virtual ss::future<> start() = 0;
+    virtual ss::future<> stop() = 0;
+
+    enum cron_finish_status { replay_topic, skip_pull, none };
+
+    /// Cron. Run it from loop in do_start event_listener function
+    virtual ss::future<event_handler::cron_finish_status>
+    preparation_before_process() = 0;
+
+    /// Process parsed event with the same coproc type
+    virtual ss::future<>
+    process(absl::btree_map<script_id, parsed_event> wsas) = 0;
+};
+
+class async_event_handler_exception final : public event_handler_exception {
+public:
+    explicit async_event_handler_exception(ss::sstring msg) noexcept
+      : event_handler_exception(std::move(msg)) {}
+};
+
+class async_event_handler final : public event_handler {
+public:
+    explicit async_event_handler(
+      ss::abort_source& abort_source, ss::sharded<pacemaker>& pacemaker);
+
+    ss::future<> start() override;
+    ss::future<> stop() override;
+
+    ss::future<event_handler::cron_finish_status>
+    preparation_before_process() override;
+
+    ss::future<>
+    process(absl::btree_map<script_id, parsed_event> wsas) override;
+
+private:
+    /// Set of known script ids to be active
+    absl::btree_set<script_id> _active_ids;
+
+    /// Pass it tot script_dispatcher
+    ss::abort_source& _abort_source;
+
+    ss::gate _gate;
+
+    /// Used to make requests to the wasm engine
+    script_dispatcher _dispatcher;
+};
+
+class data_policy_event_handler final : public event_handler {
+public:
+    ss::future<> start() override;
+    ss::future<> stop() override;
+
+    ss::future<event_handler::cron_finish_status>
+    preparation_before_process() override {
+        co_return cron_finish_status::none;
+    }
+
+    ss::future<>
+    process(absl::btree_map<script_id, parsed_event> wsas) override;
+
+    std::optional<iobuf> get_code(std::string_view name);
+
+private:
+    /// Map of known script ids to their code
+    ss::sharded<absl::btree_map<script_id, iobuf>> _scripts;
+};
+
+} // namespace coproc::wasm

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -28,6 +28,8 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sleep.hh>
 
+#include <absl/container/flat_hash_map.h>
+
 #include <exception>
 #include <system_error>
 
@@ -48,82 +50,26 @@ namespace coproc::wasm {
 ss::future<> event_listener::stop() {
     vlog(coproclog.info, "Stopping coproc::wasm::event_listener");
     _abort_source.request_abort();
-    return _gate.close().then([this] { return _client.stop(); });
+    co_await _gate.close().then([this] { return _client.stop(); });
+    co_await ss::parallel_for_each(
+      _handlers.begin(),
+      _handlers.end(),
+      [](std::pair<const event_type, wasm::event_handler*>& type_and_handler) {
+          return type_and_handler.second->stop();
+      });
 }
 
-ss::future<> event_listener::persist_actions(
-  absl::btree_map<script_id, parsed_event> wsas, model::offset last_offset) {
-    std::vector<enable_copros_request::data> enables;
-    std::vector<script_id> disables;
-    for (auto& [id, event] : wsas) {
-        /// Keeping the active_ids cache up to date solves the issue of issuing
-        /// a bunch of remove commands for scripts that aren't deployed (this
-        /// could occur during bootstrapping)
-        auto found = _active_ids.find(id);
-        if (event.header.action == event_action::remove) {
-            if (found != _active_ids.end()) {
-                disables.emplace_back(id);
-            }
-        } else {
-            /// ... or in the case if deploys are performed using the same key.
-            /// This would normally be resolved if the events came in the same
-            /// record batch by the reconcile events function, but not if they
-            /// arrived in separate batches.
-            if (found == _active_ids.end()) {
-                enables.emplace_back(enable_copros_request::data{
-                  .id = id, .source_code = std::move(event.data)});
-            }
-        }
-    }
-    /// TODO: In the future, maybe it would be cleaner to have a add/remove
-    /// endpoint, instead of two seperate RPC endpoints
-    if (!enables.empty()) {
-        enable_copros_request req{.inputs = std::move(enables)};
-        auto resp = co_await _dispatcher.enable_coprocessors(std::move(req));
-        if (resp.has_error()) {
-            vlog(
-              coproclog.error,
-              "Failed to register coprocessors with the wasm engine: {}",
-              resp.error());
-            _offset = last_offset;
-            co_return;
-        } else {
-            for (script_id id : resp.value()) {
-                vlog(
-                  coproclog.info,
-                  "Successfully registered script with id: {}",
-                  id);
-                _active_ids.insert(id);
-            }
-        }
-    }
-    if (!disables.empty()) {
-        disable_copros_request req{.ids = std::move(disables)};
-        auto resp = co_await _dispatcher.disable_coprocessors(std::move(req));
-        if (resp.has_error()) {
-            vlog(
-              coproclog.error,
-              "Failed to make disable request to the wasm engine: {}",
-              resp.error());
-            /// In this case the code will follow a path that re-enters this
-            /// method with the same inputs, and the call to enable_copros above
-            /// succeeded but the call to disable_coprocessors failed, double
-            /// registrations will be avoided because the ids have entered the
-            /// \ref active_ids cache and will not be queued for re-registration
-            _offset = last_offset;
-        } else {
-            for (script_id id : resp.value()) {
-                _active_ids.erase(id);
-            }
-        }
-    }
-}
-
-event_listener::event_listener(ss::sharded<pacemaker>& pacemaker)
-  : _client(make_client())
-  , _dispatcher(pacemaker, _abort_source) {}
+event_listener::event_listener()
+  : _client(make_client()) {}
 
 ss::future<> event_listener::start() {
+    co_await ss::parallel_for_each(
+      _handlers.begin(),
+      _handlers.end(),
+      [](std::pair<const event_type, event_handler*>& type_and_handler) {
+          return type_and_handler.second->start();
+      });
+
     (void)ss::with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _abort_source.abort_requested(); },
@@ -134,8 +80,18 @@ ss::future<> event_listener::start() {
               });
           });
     });
-    return ss::now();
+    co_return;
 }
+
+void event_listener::register_handler(event_type type, event_handler* handler) {
+    _handlers[type] = handler;
+    vlog(
+      coproclog.info,
+      "Register new handler for wasm_event_type: {}",
+      coproc_type_as_string_view(type));
+}
+
+ss::abort_source& event_listener::get_abort_source() { return _abort_source; }
 
 static ss::future<std::vector<model::record_batch>>
 decompress_wasm_events(model::record_batch_reader::data_t events) {
@@ -161,33 +117,22 @@ ss::future<> event_listener::do_start() {
             co_return;
         }
     }
-    auto heartbeat = co_await _dispatcher.heartbeat();
-    if (heartbeat.has_error()) {
-        std::error_code err = heartbeat.error();
-        if (
-          err == rpc::errc::client_request_timeout
-          || err == rpc::errc::disconnected_endpoint) {
-            vlog(
-              coproclog.error,
-              "Wasm engine failed to reply to heartbeat within the "
-              "expected "
-              "interval");
+
+    for (auto& [_, handler] : _handlers) {
+        auto cron_res = co_await handler->preparation_before_process();
+        switch (cron_res) {
+        case event_handler::cron_finish_status::skip_pull: {
             co_return;
         }
-    } else if (heartbeat.value().data != _active_ids.size()) {
-        /// There is a discrepency between the number of registered coprocs
-        /// according to redpanda and according to the wasm engine.
-        /// Reconcile all state from offset 0.
-        vlog(coproclog.info, "Replaying coprocessor state...");
-        if (co_await _dispatcher.disable_all_coprocessors()) {
-            vlog(
-              coproclog.error,
-              "Failed to reset wasm_engine state, will keep retrying...");
-        } else {
-            _active_ids.clear();
+        case event_handler::replay_topic: {
             _offset = model::offset(0);
+            break;
+        }
+        default:
+            break;
         }
     }
+
     co_await do_ingest();
 }
 
@@ -203,8 +148,8 @@ ss::future<> event_listener::do_ingest() {
         stop = co_await poll_topic(events);
     }
     auto decompressed = co_await decompress_wasm_events(std::move(events));
-    auto reconciled = wasm::reconcile_events(std::move(decompressed));
-    co_await persist_actions(std::move(reconciled), last_offset);
+    auto reconciled = wasm::reconcile_events_by_type(std::move(decompressed));
+    co_await process_events(std::move(reconciled), last_offset);
 }
 
 ss::future<ss::stop_iteration>
@@ -241,5 +186,26 @@ event_listener::poll_topic(model::record_batch_reader::data_t& events) {
     co_return initial == _offset ? ss::stop_iteration::yes
                                  : ss::stop_iteration::no;
 };
+
+ss::future<>
+event_listener::process_events(event_batch events, model::offset last_offset) {
+    for (auto& [type, prepared_events] : events) {
+        auto it = _handlers.find(type);
+        if (it == _handlers.end()) {
+            vlog(
+              coproclog.warn,
+              "Can not find handler for coproc_type: {}",
+              coproc_type_as_string_view(type));
+            continue;
+        }
+
+        try {
+            co_await it->second->process(std::move(prepared_events));
+        } catch (const async_event_handler_exception& ex) {
+            _offset = last_offset;
+            vlog(coproclog.error, "{}", ex.what());
+        }
+    }
+}
 
 } // namespace coproc::wasm

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "coproc/event_handler.h"
 #include "coproc/script_dispatcher.h"
 #include "coproc/types.h"
 #include "coproc/wasm_event.h"
@@ -20,6 +21,7 @@
 #include <seastar/core/sharded.hh>
 
 #include <absl/container/btree_set.h>
+#include <absl/container/flat_hash_map.h>
 
 #include <chrono>
 #include <filesystem>
@@ -28,24 +30,28 @@ namespace coproc::wasm {
 
 /// The wasm::event_listener listens on an internal topic called the
 /// "coprocessor_internal_topic" for events of type coproc::wasm::event.
-/// When new events arrive they are parsed, reconciled, then the appropriate RPC
-/// command is forwarded to the wasm engine
+/// When new events arrive they are parsed, reconciled, then it is forwarded to
+/// the handler for current corpoc_type
 class event_listener {
 public:
     /// class constructor
-    ///
-    /// \brief Takes the pacemaker as a reference, to call add / remove source()
-    explicit event_listener(ss::sharded<pacemaker>&);
+    event_listener();
 
     /// To be invoked once on redpanda::application startup
     ///
-    /// \brief Connects the kafka::client to this broker, and starts the loop
+    /// \brief Connects the kafka::client to this broker, starts all registred
+    /// handler and starts the loop
     ss::future<> start();
 
     /// To be invoked once on redpanda::applications call to svc->stop()
     ///
     /// \brief Shuts down the poll loop, initialized by the start() method
     ss::future<> stop();
+
+    /// Register event_handel for coproc type
+    void register_handler(event_type, event_handler*);
+
+    ss::abort_source& get_abort_source();
 
 private:
     ss::future<> do_start();
@@ -54,8 +60,7 @@ private:
     ss::future<ss::stop_iteration>
     poll_topic(model::record_batch_reader::data_t&);
 
-    ss::future<>
-      persist_actions(absl::btree_map<script_id, parsed_event>, model::offset);
+    ss::future<> process_events(event_batch events, model::offset last_offset);
 
 private:
     /// Kafka client used to poll the internal topic
@@ -68,11 +73,8 @@ private:
     /// Current offset into the 'coprocessor_internal_topic'
     model::offset _offset{0};
 
-    /// Set of known script ids to be active
-    absl::btree_set<script_id> _active_ids;
-
-    /// Used to make requests to the wasm engine
-    script_dispatcher _dispatcher;
+    absl::flat_hash_map<event_type, event_handler*>
+      _handlers; // size of this map will be 3
 };
 
 } // namespace coproc::wasm

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -12,6 +12,7 @@
 
 #include "coproc/script_dispatcher.h"
 #include "coproc/types.h"
+#include "coproc/wasm_event.h"
 #include "kafka/client/client.h"
 
 #include <seastar/core/abort_source.hh>
@@ -54,7 +55,7 @@ private:
     poll_topic(model::record_batch_reader::data_t&);
 
     ss::future<>
-      persist_actions(absl::btree_map<script_id, iobuf>, model::offset);
+      persist_actions(absl::btree_map<script_id, parsed_event>, model::offset);
 
 private:
     /// Kafka client used to poll the internal topic

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ rp_test(
     coproc_bench_tests.cc
     offset_storage_utils_tests.cc
     wasm_event_tests.cc
+    event_handler_tests.cc
     event_listener_tests.cc
     read_materialized_topic_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK

--- a/src/v/coproc/tests/event_handler_tests.cc
+++ b/src/v/coproc/tests/event_handler_tests.cc
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/event_handler.h"
+#include "coproc/wasm_event.h"
+#include "hashing/xx.h"
+#include "seastarx.h"
+
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <absl/container/btree_map.h>
+
+#include <optional>
+
+SEASTAR_THREAD_TEST_CASE(data_policy_handler_test) {
+    coproc::wasm::data_policy_event_handler handler;
+    handler.start().get();
+
+    ss::sstring name1 = "foo";
+    coproc::wasm::parsed_event event1;
+    event1.header.action = coproc::wasm::event_action::deploy;
+    event1.header.type = coproc::wasm::event_type::data_policy;
+    ss::temporary_buffer<char> data(name1.c_str(), name1.size());
+    event1.data.append(std::move(data));
+    auto script_id1 = xxhash_64(name1.c_str(), name1.size());
+
+    absl::btree_map<coproc::script_id, coproc::wasm::parsed_event> events1;
+    events1.emplace(script_id1, std::move(event1));
+
+    handler.process(std::move(events1)).get();
+
+    auto code = handler.get_code(name1);
+    auto raw_value
+      = iobuf_const_parser(code.value()).read_string(code->size_bytes());
+    BOOST_CHECK_EQUAL(raw_value, name1);
+
+    coproc::wasm::parsed_event event2;
+    event2.header.action = coproc::wasm::event_action::remove;
+    event2.header.type = coproc::wasm::event_type::data_policy;
+
+    absl::btree_map<coproc::script_id, coproc::wasm::parsed_event> events2;
+    events2.emplace(script_id1, std::move(event2));
+
+    handler.process(std::move(events2)).get();
+
+    code = handler.get_code(name1);
+
+    BOOST_CHECK(code == std::nullopt);
+
+    handler.stop().get();
+}

--- a/src/v/coproc/tests/utils/event_publisher.cc
+++ b/src/v/coproc/tests/utils/event_publisher.cc
@@ -45,7 +45,8 @@ public:
     ss::future<ss::stop_iteration> operator()(const model::record_batch& rb) {
         vassert(!rb.compressed(), "Records should not have been compressed");
         co_await model::for_each_record(rb, [this](const model::record& r) {
-            _all_valid &= (validate_event(r) == errc::none);
+            auto validate_res = coproc::wasm::validate_event(r);
+            _all_valid &= validate_res.has_value();
         });
         co_return _all_valid ? ss::stop_iteration::no : ss::stop_iteration::yes;
     }

--- a/src/v/coproc/tests/utils/wasm_event_generator.h
+++ b/src/v/coproc/tests/utils/wasm_event_generator.h
@@ -39,15 +39,17 @@ struct event {
     std::optional<bytes> script;
     std::optional<bytes> checksum;
     std::optional<event_action> action;
+    std::optional<event_type> type;
 
     /// Default constructor creates an invalid event
     event() = default;
 
     /// Use the single arg constructor to create remove events
-    event(uint64_t);
+    event(uint64_t, std::optional<event_type> = std::nullopt);
 
     // And the two arg consutrctor to create deploy events
-    event(uint64_t, cpp_enable_payload);
+    event(
+      uint64_t, cpp_enable_payload, std::optional<event_type> = std::nullopt);
 };
 
 /// \brief Generates an event that models the 'wasm_event' struct passed in. Any

--- a/src/v/coproc/wasm_event.h
+++ b/src/v/coproc/wasm_event.h
@@ -13,6 +13,7 @@
 #include "coproc/errc.h"
 #include "coproc/types.h"
 #include "model/record.h"
+#include "outcome.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/optimized_optional.hh>
@@ -25,7 +26,13 @@
 namespace coproc::wasm {
 
 /// Enumerations for all possible values for keys within the record headers
-enum class event_header { action, description, checksum };
+enum class event_header { action, description, checksum, type };
+
+/// Enumerations for all possible coproc_type
+/// TODO: think about naming!!!
+enum class event_type { async, data_policy };
+
+std::string_view coproc_type_as_string_view(event_type header);
 
 /// Enumerations for all possible values for the 'action' key within the headers
 enum class event_action { deploy, remove };
@@ -39,19 +46,42 @@ std::vector<model::record_header>::const_iterator
 get_value_for_event_header(const model::record&, event_header);
 
 /// \brief wasm::errc if record is malformed, otherwise returns
+/// wasm_event_type
+result<event_type, wasm::errc> get_coproc_type(const model::record& r);
+
+/// \brief wasm::errc if record is malformed, otherwise returns
 /// wasm_event_action::deploy or wasm_event_action::remove, representing a
 /// command to change state within the wasm engine
-std::variant<wasm::errc, event_action> get_event_action(const model::record&);
+result<event_action, wasm::errc> get_event_action(const model::record&);
 
 /// \brief errc::none if the record is valid AND the checksum passes validation
 wasm::errc verify_event_checksum(const model::record&);
 
-/// \brief performs the strictest form of validation, 'none' if all checks pass
-wasm::errc validate_event(const model::record&);
+/// \brief Structure for parsed event from model::record. It contains raw data
+/// of the event and header with action and coproc_type
+struct parsed_event {
+    struct event_header {
+        event_action action;
+        event_type type;
+    };
 
-/// \brief Returns the newest events and their data blobs if the event has
-/// passed all validators
-absl::btree_map<script_id, iobuf>
+    event_header header;
+    iobuf data;
+};
+
+/// \brief performs the strictest form of validation and fill header for event,
+/// 'none' if all checks pass
+result<parsed_event::event_header, wasm::errc>
+validate_event(const model::record&);
+
+/// \brief Returns the newest parsed events with their data blobs and headers if
+/// the event has passed all validators
+absl::btree_map<script_id, parsed_event>
   reconcile_events(std::vector<model::record_batch>);
+
+/// \brief Returns the newest parsed events grouped by type
+using event_batch
+  = absl::btree_map<event_type, absl::btree_map<script_id, parsed_event>>;
+event_batch reconcile_events_by_type(std::vector<model::record_batch>);
 
 } // namespace coproc::wasm


### PR DESCRIPTION
## Cover letter

This pr contains new logic around rpk and coproc;

New entity for coproc type.
It can be async - nodejs engine
data-policy - v8 engine

`rpk wasm deploy  <name> --type data-policy  "path"` - Data-policy type is used for notify coproc that it only stores this scripts and does not deploy it to nodejs.

`rpk wasm remove  <name> --type data-policy`

Some logic from `event_listener`  is moved to `register-service`

`nodejs_handler` contains old logic `event_listener` for nodejs service
`data_policy_handler` contains logic for storing js code for compile v8

---
### from d6ce9e0 to 8df4c12 
Fix `start` in listener. Start event_handlers before background work.
Added exception for `async_event_handler`. Added `final` for handlers classes

### from 8df4c12 to 31ed143
Use `result` for `get_event_action`, `get_coproc_type`, `validate_event`

### from 31ed143 to 937860d
Use abort_source& in async_handler from event_listener

###  from 937860d to c30f980 
- Rename cron to preparation_before_process
- Use fmt_with_ctx in handler exception

###  from 6261bac to 511507e 
- Added sharded service for scripts database

### from 511507e to 928d5e1
- test for data_policy_event_handler