### PR TITLE
Fixed handling of leader epoch in Kafka protocol

### DIFF
--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -341,10 +341,7 @@ consumer::offset_commit(std::vector<offset_commit_request_topic> topics) {
     } else { // set epoch for requests tps
         for (auto& t : topics) {
             for (auto& p : t.partitions) {
-                auto tp = model::topic_partition{t.name, p.partition_index};
-                auto leader = co_await _topic_cache.leader(tp);
-                auto broker = co_await _brokers.find(leader);
-                p.committed_leader_epoch = _fetch_sessions[broker].epoch();
+                p.committed_leader_epoch = kafka::invalid_leader_epoch;
             }
         }
     }

--- a/src/v/kafka/client/fetch_session.cc
+++ b/src/v/kafka/client/fetch_session.cc
@@ -73,7 +73,7 @@ fetch_session::make_offset_commit_request() const {
             res.back().partitions.push_back(offset_commit_request_partition{
               .partition_index = p_id,
               .committed_offset = o - model::offset(1),
-              .committed_leader_epoch = _epoch});
+              .committed_leader_epoch = invalid_leader_epoch});
         }
     }
     return res;

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -14,6 +14,7 @@
 #include "kafka/client/exceptions.h"
 #include "kafka/client/logger.h"
 #include "kafka/protocol/types.h"
+#include "kafka/types.h"
 #include "model/fundamental.h"
 #include "seastar/core/gate.hh"
 
@@ -27,7 +28,7 @@ fetch_request make_fetch_request(
     std::vector<fetch_request::partition> partitions;
     partitions.push_back(fetch_request::partition{
       .partition_index{tp.partition},
-      .current_leader_epoch = 0,
+      .current_leader_epoch = kafka::invalid_leader_epoch,
       .fetch_offset{offset},
       .log_start_offset{model::offset{-1}},
       .max_bytes = max_bytes});

--- a/src/v/kafka/client/test/fetch_session.cc
+++ b/src/v/kafka/client/test/fetch_session.cc
@@ -153,6 +153,7 @@ SEASTAR_THREAD_TEST_CASE(test_fetch_session_make_offset_commit_request_all) {
     BOOST_REQUIRE_EQUAL(req[0].partitions.size(), 1);
     const auto partition = req[0].partitions[0];
     BOOST_REQUIRE_EQUAL(partition.partition_index, ctx.tp.partition);
-    BOOST_REQUIRE_EQUAL(partition.committed_leader_epoch, ctx.expected_epoch);
+    BOOST_REQUIRE_EQUAL(
+      partition.committed_leader_epoch, kafka::invalid_leader_epoch);
     BOOST_REQUIRE_EQUAL(partition.committed_offset, ctx.expected_offset - 1);
 }

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -68,6 +68,7 @@ path_type_map = {
             "Partitions": {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "CommittedOffset": ("model::offset", "int64"),
+                "CommittedLeaderEpoch": ("kafka::leader_epoch", "int32"),
             },
         }
     },
@@ -76,6 +77,7 @@ path_type_map = {
             "Partitions": {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "CommittedOffset": ("model::offset", "int64"),
+                "CommittedLeaderEpoch": ("kafka::leader_epoch", "int32"),
             },
         },
         "MemberId": ("kafka::member_id", "string"),
@@ -97,6 +99,7 @@ path_type_map = {
             "Partitions": {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "CommittedOffset": ("model::offset", "int64"),
+                "CommittedLeaderEpoch": ("kafka::leader_epoch", "int32"),
             },
         }
     },
@@ -163,6 +166,7 @@ path_type_map = {
             "Partitions": {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "Timestamp": ("model::timestamp", "int64"),
+                "CurrentLeaderEpoch": ("kafka::leader_epoch", "int32"),
             },
         },
     },
@@ -172,6 +176,7 @@ path_type_map = {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "Timestamp": ("model::timestamp", "int64"),
                 "Offset": ("model::offset", "int64"),
+                "LeaderEpoch": ("kafka::leader_epoch", "int32"),
             },
         },
     },
@@ -221,6 +226,7 @@ path_type_map = {
             "Partitions": {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "IsrNodes": ("model::node_id", "int32"),
+                "LeaderEpoch": ("kafka::leader_epoch", "int32"),
             },
         },
     },
@@ -231,6 +237,7 @@ path_type_map = {
             "FetchPartitions": {
                 "PartitionIndex": ("model::partition_id", "int32"),
                 "FetchOffset": ("model::offset", "int64"),
+                "CurrentLeaderEpoch": ("kafka::leader_epoch", "int32"),
             },
         },
     },

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -51,7 +51,6 @@ make_topic_response_from_topic_metadata(model::topic_metadata&& tp_md) {
           p.error_code = error_code::none;
           p.partition_index = p_md.id;
           p.leader_id = p_md.leader_node.value_or(model::node_id(-1));
-          p.leader_epoch = 0;
           p.replica_nodes = std::move(replicas);
           p.isr_nodes = p.replica_nodes;
           p.offline_replicas = {};

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -83,6 +83,13 @@ enum class coordinator_type : int8_t {
     transaction = 1,
 };
 
+using leader_epoch = named_type<int32_t, struct leader_epoch_tag>;
+/**
+ * Used to mark that leader epoch is not intended to be used (Kafka protocol
+ * specific)
+ */
+static constexpr leader_epoch invalid_leader_epoch(-1);
+
 // TODO Ben: Why is this an undefined reference for pandaproxy when defined in
 // kafka/requests.cc
 inline std::ostream& operator<<(std::ostream& os, coordinator_type t) {


### PR DESCRIPTION
## Cover letter

Introduced named type for leader epoch property used in kafka protocol. This helped to identify incorrect use of  session epoch as a leader epoch in `kafka::client`. Fixed incorrectly initialized `leader_epoch` field in metadata response.

Credits to @twmb for pointing the problem out. 

Fixes: N/A

## Release notes
