### PR TITLE
archival: Limit segment upload idle time

### DIFF
--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -46,17 +46,13 @@ public:
 
     /// \brief regurn next upload candidate
     ///
-    /// \param last_offset is a last uploaded offset
-    /// \param high_watermark is current high_watermark offset for the partition
+    /// \param begin_inclusive is an inclusive begining of the range
+    /// \param end_exclusive is an exclusive end of the range
     /// \param lm is a log manager
     /// \return initializd struct on success, empty struct on failure
-    /// \note returned upload candidate can have offset which is smaller than
-    ///       last_offset because index is sparse and don't have all possible
-    ///       offsets. If index is not materialized we will upload log starting
-    ///       from the begining.
     ss::future<upload_candidate> get_next_candidate(
-      model::offset last_offset,
-      model::offset high_watermark,
+      model::offset begin_inclusive,
+      model::offset end_exclusive,
       storage::log_manager& lm);
 
 private:
@@ -75,7 +71,7 @@ private:
 
     lookup_result find_segment(
       model::offset last_offset,
-      model::offset high_watermark,
+      model::offset adjusted_lso,
       storage::log_manager& lm);
 
     model::ntp _ntp;

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -54,6 +54,9 @@ struct configuration {
     service_metrics_disabled svc_metrics_disabled;
     /// Flag that indicates that ntp-archiver level metrics are disabled
     per_ntp_metrics_disabled ntp_metrics_disabled;
+    /// Upload time limit (if segment is not uploaded this amount of time the
+    /// upload is triggered)
+    std::optional<segment_time_limit> time_limit;
 };
 
 std::ostream& operator<<(std::ostream& o, const configuration& cfg);

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -125,12 +125,12 @@ public:
     /// uploading them.
     ///
     /// \param lm is a log manager instance
-    /// \param high_watermark is a high watermark offset of the partition
-    /// \param parent is a retry chain node of the caller
-    /// \return future that returns number of uploaded/failed segments
+    /// \param last_stable_offset is a last_stable_offset offset of the
+    /// partition \param parent is a retry chain node of the caller \return
+    /// future that returns number of uploaded/failed segments
     ss::future<batch_result> upload_next_candidates(
       storage::log_manager& lm,
-      model::offset high_watermark,
+      model::offset last_stable_offset,
       retry_chain_node& parent);
 
 private:

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -390,11 +390,11 @@ scheduler_service_impl::remove_archivers(std::vector<model::ntp> to_remove) {
 }
 
 std::optional<model::offset>
-scheduler_service_impl::get_high_watermark(const model::ntp& ntp) const {
+scheduler_service_impl::get_last_stable_offset(const model::ntp& ntp) const {
     cluster::partition_manager& pm = _partition_manager.local();
     auto p = pm.get(ntp);
     if (p) {
-        return p->high_watermark();
+        return p->last_stable_offset();
     }
     return std::nullopt;
 }
@@ -470,10 +470,10 @@ ss::future<> scheduler_service_impl::run_uploads() {
                     _rtclog.debug,
                     "Checking {} for S3 upload candidates",
                     archiver->get_ntp());
-                  auto hwm = get_high_watermark(archiver->get_ntp());
-                  if (hwm) {
+                  auto lso = get_last_stable_offset(archiver->get_ntp());
+                  if (lso) {
                       return archiver->upload_next_candidates(
-                        lm, *hwm, _rtcnode);
+                        lm, *lso, _rtcnode);
                   }
                   return ss::make_ready_future<result_t>(result_t{});
               });

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -159,7 +159,7 @@ private:
     add_ntp_archiver(ss::lw_shared_ptr<ntp_archiver> archiver);
     /// Returns high watermark for the partition
     std::optional<model::offset>
-    get_high_watermark(const model::ntp& ntp) const;
+    get_last_stable_offset(const model::ntp& ntp) const;
 
     configuration _conf;
     ss::sharded<cluster::partition_manager>& _partition_manager;

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -11,11 +11,14 @@
 #include "archival/archival_policy.h"
 #include "archival/ntp_archiver_service.h"
 #include "archival/tests/service_fixture.h"
