### PR TITLE
r/rpc_client_protocol: checking result in ensure_disconnect

### DIFF
--- a/src/v/raft/rpc_client_protocol.cc
+++ b/src/v/raft/rpc_client_protocol.cc
@@ -112,7 +112,11 @@ ss::future<bool> rpc_client_protocol::ensure_disconnect(model::node_id n) {
             r.transport.shutdown();
             return was_valid;
         })
-      .then([]([[maybe_unused]] result<bool> r) { return r.value(); });
+      .then([]([[maybe_unused]] result<bool> r) {
+          // if result contains an error no connection was shut down, return
+          // false
+          return r.has_value() ? r.value() : false;
+      });
 }
 
 } // namespace raft


### PR DESCRIPTION
`with_node_client` may return `result` containing an error. When
disconnecting the client we have to check the result since when
accessing result value containing an error it throws an exception.

Signed-off-by: Michal Maslanka <michal@vectorized.io>