### PR TITLE
serde: fix for float/double and optional

### DIFF
--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -251,6 +251,20 @@ SEASTAR_THREAD_TEST_CASE(all_types_test) {
         auto parser = iobuf_parser{std::move(b)};
         BOOST_CHECK(!serde::read<std::optional<int32_t>>(parser).has_value());
     }
+
+    {
+        auto b = iobuf();
+        serde::write(b, float{-123.456});
+        auto parser = iobuf_parser{std::move(b)};
+        BOOST_CHECK(serde::read<float>(parser) == float{-123.456});
+    }
+
+    {
+        auto b = iobuf();
+        serde::write(b, double{-123.456});
+        auto parser = iobuf_parser{std::move(b)};
+        BOOST_CHECK(serde::read<double>(parser) == double{-123.456});
+    }
 }
 
 struct test_snapshot_header


### PR DESCRIPTION
- Before, calling htole32/64 with a float/double just casted the float/double to 32/64 bit integer types. This works for integer values (1.0, 2.0, ...) but not for real floating point values (e.g., 123.456).
- Before, *reinterpret_cast<To>(&t) was used. This is not allowed in C++ (type aliasing). C++20 provides `bit_cast` but not every compiler provides it. Here, a simplified version is implemented using `std::memcpy`
- `read` was used instead of `read_nested` when reading `std::optional<T>`. Switch to `read_nested` to prevent error "bytes left after reading [...]"

All bugs were found by fuzzing the code (UB sanitizer + exception was thrown).