+#include "bytes/iobuf.h"
 #include "cloud_storage/remote.h"
 #include "cloud_storage/types.h"
 #include "cluster/types.h"
 #include "model/metadata.h"
+#include "ssx/sformat.h"
 #include "storage/disk_log_impl.h"
+#include "storage/parser.h"
 #include "test_utils/fixture.h"
 #include "utils/retry_chain_node.h"
 #include "utils/unresolved_address.h"
@@ -25,6 +28,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/test/tools/old/interface.hpp>
 
 using namespace std::chrono_literals;
 using namespace archival;
@@ -284,16 +288,19 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
 
     log_segment_set(lm);
     // Starting offset is lower than offset1
-    auto upload1 = policy.get_next_candidate(
-      model::offset(0), high_watermark, lm);
+    auto upload1
+      = policy.get_next_candidate(model::offset(0), high_watermark, lm).get();
     log_upload_candidate(upload1);
     BOOST_REQUIRE(upload1.source.get() != nullptr);
     BOOST_REQUIRE(upload1.starting_offset == offset1);
 
-    auto upload2 = policy.get_next_candidate(
-      upload1.source->offsets().dirty_offset + model::offset(1),
-      high_watermark,
-      lm);
+    auto upload2 = policy
+                     .get_next_candidate(
+                       upload1.source->offsets().dirty_offset
+                         + model::offset(1),
+                       high_watermark,
+                       lm)
+                     .get();
     log_upload_candidate(upload2);
     BOOST_REQUIRE(upload2.source.get() != nullptr);
     BOOST_REQUIRE(upload2.starting_offset() == offset2);
@@ -301,10 +308,13 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload2.source != upload1.source);
     BOOST_REQUIRE(upload2.source->offsets().base_offset == offset2);
 
-    auto upload3 = policy.get_next_candidate(
-      upload2.source->offsets().dirty_offset + model::offset(1),
-      high_watermark,
-      lm);
+    auto upload3 = policy
+                     .get_next_candidate(
+                       upload2.source->offsets().dirty_offset
+                         + model::offset(1),
+                       high_watermark,
+                       lm)
+                     .get();
     log_upload_candidate(upload3);
     BOOST_REQUIRE(upload3.source.get() != nullptr);
     BOOST_REQUIRE(upload3.starting_offset() == offset3);
@@ -312,14 +322,19 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload3.source != upload2.source);
     BOOST_REQUIRE(upload3.source->offsets().base_offset == offset3);
 
-    auto upload4 = policy.get_next_candidate(
-      upload3.source->offsets().dirty_offset + model::offset(1),
-      high_watermark,
-      lm);
+    auto upload4 = policy
+                     .get_next_candidate(
+                       upload3.source->offsets().dirty_offset
+                         + model::offset(1),
+                       high_watermark,
+                       lm)
+                     .get();
     BOOST_REQUIRE(upload4.source.get() == nullptr);
 
-    auto upload5 = policy.get_next_candidate(
-      high_watermark + model::offset(1), high_watermark, lm);
+    auto upload5 = policy
+                     .get_next_candidate(
+                       high_watermark + model::offset(1), high_watermark, lm)
+                     .get();
     BOOST_REQUIRE(upload5.source.get() == nullptr);
 }
 
