### PR TITLE
Updates tx layer to support hot log truncations

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -199,10 +199,12 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::begin_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   std::chrono::milliseconds transaction_timeout_ms) {
+    return _state_lock.hold_read_lock().then([this, pid, tx_seq, transaction_timeout_ms](ss::basic_rwlock<>::holder unit) mutable {
     return get_tx_lock(pid.get_id())
       ->with([this, pid, tx_seq, transaction_timeout_ms]() {
           return do_begin_tx(pid, tx_seq, transaction_timeout_ms);
-      });
+      }).finally([u = std::move(unit)] {});
+    });
 }
 
 ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
@@ -275,10 +277,12 @@ ss::future<tx_errc> rm_stm::prepare_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
+    return _state_lock.hold_read_lock().then([this, etag, tm, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) mutable {
     return get_tx_lock(pid.get_id())
       ->with([this, etag, tm, pid, tx_seq, timeout]() {
           return do_prepare_tx(etag, tm, pid, tx_seq, timeout);
-      });
+      }).finally([u = std::move(unit)] {});
+    });
 }
 
 ss::future<tx_errc> rm_stm::do_prepare_tx(
@@ -382,8 +386,10 @@ ss::future<tx_errc> rm_stm::commit_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
+    return _state_lock.hold_read_lock().then([this, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) mutable {
     return get_tx_lock(pid.get_id())->with([this, pid, tx_seq, timeout]() {
         return do_commit_tx(pid, tx_seq, timeout);
+    }).finally([u = std::move(unit)] {});
     });
 }
 
@@ -529,8 +535,10 @@ ss::future<tx_errc> rm_stm::abort_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
+    return _state_lock.hold_read_lock().then([this, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) mutable {
     return get_tx_lock(pid.get_id())->with([this, pid, tx_seq, timeout]() {
         return do_abort_tx(pid, tx_seq, timeout);
+    }).finally([u = std::move(unit)] {});
     });
 }
 
@@ -601,13 +609,14 @@ ss::future<result<raft::replicate_result>> rm_stm::replicate(
   model::batch_identity bid,
   model::record_batch_reader b,
   raft::replicate_options opts) {
+    return _state_lock.hold_read_lock().then([this, bid, opts, b = std::move(b)](ss::basic_rwlock<>::holder unit) mutable {
     if (bid.is_transactional) {
         auto pid = bid.pid.get_id();
         return get_tx_lock(pid)->with([this, bid, b = std::move(b)]() mutable {
             return replicate_tx(bid, std::move(b));
-        });
+        }).finally([u = std::move(unit)] {});
     } else if (bid.has_idempotent() && bid.first_seq <= bid.last_seq) {
-        return replicate_seq(bid, std::move(b), opts);
+        return replicate_seq(bid, std::move(b), opts).finally([u = std::move(unit)] {});
     }
 
     return sync(_sync_timeout)
@@ -617,7 +626,8 @@ ss::future<result<raft::replicate_result>> rm_stm::replicate(
                 errc::not_leader);
           }
           return _c->replicate(std::move(b), opts);
-      });
+      }).finally([u = std::move(unit)] {});
+    });
 }
 
 ss::future<> rm_stm::stop() {
@@ -869,8 +879,10 @@ void rm_stm::track_tx(
 void rm_stm::abort_old_txes() {
     _is_autoabort_active = true;
     (void)ss::with_gate(_gate, [this] {
+        return _state_lock.hold_read_lock().then([this](ss::basic_rwlock<>::holder unit) mutable {
         return do_abort_old_txes().finally(
-          [this] { try_arm(clock_type::now() + _abort_interval_ms); });
+          [this, u = std::move(unit)] { try_arm(clock_type::now() + _abort_interval_ms); });
+        });
     });
 }
 
@@ -1341,6 +1353,16 @@ rm_stm::load_abort_snapshot(abort_index index) {
     auto data = reflection::adl<abort_snapshot>{}.from(data_parser);
 
     co_return data;
+}
+
+ss::future<> rm_stm::handle_eviction() {
+    return _state_lock.hold_write_lock().then(
+      [this]([[maybe_unused]] ss::basic_rwlock<>::holder unit) {
+          _log_state = {};
+          _mem_state = {};
+          set_next(_c->start_offset());
+          return ss::now();
+      });
 }
 
 } // namespace cluster

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -199,12 +199,15 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::begin_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   std::chrono::milliseconds transaction_timeout_ms) {
-    return _state_lock.hold_read_lock().then([this, pid, tx_seq, transaction_timeout_ms](ss::basic_rwlock<>::holder unit) mutable {
-    return get_tx_lock(pid.get_id())
-      ->with([this, pid, tx_seq, transaction_timeout_ms]() {
-          return do_begin_tx(pid, tx_seq, transaction_timeout_ms);
-      }).finally([u = std::move(unit)] {});
-    });
+    return _state_lock.hold_read_lock().then(
+      [this, pid, tx_seq, transaction_timeout_ms](
+        ss::basic_rwlock<>::holder unit) mutable {
+          return get_tx_lock(pid.get_id())
+            ->with([this, pid, tx_seq, transaction_timeout_ms]() {
+                return do_begin_tx(pid, tx_seq, transaction_timeout_ms);
+            })
+            .finally([u = std::move(unit)] {});
+      });
 }
 
 ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
