### PR TITLE
Fixed failing CI tests

### DIFF
--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -86,20 +86,6 @@ ss::future<> partition_manager::remove(const model::ntp& ntp) {
       .finally([partition] {}); // in the end remove partition
 }
 
-ss::future<> partition_manager::shutdown_all() {
-    std::vector<model::ntp> ntps;
-    ntps.reserve(_ntp_table.size());
-    std::transform(
-      _ntp_table.begin(),
-      _ntp_table.end(),
-      std::back_inserter(ntps),
-      [](const ntp_table_container::value_type& p) { return p.first; });
-
-    for (const auto& ntp : ntps) {
-        co_await shutdown(ntp);
-    }
-}
-
 ss::future<> partition_manager::shutdown(const model::ntp& ntp) {
     auto partition = get(ntp);
 

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -66,7 +66,6 @@ public:
       manage(storage::ntp_config, raft::group_id, std::vector<model::broker>);
 
     ss::future<> shutdown(const model::ntp& ntp);
-    ss::future<> shutdown_all();
     ss::future<> remove(const model::ntp& ntp);
 
     std::optional<storage::log> log(const model::ntp& ntp) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -843,19 +843,6 @@ void application::wire_up_redpanda_services() {
       fetch_session_cache,
       config::shard_local_cfg().fetch_session_eviction_timeout_ms())
       .get();
-    /**
-     * When redpanda stops we need to shutdown all partitions to prevent it
-     * accepting new requests and additionally we need to finish/fail all
-     * ongoing requests before trying to stop kafka RPC. We need this
-     * additionall action in stop sequence since it is required to have
-     * `ss::sharded` instance of partition manager before kafka server is
-     * started.
-     */
-    _deferred.emplace_back([this] {
-        partition_manager
-          .invoke_on_all(&cluster::partition_manager::shutdown_all)
-          .get();
-    });
     construct_service(
       _compaction_controller,
       std::ref(storage),

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -520,6 +520,23 @@ void application::wire_up_redpanda_services() {
         return storage::internal::chunks().start();
     }).get();
 
+    /**
+     * Last step in shutdown is to wait for all pending request to be
+     * finished/aborted
+     */
+    _deferred.emplace_back([this] {
+        if (_rpc.local_is_initialized()) {
+            _rpc.invoke_on_all(&rpc::server::wait_for_shutdown).get();
+            _rpc.stop().get();
+        }
+    });
+    _deferred.emplace_back([this] {
+        if (_kafka_server.local_is_initialized()) {
+            _kafka_server.invoke_on_all(&rpc::server::wait_for_shutdown).get();
+            _kafka_server.stop().get();
+        }
+    });
+
     // cluster
     syschecks::systemd_message("Adding raft client cache").get();
     construct_service(_raft_connection_cache).get();
@@ -701,7 +718,7 @@ void application::wire_up_redpanda_services() {
      **/
     syschecks::systemd_message("Starting internal RPC {}", rpc_cfg.local())
       .get();
-    construct_service(_rpc, &rpc_cfg).get();
+    _rpc.start(&rpc_cfg).get();
     rpc_cfg.stop().get();
 
     syschecks::systemd_message("Creating id allocator frontend").get();
@@ -820,7 +837,7 @@ void application::wire_up_redpanda_services() {
       .get();
     syschecks::systemd_message("Starting kafka RPC {}", kafka_cfg.local())
       .get();
-    construct_service(_kafka_server, &kafka_cfg).get();
+    _kafka_server.start(&kafka_cfg).get();
     kafka_cfg.stop().get();
     construct_service(
       fetch_session_cache,
@@ -973,6 +990,9 @@ void application::start_redpanda() {
       .get();
     auto& conf = config::shard_local_cfg();
     _rpc.invoke_on_all(&rpc::server::start).get();
+    // shutdown input on RPC server
+    _deferred.emplace_back(
+      [this] { _rpc.invoke_on_all(&rpc::server::shutdown_input).get(); });
     vlog(_log.info, "Started RPC server listening at {}", conf.rpc_server());
 
     if (archival_storage_enabled()) {
@@ -1025,6 +1045,10 @@ void application::start_redpanda() {
       })
       .get();
     _kafka_server.invoke_on_all(&rpc::server::start).get();
+    // shutdown Kafka server input
+    _deferred.emplace_back([this] {
+        _kafka_server.invoke_on_all(&rpc::server::shutdown_input).get();
+    });
     vlog(
       _log.info, "Started Kafka API server listening at {}", conf.kafka_api());
 

--- a/src/v/rpc/server.h
+++ b/src/v/rpc/server.h
@@ -76,6 +76,21 @@ public:
         _proto = std::move(proto);
     }
     void start();
+
+    /**
+     * The RPC server can be shutdown in two phases. First phase initiated with
+     * `shutdown_input` prevents server from accepting new requests and
+     * connections. In second phases `wait_for_shutdown` caller waits for all
+     * pending requests to finish. This interface is convinient as it allows
+     * stopping the server without waiting for downstream services to stop
+     * requests processing
+     */
+    void shutdown_input();
+    ss::future<> wait_for_shutdown();
+    /**
+     * Stop function is a nop when `shutdown_input` was previously called. Left
+     * here for convenience when dealing with `seastar::sharded` type
+     */
     ss::future<> stop();
 
     const server_configuration cfg; // NOLINT

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -21,7 +21,6 @@ from rptest.tests.end_to_end import EndToEndTest
 
 DECOMMISSION = "decommission"
 ADD = "add"
-ADD_NO_DELETE = "add_no_delete"
 ADD_TOPIC = "add_tp"
 DELETE_TOPIC = "delete_tp"
 ALLOWED_REPLICATION = [1, 3]
@@ -29,7 +28,7 @@ ALLOWED_REPLICATION = [1, 3]
 
 class NodeOperationFuzzyTest(EndToEndTest):
     def generate_random_workload(self, count, skip_nodes):
-        op_types = [ADD, DECOMMISSION, ADD_NO_DELETE]
+        op_types = [ADD, DECOMMISSION]
         tp_op_types = [ADD_TOPIC, DELETE_TOPIC]
         # current state
         active_nodes = [1, 2, 3, 4, 5]
@@ -53,7 +52,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
         for _ in range(0, count):
             if len(decommissioned_nodes) == 2:
                 id = random.choice(decommissioned_nodes)
-                operations.append((random.choice([ADD, ADD_NO_DELETE]), id))
+                operations.append((ADD, id))
                 add(id)
             elif len(decommissioned_nodes) == 0:
                 id = random.choice(eligible_active_nodes())
@@ -68,10 +67,6 @@ class NodeOperationFuzzyTest(EndToEndTest):
                 elif op == ADD:
                     id = random.choice(decommissioned_nodes)
                     operations.append((ADD, id))
-                    add(id)
-                elif op == ADD_NO_DELETE:
-                    id = random.choice(decommissioned_nodes)
-                    operations.append((ADD_NO_DELETE, id))
                     add(id)
             # topic operation
             if len(topics) == 0:
@@ -193,10 +188,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
             if op_type == ADD:
                 id = op[1]
                 restart_node(id)
-            if op_type == ADD_NO_DELETE:
-                id = op[1]
-                restart_node(id, cleanup=False)
-            elif op_type == DECOMMISSION:
+            if op_type == DECOMMISSION:
                 id = op[1]
                 decommission(id)
             elif op_type == ADD_TOPIC:


### PR DESCRIPTION
## Cover letter
During redpanda shutdown sequence we stop all partitions to prevent kafka requests from waiting before shutting down the application. Internal topics currently raft0 are managed on their own and they do not have to be shut down early. Shutting down raft0 have to be performed after we successfully stop all dependent services.

Fixes: #2164, #2161