### PR TITLE
 compatibility: added franz-go tests 

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -69,12 +69,14 @@ RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFK
     make install && \
     ldconfig
 
-# Install dependencies for kafka clients such as sarama.
+# Install dependencies for kafka clients such as sarama and franz-go
 RUN git -C /opt clone https://github.com/Shopify/sarama.git && \
     cd /opt/sarama/examples/interceptors && go mod tidy && go build && \
     cd /opt/sarama/examples/http_server && go mod tidy && go build && \
     cd /opt/sarama/examples/consumergroup && go mod tidy && go build && \
-    cd /opt/sarama/examples/sasl_scram_client && go mod tidy && go build
+    cd /opt/sarama/examples/sasl_scram_client && go mod tidy && go build && \
+    git -C /opt clone https://github.com/twmb/franz-go.git && cd /opt/franz-go && \
+    cd /opt/franz-go/examples/bench && go mod tidy && go build
 
 RUN go install github.com/twmb/kcl@latest && \
     mv /root/go/bin/kcl /usr/local/bin/

--- a/tests/rptest/services/compatibility/compat_example.py
+++ b/tests/rptest/services/compatibility/compat_example.py
@@ -17,15 +17,17 @@ class CompatExample(BackgroundThreadService):
     """
     The service that runs examples in the background
     """
-    def __init__(self, context, redpanda, topic):
+    def __init__(self, context, redpanda, topic, extra_conf={}):
         super(CompatExample, self).__init__(context, num_nodes=1)
 
         #Create the correct helper instance from the test function being run.
         #helper is an object with various methods to help run the example
-        self._helper = create_helper(context.function_name, redpanda, topic)
+        self._helper = create_helper(context.function_name, redpanda, topic,
+                                     extra_conf)
 
-        #The amount of time to run the example
-        self._timeout = 10
+        #The amount of time to run the example.
+        #If user removes timeout key, then use 10 seconds.
+        self._timeout = extra_conf.get("timeout") or 10
 
     def _worker(self, idx, node):
         start_time = time.time()

--- a/tests/rptest/services/compatibility/compat_example.py
+++ b/tests/rptest/services/compatibility/compat_example.py
@@ -20,35 +20,35 @@ class CompatExample(BackgroundThreadService):
     def __init__(self, context, redpanda, topic, extra_conf={}):
         super(CompatExample, self).__init__(context, num_nodes=1)
 
-        #Create the correct helper instance from the test function being run.
-        #helper is an object with various methods to help run the example
+        # Create the correct helper instance from the test function being run.
+        # helper is an object with various methods to help run the example
         self._helper = create_helper(context.function_name, redpanda, topic,
                                      extra_conf)
 
-        #The amount of time to run the example.
-        #If user removes timeout key, then use 10 seconds.
+        # The amount of time to run the example.
+        # If user removes timeout key, then use 10 seconds.
         self._timeout = extra_conf.get("timeout") or 10
 
     def _worker(self, idx, node):
         start_time = time.time()
 
-        #Some examples require the hostname of the node
+        # Some examples require the hostname of the node
         self._helper.set_node_name(node.name)
 
-        #Run the example until the condition is met or timeout occurs
+        # Run the example until the condition is met or timeout occurs
         output_iter = node.account.ssh_capture(self._helper.cmd())
         while not self._helper.condition_met(
         ) and time.time() < start_time + self._timeout:
             line = next(output_iter)
-            #Call to helper.condition will automatically
-            #store result in a boolean variable
+            # Call to helper.condition will automatically
+            # store result in a boolean variable
             self._helper.condition(line.rstrip())
 
-    #Used to determine if the condition is met
+    # Used to determine if the condition is met
     def ok(self):
         return self._helper.condition_met()
 
-    #Returns the node name that the example is running on
+    # Returns the node name that the example is running on
     def node_name(self):
         return self._helper.node_name()
 

--- a/tests/rptest/services/compatibility/compat_helpers.py
+++ b/tests/rptest/services/compatibility/compat_helpers.py
@@ -1,146 +1,21 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
 import os