@@ -277,12 +280,15 @@ ss::future<tx_errc> rm_stm::prepare_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
-    return _state_lock.hold_read_lock().then([this, etag, tm, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) mutable {
-    return get_tx_lock(pid.get_id())
-      ->with([this, etag, tm, pid, tx_seq, timeout]() {
-          return do_prepare_tx(etag, tm, pid, tx_seq, timeout);
-      }).finally([u = std::move(unit)] {});
-    });
+    return _state_lock.hold_read_lock().then(
+      [this, etag, tm, pid, tx_seq, timeout](
+        ss::basic_rwlock<>::holder unit) mutable {
+          return get_tx_lock(pid.get_id())
+            ->with([this, etag, tm, pid, tx_seq, timeout]() {
+                return do_prepare_tx(etag, tm, pid, tx_seq, timeout);
+            })
+            .finally([u = std::move(unit)] {});
+      });
 }
 
 ss::future<tx_errc> rm_stm::do_prepare_tx(
@@ -386,11 +392,14 @@ ss::future<tx_errc> rm_stm::commit_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
-    return _state_lock.hold_read_lock().then([this, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) mutable {
-    return get_tx_lock(pid.get_id())->with([this, pid, tx_seq, timeout]() {
-        return do_commit_tx(pid, tx_seq, timeout);
-    }).finally([u = std::move(unit)] {});
-    });
+    return _state_lock.hold_read_lock().then(
+      [this, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) mutable {
+          return get_tx_lock(pid.get_id())
+            ->with([this, pid, tx_seq, timeout]() {
+                return do_commit_tx(pid, tx_seq, timeout);
+            })
+            .finally([u = std::move(unit)] {});
+      });
 }
 
 ss::future<tx_errc> rm_stm::do_commit_tx(
@@ -535,11 +544,14 @@ ss::future<tx_errc> rm_stm::abort_tx(
   model::producer_identity pid,
   model::tx_seq tx_seq,
   model::timeout_clock::duration timeout) {
-    return _state_lock.hold_read_lock().then([this, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) mutable {
-    return get_tx_lock(pid.get_id())->with([this, pid, tx_seq, timeout]() {
-        return do_abort_tx(pid, tx_seq, timeout);
-    }).finally([u = std::move(unit)] {});
-    });
+    return _state_lock.hold_read_lock().then(
+      [this, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) mutable {
+          return get_tx_lock(pid.get_id())
+            ->with([this, pid, tx_seq, timeout]() {
+                return do_abort_tx(pid, tx_seq, timeout);
+            })
+            .finally([u = std::move(unit)] {});
+      });
 }
 
 // abort_tx is invoked strictly after a tx is canceled on the tm_stm
@@ -609,25 +621,31 @@ ss::future<result<raft::replicate_result>> rm_stm::replicate(
   model::batch_identity bid,
   model::record_batch_reader b,
   raft::replicate_options opts) {
-    return _state_lock.hold_read_lock().then([this, bid, opts, b = std::move(b)](ss::basic_rwlock<>::holder unit) mutable {
-    if (bid.is_transactional) {
-        auto pid = bid.pid.get_id();
-        return get_tx_lock(pid)->with([this, bid, b = std::move(b)]() mutable {
-            return replicate_tx(bid, std::move(b));
-        }).finally([u = std::move(unit)] {});
-    } else if (bid.has_idempotent() && bid.first_seq <= bid.last_seq) {
-        return replicate_seq(bid, std::move(b), opts).finally([u = std::move(unit)] {});
-    }
-
-    return sync(_sync_timeout)
-      .then([this, opts, b = std::move(b)](bool is_synced) mutable {
-          if (!is_synced) {
-              return ss::make_ready_future<result<raft::replicate_result>>(
-                errc::not_leader);
+    return _state_lock.hold_read_lock().then(
+      [this, bid, opts, b = std::move(b)](
+        ss::basic_rwlock<>::holder unit) mutable {
+          if (bid.is_transactional) {
+              auto pid = bid.pid.get_id();
+              return get_tx_lock(pid)
+                ->with([this, bid, b = std::move(b)]() mutable {
+                    return replicate_tx(bid, std::move(b));
+                })
+                .finally([u = std::move(unit)] {});
+          } else if (bid.has_idempotent() && bid.first_seq <= bid.last_seq) {
+              return replicate_seq(bid, std::move(b), opts)
+                .finally([u = std::move(unit)] {});
           }
-          return _c->replicate(std::move(b), opts);
-      }).finally([u = std::move(unit)] {});
-    });
+
+          return sync(_sync_timeout)
+            .then([this, opts, b = std::move(b)](bool is_synced) mutable {
+                if (!is_synced) {
+                    return ss::make_ready_future<
+                      result<raft::replicate_result>>(errc::not_leader);
+                }
+                return _c->replicate(std::move(b), opts);
+            })
+            .finally([u = std::move(unit)] {});
+      });
 }
 
 ss::future<> rm_stm::stop() {
@@ -879,10 +897,12 @@ void rm_stm::track_tx(
 void rm_stm::abort_old_txes() {
     _is_autoabort_active = true;
     (void)ss::with_gate(_gate, [this] {
-        return _state_lock.hold_read_lock().then([this](ss::basic_rwlock<>::holder unit) mutable {
-        return do_abort_old_txes().finally(
-          [this, u = std::move(unit)] { try_arm(clock_type::now() + _abort_interval_ms); });
-        });
+        return _state_lock.hold_read_lock().then(
+          [this](ss::basic_rwlock<>::holder unit) mutable {
+              return do_abort_old_txes().finally([this, u = std::move(unit)] {
+                  try_arm(clock_type::now() + _abort_interval_ms);
+              });
+          });
     });
 }
 

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -132,6 +132,9 @@ public:
 
     void testing_only_enable_transactions() { _is_tx_enabled = true; }
 
+protected:
+    ss::future<> handle_eviction() override;
+
 private:
     ss::future<checked<model::term_id, tx_errc>> do_begin_tx(
       model::producer_identity, model::tx_seq, std::chrono::milliseconds);
@@ -280,6 +283,7 @@ private:
         return lock_it->second;
     }
 
+    ss::basic_rwlock<> _state_lock;
     absl::flat_hash_map<model::producer_id, ss::lw_shared_ptr<mutex>> _tx_locks;
     log_state _log_state;
     mem_state _mem_state;

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -433,4 +433,14 @@ ss::future<> tm_stm::expire_tx(kafka::transactional_id tx_id) {
     co_await update_tx(tx, tx.etag).discard_result();
 }
 
+ss::future<> tm_stm::handle_eviction() {
+    return _state_lock.hold_write_lock().then(
+      [this]([[maybe_unused]] ss::basic_rwlock<>::holder unit) {
+          _tx_table.clear();
+          _pid_tx_id.clear();
+          set_next(_c->start_offset());
+          return ss::now();
+      });
+}
+
 } // namespace cluster

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -135,6 +135,10 @@ public:
 
     ss::future<bool> barrier();
 
+    ss::future<ss::basic_rwlock<>::holder> read_lock() {
+        return _state_lock.hold_read_lock();
+    }
+
     ss::future<checked<tm_transaction, tm_stm::op_status>>
       get_actual_tx(kafka::transactional_id);
     ss::future<checked<tm_transaction, tm_stm::op_status>>
@@ -167,10 +171,14 @@ public:
 
     std::vector<kafka::transactional_id> get_expired_txs();
 
+protected:
+    ss::future<> handle_eviction() override;
+
 private:
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
 
+    ss::basic_rwlock<> _state_lock;
     std::chrono::milliseconds _sync_timeout;
     std::chrono::milliseconds _transactional_id_expiration;
     model::violation_recovery_policy _recovery_policy;

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -259,6 +259,7 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
                 try_abort_reply{.ec = tx_errc::stm_not_found});
           }
 
