### PR TITLE
c/controller_backend: all the nodes must be a voters before finish move

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -130,18 +130,6 @@ std::error_code check_configuration_update(
     for (auto& id : group_cfg.current_config().voters) {
         all_ids.emplace(id.id());
     }
-    /**
-     * if current configuration doesn't include current node it may not be fully
-     * updated as current node may stop receiving updates. Therefore we use
-     * learners to calculate is replica set is up to date. (If configuration
-     * contains current node it will receive all updates so eventually all the
-     * nodes will become a voters)
-     */
-    if (!includes_self) {
-        for (auto& id : group_cfg.current_config().learners) {
-            all_ids.emplace(id.id());
-        }
-    }
 
     // there is different number of brokers in group configuration
     if (all_ids.size() != bs.size()) {


### PR DESCRIPTION
When partition is moved across the node we must wait until all the
replicas assigned to given partitions are the voters only this way we
may be certain that nodes are up to date before they are going to be
removed from the cluster.

Signed-off-by: Michal Maslanka <michal@vectorized.io>