@@ -408,10 +423,241 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
         BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT
     }
     {
-        auto [begin, end] = get_targets().equal_range(segment3_url);
+        auto [begin, end] = get_targets().equal_range(segment1_url);
         size_t len = std::distance(begin, end);
         BOOST_REQUIRE_EQUAL(len, 1);
         BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT
+    }
+}
+
+class counting_batch_consumer : public storage::batch_consumer {
+public:
+    struct stream_stats {
+        model::offset min_offset{model::offset::max()};
+        model::offset max_offset{model::offset::min()};
+        std::vector<model::offset> base_offsets;
+        std::vector<model::offset> last_offsets;
+    };
+
+    explicit counting_batch_consumer(stream_stats& s)
+      : batch_consumer()
+      , _stats(s) {}
+
+    consume_result
+    accept_batch_start(const model::record_batch_header&) const override {
+        return consume_result::accept_batch;
+    }
+    void consume_batch_start(
+      model::record_batch_header h,
+      [[maybe_unused]] size_t physical_base_offset,
+      [[maybe_unused]] size_t size_on_disk) override {
+        _stats.min_offset = std::min(_stats.min_offset, h.base_offset);
+        _stats.max_offset = std::max(_stats.max_offset, h.last_offset());
+        _stats.base_offsets.push_back(h.base_offset);
+        _stats.last_offsets.push_back(h.last_offset());
+    }
+    void skip_batch_start(model::record_batch_header, size_t, size_t) override {
+    }
+    void consume_records(iobuf&&) override {}
+    stop_parser consume_batch_end() override { return stop_parser::no; }
+    void print(std::ostream& o) const override {
+        fmt::print(
+          o,
+          "counting_batch_consumer, min_offset: {}, max_offset: {}, {} batches "
+          "consumed",
+          _stats.min_offset,
+          _stats.max_offset,
+          _stats.base_offsets.size());
+    }
+
+    stream_stats& _stats;
+};
+
+static counting_batch_consumer::stream_stats
+calculate_segment_stats(const ss::httpd::request& req) {
+    iobuf stream_body;
+    stream_body.append(req.content.data(), req.content_length);
+    auto stream = make_iobuf_input_stream(std::move(stream_body));
+    counting_batch_consumer::stream_stats stats{};
+    auto consumer = std::make_unique<counting_batch_consumer>(std::ref(stats));
+    storage::continuous_batch_parser parser(
+      std::move(consumer), std::move(stream));
+    parser.consume().get();
+    parser.close().get();
+    return stats;
+}
+
+// NOLINTNEXTLINE
+FIXTURE_TEST(test_partial_upload, archiver_fixture) {
+    // This test checks partial uploads. Partial upload can happen
+    // if the idle time is set in config or when the leadership is
+    // transferred to another node which has different data layout.
+    //
+    // The test creates a segment and forces a partial upload of the
+    // segment's middle part followed by the upload of the remaining
+    // data.
+    std::vector<segment_desc> segments = {
+      {manifest_ntp, model::offset(0), model::term_id(1), 10},
+    };
+
+    init_storage_api_local(segments);
+    auto s1name = archival::segment_name("0-1-v1.log");
+
+    auto segment1 = get_segment(manifest_ntp, s1name);
+    BOOST_REQUIRE(static_cast<bool>(segment1));
+
+    // Generate new manifest
+    cloud_storage::manifest manifest(manifest_ntp, manifest_revision);
+    const auto& layout = get_layouts(manifest_ntp);
+    vlog(test_log.debug, "Layout size", layout.size());
+    for (const auto& s : layout) {
+        vlog(test_log.debug, "- Segment {}", s.base_offset);
+        for (const auto& r : s.ranges) {
+            vlog(
+              test_log.debug, "-- Batch {}-{}", r.base_offset, r.last_offset);
+        }
+    }
+
+    auto last_uploaded_range = layout[0].ranges[3];
+    auto last_uploaded_offset = last_uploaded_range.base_offset
+                                - model::offset(1);
+
+    model::offset high_watermark = layout[0].ranges[7].last_offset;
+    model::offset next_uploaded_offset = high_watermark;
+
+    model::offset base_upl1 = layout[0].ranges[3].base_offset;
+    model::offset last_upl1 = layout[0].ranges[7].last_offset;
+    model::offset base_upl2 = layout[0].ranges[8].base_offset;
+    model::offset last_upl2 = layout[0].ranges[9].last_offset;
+
+    cloud_storage::manifest::segment_meta segment_meta{
+      .is_compacted = false,
+      .size_bytes = 1, // doesn't matter
+      .base_offset = model::offset(0),
+      .committed_offset = last_uploaded_offset};
+
+    manifest.add(s1name, segment_meta);
+
+    std::stringstream old_str;
+    manifest.serialize(old_str);
+
+    // Generate segment urls
+    auto url1 = "/"
+                + manifest
+                    .get_remote_segment_path(segment_name(ssx::sformat(
+                      "{}-1-v1.log", last_uploaded_offset() + 1)))()
+                    .string();
+    auto url2 = "/"
+                + manifest
+                    .get_remote_segment_path(segment_name(ssx::sformat(
+                      "{}-1-v1.log", next_uploaded_offset() + 1)))()
+                    .string();
+    vlog(
+      test_log.debug,
+      "Expected segment upload urls {} and {}, last_uploaded_offset: {}, "
+      "high_watermark: {}",
+      url1,
+      url2,
+      last_uploaded_offset,
+      high_watermark);
+
+    std::vector<s3_imposter_fixture::expectation> expectations({
+      s3_imposter_fixture::expectation{
+        .url = manifest_url, .body = ss::sstring(old_str.str())},
+      s3_imposter_fixture::expectation{.url = url1, .body = "segment1"},
+      s3_imposter_fixture::expectation{.url = url2, .body = "segment2"},
+    });
+
+    set_expectations_and_listen(expectations);
+
+    auto conf = get_configuration();
+    service_probe probe(service_metrics_disabled::yes);
+    cloud_storage::remote remote(
+      conf.connection_limit, conf.client_config, probe);
+    auto config = get_configuration();
+    config.time_limit = segment_time_limit(0s);
+    archival::ntp_archiver archiver(get_ntp_conf(), config, remote, probe);
+    auto action = ss::defer([&archiver] { archiver.stop().get(); });
+
+    retry_chain_node fib;
+
+    archiver.download_manifest(fib).get();
+
+    auto res = archiver
+                 .upload_next_candidates(
+                   get_local_storage_api().log_mgr(), high_watermark, fib)
+                 .get0();
+    BOOST_REQUIRE_EQUAL(res.num_succeded, 1);
+    BOOST_REQUIRE_EQUAL(res.num_failed, 0);
+
+    for (auto req : get_requests()) {
+        vlog(test_log.error, "{}", req._url);
+    }
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
+    {
+        auto [begin, end] = get_targets().equal_range(manifest_url);
+        size_t len = std::distance(begin, end);
+        BOOST_REQUIRE_EQUAL(len, 2);
+        std::set<ss::sstring> expected = {"PUT", "GET"};
+        for (auto it = begin; it != end; it++) {
+            auto key = it->second._method;
+            BOOST_REQUIRE(expected.contains(key));
+            expected.erase(key);
+        }
+        BOOST_REQUIRE(expected.empty());
+    }
+    {
+        auto [begin, end] = get_targets().equal_range(url1);
+        size_t len = std::distance(begin, end);
+        BOOST_REQUIRE_EQUAL(len, 1);
+        BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT
+
+        // check that the uploaded log contains the right offsets
+        auto stats = calculate_segment_stats(begin->second);
+
+        BOOST_REQUIRE_EQUAL(stats.min_offset, base_upl1);
+        BOOST_REQUIRE_EQUAL(stats.max_offset, last_upl1);
+    }
+
+    high_watermark = model::offset::max();
+    res = archiver
+            .upload_next_candidates(
+              get_local_storage_api().log_mgr(), high_watermark, fib)
+            .get0();
+    BOOST_REQUIRE_EQUAL(res.num_succeded, 1);
+    BOOST_REQUIRE_EQUAL(res.num_failed, 0);
+
+    BOOST_REQUIRE_EQUAL(get_requests().size(), 5);
+    {
+        auto [begin, end] = get_targets().equal_range(manifest_url);
+        size_t len = std::distance(begin, end);
+        BOOST_REQUIRE_EQUAL(len, 3);
+        std::multiset<ss::sstring> expected = {"PUT", "PUT", "GET"};
+        for (auto it = begin; it != end; it++) {
+            auto key = it->second._method;
+            BOOST_REQUIRE(expected.contains(key));
+            auto i = expected.find(key);
+            expected.erase(i);
+        }
+        BOOST_REQUIRE(expected.empty());
+    }
+    {
+        auto [begin, end] = get_targets().equal_range(url1);
+        size_t len = std::distance(begin, end);
+        BOOST_REQUIRE_EQUAL(len, 1);
+        BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT
+    }
+    {
+        auto [begin, end] = get_targets().equal_range(url2);
+        size_t len = std::distance(begin, end);
+        BOOST_REQUIRE_EQUAL(len, 1);
+        BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT
+
+        // check that the uploaded log contains the right offsets
+        auto stats = calculate_segment_stats(begin->second);
+
+        BOOST_REQUIRE_EQUAL(stats.min_offset, base_upl2);
+        BOOST_REQUIRE_EQUAL(stats.max_offset, last_upl2);
     }
 }
 
