### PR TITLE
c/partition_allocator: fixed handling allocation constraints

### DIFF
--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -59,8 +59,7 @@ partition_allocator::allocate_partition(partition_constraints p_constraints) {
         effective_constraits.hard_constraints.push_back(
           ss::make_lw_shared<hard_constraint_evaluator>(
             distinct_from(replicas.get())));
-        effective_constraits.add(std::move(p_constraints.constraints));
-
+        effective_constraits.add(p_constraints.constraints);
         auto replica = _allocation_strategy.allocate_replica(
           effective_constraits, *_state);
 


### PR DESCRIPTION
When partition allocator allocates partition it should use passed
constraints for all the partition replicas.
Using `std::move` when creating effective constraints set during
replica allocation caused the requested constraints to be applied to
only the first replica from allocated replica set.

Fixes: #2195 
