### PR TITLE
cluster: add health manager

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -66,6 +66,7 @@ v_cc_library(
     controller_api.cc
     members_frontend.cc
     members_backend.cc
+    health_manager.cc
     scheduling/allocation_node.cc
     scheduling/types.cc
     scheduling/allocation_state.cc

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -13,6 +13,7 @@
 
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
+#include "cluster/health_manager.h"
 #include "cluster/scheduling/leader_balancer.h"
 #include "cluster/topic_updates_dispatcher.h"
 #include "raft/group_manager.h"
@@ -96,6 +97,7 @@ private:
     ss::sharded<security_frontend> _security_frontend;
     ss::sharded<security::authorizer> _authorizer;
     ss::sharded<raft::group_manager>& _raft_manager;
+    ss::sharded<health_manager> _health_manager;
     std::unique_ptr<leader_balancer> _leader_balancer;
     consensus_ptr _raft0;
 };

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/health_manager.h"
+
+#include "cluster/logger.h"
+#include "cluster/partition_leaders_table.h"
+#include "cluster/scheduling/partition_allocator.h"
+#include "cluster/topic_table.h"
+#include "cluster/topics_frontend.h"
+#include "model/namespace.h"
+#include "seastarx.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/timer.hh>
+
+namespace cluster {
+
+health_manager::health_manager(
+  model::node_id self,
+  size_t target_replication_factor,
+  std::chrono::milliseconds tick_interval,
+  ss::sharded<topic_table>& topics,
+  ss::sharded<topics_frontend>& topics_frontend,
+  ss::sharded<partition_allocator>& allocator,
+  ss::sharded<partition_leaders_table>& leaders,
+  ss::sharded<ss::abort_source>& as)
+  : _self(self)
+  , _target_replication_factor(target_replication_factor)
+  , _tick_interval(tick_interval)
+  , _topics(topics)
+  , _topics_frontend(topics_frontend)
+  , _allocator(allocator)
+  , _leaders(leaders)
+  , _as(as)
+  , _timer([this] { tick(); }) {}
+
+ss::future<> health_manager::start() {
+    _timer.arm(_tick_interval);
+    co_return;
+}
+
+ss::future<> health_manager::stop() {
+    _timer.cancel();
+    return _gate.close();
+}
+
+ss::future<bool> health_manager::ensure_partition_replication(model::ntp ntp) {
+    auto assignment = _topics.local().get_partition_assignment(ntp);
+    if (!assignment) {
+        vlog(
+          clusterlog.warn,
+          "Health manager: partition {} has no assignment",
+          ntp);
+        co_return false;
+    }
+
+    if (assignment->replicas.size() >= _target_replication_factor) {
+        vlog(
+          clusterlog.debug,
+          "Health manager: partition {} with replication {} reached target {}",
+          ntp,
+          assignment->replicas.size(),
+          _target_replication_factor);
+        co_return true;
+    }
+
+    partition_constraints constraints(
+      ntp.tp.partition, _target_replication_factor);
+
+    auto allocation = _allocator.local().reallocate_partition(
+      constraints, *assignment);
+    if (!allocation) {
+        vlog(
+          clusterlog.warn,
+          "Health manager: allocation for {} with replication factor {} "
+          "failed: {}",
+          ntp,
+          _target_replication_factor,
+          allocation.error().message());
+        co_return false;
+    }
+
+    auto new_assignments = allocation.value().get_assignments();
+
+    auto it = std::find_if(
+      new_assignments.cbegin(),
+      new_assignments.cend(),
+      [id = ntp.tp.partition](const auto& a) { return a.id == id; });
+
+    if (it == new_assignments.cend()) {
+        vlog(
+          clusterlog.warn,
+          "Health manager: could not find new allocation for {}",
+          ntp);
+        co_return false;
+    }
+
+    /*
+     * TODO: this check that the replicas are on different nodes should be
+     * unncessary and removed once the allocation constraints are setup
+     * correctly. current the following bug is related to the allocator
+     * constraints not being applied properly:
+     *
+     *    https://github.com/vectorizedio/redpanda/issues/2195
+     */
+    {
+        std::set<model::node_id> nodes;
+        for (const auto& r : it->replicas) {
+            nodes.insert(r.node_id);
+        }
+        if (nodes.size() != _target_replication_factor) {
+            vlog(
+              clusterlog.warn,
+              "Health manager: could not satisfy allocation for {}",
+              ntp);
+            co_return false;
+        }
+    }
+
+    auto err = co_await _topics_frontend.local().move_partition_replicas(
+      ntp, it->replicas, model::timeout_clock::now() + set_replicas_timeout);
+    if (err) {
+        vlog(
+          clusterlog.warn,
+          "Health manager: error setting replicas for {}: {}",
+          ntp,
+          err);
+        co_return false;
+    }
+
+    vlog(
+      clusterlog.info,
+      "Increasing replication factor for {} to {}",
+      ntp,
+      it->replicas.size());
+
+    // short delay for things to stablize
+    co_await ss::sleep_abortable(stabilize_delay, _as.local());
+    co_return true;
+}
+
+ss::future<bool>
+health_manager::ensure_topic_replication(model::topic_namespace_view topic) {
+    auto metadata = _topics.local().get_topic_metadata(topic);
+    if (!metadata) {
+        vlog(clusterlog.debug, "Health manager: topic {} not found", topic);
+        co_return true;
+    }
+
+    for (const auto& partition : metadata->partitions) {
+        model::ntp ntp(topic.ns, topic.tp, partition.id);
+        if (!co_await ensure_partition_replication(std::move(ntp))) {
+            co_return false;
+        }
+    }
+
+    co_return true;
+}
+
+void health_manager::tick() {
+    (void)ss::try_with_gate(
+      _gate,
+      [this]() -> ss::future<> {
+          /*
+           * only active on the controller leader
+           */
+          auto cluster_leader = _leaders.local().get_leader(
+            model::controller_ntp);
+          if (cluster_leader != _self) {
+              vlog(clusterlog.trace, "Health: skipping tick as non-leader");
+              co_return;
+          }
+
+          /*
+           * we try to be conservative here. if something goes wrong we'll back
+           * off and wait before trying to fix replication for any other
+           * internal topics.
+           */
+          auto ok = co_await ensure_topic_replication(model::kafka_group_nt);
+
+          if (ok) {
+              ok = co_await ensure_topic_replication(model::id_allocator_nt);
+          }
+
+          if (ok) {
+              ok = co_await ensure_topic_replication(model::tx_manager_nt);
+          }
+
+          _timer.arm(_tick_interval);
+      })
+      .handle_exception_type([](const ss::gate_closed_exception&) {})
+      .handle_exception([this](const std::exception_ptr& e) {
+          vlog(clusterlog.info, "Health manager caught error {}", e);
+          _timer.arm(_tick_interval * 2);
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "cluster/types.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/timer.hh>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace cluster {
+
+class health_manager {
+    using clock_type = ss::lowres_clock;
+    static constexpr std::chrono::seconds set_replicas_timeout = 15s;
+    // after changing replica set introduce a short cooling off delay
+    static constexpr std::chrono::seconds stabilize_delay = 10s;
+
+public:
+    static constexpr ss::shard_id shard = 0;
+
+    health_manager(
+      model::node_id,
+      size_t,
+      std::chrono::milliseconds,
+      ss::sharded<topic_table>&,
+      ss::sharded<topics_frontend>&,
+      ss::sharded<partition_allocator>&,
+      ss::sharded<partition_leaders_table>&,
+      ss::sharded<ss::abort_source>&);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+private:
+    ss::future<bool> ensure_topic_replication(model::topic_namespace_view);
+    ss::future<bool> ensure_partition_replication(model::ntp);
+    void tick();
+
+    model::node_id _self;
+    size_t _target_replication_factor;
+    std::chrono::milliseconds _tick_interval;
+    ss::sharded<topic_table>& _topics;
+    ss::sharded<topics_frontend>& _topics_frontend;
+    ss::sharded<partition_allocator>& _allocator;
+    ss::sharded<partition_leaders_table>& _leaders;
+    ss::sharded<ss::abort_source>& _as;
+    ss::gate _gate;
+    ss::timer<clock_type> _timer;
+};
+
+} // namespace cluster

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -863,6 +863,18 @@ configuration::configuration()
       "Leadership rebalancing node mute timeout",
       required::no,
       20s)
+  , internal_topic_replication_factor(
+      *this,
+      "internal_topic_replication_factor",
+      "Target replication factor for internal topics",
+      required::no,
+      3)
+  , health_manager_tick_interval(
+      *this,
+      "health_manager_tick_interval",
+      "How often the health manager runs",
+      required::no,
+      3min)
   , _advertised_kafka_api(
       *this,
       "advertised_kafka_api",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -208,6 +208,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> leader_balancer_idle_timeout;
     property<std::chrono::milliseconds> leader_balancer_mute_timeout;
     property<std::chrono::milliseconds> leader_balancer_node_mute_timeout;
+    property<int> internal_topic_replication_factor;
+    property<std::chrono::milliseconds> health_manager_tick_interval;
 
     configuration();
 

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -35,6 +35,8 @@ inline const model::ns kafka_namespace("kafka");
 
 inline const model::ns kafka_internal_namespace("kafka_internal");
 inline const model::topic kafka_group_topic("group");
+inline const model::topic_namespace
+  kafka_group_nt(model::kafka_internal_namespace, kafka_group_topic);
 
 inline const model::topic
   coprocessor_internal_topic("coprocessor_internal_topic");
@@ -51,6 +53,8 @@ inline const model::ntp tx_manager_ntp(
   model::partition_id(0));
 
 inline const model::topic id_allocator_topic("id_allocator");
+inline const model::topic_namespace
+  id_allocator_nt(model::kafka_internal_namespace, id_allocator_topic);
 inline const model::ntp id_allocator_ntp(
   model::kafka_internal_namespace,
   model::id_allocator_topic,


### PR DESCRIPTION
Adds health manager which periodically performs cluster health and maintenance. Current use case is to monitor for under replicated internal topics and increase replication factor when possible.