+          return stm->read_lock().then([&self, stm, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) {
           return stm->barrier().then([&self, stm, pid, tx_seq, timeout](
                                        bool ready) {
               if (!ready) {
@@ -293,6 +294,7 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
                 .handle_exception_type([](const ss::semaphore_timed_out&) {
                     return try_abort_reply{.ec = tx_errc::unknown_server_error};
                 });
+          }).finally([u = std::move(unit)] {});
           });
       });
 }
@@ -537,11 +539,13 @@ ss::future<init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
                 init_tm_tx_reply{.ec = tx_errc::stm_not_found});
           }
 
+          return stm->read_lock().then([&self, stm, tx_id, transaction_timeout_ms, timeout](ss::basic_rwlock<>::holder unit) {
           return stm->get_tx_lock(tx_id)->with(
             [&self, stm, tx_id, transaction_timeout_ms, timeout]() {
                 return self.do_init_tm_tx(
                   stm, tx_id, transaction_timeout_ms, timeout);
-            });
+            }).finally([u = std::move(unit)] {});
+          });
       });
 }
 
@@ -714,10 +718,12 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::add_partition_to_tx(
                   request, tx_errc::invalid_txn_state));
           }
 
+          return stm->read_lock().then([&self, stm, request, timeout](ss::basic_rwlock<>::holder unit) {
           return stm->get_tx_lock(request.transactional_id)
             ->with([&self, stm, request, timeout]() {
                 return self.do_add_partition_to_tx(stm, request, timeout);
-            });
+            }).finally([u = std::move(unit)] {});
+          });
       });
 }
 
