### PR TITLE
Run k8s operator tests against local image

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -5,6 +5,9 @@ CONFIGURATOR_IMG_LATEST ?= "vectorized/configurator:latest"
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
+# default redpanda image to load
+REDPANDA_IMG ?= "localhost/redpanda:dev"
+
 # The BUILDKITE_JOB_ID is used to create unique kind cluster.
 # BUILDKITE_JOB_ID is set in the buildkite runner for every CI run.
 #
@@ -59,6 +62,7 @@ uninstall: manifests kustomize
 deploy: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image vectorized/redpanda-operator=${OPERATOR_IMG_LATEST}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	kind load docker-image ${REDPANDA_IMG}
 
 # Deploy pre loaded controller in the configured Kind Kubernetes cluster
 deploy-to-kind: manifests kustomize push-to-kind deploy

--- a/src/go/k8s/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: additional-configuration
   namespace: default
 spec:
-  image: "vectorized/redpanda"
+  image: "localhost/redpanda"
   version: "dev"
   replicas: 1
   resources:

--- a/src/go/k8s/tests/e2e/admin-api-tls-client-auth/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls-client-auth/00-redpanda-cluster.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: cluster-tls
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/admin-api-tls/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls/00-redpanda-cluster.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: cluster-tls
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/admin-api/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/admin-api/00-redpanda-cluster.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: cluster
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/00-redpanda-cluster.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: schema-registry-test
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/02-create-schema.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/02-create-schema.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: rpk
-        image: vectorized/redpanda:latest
+        image: localhost/redpanda:dev
         command:
         - curl
         args:

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/03-retrieve-schema.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/03-retrieve-schema.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           command:
             - curl
           args:

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-redpanda-cluster.yaml
@@ -4,8 +4,8 @@ metadata:
   name: cluster-tls
   namespace: given-cert
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/03-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/03-create-topic.yaml
@@ -18,7 +18,7 @@ spec:
             name: rpk-config
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-redpanda-cluster.yaml
@@ -4,8 +4,8 @@ metadata:
   name: cluster-tls-secret
   namespace: given-cert-secret
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/03-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/03-create-topic.yaml
@@ -22,7 +22,7 @@ spec:
             name: rpk-config
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/01-redpanda-cluster.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: "redpanda"
     app.kubernetes.io/instance: "cluster-tls"
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/03-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/03-create-topic.yaml
@@ -21,7 +21,7 @@ spec:
             name: rpk-config
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/01-redpanda-cluster.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: "redpanda"
     app.kubernetes.io/instance: "cluster-tls"
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/03-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/03-create-topic.yaml
@@ -17,7 +17,7 @@ spec:
             name: rpk-config
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/create-topic-with-client-auth/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-with-client-auth/00-redpanda-cluster.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: cluster-tls
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/create-topic-with-client-auth/02-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-with-client-auth/02-create-topic.yaml
@@ -19,7 +19,7 @@ spec:
             name: rpk-config
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/external-connectivity/00-external-connectivity.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/00-external-connectivity.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: external-connectivity
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/node-select-tolerations/02-cluster-with-tolerations.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/02-cluster-with-tolerations.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: node-select-tolerations-cluster
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/00-redpanda-cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-proxy
 spec:
-  image: "vectorized/redpanda"
+  image: "localhost/redpanda"
   version: "dev"
   replicas: 1
   resources:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/01-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/01-create-topic.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:dev
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/02-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/02-produce-message.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:dev
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/03-consume-message.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/03-consume-message.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:dev
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/00-redpanda-cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: cluster-proxy
 spec:
-  image: "vectorized/redpanda"
+  image: "localhost/redpanda"
   version: "dev"
   replicas: 1
   resources:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/01-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/01-create-topic.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:dev
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/02-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/02-produce-message.yaml
@@ -12,7 +12,7 @@ spec:
             secretName: cluster-proxy-proxy-api-node
       containers:
         - name: rpk
-          image: vectorized/redpanda:dev
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/03-consume-message.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/03-consume-message.yaml
@@ -12,7 +12,7 @@ spec:
             secretName: cluster-proxy-proxy-api-node
       containers:
         - name: rpk
