### PR TITLE
cluster: use muted nodes to improve leadership rebalancing

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -202,6 +202,7 @@ ss::future<> controller::start() {
             std::ref(_as),
             config::shard_local_cfg().leader_balancer_idle_timeout(),
             config::shard_local_cfg().leader_balancer_mute_timeout(),
+            config::shard_local_cfg().leader_balancer_node_mute_timeout(),
             _raft0);
           return _leader_balancer->start();
       });

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -208,7 +208,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
      * (e.g. on average little should change between ticks) and bounding the
      * search for leader moves.
      */
-    greedy_balanced_shards strategy(build_index());
+    greedy_balanced_shards strategy(build_index(), {});
 
     if (clusterlog.is_enabled(ss::log_level::trace)) {
         auto cores = strategy.stats();

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -45,9 +45,11 @@ leader_balancer::leader_balancer(
   ss::sharded<ss::abort_source>& as,
   std::chrono::milliseconds idle_timeout,
   std::chrono::milliseconds mute_timeout,
+  std::chrono::milliseconds node_mute_timeout,
   consensus_ptr raft0)
   : _idle_timeout(idle_timeout)
   , _mute_timeout(mute_timeout)
+  , _node_mute_timeout(node_mute_timeout)
   , _topics(topics)
   , _leaders(leaders)
   , _client(std::move(client))
@@ -208,7 +210,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
      * (e.g. on average little should change between ticks) and bounding the
      * search for leader moves.
      */
-    greedy_balanced_shards strategy(build_index(), {});
+    greedy_balanced_shards strategy(build_index(), muted_nodes());
 
     if (clusterlog.is_enabled(ss::log_level::trace)) {
         auto cores = strategy.stats();
@@ -343,6 +345,25 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
      */
     _muted.try_emplace(transfer->group, clock_type::now() + _mute_timeout);
     co_return ss::stop_iteration::no;
+}
+
+absl::flat_hash_set<model::node_id> leader_balancer::muted_nodes() const {
+    absl::flat_hash_set<model::node_id> nodes;
+    const auto now = raft::clock_type::now();
+    for (const auto& follower : _raft0->get_follower_metrics()) {
+        auto last_hbeat_age = now - follower.last_heartbeat;
+        if (last_hbeat_age > _node_mute_timeout) {
+            nodes.insert(follower.id);
+            vlog(
+              clusterlog.info,
+              "Leadership rebalancer muting node {} last heartbeat {} ms",
+              follower.id,
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                last_hbeat_age)
+                .count());
+        }
+    }
+    return nodes;
 }
 
 absl::flat_hash_set<raft::group_id> leader_balancer::muted_groups() const {

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -228,8 +228,10 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
     if (!transfer) {
         vlog(
           clusterlog.info,
-          "No leadership balance improvements found with total delta {}",
-          error);
+          "No leadership balance improvements found with total delta {}, "
+          "number of muted groups {}",
+          error,
+          _muted.size());
         if (!_timer.armed()) {
             _timer.arm(_idle_timeout);
         }

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -73,6 +73,7 @@ public:
       ss::sharded<ss::abort_source>&,
       std::chrono::milliseconds,
       std::chrono::milliseconds,
+      std::chrono::milliseconds,
       consensus_ptr);
 
     ss::future<> start();
@@ -85,6 +86,7 @@ private:
     index_type build_index();
     std::optional<model::broker_shard> find_leader_shard(const model::ntp&);
     absl::flat_hash_set<raft::group_id> muted_groups() const;
+    absl::flat_hash_set<model::node_id> muted_nodes() const;
 
     ss::future<bool> do_transfer(reassignment);
     ss::future<bool> do_transfer_local(reassignment) const;
@@ -120,6 +122,13 @@ private:
      * successfully so that we do not pertrub them too much on accident.
      */
     clock_type::duration _mute_timeout;
+
+    /*
+     * threshold timeout of not having a raft0 heartbeat after which the node
+     * will be muted. muting a node removes its capacity from consideration when
+     * choosing new rebalancing targets for leadership.
+     */
+    clock_type::duration _node_mute_timeout;
 
     struct last_known_leader {
         model::broker_shard shard;

--- a/src/v/cluster/tests/leader_balancer_test.cc
+++ b/src/v/cluster/tests/leader_balancer_test.cc
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(greedy) {
         }
     }
 
-    auto greed = cluster::greedy_balanced_shards(index);
+    auto greed = cluster::greedy_balanced_shards(index, {});
     BOOST_REQUIRE_EQUAL(greed.error(), 0);
 
     // new groups on shard 5
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(greedy) {
     index[shards[5]][raft::group_id(21)] = index[shards[5]][raft::group_id(3)];
     index[shards[5]][raft::group_id(22)] = index[shards[5]][raft::group_id(3)];
 
-    greed = cluster::greedy_balanced_shards(index);
+    greed = cluster::greedy_balanced_shards(index, {});
     BOOST_REQUIRE_GT(greed.error(), 0);
 
     // movement should be _from_ the overloaded shard

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -851,6 +851,12 @@ configuration::configuration()
       "Leadership rebalancing mute timeout",
       required::no,
       5min)
+  , leader_balancer_node_mute_timeout(
+      *this,
+      "leader_balancer_mute_timeout",
+      "Leadership rebalancing node mute timeout",
+      required::no,
+      20s)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -205,6 +205,7 @@ struct configuration final : public config_store {
     property<bool> enable_leader_balancer;
     property<std::chrono::milliseconds> leader_balancer_idle_timeout;
     property<std::chrono::milliseconds> leader_balancer_mute_timeout;
+    property<std::chrono::milliseconds> leader_balancer_node_mute_timeout;
 
     configuration();
 


### PR DESCRIPTION
Uses concept of muted node (a node that seems to be unavailable) to improve balancing. The improvements occur when a node is down for some time: prior to this patch, the node that was down would be given priority because it had the most spare capacity. But since it couldn't receive any leadership transfers, balancing among the remaining healthy nodes was non-optimal / didn't work. By muting the node we temporarily remove it from available capacity, and allow balancing across healthy nodes.

Fixes: #2092