### PR TITLE
Fix incorrect transactional error handling and flaky tests

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -61,6 +61,7 @@ v_cc_library(
     persisted_stm.cc
     tm_stm.cc
     rm_stm.cc
+    tx_helpers.cc
     security_manager.cc
     security_frontend.cc
     controller_api.cc

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -73,7 +73,7 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
     }
 
     if (!has_topic) {
-        vlog(clusterlog.warn, "can't meta cache entry for {}", nt);
+        vlog(clusterlog.warn, "can't find {} in the metadata cache", nt);
         co_return allocate_id_reply{0, errc::topic_not_exists};
     }
 
@@ -84,13 +84,17 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
     auto retries = _metadata_dissemination_retries;
     auto delay_ms = _metadata_dissemination_retry_delay_ms;
     auto aborted = false;
+    std::optional<std::string> error;
     while (!aborted && 0 < retries--) {
         auto leader_opt = _leaders.local().get_leader(model::id_allocator_ntp);
         if (unlikely(!leader_opt)) {
+            error = fmt::format(
+              "can't find {} in the leaders cache", model::id_allocator_ntp);
             vlog(
               clusterlog.trace,
-              "can't find a leader for {}",
-              model::id_allocator_ntp);
+              "waiting for {} to fill leaders cache, retries left: {}",
+              model::id_allocator_ntp,
+              retries);
             aborted = !co_await sleep_abortable(delay_ms);
             continue;
         }
@@ -101,22 +105,30 @@ id_allocator_frontend::allocate_id(model::timeout_clock::duration timeout) {
         } else {
             vlog(
               clusterlog.trace,
-              "dispatching allocate id to {} from {}",
-              leader,
-              _self);
-
+              "dispatching id allocation from {} to {} ",
+              _self,
+              leader);
             r = co_await dispatch_allocate_id_to_leader(leader, timeout);
         }
 
-        if (likely(r.ec != errc::replication_error)) {
+        if (likely(r.ec == errc::success)) {
+            error = std::nullopt;
             break;
         }
 
+        if (likely(r.ec != errc::replication_error)) {
+            error = fmt::format("id allocation failed with {}", r.ec);
+            break;
+        }
+
+        error = fmt::format("id allocation failed with {}", r.ec);
         vlog(
-          clusterlog.warn,
-          "replication of the id allocation command failed, {} retries left",
-          retries);
+          clusterlog.trace, "id allocation failed, retries left: {}", retries);
         aborted = !co_await sleep_abortable(delay_ms);
+    }
+
+    if (error) {
+        vlog(clusterlog.warn, "{}", error.value());
     }
 
     co_return r;
