### PR TITLE
leader_balancer: fix logging

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -590,6 +590,7 @@ ss::future<bool> leader_balancer::do_transfer_remote(reassignment transfer) {
         vlog(
           clusterlog.info,
           "Leadership transfer of group {} failed with error: {}",
+          transfer.group,
           res.error().message());
         co_return false;
     }
@@ -601,6 +602,7 @@ ss::future<bool> leader_balancer::do_transfer_remote(reassignment transfer) {
     vlog(
       clusterlog.info,
       "Leadership transfer of group {} failed with error: {}",
+      transfer.group,
       raft::make_error_code(res.value().result));
 
     co_return false;


### PR DESCRIPTION
## Cover letter

I was seeing messages like
```
ERROR 2021-08-18 22:48:59,565 [shard 0] cluster - ../../../src/v/cluster/scheduling/leader_balancer.cc:593 @do_transfer_remote: failed to log message: fmt='{}:{} - Leadership transfer of group {} failed with error: {}': fmt::v7::format_error (argument not found)
```

## Release notes

None