@@ -869,10 +875,12 @@ ss::future<add_offsets_tx_reply> tx_gateway_frontend::add_offsets_to_tx(
                 add_offsets_tx_reply{.error_code = tx_errc::invalid_txn_state});
           }
 
+          return stm->read_lock().then([&self, stm, request, timeout](ss::basic_rwlock<>::holder unit) {
           return stm->get_tx_lock(request.transactional_id)
             ->with([&self, stm, request, timeout]() {
                 return self.do_add_offsets_to_tx(stm, request, timeout);
-            });
+            }).finally([u = std::move(unit)] {});
+          });
       });
 }
 
@@ -958,6 +966,7 @@ ss::future<end_tx_reply> tx_gateway_frontend::end_txn(
              stm,
              timeout,
              outcome]() mutable {
+                return stm->read_lock().then([request = std::move(request), &self, stm, timeout, outcome](ss::basic_rwlock<>::holder unit) {
                 return stm->get_tx_lock(request.transactional_id)
                   ->with([request = std::move(request),
                           &self,
@@ -972,7 +981,8 @@ ss::future<end_tx_reply> tx_gateway_frontend::end_txn(
                                   tx_errc::unknown_server_error);
                             }
                         });
-                  });
+                  }).finally([u = std::move(unit)] {});
+                });
             });
 
           return decided.then(
@@ -1455,7 +1465,9 @@ ss::future<> tx_gateway_frontend::do_expire_old_txs() {
         }
 
         auto stm = partition->tm_stm();
-        return expire_old_txs(stm);
+        return stm->read_lock().then([this, stm](ss::basic_rwlock<>::holder unit) {
+        return expire_old_txs(stm).finally([u = std::move(unit)] {});
+        });
     });
 }
 

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -259,42 +259,49 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
                 try_abort_reply{.ec = tx_errc::stm_not_found});
           }
 
