### PR TITLE
rpk topic list: fixup

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/cluster/metadata.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster/metadata.go
@@ -124,7 +124,7 @@ In the broker section, the controller node is suffixed with *.
 			}
 			if topics && len(resp.Topics) > 0 {
 				header("TOPICS", func() {
-					printTopics(resp.Topics, internal, detailed)
+					PrintTopics(resp.Topics, internal, detailed)
 				})
 			}
 		},
@@ -176,7 +176,7 @@ func printBrokers(controllerID int32, brokers []kmsg.MetadataResponseBroker) {
 	}
 }
 
-func printTopics(topics []kmsg.MetadataResponseTopic, internal, detailed bool) {
+func PrintTopics(topics []kmsg.MetadataResponseTopic, internal, detailed bool) {
 	sort.Slice(topics, func(i, j int) bool {
 		return topics[i].Topic < topics[j].Topic
 	})

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -58,7 +58,7 @@ class RpkTool:
 
         lines = output.splitlines()
         for i, line in enumerate(lines):
-            if line.split() == ["Name", "Partitions", "Replicas"]:
+            if line.split() == ["NAME", "PARTITIONS", "REPLICAS"]:
                 return map(topic_line, lines[i + 1:])
 
         assert False, "Unexpected output format"

--- a/tests/rptest/tests/rpk_topic_test.py
+++ b/tests/rptest/tests/rpk_topic_test.py
@@ -12,7 +12,6 @@ from ducktape.mark import ignore
 from ducktape.mark.resource import cluster
 import ducktape.errors
 
-from ducktape.mark import ignore
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool
 from rptest.services.rpk_consumer import RpkConsumer
@@ -28,7 +27,6 @@ class RpkToolTest(RedpandaTest):
         self._ctx = ctx
         self._rpk = RpkTool(self.redpanda)
 
-    @ignore
     @cluster(num_nodes=3)
     def test_create_topic(self):
         self._rpk.create_topic("topic")


### PR DESCRIPTION
Unfortunately, calling into the metadata command directly means that
the new metadata command does not have persistent flags installed. We
also can't look at the listCmd's persistent flags because the pflag
package doesn't separate persistent and non-persistent flags in any
getter functions.

The easy fix is to just export the PrintTopics function from
cluster/offsets.go, and then call into that directly.

Closes #2229.