### PR TITLE
raft: automatic leadership rebalancing

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -71,6 +71,7 @@ v_cc_library(
     scheduling/allocation_state.cc
     scheduling/allocation_strategy.cc
     scheduling/constraints.cc
+    scheduling/leader_balancer.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -72,6 +72,7 @@ v_cc_library(
     scheduling/allocation_strategy.cc
     scheduling/constraints.cc
     scheduling/leader_balancer.cc
+    scheduling/leader_balancer_probe.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -196,6 +196,7 @@ ss::future<> controller::start() {
             std::ref(_raft_manager),
             std::ref(_as),
             config::shard_local_cfg().leader_balancer_idle_timeout(),
+            config::shard_local_cfg().leader_balancer_mute_timeout(),
             _raft0);
           return _leader_balancer->start();
       });

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -195,6 +195,7 @@ ss::future<> controller::start() {
             std::ref(_partition_manager),
             std::ref(_raft_manager),
             std::ref(_as),
+            config::shard_local_cfg().leader_balancer_idle_timeout(),
             _raft0);
           return _leader_balancer->start();
       });

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -13,7 +13,9 @@
 
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
+#include "cluster/scheduling/leader_balancer.h"
 #include "cluster/topic_updates_dispatcher.h"
+#include "raft/group_manager.h"
 #include "rpc/connection_cache.h"
 #include "security/authorizer.h"
 #include "security/credential_store.h"
@@ -31,7 +33,8 @@ public:
       ss::sharded<rpc::connection_cache>& ccache,
       ss::sharded<partition_manager>& pm,
       ss::sharded<shard_table>& st,
-      ss::sharded<storage::api>& storage);
+      ss::sharded<storage::api>& storage,
+      ss::sharded<raft::group_manager>&);
 
     model::node_id self() { return _raft0->self().id(); }
     ss::sharded<topics_frontend>& get_topics_frontend() { return _tp_frontend; }
@@ -92,6 +95,8 @@ private:
     security_manager _security_manager;
     ss::sharded<security_frontend> _security_frontend;
     ss::sharded<security::authorizer> _authorizer;
