### PR TITLE
ts-generator: fix missing parameter types

### DIFF
--- a/tools/ts-generator/example/functions.ts
+++ b/tools/ts-generator/example/functions.ts
@@ -185,7 +185,7 @@ const writeObject = <T>(
 
 /** Deserializer **/
 
-type FromBytes<T> = { fromBytes: (Buffer, number) => [T, number] };
+type FromBytes<T> = { fromBytes: (buffer: Buffer, number: number) => [T, number] };
 type ReadFunction<T> = (
   buffer: Buffer,
   offset: number,

--- a/tools/ts-generator/rpc/example/functions.ts
+++ b/tools/ts-generator/rpc/example/functions.ts
@@ -135,7 +135,7 @@ const writeObject = <T>(
 
 /** Deserializer **/
 
-type FromBytes<T> = { fromBytes: (Buffer, number) => [T, number] };
+type FromBytes<T> = { fromBytes: (buffer: Buffer, number: number) => [T, number] };
 type ReadFunction<T> = (
   buffer: Buffer,
   offset: number,

--- a/tools/ts-generator/types/functions.ts
+++ b/tools/ts-generator/types/functions.ts
@@ -185,7 +185,7 @@ const writeObject = <T>(
 
 /** Deserializer **/
 
-type FromBytes<T> = { fromBytes: (Buffer, number) => [T, number] };
+type FromBytes<T> = { fromBytes: (buffer: Buffer, number: number) => [T, number] };
 type ReadFunction<T> = (
   buffer: Buffer,
   offset: number,


### PR DESCRIPTION
## Cover letter

In TypeScript, the parameters of a function signature must have a name and optionally a type. Missing types on parameters will default to any since no type was given. Functions using that signature will not emit an error on compile-time only on run-time which makes the usage of that function not type-safe. 

The `FromBytes<T>` function signature is an example of the above explained issue.

This patch increases the type-safety by adding the correct types to the `FromBytes<T>` function signature.