@@ -458,16 +704,19 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     log_segment_set(lm);
     model::offset high_watermark{9999};
     // Starting offset is lower than offset1
-    auto upload1 = policy.get_next_candidate(
-      model::offset(0), high_watermark, lm);
+    auto upload1
+      = policy.get_next_candidate(model::offset(0), high_watermark, lm).get();
     log_upload_candidate(upload1);
     BOOST_REQUIRE(upload1.source.get() != nullptr);
     BOOST_REQUIRE(upload1.starting_offset == offset1);
 
-    auto upload2 = policy.get_next_candidate(
-      upload1.source->offsets().dirty_offset + model::offset(1),
-      high_watermark,
-      lm);
+    auto upload2 = policy
+                     .get_next_candidate(
+                       upload1.source->offsets().dirty_offset
+                         + model::offset(1),
+                       high_watermark,
+                       lm)
+                     .get();
     log_upload_candidate(upload2);
     BOOST_REQUIRE(upload2.source.get() != nullptr);
     BOOST_REQUIRE(upload2.starting_offset == offset2);
@@ -475,10 +724,13 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload2.source != upload1.source);
     BOOST_REQUIRE(upload2.source->offsets().base_offset == offset2);
 
-    auto upload3 = policy.get_next_candidate(
-      upload2.source->offsets().dirty_offset + model::offset(1),
-      high_watermark,
-      lm);
+    auto upload3 = policy
+                     .get_next_candidate(
+                       upload2.source->offsets().dirty_offset
+                         + model::offset(1),
+                       high_watermark,
+                       lm)
+                     .get();
     log_upload_candidate(upload3);
     BOOST_REQUIRE(upload3.source.get() != nullptr);
     BOOST_REQUIRE(upload3.starting_offset == offset3);
