### PR TITLE
tests: add ducktape topic autocreation test

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -38,9 +38,10 @@ class RpkTool:
     def __init__(self, redpanda):
         self._redpanda = redpanda
 
-    def create_topic(self, topic, partitions=1):
+    def create_topic(self, topic, partitions=None):
         cmd = ["create", topic]
-        cmd += ["--partitions", str(partitions)]
+        if partitions is not None:
+            cmd += ["--partitions", str(partitions)]
         return self._run_topic(cmd)
 
     def list_topics(self):

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -50,8 +50,8 @@ class TopicSpec:
             compression_type=COMPRESSION_PRODUCER,
             message_timestamp_type=TIMESTAMP_CREATE_TIME,
             segment_bytes=1 * (2 ^ 30),
-            retention_bytes=-1,
-            retention_ms=(7 * 24 * 3600 * 1000)  # one week
+            retention_bytes=None,
+            retention_ms=None
     ):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -40,19 +40,17 @@ class TopicSpec:
     TIMESTAMP_CREATE_TIME = "CreateTime"
     TIMESTAMP_LOG_APPEND_TIME = "LogAppendTime"
 
-    def __init__(
-            self,
-            *,
-            name=None,
-            partition_count=1,
-            replication_factor=3,
-            cleanup_policy=CLEANUP_DELETE,
-            compression_type=COMPRESSION_PRODUCER,
-            message_timestamp_type=TIMESTAMP_CREATE_TIME,
-            segment_bytes=1 * (2 ^ 30),
-            retention_bytes=None,
-            retention_ms=None
-    ):
+    def __init__(self,
+                 *,
+                 name=None,
+                 partition_count=1,
+                 replication_factor=3,
+                 cleanup_policy=CLEANUP_DELETE,
+                 compression_type=COMPRESSION_PRODUCER,
+                 message_timestamp_type=TIMESTAMP_CREATE_TIME,
+                 segment_bytes=1 * (2 ^ 30),
+                 retention_bytes=None,
+                 retention_ms=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -312,12 +312,12 @@ class RedpandaService(Service):
         self.logger.debug(conf)
         node.account.create_file(RedpandaService.CONFIG_FILE, conf)
 
-    def restart_nodes(self, nodes):
+    def restart_nodes(self, nodes, override_cfg_params=None):
         nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
         for node in nodes:
             self.stop_node(node)
         for node in nodes:
-            self.start_node(node)
+            self.start_node(node, override_cfg_params)
 
     def registered(self, node):
         idx = self.idx(node)

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -28,9 +28,7 @@ class AlterTopicConfiguration(RedpandaTest):
 
     def __init__(self, test_context):
         super(AlterTopicConfiguration,
-              self).__init__(test_context=test_context,
-                             num_brokers=3,
-                             topics=self.topics)
+              self).__init__(test_context=test_context, num_brokers=3)
 
         self.kafka_tools = KafkaCliTools(self.redpanda)
 

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -27,7 +27,6 @@ class RedpandaTest(Test):
                  test_context,
                  num_brokers=3,
                  extra_rp_conf=dict(),
-                 topics=None,
                  enable_pp=False,
                  enable_sr=False,
                  num_cores=3):

--- a/tests/rptest/tests/topic_autocreate_test.py
+++ b/tests/rptest/tests/topic_autocreate_test.py
@@ -1,0 +1,66 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
+
+
+class TopicAutocreateTest(RedpandaTest):
+    """
+    Verify that autocreation works, and that the settings of an autocreated
+    topic match those for a topic created by hand with rpk.
+    """
+    def __init__(self, test_context):
+        super(TopicAutocreateTest, self).__init__(
+            test_context=test_context,
+            num_brokers=1,
+            extra_rp_conf={'auto_create_topics_enabled': False})
+
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
+
+    @cluster(num_nodes=1)
+    def topic_autocreate_test(self):
+        auto_topic = 'autocreated'
+        manual_topic = "manuallycreated"
+
+        # With autocreation disabled, producing to a nonexistent topic should not work.
+        try:
+            # Use rpk rather than kafka CLI because rpk errors out promptly
+            self.rpk.produce(auto_topic, "foo", "bar")
+        except Exception as e:
+            # The write failed, and shouldn't have created a topic
+            assert auto_topic not in self.kafka_tools.list_topics()
+        else:
+            assert False, "Producing to a nonexistent topic should fail"
+
+        # Enable autocreation
+        self.redpanda.restart_nodes(self.redpanda.nodes,
+                                    {'auto_create_topics_enabled': True})
+
+        # Auto create topic
+        assert auto_topic not in self.kafka_tools.list_topics()
+        self.kafka_tools.produce(auto_topic, 1, 4096)
+        assert auto_topic in self.kafka_tools.list_topics()
+        auto_topic_spec = self.kafka_tools.describe_topic(auto_topic)
+        assert auto_topic_spec.retention_ms is None
+        assert auto_topic_spec.retention_bytes is None
+
+        # Create topic by hand, compare its properties to the autocreated one
+        self.rpk.create_topic(manual_topic)
+        manual_topic_spec = self.kafka_tools.describe_topic(auto_topic)
+        assert manual_topic_spec.retention_ms == auto_topic_spec.retention_ms
+        assert manual_topic_spec.retention_bytes == auto_topic_spec.retention_bytes
+
+        # Clear name and compare the rest of the attributes
+        manual_topic_spec.name = auto_topic_spec.name = None
+        assert manual_topic_spec == auto_topic_spec


### PR DESCRIPTION
## Cover letter

This is a simple ducktape test for topic autocreation, along with a few test framework changes that came up while writing it.  Clearly this overlaps with the unit testing of the feature (autocreate_test.cc), but it's a good thing to have end to end testing as well.

## Release notes

Not user facing.