### PR TITLE
schema_registry: Introduce POST /subjects/{subject}

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -273,6 +273,57 @@
       }
     },
     "/subjects/{subject}": {
+      "post": {
+        "summary": "Check if a schema is already registred for the subject.",
+        "operationId": "post_subject",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "schema_def",
+            "in": "body",
+            "schema":  {
+              "$ref": "#/definitions/schema_def"
+            }
+          }
+        ],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/subject_schema"
+            }
+          },
+          "409": {
+            "description": "Incompatible schema",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "422": {
+            "description": "Invalid schema",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      },
       "delete": {
         "summary": "Delete all schemas for the subject.",
         "operationId": "delete_subject",

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -458,18 +458,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "integer"
-                },
-                "schema": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/subject_schema"
             }
           },
           "404": {

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -37,4 +37,21 @@
           }
         }
       }
+    },
+    "subject_schema": {
+      "type": "object",
+      "properties": {
+        "subject": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "version": {
+          "type": "integer"
+        },
+        "schema": {
+          "type": "string"
+        }
+      }
     }

--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy Schema Registry",
-    "version": "0.0.2"
+    "version": "0.0.3"
   },
   "host": "{{Host}}",
   "basePath": "/",

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -30,6 +30,8 @@ struct reply_error_category final : std::error_category {
             return "HTTP 415 Unsupported Media Type";
         case reply_error_code::unprocessable_entity:
             return "HTTP 422 Unprocesable Entity";
+        case reply_error_code::internal_server_error:
+            return "HTTP 500 Internal Server Error";
         case reply_error_code::kafka_bad_request:
             return "kafka_bad_request";
         case reply_error_code::kafka_authentication_error:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -29,6 +29,7 @@ enum class reply_error_code : uint16_t {
     conflict = 409,
     unsupported_media_type = 415,
     unprocessable_entity = 422,
+    internal_server_error = 500,
     kafka_bad_request = 40002,
     kafka_authentication_error = 40101,
     kafka_authorization_error = 40301,

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -45,6 +45,8 @@ struct error_category final : std::error_category {
                    "permanently";
         case error_code::subject_version_not_deleted:
             return "Version not deleted before being permanently deleted";
+        case error_code::subject_schema_invalid:
+            return "Error while looking up schema under subject";
         case error_code::write_collision:
             return "Too many retries on write collision";
         case error_code::topic_parse_error:
@@ -71,6 +73,8 @@ struct error_category final : std::error_category {
             return reply_error_code::subject_version_soft_deleted; // 40406
         case error_code::subject_version_not_deleted:
             return reply_error_code::subject_version_not_deleted; // 40407
+        case error_code::subject_schema_invalid:
+            return reply_error_code::internal_server_error; // 500
         case error_code::write_collision:
             return reply_error_code::write_collision; // 50301
         case error_code::schema_invalid:

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -26,6 +26,7 @@ enum class error_code {
     subject_not_deleted,
     subject_version_soft_deleted,
     subject_version_not_deleted,
+    subject_schema_invalid,
     write_collision,
     topic_parse_error,
 };

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -54,6 +54,11 @@ inline void outcome_throw_as_system_error_with_payload(const error_info& ei) {
 template<typename T>
 using result = result<T, error_info>;
 
+inline error_info schema_not_found() {
+    return error_info{
+      error_code::schema_id_not_found, fmt::format("Schema not found")};
+}
+
 inline error_info not_found(schema_id id) {
     return error_info{
       error_code::schema_id_not_found,
@@ -113,6 +118,12 @@ inline error_info invalid_schema_type(schema_type type) {
     return {
       error_code::schema_invalid,
       fmt::format("Invalid schema type {}", to_string_view(type))};
+}
+
+inline error_info invalid_subject_schema(const subject& sub) {
+    return {
+      error_code::subject_schema_invalid,
+      fmt::format("Error while looking up schema under subject {}", sub())};
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -43,6 +43,9 @@ ss::future<ctx_server<service>::reply_t> get_subjects(
 ss::future<ctx_server<service>::reply_t> get_subject_versions(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> post_subject(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> post_subject_versions(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -79,6 +79,10 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       wrap(gate, es, get_subject_versions)});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::post_subject,
+      wrap(gate, es, post_subject)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::post_subject_versions,
       wrap(gate, es, post_subject_versions)});
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -110,6 +110,38 @@ ss::future<bool> sharded_store::upsert(
     co_return co_await upsert_subject(marker, sub, version, id, deleted);
 }
 
+ss::future<subject_schema> sharded_store::has_schema(
+  subject sub, schema_definition def, schema_type type) {
+    auto versions = co_await get_versions(sub, include_deleted::no);
+
+    if (validate(def(), type).has_error()) {
+        throw as_exception(invalid_subject_schema(sub));
+    }
+
+    std::optional<subject_schema> sub_schema;
+    for (auto ver : versions) {
+        try {
+            auto res = co_await get_subject_schema(
+              sub, ver, include_deleted::no);
+            if (def == res.definition) {
+                sub_schema.emplace(std::move(res));
+                break;
+            }
+        } catch (const exception& e) {
+            if (
+              e.code() == error_code::subject_not_found
+              || e.code() == error_code::subject_version_not_found) {
+            } else {
+                throw;
+            }
+        }
+    };
+    if (!sub_schema.has_value()) {
+        throw as_exception(schema_not_found());
+    }
+    co_return std::move(sub_schema).value();
+}
+
 ss::future<schema> sharded_store::get_schema(const schema_id& id) {
     auto schema = co_await _store.invoke_on(
       shard_for(id), _smp_opts, &store::get_schema, id);

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -44,6 +44,9 @@ public:
       schema_version version,
       is_deleted deleted);
 
+    ss::future<subject_schema>
+    has_schema(subject sub, schema_definition def, schema_type type);
+
     ///\brief Return a schema by id.
     ss::future<schema> get_schema(const schema_id& id);
 


### PR DESCRIPTION
## Cover letter

Introduce `POST /subjects/{subject}` - Check if a schema is already registered for the subject.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/c68f028b6ca150fab56b7189da7a6c17187ef57f..b126bd3e813ff6e18c0a80528346ea17b1e31753)
* Make exception handler more specific

## Release notes

Schema Registry: Introduce `POST /subjects/{subject}`