### PR TITLE
Backport: storage: avoid file size moving backward

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -253,7 +253,7 @@ ss::future<> segment::do_flush() {
         // finishes we guarantee that all previous flushes finished.
         _tracker.committed_offset = std::max(o, _tracker.committed_offset);
         _tracker.stable_offset = _tracker.committed_offset;
-        _reader.set_file_size(fsize);
+        _reader.set_file_size(std::max(fsize, _reader.file_size()));
     });
 }
 


### PR DESCRIPTION
Backport of https://github.com/vectorizedio/redpanda/pull/2102

Fixes: #1971

Tested with many-producers tool.  Before fix it crashed in 10 seconds, after fix it ran til it filled up the disk.