### PR TITLE
Node operations fuzzing test adjustments

### DIFF
--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -164,6 +164,8 @@ class NodeOperationFuzzyTest(EndToEndTest):
             if cleanup:
                 self.redpanda.clean_node(self.redpanda.nodes[node_id - 1])
             self.redpanda.start_node(self.redpanda.nodes[node_id - 1])
+            admin = Admin(self.redpanda)
+            admin.set_log_level("cluster", "trace")
 
             def has_new_replicas():
                 per_node = replicas_per_node()
@@ -172,6 +174,8 @@ class NodeOperationFuzzyTest(EndToEndTest):
 
             wait_until(has_new_replicas, timeout_sec=240, backoff_sec=2)
 
+        admin = Admin(self.redpanda)
+        admin.set_log_level("cluster", "trace")
         work = self.generate_random_workload(10)
         self.redpanda.logger.info(f"node operations to execute: {work}")
         for op in work:

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -28,7 +28,7 @@ ALLOWED_REPLICATION = [1, 3]
 
 
 class NodeOperationFuzzyTest(EndToEndTest):
-    def generate_random_workload(self, count):
+    def generate_random_workload(self, count, skip_nodes):
         op_types = [ADD, DECOMMISSION, ADD_NO_DELETE]
         tp_op_types = [ADD_TOPIC, DELETE_TOPIC]
         # current state
@@ -36,6 +36,11 @@ class NodeOperationFuzzyTest(EndToEndTest):
         decommissioned_nodes = []
         operations = []
         topics = []
+
+        def eligible_active_nodes():
+            return list(
+                filter(lambda n: not (n == 1 or n in skip_nodes),
+                       active_nodes))
 
         def decommission(id):
             active_nodes.remove(id)
@@ -51,13 +56,13 @@ class NodeOperationFuzzyTest(EndToEndTest):
                 operations.append((random.choice([ADD, ADD_NO_DELETE]), id))
                 add(id)
             elif len(decommissioned_nodes) == 0:
-                id = random.choice(active_nodes[1:])
+                id = random.choice(eligible_active_nodes())
                 operations.append((DECOMMISSION, id))
                 decommission(id)
             else:
                 op = random.choice(op_types)
                 if op == DECOMMISSION:
-                    id = random.choice(active_nodes[1:])
+                    id = random.choice(eligible_active_nodes())
                     operations.append((DECOMMISSION, id))
                     decommission(id)
                 elif op == ADD:
@@ -126,6 +131,15 @@ class NodeOperationFuzzyTest(EndToEndTest):
         self.start_producer(1, throughput=100)
         self.start_consumer(1)
         self.await_startup()
+        admin = Admin(self)
+        nodes_to_skip = set()
+        for n in self.redpanda.nodes:
+            p = admin.get_partitions(namespace="kafka_internal",
+                                     topic="group",
+                                     node=n,
+                                     partition=0)
+            self.redpanda.logger.info(f"group partition: {p}")
+            nodes_to_skip.add(p["replicas"][0]["node_id"])
 
         def decommission(node_id):
             self.logger.info(f"decommissioning node: {node_id}")
@@ -176,7 +190,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
 
         admin = Admin(self.redpanda)
         admin.set_log_level("cluster", "trace")
-        work = self.generate_random_workload(10)
+        work = self.generate_random_workload(10, skip_nodes=nodes_to_skip)
         self.redpanda.logger.info(f"node operations to execute: {work}")
         for op in work:
             op_type = op[0]

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -123,7 +123,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
         # select one of the topics to use in consumer/producer
         self.topic = random.choice(topics).name
 
-        self.start_producer(1)
+        self.start_producer(1, throughput=100)
         self.start_consumer(1)
         self.await_startup()
 


### PR DESCRIPTION
## Cover letter

Fixed partition operation error caused by the raft group not being able to elect a new leader and make progress. 

### Details
It is possible in some situations that node will have to wait indefinitely for configuration to be replicated after it became a leader. (consider situation in which there is only one voter in raft configuration). If this situation happen vote timeout will never be rearmed and no new leader will be elected in the cluster.

Example that may lead to the error:

Raft group configuration (voters: {1}, learner: {2})

1) node 1 became a leader
2) node 1 request replication (request to {2} was skipped since it is
   recovering)
3) node 1 receives append_entries_request from a node that is replying
   controller history (old revision of current raft group)
4) node 1 lose leadership
5) node 1 waits for replication to finish - vote timer is not rearmed

In this scenario node 2 can not be elected as a leader since it is a learner. There is no leader in the raft group



Made some adjustments in `node_opertions_fuzzying` test to make it less dependent on environment.



Fixes: #2096