-          return stm->read_lock().then([&self, stm, pid, tx_seq, timeout](ss::basic_rwlock<>::holder unit) {
-          return stm->barrier().then([&self, stm, pid, tx_seq, timeout](
-                                       bool ready) {
-              if (!ready) {
-                  return ss::make_ready_future<try_abort_reply>(
-                    try_abort_reply{.ec = tx_errc::unknown_server_error});
-              }
-              auto tx_id_opt = stm->get_id_by_pid(pid);
-              if (!tx_id_opt) {
-                  return ss::make_ready_future<try_abort_reply>(
-                    try_abort_reply{.aborted = true, .ec = tx_errc::none});
-              }
-              auto tx_id = tx_id_opt.value();
+          return stm->read_lock().then([&self, stm, pid, tx_seq, timeout](
+                                         ss::basic_rwlock<>::holder unit) {
+              return stm->barrier()
+                .then([&self, stm, pid, tx_seq, timeout](bool ready) {
+                    if (!ready) {
+                        return ss::make_ready_future<try_abort_reply>(
+                          try_abort_reply{.ec = tx_errc::unknown_server_error});
+                    }
+                    auto tx_id_opt = stm->get_id_by_pid(pid);
+                    if (!tx_id_opt) {
+                        return ss::make_ready_future<try_abort_reply>(
+                          try_abort_reply{
+                            .aborted = true, .ec = tx_errc::none});
+                    }
+                    auto tx_id = tx_id_opt.value();
 
-              auto tx_opt = stm->get_tx_by_id(tx_id);
-              if (!tx_opt) {
-                  return ss::make_ready_future<try_abort_reply>(
-                    try_abort_reply{.aborted = true, .ec = tx_errc::none});
-              }
-              auto tx = tx_opt.value();
-              if (tx.pid != pid || tx.tx_seq != tx_seq) {
-                  return ss::make_ready_future<try_abort_reply>(
-                    try_abort_reply{.aborted = true, .ec = tx_errc::none});
-              }
+                    auto tx_opt = stm->get_tx_by_id(tx_id);
+                    if (!tx_opt) {
+                        return ss::make_ready_future<try_abort_reply>(
+                          try_abort_reply{
+                            .aborted = true, .ec = tx_errc::none});
+                    }
+                    auto tx = tx_opt.value();
+                    if (tx.pid != pid || tx.tx_seq != tx_seq) {
+                        return ss::make_ready_future<try_abort_reply>(
+                          try_abort_reply{
+                            .aborted = true, .ec = tx_errc::none});
+                    }
 
-              return stm->get_tx_lock(tx_id)
-                ->with(
-                  timeout,
-                  [&self, stm, tx_id, pid, tx_seq, timeout]() {
-                      return self.do_try_abort(
-                        stm, tx_id, pid, tx_seq, timeout);
-                  })
-                .handle_exception_type([](const ss::semaphore_timed_out&) {
-                    return try_abort_reply{.ec = tx_errc::unknown_server_error};
-                });
-          }).finally([u = std::move(unit)] {});
+                    return stm->get_tx_lock(tx_id)
+                      ->with(
+                        timeout,
+                        [&self, stm, tx_id, pid, tx_seq, timeout]() {
+                            return self.do_try_abort(
+                              stm, tx_id, pid, tx_seq, timeout);
+                        })
+                      .handle_exception_type(
+                        [](const ss::semaphore_timed_out&) {
+                            return try_abort_reply{
+                              .ec = tx_errc::unknown_server_error};
+                        });
+                })
+                .finally([u = std::move(unit)] {});
           });
       });
 }
@@ -539,13 +546,17 @@ ss::future<init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
                 init_tm_tx_reply{.ec = tx_errc::stm_not_found});
           }
 
-          return stm->read_lock().then([&self, stm, tx_id, transaction_timeout_ms, timeout](ss::basic_rwlock<>::holder unit) {
-          return stm->get_tx_lock(tx_id)->with(
-            [&self, stm, tx_id, transaction_timeout_ms, timeout]() {
-                return self.do_init_tm_tx(
-                  stm, tx_id, transaction_timeout_ms, timeout);
-            }).finally([u = std::move(unit)] {});
-          });
+          return stm->read_lock().then(
+            [&self, stm, tx_id, transaction_timeout_ms, timeout](
+              ss::basic_rwlock<>::holder unit) {
+                return stm->get_tx_lock(tx_id)
+                  ->with(
+                    [&self, stm, tx_id, transaction_timeout_ms, timeout]() {
+                        return self.do_init_tm_tx(
+                          stm, tx_id, transaction_timeout_ms, timeout);
+                    })
+                  .finally([u = std::move(unit)] {});
+            });
       });
 }
 
