### PR TITLE
task/rpk: add `-modcacherw` flag to `go test`

### DIFF
--- a/taskfiles/rpk.yml
+++ b/taskfiles/rpk.yml
@@ -50,7 +50,7 @@ tasks:
     dir: "{{.SRC_DIR}}/src/go/rpk"
     cmds:
     - |
-      cmd="{{.GO_BUILD_ROOT}}/bin/go test ./..."
+      cmd="{{.GO_BUILD_ROOT}}/bin/go test -modcacherw ./..."
       if [ '{{.CACHE_TESTS}}' != 'true' ]; then
         cmd="$cmd -count=1"
       fi


### PR DESCRIPTION
Fix for cleanup failures on containerized environments.