@@ -486,9 +738,12 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload3.source != upload2.source);
     BOOST_REQUIRE(upload3.source->offsets().base_offset == offset3);
 
-    auto upload4 = policy.get_next_candidate(
-      upload3.source->offsets().dirty_offset + model::offset(1),
-      high_watermark,
-      lm);
+    auto upload4 = policy
+                     .get_next_candidate(
+                       upload3.source->offsets().dirty_offset
+                         + model::offset(1),
+                       high_watermark,
+                       lm)
+                     .get();
     BOOST_REQUIRE(upload4.source.get() == nullptr);
 }

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -90,6 +90,17 @@ struct segment_desc {
     model::ntp ntp;
     model::offset base_offset;
     model::term_id term;
+    std::optional<size_t> num_batches;
+};
+
+struct offset_range {
+    model::offset base_offset;
+    model::offset last_offset;
+};
+
+struct segment_layout {
+    model::offset base_offset;
+    std::vector<offset_range> ranges;
 };
 
 /// This utility can be used to match content of the log
@@ -154,9 +165,16 @@ public:
     /// The method doesn't add topics, only creates segments in data_dir
     void init_storage_api_local(std::vector<segment_desc>& segm);
 
+    std::vector<segment_layout> get_layouts(const model::ntp& ntp) const {
+        return layouts.find(ntp)->second;
+    }
+
+protected:
 private:
     void
     initialize_shard(storage::api& api, const std::vector<segment_desc>& segm);
