### PR TITLE
Implemented `CreatePartitionsAPI`

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -59,6 +59,8 @@ static constexpr int8_t delete_topic_cmd_type = 1;
 static constexpr int8_t move_partition_replicas_cmd_type = 2;
 static constexpr int8_t finish_moving_partition_replicas_cmd_type = 3;
 static constexpr int8_t update_topic_properties_cmd_type = 4;
+static constexpr int8_t create_partition_cmd_type = 5;
+
 static constexpr int8_t create_user_cmd_type = 5;
 static constexpr int8_t delete_user_cmd_type = 6;
 static constexpr int8_t update_user_cmd_type = 7;
@@ -97,6 +99,12 @@ using update_topic_properties_cmd = controller_command<
   model::topic_namespace,
   incremental_topic_updates,
   update_topic_properties_cmd_type,
+  model::record_batch_type::topic_management_cmd>;
+
+using create_partition_cmd = controller_command<
+  model::topic_namespace,
+  create_partititions_configuration_assignment,
+  create_partition_cmd_type,
   model::record_batch_type::topic_management_cmd>;
 
 using create_user_cmd = controller_command<

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -119,6 +119,7 @@ ss::future<> controller::start() {
             std::ref(_connections),
             std::ref(_partition_allocator),
             std::ref(_partition_leaders),
+            std::ref(_tp_state),
             std::ref(_as));
       })
       .then([this] {

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(srcs
     controller_api_tests.cc
     decommissioning_tests.cc
     replicas_rebalancing_tests.cc
+    create_partitions_test.cc
     id_allocator_stm_test.cc)
 
 rp_test(

--- a/src/v/cluster/tests/create_partitions_test.cc
+++ b/src/v/cluster/tests/create_partitions_test.cc
@@ -1,0 +1,51 @@
+#include "cluster/tests/rebalancing_tests_fixture.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "model/timeout_clock.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+#include <system_error>
+
+model::topic_namespace make_tp_ns(const ss::sstring& tp) {
+    return model::topic_namespace(model::kafka_namespace, model::topic(tp));
+}
+
+FIXTURE_TEST(test_creating_partitions, rebalancing_tests_fixture) {
+    start_cluster(3);
+    create_topic(create_topic_cfg("test-1", 3, 1));
+    create_topic(create_topic_cfg("test-2", 4, 3));
+
+    cluster::create_partititions_configuration cfg_test_1(
+      make_tp_ns("test-1"), 3);
+    cluster::create_partititions_configuration cfg_test_2(
+      make_tp_ns("test-2"), 5);
+
+    auto res = (*get_leader_node_application())
+                 ->controller->get_topics_frontend()
+                 .local()
+                 .create_partitions({cfg_test_1, cfg_test_2}, model::no_timeout)
+                 .get();
+
+    BOOST_REQUIRE_EQUAL(res.size(), 2);
+    BOOST_REQUIRE_EQUAL(
+      res[0].ec, cluster::make_error_code(cluster::errc::success));
+    auto& topics
+      = (*get_leader_node_application())->controller->get_topics_state();
+    auto tp_1_md = topics.local().get_topic_metadata(make_tp_ns("test-1"));
+    auto tp_2_md = topics.local().get_topic_metadata(make_tp_ns("test-2"));
+
+    // total 6 partitions
+    BOOST_REQUIRE_EQUAL(tp_1_md->partitions.size(), 3 + 3);
+    for (auto i = 0; i < 6; ++i) {
+        BOOST_REQUIRE_EQUAL(tp_1_md->partitions[i].id, model::partition_id(i));
+    }
+
+    // total 9 partitions
+    BOOST_REQUIRE_EQUAL(tp_2_md->partitions.size(), 4 + 5);
+    for (auto i = 0; i < 9; ++i) {
+        BOOST_REQUIRE_EQUAL(tp_2_md->partitions[i].id, model::partition_id(i));
+    }
+}

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -64,7 +64,7 @@ public:
     cluster::topic_configuration create_topic_cfg(
       ss::sstring topic, int partitions, int replication_factor) {
         model::topic_namespace tp_ns(
-          model::ns("test"), model::topic(std::move(topic)));
+          model::kafka_namespace, model::topic(std::move(topic)));
 
         return cluster::topic_configuration(
           tp_ns.ns, tp_ns.tp, partitions, replication_factor);

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -80,6 +80,30 @@ topic_table::apply(delete_topic_cmd cmd, model::offset offset) {
     }
     return ss::make_ready_future<std::error_code>(errc::topic_not_exists);
 }
+ss::future<std::error_code>
+topic_table::apply(create_partition_cmd cmd, model::offset offset) {
+    auto tp = _topics.find(cmd.key);
+    if (tp == _topics.end()) {
+        co_return errc::topic_not_exists;
+    }
+
+    // add partitions
+    auto prev_partition_count = tp->second.configuration.cfg.partition_count;
+    tp->second.configuration.cfg.partition_count
+      += cmd.value.cfg.partition_count;
+    // add assignments
+    for (auto& p_as : cmd.value.assignments) {
+        p_as.id += model::partition_id(prev_partition_count);
+        tp->second.configuration.assignments.push_back(p_as);
+        // propagate deltas
+        auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, p_as.id);
+        _pending_deltas.emplace_back(
+          std::move(ntp), std::move(p_as), offset, delta::op_type::add);
+    }
+
+    notify_waiters();
+    co_return errc::success;
+}
 
 ss::future<std::error_code>
 topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -73,7 +73,8 @@ public:
       delete_topic_cmd,
       move_partition_replicas_cmd,
       finish_moving_partition_replicas_cmd,
-      update_topic_properties_cmd>{};
+      update_topic_properties_cmd,
+      create_partition_cmd>{};
 
     /// State machine applies
     ss::future<std::error_code> apply(create_topic_cmd, model::offset);
@@ -84,6 +85,7 @@ public:
       apply(finish_moving_partition_replicas_cmd, model::offset);
     ss::future<std::error_code>
       apply(update_topic_properties_cmd, model::offset);
+    ss::future<std::error_code> apply(create_partition_cmd, model::offset);
     ss::future<> stop();
 
     /// Delta API

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -86,6 +86,15 @@ topic_updates_dispatcher::apply_update(model::record_batch b) {
             },
             [this, base_offset](update_topic_properties_cmd cmd) {
                 return dispatch_updates_to_cores(std::move(cmd), base_offset);
+            },
+            [this, base_offset](create_partition_cmd cmd) {
+                return dispatch_updates_to_cores(cmd, base_offset)
+                  .then([this, cmd](std::error_code ec) {
+                      if (ec == errc::success) {
+                          update_allocations(cmd);
+                      }
+                      return ec;
+                  });
             });
       });
 }
