### PR TITLE
Backport: raft: Force TCP connections to disconnect if heartbeats aren't getting responses

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -122,6 +122,13 @@ configuration::configuration()
       "raft heartbeat RPC timeout",
       required::no,
       3s)
+  , raft_heartbeat_disconnect_failures(
+      *this,
+      "raft_heartbeat_disconnect_failures",
+      "After how many failed heartbeats to forcibly close an unresponsive TCP "
+      "connection.  Set to 0 to disable force disconnection.",
+      required::no,
+      3)
   , seed_servers(
       *this,
       "seed_servers",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -62,6 +62,7 @@ struct configuration final : public config_store {
     property<int32_t> seed_server_meta_topic_partitions;
     property<std::chrono::milliseconds> raft_heartbeat_interval_ms;
     property<std::chrono::milliseconds> raft_heartbeat_timeout_ms;
+    property<size_t> raft_heartbeat_disconnect_failures;
     property<std::vector<seed_server>> seed_servers;
     property<int16_t> min_version;
     property<int16_t> max_version;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -302,6 +302,10 @@ public:
     void update_suppress_heartbeats(
       vnode, follower_req_seq, heartbeats_suppressed);
 
+    void update_heartbeat_status(vnode, bool);
+
+    bool should_reconnect_follower(vnode);
+
     std::vector<follower_metrics> get_follower_metrics() const;
 
     const configuration_manager& get_configuration_manager() const {
@@ -549,6 +553,7 @@ private:
 
     std::chrono::milliseconds _replicate_append_timeout;
     std::chrono::milliseconds _recovery_append_timeout;
+    size_t _heartbeat_disconnect_failures;
     ss::metrics::metric_groups _metrics;
     ss::abort_source _as;
     storage::api& _storage;

--- a/src/v/raft/consensus_client_protocol.h
+++ b/src/v/raft/consensus_client_protocol.h
@@ -45,6 +45,8 @@ public:
         timeout_now(model::node_id, timeout_now_request&&, rpc::client_opts)
           = 0;
 
+        virtual ss::future<bool> ensure_disconnect(model::node_id) = 0;
+
         virtual ~impl() noexcept = default;
     };
 
@@ -84,6 +86,10 @@ public:
       timeout_now_request&& r,
       rpc::client_opts opts) {
         return _impl->timeout_now(target_node, std::move(r), std::move(opts));
+    }
+
+    ss::future<bool> ensure_disconnect(model::node_id target_node) {
+        return _impl->ensure_disconnect(target_node);
     }
 
 private:

--- a/src/v/raft/rpc_client_protocol.cc
+++ b/src/v/raft/rpc_client_protocol.cc
@@ -112,7 +112,11 @@ ss::future<bool> rpc_client_protocol::ensure_disconnect(model::node_id n) {
             r.transport.shutdown();
             return was_valid;
         })
-      .then([]([[maybe_unused]] result<bool> r) { return r.value(); });
+      .then([]([[maybe_unused]] result<bool> r) {
+          // if result contains an error no connection was shut down, return
+          // false
+          return r.has_value() ? r.value() : false;
+      });
 }
 
 } // namespace raft

--- a/src/v/raft/rpc_client_protocol.h
+++ b/src/v/raft/rpc_client_protocol.h
@@ -46,6 +46,8 @@ public:
     ss::future<result<timeout_now_reply>>
     timeout_now(model::node_id, timeout_now_request&&, rpc::client_opts) final;
 
+    ss::future<bool> ensure_disconnect(model::node_id) final;
+
 private:
     model::node_id _self;
     ss::sharded<rpc::connection_cache>& _connection_cache;

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -800,6 +800,9 @@ struct raft_test_fixture {
     raft_test_fixture() {
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg().get("disable_metrics").set_value(true);
+            config::shard_local_cfg()
+              .get("raft_heartbeat_disconnect_failures")
+              .set_value((size_t)0);
         }).get();
     }
 

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -81,6 +81,7 @@ struct follower_index_metadata {
     // timestamp of last append_entries_rpc call
     clock_type::time_point last_append_timestamp;
     clock_type::time_point last_hbeat_timestamp;
+    uint32_t heartbeats_failed{0};
     // The pair of sequences used to track append entries requests sent and
     // received by the follower. Every time append entries request is created
     // the `last_sent_seq` is incremented before accessing raft protocol state


### PR DESCRIPTION
## Cover letter

This was apparently a reproducible hang on node restarts in customer environment, so seems like a good candidate for backport.

Original PRs: https://github.com/vectorizedio/redpanda/pull/1937 , https://github.com/vectorizedio/redpanda/pull/2016
Original issue: https://github.com/vectorizedio/support/issues/79

## Release notes

A new configuration option `raft_heartbeat_disconnect_failures` is added, defaulting to three missed heartbeats before connections are closed (i.e. reconnected).  This should not need manual adjustment unless running on extremely overloaded systems which are emitting many `Closed unresponsive connection` log messages.
