### PR TITLE
admin brokers command: remove describe, remove stray fmt.Println

### DIFF
--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -95,7 +95,6 @@ var rng = func() func(int) int {
 // the body into into, which is expected to be a pointer to a struct.
 func (a *AdminAPI) sendAny(method, path string, body, into interface{}) error {
 	pick := rng(len(a.urls))
-	fmt.Println(pick)
 	url := a.urls[pick] + path
 	res, err := a.sendAndReceive(context.Background(), method, url, body)
 	if err != nil {

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -30,15 +30,7 @@ func (a *AdminAPI) Brokers() ([]Broker, error) {
 	defer func() {
 		sort.Slice(bs, func(i, j int) bool { return bs[i].NodeID < bs[j].NodeID })
 	}()
-	a.Broker(0)
 	return bs, a.sendAny(http.MethodGet, brokersEndpoint, nil, &bs)
-}
-
-// Broker returns the status of a single broker, which includes membership
-// status.
-func (a *AdminAPI) Broker(node int) (Broker, error) {
-	var b Broker
-	return b, a.sendAny(http.MethodGet, fmt.Sprintf("%s/%d", brokersEndpoint, node), nil, &b)
 }
 
 // DecommissionBroker issues a decommission request for the given broker.

--- a/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/admin/brokers/brokers.go
@@ -33,7 +33,6 @@ func NewCommand(
 	closures := closures{hostsClosure, tlsClosure}
 	cmd.AddCommand(
 		newListCommand(closures),
-		newDescribeCommand(closures),
 		newDecommissionBroker(closures),
 		newRecommissionBroker(closures),
 	)
@@ -67,44 +66,11 @@ func newListCommand(closures closures) *cobra.Command {
 			bs, err := cl.Brokers()
 			out.MaybeDie(err, "unable to request brokers: %v", err)
 
-			tw := out.NewTable("Node ID", "Num Cores")
-			defer tw.Flush()
-			for _, b := range bs {
-				tw.Print(b.NodeID, b.NumCores)
-			}
-		},
-	}
-}
-
-func newDescribeCommand(closures closures) *cobra.Command {
-	return &cobra.Command{
-		Use:   "describe [BROKER ID]",
-		Short: "Describe a single broker in your cluster.",
-		Long: `Describe a single broker in your cluster.
-
-Descrbing a single broker prints a little bit more information than listing all
-brokers.
-`,
-		Args: cobra.ExactArgs(1),
-		Run: func(_ *cobra.Command, args []string) {
-			broker, err := strconv.Atoi(args[0])
-			out.MaybeDie(err, "invalid broker %s: %v", args[0], err)
-			if broker < 0 {
-				out.Die("invalid negative broker id %v", broker)
-			}
-
-			hosts, tls, err := closures.eval()
-			out.MaybeDie(err, "unable to load configuration: %v", err)
-
-			cl, err := admin.NewAdminAPI(hosts, tls)
-			out.MaybeDie(err, "unable to initialize admin client: %v", err)
-
-			b, err := cl.Broker(broker)
-			out.MaybeDie(err, "unable to request broker: %v", err)
-
 			tw := out.NewTable("Node ID", "Num Cores", "Membership Status")
 			defer tw.Flush()
-			tw.Print(b.NodeID, b.NumCores, b.MembershipStatus)
+			for _, b := range bs {
+				tw.Print(b.NodeID, b.NumCores, b.MembershipStatus)
+			}
 		},
 	}
 }


### PR DESCRIPTION
The "describe" command for brokers only existed because at the time the
list API did not return the membership status.

Now that list returns membership status (#1933), describe is useless: it
returns the same information as list, but only for one broker.

This also removes a stray println that accidentally made it into tip.
