### PR TITLE
kafka: fix autocreated topics disabling cleanup deletion

### DIFF
--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -312,8 +312,8 @@ struct topic_properties {
     std::optional<model::compaction_strategy> compaction_strategy;
     std::optional<model::timestamp_type> timestamp_type;
     std::optional<size_t> segment_size;
-    tristate<size_t> retention_bytes;
-    tristate<std::chrono::milliseconds> retention_duration;
+    tristate<size_t> retention_bytes{std::nullopt};
+    tristate<std::chrono::milliseconds> retention_duration{std::nullopt};
 
     bool is_compacted() const;
     bool has_overrides() const;


### PR DESCRIPTION
## Cover letter

Make the default values of retention.ms and retention.bytes consistent across manual topic creation and autocreation of topics with `auto_create_topics_enabled`

Fixes: https://github.com/vectorizedio/redpanda/issues/2008

## Release notes

For users with `auto_create_topics_enabled` set to true, this is a user-visible behavioral change.  Previously, autocreated topics had retention.ms and retention.bytes set to -1 by default during autocreation.  These topics would not delete data even if the topic cleanup policy was set to delete.

This change only affects newly created topics -- previously autocreated topics will not be changed.