### PR TITLE
schema_registry: Improve delete_subject

### DIFF
--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -279,7 +279,7 @@ seq_writer::delete_subject_impermanent(subject sub) {
       -> ss::future<std::optional<std::vector<schema_version>>> {
         // Grab the versions before they're gone.
         auto versions = co_await seq._store.get_versions(
-          sub, include_deleted::yes);
+          sub, include_deleted::no);
 
         // Inspect the subject to see if its already deleted
         if (co_await seq._store.is_subject_deleted(sub)) {

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -267,11 +267,11 @@ public:
         auto& versions = sub_it->second.versions;
         std::vector<schema_version> res;
         res.reserve(versions.size());
-        std::transform(
-          versions.begin(),
-          versions.end(),
-          std::back_inserter(res),
-          [](const auto& v) { return v.version; });
+        for (const auto& ver : versions) {
+            if (permanent || !ver.deleted) {
+                res.push_back(ver.version);
+            }
+        }
 
         if (permanent) {
             _subjects.erase(sub_it);

--- a/src/v/pandaproxy/schema_registry/test/store.cc
+++ b/src/v/pandaproxy/schema_registry/test/store.cc
@@ -586,3 +586,43 @@ BOOST_AUTO_TEST_CASE(test_store_delete_subject_version) {
       s.delete_subject_version(subject0, pps::schema_version{1}).error().code(),
       pps::error_code::subject_version_not_found);
 }
+
+BOOST_AUTO_TEST_CASE(test_store_delete_subject_after_delete_version) {
+    std::vector<pps::schema_version> expected_vers{{pps::schema_version{2}}};
+
+    pps::store s;
+    s.set_compatibility(pps::compatibility_level::none).value();
+
+    pps::seq_marker dummy_marker;
+
+    // First insert, expect id{1}, version{1}
+    s.insert(subject0, string_def0, pps::schema_type::avro);
+    s.insert(subject0, int_def0, pps::schema_type::avro);
+
+    // delete version 1
+    s.upsert_subject(
+      dummy_marker,
+      subject0,
+      pps::schema_version{1},
+      pps::schema_id{1},
+      pps::is_deleted::yes);
+
+    auto del_res = s.delete_subject(
+      dummy_marker, subject0, pps::permanent_delete::no);
+    BOOST_REQUIRE(del_res.has_value());
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      del_res.value().cbegin(),
+      del_res.value().cend(),
+      expected_vers.cbegin(),
+      expected_vers.cend());
+
+    expected_vers = {{pps::schema_version{1}}, {pps::schema_version{2}}};
+    del_res = s.delete_subject(
+      dummy_marker, subject0, pps::permanent_delete::yes);
+    BOOST_REQUIRE(del_res.has_value());
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      del_res.value().cbegin(),
+      del_res.value().cend(),
+      expected_vers.cbegin(),
+      expected_vers.cend());
+}

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -609,9 +609,15 @@ class SchemaRegistryTest(RedpandaTest):
         self.logger.debug(result_raw)
         assert result_raw.status_code == requests.codes.not_found
 
-        self.logger.debug("Soft delete subject")
+        self.logger.debug("delete version 2")
+        result_raw = self._delete_subject_version(subject=f"{topic}-key",
+                                                  version=2)
+        assert result_raw.status_code == requests.codes.ok
+
+        self.logger.debug("Soft delete subject - expect 1,3")
         result_raw = self._delete_subject(subject=f"{topic}-key")
         assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json() == [1, 3]
 
         self.logger.debug("Get versions")
         result_raw = self._get_subjects_subject_versions(
@@ -631,6 +637,7 @@ class SchemaRegistryTest(RedpandaTest):
                                           permanent=True)
         self.logger.debug(result_raw)
         assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json() == [1, 2, 3]
 
     @cluster(num_nodes=3)
     def test_delete_subject_version(self):


### PR DESCRIPTION
When deleting a subject:
* Soft - should not return soft-deleted versions
* Perm - should return all versions

Signed-off-by: Ben Pope <ben@vectorized.io>

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/5e1f1ddb91ad89fcab4f2fe3dbbe31bfcc27e3fb..26d15db02bfcafdd026abfc5ea245c0e8b88c6b7)
* `task lint:python`

## Cover letter

schema_registry: Soft-deleting a subject no longer returns soft-deleted versions
