### PR TITLE
Controlling number of concurrent follower requests

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -13,8 +13,33 @@
 #include "model/metadata.h"
 #include "units.h"
 
+#include <cstdint>
+
 namespace config {
 using namespace std::chrono_literals;
+
+uint32_t default_raft_non_local_requests() {
+    /**
+     * raft max non local requests
+     * - up to 7000 groups per core
+     * - up to 256 concurrent append entries per group
+     * - additional requests like (vote, snapshot, timeout now)
+     *
+     * All the values have to be multiplied by core count minus one since
+     * part of the requests will be core local
+     *
+     * 7000*256 * (number of cores-1) + 10 * 7000 * (number of cores-1)
+     *         ^                                 ^
+     * append entries requests          additional requests
+     */
+    static constexpr uint32_t max_partitions_per_core = 7000;
+    static constexpr uint32_t max_append_requests_per_follower = 256;
+    static constexpr uint32_t additional_requests_per_follower = 10;
+
+    return max_partitions_per_core
+           * (max_append_requests_per_follower + additional_requests_per_follower)
+           * (ss::smp::count - 1);
+}
 
 configuration::configuration()
   : data_directory(
@@ -499,6 +524,20 @@ configuration::configuration()
       "Raft learner recovery rate limit in bytes per sec",
       required::no,
       100_MiB)
+  , raft_smp_max_non_local_requests(
+      *this,
+      "raft_smp_max_non_local_requests",
+      "Maximum number of x-core requests pending in Raft seastar::smp group. "
+      "(for more details look at `seastar::smp_service_group` documentation)",
+      required::no,
+      default_raft_non_local_requests())
+  , raft_max_concurrent_append_requests_per_follower(
+      *this,
+      "raft_max_concurrent_append_requests_per_follower",
+      "Maximum number of concurrent append entries requests sent by leader to "
+      "one follower",
+      required::no,
+      16)
   , reclaim_min_size(
       *this,
       "reclaim_min_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -133,6 +133,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> recovery_append_timeout_ms;
     property<size_t> raft_replicate_batch_window_size;
     property<size_t> raft_learner_recovery_rate;
+    property<uint32_t> raft_smp_max_non_local_requests;
+    property<uint32_t> raft_max_concurrent_append_requests_per_follower;
 
     property<size_t> reclaim_min_size;
     property<size_t> reclaim_max_size;

--- a/src/v/raft/CMakeLists.txt
+++ b/src/v/raft/CMakeLists.txt
@@ -31,6 +31,7 @@ v_cc_library(
     configuration_manager.cc
     group_configuration.cc
     append_entries_buffer.cc
+    follower_queue.cc
   DEPS
     v::storage
     raft_rpc

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -60,7 +60,10 @@ consensus::consensus(
   , _disk_timeout(disk_timeout)
   , _client_protocol(client)
   , _leader_notification(std::move(cb))
-  , _fstats(_self)
+  , _fstats(
+      _self,
+      config::shard_local_cfg()
+        .raft_max_concurrent_append_requests_per_follower())
   , _batcher(this, config::shard_local_cfg().raft_replicate_batch_window_size())
   , _event_manager(this)
   , _ctxlog(group, _log.config().ntp())

--- a/src/v/raft/follower_queue.cc
+++ b/src/v/raft/follower_queue.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "raft/follower_queue.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace raft {
+
+follower_queue::follower_queue(uint32_t max_concurrent_append_entries)
+  : _max_concurrent_append_entries(max_concurrent_append_entries)
+  , _sem(std::make_unique<ss::semaphore>(_max_concurrent_append_entries)) {}
+
+ss::future<ss::semaphore_units<>> follower_queue::get_append_entries_unit() {
+    co_return co_await ss::get_units(*_sem, 1);
+}
+
+} // namespace raft

--- a/src/v/raft/follower_queue.h
+++ b/src/v/raft/follower_queue.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "raft/group_configuration.h"
+
+#include <seastar/core/semaphore.hh>
+
+namespace raft {
+
+class follower_queue {
+public:
+    explicit follower_queue(uint32_t);
+
+    follower_queue(follower_queue&&) noexcept = default;
+    follower_queue(const follower_queue&) = delete;
+    follower_queue& operator=(follower_queue&&) = default;
+    follower_queue& operator=(const follower_queue&) = delete;
+    ~follower_queue() {
+        vassert(is_idle(), "can not remove not idle follower queue");
+    }
+
+    ss::future<ss::semaphore_units<>> get_append_entries_unit();
+
+    ss::future<> stop();
+
+    bool is_idle() const {
+        return _sem->waiters() == 0
+               && _sem->available_units() == _max_concurrent_append_entries;
+    }
+
+private:
+    /**
+     * TODO: consider using queue depth control to automatically adjust number
+     * of concurrent requests per follower. In general it should be fine to make
+     * this static since scaling throughput is usually achieved by increasing
+     * partition count. We may need to increase number of concurrent requests
+     * per partition to increase throughput when partition number is low and we
+     * are fine with increasing latency.
+     *
+     * Things to consider:
+     * - per shard concurrency controll
+     * - token-bucket based throughput limitter
+     */
+    uint32_t _max_concurrent_append_entries;
+    std::unique_ptr<ss::semaphore> _sem;
+};
+
+} // namespace raft

--- a/src/v/raft/follower_stats.h
+++ b/src/v/raft/follower_stats.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "model/metadata.h"
+#include "raft/follower_queue.h"
 #include "raft/types.h"
 #include "vassert.h"
 
@@ -25,8 +26,9 @@ public:
     using iterator = container_t::iterator;
     using const_iterator = container_t::const_iterator;
 
-    explicit follower_stats(vnode self)
-      : _self(self) {}
+    explicit follower_stats(vnode self, uint32_t max_concurrent_append_entries)
+      : _self(self)
+      , _max_concurrent_append_entries(max_concurrent_append_entries) {}
 
     const follower_index_metadata& get(vnode n) const {
         auto it = _followers.find(n);
@@ -67,12 +69,18 @@ public:
 
     size_t size() const { return _followers.size(); }
 
+    ss::future<ss::semaphore_units<>> get_append_entries_unit(vnode);
+
+    void return_append_entries_units(vnode);
+
     void update_with_configuration(const group_configuration&);
 
 private:
     friend std::ostream& operator<<(std::ostream&, const follower_stats&);
     vnode _self;
+    uint32_t _max_concurrent_append_entries;
     container_t _followers;
+    absl::node_hash_map<vnode, follower_queue> _queues;
 };
 
 } // namespace raft

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -203,8 +203,12 @@ void application::initialize(
     if (config::shard_local_cfg().enable_pid_file()) {
         syschecks::pidfile_create(config::shard_local_cfg().pidfile_path());
     }
+    smp_groups::config smp_groups_cfg{
+      .raft_group_max_non_local_requests
+      = config::shard_local_cfg().raft_smp_max_non_local_requests(),
+    };
 
-    smp_service_groups.create_groups().get();
+    smp_service_groups.create_groups(smp_groups_cfg).get();
     _deferred.emplace_back(
       [this] { smp_service_groups.destroy_groups().get(); });
 

--- a/src/v/resource_mgmt/smp_groups.h
+++ b/src/v/resource_mgmt/smp_groups.h
@@ -22,15 +22,32 @@
 // group.
 class smp_groups {
 public:
-    smp_groups() = default;
-    ss::future<> create_groups() {
-        const unsigned default_max_nonlocal_requests = 5000;
+    static constexpr unsigned default_max_nonlocal_requests = 5000;
+    struct config {
+        uint32_t kafka_group_max_non_local_requests
+          = default_max_nonlocal_requests;
+        uint32_t raft_group_max_non_local_requests
+          = default_max_nonlocal_requests;
+        uint32_t cluster_group_max_non_local_requests
+          = default_max_nonlocal_requests;
+        uint32_t coproc_group_max_non_local_requests
+          = default_max_nonlocal_requests;
+        uint32_t proxy_group_max_non_local_requests
+          = default_max_nonlocal_requests;
+    };
 
-        _raft = co_await create_service_group(default_max_nonlocal_requests);
-        _kafka = co_await create_service_group(default_max_nonlocal_requests);
-        _cluster = co_await create_service_group(default_max_nonlocal_requests);
-        _coproc = co_await create_service_group(default_max_nonlocal_requests);
-        _proxy = co_await create_service_group(default_max_nonlocal_requests);
+    smp_groups() = default;
+    ss::future<> create_groups(config cfg) {
+        _raft = co_await create_service_group(
+          cfg.raft_group_max_non_local_requests);
+        _kafka = co_await create_service_group(
+          cfg.kafka_group_max_non_local_requests);
+        _cluster = co_await create_service_group(
+          cfg.cluster_group_max_non_local_requests);
+        _coproc = co_await create_service_group(
+          cfg.coproc_group_max_non_local_requests);
+        _proxy = co_await create_service_group(
+          cfg.proxy_group_max_non_local_requests);
     }
 
     ss::smp_service_group raft_smp_sg() { return *_raft; }


### PR DESCRIPTION
## Cover letter

## Controlling number of pending append entries requests per follower

 In redpanda raft implementation it is beneficial to have multiple  concurrent append entries requests pending per follower since on the follower side we do flush coalescing and batching. This improves both latency and throughput. Backpressure propagation isn't currently possible on the follower since leader use timeouts when sending append entries RPCs to followers. Added limiting number of concurrent append entries sent to the followers to prevent follower from being overloaded.

## SMP queue limit increase

 Increased the maximum number of concurrent x-core dispatches in raft group. Previous value of 5000 imposed an artificial limit on number of requests that redpanda could handle. Requests queued in `raft::service` were waiting on available slots in `raft` smp service group which is a waste of time since they can be dispatched to the group and handled in batch.


## Follow up

An ideal solution would be to propagate backpressure from follower RPC service over the network to the leader. This way we wouldn't require any concurrency control ion the leader. This solution have to be changed in future. 

Follow up ticket: #2213 



Fixes: N/A

## Release notes