@@ -165,7 +177,7 @@ id_allocator_frontend::do_allocate_id(model::timeout_clock::duration timeout) {
         if (!shard) {
             vlog(
               clusterlog.warn,
-              "can't find a shard for {}",
+              "can't find {} in the shard table",
               model::id_allocator_ntp);
             co_return allocate_id_reply{0, errc::no_leader_controller};
         }

--- a/src/v/cluster/id_allocator_frontend.cc
+++ b/src/v/cluster/id_allocator_frontend.cc
@@ -17,6 +17,7 @@
 #include "cluster/partition_manager.h"
 #include "cluster/shard_table.h"
 #include "cluster/topics_frontend.h"
+#include "cluster/tx_helpers.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "model/namespace.h"
@@ -28,15 +29,6 @@
 
 namespace cluster {
 using namespace std::chrono_literals;
-
-static ss::future<bool> sleep_abortable(std::chrono::milliseconds dur) {
-    try {
-        co_await ss::sleep_abortable(dur);
-        co_return true;
-    } catch (const ss::sleep_aborted&) {
-        co_return false;
-    }
-}
 
 cluster::errc map_errc_fixme(std::error_code ec);
 

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -209,6 +209,10 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   std::chrono::milliseconds transaction_timeout_ms) {
+    if (!_c->is_leader()) {
+        co_return tx_errc::leader_not_found;
+    }
+
     if (!co_await sync(_sync_timeout)) {
         co_return tx_errc::stale;
     }

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -113,6 +113,10 @@ tm_stm::update_tx(tm_transaction tx, model::term_id term) {
 ss::future<checked<tm_transaction, tm_stm::op_status>>
 tm_stm::try_change_status(
   kafka::transactional_id tx_id, tm_transaction::tx_status status) {
+    if (!_c->is_leader()) {
+        co_return tm_stm::op_status::not_leader;
+    }
+
     auto is_ready = co_await sync(_sync_timeout);
     if (!is_ready) {
         co_return tm_stm::op_status::unknown;
@@ -131,6 +135,10 @@ tm_stm::try_change_status(
 
 ss::future<checked<tm_transaction, tm_stm::op_status>>
 tm_stm::get_actual_tx(kafka::transactional_id tx_id) {
+    if (!_c->is_leader()) {
+        co_return tm_stm::op_status::not_leader;
+    }
+
     auto is_ready = co_await sync(_sync_timeout);
     if (!is_ready) {
         co_return tm_stm::op_status::unknown;
@@ -214,6 +222,10 @@ ss::future<tm_stm::op_status> tm_stm::register_new_producer(
   kafka::transactional_id tx_id,
   std::chrono::milliseconds transaction_timeout_ms,
   model::producer_identity pid) {
+    if (!_c->is_leader()) {
+        co_return tm_stm::op_status::not_leader;
+    }
+
     auto is_ready = co_await sync(_sync_timeout);
     if (!is_ready) {
         co_return tm_stm::op_status::unknown;

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -102,6 +102,7 @@ public:
         not_found,
         conflict,
         unknown,
+        not_leader,
     };
 
     explicit tm_stm(ss::logger&, raft::consensus*);

--- a/src/v/cluster/tx_helpers.cc
+++ b/src/v/cluster/tx_helpers.cc
@@ -1,0 +1,16 @@
+#include "cluster/tx_helpers.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace cluster {
+
+ss::future<bool> sleep_abortable(std::chrono::milliseconds dur) {
+    try {
+        co_await ss::sleep_abortable(dur);
+        co_return true;
+    } catch (const ss::sleep_aborted&) {
+        co_return false;
+    }
+}
+
+} // namespace cluster

--- a/src/v/cluster/tx_helpers.h
+++ b/src/v/cluster/tx_helpers.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "seastarx.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+
+namespace cluster {
+ss::future<bool> sleep_abortable(std::chrono::milliseconds dur);
+}

--- a/src/v/kafka/server/handlers/add_partitions_to_txn.cc
+++ b/src/v/kafka/server/handlers/add_partitions_to_txn.cc
@@ -56,6 +56,9 @@ ss::future<response_ptr> add_partitions_to_txn_handler::handle(
                       case cluster::tx_errc::none:
                           partition.error_code = error_code::none;
                           break;
+                      case cluster::tx_errc::not_coordinator:
+                          partition.error_code = error_code::not_coordinator;
+                          break;
                       case cluster::tx_errc::invalid_producer_id_mapping:
                           partition.error_code
                             = error_code::invalid_producer_id_mapping;

--- a/src/v/kafka/server/handlers/end_txn.cc
+++ b/src/v/kafka/server/handlers/end_txn.cc
@@ -44,6 +44,9 @@ ss::future<response_ptr> end_txn_handler::handle(
               case cluster::tx_errc::none:
                   data.error_code = error_code::none;
                   break;
+              case cluster::tx_errc::not_coordinator:
+                  data.error_code = error_code::not_coordinator;
+                  break;
               case cluster::tx_errc::fenced:
                   data.error_code = error_code::invalid_producer_epoch;
                   break;

--- a/src/v/kafka/server/handlers/init_producer_id.cc
+++ b/src/v/kafka/server/handlers/init_producer_id.cc
@@ -50,7 +50,8 @@ ss::future<response_ptr> init_producer_id_handler::handle(
               .then([&ctx](cluster::init_tm_tx_reply r) {
                   init_producer_id_response reply;
 
-                  if (r.ec == cluster::tx_errc::none) {
+                  switch (r.ec) {
+                  case cluster::tx_errc::none:
                       reply.data.producer_id = kafka::producer_id(r.pid.id);
                       reply.data.producer_epoch = r.pid.epoch;
                       vlog(
@@ -58,9 +59,14 @@ ss::future<response_ptr> init_producer_id_handler::handle(
                         "allocated pid {} with epoch {} via tx_gateway",
                         reply.data.producer_id,
                         reply.data.producer_epoch);
-                  } else {
+                      break;
+                  case cluster::tx_errc::not_coordinator:
+                      reply.data.error_code = error_code::not_coordinator;
+                      break;
+                  default:
                       vlog(klog.warn, "failed to allocate pid, ec: {}", r.ec);
                       reply.data.error_code = error_code::broker_not_available;
+                      break;
                   }
 
                   return ctx.respond(std::move(reply));


### PR DESCRIPTION
The change updates transactional layer to return not_coordinator error code instead of unknown_server_error in cases when clients access not a primary node of the transactional coordinator. Since not_coordinator is a retryable error Kafka clients handle it internally without propagating to the user. It fixes the open messaging initialization error

During the testing I found a couple of flaky tests, the rest of the PR addresses them.

[ch4368]