-          image: vectorized/redpanda:dev
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/00-redpanda-cluster.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: cluster-proxy
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/01-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/01-create-topic.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/02-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/02-produce-message.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/03-consume-message.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/03-consume-message.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/produce-consume/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-redpanda-cluster.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: cluster-sample
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 3
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/produce-consume/04-delete-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/04-delete-topic.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/produce-tls/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/00-redpanda-cluster.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: thisisverylongnamethatishittingthemax40c
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/produce-tls/02-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/02-create-topic.yaml
@@ -15,7 +15,7 @@ spec:
             name: rpk-config
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/produce-tls/03-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/03-produce-message.yaml
@@ -18,7 +18,7 @@ spec:
             name: rpk-config
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/00-redpanda-cluster.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: schema-registry
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/01-create-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/01-create-schema.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           command:
             - curl
           args:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/02-retrieve-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/02-retrieve-schema.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           command:
             - curl
           args:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/03-delete-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/03-delete-schema.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           command:
             - curl
           args:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/05-create-schema-with-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/05-create-schema-with-tls.yaml
@@ -12,7 +12,7 @@ spec:
           secretName: schema-registry-schema-registry-node
       containers:
       - name: rpk
-        image: vectorized/redpanda:latest
+        image: localhost/redpanda:dev
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/06-retrieve-schema-with-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/06-retrieve-schema-with-tls.yaml
@@ -12,7 +12,7 @@ spec:
             secretName: schema-registry-schema-registry-node
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/07-delete-schema-with-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/07-delete-schema-with-tls.yaml
@@ -12,7 +12,7 @@ spec:
             secretName: schema-registry-schema-registry-node
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/09-create-schema-with-client-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/09-create-schema-with-client-tls.yaml
@@ -12,7 +12,7 @@ spec:
             secretName: schema-registry-schema-registry-node
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/10-retrieve-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/10-retrieve-schema.yaml
@@ -12,7 +12,7 @@ spec:
             secretName: schema-registry-schema-registry-node
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/11-delete-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/11-delete-schema.yaml
@@ -12,7 +12,7 @@ spec:
             secretName: schema-registry-schema-registry-node
       containers:
         - name: rpk
-          image: vectorized/redpanda:latest
+          image: localhost/redpanda:dev
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
@@ -8,7 +8,7 @@ spec:
       initContainers:
         - image: "vectorized/configurator:v21.6.6"
       containers:
-        - image: "vectorized/redpanda:latest"
-        - image: "vectorized/redpanda:latest"
+        - image: "localhost/redpanda:dev"
+        - image: "localhost/redpanda:dev"
 status:
   readyReplicas: 2

--- a/src/go/k8s/tests/e2e/update-conf-image/01-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/01-current-image.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: update-image-cluster
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
@@ -14,9 +14,9 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
     - name: rpk-status
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 
@@ -29,9 +29,9 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
     - name: rpk-status
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-new-image.yaml
@@ -3,4 +3,5 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 spec:
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
@@ -14,9 +14,9 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
     - name: rpk-status
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 
@@ -29,8 +29,8 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
     - name: rpk-status
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image.yaml
@@ -3,4 +3,5 @@ kind: Cluster
 metadata:
   name: up-img
 spec:
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"

--- a/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
@@ -14,9 +14,9 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
     - name: rpk-status
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 
@@ -29,8 +29,8 @@ metadata:
 spec:
   containers:
     - name: redpanda
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
     - name: rpk-status
-      image: "vectorized/redpanda:latest"
+      image: "localhost/redpanda:dev"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls/01-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-new-image.yaml
@@ -3,4 +3,5 @@ kind: Cluster
 metadata:
   name: up-img
 spec:
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"

--- a/src/go/k8s/tests/e2e/update/00-one-replica.yaml
+++ b/src/go/k8s/tests/e2e/update/00-one-replica.yaml
@@ -3,8 +3,8 @@ kind: Cluster
 metadata:
   name: update-cluster
 spec:
-  image: "vectorized/redpanda"
-  version: "latest"
+  image: "localhost/redpanda"
+  version: "dev"
   replicas: 1
   resources:
     requests:


### PR DESCRIPTION
(creating this again since #2069 cannot be reopened anymore)

Assume local image of RP has been built and use it to run operator e2e tests, as opposed to downloading from dockerhub.

Companion PR: vectorizedio/vtools#222

