### PR TITLE
kafka/tx: init consumer group's term on creation

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -323,6 +323,7 @@ ss::future<> group_manager::recover_partition(
         if (!group) {
             group = ss::make_lw_shared<kafka::group>(
               group_id, group_state::empty, _conf, p->partition);
+            group->reset_tx_state(term);
             _groups.emplace(group_id, group);
         }
         for (const auto& [_, tx] : group_stm.prepared_txs()) {
@@ -586,6 +587,7 @@ group_manager::join_group(join_group_request&& r) {
         auto p = it->second->partition;
         group = ss::make_lw_shared<kafka::group>(
           r.data.group_id, group_state::empty, _conf, p);
+        group->reset_tx_state(it->second->term);
         _groups.emplace(r.data.group_id, group);
         _groups.rehash(0);
         is_new_group = true;
@@ -709,6 +711,7 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
 
               group = ss::make_lw_shared<kafka::group>(
                 r.data.group_id, group_state::empty, _conf, p->partition);
+              group->reset_tx_state(p->term);
               _groups.emplace(r.data.group_id, group);
               _groups.rehash(0);
           }
@@ -877,9 +880,10 @@ group_manager::offset_commit(offset_commit_request&& r) {
         if (r.data.generation_id < 0) {
             // <kafka>the group is not relying on Kafka for group management, so
             // allow the commit</kafka>
-            auto p = _partitions.find(r.ntp)->second->partition;
+            auto p = _partitions.find(r.ntp)->second;
             group = ss::make_lw_shared<kafka::group>(
-              r.data.group_id, group_state::empty, _conf, p);
+              r.data.group_id, group_state::empty, _conf, p->partition);
+            group->reset_tx_state(p->term);
             _groups.emplace(r.data.group_id, group);
             _groups.rehash(0);
         } else {


### PR DESCRIPTION
Fixes a bug. Each time we create a group we should set its term otherwise when the group processes a tx request it will reject the request assuming the group's state as stale since its term doesn't match the partition's term.