### PR TITLE
tx/sync: fix transaction related pauses

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -175,7 +175,7 @@ raft::replicate_stages partition::replicate_in_stages(
         }
     }
 
-    if (bid.is_transactional || bid.has_idempotent()) {
+    if (_rm_stm) {
         ss::promise<> p;
         auto f = p.get_future();
         auto replicate_finished
@@ -259,7 +259,7 @@ ss::future<result<raft::replicate_result>> partition::replicate(
         }
     }
 
-    if (bid.is_transactional || bid.has_idempotent()) {
+    if (_rm_stm) {
         return _rm_stm->replicate(bid, std::move(r), opts);
     } else {
         return _raft->replicate(std::move(r), opts);

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -103,6 +103,12 @@ public:
     ss::future<bool>
     wait_no_throw(model::offset offset, model::timeout_clock::duration);
 
+private:
+    ss::future<> wait_offset_committed(
+      model::timeout_clock::duration, model::offset, model::term_id);
+    ss::future<bool>
+      do_sync(model::timeout_clock::duration, model::offset, model::term_id);
+
 protected:
     virtual ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) = 0;
     virtual ss::future<stm_snapshot> take_snapshot() = 0;
@@ -111,8 +117,6 @@ protected:
     ss::future<> persist_snapshot(stm_snapshot&&);
     ss::future<> do_make_snapshot();
 
-    ss::future<> wait_offset_committed(
-      model::timeout_clock::duration, model::offset, model::term_id);
     /*
      * `sync` checks that current node is a leader and if `sync` wasn't
      * called within its term it waits until the state machine is caught

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -606,7 +606,14 @@ ss::future<result<raft::replicate_result>> rm_stm::replicate(
         return replicate_seq(bid, std::move(b), opts);
     }
 
-    return _c->replicate(std::move(b), opts);
+    return sync(_sync_timeout)
+      .then([this, opts, b = std::move(b)](bool is_synced) mutable {
+          if (!is_synced) {
+              return ss::make_ready_future<result<raft::replicate_result>>(
+                errc::not_leader);
+          }
+          return _c->replicate(std::move(b), opts);
+      });
 }
 
 ss::future<> rm_stm::stop() {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -286,7 +286,7 @@ configuration::configuration()
       "tm_sync_timeout_ms",
       "Time to wait state catch up before rejecting a request",
       required::no,
-      2000ms)
+      10s)
   , tm_violation_recovery_policy(
       *this,
       "tm_violation_recovery_policy",
@@ -299,7 +299,7 @@ configuration::configuration()
       "rm_sync_timeout_ms",
       "Time to wait state catch up before rejecting a request",
       required::no,
-      2000ms)
+      10s)
   , tx_timeout_delay_ms(
       *this,
       "tx_timeout_delay_ms",


### PR DESCRIPTION
The PR improves logging and fixes persisted_stm/sync availability issue.

`state_machine::wait` works only with committed offsets. `refresh_commit_index` executes disk flushes to turn dirty offsets into committed offsets. Previously we were querying dirty offset after executing the refresh index function. And sometimes it led to a situation where we were getting a fresher than flushed dirty offset. So when we were calling state_machine::wait using that offset it caused stalls and time-outs.
    
Fixing the problem by caching dirty offset before calling `refresh_commit_index`