### PR TITLE
Fixed marking group as being loaded

### DIFF
--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -251,12 +251,12 @@ ss::future<> group_manager::handle_partition_leader_change(
      * otherwise, we can remove any groups and commits that map to this
      * partition.
      */
-    p->loading = true;
     if (leader_id != _self.id()) {
         // TODO: we are not yet handling group / partition deletion
         return ss::make_ready_future<>();
     }
 
+    p->loading = true;
     auto timeout
       = ss::lowres_clock::now()
         + config::shard_local_cfg().kafka_group_recovery_timeout_ms();

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -246,13 +246,27 @@ ss::future<> group_manager::handle_partition_leader_change(
   ss::lw_shared_ptr<attached_partition> p,
   std::optional<model::node_id> leader_id) {
     /*
-     * TODO: when we are becoming a leader for this partition we'll recover
-     * groups and commits from the log and re-populate the in-memory cache.
-     * otherwise, we can remove any groups and commits that map to this
-     * partition.
+     * When a partition is attached it is initially NOT in the loading state.
+     * Shortly after we should receive a leadership change upcall. If we are the
+     * leader then we will start loading (and clear the loading bit when we are
+     * done). Otherwise, we clear the loading bit.
+     *
+     * The reason that a newly attached partition AND partitions that lose
+     * leadership have their loading bit cleared is not because this state makes
+     * total sense (it is really neither loading nor non-loading state as it
+     * should never be queried in a non-leader state), but rather because some
+     * APIs like list_groups will return an error if _any_ partition is in the
+     * loading state. However, this should only apply to leader partitions, and
+     * we rely on higher level routing to avoid requests from hitting non-leader
+     * partitions (this check is circumvented for list groups).
+     *
+     * Ideally what we do disconnect or detatch partitions when leadership is
+     * lost. At this time we could also GC group state:
+     *
+     *    https://github.com/vectorizedio/redpanda/issues/2217
      */
     if (leader_id != _self.id()) {
-        // TODO: we are not yet handling group / partition deletion
+        p->loading = false;
         return ss::make_ready_future<>();
     }
 

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -195,7 +195,7 @@ private:
         model::term_id term{-1};
 
         explicit attached_partition(ss::lw_shared_ptr<cluster::partition> p)
-          : loading(true)
+          : loading(false)
           , partition(std::move(p)) {}
     };
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -76,6 +76,9 @@ RUN git -C /opt clone https://github.com/Shopify/sarama.git && \
     cd /opt/sarama/examples/consumergroup && go mod tidy && go build && \
     cd /opt/sarama/examples/sasl_scram_client && go mod tidy && go build
 
+RUN go install github.com/twmb/kcl@latest && \
+    mv /root/go/bin/kcl /usr/local/bin/
+
 # Expose port 8080 for any http examples within clients
 EXPOSE 8080
 

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import subprocess
+import time
+
+
+class KCL:
+    def __init__(self, redpanda):
+        self._redpanda = redpanda
+
+    def list_groups(self):
+        return self._cmd(["group", "list"])
+
+    def produce(self, topic, msg):
+        return self._cmd(["produce", topic], input=msg)
+
+    def consume(self, topic, n=None, group=None):
+        cmd = ["consume"]
+        if group is not None:
+            cmd += ["-g", group]
+        if n is not None:
+            cmd.append(f"-n{n}")
+        cmd.append(topic)
+        return self._cmd(cmd)
+
+    def _cmd(self, cmd, input=None):
+        brokers = self._redpanda.brokers()
+        cmd = ["kcl", "-X", f"seed_brokers={brokers}", "--no-config-file"
+               ] + cmd
+        for retry in reversed(range(5)):
+            try:
+                res = subprocess.check_output(cmd, text=True, input=input)
+                self._redpanda.logger.debug(res)
+                return res
+            except subprocess.CalledProcessError as e:
+                if retry == 0:
+                    raise
+                self._redpanda.logger.debug(
+                    "kcl retrying after exit code {}: {}".format(
+                        e.returncode, e.output))
+                time.sleep(1)

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+
+from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.kcl import KCL
+
+
+class ListGroupsReplicationFactorTest(RedpandaTest):
+    """
+    We encountered an issue where listing groups would return a
+    coordinator-loading error when the underlying group membership topic had a
+    replication factor of 3 (we had not noticed this until we noticed that
+    replication factor were defaulted to 1). it isn't clear if this is specific
+    to `kcl` but that is the client that we encountered the issue with.
+    """
+    topics = (TopicSpec(), )
+
+    def __init__(self, test_context):
+        extra_rp_conf = dict(default_topic_replications=3, )
+
+        super(ListGroupsReplicationFactorTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             extra_rp_conf=extra_rp_conf)
+
+    @cluster(num_node=3)
+    def test_list_groups(self):
+        kcl = KCL(self.redpanda)
+        kcl.produce(self.topic, "msg\n")
+        kcl.consume(self.topic, n=1, group="g0")
+        kcl.list_groups()
+        out = kcl.list_groups()
+        assert "COORDINATOR_LOAD_IN_PROGRESS" not in out


### PR DESCRIPTION
When partition underlying the consumer group become a leader it loads
group state from the log. Partitions should be marked with `loading`
flag only after `group_manager` receive leadership notification and its
start consumer group state recovery.