### PR TITLE
Archival cache

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -4,6 +4,7 @@ v_cc_library(
   SRCS
     manifest.cc
     remote.cc
+    cache_service.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/logger.h"
+#include "random/generators.h"
+#include "utils/gate_guard.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/print.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/util/defer.hh>
+
+#include <cloud_storage/cache_service.h>
+
+#include <exception>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <system_error>
+
+namespace cloud_storage {
+
+cache::cache(std::filesystem::path cache_dir) noexcept
+  : _cache_dir(std::move(cache_dir))
+  , _cnt(0) {}
+
+ss::future<> cache::start() {
+    vlog(cst_log.debug, "Starting archival cache service");
+    // todo: start maintenance cycle here
+    return ss::make_ready_future<>();
+}
+
+ss::future<> cache::stop() {
+    vlog(cst_log.debug, "Stopping archival cache service");
+    return _gate.close();
+}
+
+ss::future<std::optional<cache_item>> cache::get(std::filesystem::path key) {
+    gate_guard guard{_gate};
+    vlog(cst_log.debug, "Trying to get {} from archival cache.", key.native());
+    ss::file cache_file;
+    try {
+        cache_file = co_await ss::open_file_dma(
+          (_cache_dir / key).native(), ss::open_flags::ro);
+    } catch (std::filesystem::filesystem_error& e) {
+        if (e.code() == std::errc::no_such_file_or_directory) {
+            co_return std::nullopt;
+        } else {
+            throw;
+        }
+    }
+
+    auto data_size = co_await cache_file.size();
+    auto data_stream = ss::make_file_input_stream(cache_file);
+    co_return std::optional(cache_item{std::move(data_stream), data_size});
+}
+
+ss::future<>
+cache::put(std::filesystem::path key, ss::input_stream<char>& data) {
+    gate_guard guard{_gate};
+    vlog(cst_log.debug, "Trying to put {} to archival cache.", key.native());
+
+    auto filename = (_cache_dir / key).filename();
+    auto dir_path = (_cache_dir / key).remove_filename();
+    co_await ss::recursive_touch_directory(dir_path.string());
+
+    // tmp file is used to protect against concurrent writes to the same file.
+    // One tmp file is written only once by one thread. tmp file should not be
+    // read directly. _cnt is an atomic counter that ensures the uniqueness of
+    // names for tmp files within one shard, while shard_id ensures uniqueness
+    // across multiple shards.
+    auto tmp_filename = std::filesystem::path(ss::format(
+      "{}_{}_{}.part", filename.string(), ss::this_shard_id(), (++_cnt)));
+    auto flags = ss::open_flags::wo | ss::open_flags::create
+                 | ss::open_flags::exclusive;
+    auto tmp_cache_file = co_await ss::open_file_dma(
+      (dir_path / tmp_filename).native(), flags);
+    auto out = co_await ss::make_file_output_stream(tmp_cache_file);
+
+    co_await ss::copy(data, out)
+      .then([&out]() { return out.flush(); })
+      .finally([&out]() { return out.close(); });
+
+    // commit write transaction
+    co_await ss::rename_file(
+      (dir_path / tmp_filename).native(), (dir_path / filename).native());
+}
+
+ss::future<bool> cache::is_cached(const std::filesystem::path& key) {
+    gate_guard guard{_gate};
+    vlog(cst_log.debug, "Checking {} in archival cache.", key.native());
+    return ss::file_exists((_cache_dir / key).native());
+}
+
+ss::future<> cache::invalidate(const std::filesystem::path& key) {
+    gate_guard guard{_gate};
+    vlog(
+      cst_log.debug,
+      "Trying to invalidate {} from archival cache.",
+      key.native());
+    try {
+        co_await ss::remove_file((_cache_dir / key).native());
+    } catch (std::filesystem::filesystem_error& e) {
+        if (e.code() == std::errc::no_such_file_or_directory) {
+            co_return;
+        } else {
+            throw;
+        }
+    }
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/iostream.hh>
+
+#include <filesystem>
+
+namespace cloud_storage {
+
+struct cache_item {
+    ss::input_stream<char> body;
+    size_t size;
+};
+
+class cache {
+public:
+    /// C-tor.
+    ///
+    /// \param cache_dir is a directory where cached data is stored
+    explicit cache(std::filesystem::path cache_dir) noexcept;
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    /// Get cached value as a stream if it exists on disk
+    ss::future<std::optional<cache_item>> get(std::filesystem::path key);
+
+    /// Add new value to the cache, overwrite if it's already exist
+    ss::future<> put(std::filesystem::path key, ss::input_stream<char>& data);
+
+    /// Return true if the following object is already in the cache
+    ss::future<bool> is_cached(const std::filesystem::path& key);
+
+    /// Remove element from cache by key
+    ss::future<> invalidate(const std::filesystem::path& key);
+
+private:
+    std::filesystem::path _cache_dir;
+    ss::gate _gate;
+    uint64_t _cnt;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 rp_test(
   UNIT_TEST
   BINARY_NAME test_cloud_storage
-  SOURCES manifest_test.cc s3_imposter.cc remote_test.cc
+  SOURCES manifest_test.cc s3_imposter.cc remote_test.cc cache_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::cloud_storage v::storage_test_utils
   ARGS "-- -c 1"

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "cache_test_fixture.h"
+#include "cloud_storage/cache_service.h"
+#include "test_utils/fixture.h"
+#include "units.h"
+
+#include <seastar/core/seastar.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace cloud_storage;
+
+FIXTURE_TEST(put_creates_file, cache_test_fixture) {
+    ss::sstring data_string;
+    while (data_string.length() < 4096) {
+        data_string += SAMPLE_STRING1;
+    }
+    iobuf buf;
+    buf.append(data_string.data(), data_string.length());
+
+    auto input = make_iobuf_input_stream(std::move(buf));
+    cache_service.put(KEY, input).get();
+
+    bool file_exists = ss::file_exists((CACHE_DIR / KEY).native()).get();
+    BOOST_CHECK(file_exists);
+}
+
+FIXTURE_TEST(get_after_put, cache_test_fixture) {
+    ss::sstring data_string;
+    while (data_string.length() < 4096) {
+        data_string += SAMPLE_STRING1;
+    }
+    iobuf buf;
+    buf.append(data_string.data(), data_string.length());
+
+    auto input = make_iobuf_input_stream(std::move(buf));
+    cache_service.put(KEY, input).get();
+
+    std::optional<cloud_storage::cache_item> returned_item
+      = cache_service.get(KEY).get();
+    BOOST_REQUIRE(returned_item);
+    BOOST_CHECK_EQUAL(returned_item->size, data_string.length());
+
+    auto read_buf
+      = returned_item->body.read_exactly(data_string.length()).get();
+    BOOST_CHECK_EQUAL(
+      std::string_view(read_buf.get(), read_buf.size()), data_string);
+    BOOST_CHECK(!returned_item->body.read().get().get());
+}
+
+FIXTURE_TEST(put_rewrites_file, cache_test_fixture) {
+    ss::sstring data_string1, data_string2;
+    while (data_string1.length() < 4096) {
+        data_string1 += SAMPLE_STRING1;
+    }
+    while (data_string2.length() < 4096) {
+        data_string2 += SAMPLE_STRING2;
+    }
+    iobuf buf1, buf2;
+    buf1.append(data_string1.data(), data_string1.length());
+    buf2.append(data_string2.data(), data_string2.length());
+
+    auto input1 = make_iobuf_input_stream(std::move(buf1));
+    cache_service.put(KEY, input1).get();
+
+    auto input2 = make_iobuf_input_stream(std::move(buf2));
+    cache_service.put(KEY, input2).get();
+
+    std::optional<cloud_storage::cache_item> returned_item
+      = cache_service.get(KEY).get();
+    BOOST_REQUIRE(returned_item);
+    BOOST_CHECK_EQUAL(returned_item->size, data_string2.length());
+
+    auto read_buf
+      = returned_item->body.read_exactly(data_string2.length()).get();
+    BOOST_CHECK_EQUAL(
+      std::string_view(read_buf.get(), read_buf.size()), data_string2);
+    BOOST_CHECK(!returned_item->body.read().get().get());
+}
+
+FIXTURE_TEST(get_missing_file, cache_test_fixture) {
+    std::optional<cloud_storage::cache_item> returned_item
+      = cache_service.get(WRONG_KEY).get();
+
+    BOOST_CHECK(!returned_item);
+}
+
+FIXTURE_TEST(missing_file_not_cached, cache_test_fixture) {
+    bool is_cached = cache_service.is_cached(WRONG_KEY).get();
+
+    BOOST_CHECK(!is_cached);
+}
+
+FIXTURE_TEST(is_cached_after_put_success, cache_test_fixture) {
+    iobuf buf;
+    auto input = make_iobuf_input_stream(std::move(buf));
+    cache_service.put(KEY, input).get();
+
+    bool is_cached = cache_service.is_cached(KEY).get();
+
+    BOOST_CHECK(is_cached);
+}
+
+FIXTURE_TEST(after_invalidate_is_not_cached, cache_test_fixture) {
+    iobuf buf;
+    auto input = make_iobuf_input_stream(std::move(buf));
+    cache_service.put(KEY, input).get();
+    cache_service.invalidate(KEY).get();
+
+    bool is_cached = cache_service.is_cached(KEY).get();
+
+    BOOST_CHECK(!is_cached);
+}
+
+FIXTURE_TEST(invalidate_missing_file_ok, cache_test_fixture) {
+    BOOST_CHECK_NO_THROW(cache_service.invalidate(WRONG_KEY).get());
+}

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+#include "cloud_storage/cache_service.h"
+#include "seastarx.h"
+
+#include <seastar/core/seastar.hh>
+
+#include <boost/filesystem/operations.hpp>
+
+#include <filesystem>
+
+using namespace cloud_storage;
+
+class cache_test_fixture {
+public:
+    const std::filesystem::path KEY{"abc001/test_topic/test_cache_file.txt"};
+    const std::filesystem::path WRONG_KEY{"abc001/test_topic/wrong_key.txt"};
+
+    const std::filesystem::path CACHE_DIR{"test_cache_dir"};
+
+    const ss::sstring SAMPLE_STRING1 = ss::sstring("Test data");
+    const ss::sstring SAMPLE_STRING2 = ss::sstring("New test data!");
+
+    cloud_storage::cache cache_service;
+
+    cache_test_fixture()
+      : cache_service(CACHE_DIR) {
+        cache_service.start().get();
+    }
+
+    ~cache_test_fixture() {
+        boost::filesystem::remove_all(CACHE_DIR.native());
+        cache_service.stop().get();
+    }
+};

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -827,6 +827,25 @@ configuration::configuration()
       "remote storage (sec)",
       required::no,
       std::nullopt)
+  , cloud_storage_cache_directory(
+      *this,
+      "cloud_storage_cache_directory",
+      "Directory for archival cache. Should be present when "
+      "`cloud_storage_enabled` is present",
+      required::no,
+      (data_directory.value().path / "archival_cache").native())
+  , cloud_storage_cache_size(
+      *this,
+      "cloud_storage_cache_size",
+      "Max size of archival cache",
+      required::no,
+      20_GiB)
+  , cloud_storage_cache_check_interval_ms(
+      *this,
+      "cloud_storage_cache_check_interval",
+      "Timeout to check if cache eviction should be triggered",
+      required::no,
+      30s)
   , superusers(
       *this, "superusers", "List of superuser usernames", required::no, {})
   , kafka_qdc_latency_alpha(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -22,6 +22,7 @@
 #include "model/timestamp.h"
 #include "utils/unresolved_address.h"
 
+#include <seastar/core/sstring.hh>
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/ip.hh>
 #include <seastar/net/socket_defs.hh>
@@ -191,6 +192,11 @@ struct configuration final : public config_store {
       cloud_storage_max_connection_idle_time_ms;
     property<std::optional<std::chrono::seconds>>
       cloud_storage_segment_max_upload_interval_sec;
+
+    // Archival cache
+    property<std::optional<ss::sstring>> cloud_storage_cache_directory;
+    property<size_t> cloud_storage_cache_size;
+    property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
 
     one_or_many_property<ss::sstring> superusers;
 


### PR DESCRIPTION
Cache service is handling file operations for archival cache. Fetching data from S3 will create two data streams, one of which will be passed to the client, and another one will be passed to the cache system. When retrieving data, first cache will be checked, and if data is not present in the cache, then it will be retrieved from S3. Both segments and manifests will be cached.

- In [force push](https://github.com/vectorizedio/redpanda/compare/58f799e2e2d1cca8930655b06a85e3ac26cc42dc..7ec2f8279f8e666ade911e03fb2415a835733e77):

  - add test fixture

- In [force push](https://github.com/vectorizedio/redpanda/compare/7ec2f8279f8e666ade911e03fb2415a835733e77..246f97bbe42491f7a799cc396184fcb3555b7bdc): 
  - address comments about error handling
  
 - In [force push](https://github.com/vectorizedio/redpanda/compare/5ab40d7a7b2eff744a3103f70907c9b3d16f52b5..69720814d0374592c424290f12ea6b2ff315b2dd):
   - use `string_view` in tests
   - delete unused fields
   
 - In [force push](https://github.com/vectorizedio/redpanda/compare/69720814d0374592c424290f12ea6b2ff315b2dd..b3d7eac8862db1e427a83211b030e873ead4ef82):
   - use `.finally()` instead of `try{}`
   - add logging
   - `flush()` output stream before closing it
   
 - In [force push](https://github.com/vectorizedio/redpanda/compare/b3d7eac8862db1e427a83211b030e873ead4ef82..72003fcf05c2836ba691ac9d7921da0b0ed04bea):
    - add comment about semantics of tmp file
    - change flags for tmp file to `wo | create | exclusive`