### PR TITLE
[data-policy]: Integrating data-policy with kafka API

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -128,6 +128,7 @@ ss::future<> controller::start() {
             std::ref(_partition_allocator),
             std::ref(_partition_leaders),
             std::ref(_tp_state),
+            std::ref(_data_policy_frontend),
             std::ref(_as));
       })
       .then([this] {

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -46,13 +46,15 @@ controller::controller(
   ss::sharded<partition_manager>& pm,
   ss::sharded<shard_table>& st,
   ss::sharded<storage::api>& storage,
-  ss::sharded<raft::group_manager>& raft_manager)
+  ss::sharded<raft::group_manager>& raft_manager,
+  ss::sharded<v8_engine::data_policy_table>& data_policy_table)
   : _connections(ccache)
   , _partition_manager(pm)
   , _shard_table(st)
   , _storage(storage)
   , _tp_updates_dispatcher(_partition_allocator, _tp_state)
   , _security_manager(_credentials, _authorizer)
+  , _data_policy_manager(data_policy_table)
   , _raft_manager(raft_manager) {}
 
 ss::future<> controller::wire_up() {
@@ -90,7 +92,6 @@ ss::future<> controller::start() {
           // validate configuration invariants to exit early
           return _members_manager.local().validate_configuration_invariants();
       })
-      .then([this] { return _data_policy_manager.start(); })
       .then([this] {
           return _stm.start_single(
             std::ref(clusterlog),
@@ -261,7 +262,6 @@ ss::future<> controller::stop() {
           .then([this] { return _authorizer.stop(); })
           .then([this] { return _credentials.stop(); })
           .then([this] { return _tp_state.stop(); })
-          .then([this] { return _data_policy_manager.stop(); })
           .then([this] { return _members_manager.stop(); })
           .then([this] { return _partition_allocator.stop(); })
           .then([this] { return _partition_leaders.stop(); })

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -35,7 +35,8 @@ public:
       ss::sharded<partition_manager>& pm,
       ss::sharded<shard_table>& st,
       ss::sharded<storage::api>& storage,
-      ss::sharded<raft::group_manager>&);
+      ss::sharded<raft::group_manager>&,
+      ss::sharded<v8_engine::data_policy_table>&);
 
     model::node_id self() { return _raft0->self().id(); }
     ss::sharded<topics_frontend>& get_topics_frontend() { return _tp_frontend; }

--- a/src/v/cluster/data_policy_manager.h
+++ b/src/v/cluster/data_policy_manager.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/commands.h"
+#include "v8_engine/data_policy_table.h"
 
 #include <absl/container/flat_hash_map.h>
 
@@ -21,8 +22,8 @@ namespace cluster {
 
 class data_policy_manager {
 public:
-    using container_type
-      = absl::flat_hash_map<model::topic_namespace, v8_engine::data_policy>;
+    explicit data_policy_manager(ss::sharded<v8_engine::data_policy_table>& dps)
+      : _dps(dps) {}
 
     static constexpr auto commands
       = make_commands_list<create_data_policy_cmd, delete_data_policy_cmd>();
@@ -34,13 +35,8 @@ public:
                == model::record_batch_type::data_policy_management_cmd;
     }
 
-    const container_type& get_current_state() const { return _dps.local(); }
-
-    ss::future<> start() { return _dps.start(); }
-    ss::future<> stop() { return _dps.stop(); }
-
 private:
-    ss::sharded<container_type> _dps;
+    ss::sharded<v8_engine::data_policy_table>& _dps;
 };
 
 } // namespace cluster

--- a/src/v/cluster/tests/data_policy_controller_test.cc
+++ b/src/v/cluster/tests/data_policy_controller_test.cc
@@ -62,9 +62,11 @@ FIXTURE_TEST(test_change_data_policy, cluster_test_fixture) {
             .get();
     BOOST_REQUIRE_EQUAL(res, cluster::errc::data_policy_not_exists);
 
-    auto n1_map = n1->controller->dp_manager().get_current_state();
+    auto dp_table = n1->data_policies.local();
 
-    BOOST_REQUIRE_EQUAL(n1_map.size(), 1);
-    BOOST_REQUIRE_EQUAL(n1_map.at(topic1).function_name(), dp1.function_name());
-    BOOST_REQUIRE_EQUAL(n1_map.at(topic1).script_name(), dp1.script_name());
+    BOOST_REQUIRE_EQUAL(dp_table.size(), 1);
+    auto dp = dp_table.get_data_policy(topic1);
+    BOOST_ASSERT(dp.has_value());
+    BOOST_REQUIRE_EQUAL(dp.value().function_name(), dp1.function_name());
+    BOOST_REQUIRE_EQUAL(dp.value().script_name(), dp1.script_name());
 }

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/controller_stm.h"
+#include "cluster/data_policy_frontend.h"
 #include "cluster/fwd.h"
 #include "cluster/scheduling/types.h"
 #include "cluster/topic_table.h"
@@ -38,6 +39,7 @@ public:
       ss::sharded<partition_allocator>&,
       ss::sharded<partition_leaders_table>&,
       ss::sharded<topic_table>&,
+      ss::sharded<data_policy_frontend>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<std::vector<topic_result>> create_topics(
@@ -82,6 +84,8 @@ private:
       model::node_id,
       std::vector<topic_configuration>,
       model::timeout_clock::duration);
+    ss::future<std::error_code> do_update_data_policy(
+      topic_properties_update&, model::timeout_clock::time_point);
     ss::future<topic_result> do_update_topic_properties(
       topic_properties_update, model::timeout_clock::time_point);
     ss::future<> update_leaders_with_estimates(std::vector<ntp_leader>);
@@ -101,6 +105,7 @@ private:
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_leaders_table>& _leaders;
     ss::sharded<topic_table>& _topics;
+    ss::sharded<data_policy_frontend>& _dp_frontend;
     ss::sharded<ss::abort_source>& _as;
 };
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -347,6 +347,10 @@ struct incremental_topic_updates {
     property_update<std::optional<size_t>> segment_size;
     property_update<tristate<size_t>> retention_bytes;
     property_update<tristate<std::chrono::milliseconds>> retention_duration;
+
+    // Data-policy property is replicated by data_policy_frontend and handled by
+    // data_policy_manager.
+    property_update<std::optional<v8_engine::data_policy>> data_policy;
 };
 
 /**

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -419,6 +419,17 @@ ss::future<response_ptr> describe_configs_handler::handle(
               request.data.include_synonyms,
               &describe_as_string<model::timestamp_type>);
 
+            // Data-policy property
+            ss::sstring property_name = "redpanda.datapolicy";
+            add_topic_config(
+              result,
+              property_name,
+              v8_engine::data_policy("", ""),
+              property_name,
+              ctx.data_policy_table().get_data_policy(topic),
+              request.data.include_synonyms,
+              &describe_as_string<v8_engine::data_policy>);
+
             break;
         }
 

--- a/src/v/kafka/server/handlers/details/data_policy.h
+++ b/src/v/kafka/server/handlers/details/data_policy.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "kafka/server/handlers/topics/types.h"
+#include "v8_engine/data_policy.h"
+#include "vlog.h"
+
+namespace kafka {
+
+struct data_policy_parser {
+    cluster::incremental_update_operation op{
+      cluster::incremental_update_operation::none};
+
+    std::optional<ss::sstring> function_name;
+    std::optional<ss::sstring> script_name;
+};
+
+inline std::optional<v8_engine::data_policy>
+data_policy_from_parser(const data_policy_parser& parser) {
+    if (!parser.function_name.has_value() && !parser.script_name.has_value()) {
+        return std::nullopt;
+    }
+
+    if (!parser.function_name.has_value()) {
+        throw v8_engine::data_policy_exeption(fmt_with_ctx(
+          fmt::format,
+          "Can not find {} in update for data-policy",
+          topic_property_data_policy_function_name));
+    }
+
+    if (!parser.script_name.has_value()) {
+        throw v8_engine::data_policy_exeption(fmt_with_ctx(
+          fmt::format,
+          "Can not find {} in update for data-policy",
+          topic_property_data_policy_script_name));
+    }
+
+    return v8_engine::data_policy(
+      parser.function_name.value(), parser.script_name.value());
+}
+
+inline void update_data_policy_op(
+  data_policy_parser& parser, cluster::incremental_update_operation op) {
+    if (
+      parser.op != cluster::incremental_update_operation::none
+      && parser.op != op) {
+        throw v8_engine::data_policy_exeption(fmt_with_ctx(
+          fmt::format,
+          "Operation for redpanda.datapolicy can not be different(previous:{}, "
+          "current:{})",
+          parser.op,
+          op));
+    } else if (parser.op == cluster::incremental_update_operation::none) {
+        parser.op = op;
+    }
+}
+
+inline bool update_data_policy_parser(
+  data_policy_parser& parser,
+  std::string_view key,
+  const std::optional<ss::sstring>& value,
+  config_resource_operation op) {
+    if (op == config_resource_operation::remove) {
+        update_data_policy_op(
+          parser, cluster::incremental_update_operation::remove);
+    }
+    if (op == config_resource_operation::set) {
+        update_data_policy_op(
+          parser, cluster::incremental_update_operation::set);
+    }
+
+    if (key == topic_property_data_policy_function_name) {
+        parser.function_name = value;
+        return true;
+    }
+
+    if (key == topic_property_data_policy_script_name) {
+        parser.script_name = value;
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -46,6 +46,12 @@ static constexpr std::string_view topic_property_retention_bytes
 static constexpr std::string_view topic_property_retention_duration
   = "retention.ms";
 
+// Data-policy property
+static constexpr std::string_view topic_property_data_policy_function_name
+  = "redpanda.datapolicy.function.name";
+static constexpr std::string_view topic_property_data_policy_script_name
+  = "redpanda.datapolicy.script.name";
+
 /// \brief Type representing Kafka protocol response from
 /// CreateTopics, DeleteTopics and CreatePartitions requests
 /// the types used here match the types used in Kafka protocol specification

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -49,6 +49,7 @@ protocol::protocol(
   ss::sharded<cluster::security_frontend>& sec_fe,
   ss::sharded<cluster::controller_api>& controller_api,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
+  ss::sharded<v8_engine::data_policy_table>& data_policy_table,
   std::optional<qdc_monitor::config> qdc_config) noexcept
   : _smp_group(smp)
   , _topics_frontend(tf)
@@ -68,7 +69,8 @@ protocol::protocol(
   , _authorizer(authorizer)
   , _security_frontend(sec_fe)
   , _controller_api(controller_api)
-  , _tx_gateway_frontend(tx_gateway_frontend) {
+  , _tx_gateway_frontend(tx_gateway_frontend)
+  , _data_policy_table(data_policy_table) {
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);
     }

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -21,6 +21,7 @@
 #include "security/authorizer.h"
 #include "security/credential_store.h"
 #include "utils/ema.h"
+#include "v8_engine/data_policy_table.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
@@ -46,6 +47,7 @@ public:
       ss::sharded<cluster::security_frontend>&,
       ss::sharded<cluster::controller_api>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
+      ss::sharded<v8_engine::data_policy_table>&,
       std::optional<qdc_monitor::config>) noexcept;
 
     ~protocol() noexcept override = default;
@@ -95,6 +97,10 @@ public:
         return _security_frontend.local();
     }
 
+    v8_engine::data_policy_table& data_policy_table() {
+        return _data_policy_table.local();
+    }
+
     void update_produce_latency(std::chrono::steady_clock::duration x) {
         if (_qdc_mon) {
             _qdc_mon->ema.update(x);
@@ -137,6 +143,7 @@ private:
     ss::sharded<cluster::security_frontend>& _security_frontend;
     ss::sharded<cluster::controller_api>& _controller_api;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
+    ss::sharded<v8_engine::data_policy_table>& _data_policy_table;
     std::optional<qdc_monitor> _qdc_mon;
     kafka::fetch_metadata_cache _fetch_metadata_cache;
 

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -172,6 +172,10 @@ public:
         return _conn->server().security_frontend();
     }
 
+    v8_engine::data_policy_table& data_policy_table() const {
+        return _conn->server().data_policy_table();
+    }
+
     security::authorizer& authorizer() { return _conn->server().authorizer(); }
 
     cluster::controller_api& controller_api() {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1031,6 +1031,7 @@ void application::start_redpanda() {
             controller->get_security_frontend(),
             controller->get_api(),
             tx_gateway_frontend,
+            data_policies,
             qdc_config);
           s.set_protocol(std::move(proto));
       })

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -589,6 +589,8 @@ void application::wire_up_redpanda_services() {
 
     // controller
 
+    construct_service(data_policies).get();
+
     syschecks::systemd_message("Creating cluster::controller").get();
 
     construct_single_service(
@@ -597,7 +599,8 @@ void application::wire_up_redpanda_services() {
       partition_manager,
       shard_table,
       storage,
-      std::ref(raft_group_manager));
+      std::ref(raft_group_manager),
+      data_policies);
 
     controller->wire_up().get0();
     syschecks::systemd_message("Creating kafka metadata cache").get();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -36,6 +36,7 @@
 #include "security/credential_store.h"
 #include "storage/compaction_controller.h"
 #include "storage/fwd.h"
+#include "v8_engine/data_policy_table.h"
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -92,6 +93,7 @@ public:
     ss::sharded<kafka::rm_group_frontend> rm_group_frontend;
     ss::sharded<cluster::rm_partition_frontend> rm_partition_frontend;
     ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    ss::sharded<v8_engine::data_policy_table> data_policies;
 
 private:
     using deferred_actions

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -95,6 +95,7 @@ public:
           app.controller->get_security_frontend(),
           app.controller->get_api(),
           app.tx_gateway_frontend,
+          app.data_policies,
           std::nullopt);
     }
 

--- a/src/v/v8_engine/CMakeLists.txt
+++ b/src/v/v8_engine/CMakeLists.txt
@@ -5,6 +5,7 @@ v_cc_library(
     executor.cc
     script.cc
     data_policy.cc
+    data_policy_table.cc
   DEPS
     Seastar::seastar
     v8_monolith

--- a/src/v/v8_engine/data_policy.cc
+++ b/src/v/v8_engine/data_policy.cc
@@ -10,6 +10,19 @@
 
 #include "v8_engine/data_policy.h"
 
+namespace v8_engine {
+
+std::ostream& operator<<(std::ostream& os, const data_policy& datapolicy) {
+    fmt::print(
+      os,
+      "function_name: {} script_name: {}",
+      datapolicy._function_name,
+      datapolicy._script_name);
+    return os;
+}
+
+} // namespace v8_engine
+
 namespace reflection {
 
 void reflection::adl<v8_engine::data_policy>::to(

--- a/src/v/v8_engine/data_policy.h
+++ b/src/v/v8_engine/data_policy.h
@@ -22,6 +22,17 @@
 
 namespace v8_engine {
 
+class data_policy_exeption final : public std::exception {
+public:
+    explicit data_policy_exeption(ss::sstring msg) noexcept
+      : _msg(std::move(msg)) {}
+
+    const char* what() const noexcept final { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
+
 // Datapolicy property for v8_engine. In first version it contains only
 // function_name and script_name, in the future it will contain ACLs, geo,
 // e.t.c.

--- a/src/v/v8_engine/data_policy.h
+++ b/src/v/v8_engine/data_policy.h
@@ -55,6 +55,8 @@ private:
     operator<<(std::ostream& os, const data_policy& datapolicy);
 };
 
+std::ostream& operator<<(std::ostream& os, const data_policy& datapolicy);
+
 } // namespace v8_engine
 
 namespace reflection {

--- a/src/v/v8_engine/data_policy_table.cc
+++ b/src/v/v8_engine/data_policy_table.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "v8_engine/data_policy_table.h"
+
+namespace v8_engine {
+
+bool data_policy_table::insert(
+  model::topic_namespace topic, v8_engine::data_policy dp) {
+    return _dps.insert({topic, std::move(dp)}).second;
+}
+
+bool data_policy_table::erase(model::topic_namespace topic) {
+    return _dps.erase(topic) == 1;
+}
+
+std::optional<v8_engine::data_policy>
+data_policy_table::get_data_policy(const model::topic_namespace& topic) const {
+    auto it = _dps.find(topic);
+    if (it == _dps.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+} // namespace v8_engine

--- a/src/v/v8_engine/data_policy_table.h
+++ b/src/v/v8_engine/data_policy_table.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "model/metadata.h"
+#include "v8_engine/data_policy.h"
+
+#include <absl/container/node_hash_map.h>
+
+namespace v8_engine {
+
+class data_policy_table {
+public:
+    using container_type
+      = absl::node_hash_map<model::topic_namespace, v8_engine::data_policy>;
+
+    bool insert(model::topic_namespace, v8_engine::data_policy);
+
+    bool erase(model::topic_namespace);
+
+    std::optional<v8_engine::data_policy>
+    get_data_policy(const model::topic_namespace& topic) const;
+
+    size_t size() const { return _dps.size(); }
+
+private:
+    container_type _dps;
+};
+
+} // namespace v8_engine

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -27,6 +27,8 @@ class TopicSpec:
     PROPERTY_SEGMENT_SIZE = "segment.bytes"
     PROPERTY_RETENTION_BYTES = "retention.bytes"
     PROPERTY_RETENTION_TIME = "retention.ms"
+    PROPERTY_DATA_POLICY_FUNCTION_NAME = "redpanda.datapolicy.function.name"
+    PROPERTY_DATA_POLICY_SCRIPT_NAME = "redpanda.datapolicy.script.name"
 
     # compression types
     COMPRESSION_NONE = "none"
@@ -50,7 +52,8 @@ class TopicSpec:
                  message_timestamp_type=TIMESTAMP_CREATE_TIME,
                  segment_bytes=1 * (2 ^ 30),
                  retention_bytes=None,
-                 retention_ms=None):
+                 retention_ms=None,
+                 redpanda_datapolicy=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -60,6 +63,7 @@ class TopicSpec:
         self.segment_bytes = segment_bytes
         self.retention_bytes = retention_bytes
         self.retention_ms = retention_ms
+        self.redpanda_datapolicy = redpanda_datapolicy
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/data_policy_test.py
+++ b/tests/rptest/tests/data_policy_test.py
@@ -1,0 +1,65 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.types import TopicSpec
+
+import json
+
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class DataPolicyTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=1, replication_factor=3), )
+
+    def __init__(self, test_context):
+        super(DataPolicyTest, self).__init__(test_context=test_context,
+                                             num_brokers=3)
+
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+
+    def _get_data_policy(self, function_name, script_name):
+        return "function_name: {} script_name: {}".format(
+            function_name, script_name)
+
+    @cluster(num_nodes=3)
+    def test_default_data_policy(self):
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        spec = kafka_tools.describe_topic(topic)
+        assert spec.redpanda_datapolicy == None
+
+    @cluster(num_nodes=3)
+    def test_set_data_policy(self):
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        res = kafka_tools.alter_topic_config(
+            topic, {
+                TopicSpec.PROPERTY_DATA_POLICY_FUNCTION_NAME: "1",
+                TopicSpec.PROPERTY_DATA_POLICY_SCRIPT_NAME: "2"
+            })
+        spec = kafka_tools.describe_topic(topic)
+        assert spec.redpanda_datapolicy == self._get_data_policy(1, 2)
+
+    @cluster(num_nodes=3)
+    def test_incremental_config(self):
+        topic = self.topics[0].name
+        kafka_tools = KafkaCliTools(self.redpanda)
+        res = kafka_tools.alter_topic_config(
+            topic, {
+                TopicSpec.PROPERTY_DATA_POLICY_FUNCTION_NAME: "1",
+                TopicSpec.PROPERTY_DATA_POLICY_SCRIPT_NAME: "2"
+            })
+        spec = kafka_tools.describe_topic(topic)
+        assert spec.redpanda_datapolicy == self._get_data_policy(1, 2)
+        res = kafka_tools.alter_topic_config(
+            topic, {TopicSpec.PROPERTY_DATA_POLICY_FUNCTION_NAME: "3"})
+        spec = kafka_tools.describe_topic(topic)
+        assert spec.redpanda_datapolicy == self._get_data_policy(1, 2)


### PR DESCRIPTION
## Cover letter
This pr implements kafka layer for data_policy.
There is new topic property: `redpanda.datapolicy`. User can change data-policy property through incremental/alter congif requests. 

For change dp user need to add 2 property changes in one update request (redpanda.datapolicy.function.name, redpanda.datapolicy.script.name

One update command can contain different topic property, so we need to try update it "atomically" if update contains data-policy

This pr is part of #1964

---
### from f9bfd80 to 9f12734
- Added data_policy_table. It is used inside data_policy_manager to update state, and inside describe_config
- Fix logic about adding data_policy cmd in log.
- delete logic around check topic in manager, and delte dp with topic

### from 9f12734 to f4d2488 and  from f4d2488 to 86baf71
- Use validation for json
- move operator<</>> for data_policy to kafka folder

###  from 4965634 to 57b328b
- Do not use json for parsing datpolicy
- Fix tests
- Added new topic-property

###  from 57b328b to b698603
- small ducktape test

### from b698603 to c002013
- Edit commit messages
- Use node_hash_map in dp_table 