### PR TITLE
admin_server: fix double-free of the dashboard handler

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -136,12 +136,11 @@ void admin_server::configure_admin_routes() {
 
 void admin_server::configure_dashboard() {
     if (_cfg.dashboard_dir) {
-        _dashboard_handler = std::make_unique<dashboard_handler>(
-          *_cfg.dashboard_dir);
+        auto handler = std::make_unique<dashboard_handler>(*_cfg.dashboard_dir);
         _server._routes.add(
           ss::httpd::operation_type::GET,
           ss::httpd::url("/dashboard").remainder("path"),
-          _dashboard_handler.get());
+          handler.release());
     }
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -102,7 +102,6 @@ private:
     ss::sharded<cluster::partition_manager>& _partition_manager;
     cluster::controller* _controller;
     ss::sharded<cluster::shard_table>& _shard_table;
-    std::unique_ptr<dashboard_handler> _dashboard_handler;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
     bool _ready{false};
 };


### PR DESCRIPTION
## Cover letter

Fix the segfault that happens during the shutdown if the HTTP dashboard is enabled. 

Seastar docs are pretty vague about the ownership semantics, but it looks like `seastar::http_server` is deleting the handlers itself: https://github.com/vectorizedio/seastar/blob/5f88b17f3270628f521dd66ef52352dada150eb2/include/seastar/http/matchrules.hh#L51

## Release notes

None.