### PR TITLE
schema_registry: Don't retry non-retryable errors

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -87,6 +87,23 @@ static void set_local_kafka_client_config(
     }
 }
 
+static void set_sr_local_kafka_client_config(
+  std::optional<kafka::client::configuration>& client_config,
+  const config::configuration& config) {
+    set_local_kafka_client_config(client_config, config);
+    if (client_config.has_value()) {
+        if (!client_config->produce_batch_delay.is_overriden()) {
+            client_config->produce_batch_delay.set_value(0ms);
+        }
+        if (!client_config->produce_batch_record_count.is_overriden()) {
+            client_config->produce_batch_record_count.set_value(int32_t(0));
+        }
+        if (!client_config->produce_batch_size_bytes.is_overriden()) {
+            client_config->produce_batch_size_bytes.set_value(int32_t(0));
+        }
+    }
+}
+
 application::application(ss::sstring logger_name)
   : _log(std::move(logger_name))
   , _rm_group_proxy(std::ref(rm_group_frontend)){
@@ -311,7 +328,7 @@ void application::hydrate_config(const po::variables_map& cfg) {
         if (config["schema_registry_client"]) {
             _schema_reg_client_config.emplace(config["schema_registry_client"]);
         } else {
-            set_local_kafka_client_config(
+            set_sr_local_kafka_client_config(
               _schema_reg_client_config, config::shard_local_cfg());
         }
         _schema_reg_config->for_each(config_printer("schema_registry"));


### PR DESCRIPTION
## Cover letter

Don't retry non-retryable errors in `sequenced_write`
Improve client defaults - There is no reason for the schema registry to do any produce batching.

The karapace test suite now runs in 12s instead of 180s, and is comparable to other implementations.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Schema Registry: Improve performance
