### PR TITLE
backport/v21.8.x: #1984

### DIFF
--- a/tests/rptest/tests/rpk_topic_test.py
+++ b/tests/rptest/tests/rpk_topic_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import ignore
 from ducktape.mark.resource import cluster
 import ducktape.errors
 
@@ -162,6 +163,7 @@ class RpkToolTest(RedpandaTest):
                    backoff_sec=20,
                    err_msg="Message didn't appear.")
 
+    @ignore
     @cluster(num_nodes=4)
     def test_consume_from_partition(self):
         topic = 'topic_partition'


### PR DESCRIPTION
* https://github.com/vectorizedio/redpanda/pull/1984