@@ -159,6 +168,20 @@ void topic_updates_dispatcher::update_allocations(const create_topic_cmd& cmd) {
 
     _partition_allocator.local().update_allocation_state(
       std::move(shards), max_group_id);
+}
+
+void topic_updates_dispatcher::update_allocations(
+  const create_partition_cmd& cmd) {
+    // for create topics we update allocation state
+    std::vector<model::broker_shard> shards;
+    raft::group_id max_group_id = raft::group_id(0);
+    for (auto& pas : cmd.value.assignments) {
+        max_group_id = std::max(max_group_id, pas.group);
+        std::move(
+          pas.replicas.begin(), pas.replicas.end(), std::back_inserter(shards));
+    }
+
+    _partition_allocator.local().update_allocation_state(shards, max_group_id);
 }
 
 } // namespace cluster

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -58,7 +58,8 @@ public:
       delete_topic_cmd,
       move_partition_replicas_cmd,
       finish_moving_partition_replicas_cmd,
-      update_topic_properties_cmd>();
+      update_topic_properties_cmd,
+      create_partition_cmd>();
 
     bool is_batch_applicable(const model::record_batch& batch) const {
         return batch.header().type
@@ -70,6 +71,7 @@ private:
     ss::future<std::error_code> dispatch_updates_to_cores(Cmd, model::offset);
 
     void update_allocations(const create_topic_cmd&);
+    void update_allocations(const create_partition_cmd&);
     void deallocate_topic(const model::topic_metadata&);
     void reallocate_partition(
       const std::vector<model::broker_shard>&,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -384,7 +384,23 @@ struct topic_configuration {
     friend std::ostream& operator<<(std::ostream&, const topic_configuration&);
 };
 
+struct create_partititions_configuration {
+    using custom_assignment = std::vector<model::node_id>;
+    create_partititions_configuration(model::topic_namespace, int32_t);
+
+    model::topic_namespace tp_ns;
+    int32_t partition_count;
+
+    // TODO: use when we will start supporting custom partitions assignment
+    std::vector<custom_assignment> custom_assignments;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const create_partititions_configuration&);
+};
+
 struct topic_configuration_assignment {
+    topic_configuration_assignment() = delete;
+
     topic_configuration_assignment(
       topic_configuration cfg, std::vector<partition_assignment> pas)
       : cfg(std::move(cfg))
@@ -394,6 +410,20 @@ struct topic_configuration_assignment {
     std::vector<partition_assignment> assignments;
 
     model::topic_metadata get_metadata() const;
+};
+
+struct create_partititions_configuration_assignment {
+    create_partititions_configuration_assignment(
+      create_partititions_configuration cfg,
+      std::vector<partition_assignment> pas)
+      : cfg(std::move(cfg))
+      , assignments(std::move(pas)) {}
+
+    create_partititions_configuration cfg;
+    std::vector<partition_assignment> assignments;
+
+    friend std::ostream& operator<<(
+      std::ostream&, const create_partititions_configuration_assignment&);
 };
 
 struct topic_result {
@@ -710,6 +740,18 @@ template<>
 struct adl<cluster::delete_acls_result> {
     void to(iobuf&, cluster::delete_acls_result&&);
     cluster::delete_acls_result from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::create_partititions_configuration> {
+    void to(iobuf&, cluster::create_partititions_configuration&&);
+    cluster::create_partititions_configuration from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::create_partititions_configuration_assignment> {
+    void to(iobuf&, cluster::create_partititions_configuration_assignment&&);
+    cluster::create_partititions_configuration_assignment from(iobuf_parser&);
 };
 
 } // namespace reflection

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -32,6 +32,7 @@ set(handlers_srcs
   server/handlers/describe_log_dirs.cc
   server/handlers/create_acls.cc
   server/handlers/delete_acls.cc
+  server/handlers/create_partitions.cc
   server/handlers/topics/types.cc
   server/handlers/topics/topic_utils.cc
 )

--- a/src/v/kafka/protocol/create_partitions.h
+++ b/src/v/kafka/protocol/create_partitions.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/protocol/schemata/create_partitions_request.h"
+#include "kafka/protocol/schemata/create_partitions_response.h"
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+namespace kafka {
+
+struct create_partitions_response;
+
+class create_partitions_api final {
+public:
+    using response_type = create_partitions_response;
+
+    static constexpr const char* name = "create partitions";
+    static constexpr api_key key = api_key(37);
+};
+
+struct create_partitions_request final {
+    using api_type = create_partitions_api;
+
+    create_partitions_request_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(request_reader& reader, api_version version) {
+        data.decode(reader, version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const create_partitions_request& r) {
+    return os << r.data;
+}
+
+struct create_partitions_response final {
+    using api_type = create_partitions_api;
+
+    create_partitions_response_data data;
+
+    void encode(response_writer& writer, api_version version) {
+        data.encode(writer, version);
+    }
+
+    void decode(iobuf buf, api_version version) {
+        data.decode(std::move(buf), version);
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& os, const create_partitions_response& r) {
+    return os << r.data;
+}
+
+} // namespace kafka

--- a/src/v/kafka/protocol/schemata/CMakeLists.txt
+++ b/src/v/kafka/protocol/schemata/CMakeLists.txt
@@ -60,7 +60,9 @@ set(schemata
   fetch_request.json
   fetch_response.json
   end_txn_request.json
-  end_txn_response.json
+  end_txn_response.json  
+  create_partitions_request.json
+  create_partitions_response.json
   add_offsets_to_txn_request.json
   add_offsets_to_txn_response.json)
 

--- a/src/v/kafka/protocol/schemata/create_partitions_request.json
+++ b/src/v/kafka/protocol/schemata/create_partitions_request.json
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+    "apiKey": 37,
+    "type": "request",
+    "name": "CreatePartitionsRequest",
+    // Version 1 is the same as version 0.
+    //
+    // Version 2 adds flexible version support
+    //
+    // Version 3 is identical to version 2 but may return a THROTTLING_QUOTA_EXCEEDED error
+    // in the response if the partitions creation is throttled (KIP-599).
+    "validVersions": "0-3",
+    "flexibleVersions": "2+",
+    "fields": [
+      { "name": "Topics", "type": "[]CreatePartitionsTopic", "versions": "0+",
+        "about": "Each topic that we want to create new partitions inside.",  "fields": [
+        { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
+          "about": "The topic name." },
+        { "name": "Count", "type": "int32", "versions": "0+",
+          "about": "The new partition count." },
+        { "name": "Assignments", "type": "[]CreatePartitionsAssignment", "versions": "0+", "nullableVersions": "0+", 
+          "about": "The new partition assignments.", "fields": [
+          { "name": "BrokerIds", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
+            "about": "The assigned broker IDs." }
+        ]}
+      ]},
+      { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+        "about": "The time in ms to wait for the partitions to be created." },
+      { "name": "ValidateOnly", "type": "bool", "versions": "0+",
+        "about": "If true, then validate the request, but don't actually increase the number of partitions." }
+    ]
+  }

--- a/src/v/kafka/protocol/schemata/create_partitions_response.json
+++ b/src/v/kafka/protocol/schemata/create_partitions_response.json
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+    "apiKey": 37,
+    "type": "response",
+    "name": "CreatePartitionsResponse",
+    // Starting in version 1, on quota violation, brokers send out responses before throttling.
+    //
+    // Version 2 adds flexible version support
+    //
+    // Version 3 is identical to version 2 but may return a THROTTLING_QUOTA_EXCEEDED error
+    // in the response if the partitions creation is throttled (KIP-599).
+    "validVersions": "0-3",
+    "flexibleVersions": "2+",
+    "fields": [
+      { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+        "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+      { "name": "Results", "type": "[]CreatePartitionsTopicResult", "versions": "0+",
+        "about": "The partition creation results for each topic.", "fields": [
+        { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+          "about": "The topic name." },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The result error, or zero if there was no error."},
+        { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
+          "default": "null", "about": "The result message, or null if there was no error."}
+      ]}
+    ]
+  }

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -248,6 +248,9 @@ path_type_map = {
     "InitProducerIdRequestData": {
         "TransactionTimeoutMs": ("std::chrono::milliseconds", "int32")
     },
+    "CreatePartitionsRequestData": {
+        "TimeoutMs": ("std::chrono::milliseconds", "int32")
+    },
 }
 
 # a few kafka field types specify an entity type
@@ -380,6 +383,9 @@ STRUCT_TYPES = [
     "FetchableTopicResponse",
     "FetchablePartitionResponse",
     "AbortedTransaction",
+    "CreatePartitionsTopic",
+    "CreatePartitionsTopicResult",
+    "CreatePartitionsAssignment",
 ]
 
 SCALAR_TYPES = list(basic_type_map.keys())

--- a/src/v/kafka/server/handlers/api_versions.cc
+++ b/src/v/kafka/server/handlers/api_versions.cc
@@ -53,7 +53,8 @@ using request_types = make_request_types<
   add_partitions_to_txn_handler,
   txn_offset_commit_handler,
   add_offsets_to_txn_handler,
-  end_txn_handler>;
+  end_txn_handler,
+  create_partitions_handler>;
 
 template<typename RequestType>
 static auto make_api() {

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -1,0 +1,219 @@
+
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/handlers/create_partitions.h"
+
+#include "cluster/metadata_cache.h"
+#include "cluster/topics_frontend.h"
+#include "cluster/types.h"
+#include "kafka/protocol/errors.h"
+#include "kafka/protocol/schemata/create_partitions_request.h"
+#include "kafka/protocol/schemata/create_partitions_response.h"
+#include "kafka/server/errors.h"
+#include "kafka/server/fwd.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/timeout_clock.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sstring.hh>
+
+#include <absl/container/node_hash_map.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iterator>
+#include <vector>
+
+namespace kafka {
+
+create_partitions_topic_result
+make_result(const create_partitions_topic& tp, error_code ec) {
+    return {
+      .name = tp.name,
+      .error_code = ec,
+    };
+}
+
+using request_iterator = std::vector<create_partitions_topic>::iterator;
+
+template<typename ResultIter>
+request_iterator validate_range_duplicates(
+  request_iterator begin, request_iterator end, ResultIter out_it) {
+    using type = create_partitions_topic;
+    absl::node_hash_map<model::topic_view, uint32_t> freq;
+
+    freq.reserve(std::distance(begin, end));
+    for (auto const& r : boost::make_iterator_range(begin, end)) {
+        freq[r.name]++;
+    }
+    auto valid_range_end = std::partition(
+      begin, end, [&freq](const type& item) { return freq[item.name] == 1; });
+
+    std::transform(valid_range_end, end, out_it, [](const type& req) {
+        return create_partitions_topic_result{
+          .name = req.name,
+          .error_code = error_code::invalid_request,
+          .error_message = "request contains duplicated topics",
+        };
+    });
+    return valid_range_end;
+}
+template<typename ResultIter, typename Predicate>
+request_iterator validate_range(
+  request_iterator begin,
+  request_iterator end,
+  ResultIter out_it,
+  error_code ec,
+  const ss::sstring& error_message,
+  Predicate&& p) {
+    auto valid_range_end = std::partition(
+      begin, end, std::forward<Predicate>(p));
+
+    std::transform(
+      valid_range_end,
+      end,
+      out_it,
+      [ec, &error_message](const create_partitions_topic& req) {
+          return create_partitions_topic_result{
+            .name = req.name,
+            .error_code = ec,
+            .error_message = error_message,
+          };
+      });
+    return valid_range_end;
+}
+
+ss::future<std::vector<cluster::topic_result>> do_create_partitions(
+  request_context& ctx,
+  request_iterator begin,
+  request_iterator end,
+  model::timeout_clock::time_point timeout) {
+    const auto sz = std::distance(begin, end);
+    if (sz == 0) {
+        co_return std::vector<cluster::topic_result>{};
+    }
+    std::vector<cluster::create_partititions_configuration> partitions;
+    partitions.reserve(sz);
+
+    std::transform(
+      begin,
+      end,
+      std::back_inserter(partitions),
+      [](create_partitions_topic& tp) {
+          return cluster::create_partititions_configuration(
+            model::topic_namespace(model::kafka_namespace, std::move(tp.name)),
+            tp.count);
+      });
+
+    co_return co_await ctx.topics_frontend().create_partitions(
+      std::move(partitions), timeout);
+}
+
+template<>
+ss::future<response_ptr> create_partitions_handler::handle(
+  request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
+    create_partitions_request request;
+    request.decode(ctx.reader(), ctx.header().version);
+    create_partitions_response resp;
+
+    if (request.data.topics.empty()) {
+        co_return co_await ctx.respond(resp);
+    }
+
+    resp.data.results.reserve(request.data.topics.size());
+
+    // authorize
+    auto valid_range_end = validate_range(
+      request.data.topics.begin(),
+      request.data.topics.end(),
+      std::back_inserter(resp.data.results),
+      error_code::topic_authorization_failed,
+      "Topic authorization failed",
+      [&ctx](const create_partitions_topic& tp) {
+          return ctx.authorized(security::acl_operation::alter, tp.name);
+      });
+
+    // check duplicates
+    valid_range_end = validate_range_duplicates(
+      request.data.topics.begin(),
+      valid_range_end,
+      std::back_inserter(resp.data.results));
+
+    // validate topics existence
+    valid_range_end = validate_range(
+      request.data.topics.begin(),
+      valid_range_end,
+      std::back_inserter(resp.data.results),
+      error_code::invalid_topic_exception,
+      "Topic does not exist",
+      [&ctx](const create_partitions_topic& tp) {
+          return ctx.metadata_cache()
+            .get_topic_metadata(
+              model::topic_namespace(model::kafka_namespace, tp.name))
+            .has_value();
+      });
+
+    // validate custom assignment
+    valid_range_end = validate_range(
+      request.data.topics.begin(),
+      valid_range_end,
+      std::back_inserter(resp.data.results),
+      error_code::invalid_request,
+      "Partition count has to be greater than 0",
+      [](const create_partitions_topic& tp) { return tp.count > 0; });
+
+    // validate custom assignment
+    valid_range_end = validate_range(
+      request.data.topics.begin(),
+      valid_range_end,
+      std::back_inserter(resp.data.results),
+      error_code::invalid_request,
+      "Redpanda does not yet support custom partitions assignment",
+      [](const create_partitions_topic& tp) {
+          return !tp.assignments.has_value();
+      });
+
+    if (request.data.validate_only) {
+        std::transform(
+          request.data.topics.begin(),
+          valid_range_end,
+          std::back_inserter(resp.data.results),
+          [](const create_partitions_topic& tp) {
+              return create_partitions_topic_result{
+                .name = tp.name,
+                .error_code = error_code::none,
+              };
+          });
+        co_return co_await ctx.respond(std::move(resp));
+    }
+
+    auto results = co_await do_create_partitions(
+      ctx,
+      request.data.topics.begin(),
+      valid_range_end,
+      model::timeout_clock::now()
+        + std::chrono::milliseconds(request.data.timeout_ms));
+
+    std::transform(
+      results.begin(),
+      results.end(),
+      std::back_inserter(resp.data.results),
+      [](cluster::topic_result& r) {
+          return create_partitions_topic_result{
+            .name = std::move(r.tp_ns.tp),
+            .error_code = map_topic_error_code(r.ec),
+          };
+      });
+
+    co_return co_await ctx.respond(std::move(resp));
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/create_partitions.h
+++ b/src/v/kafka/server/handlers/create_partitions.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "kafka/protocol/create_partitions.h"
+#include "kafka/server/handlers/handler.h"
+
+namespace kafka {
+
+using create_partitions_handler = handler<create_partitions_api, 0, 1>;
+
+}

--- a/src/v/kafka/server/handlers/handlers.h
+++ b/src/v/kafka/server/handlers/handlers.h
@@ -15,6 +15,7 @@
 #include "kafka/server/handlers/alter_configs.h"
 #include "kafka/server/handlers/api_versions.h"
 #include "kafka/server/handlers/create_acls.h"
+#include "kafka/server/handlers/create_partitions.h"
 #include "kafka/server/handlers/create_topics.h"
 #include "kafka/server/handlers/delete_acls.h"
 #include "kafka/server/handlers/delete_groups.h"

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -299,6 +299,8 @@ process_request(request_context&& ctx, ss::smp_service_group g) {
         return do_process<add_offsets_to_txn_handler>(std::move(ctx), g);
     case end_txn_handler::api::key:
         return do_process<end_txn_handler>(std::move(ctx), g);
+    case create_partitions_handler::api::key:
+        return do_process<create_partitions_handler>(std::move(ctx), g);
     };
     throw std::runtime_error(
       fmt::format("Unsupported API {}", ctx.header().key));

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -72,6 +72,14 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
             ]
         return self._run("kafka-topics.sh", args)
 
+    def add_topic_partitions(self, topic, partitions):
+        self._redpanda.logger.debug("Adding %d partitions to topic: %s",
+                                    partitions, topic)
+        args = ['--alter']
+        args += ["--topic", topic]
+        args += ["--partitions", f"{partitions}"]
+        return self._run("kafka-topics.sh", args)
+
     def delete_topic(self, topic):
         self._redpanda.logger.debug("Deleting topic: %s", topic)
         args = ["--delete"]

--- a/tests/rptest/tests/create_partitions_test.py
+++ b/tests/rptest/tests/create_partitions_test.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+
+from rptest.clients.types import TopicSpec
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+
+
+class CreatePartitionsTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=2, replication_factor=3), )
+
+    @cluster(num_nodes=3)
+    def test_create_partitions(self):
+        topic = self.topics[0].name
+        cli = KafkaCliTools(self.redpanda)
+        # add 5 partitions to the topic
+        cli.add_topic_partitions(topic, 5)
+
+        res = cli.describe_topic(topic)
+        # initially topic had 2 partitions, we added 5
+        assert res.partition_count == 7


### PR DESCRIPTION
## Cover letter

Added support for create partitions API. Currently we do not yet support custom partitions assignment but in this PR all the types are ready to handle it in a future.

Fixes: #1461 

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
