### PR TITLE
storage: avoid file size moving backward

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -253,7 +253,7 @@ ss::future<> segment::do_flush() {
         // finishes we guarantee that all previous flushes finished.
         _tracker.committed_offset = std::max(o, _tracker.committed_offset);
         _tracker.stable_offset = _tracker.committed_offset;
-        _reader.set_file_size(fsize);
+        _reader.set_file_size(std::max(fsize, _reader.file_size()));
     });
 }
 


### PR DESCRIPTION
In 9c7086318027b0f2bf4e1fd8511133feefc750e4 it was identified that many parallel flushes that capture dirty offset before a scheduling point could result in the committed offset moving backwards depending on which order the flush completions ran.

The same issue occurs with the file size, leading the file size moving backwards under parallel flush loads.

Fixes: #1971

@jcsp I spent most of the day trying to reproduce #1971 with very little luck (once or twice triggered with probably 20+ attempts). So it would be great if you could test this on (1) v21.8.x and (2) I think on one of the sha1's from a few days ago before all of Michal's fixes. I'm not sure about (2) but it seems like a good extra test point. For (1) it might be useful to add to the load generate many small fetches that run concurrently with produces.

@mmaslankaprv do you recall if you had thought about applying the same fix from 9c7086318027b0f2bf4e1fd8511133feefc750e4 to file size when you had added a similar fix for committed offset a few lines above the fix in this PR?