### PR TITLE
Add new defaults for transactions

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -26,30 +26,20 @@ import (
 // nolint:funlen // this is ok for a test
 func TestDefault(t *testing.T) {
 	type test struct {
-		name                           string
-		replicas                       int32
-		additionalConfigurationPresent bool
+		name                                string
+		replicas                            int32
+		additionalConfigurationSetByWebhook bool
 	}
 	tests := []test{
 		{
-			name:                           "do not set default topic replication when there is less than 3 replicas",
-			replicas:                       0,
-			additionalConfigurationPresent: false,
+			name:                                "do not set default topic replication when there is less than 3 replicas",
+			replicas:                            2,
+			additionalConfigurationSetByWebhook: false,
 		},
 		{
-			name:                           "do not set default topic replication when there is less than 3 replicas",
-			replicas:                       1,
-			additionalConfigurationPresent: false,
-		},
-		{
-			name:                           "do not set default topic replication when there is less than 3 replicas",
-			replicas:                       2,
-			additionalConfigurationPresent: false,
-		},
-		{
-			name:                           "do not set default topic replication when there is less than 3 replicas",
-			replicas:                       3,
-			additionalConfigurationPresent: true,
+			name:                                "sets default topic replication",
+			replicas:                            3,
+			additionalConfigurationSetByWebhook: true,
 		},
 	}
 	for _, tt := range tests {
@@ -67,7 +57,7 @@ func TestDefault(t *testing.T) {
 
 			redpandaCluster.Default()
 			_, exist := redpandaCluster.Spec.AdditionalConfiguration["redpanda.default_topic_replications"]
-			if exist != tt.additionalConfigurationPresent {
+			if exist != tt.additionalConfigurationSetByWebhook {
 				t.Fail()
 			}
 		})

--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook_test.go
@@ -49,30 +49,33 @@ func TestDefault(t *testing.T) {
 			configAlreadyPresent:                true,
 		},
 	}
+	fields := []string{"redpanda.default_topic_replications", "redpanda.transaction_coordinator_replication", "redpanda.id_allocator_replication"}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			redpandaCluster := &v1alpha1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "",
-				},
-				Spec: v1alpha1.ClusterSpec{
-					Replicas:      pointer.Int32Ptr(tt.replicas),
-					Configuration: v1alpha1.RedpandaConfig{},
-				},
-			}
+		for _, field := range fields {
+			t.Run(tt.name, func(t *testing.T) {
+				redpandaCluster := &v1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "",
+					},
+					Spec: v1alpha1.ClusterSpec{
+						Replicas:      pointer.Int32Ptr(tt.replicas),
+						Configuration: v1alpha1.RedpandaConfig{},
+					},
+				}
 
-			if tt.configAlreadyPresent {
-				redpandaCluster.Spec.AdditionalConfiguration = make(map[string]string)
-				redpandaCluster.Spec.AdditionalConfiguration["redpanda.default_topic_replications"] = "111"
-			}
+				if tt.configAlreadyPresent {
+					redpandaCluster.Spec.AdditionalConfiguration = make(map[string]string)
+					redpandaCluster.Spec.AdditionalConfiguration[field] = "111"
+				}
 
-			redpandaCluster.Default()
-			val, exist := redpandaCluster.Spec.AdditionalConfiguration["redpanda.default_topic_replications"]
-			if (exist && val == "3") != tt.additionalConfigurationSetByWebhook {
-				t.Fail()
-			}
-		})
+				redpandaCluster.Default()
+				val, exist := redpandaCluster.Spec.AdditionalConfiguration[field]
+				if (exist && val == "3") != tt.additionalConfigurationSetByWebhook {
+					t.Fail()
+				}
+			})
+		}
 	}
 
 	t.Run("missing schema registry does not set default port", func(t *testing.T) {


### PR DESCRIPTION
## Cover letter

This adds the following default configuration:
```
transaction_coordinator_replication: 3
id_allocator_replication: 3
```

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
On k8s, by default we set transaction_coordinator_replication and id_allocator_replication to 3 when having at least 3 replicas.