### PR TITLE
tools: wait for exit code in cmake_test.py

### DIFF
--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -240,7 +240,7 @@ class TestRunner():
         t.start()
         t.join()
 
-        sys.exit(p.returncode)
+        sys.exit(p.wait())
 
 
 def main():


### PR DESCRIPTION
## Cover letter

When this was refactored with streaming handling
of stderr, we dropped out when the stream closed,
which does not set the returncode on the python
process object.  Call wait() to get the returncode
instead.

## Release notes
Not user visibile