### PR TITLE
docs/config: Fix rpk field name & value

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -539,7 +539,7 @@ rpk:
     sasl:
       user: user
       password: pass
-      method: scram-sha256
+      type: SCRAM-SHA-256
 
   # The Admin API configuration
   admin_api:


### PR DESCRIPTION
The actual field for the SCRAM method is `type`. We will change this later on in a way that's backwards compatible, but for the moment, this will fix the docs.