### PR TITLE
Propagating raft append entries request backpressure

### DIFF
--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -81,6 +81,7 @@ namespace raft {
 
 class replicate_entries_stm {
 public:
+    using units_t = std::vector<ss::semaphore_units<>>;
     replicate_entries_stm(
       consensus*,
       append_entries_request,
@@ -111,13 +112,14 @@ private:
     ss::future<result<storage::append_result>> append_to_self();
     consensus* _ptr;
     /// we keep a copy around until we finish the retries
-    append_entries_request _req;
+    std::unique_ptr<append_entries_request> _req;
     absl::flat_hash_map<vnode, follower_req_seq> _followers_seq;
     ss::semaphore _share_sem;
     ss::semaphore _dispatch_sem{0};
     ss::gate _req_bg;
     ctx_log _ctxlog;
     model::offset _dirty_offset;
+    ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> _units;
 };
 
 } // namespace raft

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -108,8 +108,12 @@ public:
 
 private:
     using sequence_t = named_type<uint64_t, struct sequence_tag>;
+    struct entry {
+        std::unique_ptr<netbuf> buffer;
+        client_opts::resource_units_t resource_units;
+    };
     using requests_queue_t
-      = absl::btree_map<sequence_t, std::unique_ptr<netbuf>>;
+      = absl::btree_map<sequence_t, std::unique_ptr<entry>>;
     friend client_context_impl;
     ss::future<> do_reads();
     ss::future<> dispatch(header);


### PR DESCRIPTION
## Cover letter

Implemented propagating backpressure from RPC layer to Kafka layer through raft. Previously number of requests queued in RPC system was unbounded. This might lead to OOM during high throughput load. 

Fixed issue by passing resource related `semaphore_units` down to RPC layer. The resource units are released when request is sent over the wire and is not longer needed.

Fixes: #2050 

## Release notes
Release note: [1-2 sentences of what this PR changes]
