### PR TITLE
rpk: Support using lowercase for the SASL mechanism

### DIFF
--- a/src/go/rpk/pkg/kafka/client.go
+++ b/src/go/rpk/pkg/kafka/client.go
@@ -12,6 +12,7 @@ package kafka
 import (
 	"crypto/tls"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -192,7 +193,8 @@ func ConfigureSASL(
 	saramaConf.Net.SASL.Handshake = true
 	saramaConf.Net.SASL.User = sasl.User
 	saramaConf.Net.SASL.Password = sasl.Password
-	switch sasl.Mechanism {
+
+	switch strings.ToUpper(sasl.Mechanism) {
 	case sarama.SASLTypeSCRAMSHA256:
 		saramaConf.Net.SASL.SCRAMClientGeneratorFunc =
 			func() sarama.SCRAMClient {

--- a/src/go/rpk/pkg/kafka/client_test.go
+++ b/src/go/rpk/pkg/kafka/client_test.go
@@ -148,11 +148,31 @@ func TestConfigureSASL(t *testing.T) {
 			require.Equal(st, sarama.SASLTypeSCRAMSHA256, string(cfg.Net.SASL.Mechanism))
 		},
 	}, {
+		name: "it should set the appropriate mechanism for SCRAM-SHA-256 (lowercase)",
+		sasl: &config.SASL{
+			User:      "user1",
+			Password:  "pass",
+			Mechanism: "scram-sha-256",
+		},
+		check: func(st *testing.T, cfg *sarama.Config) {
+			require.Equal(st, sarama.SASLTypeSCRAMSHA256, string(cfg.Net.SASL.Mechanism))
+		},
+	}, {
 		name: "it should set the appropriate mechanism for SCRAM-SHA-512",
 		sasl: &config.SASL{
 			User:      "user1",
 			Password:  "pass",
 			Mechanism: "SCRAM-SHA-512",
+		},
+		check: func(st *testing.T, cfg *sarama.Config) {
+			require.Equal(st, sarama.SASLTypeSCRAMSHA512, string(cfg.Net.SASL.Mechanism))
+		},
+	}, {
+		name: "it should set the appropriate mechanism for SCRAM-SHA-512 (lowercase)",
+		sasl: &config.SASL{
+			User:      "user1",
+			Password:  "pass",
+			Mechanism: "scram-sha-512",
 		},
 		check: func(st *testing.T, cfg *sarama.Config) {
 			require.Equal(st, sarama.SASLTypeSCRAMSHA512, string(cfg.Net.SASL.Mechanism))


### PR DESCRIPTION
The kafka client builder function should support specifying the SASL mechanism in lowercase, since it's not unreasonable to think that a user will write it that way. 

Fix #2042