-
-#The Sarama root directory
-TESTS_DIR = os.path.join("/opt", "sarama")
+from .sarama_helpers import SaramaHelperFactory
 
 
-class SaramaHelper:
-    """
-    The base class for sarama example helpers
-    """
-    def __init__(self, redpanda):
-        #Instance of redpanda
-        self._redpanda = redpanda
-
-        #The result of the internal condiiton.
-        #The internal condition is defined in the children.
-        self._condition_met = False
-
-    #Calls the internal condition and
-    #automatically stores the result
-    def condition(self, line):
-        self._condition_met = self._condition(line)
-
-    #Was the internal condition met?
-    def condition_met(self):
-        return self._condition_met
-
-    #Set the name of the node assigned to
-    #this example.
-    def set_node_name(self, node_name):
-        #Noop by default since some examples
-        #don't need this
-        pass
-
-
-class SaramaInterceptorsHelper(SaramaHelper):
-    """
-    The helper class for Sarama's interceptors example
-    """
-    def __init__(self, redpanda, topic):
-        super(SaramaInterceptorsHelper, self).__init__(redpanda)
-
-        #The kafka topic
-        self._topic = topic
-
-    #The internal condition to determine if the
-    #example is successful. Returns boolean.
-    def _condition(self, line):
-        return 'SpanContext' in line
-
-    #Return the command to call in the shell
-    def cmd(self):
-        EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/interceptors")
-        cmd = f"interceptors -brokers {self._redpanda.brokers()} -topic {self._topic}"
-        return os.path.join(EXAMPLE_DIR, cmd)
-
-    #Return the process name to kill
-    def process_to_kill(self):
-        return "interceptors"
-
-
-class SaramaHttpServerHelper(SaramaHelper):
-    """
-    The helper class for Sarama's http server example
-    """
-    def __init__(self, redpanda):
-        super(SaramaHttpServerHelper, self).__init__(redpanda)
-
-        #The name of the node assigned to this example
-        self._node_name = ""
-
-    #The internal condition to determine if the
-    #example is successful. Returns boolean.
-    def _condition(self, line):
-        return 'Listening for requests' in line
-
-    #Return the command to call in the shell
-    def cmd(self):
-        EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/http_server")
-        cmd = f"http_server -addr {self._node_name}:8080 -brokers {self._redpanda.brokers()}"
-        return os.path.join(EXAMPLE_DIR, cmd)
-
-    #Return the process name to kill
-    def process_to_kill(self):
-        return "http_server"
-
-    #What is the name of the node
-    #assigned to this example?
-    def node_name(self):
-        return self._node_name
-
-    #Set the name of the node assigned to
-    #this example.
-    def set_node_name(self, node_name):
-        self._node_name = node_name
-
-
-class SaramaConsumerGroupHelper(SaramaHelper):
-    """
-    The helper class for Sarama's consumergroup example
-    """
-    def __init__(self, redpanda, topic):
-        super(SaramaConsumerGroupHelper, self).__init__(redpanda)
-
-        #The kafka topic
-        self._topic = topic
-
-    #The internal condition to determine if the
-    #example is successful. Returns boolean.
-    def _condition(self, line):
-        return 'Message claimed:' in line
-
-    #Return the command to call in the shell
-    def cmd(self):
-        EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/consumergroup")
-        cmd = f"consumer -brokers=\"{self._redpanda.brokers()}\" -topics=\"{self._topic}\" -group=\"example\""
-        return os.path.join(EXAMPLE_DIR, cmd)
-
-    #Return the process name to kill
-    def process_to_kill(self):
-        return "consumer"
-
-
-#A factory method to produce the command to run
-#Sarama's SASL/SCRAM authentication example.
-#Here, we do not create a SaramaHelper because
-#the SASL/SCRAM example runs in the foreground.
-def sarama_sasl_scram(redpanda, topic):
-    EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/sasl_scram_client")
-    creds = redpanda.SUPERUSER_CREDENTIALS
-    cmd = f"sasl_scram_client -brokers {redpanda.brokers()} -username {creds[0]} -passwd {creds[1]} -topic {topic} -algorithm sha256"
-
-    return os.path.join(EXAMPLE_DIR, cmd)
-
-
-#A factory method to create the necessary helper class
-#determined by the test function name
-def create_helper(func_name, redpanda, topic):
-    if func_name == "test_sarama_interceptors":
-        return SaramaInterceptorsHelper(redpanda, topic)
-    elif func_name == "test_sarama_http_server":
-        return SaramaHttpServerHelper(redpanda)
-    elif func_name == "test_sarama_consumergroup":
-        return SaramaConsumerGroupHelper(redpanda, topic)
+#A factory method to create the necessary
+#kafka client factory
+def create_helper(func_name, redpanda, topic, extra_conf):
+    if "sarama" in func_name:
+        factory = SaramaHelperFactory(func_name, redpanda, topic)
+        return factory.create_sarama_helpers()
     else:
         raise RuntimeError("create_helper failed: Invalid function name")

--- a/tests/rptest/services/compatibility/compat_helpers.py
+++ b/tests/rptest/services/compatibility/compat_helpers.py
@@ -9,6 +9,7 @@
 
 import os
 from .sarama_helpers import SaramaHelperFactory
+from .franzgo_helpers import FranzGoHelperFactory
 
 
 #A factory method to create the necessary
@@ -17,5 +18,8 @@ def create_helper(func_name, redpanda, topic, extra_conf):
     if "sarama" in func_name:
         factory = SaramaHelperFactory(func_name, redpanda, topic)
         return factory.create_sarama_helpers()
+    elif "franzgo" in func_name:
+        factory = FranzGoHelperFactory(func_name, redpanda, topic, extra_conf)
+        return factory.create_franzgo_helpers()
     else:
         raise RuntimeError("create_helper failed: Invalid function name")

--- a/tests/rptest/services/compatibility/compat_helpers.py
+++ b/tests/rptest/services/compatibility/compat_helpers.py
@@ -12,8 +12,8 @@ from .sarama_helpers import SaramaHelperFactory
 from .franzgo_helpers import FranzGoHelperFactory
 
 
-#A factory method to create the necessary
-#kafka client factory
+# A factory method to create the necessary
+# kafka client factory
 def create_helper(func_name, redpanda, topic, extra_conf):
     if "sarama" in func_name:
         factory = SaramaHelperFactory(func_name, redpanda, topic)

