### PR TITLE
Fixed shutting down raft

### DIFF
--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -19,11 +19,14 @@
 #include "resource_mgmt/io_priority.h"
 #include "vlog.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/smp.hh>
 
+#include <algorithm>
 #include <exception>
+#include <iterator>
 
 namespace cluster {
 
@@ -80,6 +83,20 @@ ss::future<> partition_manager::remove(const model::ntp& ntp) {
       .then([partition] { return partition->stop(); })
       .then([this, ntp] { return _storage.log_mgr().remove(ntp); })
       .finally([partition] {}); // in the end remove partition
+}
+
+ss::future<> partition_manager::shutdown_all() {
+    std::vector<model::ntp> ntps;
+    ntps.reserve(_ntp_table.size());
+    std::transform(
+      _ntp_table.begin(),
+      _ntp_table.end(),
+      std::back_inserter(ntps),
+      [](const ntp_table_container::value_type& p) { return p.first; });
+
+    for (const auto& ntp : ntps) {
+        co_await shutdown(ntp);
+    }
 }
 
 ss::future<> partition_manager::shutdown(const model::ntp& ntp) {

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -65,6 +65,7 @@ public:
       manage(storage::ntp_config, raft::group_id, std::vector<model::broker>);
 
     ss::future<> shutdown(const model::ntp& ntp);
+    ss::future<> shutdown_all();
     ss::future<> remove(const model::ntp& ntp);
 
     std::optional<storage::log> log(const model::ntp& ntp) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -157,8 +157,8 @@ ss::future<> consensus::stop() {
 
     return _event_manager.stop()
       .then([this] { return _append_requests_buffer.stop(); })
-      .then([this] { return _bg.close(); })
       .then([this] { return _batcher.stop(); })
+      .then([this] { return _bg.close(); })
       .then([this] {
           // close writer if we have to
           if (likely(!_snapshot_writer)) {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -338,6 +338,11 @@ private:
     do_append_entries(append_entries_request&&);
     ss::future<install_snapshot_reply>
     do_install_snapshot(install_snapshot_request&& r);
+
+    ss::future<result<replicate_result>> dispatch_replicate(
+      append_entries_request,
+      std::vector<ss::semaphore_units<>>,
+      absl::flat_hash_map<vnode, follower_req_seq>);
     /**
      * Hydrate the consensus state with the data from the snapshot
      */

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -48,17 +48,16 @@ public:
     replicate_stages
     replicate(std::optional<model::term_id>, model::record_batch_reader&&);
 
-    ss::future<> flush(ss::semaphore_units<> u);
     ss::future<> stop();
 
-    // it will lock on behalf of caller to append entries to leader log.
+private:
+    ss::future<> flush(ss::semaphore_units<> u);
     ss::future<> do_flush(
-      std::vector<item_ptr>&&,
-      append_entries_request&&,
+      std::vector<item_ptr>,
+      append_entries_request,
       std::vector<ss::semaphore_units<>>,
       absl::flat_hash_map<vnode, follower_req_seq>);
 
-private:
     ss::future<item_ptr>
     do_cache(std::optional<model::term_id>, model::record_batch_reader&&);
     ss::future<replicate_batcher::item_ptr> do_cache_with_backpressure(

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -17,6 +17,7 @@
 #include "units.h"
 #include "utils/mutex.h"
 
+#include <seastar/core/gate.hh>
 #include <seastar/core/semaphore.hh>
 
 #include <absl/container/flat_hash_map.h>
@@ -70,6 +71,7 @@ private:
     size_t _max_batch_size;
     std::vector<item_ptr> _item_cache;
     mutex _lock;
+    ss::gate _bg;
 };
 
 } // namespace raft

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -247,8 +247,7 @@ class RedpandaService(Service):
         pids = self.pids(node)
 
         for pid in pids:
-            # TODO: change SIGKILL back to SIGTERM after we solve graceful shutdown issue
-            node.account.signal(pid, signal.SIGKILL, allow_fail=False)
+            node.account.signal(pid, signal.SIGTERM, allow_fail=False)
 
         timeout_sec = 30
         wait_until(lambda: len(self.pids(node)) == 0,


### PR DESCRIPTION
## Cover letter

Fixed shutting down Raft groups and redpanda application. Failing to stop partition may lead to situation in which partition movement related with decommissioning or node addition will never finish.  


## Release notes