### PR TITLE
Clarify some log messages & metrics

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -226,7 +226,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
     if (!transfer) {
         vlog(
           clusterlog.info,
-          "No leadership balance improvements found with total error {}",
+          "No leadership balance improvements found with total delta {}",
           error);
         if (!_timer.armed()) {
             _timer.arm(_idle_timeout);
@@ -316,7 +316,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
         _probe.leader_transfer_succeeded();
         vlog(
           clusterlog.info,
-          "Leadership for group {} moved from {} to {} (target {}). Error {}",
+          "Leadership for group {} moved from {} to {} (target {}). Delta {}",
           transfer->group,
           transfer->from,
           *leader_shard,

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -235,7 +235,7 @@ consensus::success_reply consensus::update_follower_index(
       && reply.last_dirty_log_index < _log.offsets().dirty_offset) {
         vlog(
           _ctxlog.trace,
-          "ignorring reordered reply {} from node {} - last: {} current: {} ",
+          "ignoring reordered reply {} from node {} - last: {} current: {} ",
           reply,
           reply.node_id,
           idx.last_received_seq,
@@ -266,7 +266,7 @@ consensus::success_reply consensus::update_follower_index(
 
     // check preconditions for processing the reply
     if (!is_leader()) {
-        vlog(_ctxlog.debug, "ignorring append entries reply, not leader");
+        vlog(_ctxlog.debug, "ignoring append entries reply, not leader");
         return success_reply::no;
     }
     // If RPC request or response contains term T > currentTerm:
@@ -390,7 +390,7 @@ void consensus::successfull_append_entries_reply(
     idx.next_index = details::next_offset(idx.last_dirty_log_index);
     vlog(
       _ctxlog.trace,
-      "Updated node {} match {} and next {} indicies",
+      "Updated node {} match {} and next {} indices",
       idx.node_id,
       idx.match_index,
       idx.next_index);
@@ -1244,7 +1244,7 @@ ss::future<vote_reply> consensus::do_vote(vote_request&& r) {
     if (n_priority < _target_priority && !r.leadership_transfer) {
         vlog(
           _ctxlog.info,
-          "not grainting vote to node {}, it has priority {} which is lower "
+          "not granting vote to node {}, it has priority {} which is lower "
           "than current target priority {}",
           r.node_id,
           n_priority,
@@ -1428,7 +1428,7 @@ consensus::do_append_entries(append_entries_request&& r) {
       && r.meta.prev_log_term != last_log_term) {
         vlog(
           _ctxlog.debug,
-          "Rejecting append entries. missmatching entry term at offset: "
+          "Rejecting append entries. mismatching entry term at offset: "
           "{}, current term: {} request term: {}",
           r.meta.prev_log_index,
           last_log_term,

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -233,7 +233,7 @@ void heartbeat_manager::process_reply(
     if (!r) {
         vlog(
           hbeatlog.trace,
-          "Could not send hearbeats to node:{}, reason:{}, message:{}",
+          "Could not send heartbeats to node:{}, reason:{}, message:{}",
           n,
           r,
           r.error().message());
@@ -287,7 +287,7 @@ void heartbeat_manager::dispatch_heartbeats() {
             });
         });
     }).handle_exception([](const std::exception_ptr& e) {
-        vlog(hbeatlog.warn, "Error dispatching hearbeats - {}", e);
+        vlog(hbeatlog.warn, "Error dispatching heartbeats - {}", e);
     });
     // update last
     _hbeat = clock_type::now();

--- a/src/v/rpc/probes.cc
+++ b/src/v/rpc/probes.cc
@@ -43,7 +43,7 @@ void server_probe::setup_metrics(
           "requests_completed",
           [this] { return _requests_completed; },
           sm::description(
-            ssx::sformat("{}: Number of successfull requests", proto))),
+            ssx::sformat("{}: Number of successful requests", proto))),
         sm::make_total_bytes(
           "received_bytes",
           [this] { return _in_bytes; },
@@ -178,7 +178,7 @@ void client_probe::setup_metrics(
         sm::make_derive(
           "requests_blocked_memory",
           [this] { return _requests_blocked_memory; },
-          sm::description("Number of requests that are blocked beacause"
+          sm::description("Number of requests that are blocked because"
                           " of insufficient memory"),
           labels),
       });

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -530,10 +530,7 @@ ss::future<compaction_result> self_compact_segment(
           case compacted_index::recovery_state::missing:
               [[fallthrough]];
           case compacted_index::recovery_state::needsrebuild: {
-              vlog(
-                stlog.warn,
-                "Detected corrupt or missing index file:{}, recovering...",
-                idx_path);
+              vlog(stlog.info, "Rebuilding index file... ({})", idx_path);
               pb.corrupted_compaction_index();
               return s->read_lock()
                 .then([s, cfg, &pb, idx_path](ss::rwlock::holder h) {
@@ -545,7 +542,7 @@ ss::future<compaction_result> self_compact_segment(
                 .then([s, cfg, &pb, idx_path, &readers_cache] {
                     vlog(
                       stlog.info,
-                      "recovered index: {}, attempting compaction again",
+                      "rebuilt index: {}, attempting compaction again",
                       idx_path);
                     return self_compact_segment(s, cfg, pb, readers_cache);
                 });


### PR DESCRIPTION
## Cover letter

Some non-functional changes to human readable output:
- Clarify some misleadingly scary sounding log messages
- Fix some typos in raft logs that made grepping for misspelled words awkward
- Fix some rpc metric descriptions that surfaced misspelled words into user-visible grafana dashboards

Fixes: https://github.com/vectorizedio/redpanda/issues/1976

## Release notes

None.