--- a/tests/rptest/services/compatibility/compat_producer.py
+++ b/tests/rptest/services/compatibility/compat_producer.py
@@ -19,10 +19,10 @@ class CompatProducer(BackgroundThreadService):
     """
     def __init__(self, context, redpanda, topic):
         super(CompatProducer, self).__init__(context, num_nodes=1)
-        #The instance of redpanda
+        # The instance of redpanda
         self._redpanda = redpanda
 
-        #The kafka topic
+        # The kafka topic
         self._topic = topic
 
     def _worker(self, idx, node):

--- a/tests/rptest/services/compatibility/franzgo_helpers.py
+++ b/tests/rptest/services/compatibility/franzgo_helpers.py
@@ -1,0 +1,108 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+from .helpers_base import HelperBase, HelperFactoryBase
+import time
+
+#The franz-go root directory
+TESTS_DIR = os.path.join("/opt", "franz-go")
+
+
+class FranzGoBench(HelperBase):
+    """
+    The common items between helper classes
+    for the franz-go bench example.
+    """
+    def __init__(self, redpanda, topic, extra_conf):
+        super(FranzGoBench, self).__init__(redpanda)
+
+        #The kafka topic
+        self._topic = topic
+
+        #Number of records produced
+        self._recs = 0
+
+        self._extra_conf = extra_conf
+
+    #The internal condition to determine if the
+    #example is successful. Returns boolean.
+    def _condition(self, line):
+        #Multiply by 1k because the number of recs
+        #is formated as XXX.XXk records/s
+        self._recs += float(line.split()[2][:-1]) * 1000
+        return self._recs >= self._extra_conf.get("max_records")
+
+    #Return the process name to kill
+    def process_to_kill(self):
+        return "bench"
+
+
+class FranzGoBenchProduceHelper(FranzGoBench):
+    """
+    The helper class for franz-go's bench example
+    using the producer endpoint
+    """
+    def __init__(self, redpanda, topic, extra_conf):
+        super(FranzGoBenchProduceHelper,
+              self).__init__(redpanda, topic, extra_conf)
+
+    #Return the command to call in the shell
+    def cmd(self):
+        EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/bench")
+        cmd = f"bench -brokers {self._redpanda.brokers()} -topic {self._topic} -record-bytes 1000"
+
+        return os.path.join(EXAMPLE_DIR, cmd)
+
+
+class FranzGoBenchConsumeHelper(FranzGoBench):
+    """
+    The helper class for franz-go's bench example
+    using the consumer endpoint
+    """
+    def __init__(self, redpanda, topic, extra_conf):
+        super(FranzGoBenchConsumeHelper,
+              self).__init__(redpanda, topic, extra_conf)
+
+    #Return the command to call in the shell
+    def cmd(self):
+        EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/bench")
+        cmd = f"bench -brokers {self._redpanda.brokers()} -topic {self._topic} -record-bytes 1000 -consume"
+
+        group = self._extra_conf.get("group")
+        if group:
+            cmd = cmd + f" -group {group}"
+
+        return os.path.join(EXAMPLE_DIR, cmd)
+
+
+class FranzGoHelperFactory(HelperFactoryBase):
+    """
+    The concrete factory for creating FranzGo's
+    helper classes.
+    """
+    def __init__(self, func_name, redpanda, topic, extra_conf):
+        super(FranzGoHelperFactory, self).__init__(func_name, redpanda, topic)
+
+        self._extra_conf = extra_conf or dict()
+
+    #The factory method for franz-go
+    def create_franzgo_helpers(self):
+        #Explictly checking None because "consume" is boolean
+        #and False may satisfy this condition
+        if not isinstance(self._extra_conf.get("consume"), bool):
+            raise RuntimeError(
+                "create_franzgo_helpers failed: consume must be bool.")
+
+        if self._extra_conf.get("consume"):
+            return FranzGoBenchConsumeHelper(self._redpanda, self._topic,
+                                             self._extra_conf)
+        else:
+            return FranzGoBenchProduceHelper(self._redpanda, self._topic,
+                                             self._extra_conf)

--- a/tests/rptest/services/compatibility/franzgo_helpers.py
+++ b/tests/rptest/services/compatibility/franzgo_helpers.py
@@ -58,6 +58,11 @@ class FranzGoBenchProduceHelper(FranzGoBench):
         EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/bench")
         cmd = f"bench -brokers {self._redpanda.brokers()} -topic {self._topic} -record-bytes 1000"
 
+        auth = self._extra_conf.get("enable_sasl")
+        if auth:
+            creds = self._redpanda.SUPERUSER_CREDENTIALS
+            cmd = cmd + f" -sasl-user {creds[0]} -sasl-pass {creds[1]} -sasl-method {creds[2]}"
+
         return os.path.join(EXAMPLE_DIR, cmd)
 
 
@@ -78,6 +83,11 @@ class FranzGoBenchConsumeHelper(FranzGoBench):
         group = self._extra_conf.get("group")
         if group:
             cmd = cmd + f" -group {group}"
+
+        auth = self._extra_conf.get("enable_sasl")
+        if auth:
+            creds = self._redpanda.SUPERUSER_CREDENTIALS
+            cmd = cmd + f" -sasl-user {creds[0]} -sasl-pass {creds[1]} -sasl-method {creds[2]}"
 
         return os.path.join(EXAMPLE_DIR, cmd)
 

--- a/tests/rptest/services/compatibility/franzgo_helpers.py
+++ b/tests/rptest/services/compatibility/franzgo_helpers.py
@@ -11,7 +11,7 @@ import os
 from .helpers_base import HelperBase, HelperFactoryBase
 import time
 
-#The franz-go root directory
+# The franz-go root directory
 TESTS_DIR = os.path.join("/opt", "franz-go")
 
 
@@ -23,23 +23,23 @@ class FranzGoBench(HelperBase):
     def __init__(self, redpanda, topic, extra_conf):
         super(FranzGoBench, self).__init__(redpanda)
 
-        #The kafka topic
+        # The kafka topic
         self._topic = topic
 
-        #Number of records produced
+        # Number of records produced
         self._recs = 0
 
         self._extra_conf = extra_conf
 
-    #The internal condition to determine if the
-    #example is successful. Returns boolean.
+    # The internal condition to determine if the
+    # example is successful. Returns boolean.
     def _condition(self, line):
-        #Multiply by 1k because the number of recs
-        #is formated as XXX.XXk records/s
+        # Multiply by 1k because the number of recs
+        # is formated as XXX.XXk records/s
         self._recs += float(line.split()[2][:-1]) * 1000
         return self._recs >= self._extra_conf.get("max_records")
 
-    #Return the process name to kill
+    # Return the process name to kill
     def process_to_kill(self):
         return "bench"
 
@@ -53,7 +53,7 @@ class FranzGoBenchProduceHelper(FranzGoBench):
         super(FranzGoBenchProduceHelper,
               self).__init__(redpanda, topic, extra_conf)
 
-    #Return the command to call in the shell
+    # Return the command to call in the shell
     def cmd(self):
         EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/bench")
         cmd = f"bench -brokers {self._redpanda.brokers()} -topic {self._topic} -record-bytes 1000"
@@ -75,7 +75,7 @@ class FranzGoBenchConsumeHelper(FranzGoBench):
         super(FranzGoBenchConsumeHelper,
               self).__init__(redpanda, topic, extra_conf)
 
-    #Return the command to call in the shell
+    # Return the command to call in the shell
     def cmd(self):
         EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/bench")
         cmd = f"bench -brokers {self._redpanda.brokers()} -topic {self._topic} -record-bytes 1000 -consume"
@@ -102,10 +102,10 @@ class FranzGoHelperFactory(HelperFactoryBase):
 
         self._extra_conf = extra_conf or dict()
 
-    #The factory method for franz-go
+    # The factory method for franz-go
     def create_franzgo_helpers(self):
-        #Explictly checking None because "consume" is boolean
-        #and False may satisfy this condition
+        # Explictly checking None because "consume" is boolean
+        # and False may satisfy this condition
         if not isinstance(self._extra_conf.get("consume"), bool):
             raise RuntimeError(
                 "create_franzgo_helpers failed: consume must be bool.")

--- a/tests/rptest/services/compatibility/helpers_base.py
+++ b/tests/rptest/services/compatibility/helpers_base.py
@@ -1,0 +1,57 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+
+class HelperBase:
+    """
+    The base class for example helpers
+    """
+    def __init__(self, redpanda):
+        # Instance of redpanda
+        self._redpanda = redpanda
+
+        # The result of the internal condiiton.
+        # The internal condition is defined in the children.
+        self._condition_met = False
+
+    # Calls the internal condition and
+    # automatically stores the result
+    def condition(self, line):
+        self._condition_met = self._condition(line)
+
+    # Was the internal condition met?
+    def condition_met(self):
+        return self._condition_met
+
+    # Set the name of the node assigned to
+    # this example.
+    def set_node_name(self, node_name):
+        # Noop by default since some examples
+        # don't need this
+        pass
+
+
+class HelperFactoryBase:
+    """
+    The abstract factory for creating helper classes
+    for a particular kafka client. The class instance
+    is determined by the test function name.
+    """
+    def __init__(self, func_name, redpanda, topic):
+        self._func_name = func_name
+        self._redpanda = redpanda
+        self._topic = topic
+
+    # The factory method for sarama
+    def create_sarama_helpers(self):
+        pass
+
+    # The factory method for franz-go
+    def create_franzgo_helpers(self):
+        pass

--- a/tests/rptest/services/compatibility/sarama_helpers.py
+++ b/tests/rptest/services/compatibility/sarama_helpers.py
@@ -1,0 +1,134 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+from .helpers_base import HelperBase, HelperFactoryBase
+
+#The Sarama root directory
+TESTS_DIR = os.path.join("/opt", "sarama")
+
+
+class SaramaInterceptorsHelper(HelperBase):
+    """
+    The helper class for Sarama's interceptors example
+    """
+    def __init__(self, redpanda, topic):
+        super(SaramaInterceptorsHelper, self).__init__(redpanda)
+
+        #The kafka topic
+        self._topic = topic
+
+    #The internal condition to determine if the
+    #example is successful. Returns boolean.
+    def _condition(self, line):
+        return 'SpanContext' in line
+
+    #Return the command to call in the shell
+    def cmd(self):
+        EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/interceptors")
+        cmd = f"interceptors -brokers {self._redpanda.brokers()} -topic {self._topic}"
+        return os.path.join(EXAMPLE_DIR, cmd)
+
+    #Return the process name to kill
+    def process_to_kill(self):
+        return "interceptors"
+
+
+class SaramaHttpServerHelper(HelperBase):
+    """
+    The helper class for Sarama's http server example
+    """
+    def __init__(self, redpanda):
+        super(SaramaHttpServerHelper, self).__init__(redpanda)
+
+        #The name of the node assigned to this example
+        self._node_name = ""
+
+    #The internal condition to determine if the
+    #example is successful. Returns boolean.
+    def _condition(self, line):
+        return 'Listening for requests' in line
+
+    #Return the command to call in the shell
+    def cmd(self):
+        EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/http_server")
+        cmd = f"http_server -addr {self._node_name}:8080 -brokers {self._redpanda.brokers()}"
+        return os.path.join(EXAMPLE_DIR, cmd)
+
+    #Return the process name to kill
+    def process_to_kill(self):
+        return "http_server"
+
+    #What is the name of the node
+    #assigned to this example?
+    def node_name(self):
+        return self._node_name
+
+    #Set the name of the node assigned to
+    #this example.
+    def set_node_name(self, node_name):
+        self._node_name = node_name
+
+
+class SaramaConsumerGroupHelper(HelperBase):
+    """
+    The helper class for Sarama's consumergroup example
+    """
+    def __init__(self, redpanda, topic):
+        super(SaramaConsumerGroupHelper, self).__init__(redpanda)
+
+        #The kafka topic
+        self._topic = topic
+
+    #The internal condition to determine if the
+    #example is successful. Returns boolean.
+    def _condition(self, line):
+        return 'Message claimed:' in line
+
+    #Return the command to call in the shell
+    def cmd(self):
+        EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/consumergroup")
+        cmd = f"consumer -brokers=\"{self._redpanda.brokers()}\" -topics=\"{self._topic}\" -group=\"example\""
+        return os.path.join(EXAMPLE_DIR, cmd)
+
+    #Return the process name to kill
+    def process_to_kill(self):
+        return "consumer"
+
+
+#A factory method to produce the command to run
+#Sarama's SASL/SCRAM authentication example.
+#Here, we do not create a HelperBase because
+#the SASL/SCRAM example runs in the foreground.
+def sarama_sasl_scram(redpanda, topic):
+    EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/sasl_scram_client")
+    creds = redpanda.SUPERUSER_CREDENTIALS
+    cmd = f"sasl_scram_client -brokers {redpanda.brokers()} -username {creds[0]} -passwd {creds[1]} -topic {topic} -algorithm sha256"
+
+    return os.path.join(EXAMPLE_DIR, cmd)
+
+
+class SaramaHelperFactory(HelperFactoryBase):
+    """
+    The concrete factory for creating Sarama's
+    helper classes.
+    """
+    def __init__(self, func_name, redpanda, topic):
+        super(SaramaHelperFactory, self).__init__(func_name, redpanda, topic)
+
+    #The factory method for sarama
+    def create_sarama_helpers(self):
+        if self._func_name == "test_sarama_interceptors":
+            return SaramaInterceptorsHelper(self._redpanda, self._topic)
+        elif self._func_name == "test_sarama_http_server":
+            return SaramaHttpServerHelper(self._redpanda)
+        elif self._func_name == "test_sarama_consumergroup":
+            return SaramaConsumerGroupHelper(self._redpanda, self._topic)
+        else:
+            raise RuntimeError("create_helper failed: Invalid function name")

--- a/tests/rptest/services/compatibility/sarama_helpers.py
+++ b/tests/rptest/services/compatibility/sarama_helpers.py
@@ -10,7 +10,7 @@
 import os
 from .helpers_base import HelperBase, HelperFactoryBase
 
-#The Sarama root directory
+# The Sarama root directory
 TESTS_DIR = os.path.join("/opt", "sarama")
 
 
@@ -21,21 +21,21 @@ class SaramaInterceptorsHelper(HelperBase):
     def __init__(self, redpanda, topic):
         super(SaramaInterceptorsHelper, self).__init__(redpanda)
 
-        #The kafka topic
+        # The kafka topic
         self._topic = topic
 
-    #The internal condition to determine if the
-    #example is successful. Returns boolean.
+    # The internal condition to determine if the
+    # example is successful. Returns boolean.
     def _condition(self, line):
         return 'SpanContext' in line
 
-    #Return the command to call in the shell
+    # Return the command to call in the shell
     def cmd(self):
         EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/interceptors")
         cmd = f"interceptors -brokers {self._redpanda.brokers()} -topic {self._topic}"
         return os.path.join(EXAMPLE_DIR, cmd)
 
-    #Return the process name to kill
+    # Return the process name to kill
     def process_to_kill(self):
         return "interceptors"
 
@@ -47,31 +47,31 @@ class SaramaHttpServerHelper(HelperBase):
     def __init__(self, redpanda):
         super(SaramaHttpServerHelper, self).__init__(redpanda)
 
-        #The name of the node assigned to this example
+        # The name of the node assigned to this example
         self._node_name = ""
 
-    #The internal condition to determine if the
-    #example is successful. Returns boolean.
+    # The internal condition to determine if the
+    # example is successful. Returns boolean.
     def _condition(self, line):
         return 'Listening for requests' in line
 
-    #Return the command to call in the shell
+    # Return the command to call in the shell
     def cmd(self):
         EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/http_server")
         cmd = f"http_server -addr {self._node_name}:8080 -brokers {self._redpanda.brokers()}"
         return os.path.join(EXAMPLE_DIR, cmd)
 
-    #Return the process name to kill
+    # Return the process name to kill
     def process_to_kill(self):
         return "http_server"
 
-    #What is the name of the node
-    #assigned to this example?
+    # What is the name of the node
+    # assigned to this example?
     def node_name(self):
         return self._node_name
 
-    #Set the name of the node assigned to
-    #this example.
+    # Set the name of the node assigned to
+    # this example.
     def set_node_name(self, node_name):
         self._node_name = node_name
 
@@ -83,29 +83,29 @@ class SaramaConsumerGroupHelper(HelperBase):
     def __init__(self, redpanda, topic):
         super(SaramaConsumerGroupHelper, self).__init__(redpanda)
 
-        #The kafka topic
+        # The kafka topic
         self._topic = topic
 
-    #The internal condition to determine if the
-    #example is successful. Returns boolean.
+    # The internal condition to determine if the
+    # example is successful. Returns boolean.
     def _condition(self, line):
         return 'Message claimed:' in line
 
-    #Return the command to call in the shell
+    # Return the command to call in the shell
     def cmd(self):
         EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/consumergroup")
         cmd = f"consumer -brokers=\"{self._redpanda.brokers()}\" -topics=\"{self._topic}\" -group=\"example\""
         return os.path.join(EXAMPLE_DIR, cmd)
 
-    #Return the process name to kill
+    # Return the process name to kill
     def process_to_kill(self):
         return "consumer"
 
 
-#A factory method to produce the command to run
-#Sarama's SASL/SCRAM authentication example.
-#Here, we do not create a HelperBase because
-#the SASL/SCRAM example runs in the foreground.
+# A factory method to produce the command to run
+# Sarama's SASL/SCRAM authentication example.
+# Here, we do not create a HelperBase because
+# the SASL/SCRAM example runs in the foreground.
 def sarama_sasl_scram(redpanda, topic):
     EXAMPLE_DIR = os.path.join(TESTS_DIR, "examples/sasl_scram_client")
     creds = redpanda.SUPERUSER_CREDENTIALS
@@ -122,7 +122,7 @@ class SaramaHelperFactory(HelperFactoryBase):
     def __init__(self, func_name, redpanda, topic):
         super(SaramaHelperFactory, self).__init__(func_name, redpanda, topic)
 
-    #The factory method for sarama
+    # The factory method for sarama
     def create_sarama_helpers(self):
         if self._func_name == "test_sarama_interceptors":
             return SaramaInterceptorsHelper(self._redpanda, self._topic)

--- a/tests/rptest/tests/compatibility/franzgo_auth_test.py
+++ b/tests/rptest/tests/compatibility/franzgo_auth_test.py
@@ -1,0 +1,92 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.services.compatibility.compat_example import CompatExample
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+
+
+class FranzGoAuthTest(RedpandaTest):
+    """
+    Test FranzGo bench example using sasl authentication.
+    """
+    topics = (TopicSpec(), )
+
+    def __init__(self, test_context):
+        #idempotence is necessary for bench example
+        extra_rp_conf = {"enable_idempotence": True, "enable_sasl": True}
+        super(FranzGoAuthTest, self).__init__(test_context=test_context,
+                                              extra_rp_conf=extra_rp_conf)
+
+        #A representation of the bench producer endpoint
+        self._prod_conf = {
+            "consume": False,
+
+            #Amount of records to produce.
+            #1mill seems like a good starting point. Could be scaled.
+            "max_records": 1000000,
+
+            #Custom timeout of 30s instead of the default 10s
+            #because sometimes no records are produced early on
+            #which eats-up execution time.
+            "timeout": 30,
+            "enable_sasl": True
+        }
+        self._producer = CompatExample(test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       extra_conf=self._prod_conf)
+
+        #A representation of the bench consumer endpoint
+        self._cons_conf = {
+            "consume": True,
+
+            #Amount of records to consume
+            #1mill seems like a good starting point. Could be scaled.
+            "max_records": 1000000,
+
+            #Custom timeout of 120s instead of the default 10s
+            #because the default is not long enough to consume
+            #1mill records.
+            "timeout": 120,
+            "enable_sasl": True
+        }
+        self._consumer = CompatExample(test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       extra_conf=self._cons_conf)
+
+    @cluster(num_nodes=5)
+    def test_franzgo_bench_w_auth(self):
+        #Start the produce bench
+        self._producer.start()
+
+        #Wait until the example is ok.
+        #Add 30s to the timeout incase the example
+        #took the full amount of time to produce
+        wait_until(lambda: self._producer.ok(),
+                   timeout_sec=self._prod_conf["timeout"] + 30,
+                   backoff_sec=5,
+                   err_msg="franz-go bench_no_auth produce test failed")
+
+        #Start the consume bench.
+        #Running the example sequentially because
+        #it's easier to debug.
+        self._consumer.start()
+
+        #Wait until the example is OK to terminate
+        #Add 30s to the timeout incase the example
+        #took the full amount of time to consume
+        wait_until(lambda: self._consumer.ok(),
+                   timeout_sec=self._cons_conf["timeout"] + 30,
+                   backoff_sec=5,
+                   err_msg="franz-go bench_no_auth consume test failed")

--- a/tests/rptest/tests/compatibility/franzgo_auth_test.py
+++ b/tests/rptest/tests/compatibility/franzgo_auth_test.py
@@ -22,23 +22,23 @@ class FranzGoAuthTest(RedpandaTest):
     topics = (TopicSpec(), )
 
     def __init__(self, test_context):
-        #idempotence is necessary for bench example
+        # idempotence is necessary for bench example
         extra_rp_conf = {"enable_idempotence": True, "enable_sasl": True}
         super(FranzGoAuthTest, self).__init__(test_context=test_context,
                                               extra_rp_conf=extra_rp_conf)
 
-        #A representation of the bench producer endpoint
+        # A representation of the bench producer endpoint
         self._prod_conf = {
             "consume": False,
 
-            #Amount of records to produce.
-            #1mill seems like a good starting point. Could be scaled.
+            # Amount of records to produce.
+            # 1mill seems like a good starting point. Could be scaled.
             "max_records": 1000000,
 
-            #Custom timeout of 30s instead of the default 10s
-            #because sometimes no records are produced early on
-            #which eats-up execution time.
-            "timeout": 30,
+            # Custom timeout of 30s instead of the default 10s
+            # because sometimes no records are produced early on
+            # which eats-up execution time.
+            "timeout": 300,
             "enable_sasl": True
         }
         self._producer = CompatExample(test_context,
@@ -46,18 +46,18 @@ class FranzGoAuthTest(RedpandaTest):
                                        self.topic,
                                        extra_conf=self._prod_conf)
 
-        #A representation of the bench consumer endpoint
+        # A representation of the bench consumer endpoint
         self._cons_conf = {
             "consume": True,
 
-            #Amount of records to consume
-            #1mill seems like a good starting point. Could be scaled.
+            # Amount of records to consume
+            # 1mill seems like a good starting point. Could be scaled.
             "max_records": 1000000,
 
-            #Custom timeout of 120s instead of the default 10s
-            #because the default is not long enough to consume
-            #1mill records.
-            "timeout": 120,
+            # Custom timeout of 120s instead of the default 10s
+            # because the default is not long enough to consume
+            # 1mill records.
+            "timeout": 300,
             "enable_sasl": True
         }
         self._consumer = CompatExample(test_context,
@@ -67,25 +67,25 @@ class FranzGoAuthTest(RedpandaTest):
 
     @cluster(num_nodes=5)
     def test_franzgo_bench_w_auth(self):
-        #Start the produce bench
+        # Start the produce bench
         self._producer.start()
 
-        #Wait until the example is ok.
-        #Add 30s to the timeout incase the example
-        #took the full amount of time to produce
+        # Wait until the example is ok.
+        # Add 30s to the timeout incase the example
+        # took the full amount of time to produce
         wait_until(lambda: self._producer.ok(),
                    timeout_sec=self._prod_conf["timeout"] + 30,
                    backoff_sec=5,
                    err_msg="franz-go bench_no_auth produce test failed")
 
-        #Start the consume bench.
-        #Running the example sequentially because
-        #it's easier to debug.
+        # Start the consume bench.
+        # Running the example sequentially because
+        # it's easier to debug.
         self._consumer.start()
 
-        #Wait until the example is OK to terminate
-        #Add 30s to the timeout incase the example
-        #took the full amount of time to consume
+        # Wait until the example is OK to terminate
+        # Add 30s to the timeout incase the example
+        # took the full amount of time to consume
         wait_until(lambda: self._consumer.ok(),
                    timeout_sec=self._cons_conf["timeout"] + 30,
                    backoff_sec=5,

--- a/tests/rptest/tests/compatibility/franzgo_test.py
+++ b/tests/rptest/tests/compatibility/franzgo_test.py
@@ -1,0 +1,152 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.services.compatibility.compat_example import CompatExample
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+
+
+class FranzGoBase(RedpandaTest):
+    """
+    Test FranzGo bench example.
+    Not using any other example because bench tests the same
+    APIs and code that the other examples do.
+    """
+    topics = (TopicSpec(), )
+
+    def __init__(self, test_context):
+        #idempotence is necessary for bench example
+        extra_rp_conf = {"enable_idempotence": True}
+        self._ctx = test_context
+
+        super(FranzGoBase, self).__init__(test_context=test_context,
+                                          extra_rp_conf=extra_rp_conf)
+
+        #A representation of the bench producer endpoint
+        self._prod_conf = {
+            "consume": False,
+
+            #Amount of records to produce.
+            #1mill seems like a good starting point. Could be scaled.
+            "max_records": 1000000,
+
+            #Custom timeout of 30s instead of the default 10s
+            #because sometimes no records are produced early on
+            #which eats-up execution time.
+            "timeout": 30
+        }
+        self._producer = None
+
+        #A representation of the bench consumer endpoint
+        self._cons_conf = {
+            "consume": True,
+
+            #Amount of records to consume
+            #1mill seems like a good starting point. Could be scaled.
+            "max_records": 1000000,
+
+            #Custom timeout of 120s instead of the default 10s
+            #because the default is not long enough to consume
+            #1mill records.
+            "timeout": 120
+        }
+        self._consumer = None
+
+    def setUp(self):
+        if self._producer or self._consumer:
+            raise RuntimeError("producer or consumer bench already init")
+
+        self._producer = CompatExample(self._ctx,
+                                       self.redpanda,
+                                       self.topic,
+                                       extra_conf=self._prod_conf)
+        self._consumer = CompatExample(self._ctx,
+                                       self.redpanda,
+                                       self.topic,
+                                       extra_conf=self._cons_conf)
+
+        super().setUp()
+
+
+class FranzGoWithoutGroupTest(FranzGoBase):
+    """
+    Test FranzGo bench example without group consuming.
+    """
+    def __init__(self, test_context):
+        super(FranzGoWithoutGroupTest,
+              self).__init__(test_context=test_context)
+
+    @cluster(num_nodes=5)
+    def test_franzgo_bench_wo_group(self):
+        #Start the produce bench
+        self._producer.start()
+
+        #Wait until the example is ok.
+        #Add 30s to the timeout incase the example
+        #took the full amount of time to produce
+        wait_until(lambda: self._producer.ok(),
+                   timeout_sec=self._prod_conf["timeout"] + 30,
+                   backoff_sec=5,
+                   err_msg="franz-go bench_wo_group produce test failed")
+
+        #Start the consume bench.
+        #Running the example sequentially because
+        #it's easier to debug.
+        self._consumer.start()
+
+        #Wait until the example is OK to terminate
+        #Add 30s to the timeout incase the example
+        #took the full amount of time to consume
+        wait_until(lambda: self._consumer.ok(),
+                   timeout_sec=self._cons_conf["timeout"] + 30,
+                   backoff_sec=5,
+                   err_msg="franz-go bench_wo_group consume test failed")
+
+
+class FranzGoWithGroupTest(FranzGoBase):
+    """
+    Test FranzGo bench example with group consuming.
+    """
+    def __init__(self, test_context):
+        super(FranzGoWithGroupTest, self).__init__(test_context=test_context)
+
+        #Using TopicSpec to generate random string
+        string_gen = TopicSpec()
+
+        #Add group to the consumer configuration
+        self._cons_conf["group"] = f"group-{string_gen._random_topic_suffix()}"
+
+    @cluster(num_nodes=5)
+    def test_franzgo_bench_w_group(self):
+        #Start the produce bench
+        self._producer.start()
+
+        #Wait until the example is ok.
+        #Add 30s to the timeout incase the example
+        #took the full amount of time to produce
+        wait_until(lambda: self._producer.ok(),
+                   timeout_sec=self._prod_conf["timeout"] + 30,
+                   backoff_sec=5,
+                   err_msg="franz-go bench_w_group produce test failed")
+
+        #Start the consume bench.
+        #Running the example sequentially because
+        #it's easier to debug.
+        self._consumer.start()
+
+        #Wait until the example is OK to terminate
+        #Add 30s to the timeout incase the example
+        #took the full amount of time to consume
+        wait_until(lambda: self._consumer.ok(),
+                   timeout_sec=self._cons_conf["timeout"] + 30,
+                   backoff_sec=5,
+                   err_msg="franz-go bench_w_group consume test failed")

--- a/tests/rptest/tests/compatibility/franzgo_test.py
+++ b/tests/rptest/tests/compatibility/franzgo_test.py
@@ -24,40 +24,40 @@ class FranzGoBase(RedpandaTest):
     topics = (TopicSpec(), )
 
     def __init__(self, test_context):
-        #idempotence is necessary for bench example
+        # idempotence is necessary for bench example
         extra_rp_conf = {"enable_idempotence": True}
         self._ctx = test_context
 
         super(FranzGoBase, self).__init__(test_context=test_context,
                                           extra_rp_conf=extra_rp_conf)
 
-        #A representation of the bench producer endpoint
+        # A representation of the bench producer endpoint
         self._prod_conf = {
             "consume": False,
 
-            #Amount of records to produce.
-            #1mill seems like a good starting point. Could be scaled.
+            # Amount of records to produce.
+            # 1mill seems like a good starting point. Could be scaled.
             "max_records": 1000000,
 
-            #Custom timeout of 30s instead of the default 10s
-            #because sometimes no records are produced early on
-            #which eats-up execution time.
-            "timeout": 30
+            # Custom timeout of 30s instead of the default 10s
+            # because sometimes no records are produced early on
+            # which eats-up execution time.
+            "timeout": 300
         }
         self._producer = None
 
-        #A representation of the bench consumer endpoint
+        # A representation of the bench consumer endpoint
         self._cons_conf = {
             "consume": True,
 
-            #Amount of records to consume
-            #1mill seems like a good starting point. Could be scaled.
+            # Amount of records to consume
+            # 1mill seems like a good starting point. Could be scaled.
             "max_records": 1000000,
 
-            #Custom timeout of 120s instead of the default 10s
-            #because the default is not long enough to consume
-            #1mill records.
-            "timeout": 120
+            # Custom timeout of 120s instead of the default 10s
+            # because the default is not long enough to consume
+            # 1mill records.
+            "timeout": 300
         }
         self._consumer = None
 
@@ -87,25 +87,25 @@ class FranzGoWithoutGroupTest(FranzGoBase):
 
     @cluster(num_nodes=5)
     def test_franzgo_bench_wo_group(self):
-        #Start the produce bench
+        # Start the produce bench
         self._producer.start()
 
-        #Wait until the example is ok.
-        #Add 30s to the timeout incase the example
-        #took the full amount of time to produce
+        # Wait until the example is ok.
+        # Add 30s to the timeout incase the example
+        # took the full amount of time to produce
         wait_until(lambda: self._producer.ok(),
                    timeout_sec=self._prod_conf["timeout"] + 30,
                    backoff_sec=5,
                    err_msg="franz-go bench_wo_group produce test failed")
 
-        #Start the consume bench.
-        #Running the example sequentially because
-        #it's easier to debug.
+        # Start the consume bench.
+        # Running the example sequentially because
+        # it's easier to debug.
         self._consumer.start()
 
-        #Wait until the example is OK to terminate
-        #Add 30s to the timeout incase the example
-        #took the full amount of time to consume
+        # Wait until the example is OK to terminate
+        # Add 30s to the timeout incase the example
+        # took the full amount of time to consume
         wait_until(lambda: self._consumer.ok(),
                    timeout_sec=self._cons_conf["timeout"] + 30,
                    backoff_sec=5,
@@ -119,33 +119,33 @@ class FranzGoWithGroupTest(FranzGoBase):
     def __init__(self, test_context):
         super(FranzGoWithGroupTest, self).__init__(test_context=test_context)
 
-        #Using TopicSpec to generate random string
+        # Using TopicSpec to generate random string
         string_gen = TopicSpec()
 
-        #Add group to the consumer configuration
+        # Add group to the consumer configuration
         self._cons_conf["group"] = f"group-{string_gen._random_topic_suffix()}"
 
     @cluster(num_nodes=5)
     def test_franzgo_bench_w_group(self):
-        #Start the produce bench
+        # Start the produce bench
         self._producer.start()
 
-        #Wait until the example is ok.
-        #Add 30s to the timeout incase the example
-        #took the full amount of time to produce
+        # Wait until the example is ok.
+        # Add 30s to the timeout incase the example
+        # took the full amount of time to produce
         wait_until(lambda: self._producer.ok(),
                    timeout_sec=self._prod_conf["timeout"] + 30,
                    backoff_sec=5,
                    err_msg="franz-go bench_w_group produce test failed")
 
-        #Start the consume bench.
-        #Running the example sequentially because
-        #it's easier to debug.
+        # Start the consume bench.
+        # Running the example sequentially because
+        # it's easier to debug.
         self._consumer.start()
 
-        #Wait until the example is OK to terminate
-        #Add 30s to the timeout incase the example
-        #took the full amount of time to consume
+        # Wait until the example is OK to terminate
+        # Add 30s to the timeout incase the example
+        # took the full amount of time to consume
         wait_until(lambda: self._consumer.ok(),
                    timeout_sec=self._cons_conf["timeout"] + 30,
                    backoff_sec=5,

--- a/tests/rptest/tests/compatibility/sarama_scram_test.py
+++ b/tests/rptest/tests/compatibility/sarama_scram_test.py
@@ -13,7 +13,7 @@ from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.compatibility.compat_helpers import sarama_sasl_scram
+from rptest.services.compatibility.sarama_helpers import sarama_sasl_scram
 
 
 class SaramaScramTest(RedpandaTest):
@@ -44,7 +44,6 @@ class SaramaScramTest(RedpandaTest):
             result = node.account.ssh_output(cmd,
                                              allow_fail=True,
                                              timeout_sec=10).decode()
-            self.logger.debug(result)
             return "wrote message at partition:" in result
 
         #Using wait_until for auto-retry because sometimes

--- a/tests/rptest/tests/compatibility/sarama_scram_test.py
+++ b/tests/rptest/tests/compatibility/sarama_scram_test.py
@@ -31,23 +31,23 @@ class SaramaScramTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def test_sarama_sasl_scram(self):
-        #Get the SASL SCRAM command and a ducktape node
+        # Get the SASL SCRAM command and a ducktape node
         cmd = sarama_sasl_scram(self.redpanda, self.topic)
         n = random.randint(0, len(self.redpanda.nodes))
         node = self.redpanda.get_node(n)
 
         def try_cmd():
-            #Allow fail because the process exits with
-            #non-zero if redpanda is in the middle of a
-            #leadership election. Instead we want to
-            #retry the cmd.
+            # Allow fail because the process exits with
+            # non-zero if redpanda is in the middle of a
+            # leadership election. Instead we want to
+            # retry the cmd.
             result = node.account.ssh_output(cmd,
                                              allow_fail=True,
                                              timeout_sec=10).decode()
             return "wrote message at partition:" in result
 
-        #Using wait_until for auto-retry because sometimes
-        #redpanda is in the middle of a leadership election
+        # Using wait_until for auto-retry because sometimes
+        # redpanda is in the middle of a leadership election
         wait_until(lambda: try_cmd(),
                    timeout_sec=60,
                    backoff_sec=5,

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -28,19 +28,19 @@ class SaramaTest(RedpandaTest):
     def __init__(self, test_context):
         super(SaramaTest, self).__init__(test_context=test_context)
 
-        #The produce is only for the consumer group example
+        # The produce is only for the consumer group example
         self._producer = CompatProducer(test_context, self.redpanda,
                                         self.topic)
 
-        #A representation of the example to be run in the background
+        # A representation of the example to be run in the background
         self._example = CompatExample(test_context, self.redpanda, self.topic)
 
     @cluster(num_nodes=5)
     def test_sarama_interceptors(self):
-        #Start the example
+        # Start the example
         self._example.start()
 
-        #Wait until the example is OK to terminate
+        # Wait until the example is OK to terminate
         wait_until(lambda: self._example.ok(),
                    timeout_sec=30,
                    backoff_sec=5,
@@ -48,31 +48,31 @@ class SaramaTest(RedpandaTest):
 
     @cluster(num_nodes=5)
     def test_sarama_http_server(self):
-        #Start the example
+        # Start the example
         self._example.start()
 
-        #Wait for the server to load
+        # Wait for the server to load
         wait_until(lambda: self._example.ok(),
                    timeout_sec=30,
                    backoff_sec=5,
                    err_msg="sarama http_server failed to load")
 
-        #Get the node the server is on and
-        #a ducktape node
+        # Get the node the server is on and
+        # a ducktape node
         server_name = self._example.node_name()
         n = random.randint(0, len(self.redpanda.nodes))
         node = self.redpanda.get_node(n)
 
-        #Http get request using curl
+        # Http get request using curl
         curl = f"curl -SL http://{server_name}:8080/"
 
         def try_curl():
             result = node.account.ssh_output(curl, timeout_sec=5).decode()
             return "Your data is stored with unique identifier" in result
 
-        #Using wait_until for auto-retry because sometimes
-        #redpanda is in the middle of a leadership election when
-        #we try to http get.
+        # Using wait_until for auto-retry because sometimes
+        # redpanda is in the middle of a leadership election when
+        # we try to http get.
         wait_until(lambda: try_curl(),
                    timeout_sec=60,
                    backoff_sec=5,
@@ -80,13 +80,13 @@ class SaramaTest(RedpandaTest):
 
     @cluster(num_nodes=5)
     def test_sarama_consumergroup(self):
-        #Run the publisher
+        # Run the publisher
         self._producer.start()
 
-        #Start the example
+        # Start the example
         self._example.start()
 
-        #Wait until the example is OK to terminate
+        # Wait until the example is OK to terminate
         wait_until(lambda: self._example.ok(),
                    timeout_sec=30,
                    backoff_sec=5,

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -68,7 +68,6 @@ class SaramaTest(RedpandaTest):
 
         def try_curl():
             result = node.account.ssh_output(curl, timeout_sec=5).decode()
-            self.logger.debug(result)
             return "Your data is stored with unique identifier" in result
 
         #Using wait_until for auto-retry because sometimes


### PR DESCRIPTION
## Cover letter
Providing Kafka compatibility via Kafka clients is an on-going effort. This PR creates ducktape tests for the franz-go client.

Changes from force-push [98209ff](https://github.com/vectorizedio/redpanda/commit/98209ff61e0acb104394b058b6d85eac32eb4e56):
* Fix comment spacing
* Fix commit message phrasing

Changes from force-push [1a16ab5](https://github.com/vectorizedio/redpanda/commit/1a16ab5a513e7765cc80a62bd631b1fddf0a7864):
* Increase timeouts in franz-go tests for CI

Changes from force-push [bf556ad](https://github.com/vectorizedio/redpanda/commit/bf556ad3ba1372a813862afe6a05ddbd0210f459):
* Rebase on dev to fix simple_e2e_test failure in CI

## Release notes

Release note: Created test cases for @twmb's [franz-go](https://github.com/twmb/franz-go) kafka client for golang.
