### PR TITLE
schema_registry: Introduce GET /schemas/ids/{id}/versions

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -236,6 +236,57 @@
         }
       }
     },
+    "/schemas/ids/{id}/versions": {
+      "get": {
+        "summary": "Get a list of subject-version for the schema id.",
+        "operationId": "get_schemas_ids_id_versions",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "subject": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Schema not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
     "/subjects": {
       "get": {
         "summary": "Retrieve a list of subjects.",

--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy Schema Registry",
-    "version": "0.0.3"
+    "version": "0.0.4"
   },
   "host": "{{Host}}",
   "basePath": "/",

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -37,6 +37,9 @@ ss::future<ctx_server<service>::reply_t> get_schemas_types(
 ss::future<ctx_server<service>::reply_t> get_schemas_ids_id(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_versions(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> get_subjects(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id_versions.h
+++ b/src/v/pandaproxy/schema_registry/requests/get_schemas_ids_id_versions.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/json/rjson_util.h"
+#include "pandaproxy/schema_registry/types.h"
+
+namespace pandaproxy::schema_registry {
+
+struct get_schemas_ids_id_versions_response {
+    std::vector<subject_version> subject_versions;
+};
+
+inline void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const get_schemas_ids_id_versions_response& res) {
+    w.StartArray();
+    for (const auto& sv : res.subject_versions) {
+        w.StartObject();
+        w.Key("subject");
+        ::json::rjson_serialize(w, sv.sub);
+        w.Key("version");
+        ::json::rjson_serialize(w, sv.version);
+        w.EndObject();
+    }
+    w.EndArray();
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -71,6 +71,10 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       wrap(gate, es, get_schemas_ids_id)});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::get_schemas_ids_id_versions,
+      wrap(gate, es, get_schemas_ids_id_versions)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::get_subjects,
       wrap(gate, es, get_subjects)});
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -50,6 +50,10 @@ public:
     ///\brief Return a schema by id.
     ss::future<schema> get_schema(const schema_id& id);
 
+    ///\brief Return a list of subject-versions for the shema id.
+    ss::future<std::vector<subject_version>>
+    get_schema_subject_versions(schema_id id);
+
     ///\brief Return a schema by subject and version.
     ss::future<subject_schema> get_subject_schema(
       const subject& sub, schema_version version, include_deleted inc_dec);

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -78,6 +78,19 @@ public:
                                       : s_it->first;
     }
 
+    ///\brief Return a list of subject-versions for the shema id.
+    std::vector<subject_version> get_schema_subject_versions(schema_id id) {
+        std::vector<subject_version> svs;
+        for (const auto& s : _subjects) {
+            for (const auto& vs : s.second.versions) {
+                if (vs.id == id && !vs.deleted) {
+                    svs.emplace_back(s.first, vs.version);
+                }
+            }
+        }
+        return svs;
+    }
+
     ///\brief Return subject_version_id for a subject and version
     result<subject_version_id> get_subject_version_id(
       const subject& sub,

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -86,6 +86,14 @@ static constexpr schema_version invalid_schema_version{-1};
 using schema_id = named_type<int32_t, struct schema_id_tag>;
 static constexpr schema_id invalid_schema_id{-1};
 
+struct subject_version {
+    subject_version(subject s, schema_version v)
+      : sub{std::move(s)}
+      , version{v} {}
+    subject sub;
+    schema_version version;
+};
+
 // Very similar to topic_key_type, separate to avoid intermingling storage code
 enum class seq_marker_key_type { invalid = 0, schema, delete_subject, config };
 


### PR DESCRIPTION
## Cover letter

Introduce `GET /schemas/ids/{id}/versions`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/ae319aecb4ff6c6856be8be62d54cf6c7cfa0f4e..1969945a19d6795c594002a6ba7ada089871a9bc)
* Fix store tests - `ctest -L pandaproxy` doesn't seem to detect errors in the unit test
* Remove unused variable in handler
* Add ducktape test for 40403 if schema not found

## Release notes

schema_registry: Introduce `GET /schemas/ids/{id}/versions`