### PR TITLE
k/produce: do not return unknown_server_error when leadership changed

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -125,6 +125,7 @@ static error_code map_produce_error_code(std::error_code ec) {
     if (ec.category() == raft::error_category()) {
         switch (static_cast<raft::errc>(ec.value())) {
         case raft::errc::not_leader:
+        case raft::errc::replicated_entry_truncated:
             return error_code::not_leader_for_partition;
         default:
             return error_code::unknown_server_error;


### PR DESCRIPTION
When leadership changed when waiting for replication raft return an
error `replicated_entry_truncated`. This error have to be translated to
`NOT_LEADER_FOR_PARTITION` Kafka error. This way client will retry
producing to the topic.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
