### PR TITLE
r/consensus: fixed suppressing follower heartbeats

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2458,7 +2458,13 @@ heartbeats_suppressed consensus::are_heartbeats_suppressed(vnode id) const {
 void consensus::update_suppress_heartbeats(
   vnode id, follower_req_seq last_seq, heartbeats_suppressed suppressed) {
     if (auto it = _fstats.find(id); it != _fstats.end()) {
-        if (last_seq <= it->second.last_sent_seq) {
+        /**
+         * Since there may be concurrent sources causing heartbeats suppression
+         * we use last_suppress_heartbeats_seq to control concurrency of
+         * heartbeats state update
+         */
+        if (last_seq >= it->second.last_suppress_heartbeats_seq) {
+            it->second.last_suppress_heartbeats_seq = last_seq;
             it->second.suppress_heartbeats = suppressed;
         }
     }

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -149,10 +149,11 @@ struct follower_index_metadata {
      */
     ss::condition_variable follower_state_change;
     /**
-     * We prevent race conditions accessing suppress_heartbeats flag using the
-     * `last_sent_seq` value for version control.
+     * We prevent race conditions accessing suppress_heartbeats with MVCC based
+     * on last_suppress_heartbeats_seq field.
      */
     heartbeats_suppressed suppress_heartbeats = heartbeats_suppressed::no;
+    follower_req_seq last_suppress_heartbeats_seq{0};
 };
 /**
  * class containing follower statistics, this may be helpful for debugging,


### PR DESCRIPTION
In redpanda raft implementation we allow to have multiple append entries
request pending in flight to each follower. When append entries request
is send to the follower we suppress sending heartbeat requests. When
multiple requests are pending to be replied by the follower we have to
guarantee that heartbeats will be suppressed until the last request was
replied.
Fixed updating heartbeat suppression state by correctly using MVCC in
follower stats. Now we only allow to update heartbeat suppression state
with response that is later than last update. This fixes not necessary
log truncation that was occurring when testing redpanda with heavy load.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