+
+    std::unordered_map<model::ntp, std::vector<segment_layout>> layouts;
 };
 
 archival::configuration get_configuration();

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage/types.h"
+#include "seastar/core/lowres_clock.hh"
 #include "seastar/core/sstring.hh"
 #include "seastar/util/bool_class.hh"
 #include "seastarx.h"
@@ -30,5 +31,8 @@ using service_metrics_disabled
   = ss::bool_class<struct service_metrics_disabled_tag>;
 using per_ntp_metrics_disabled
   = ss::bool_class<struct per_ntp_metrics_disabled_tag>;
+
+using segment_time_limit
+  = named_type<ss::lowres_clock::duration, struct segment_time_limit_tag>;
 
 } // namespace archival

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -820,6 +820,13 @@ configuration::configuration()
       "Max https connection idle time (ms)",
       required::no,
       5s)
+  , cloud_storage_segment_max_upload_interval_sec(
+      *this,
+      "cloud_storage_segment_max_upload_interval_sec",
+      "Time that segment can be kept locally without uploading it to the "
+      "remote storage (sec)",
+      required::no,
+      std::nullopt)
   , superusers(
       *this, "superusers", "List of superuser usernames", required::no, {})
   , kafka_qdc_latency_alpha(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -189,6 +189,8 @@ struct configuration final : public config_store {
       cloud_storage_manifest_upload_timeout_ms;
     property<std::chrono::milliseconds>
       cloud_storage_max_connection_idle_time_ms;
+    property<std::optional<std::chrono::seconds>>
+      cloud_storage_segment_max_upload_interval_sec;
 
     one_or_many_property<ss::sstring> superusers;
 
@@ -418,6 +420,23 @@ struct convert<std::chrono::milliseconds> {
             return res;
         }
         rhs = std::chrono::milliseconds(secs);
+        return true;
+    }
+};
+
+template<>
+struct convert<std::chrono::seconds> {
+    using type = std::chrono::seconds;
+
+    static Node encode(const type& rhs) { return Node(rhs.count()); }
+
+    static bool decode(const Node& node, type& rhs) {
+        type::rep secs;
+        auto res = convert<type::rep>::decode(node, secs);
+        if (!res) {
+            return res;
+        }
+        rhs = std::chrono::seconds(secs);
         return true;
     }
 };