+    ss::sharded<raft::group_manager>& _raft_manager;
+    std::unique_ptr<leader_balancer> _leader_balancer;
     consensus_ptr _raft0;
 };
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -129,7 +129,7 @@ public:
 
     ss::future<std::error_code>
     transfer_leadership(std::optional<model::node_id> target) {
-        return _raft->transfer_leadership(target);
+        return _raft->do_transfer_leadership(target);
     }
 
     ss::future<std::error_code> update_replica_set(

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -1,0 +1,597 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/scheduling/leader_balancer.h"
+
+#include "cluster/logger.h"
+#include "cluster/partition_leaders_table.h"
+#include "cluster/scheduling/leader_balancer_greedy.h"
+#include "cluster/shard_table.h"
+#include "cluster/topic_table.h"
+#include "model/namespace.h"
+#include "random/generators.h"
+#include "rpc/types.h"
+#include "seastarx.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/timer.hh>
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
+#include <algorithm>
+#include <chrono>
+
+namespace cluster {
+
+leader_balancer::leader_balancer(
+  topic_table& topics,
+  partition_leaders_table& leaders,
+  raft::consensus_client_protocol client,
+  ss::sharded<shard_table>& shard_table,
+  ss::sharded<partition_manager>& partition_manager,
+  ss::sharded<raft::group_manager>& group_manager,
+  ss::sharded<ss::abort_source>& as,
+  consensus_ptr raft0)
+  : _topics(topics)
+  , _leaders(leaders)
+  , _client(std::move(client))
+  , _shard_table(shard_table)
+  , _partition_manager(partition_manager)
+  , _group_manager(group_manager)
+  , _as(as)
+  , _raft0(std::move(raft0))
+  , _timer([this] { trigger_balance(); }) {}
+
+ss::future<> leader_balancer::start() {
+    /*
+     * register for raft0 leadership change notifications. shutdown the balancer
+     * when we lose leadership, and start it when we gain leadership.
+     */
+    _leader_notify_handle
+      = _group_manager.local().register_leadership_notification(
+        [this](
+          raft::group_id group, model::term_id, std::optional<model::node_id>) {
+            if (group != _raft0->group()) {
+                return;
+            }
+            if (_raft0->is_leader()) {
+                vlog(
+                  clusterlog.info,
+                  "Leader balancer: controller leadership detected. Starting "
+                  "rebalancer in {} seconds",
+                  std::chrono::duration_cast<std::chrono::seconds>(
+                    leader_activation_delay)
+                    .count());
+                _timer.cancel();
+                _timer.arm(leader_activation_delay);
+            } else {
+                vlog(
+                  clusterlog.info,
+                  "Leader balancer: controller leadership lost");
+                _need_controller_refresh = true;
+                _timer.cancel();
+                _timer.arm(idle_timeout);
+            }
+        });
+
+    /*
+     * register_leadership_notification above may run callbacks synchronously
+     * during registration, so make sure the timer is unarmed before arming.
+     */
+    if (!_timer.armed()) {
+        _timer.arm(idle_timeout);
+    }
+
+    co_return;
+}
+
+ss::future<> leader_balancer::stop() {
+    _group_manager.local().unregister_leadership_notification(
+      _leader_notify_handle);
+    _timer.cancel();
+    return _gate.close();
+}
+
+void leader_balancer::trigger_balance() {
+    /*
+     * there are many ways in which the rebalance fiber may not exit quickly
+     * (e.g. rpc timeouts) because of this, it is possible for leadership to
+     * change (e.g. lose, and then regain) to trigger an upcall that starts the
+     * rebalance process before the previous fiber has exited. when it appears
+     * that this has happened avoid starting a new balancer fiber. however,
+     * schedule a retry because it could be that we were also racing with the
+     * previous fiber on its way out.
+     */
+    if (_gate.get_count()) {
+        vlog(
+          clusterlog.info, "Cannot start rebalance until previous fiber exits");
+        _timer.arm(idle_timeout);
+    }
+
+    (void)ss::try_with_gate(_gate, [this] {
+        return ss::repeat([this] {
+                   if (_as.local().abort_requested()) {
+                       return ss::make_ready_future<ss::stop_iteration>(
+                         ss::stop_iteration::yes);
+                   }
+                   return balance();
+               })
+          .handle_exception_type([](const ss::gate_closed_exception&) {})
+          .handle_exception_type([this](const std::exception& e) {
+              vlog(
+                clusterlog.info,
+                "Leadership rebalance experienced an unhandled error: {}. "
+                "Retrying in {} seconds",
+                e,
+                std::chrono::duration_cast<std::chrono::seconds>(idle_timeout)
+                  .count());
+              _timer.cancel();
+              _timer.arm(idle_timeout);
+          });
+    }).handle_exception_type([](const ss::gate_closed_exception&) {});
+}
+
+ss::future<ss::stop_iteration> leader_balancer::balance() {
+    /*
+     * GC the muted and last leader indices
+     */
+    absl::erase_if(
+      _muted, [now = clock_type::now()](auto g) { return now >= g.second; });
+
+    absl::erase_if(_last_leader, [now = clock_type::now()](auto g) {
+        return now >= g.second.expires;
+    });
+
+    if (!_raft0->is_leader()) {
+        vlog(clusterlog.debug, "Leadership balancer tick: not leader");
+        if (!_timer.armed()) {
+            _timer.arm(idle_timeout);
+        }
+        _need_controller_refresh = true;
+        co_return ss::stop_iteration::yes;
+    }
+
+    /*
+     * if we are running the rebalancer after having lost leadership, then
+     * inject a barrier into the raft0 group which will cause us to wait
+     * until the controller has replayed its log. if an error occurs, retry
+     * after a short delay to account for transient issues on startup.
+     */
+    if (_need_controller_refresh) {
+        auto res = co_await _raft0->linearizable_barrier();
+        if (!res) {
+            vlog(
+              clusterlog.debug,
+              "Leadership balancer tick: failed to wait on controller "
+              "update: {}. Retrying in {} seconds",
+              res.error().message(),
+              std::chrono::duration_cast<std::chrono::seconds>(
+                leader_activation_delay)
+                .count());
+            if (!_timer.armed()) {
+                _timer.arm(leader_activation_delay);
+            }
+            co_return ss::stop_iteration::yes;
+        }
+        _need_controller_refresh = false;
+    }
+
+    if (_as.local().abort_requested()) {
+        co_return ss::stop_iteration::yes;
+    }
+
+    /*
+     * For simplicity the current implementation rebuilds the index on each
+     * rebalancing tick. Testing shows that this takes up to a couple
+     * hundred microseconds for up to 1000s of raft groups. This can be
+     * optimized later by attempting to minimize the number of rebuilds
+     * (e.g. on average little should change between ticks) and bounding the
+     * search for leader moves.
+     */
+    greedy_balanced_shards strategy(build_index());
+
+    if (clusterlog.is_enabled(ss::log_level::trace)) {
+        auto cores = strategy.stats();
+        for (const auto& core : cores) {
+            vlog(
+              clusterlog.trace,
+              "Leadership balancing stats: core {} leaders {}",
+              core.shard,
+              core.leaders);
+        }
+    }
+
+    auto error = strategy.error();
+    auto transfer = strategy.find_movement(muted_groups());
+    if (!transfer) {
+        vlog(
+          clusterlog.info,
+          "No leadership balance improvements found with total error {}",
+          error);
+        if (!_timer.armed()) {
+            _timer.arm(idle_timeout);
+        }
+        co_return ss::stop_iteration::yes;
+    }
+
+    auto success = co_await do_transfer(*transfer);
+    if (!success) {
+        vlog(
+          clusterlog.info,
+          "Error transferring leadership group {} from {} to {}",
+          transfer->group,
+          transfer->from,
+          transfer->to);
+        /*
+         * a common scenario is that a node loses all its leadership (e.g.
+         * restarts) and then it is recognized as having lots of extra capacity
+         * (which it does). but the balancer doesn't consider node health when
+         * making decisions. so when we fail transfer we inject a short delay
+         * to avoid spinning on sending transfer requests to a failed node. of
+         * course failure can happen for other reasons, so don't delay a lot.
+         */
+        co_await ss::sleep_abortable(5s, _as.local());
+        _muted.try_emplace(transfer->group, clock_type::now() + mute_timeout);
+        co_return ss::stop_iteration::no;
+    }
+
+    if (_as.local().abort_requested()) {
+        co_return ss::stop_iteration::yes;
+    }
+
+    /*
+     * reverse the mapping from raft::group_id to model::ntp so that we can
+     * look up its leadership information in the metadata table. we should
+     * fix this with better indexing / interfaces.
+     *
+     *   See: https://github.com/vectorizedio/redpanda/issues/2032
+     */
+    std::optional<model::ntp> ntp;
+    for (const auto& topic : _topics.topics_map()) {
+        for (const auto& partition : topic.second.configuration.assignments) {
+            if (partition.group == transfer->group) {
+                ntp = model::ntp(topic.first.ns, topic.first.tp, partition.id);
+                break;
+            }
+        }
+    }
+
+    /*
+     * if the group is now not found in the topics table it is probably
+     * something benign like we were racing with topic deletion.
+     */
+    if (!ntp) {
+        vlog(
+          clusterlog.info,
+          "Leadership balancer muting group {} not found in topics table",
+          transfer->group);
+        co_await ss::sleep_abortable(5s, _as.local());
+        _muted.try_emplace(transfer->group, clock_type::now() + mute_timeout);
+        co_return ss::stop_iteration::no;
+    }
+
+    /*
+     * leadership reported success. wait for the event to be propogated to the
+     * cluster and reflected in the local metadata.
+     */
+    int retries = 6;
+    auto delay = 300ms; // w/ doubling, about 20 second
+    std::optional<model::broker_shard> leader_shard;
+    while (retries--) {
+        co_await ss::sleep_abortable(delay, _as.local());
+        leader_shard = find_leader_shard(*ntp);
+
+        // no leader shard (possibly intermediate state) or no movement yet
+        if (!leader_shard || *leader_shard == transfer->from) {
+            delay *= 2;
+            continue;
+        }
+
+        break;
+    }
+
+    if (leader_shard && *leader_shard != transfer->from) {
+        vlog(
+          clusterlog.info,
+          "Leadership for group {} moved from {} to {} (target {}). Error {}",
+          transfer->group,
+          transfer->from,
+          *leader_shard,
+          transfer->to,
+          error);
+    } else {
+        vlog(
+          clusterlog.info,
+          "Leadership movement for group {} from {} to {} timed out "
+          "(leader_shard {})",
+          transfer->group,
+          transfer->from,
+          transfer->to,
+          leader_shard);
+    }
+
+    /*
+     * if leadership moved, or it timed out we'll mute the group for a while and
+     * continue to avoid any thrashing. notice that we don't check for movement
+     * to the exact shard we requested. this is because we want to avoid
+     * thrashing (we'll still mute the group), but also because we may have
+     * simply been racing with organic leadership movement.
+     */
+    _muted.try_emplace(transfer->group, clock_type::now() + mute_timeout);
+    co_return ss::stop_iteration::no;
+}
+
+absl::flat_hash_set<raft::group_id> leader_balancer::muted_groups() const {
+    absl::flat_hash_set<raft::group_id> res;
+    res.reserve(_muted.size());
+    for (const auto& e : _muted) {
+        res.insert(e.first);
+    }
+    return res;
+}
+
+std::optional<model::broker_shard>
+leader_balancer::find_leader_shard(const model::ntp& ntp) {
+    /*
+     * look up the broker_shard for ntp's leader. we simply seem to lack
+     * interfaces for making this query concise, but it is rarely needed.
+     */
+    auto leader_node = _leaders.get_leader(ntp);
+    if (!leader_node) {
+        return std::nullopt;
+    }
+
+    auto config_it = _topics.topics_map().find(
+      model::topic_namespace_view(ntp));
+    if (config_it == _topics.topics_map().end()) {
+        return std::nullopt;
+    }
+
+    for (const auto& partition : config_it->second.configuration.assignments) {
+        if (partition.id != ntp.tp.partition) {
+            continue;
+        }
+
+        /*
+         * scan through the replicas until we find the leader node and then
+         * pluck out the shard from that assignment.
+         */
+        for (const auto& replica : partition.replicas) {
+            if (replica.node_id == *leader_node) {
+                return model::broker_shard{replica.node_id, replica.shard};
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+/*
+ * builds an index that maps each core in the cluster to the set of replica
+ * groups such that the leader of each mapped replica group is on the given
+ * core. the index is used by a balancing strategy to compute metrics and to
+ * search for leader movements that improve overall balance in the cluster. the
+ * index is computed from controller metadata.
+ */
+leader_balancer::index_type leader_balancer::build_index() {
+    absl::flat_hash_set<model::broker_shard> cores;
+    index_type index;
+
+    // for each ntp in the cluster
+    for (const auto& topic : _topics.topics_map()) {
+        for (const auto& partition : topic.second.configuration.assignments) {
+            if (partition.replicas.empty()) {
+                vlog(
+                  clusterlog.warn,
+                  "Leadership encountered partition with no partition "
+                  "assignment: {}",
+                  model::ntp(topic.first.ns, topic.first.tp, partition.id));
+                continue;
+            }
+
+            /*
+             * skip balancing for the controller partition, otherwise we might
+             * just constantly move ourselves around.
+             */
+            if (
+              topic.first.ns == model::controller_ntp.ns
+              && topic.first.tp == model::controller_ntp.tp.topic) {
+                continue;
+            }
+
+            /*
+             * map the ntp to its leader's shard. first we look up the leader
+             * node, then find the corresponding shard from its replica set.
+             * it's possible that we don't find this information because of
+             * transient states or inconsistencies from joining metadata.
+             */
+            std::optional<model::broker_shard> leader_core;
+            auto leader_node = _leaders.get_leader(topic.first, partition.id);
+            if (leader_node) {
+                auto it = std::find_if(
+                  partition.replicas.cbegin(),
+                  partition.replicas.cend(),
+                  [node = *leader_node](const auto& replica) {
+                      return replica.node_id == node;
+                  });
+
+                if (it != partition.replicas.cend()) {
+                    leader_core = *it;
+                    _last_leader.insert_or_assign(
+                      partition.group,
+                      last_known_leader{
+                        *leader_core, clock_type::now() + mute_timeout});
+                } else {
+                    vlog(
+                      clusterlog.info,
+                      "Group {} has leader node but no leader shard: {}",
+                      partition.group,
+                      partition.replicas);
+                }
+            }
+
+            /*
+             * if no leader node or core was found then we still want to
+             * represent the resource in the index to avoid an artificial
+             * imbalance. use the last known assignment if available, or
+             * otherwise a random replica choice.
+             */
+            bool needs_mute = false;
+            if (!leader_core) {
+                if (auto it = _last_leader.find(partition.group);
+                    it != _last_leader.end()) {
+                    leader_core = it->second.shard;
+                } else {
+                    /*
+                     * if there is no leader core then select a random broker
+                     * shard assignment. there is no point in trying to
+                     * constrain the choice if leader_node is known because
+                     * otherwise it would have been found above!
+                     */
+                    std::vector<model::broker_shard> leader;
+                    std::sample(
+                      partition.replicas.cbegin(),
+                      partition.replicas.cend(),
+                      std::back_inserter(leader),
+                      1,
+                      random_generators::internal::gen);
+                    // partition.replicas.empty() is checked above
+                    vassert(!leader.empty(), "Failed to select replica");
+                    leader_core = leader.front();
+                }
+                needs_mute = true;
+            }
+
+            // track superset of cores
+            for (const auto& replica : partition.replicas) {
+                cores.emplace(replica);
+            }
+
+            if (needs_mute) {
+                auto it = _muted.find(partition.group);
+                if (
+                  it == _muted.end()
+                  || (it->second - clock_type::now())
+                       < leader_activation_delay) {
+                    _muted.insert_or_assign(
+                      it,
+                      partition.group,
+                      clock_type::now() + leader_activation_delay);
+                }
+            }
+
+            index[*leader_core][partition.group] = partition.replicas;
+        }
+    }
+
+    /*
+     * ensure that the resulting index contains all cores by adding missing
+     * cores (with empty replica sets) from the observed superset.
+     *
+     * the reason this is important is because if a node loses all its
+     * leaderships (e.g. it is offline for some time) then all its cores
+     * should still be present in the index represented as having full
+     * available capacity. if no leadership is found on the core, the
+     * accounting above will ignore core.
+     */
+    for (const auto& core : cores) {
+        index.try_emplace(core);
+    }
+
+    return index;
+}
+
+ss::future<bool> leader_balancer::do_transfer(reassignment transfer) {
+    vlog(
+      clusterlog.debug,
+      "Transferring leadership for group {} from {} to {}",
+      transfer.group,
+      transfer.from,
+      transfer.to);
+
+    if (transfer.from.node_id == _raft0->self().id()) {
+        co_return co_await do_transfer_local(transfer);
+    } else {
+        co_return co_await do_transfer_remote(transfer);
+    }
+}
+
+ss::future<bool>
+leader_balancer::do_transfer_local(reassignment transfer) const {
+    if (!_shard_table.local().contains(transfer.group)) {
+        vlog(
+          clusterlog.info,
+          "Cannot complete group {} leader transfer: shard not found",
+          transfer.group);
+        co_return false;
+    }
+    auto shard = _shard_table.local().shard_for(transfer.group);
+    auto func = [transfer, shard](cluster::partition_manager& pm) {
+        auto consensus = pm.consensus_for(transfer.group);
+        if (!consensus) {
+            vlog(
+              clusterlog.info,
+              "Cannot complete group {} leader transfer: group instance "
+              "not found on shard {}",
+              transfer.group,
+              shard);
+            return ss::make_ready_future<bool>(false);
+        }
+        return consensus->do_transfer_leadership(transfer.to.node_id)
+          .then([group = transfer.group](std::error_code err) {
+              if (err) {
+                  vlog(
+                    clusterlog.info,
+                    "Leadership transfer of group {} failed with error: {}",
+                    group,
+                    err.message());
+                  return ss::make_ready_future<bool>(false);
+              }
+              return ss::make_ready_future<bool>(true);
+          });
+    };
+    co_return co_await _partition_manager.invoke_on(shard, std::move(func));
+}
+
+ss::future<bool> leader_balancer::do_transfer_remote(reassignment transfer) {
+    raft::transfer_leadership_request req{
+      .group = transfer.group, .target = transfer.to.node_id};
+
+    auto res = co_await _client.transfer_leadership(
+      transfer.from.node_id,
+      std::move(req), // NOLINT(hicpp-move-const-arg,performance-move-const-arg)
+      rpc::client_opts(leader_transfer_rpc_timeout));
+
+    if (!res) {
+        vlog(
+          clusterlog.info,
+          "Leadership transfer of group {} failed with error: {}",
+          res.error().message());
+        co_return false;
+    }
+
+    if (res.value().success) {
+        co_return true;
+    }
+
+    vlog(
+      clusterlog.info,
+      "Leadership transfer of group {} failed with error: {}",
+      raft::make_error_code(res.value().result));
+
+    co_return false;
+}
+
+} // namespace cluster

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -62,13 +62,6 @@ class leader_balancer {
      */
     static constexpr clock_type::duration leader_transfer_rpc_timeout = 30s;
 
-    /*
-     * timeout used to mute groups. groups are muted in various scenarios such
-     * as if they experience errors being moved, but also if they are moved
-     * successfully so that we do not pertrub them too much on accident.
-     */
-    static constexpr clock_type::duration mute_timeout = 5min;
-
 public:
     leader_balancer(
       topic_table&,
@@ -78,6 +71,7 @@ public:
       ss::sharded<partition_manager>&,
       ss::sharded<raft::group_manager>&,
       ss::sharded<ss::abort_source>&,
+      std::chrono::milliseconds,
       std::chrono::milliseconds,
       consensus_ptr);
 
@@ -119,6 +113,14 @@ private:
      *   timeout to something larger like 5 minutes.
      */
     clock_type::duration _idle_timeout;
+
+    /*
+     * timeout used to mute groups. groups are muted in various scenarios such
+     * as if they experience errors being moved, but also if they are moved
+     * successfully so that we do not pertrub them too much on accident.
+     */
+    clock_type::duration _mute_timeout;
+
 
     struct last_known_leader {
         model::broker_shard shard;

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "absl/container/node_hash_map.h"
+#include "cluster/partition_manager.h"
+#include "cluster/scheduling/leader_balancer_strategy.h"
+#include "cluster/types.h"
+#include "raft/consensus.h"
+#include "raft/consensus_client_protocol.h"
+#include "seastarx.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/timer.hh>
+
+using namespace std::chrono_literals;
+
+namespace cluster {
+
+/**
+ * When a node crashes / restarts the most likely result is that it loses
+ * leadership for all partitions with replicas assigned to it. The leadership
+ * rebalancer will then react by treating this as spare capacity, and attempting
+ * to move leadership back. If the node takes a while to boot up then these
+ * movements will fail and the groups being moved with be temporarily muted from
+ * further movement. Thus the mute timeout should be chosen with this in mind:
+ * too long, and leadership recovery will take a long time. Too short and it
+ * will be very noise with timeouts and RPC errros.
+ *
+ * TODO:
+ *   - One approach to dealing with such situations in a smarter way might be to
+ *   attempt to gauge the health of a node (e.g. tapping into rpc connection
+ *   info, observing repeated failures, or pinging a node's health endpoint).
+ *   This information could then be used reduce failed movement requests and
+ *   improve responsiveness.
+ *
+ *   - Ultimately a more principled approach may be better: computing and
+ *   disseminating a global schedule, a distributed choice-of-two strategy,
+ *   push-pull p2p balancing. There are many options that are better than this
+ *   centralized greedy approach :)
+ */
+class leader_balancer {
+    using clock_type = ss::lowres_clock;
+
+    /*
+     * after becoming the raft0 leader apply a delay before the rebalancer
+     * starts in order to give the system some time to stabilize.
+     */
+    static constexpr clock_type::duration leader_activation_delay = 30s;
+
+    /*
+     * normally leadership transfer should be fast. if a timeout occurs the
+     * group will be retried again after other group rebalances are tried.
+     */
+    static constexpr clock_type::duration leader_transfer_rpc_timeout = 30s;
+
+    /*
+     * the balancer will go idle in different scenarios such as losing raft0
+     * leadership, or when leadership balance cannot be improved.  for good
+     * responsivenss, sub-system upcalls may wake-up the balancer when
+     * leadership is regained or some threshold set of leadership change is
+     * identified. as a defensive measure, we set an idle timeout to run a
+     * balancing tick at low frequency in case some upcall is missed.
+     *
+     * TODO:
+     *   - raft0 leadership upcall is active, but we require polling to wake-up
+     *   the balancer when it has gone idel because balancing completed. for
+     *   this we need ot add an upcall notification mechanism to the leaders
+     *   table / dissemination framework.
+     *
+     *      See: https://github.com/vectorizedio/redpanda/issues/2031
+     *
+     *   Once this item is complete it would also make sense to increase this
+     *   timeout to something larger like 5 minutes.
+     */
+    static constexpr clock_type::duration idle_timeout = 2min;
+
+    /*
+     * timeout used to mute groups. groups are muted in various scenarios such
+     * as if they experience errors being moved, but also if they are moved
+     * successfully so that we do not pertrub them too much on accident.
+     */
+    static constexpr clock_type::duration mute_timeout = 5min;
+
+public:
+    leader_balancer(
+      topic_table&,
+      partition_leaders_table&,
+      raft::consensus_client_protocol,
+      ss::sharded<shard_table>&,
+      ss::sharded<partition_manager>&,
+      ss::sharded<raft::group_manager>&,
+      ss::sharded<ss::abort_source>&,
+      consensus_ptr);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+private:
+    using index_type = leader_balancer_strategy::index_type;
+    using reassignment = leader_balancer_strategy::reassignment;
+
+    index_type build_index();
+    std::optional<model::broker_shard> find_leader_shard(const model::ntp&);
+    absl::flat_hash_set<raft::group_id> muted_groups() const;
+
+    ss::future<bool> do_transfer(reassignment);
+    ss::future<bool> do_transfer_local(reassignment) const;
+    ss::future<bool> do_transfer_remote(reassignment);
+
+    void trigger_balance();
+    ss::future<ss::stop_iteration> balance();
+
+    struct last_known_leader {
+        model::broker_shard shard;
+        clock_type::time_point expires;
+    };
+    absl::btree_map<raft::group_id, last_known_leader> _last_leader;
+
+    bool _need_controller_refresh{true};
+    absl::btree_map<raft::group_id, clock_type::time_point> _muted;
+    cluster::notification_id_type _leader_notify_handle;
+    topic_table& _topics;
+    partition_leaders_table& _leaders;
+    raft::consensus_client_protocol _client;
+    ss::sharded<shard_table>& _shard_table;
+    ss::sharded<partition_manager>& _partition_manager;
+    ss::sharded<raft::group_manager>& _group_manager;
+    ss::sharded<ss::abort_source>& _as;
+    consensus_ptr _raft0;
+    ss::gate _gate;
+    ss::timer<clock_type> _timer;
+};
+
+} // namespace cluster

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "absl/container/node_hash_map.h"
 #include "cluster/partition_manager.h"
+#include "cluster/scheduling/leader_balancer_probe.h"
 #include "cluster/scheduling/leader_balancer_strategy.h"
 #include "cluster/types.h"
 #include "raft/consensus.h"
@@ -125,6 +126,7 @@ private:
     };
     absl::btree_map<raft::group_id, last_known_leader> _last_leader;
 
+    leader_balancer_probe _probe;
     bool _need_controller_refresh{true};
     absl::btree_map<raft::group_id, clock_type::time_point> _muted;
     cluster::notification_id_type _leader_notify_handle;

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -121,7 +121,6 @@ private:
      */
     clock_type::duration _mute_timeout;
 
-
     struct last_known_leader {
         model::broker_shard shard;
         clock_type::time_point expires;

--- a/src/v/cluster/scheduling/leader_balancer_greedy.h
+++ b/src/v/cluster/scheduling/leader_balancer_greedy.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/scheduling/leader_balancer_strategy.h"
+
+#include <boost/range/adaptor/reversed.hpp>
+
+/*
+ * Greedy shard balancer strategy is to move leaders from the most loaded core
+ * to the least loaded core. The strategy treats all cores equally, ignoring
+ * node-level balancing.
+ */
+namespace cluster {
+
+class greedy_balanced_shards final : private leader_balancer_strategy {
+    /*
+     * avoid rounding errors when determining if a move improves balance by
+     * adding a small amount of jitter. effectively a move needs to improve by
+     * more than this value.
+     */
+    static constexpr double error_jitter = 0.000001;
+
+public:
+    explicit greedy_balanced_shards(index_type cores)
+      : _cores(std::move(cores))
+      , _num_groups(num_groups()) {
+        rebuild_load_index();
+    }
+
+    double error() const final {
+        auto target_load = static_cast<double>(_num_groups)
+                           / static_cast<double>(_cores.size());
+        return std::accumulate(
+          _cores.cbegin(),
+          _cores.cend(),
+          double{0},
+          [target_load](auto acc, const auto& e) {
+              double num_groups = e.second.size();
+              return acc + pow(num_groups - target_load, 2);
+          });
+    }
+
+    /*
+     * Compute new error for the given reassignment.
+     */
+    double adjusted_error(
+      const model::broker_shard& from, const model::broker_shard& to) const {
+        auto target_load = static_cast<double>(_num_groups)
+                           / static_cast<double>(_cores.size());
+        auto e = error();
+        const auto from_count = static_cast<double>(_cores.at(from).size());
+        const auto to_count = static_cast<double>(_cores.at(to).size());
+        // subtract original contribution
+        e -= pow(from_count - target_load, 2);
+        e -= pow(to_count - target_load, 2);
+        // add back in the adjusted amount
+        e += pow(from_count - 1 - target_load, 2);
+        e += pow(to_count + 1 - target_load, 2);
+        return e;
+    }
+
+    /*
+     * Find a group reassignment that improves overall error. The general
+     * approach is to select a group from the highest loaded shard and move
+     * leadership for that group to the least loaded shard that the group is
+     * compatible with.
+     *
+     * Clearly this is a costly method in terms of runtime complexity.
+     * Measurements for clusters with several thousand partitions indicate a
+     * real time execution cost of at most a couple hundred micros. Other
+     * strategies are sure to improve this as we tackle larger configurations.
+     */
+    std::optional<reassignment>
+    find_movement(const absl::flat_hash_set<raft::group_id>& skip) const final {
+        const auto curr_error = error();
+
+        /*
+         * from: high load core
+         * to: less loaded core
+         */
+        for (const auto& from : boost::adaptors::reverse(_load)) {
+            for (const auto& to : _load) {
+                // consider group from high load core
+                for (const auto& group : from->second) {
+                    if (skip.contains(group.first)) {
+                        continue;
+                    }
+                    /*
+                     * a valid move requires that the group's replica set
+                     * contain the less loaded `to` core.
+                     */
+                    const auto it = std::find(
+                      group.second.cbegin(), group.second.cend(), to->first);
+                    if (it == group.second.cend()) {
+                        continue;
+                    }
+                    /*
+                     * choose reassignment if error improves
+                     */
+                    if (
+                      (adjusted_error(from->first, to->first) + error_jitter)
+                      < curr_error) {
+                        return reassignment{
+                          group.first, from->first, to->first};
+                    }
+                }
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    std::vector<shard_load> stats() const final {
+        std::vector<shard_load> ret;
+        ret.reserve(_load.size());
+        std::transform(
+          _load.cbegin(),
+          _load.cend(),
+          std::back_inserter(ret),
+          [](const auto& e) {
+              // oddly, absl::btree::size returns a signed type
+              return shard_load{
+                e->first, static_cast<size_t>(e->second.size())};
+          });
+        return ret;
+    }
+
+private:
+    size_t num_groups() const {
+        return std::accumulate(
+          _cores.cbegin(),
+          _cores.cend(),
+          size_t{0},
+          [](auto acc, const auto& e) { return acc + e.second.size(); });
+    }
+
+    /*
+     * build the load index, which is a vector of iterators to each element in
+     * the core index, where the iterators in the load index are sorted by the
+     * number of groups having their leader on a given core.
+     */
+    void rebuild_load_index() {
+        _load.clear();
+        _load.reserve(_cores.size());
+        for (auto it = _cores.cbegin(); it != _cores.cend(); ++it) {
+            _load.push_back(it);
+        }
+        std::sort(_load.begin(), _load.end(), [](const auto& a, const auto& b) {
+            return a->second.size() < b->second.size();
+        });
+    }
+
+    index_type _cores;
+    size_t _num_groups;
+    std::vector<index_type::const_iterator> _load;
+};
+
+} // namespace cluster

--- a/src/v/cluster/scheduling/leader_balancer_probe.cc
+++ b/src/v/cluster/scheduling/leader_balancer_probe.cc
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/scheduling/leader_balancer_probe.h"
+
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "prometheus/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace cluster {
+
+void leader_balancer_probe::setup_metrics() {
+    namespace sm = ss::metrics;
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name("leader_balancer"),
+      {sm::make_derive(
+         "leader_transfer_error",
+         [this] { return _leader_transfer_error; },
+         sm::description("Number of errors attempting to transfer leader")),
+       sm::make_derive(
+         "leader_transfer_succeeded",
+         [this] { return _leader_transfer_succeeded; },
+         sm::description("Number of successful leader transfers")),
+       sm::make_derive(
+         "leader_transfer_timeout",
+         [this] { return _leader_transfer_timeout; },
+         sm::description("Number of timeouts attempting to transfer leader")),
+       sm::make_derive(
+         "leader_transfer_no_improvement",
+         [this] { return _leader_transfer_no_improvement; },
+         sm::description("Number of times no balance improvement was found"))});
+}
+
+} // namespace cluster

--- a/src/v/cluster/scheduling/leader_balancer_probe.h
+++ b/src/v/cluster/scheduling/leader_balancer_probe.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "model/fundamental.h"
+#include "seastarx.h"
+
+#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_registration.hh>
+
+namespace cluster {
+
+class leader_balancer_probe final {
+public:
+    void setup_metrics();
+
+    void leader_transfer_error() { ++_leader_transfer_error; }
+    void leader_transfer_succeeded() { ++_leader_transfer_succeeded; }
+    void leader_transfer_timeout() { ++_leader_transfer_timeout; }
+    void leader_transfer_no_improvement() { ++_leader_transfer_no_improvement; }
+
+private:
+    uint64_t _leader_transfer_error = 0;
+    uint64_t _leader_transfer_succeeded = 0;
+    uint64_t _leader_transfer_timeout = 0;
+    uint64_t _leader_transfer_no_improvement = 0;
+
+    ss::metrics::metric_groups _metrics;
+};
+
+} // namespace cluster

--- a/src/v/cluster/scheduling/leader_balancer_strategy.h
+++ b/src/v/cluster/scheduling/leader_balancer_strategy.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "absl/container/btree_map.h"
+#include "absl/container/node_hash_map.h"
+#include "cluster/types.h"
+#include "raft/types.h"
+
+namespace cluster {
+
+/*
+ * Leader balancing strategy interface.
+ *
+ * An implementation will normally accept the current system state as an
+ * instance of `index_type` and then be expected to return an assignment via
+ * `find_movement` which improves the overall error metric.
+ */
+class leader_balancer_strategy {
+public:
+    /*
+     * Map a shard to the set of groups whose replica sets contain the shard as
+     * a leader of the group. For convenience, the data structure also contains
+     * the replica set of each group.
+     */
+    using index_type = absl::node_hash_map<
+      model::broker_shard,
+      absl::btree_map<raft::group_id, std::vector<model::broker_shard>>>;
+
+    /*
+     * Represent leadership transfer for a group.
+     */
+    struct reassignment {
+        raft::group_id group;
+        model::broker_shard from;
+        model::broker_shard to;
+    };
+
+    /*
+     * Leaders per shard.
+     */
+    struct shard_load {
+        model::broker_shard shard;
+        size_t leaders;
+    };
+
+    /*
+     * Compute error for the current leadership configuration.
+     *
+     * target = num_groups / num_shards
+     * error = sum((shard.load - target)^2 for each shard)
+     */
+    virtual double error() const = 0;
+
+    /*
+     * Find a group reassignment that reduces total error.
+     */
+    virtual std::optional<reassignment>
+    find_movement(const absl::flat_hash_set<raft::group_id>& skip) const = 0;
+
+    /*
+     * Return current strategy stats.
+     */
+    virtual std::vector<shard_load> stats() const = 0;
+};
+
+} // namespace cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -61,3 +61,12 @@ rp_test(
   DEFINITIONS SEASTAR_TESTING_MAIN
   LABELS cluster
 )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME leader_balancer_test
+  SOURCES leader_balancer_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES Boost::unit_test_framework v::cluster
+  LABELS cluster
+)

--- a/src/v/cluster/tests/leader_balancer_test.cc
+++ b/src/v/cluster/tests/leader_balancer_test.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#define BOOST_TEST_MODULE leader_balancer
+
+#include "cluster/scheduling/leader_balancer_greedy.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+BOOST_AUTO_TEST_CASE(greedy) {
+    cluster::leader_balancer_strategy::index_type index;
+
+    // 10 nodes, 2 cores -> 20 shards
+    std::vector<model::broker_shard> shards;
+    for (auto n = 0U; n < 10; n++) {
+        for (auto s = 0U; s < 2; s++) {
+            model::broker_shard shard{model::node_id(n), s};
+            shards.push_back(shard);
+        }
+    }
+
+    size_t replica = 0;
+    for (auto shard : shards) {
+        // 10 groups per shard
+        for (auto g = 0U; g < 10; g++) {
+            raft::group_id group(g);
+            // 3 replica per group
+            std::vector<model::broker_shard> replicas;
+            replicas.push_back(shard); // the "leader"
+            while (replicas.size() != 3) {
+                if (shards[replica % shards.size()] != shard) {
+                    replicas.push_back(shards[replica % shards.size()]);
+                }
+                ++replica;
+            }
+            index[shard][group] = std::move(replicas);
+        }
+    }
+
+    auto greed = cluster::greedy_balanced_shards(index);
+    BOOST_REQUIRE_EQUAL(greed.error(), 0);
+
+    // new groups on shard 5
+    index[shards[5]][raft::group_id(20)] = index[shards[5]][raft::group_id(3)];
+    index[shards[5]][raft::group_id(21)] = index[shards[5]][raft::group_id(3)];
+    index[shards[5]][raft::group_id(22)] = index[shards[5]][raft::group_id(3)];
+
+    greed = cluster::greedy_balanced_shards(index);
+    BOOST_REQUIRE_GT(greed.error(), 0);
+
+    // movement should be _from_ the overloaded shard
+    auto movement = greed.find_movement({});
+    BOOST_REQUIRE(movement);
+    BOOST_REQUIRE_EQUAL(movement->from, shards[5]);
+}

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -121,9 +121,6 @@ public:
     /// Checks if it has given partition
     bool contains(model::topic_namespace_view, model::partition_id) const;
 
-    /// Returns partition leader
-    std::optional<model::node_id> get_leader(const model::ntp&) const;
-
     /// Updates partition leader and notify waiters if needed
     void update_partition_leader(
       const model::ntp&, model::term_id, std::optional<model::node_id>);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -845,6 +845,12 @@ configuration::configuration()
       "Leadership rebalancing idle timeout",
       required::no,
       2min)
+  , leader_balancer_mute_timeout(
+      *this,
+      "leader_balancer_mute_timeout",
+      "Leadership rebalancing mute timeout",
+      required::no,
+      5min)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -833,6 +833,12 @@ configuration::configuration()
       "Enable automatic partition rebalancing when new nodes are added",
       required::no,
       false)
+  , enable_leader_balancer(
+      *this,
+      "enable_leader_balancer",
+      "Enable automatic leadership rebalancing",
+      required::no,
+      true)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -839,6 +839,12 @@ configuration::configuration()
       "Enable automatic leadership rebalancing",
       required::no,
       true)
+  , leader_balancer_idle_timeout(
+      *this,
+      "leader_balancer_idle_timeout",
+      "Leadership rebalancing idle timeout",
+      required::no,
+      2min)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -202,6 +202,8 @@ struct configuration final : public config_store {
     one_or_many_property<ss::sstring> full_raft_configuration_recovery_pattern;
     property<bool> enable_auto_rebalance_on_node_add;
 
+    property<bool> enable_leader_balancer;
+
     configuration();
 
     void read_yaml(const YAML::Node& root_node) override;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -204,6 +204,7 @@ struct configuration final : public config_store {
 
     property<bool> enable_leader_balancer;
     property<std::chrono::milliseconds> leader_balancer_idle_timeout;
+    property<std::chrono::milliseconds> leader_balancer_mute_timeout;
 
     configuration();
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -203,6 +203,7 @@ struct configuration final : public config_store {
     property<bool> enable_auto_rebalance_on_node_add;
 
     property<bool> enable_leader_balancer;
+    property<std::chrono::milliseconds> leader_balancer_idle_timeout;
 
     configuration();
 

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -182,6 +182,11 @@ struct broker_shard {
     uint32_t shard;
     friend std::ostream& operator<<(std::ostream&, const broker_shard&);
     bool operator==(const broker_shard&) const = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const broker_shard& s) {
+        return H::combine(std::move(h), s.node_id(), s.shard);
+    }
 };
 
 struct partition_metadata {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2133,19 +2133,6 @@ group_configuration consensus::config() const {
     return _configuration_manager.get_latest();
 }
 
-static std::ostream&
-operator<<(std::ostream& os, const consensus::vote_state& state) {
-    switch (state) {
-    case consensus::vote_state::leader:
-        return os << "{leader}";
-    case consensus::vote_state::follower:
-        return os << "{follower}";
-    case consensus::vote_state::candidate:
-        return os << "{candidate}";
-    }
-    std::terminate(); // make gcc happy
-}
-
 ss::future<timeout_now_reply> consensus::timeout_now(timeout_now_request&& r) {
     if (unlikely(is_request_target_node_invalid("timeout_now", r))) {
         return ss::make_ready_future<timeout_now_reply>(timeout_now_reply{

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -271,8 +271,10 @@ public:
      * Attempt to transfer leadership to another node in this raft group. If no
      * node is specified, the most up-to-date node will be selected.
      */
+    ss::future<transfer_leadership_reply>
+      transfer_leadership(transfer_leadership_request);
     ss::future<std::error_code>
-      transfer_leadership(std::optional<model::node_id>);
+      do_transfer_leadership(std::optional<model::node_id>);
 
     ss::future<> remove_persistent_state();
 

--- a/src/v/raft/consensus_client_protocol.h
+++ b/src/v/raft/consensus_client_protocol.h
@@ -47,6 +47,11 @@ public:
 
         virtual ss::future<bool> ensure_disconnect(model::node_id) = 0;
 
+        virtual ss::future<result<transfer_leadership_reply>>
+        transfer_leadership(
+          model::node_id, transfer_leadership_request&&, rpc::client_opts)
+          = 0;
+
         virtual ~impl() noexcept = default;
     };
 
@@ -90,6 +95,14 @@ public:
 
     ss::future<bool> ensure_disconnect(model::node_id target_node) {
         return _impl->ensure_disconnect(target_node);
+    }
+
+    ss::future<result<transfer_leadership_reply>> transfer_leadership(
+      model::node_id target_node,
+      transfer_leadership_request&& r,
+      rpc::client_opts opts) {
+        return _impl->transfer_leadership(
+          target_node, std::move(r), std::move(opts));
     }
 
 private:

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -15,7 +15,7 @@
 
 namespace raft {
 
-enum class errc {
+enum class errc : int16_t {
     success = 0, // must be 0
     disconnected_endpoint,
     exponential_backoff,

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -78,6 +78,8 @@ public:
         }
     }
 
+    consensus_client_protocol raft_client() const { return _client; }
+
 private:
     void trigger_leadership_notification(raft::leadership_status);
     void setup_metrics();

--- a/src/v/raft/raftgen.json
+++ b/src/v/raft/raftgen.json
@@ -29,6 +29,11 @@
             "name": "timeout_now",
             "input_type": "timeout_now_request",
             "output_type": "timeout_now_reply"
+        },
+        {
+            "name": "transfer_leadership",
+            "input_type": "transfer_leadership_request",
+            "output_type": "transfer_leadership_reply"
         }
     ]
 }

--- a/src/v/raft/rpc_client_protocol.cc
+++ b/src/v/raft/rpc_client_protocol.cc
@@ -119,4 +119,19 @@ ss::future<bool> rpc_client_protocol::ensure_disconnect(model::node_id n) {
       });
 }
 
+ss::future<result<transfer_leadership_reply>>
+rpc_client_protocol::transfer_leadership(
+  model::node_id n, transfer_leadership_request&& r, rpc::client_opts opts) {
+    return _connection_cache.local().with_node_client<raftgen_client_protocol>(
+      _self,
+      ss::this_shard_id(),
+      n,
+      opts.timeout,
+      [r = std::move(r),
+       opts = std::move(opts)](raftgen_client_protocol client) mutable {
+          return client.transfer_leadership(std::move(r), std::move(opts))
+            .then(&rpc::get_ctx_data<transfer_leadership_reply>);
+      });
+}
+
 } // namespace raft

--- a/src/v/raft/rpc_client_protocol.h
+++ b/src/v/raft/rpc_client_protocol.h
@@ -48,6 +48,9 @@ public:
 
     ss::future<bool> ensure_disconnect(model::node_id) final;
 
+    ss::future<result<transfer_leadership_reply>> transfer_leadership(
+      model::node_id, transfer_leadership_request&&, rpc::client_opts) final;
+
 private:
     model::node_id _self;
     ss::sharded<rpc::connection_cache>& _connection_cache;

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -460,6 +460,18 @@ struct timeout_now_reply {
     status result;
 };
 
+// if not target is specified then the most up-to-date node will be selected
+struct transfer_leadership_request {
+    group_id group;
+    std::optional<model::node_id> target;
+    raft::group_id target_group() const { return group; }
+};
+
+struct transfer_leadership_reply {
+    bool success{false};
+    raft::errc result;
+};
+
 // key types used to store data in key-value store
 enum class metadata_key : int8_t {
     voted_for = 0,

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -348,7 +348,7 @@ void admin_server::register_raft_routes() {
                 if (!consensus) {
                     throw ss::httpd::not_found_exception();
                 }
-                return consensus->transfer_leadership(target).then(
+                return consensus->do_transfer_leadership(target).then(
                   [](std::error_code err) {
                       if (err) {
                           throw ss::httpd::server_error_exception(fmt::format(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -567,7 +567,8 @@ void application::wire_up_redpanda_services() {
       _raft_connection_cache,
       partition_manager,
       shard_table,
-      storage);
+      storage,
+      std::ref(raft_group_manager));
 
     controller->wire_up().get0();
     syschecks::systemd_message("Creating kafka metadata cache").get();

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -111,6 +111,9 @@ struct client_opts {
     explicit client_opts(clock_type::time_point client_send_timeout) noexcept
       : client_opts(client_send_timeout, compression_type::none, 1024) {}
 
+    explicit client_opts(clock_type::duration client_send_timeout) noexcept
+      : client_opts(clock_type::now() + client_send_timeout) {}
+
     client_opts(const client_opts&) = delete;
     client_opts(client_opts&&) = default;
 

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -101,9 +101,7 @@ class AutomaticLeadershipBalancingTest(RedpandaTest):
     topics = (TopicSpec(partition_count=63, replication_factor=3), )
 
     def __init__(self, test_context):
-        extra_rp_conf = dict(
-            leader_balancer_idle_timeout=20000,
-        )
+        extra_rp_conf = dict(leader_balancer_idle_timeout=20000, )
 
         super(AutomaticLeadershipBalancingTest,
               self).__init__(test_context=test_context,

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import collections
 import random
 import time
 
@@ -91,3 +92,71 @@ class LeadershipTransferTest(RedpandaTest):
                    err_msg="No partition with leader available")
 
         return partition[0]
+
+
+class AutomaticLeadershipBalancingTest(RedpandaTest):
+    # number cores = 3 (default)
+    # number nodes = 3 (default)
+    # parts per core = 7
+    topics = (TopicSpec(partition_count=63, replication_factor=3), )
+
+    def __init__(self, test_context):
+        extra_rp_conf = dict(
+            leader_balancer_idle_timeout=20000,
+        )
+
+        super(AutomaticLeadershipBalancingTest,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf=extra_rp_conf)
+
+    def _get_leaders_by_node(self):
+        kc = KafkaCat(self.redpanda)
+        md = kc.metadata()
+        topic = next(filter(lambda t: t["topic"] == self.topic, md["topics"]))
+        leaders = (p["leader"] for p in topic["partitions"])
+        return collections.Counter(leaders)
+
+    @cluster(num_nodes=3)
+    def test_automatic_rebalance(self):
+        def all_partitions_present(num_nodes, per_node=None):
+            leaders = self._get_leaders_by_node()
+            for l in leaders:
+                self.redpanda.logger.debug(f"Leaders on {l}: {leaders[l]}")
+            count = sum(leaders[l] for l in leaders)
+            total = len(leaders) == num_nodes and count == 63
+            if per_node is not None:
+                per_node_sat = all((leaders[l] > per_node for l in leaders))
+                return total and per_node_sat
+            return total
+
+        # wait until all the partition leaders are elected on all three nodes
+        wait_until(lambda: all_partitions_present(3),
+                   timeout_sec=30,
+                   backoff_sec=2,
+                   err_msg="Leadership did not stablize")
+
+        # stop node and wait for all leaders to transfer
+        # to another node
+        node = self.redpanda.nodes[0]
+        self.redpanda.stop_node(node)
+        wait_until(lambda: all_partitions_present(2),
+                   timeout_sec=30,
+                   backoff_sec=2,
+                   err_msg="Leadership did not move to running nodes")
+
+        leaders = self._get_leaders_by_node()
+        assert self.redpanda.idx(node) not in leaders
+
+        # sleep for a bit to avoid triggering any of the sticky leaderhsip
+        # optimizations
+        time.sleep(60)
+
+        # restart the stopped node and wait for 15 (out of 21) leaders to be
+        # rebalanced on to the node. the error minimization done in the leader
+        # balancer is a little fuzzy so it problematic to assert an exact target
+        # number that should return
+        self.redpanda.start_node(node)
+        wait_until(lambda: all_partitions_present(3, 15),
+                   timeout_sec=300,
+                   backoff_sec=10,
+                   err_msg="Leadership did not stablize")


### PR DESCRIPTION
Implements automatic leadership balancing. A rebalancing service runs on the active controller, polls for improvements to the partition leadership distribution, and dispatches requests to peers for leadership transfer.

Fixes: https://github.com/vectorizedio/redpanda/issues/1747

### Overview

Leadership of raft groups can accumulate on nodes disproportionally to other nodes. For example, if a node stop, leadership on the node will be transferred to other nodes. However, when the node starts again, leadership will not automatically be moved back. This can lead to imbalance that needs to be resolved because leaders are responsible for more work than followers, and thus, nodes can become overloaded.

To address this we've added an automatic leadership rebalancing feature. It is a service that runs as a singleton in the cluster as part of the controller. Specifically the rebalancing service runs wherever the leader for the controller is currently.

The basic operation of the balancer is to run a loop that calculates a leadership movement that improves leadership balance in the cluster. It does this by accumulating a global view of all leadership and partition assignments, and then moving a leader from an overloaded node to a less loaded node. The approach is greedy, but appears to work well in practice.

There are two configuration knobs:

* idle timeout (2min)
* mute timeout (5min)

The idle timeout is how often the controller polls for leadership when not the active controller. The actual cost of the polling is a check of a boolean, so it can be frequent, for example 1 min. In principle this knob is unnecessary: we receive upcalls on leadership change, but this is used here as a defensive mechanism in case an upcall is missed. It can probably be removed later.

* The idle timeout is also used in a few other places. If processing encounters an unhandled exception, we'll back off for a full idle timeout period.

* If no improvements can be made to the balance we back off for an idle timeout.

The mute timeout is used to mute raft groups from consideration. This happens in a number of places

* On successful move (to avoid repeated movements)
* On RPC failures and other movement failures

### Testing notes

The primary metric for this feature is that leadership rebalancing converges to a good solution in a reasonable amount of time.

* Testing for large numbers of partitions (may take a while)
* Testing that things continue to work after many node failures
* ???

### Revision 1

[Force push diff](https://github.com/vectorizedio/redpanda/compare/f18e29901239bf5f97d920badc65ff3a29993a24..5fcdd8113bfca07fba03d92f1c66abc38dc6a1e5)

* Prometheus probes
* Faster in the happy case
* Configurable timeouts
* Tracking previous leaders
* Unit test for greedy strategy
* Enable/disable rebalancing feature
* Better error reporting on controller