### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,101 @@
-*                          @senior7515 @dotnwat
-/cmake/                    @benpope @ivotron
-/conf/                     @0x5d
-/docs/                     @bmansheim
-/src/go/                   @0x5d @mmaslankaprv
-/src/consistency-testing/  @rystsov
-/src/v/bytes/              @senior7515 @dotnwat
-/src/v/cluster/            @senior7515 @dotnwat @mmaslankaprv
-/src/v/coproc/             @graphcareful @dotnwat
-/src/v/pandaproxy/         @benpope @dotnwat
-/src/v/raft/               @senior7515 @dotnwat @mmaslankaprv
-/src/js/                   @0x5d @andresaristizabal
+#
+# docs, prose, legal
+#
+licenses           @senior7515 @dswang
+*.md               @bmansheim
+/docs              @bmansheim
+/CONTRIBUTING.md   @dotnwat
 
-# core
-/cmake        @vectorizedio/core
-/src/v        @vectorizedio/core
+#
+# editors
+#
+/.vim             @dotnwat
+/.dir-locals.el   @graphcareful
+
+#
+# cloud
+#
 /src/go/k8s   @vectorizedio/k8s
+
+#
+# build
+#
+/.clang-format             @ivotron
+/.clang-tidy               @ivotron
+/.clang_complete           @ivotron
+/.github                   @ivotron
+/.gitignore                @ivotron
+/.gitorderfile             @ivotron
+/.style.yapf               @ivotron
+/build.sh                  @ivotron
+/cmake                     @ivotron        @benpope
+/install-dependencies.sh   @ivotron
+/.yapfignore               @ivotron
+/tools                     @ivotron
+
+#
+# core
+#
+/src/js                @andresaristizabal
+/src/v/archival        @lazin               @lenaan         @ztlpn
+/src/v/bytes           @dotnwat
+/src/v/cloud_storage   @lazin               @lenaan
+/src/v/cluster         @mmaslankaprv        @ztlpn          @vadimplh
+/src/v/compression     @dotnwat
+/src/v/config          @mmaslankaprv
+/src/v/coproc          @graphcareful        @vadimplh
+/src/v/dashboard       @yougotashovel
+/src/v/finjector       @rystsov
+/src/v/hashing         @dotnwat
+/src/v/http            @lazin
+/src/v/json            @benpope
+/src/v/kafka           @dotnwat             @nyalialui
+/src/v/kafka/client    @benpope
+/src/v/model           @dotnwat             @mmaslankaprv
+/src/v/pandaproxy      @benpope             @nyalialui
+/src/v/platform        @lazin               @benpope
+/src/v/prometheus      @dotnwat
+/src/v/raft            @mmaslankaprv        @ztlpn          @jcsp        @vadimplh
+/src/v/random          @dotnwat
+/src/v/redpanda        @dotnwat             @mmaslankaprv
+/src/v/reflection      @graphcareful        @benpope
+/src/v/resource_mgmt   @mmaslankaprv
+/src/v/rpc             @mmaslankaprv        @jcsp
+/src/v/s3              @lazin               @ivotron
+/src/v/security        @dotnwat
+/src/v/serde           @felixguendling      @benpope
+/src/v/ssx             @benpope
+/src/v/storage         @dotnwat             @ivotron        @lenaan      @vadimplh
+/src/v/syschecks       @mmaslankaprv
+/src/v/test_utils      @graphcareful
+/src/v/utils           @benpope
+/src/v/v8_engine       @vadimplh
+
+#
+# rpk
+#
+/src/go/rpk        @twmb @0x5d @lenaan
+
+#
+# transactions and idempotent producer
+#
+/src/v/cluster/rm_*                             @rystsov
+/src/v/cluster/id_allocator*                    @rystsov
+/src/v/cluster/persisted_stm.*                  @rystsov
+/src/v/cluster/tm_*                             @rystsov
+/src/v/cluster/tx_*                             @rystsov
+/src/v/cluster/tests/idempotency_tests.cc       @rystsov
+/src/v/cluster/tests/id_allocator_stm_test.cc   @rystsov
+/src/v/cluster/tests/rm_stm_tests.cc            @rystsov
+/src/v/cluster/tests/tm_stm_tests.cc            @rystsov
+/src/v/kafka/server/rm_group_frontend.*         @rystsov
+/src/v/kafka/**/*init_producer_id*              @rystsov
+/src/v/kafka/**/*txn*                           @rystsov
+
+#
+# testing
+#
+/tests                              @dotnwat        @ivotron        @nyalialui
+/src/consistency-testing            @rystsov
+/tests/java/tx-verifier             @rystsov
+/tests/rptest/tests/compatibility   @nyalialui


### PR DESCRIPTION
Looks like we've got ourselves a monorepo, and as we've all probably experienced, the automatic GitHub reviewer choices are merely _ok_ rather than great. In an effort to make those automatic choices more precise, and also to document who is knowledgable about which areas, this patch updates the GitHub CODEOWNERS file.

I've seeded this file based on what I know, and I reached out to several people to help. So I think now we can open up the floor and knock this out. Please comment about changes and I'll apply the updates. The general idea is to own a few areas (if you're new maybe that isn't clear yet) and provide reviews, and then for everyone to be listed in other areas of interest / coming up to speed.

If it is helpful the directory structure can also be made more precise where needed.

Of course everyone is welcome and encouraged to review any PR, so despite the name code _owners_, it's really just a way to teach the GitHub brain to be smarter.

edit: I can't request more than 15 reviewers boo!

@ztlpn 
@yougotashovel 
@VadimPlh 
@twmb 
@simon0191 
@rystsov 
@NyaliaLui 
@mmaslankaprv 
@Mateoc 
@LenaAn 
@Lazin 
@laurajaramillovectorized 
@jcsp 