--- a/src/v/storage/segment_appender_utils.cc
+++ b/src/v/storage/segment_appender_utils.cc
@@ -25,7 +25,7 @@
 #include <type_traits>
 namespace storage {
 
-static iobuf disk_header_to_iobuf(const model::record_batch_header& h) {
+iobuf disk_header_to_iobuf(const model::record_batch_header& h) {
 #ifndef NDEBUG
     vassert(h.header_crc != 0, "Header cannot have an unset crc:{}", h);
 #endif

--- a/src/v/storage/segment_appender_utils.h
+++ b/src/v/storage/segment_appender_utils.h
@@ -16,6 +16,8 @@
 
 namespace storage {
 
+iobuf disk_header_to_iobuf(const model::record_batch_header& h);
+
 ss::future<>
 write(segment_appender& appender, const model::record_batch& batch);
 

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -64,6 +64,8 @@ public:
     /// starting at position @pos
     ss::input_stream<char>
     data_stream(size_t pos, const ss::io_priority_class&);
+    ss::input_stream<char>
+    data_stream(size_t pos_begin, size_t pos_end, const ss::io_priority_class&);
 
 private:
     ss::sstring _filename;

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -18,7 +18,7 @@ from rptest.services.redpanda import RedpandaService
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 import time
 import os
 import json
@@ -155,7 +155,7 @@ class ArchivalTest(RedpandaTest):
 
     def __init__(self, test_context):
         self.s3_bucket_name = f"panda-bucket-{uuid.uuid1()}"
-        extra_rp_conf = dict(
+        self._extra_rp_conf = dict(
             developer_mode=True,
             cloud_storage_enabled=True,
             cloud_storage_access_key=ArchivalTest.s3_access_key,
@@ -170,7 +170,7 @@ class ArchivalTest(RedpandaTest):
             log_segment_size=1048576  # 1MB
         )
         super(ArchivalTest, self).__init__(test_context=test_context,
-                                           extra_rp_conf=extra_rp_conf)
+                                           extra_rp_conf=self._extra_rp_conf)
 
         self.kafka_tools = KafkaCliTools(self.redpanda)
         self.s3_client = S3Client(
@@ -294,6 +294,93 @@ class ArchivalTest(RedpandaTest):
         time.sleep(5)
         self.kafka_tools.produce(self.topic, 5000, 1024)
         validate(self._cross_node_verify, self.logger, 90)
+
+    @cluster(num_nodes=3)
+    def test_timeboxed_uploads(self):
+        """This test checks segment upload time limit. The feature is enabled in the
+        configuration. The configuration defines maximum time interval between uploads.
+        If the option is set then redpanda will start uploading a segment partially if
+        configured amount of time passed since previous upload and the segment has some
+        new data.
+        The test sets the timeout value to 1s. Then it uploads data in batches with delays
+        between the batches. The segment size is set to 1GiB. We upload 10MiB total. So
+        normally, there won't be any data uploaded to Minio. But since the time limit for
+        a segment is set to 1s we will see a bunch of segments in the bucket. The offsets
+        of the segments won't align with the segment in the redpanda data directory. But
+        their respective offset ranges should align and the sizes should make sense.
+        """
+        self._extra_rp_conf.update(
+            log_segment_size=1024 * 1024 * 1024,
+            cloud_storage_segment_max_upload_interval_sec=1)
+        # We have to restart redpanda in order for these config changes
+        # to take effect.
+        for node in self.redpanda.nodes:
+            self.redpanda.stop_node(node)
+        time.sleep(5)
+        for node in self.redpanda.nodes:
+            self.redpanda.start_node(node)
+        time.sleep(5)
+
+        # The offsets of the segments in the Minio bucket won't necessary
+        # correlate with the write bursts here. The upload depends on the
+        # timeout but also on raft and current high_watermark. So we can
+        # expect that the bucket won't have 9 segments with 1000 offsets.
+        # The actual segments will be larger.
+        for i in range(0, 10):
+            self.kafka_tools.produce(self.topic, 1000, 1024)
+            time.sleep(1)
+        time.sleep(5)
+
+        def check_upload():
+            # check that the upload happened
+            ntps = set()
+            sizes = {}
+
+            for node in self.redpanda.nodes:
+                checksums = self._get_redpanda_log_segment_checksums(node)
+                self.logger.info(
+                    f"Node: {node.account.hostname} checksums: {checksums}")
+                lst = [
+                    _parse_normalized_segment_path(path, md5, size)
+                    for path, (md5, size) in checksums.items()
+                ]
+                lst = sorted(lst, key=lambda x: x.base_offset)
+                segments = defaultdict(int)
+                sz = defaultdict(int)
+                for it in lst:
+                    ntps.add(it.ntp)
+                    sz[it.ntp] += it.size
+                    segments[it.ntp] += 1
+                for ntp, s in segments.items():
+                    assert s != 0, f"expected to have at least one segment per partition, got {s}"
+                for ntp, s in sz.items():
+                    if ntp not in sizes:
+                        sizes[ntp] = s
+
+            # Download manifest for partitions
+            for ntp in ntps:
+                manifest = self._download_partition_manifest(ntp)
+                self.logger.info(f"downloaded manifest {manifest}")
+                segments = []
+                for _, segment in manifest['segments'].items():
+                    segments.append(segment)
+
+                segments = sorted(segments, key=lambda s: s['base_offset'])
+                self.logger.info(f"sorted segments {segments}")
+
+                prev_committed_offset = -1
+                size = 0
+                for segment in segments:
+                    self.logger.info(
+                        f"checking {segment} prev: {prev_committed_offset}")
+                    base_offset = segment['base_offset']
+                    assert prev_committed_offset + 1 == base_offset
+                    prev_committed_offset = segment['committed_offset']
+                    size += segment['size_bytes']
+                assert sizes[ntp] >= size
+                assert size > 0
+
+        validate(check_upload, self.logger, 90)
 
     def _check_bucket_is_emtpy(self):
         allobj = self._list_objects()
@@ -467,8 +554,11 @@ class ArchivalTest(RedpandaTest):
                                 )
                                 if actual_hash == msegm.md5:
                                     manifest_segments[mix] = None
-                                    self.logger.info(f"partial match for segment {msegm.ntp} {msegm.base_offset}-" +\
-                                                    f"{msegm.committed_offset} on {node_key}")
+                                    self.logger.info(
+                                        f"partial match for segment {msegm.ntp} {msegm.base_offset}-"
+                                        +
+                                        f"{msegm.committed_offset} on {node_key}"
+                                    )
                                     found = True
                                     break
                         if not found:


### PR DESCRIPTION
## Cover letter

Add ability to limit upload idle time. Normally, only sealed segments are uploaded. This can be problematic for topics which grows slowly. Such topics will be uploaded rarely.
This PR adds a mechanism that will trigger partial upload of the non-sealed segment if previous upload happened configure number of seconds ago. This will create more than one segment in the S3 bucket for every segment on disk. For partitions which receive enough data redpanda will still upload only sealed segments.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/0182f4905284965a4b64d4fb33f05962d89da0bf..4eec85dcf97ea39bae31e11c8594b3ec061b6d5c):
- Code review comments fixed.
- Add commit that implements a `transform_stream` function which is similar to `ss::copy` but work on record batch level and allows for fine-grained control over the data stream.
- The logic in the archival policy changed in a big way. 
  - The partial uploads are no longer handled by the index alone. The algorithm finds the beginning of the record batch closest to the `last_offset` and then the `transform_stream` is used to scan the stream and find the actual location of the record batch which should be uploaded next. This is needed because the index lookup can undershoot and return the value which has an offset which is less than the one we want.
  - Same i s done for the end of the upload. If the idle timeout is reached the active segment is uploaded partially. The last offset that should be uploaded is found using the index + quick scan.
  - If there is no index the algorithm will end up scanning the whole segment.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/4eec85dcf97ea39bae31e11c8594b3ec061b6d5c..47dafeb8e7b7b2c09a9cd9de84edc55fcf660235):
- Changed default value for the configuration parameter from 0s to `std::nullopt`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/47dafeb8e7b7b2c09a9cd9de84edc55fcf660235..2d4456b637189106e9bf14ec160fbf88f3bb6cdb):
- Rebase dev branch

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/2d4456b637189106e9bf14ec160fbf88f3bb6cdb..1154461f974f00a7e603c5461bd31f8dfec537f9):
- Fix ducktape test

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/cd03d9b066f1b9cddb67abbd827f875f07f92beb..059962c0447a1d67b29ecc52fbe802ba9ceba7dc)
- Fix code review issues
- Fix off by one error in segment scanning in the partial upload logic
- Improved test suite
- Switched archival from using high watermark as a safe upload limit to last stable offset 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/059962c0447a1d67b29ecc52fbe802ba9ceba7dc..a3fcdbc1791af472504ec8d63c9ddfd785172354)
- Fix off by one error caused by transition from HW to LSO
- Update unit-test (add more cases)

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/a3fcdbc1791af472504ec8d63c9ddfd785172354..c29aa82a367e0bf22ee787512a8084bec2105f2f)
- Make linter happy

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/e7e7ba71f0fc3c45a6884ba154df0292738d461f..38409590dbc112318f33a8e92fe0bb0acd72634b)
- Fix segfault caused by the compiler bug

Canges in [force push](https://github.com/vectorizedio/redpanda/compare/38409590dbc112318f33a8e92fe0bb0acd72634b..e3b4e1881ba3ceadadbb203a3bd2773d4164571f)
- Added the comment regarding compiler bug

Changes in [push](https://github.com/Lazin/redpanda/commit/26e4636f2d79e5fc7ca5ec3f335c07432e674989)
- Upload loop is rewritten using continuations passing style instead of coroutines 

## Release notes

N/A