### PR TITLE
[data-policy] Controller layer for data-policy

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -63,6 +63,7 @@ v_cc_library(
     rm_stm.cc
     security_manager.cc
     security_frontend.cc
+    data_policy_frontend.cc
     controller_api.cc
     members_frontend.cc
     members_backend.cc
@@ -83,5 +84,6 @@ v_cc_library(
     Roaring::roaring
     absl::flat_hash_map
     v::model
+    v::v8_engine
   )
 add_subdirectory(tests)

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -63,6 +63,7 @@ v_cc_library(
     rm_stm.cc
     security_manager.cc
     security_frontend.cc
+    data_policy_manager.cc
     data_policy_frontend.cc
     controller_api.cc
     members_frontend.cc

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -66,6 +66,11 @@ static constexpr int8_t delete_user_cmd_type = 6;
 static constexpr int8_t update_user_cmd_type = 7;
 static constexpr int8_t create_acls_cmd_type = 8;
 static constexpr int8_t delete_acls_cmd_type = 9;
+
+// data policy commands
+static constexpr int8_t create_data_policy_cmd_type = 0;
+static constexpr int8_t delete_data_policy_cmd_type = 1;
+
 // node management commands
 static constexpr int8_t decommission_node_cmd_type = 0;
 static constexpr int8_t recommission_node_cmd_type = 1;
@@ -136,6 +141,18 @@ using delete_acls_cmd = controller_command<
   int8_t, // unused
   delete_acls_cmd_type,
   model::record_batch_type::acl_management_cmd>;
+
+using create_data_policy_cmd = controller_command<
+  model::topic_namespace,
+  create_data_policy_cmd_data,
+  create_data_policy_cmd_type,
+  model::record_batch_type::data_policy_management_cmd>;
+
+using delete_data_policy_cmd = controller_command<
+  model::topic_namespace,
+  std::optional<ss::sstring>,
+  delete_data_policy_cmd_type,
+  model::record_batch_type::data_policy_management_cmd>;
 
 using decommission_node_cmd = controller_command<
   model::node_id,

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -13,6 +13,7 @@
 #include "cluster/controller_api.h"
 #include "cluster/controller_backend.h"
 #include "cluster/controller_service.h"
+#include "cluster/data_policy_frontend.h"
 #include "cluster/fwd.h"
 #include "cluster/logger.h"
 #include "cluster/members_backend.h"
@@ -89,6 +90,7 @@ ss::future<> controller::start() {
           // validate configuration invariants to exit early
           return _members_manager.local().validate_configuration_invariants();
       })
+      .then([this] { return _data_policy_manager.start(); })
       .then([this] {
           return _stm.start_single(
             std::ref(clusterlog),
@@ -96,7 +98,8 @@ ss::future<> controller::start() {
             raft::persistent_last_applied::yes,
             std::ref(_tp_updates_dispatcher),
             std::ref(_security_manager),
-            std::ref(_members_manager));
+            std::ref(_members_manager),
+            std::ref(_data_policy_manager));
       })
       .then([this] {
           return _members_frontend.start(
@@ -113,6 +116,9 @@ ss::future<> controller::start() {
             std::ref(_partition_leaders),
             std::ref(_as),
             std::ref(_authorizer));
+      })
+      .then([this] {
+          return _data_policy_frontend.start(std::ref(_stm), std::ref(_as));
       })
       .then([this] {
           return _tp_frontend.start(
@@ -232,11 +238,13 @@ ss::future<> controller::stop() {
           .then([this] { return _backend.stop(); })
           .then([this] { return _tp_frontend.stop(); })
           .then([this] { return _security_frontend.stop(); })
+          .then([this] { return _data_policy_frontend.stop(); })
           .then([this] { return _members_frontend.stop(); })
           .then([this] { return _stm.stop(); })
           .then([this] { return _authorizer.stop(); })
           .then([this] { return _credentials.stop(); })
           .then([this] { return _tp_state.stop(); })
+          .then([this] { return _data_policy_manager.stop(); })
           .then([this] { return _members_manager.stop(); })
           .then([this] { return _partition_allocator.stop(); })
           .then([this] { return _partition_leaders.stop(); })

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -56,6 +56,11 @@ public:
         return _security_frontend;
     }
 
+    ss::sharded<data_policy_frontend>& get_data_policy_frontend() {
+        return _data_policy_frontend;
+    }
+    data_policy_manager& dp_manager() { return _data_policy_manager; }
+
     ss::sharded<security::authorizer>& get_authorizer() { return _authorizer; }
 
     ss::sharded<controller_api>& get_api() { return _api; }
@@ -93,7 +98,9 @@ private:
     topic_updates_dispatcher _tp_updates_dispatcher;
     ss::sharded<security::credential_store> _credentials;
     security_manager _security_manager;
+    data_policy_manager _data_policy_manager;
     ss::sharded<security_frontend> _security_frontend;
+    ss::sharded<data_policy_frontend> _data_policy_frontend;
     ss::sharded<security::authorizer> _authorizer;
     ss::sharded<raft::group_manager>& _raft_manager;
     std::unique_ptr<leader_balancer> _leader_balancer;

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/data_policy_manager.h"
 #include "cluster/members_manager.h"
 #include "cluster/security_manager.h"
 #include "cluster/topic_updates_dispatcher.h"
@@ -22,7 +23,8 @@ namespace cluster {
 using controller_stm = raft::mux_state_machine<
   topic_updates_dispatcher,
   security_manager,
-  members_manager>;
+  members_manager,
+  data_policy_manager>;
 
 static constexpr ss::shard_id controller_stm_shard = 0;
 

--- a/src/v/cluster/data_policy_frontend.cc
+++ b/src/v/cluster/data_policy_frontend.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/data_policy_frontend.h"
+
+#include "cluster/cluster_utils.h"
+
+#include <optional>
+
+namespace cluster {
+
+data_policy_frontend::data_policy_frontend(
+  ss::sharded<controller_stm>& stm, ss::sharded<ss::abort_source>& as) noexcept
+  : _stm(stm)
+  , _as(as) {}
+
+ss::future<std::error_code> data_policy_frontend::create_data_policy(
+  model::topic_namespace topic,
+  v8_engine::data_policy dp,
+  model::timeout_clock::time_point tout) {
+    create_data_policy_cmd_data cmd_data{.dp = std::move(dp)};
+    create_data_policy_cmd cmd(std::move(topic), std::move(cmd_data));
+    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
+}
+
+ss::future<std::error_code> data_policy_frontend::clear_data_policy(
+  model::topic_namespace topic, model::timeout_clock::time_point tout) {
+    delete_data_policy_cmd cmd(std::move(topic), std::nullopt);
+    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
+}
+
+} // namespace cluster

--- a/src/v/cluster/data_policy_frontend.h
+++ b/src/v/cluster/data_policy_frontend.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/controller_stm.h"
+#include "cluster/fwd.h"
+#include "model/timeout_clock.h"
+#include "v8_engine/data_policy.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/sharded.hh>
+
+namespace cluster {
+
+class data_policy_frontend final {
+public:
+    data_policy_frontend(
+      ss::sharded<controller_stm>&, ss::sharded<ss::abort_source>&) noexcept;
+
+    ss::future<std::error_code> create_data_policy(
+      model::topic_namespace,
+      v8_engine::data_policy,
+      model::timeout_clock::time_point);
+
+    ss::future<std::error_code> clear_data_policy(
+      model::topic_namespace, model::timeout_clock::time_point);
+
+private:
+    ss::sharded<controller_stm>& _stm;
+    ss::sharded<ss::abort_source>& _as;
+};
+
+} // namespace cluster

--- a/src/v/cluster/data_policy_manager.cc
+++ b/src/v/cluster/data_policy_manager.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/data_policy_manager.h"
+
+#include "cluster/cluster_utils.h"
+#include "cluster/errc.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+
+#include <optional>
+#include <system_error>
+
+namespace cluster {
+
+namespace {
+
+template<typename Cmd>
+std::error_code do_apply(Cmd cmd, data_policy_manager::container_type& db) {
+    return ss::visit(
+      std::move(cmd),
+      [&db](create_data_policy_cmd cmd) {
+          auto [_, res] = db.insert({cmd.key, std::move(cmd.value.dp)});
+          return res ? std::error_code(errc::success)
+                     : std::error_code(errc::data_policy_already_exists);
+      },
+      [&db](delete_data_policy_cmd cmd) {
+          if (db.erase(cmd.key) == 0) {
+              return std::error_code(errc::data_policy_not_exists);
+          } else {
+              return std::error_code(errc::success);
+          }
+      });
+}
+
+template<typename Cmd>
+ss::future<std::error_code> dispatch_updates_to_cores(
+  Cmd cmd, ss::sharded<data_policy_manager::container_type>& db) {
+    auto res = co_await db.map_reduce0(
+      [cmd](data_policy_manager::container_type& local_db) {
+          return do_apply(std::move(cmd), local_db);
+      },
+      std::optional<std::error_code>{},
+      [](std::optional<std::error_code> result, std::error_code error_code) {
+          if (!result.has_value()) {
+              result = error_code;
+          } else {
+              vassert(
+                result.value() == error_code,
+                "State inconsistency across shards detected, "
+                "expected result: {}, have: {}",
+                result->value(),
+                error_code);
+          }
+          return result.value();
+      });
+    co_return res.value();
+}
+
+} // namespace
+
+ss::future<std::error_code>
+data_policy_manager::apply_update(model::record_batch batch) {
+    return deserialize(std::move(batch), commands).then([this](auto cmd) {
+        return dispatch_updates_to_cores(std::move(cmd), _dps);
+    });
+}
+
+} // namespace cluster

--- a/src/v/cluster/data_policy_manager.h
+++ b/src/v/cluster/data_policy_manager.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/commands.h"
+
+#include <absl/container/flat_hash_map.h>
+
+#include <system_error>
+
+namespace cluster {
+
+class data_policy_manager {
+public:
+    using container_type
+      = absl::flat_hash_map<model::topic_namespace, v8_engine::data_policy>;
+
+    static constexpr auto commands
+      = make_commands_list<create_data_policy_cmd, delete_data_policy_cmd>();
+
+    ss::future<std::error_code> apply_update(model::record_batch);
+
+    bool is_batch_applicable(const model::record_batch& batch) const {
+        return batch.header().type
+               == model::record_batch_type::data_policy_management_cmd;
+    }
+
+    const container_type& get_current_state() const { return _dps.local(); }
+
+    ss::future<> start() { return _dps.start(); }
+    ss::future<> stop() { return _dps.stop(); }
+
+private:
+    ss::sharded<container_type> _dps;
+};
+
+} // namespace cluster

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -51,6 +51,8 @@ enum class errc : int16_t {
     partition_configuration_in_joint_mode,
     partition_configuration_leader_config_not_committed,
     partition_configuration_differs,
+    data_policy_already_exists,
+    data_policy_not_exists,
 
 };
 struct errc_category final : public std::error_category {
@@ -138,6 +140,10 @@ struct errc_category final : public std::error_category {
             return "Partition configuration wasn't committed on the leader";
         case errc::partition_configuration_differs:
             return "Current and requested partition configuration differs";
+        case errc::data_policy_already_exists:
+            return "Data-policy already exists";
+        case errc::data_policy_not_exists:
+            return "Data-policy does not exist";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -34,5 +34,6 @@ class security_frontend;
 class controller_api;
 class members_frontend;
 class members_backend;
+class data_policy_frontend;
 
 } // namespace cluster

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -53,10 +53,6 @@ public:
       std::vector<security::acl_binding_filter>,
       model::timeout_clock::duration);
 
-    template<typename Cmd>
-    ss::future<std::error_code>
-    replicate_and_wait(Cmd&&, model::timeout_clock::time_point);
-
 private:
     ss::future<std::vector<errc>> do_create_acls(
       std::vector<security::acl_binding>, model::timeout_clock::duration);

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -37,13 +37,14 @@ set(srcs
     decommissioning_tests.cc
     replicas_rebalancing_tests.cc
     create_partitions_test.cc
-    id_allocator_stm_test.cc)
+    id_allocator_stm_test.cc
+    data_policy_controller_test.cc)
 
 rp_test(
   UNIT_TEST
   BINARY_NAME test_cluster
   SOURCES ${srcs}
-  LIBRARIES v::seastar_testing_main v::application v::storage_test_utils
+  LIBRARIES v::seastar_testing_main v::application v::storage_test_utils v::v8_engine
   LABELS cluster
 )
 
@@ -53,7 +54,7 @@ set_source_files_properties(
     partition_allocator_tests.cc
     allocation_bench.cc
   PROPERTIES SKIP_UNITY_BUILD_INCLUSION 1)
-  
+
 rp_test(
   UNIT_TEST
   BINARY_NAME partition_moving_test

--- a/src/v/cluster/tests/data_policy_controller_test.cc
+++ b/src/v/cluster/tests/data_policy_controller_test.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/data_policy_frontend.h"
+#include "cluster/errc.h"
+#include "cluster/tests/cluster_test_fixture.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+#include "test_utils/fixture.h"
+#include "v8_engine/data_policy.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <system_error>
+
+FIXTURE_TEST(test_change_data_policy, cluster_test_fixture) {
+    auto n1 = create_node_application(model::node_id{0});
+    wait_for_controller_leadership(model::node_id{0}).get();
+    wait_for_all_members(3s).get();
+
+    model::topic_namespace topic1(test_ns, model::topic("0"));
+    model::topic_namespace topic2(test_ns, model::topic("1"));
+    model::topic_namespace topic3(test_ns, model::topic("2"));
+
+    v8_engine::data_policy dp1("1", "2");
+    auto res = n1->controller->get_data_policy_frontend()
+                 .local()
+                 .create_data_policy(
+                   topic1, dp1, 3s + model::timeout_clock::now())
+                 .get();
+    BOOST_REQUIRE_EQUAL(res, cluster::errc::success);
+
+    res = n1->controller->get_data_policy_frontend()
+            .local()
+            .create_data_policy(topic2, dp1, 3s + model::timeout_clock::now())
+            .get();
+    BOOST_REQUIRE_EQUAL(res, cluster::errc::success);
+
+    v8_engine::data_policy dp2("2", "2");
+    res = n1->controller->get_data_policy_frontend()
+            .local()
+            .create_data_policy(topic1, dp2, 3s + model::timeout_clock::now())
+            .get();
+    BOOST_REQUIRE_EQUAL(res, cluster::errc::data_policy_already_exists);
+
+    res = n1->controller->get_data_policy_frontend()
+            .local()
+            .clear_data_policy(topic2, 3s + model::timeout_clock::now())
+            .get();
+    BOOST_REQUIRE_EQUAL(res, cluster::errc::success);
+
+    res = n1->controller->get_data_policy_frontend()
+            .local()
+            .clear_data_policy(topic3, 3s + model::timeout_clock::now())
+            .get();
+    BOOST_REQUIRE_EQUAL(res, cluster::errc::data_policy_not_exists);
+
+    auto n1_map = n1->controller->dp_manager().get_current_state();
+
+    BOOST_REQUIRE_EQUAL(n1_map.size(), 1);
+    BOOST_REQUIRE_EQUAL(n1_map.at(topic1).function_name(), dp1.function_name());
+    BOOST_REQUIRE_EQUAL(n1_map.at(topic1).script_name(), dp1.script_name());
+}

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -78,10 +78,6 @@ private:
     ss::future<topic_result>
       do_delete_topic(model::topic_namespace, model::timeout_clock::time_point);
 
-    template<typename Cmd>
-    ss::future<std::error_code>
-    replicate_and_wait(Cmd&&, model::timeout_clock::time_point);
-
     ss::future<std::vector<topic_result>> dispatch_create_to_leader(
       model::node_id,
       std::vector<topic_configuration>,

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -779,4 +779,22 @@ adl<cluster::create_partititions_configuration_assignment>::from(
       std::move(cfg), std::move(p_as));
 };
 
+void adl<cluster::create_data_policy_cmd_data>::to(
+  iobuf& out, cluster::create_data_policy_cmd_data&& dp_cmd_data) {
+    return serialize(
+      out, dp_cmd_data.current_version, std::move(dp_cmd_data.dp));
+}
+
+cluster::create_data_policy_cmd_data
+adl<cluster::create_data_policy_cmd_data>::from(iobuf_parser& in) {
+    auto version = adl<int8_t>{}.from(in);
+    vassert(
+      version == cluster::create_data_policy_cmd_data::current_version,
+      "Unexpected set_data_policy_cmd version {} (expected {})",
+      version,
+      cluster::create_data_policy_cmd_data::current_version);
+    auto dp = adl<v8_engine::data_policy>{}.from(in);
+    return cluster::create_data_policy_cmd_data{.dp = std::move(dp)};
+}
+
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -24,6 +24,7 @@
 #include "storage/ntp_config.h"
 #include "tristate.h"
 #include "utils/to_string.h"
+#include "v8_engine/data_policy.h"
 
 #include <fmt/format.h>
 
@@ -576,6 +577,11 @@ struct backend_operation {
     friend std::ostream& operator<<(std::ostream&, const backend_operation&);
 };
 
+struct create_data_policy_cmd_data {
+    static constexpr int8_t current_version = 1; // In future dp will be vector
+    v8_engine::data_policy dp;
+};
+
 enum class reconciliation_status : int8_t {
     done,
     in_progress,
@@ -754,6 +760,12 @@ template<>
 struct adl<cluster::create_partititions_configuration_assignment> {
     void to(iobuf&, cluster::create_partititions_configuration_assignment&&);
     cluster::create_partititions_configuration_assignment from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::create_data_policy_cmd_data> {
+    void to(iobuf&, cluster::create_data_policy_cmd_data&&);
+    cluster::create_data_policy_cmd_data from(iobuf_parser&);
 };
 
 } // namespace reflection

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -395,6 +395,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::group_abort_tx";
     case record_batch_type::node_management_cmd:
         return o << "batch_type::node_management_cmd";
+    case record_batch_type::data_policy_management_cmd:
+        return o << "batch_type::data_policy_management_cmd";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -35,6 +35,7 @@ enum class record_batch_type : int8_t {
     group_commit_tx = 15,     // group_commit_tx_batch_type
     group_abort_tx = 16,      // group_abort_tx_batch_type
     node_management_cmd = 17, // controller node management
+    data_policy_management_cmd = 18, // data-policy management
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/v8_engine/CMakeLists.txt
+++ b/src/v/v8_engine/CMakeLists.txt
@@ -4,8 +4,10 @@ v_cc_library(
     environment.cc
     executor.cc
     script.cc
+    data_policy.cc
   DEPS
     Seastar::seastar
-    v8_monolith)
+    v8_monolith
+    v_reflection)
 
 add_subdirectory(tests)

--- a/src/v/v8_engine/data_policy.cc
+++ b/src/v/v8_engine/data_policy.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "v8_engine/data_policy.h"
+
+namespace reflection {
+
+void reflection::adl<v8_engine::data_policy>::to(
+  iobuf& out, v8_engine::data_policy&& dp) {
+    reflection::serialize(
+      out, dp.version, dp.function_name(), dp.script_name());
+}
+
+v8_engine::data_policy
+reflection::adl<v8_engine::data_policy>::from(iobuf_parser& in) {
+    auto version = reflection::adl<int8_t>{}.from(in);
+    vassert(
+      version == v8_engine::data_policy::version,
+      "Unexpected data_policy version");
+    auto function_name = reflection::adl<ss::sstring>{}.from(in);
+    auto script_name = reflection::adl<ss::sstring>{}.from(in);
+    return v8_engine::data_policy(
+      std::move(function_name), std::move(script_name));
+}
+
+} // namespace reflection

--- a/src/v/v8_engine/data_policy.h
+++ b/src/v/v8_engine/data_policy.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "json/json.h"
+#include "reflection/adl.h"
+#include "seastarx.h"
+#include "vlog.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <exception>
+#include <string_view>
+
+namespace v8_engine {
+
+// Datapolicy property for v8_engine. In first version it contains only
+// function_name and script_name, in the future it will contain ACLs, geo,
+// e.t.c.
+class data_policy {
+public:
+    static constexpr int8_t version{1};
+
+    data_policy(ss::sstring fn, ss::sstring sn) noexcept
+      : _function_name(std::move(fn))
+      , _script_name(std::move(sn)) {}
+
+    const ss::sstring& function_name() const { return _function_name; }
+    const ss::sstring& script_name() const { return _script_name; }
+
+private:
+    ss::sstring _function_name;
+    ss::sstring _script_name;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const data_policy& datapolicy);
+};
+
+} // namespace v8_engine
+
+namespace reflection {
+
+template<>
+struct adl<v8_engine::data_policy> {
+    void to(iobuf& out, v8_engine::data_policy&& dp);
+    v8_engine::data_policy from(iobuf_parser& in);
+};
+
+} // namespace reflection


### PR DESCRIPTION
## Cover letter
This pr provides API for replicate data_policy property for topic.
In the future, when data_policy will be changed in alter_topic_config, frontend will create cmd for set or clean dp and replicate it to each node.
After that manager will handle this events and update queue for v8_scripts dispatcher, which will apply new cmds in background.

### Pipeline:
update topic config -> frontend replicates new data-policy -> manager handles -> add new event to local queue for v8 script_dispatcher -> dispatcher apply new cmd

---

There are some changes

- Data_policy property. This class contains function_name and script_name for v8_engine.
- data_policy_fronted creates command when data_policy is changed (In the future it will be integrating with topic config update)
- data_policy_manager handles data_policy updates (In the future it will deliver updates to v8 scripts_dispatcher)

This pr is part of https://github.com/vectorizedio/redpanda/pull/1964

---
### from f80546d to 095ccc0 
- use `fmt_with_ctx` in exception
- edit exception message (add more info)
- fix typos
- change operator<< for data-policy
- edit version in data_policy
- delete default constructor for data-policy

### from  095ccc0 to 8b60274 and  from 8b60274 to 93f4a11
- Add database for data_policy to manager and interface for get it
- Added test for data_policy controller API
- Check failbit in get_line
- Change data_policy class(getter for fields, constructor from json was moved to fabric function)
- small changes in frontend manager constructors

### from 93f4a11 to cc3ea7c
- fuix build

### from cc3ea7c to 6ffe7e7
- Use CRUD for data_policy controller API
- Added optional to delete_command for future

###  from 6ffe7e7 to 15b1465
- Use sharded map in data_policy_manager
- Change naming for data-policy cmd
- delete json stuff from data-policy

### from 15b1465 to ebebbd4
- fix CMake delete useless target

### from ebebbd4 to 2227a07
- made tests easier

### from 2227a07 to 5bcf368 
- Change location for stop manager

###  from 5bcf368 to 98d8ca0 
- use map_reduce0 in manager to update data_policy database on each core
- return error in create if data-policy already exists