### PR TITLE
Fixed handling of backpressure semaphore in RPC simple protocol

### DIFF
--- a/src/v/rpc/simple_protocol.h
+++ b/src/v/rpc/simple_protocol.h
@@ -14,6 +14,7 @@
 #include "rpc/server.h"
 #include "rpc/service.h"
 namespace rpc {
+struct server_context_impl;
 class simple_protocol final : public server::protocol {
 public:
     template<typename T, typename... Args>
@@ -29,6 +30,8 @@ public:
 
 private:
     ss::future<> dispatch_method_once(header, server::resources);
+    void dispatch_in_background(
+      uint32_t, server::resources, ss::lw_shared_ptr<server_context_impl>);
 
     std::vector<std::unique_ptr<service>> _services;
 };


### PR DESCRIPTION
## Cover letter

Previously we were waiting for memory usage limiting semaphore in background. This may lead to the situation in which we end up with unbounded number of requests pending to be processed. Change implementation to wait for the memory semaphore in foreground this way we prevent server instance from consuming next requests before processing the previous one when memory semaphore is empty.