@@ -718,12 +729,14 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::add_partition_to_tx(
                   request, tx_errc::invalid_txn_state));
           }
 
-          return stm->read_lock().then([&self, stm, request, timeout](ss::basic_rwlock<>::holder unit) {
-          return stm->get_tx_lock(request.transactional_id)
-            ->with([&self, stm, request, timeout]() {
-                return self.do_add_partition_to_tx(stm, request, timeout);
-            }).finally([u = std::move(unit)] {});
-          });
+          return stm->read_lock().then(
+            [&self, stm, request, timeout](ss::basic_rwlock<>::holder unit) {
+                return stm->get_tx_lock(request.transactional_id)
+                  ->with([&self, stm, request, timeout]() {
+                      return self.do_add_partition_to_tx(stm, request, timeout);
+                  })
+                  .finally([u = std::move(unit)] {});
+            });
       });
 }
 
@@ -875,12 +888,14 @@ ss::future<add_offsets_tx_reply> tx_gateway_frontend::add_offsets_to_tx(
                 add_offsets_tx_reply{.error_code = tx_errc::invalid_txn_state});
           }
 
-          return stm->read_lock().then([&self, stm, request, timeout](ss::basic_rwlock<>::holder unit) {
-          return stm->get_tx_lock(request.transactional_id)
-            ->with([&self, stm, request, timeout]() {
-                return self.do_add_offsets_to_tx(stm, request, timeout);
-            }).finally([u = std::move(unit)] {});
-          });
+          return stm->read_lock().then(
+            [&self, stm, request, timeout](ss::basic_rwlock<>::holder unit) {
+                return stm->get_tx_lock(request.transactional_id)
+                  ->with([&self, stm, request, timeout]() {
+                      return self.do_add_offsets_to_tx(stm, request, timeout);
+                  })
+                  .finally([u = std::move(unit)] {});
+            });
       });
 }
 
@@ -966,23 +981,27 @@ ss::future<end_tx_reply> tx_gateway_frontend::end_txn(
              stm,
              timeout,
              outcome]() mutable {
-                return stm->read_lock().then([request = std::move(request), &self, stm, timeout, outcome](ss::basic_rwlock<>::holder unit) {
-                return stm->get_tx_lock(request.transactional_id)
-                  ->with([request = std::move(request),
-                          &self,
-                          stm,
-                          timeout,
-                          outcome]() mutable {
-                      return self
-                        .do_end_txn(std::move(request), stm, timeout, outcome)
-                        .finally([outcome]() {
-                            if (!outcome->available()) {
-                                outcome->set_value(
-                                  tx_errc::unknown_server_error);
-                            }
-                        });
-                  }).finally([u = std::move(unit)] {});
-                });
+                return stm->read_lock().then(
+                  [request = std::move(request), &self, stm, timeout, outcome](
+                    ss::basic_rwlock<>::holder unit) {
+                      return stm->get_tx_lock(request.transactional_id)
+                        ->with([request = std::move(request),
+                                &self,
+                                stm,
+                                timeout,
+                                outcome]() mutable {
+                            return self
+                              .do_end_txn(
+                                std::move(request), stm, timeout, outcome)
+                              .finally([outcome]() {
+                                  if (!outcome->available()) {
+                                      outcome->set_value(
+                                        tx_errc::unknown_server_error);
+                                  }
+                              });
+                        })
+                        .finally([u = std::move(unit)] {});
+                  });
             });
 
           return decided.then(
@@ -1465,9 +1484,10 @@ ss::future<> tx_gateway_frontend::do_expire_old_txs() {
         }
 
         auto stm = partition->tm_stm();
-        return stm->read_lock().then([this, stm](ss::basic_rwlock<>::holder unit) {
-        return expire_old_txs(stm).finally([u = std::move(unit)] {});
-        });
+        return stm->read_lock().then(
+          [this, stm](ss::basic_rwlock<>::holder unit) {
+              return expire_old_txs(stm).finally([u = std::move(unit)] {});
+          });
     });
 }
 

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -101,6 +101,7 @@ public:
 
 protected:
     void set_next(model::offset offset);
+    virtual ss::future<> handle_eviction();
     ss::gate _gate;
 
 private:


### PR DESCRIPTION
## Cover letter

Fixes 'a read before start offset' problem happening after a rejoined node wipes its log including the current position of a state machine.