### PR TITLE
Fixed raft error handling related with accessing stopped partition 

### DIFF
--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -25,7 +25,9 @@ using namespace std::chrono_literals; // NOLINT
 class rebalancing_tests_fixture : public cluster_test_fixture {
 public:
     rebalancing_tests_fixture()
-      : test_logger("rebalancing-test") {}
+      : test_logger("rebalancing-test") {
+        set_configuration("enable_auto_rebalance_on_node_add", true);
+    }
 
     ~rebalancing_tests_fixture() {
         for (auto& [id, _] : apps) {
@@ -59,6 +61,7 @@ public:
         auto nid = model::node_id(id);
         apps.emplace(nid, create_node_application(nid));
         set_configuration("disable_metrics", true);
+        set_configuration("enable_auto_rebalance_on_node_add", true);
     }
 
     cluster::topic_configuration create_topic_cfg(

--- a/src/v/cluster/tests/replicas_rebalancing_tests.cc
+++ b/src/v/cluster/tests/replicas_rebalancing_tests.cc
@@ -1,8 +1,10 @@
 
+#include "cluster/controller_api.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/tests/rebalancing_tests_fixture.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
+#include "ssx/future-util.h"
 #include "test_utils/async.h"
 
 #include <absl/container/node_hash_map.h>
@@ -54,6 +56,42 @@ void wait_for_even_replicas_distribution(
       .get();
 }
 
+void wait_for_all_partition_moves_to_finish(
+  cluster::metadata_cache& cache, cluster::controller_api& api) {
+    tests::cooperative_spin_wait_with_timeout(60s, [&cache, &api] {
+        auto topics = cache.all_topics();
+        return ss::do_with(
+          cache.all_topics(),
+          [&api](std::vector<model::topic_namespace>& topics) {
+              return ssx::parallel_transform(
+                       topics.begin(),
+                       topics.end(),
+                       [&api](const model::topic_namespace& tp) {
+                           return api.get_reconciliation_state(tp).then(
+                             [](auto res) {
+                                 if (res.has_error()) {
+                                     return false;
+                                 }
+                                 auto states = std::move(res.value());
+                                 return std::all_of(
+                                   states.begin(),
+                                   states.end(),
+                                   [](const cluster::ntp_reconciliation_state&
+                                        st) {
+                                       return st.status()
+                                              == cluster::
+                                                reconciliation_status::done;
+                                   });
+                             });
+                       })
+                .then([](std::vector<bool> results) {
+                    return std::all_of(
+                      results.begin(), results.end(), [](bool r) { return r; });
+                });
+          });
+    }).get();
+}
+
 FIXTURE_TEST(test_adding_single_node_to_cluster, rebalancing_tests_fixture) {
     start_cluster(3);
     // in total we have 24 partition replicas
@@ -65,6 +103,9 @@ FIXTURE_TEST(test_adding_single_node_to_cluster, rebalancing_tests_fixture) {
 
     // add node
     add_node(10);
+    wait_for_all_partition_moves_to_finish(
+      apps.begin()->second->metadata_cache.local(),
+      apps.begin()->second->controller->get_api().local());
 
     // wait until all the nodes will host between 4 and 8 replicas
     wait_for_even_replicas_distribution(
@@ -80,13 +121,15 @@ FIXTURE_TEST(test_adding_multiple_nodes, rebalancing_tests_fixture) {
     populate_all_topics_with_data();
     // add node
     add_node(2);
-
     // wait until all nodes will host between 16 and 20 partitons
     wait_for_even_replicas_distribution(
       14, 22, model::node_id(2), apps.begin()->second->metadata_cache.local());
 
     // add second node
     add_node(3);
+    wait_for_all_partition_moves_to_finish(
+      apps.begin()->second->metadata_cache.local(),
+      apps.begin()->second->controller->get_api().local());
     // wait until all nodes will host between 10 and 14 partitons
     wait_for_even_replicas_distribution(
       8, 16, model::node_id(3), apps.begin()->second->metadata_cache.local());

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -912,6 +912,10 @@ ss::future<std::error_code> consensus::replace_configuration(
 }
 
 ss::future<> consensus::start() {
+    return ss::try_with_gate(_bg, [this] { return do_start(); });
+}
+
+ss::future<> consensus::do_start() {
     vlog(_ctxlog.info, "Starting");
     return _op_lock.with([this] {
         read_voted_for();

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -338,6 +338,7 @@ private:
     do_append_entries(append_entries_request&&);
     ss::future<install_snapshot_reply>
     do_install_snapshot(install_snapshot_request&& r);
+    ss::future<> do_start();
 
     ss::future<result<replicate_result>> dispatch_replicate(
       append_entries_request,

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -36,7 +36,8 @@ enum class errc : int16_t {
     invalid_target_node,
     shutting_down,
     replicate_batcher_cache_error,
-    group_not_exists
+    group_not_exists,
+    replicate_first_stage_exception,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "raft::errc"; }
@@ -86,6 +87,9 @@ struct errc_category final : public std::error_category {
             return "unable to append batch to replicate batcher cache";
         case errc::group_not_exists:
             return "raft group does not exists on target broker";
+        case errc::replicate_first_stage_exception:
+            return "unable to finish replicate since exception was thrown in "
+                   "first phase";
         }
         return "cluster::errc::unknown";
     }


### PR DESCRIPTION
## Cover letter

Fixed error handling in `raft::consensus` that is related with race condition between raft instance being shut down and accessed. This is critical for partition movement as raft groups are dynamically shut down and recreated. 

Fixes: N/A

