### PR TITLE
storage: make chunk_size configurable at runtime

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -635,6 +635,12 @@ configuration::configuration()
       "cache",
       required::no,
       60s)
+  , append_chunk_size(
+      *this,
+      "append_chunk_size",
+      "Size of direct write operations to disk",
+      required::no,
+      16_KiB)
   , max_compacted_log_segment_size(
       *this,
       "max_compacted_log_segment_size",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -11,6 +11,7 @@
 
 #include "config/base_property.h"
 #include "model/metadata.h"
+#include "storage/chunk_cache.h"
 #include "units.h"
 
 #include <cstdint>
@@ -640,7 +641,8 @@ configuration::configuration()
       "append_chunk_size",
       "Size of direct write operations to disk",
       required::no,
-      16_KiB)
+      16_KiB,
+      storage::internal::chunk_cache::validate_chunk_size)
   , max_compacted_log_segment_size(
       *this,
       "max_compacted_log_segment_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -153,6 +153,7 @@ struct configuration final : public config_store {
     property<bool> release_cache_on_segment_roll;
     property<std::chrono::milliseconds> segment_appender_flush_timeout_ms;
     property<std::chrono::milliseconds> fetch_session_eviction_timeout_ms;
+    property<size_t> append_chunk_size;
     property<size_t> max_compacted_log_segment_size;
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -41,6 +41,17 @@ public:
     chunk_cache& operator=(const chunk_cache&) = delete;
     ~chunk_cache() noexcept = default;
 
+    /** Validator for chunk size configuration setting */
+    static std::optional<ss::sstring> validate_chunk_size(const size_t& value) {
+        if (value % alignment != 0) {
+            return "Chunk size must be multiple of 4096";
+        } else if (value < alignment) {
+            return "Chunk size must be at least 4096";
+        } else {
+            return std::nullopt;
+        }
+    }
+
     ss::future<> start() {
         const auto num_chunks = memory_groups::chunk_cache_min_memory()
                                 / _chunk_size;

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -32,7 +32,8 @@ public:
 
     chunk_cache() noexcept
       : _size_target(memory_groups::chunk_cache_min_memory())
-      , _size_limit(memory_groups::chunk_cache_max_memory()) {}
+      , _size_limit(memory_groups::chunk_cache_max_memory())
+      , _chunk_size(config::shard_local_cfg().append_chunk_size()) {}
 
     chunk_cache(chunk_cache&&) = delete;
     chunk_cache& operator=(chunk_cache&&) = delete;
@@ -42,24 +43,24 @@ public:
 
     ss::future<> start() {
         const auto num_chunks = memory_groups::chunk_cache_min_memory()
-                                / chunk::chunk_size;
+                                / _chunk_size;
         return ss::do_for_each(
           boost::counting_iterator<size_t>(0),
           boost::counting_iterator<size_t>(num_chunks),
           [this](size_t) {
-              auto c = ss::make_lw_shared<chunk>(alignment);
-              _size_total += chunk::chunk_size;
+              auto c = ss::make_lw_shared<chunk>(_chunk_size, alignment);
+              _size_total += _chunk_size;
               add(c);
           });
     }
 
     void add(const chunk_ptr& chunk) {
         if (_size_available >= _size_target) {
-            _size_total -= chunk::chunk_size;
+            _size_total -= _chunk_size;
             return;
         }
         _chunks.push_back(chunk);
-        _size_available += chunk::chunk_size;
+        _size_available += _chunk_size;
         if (_sem.waiters()) {
             _sem.signal();
         }
@@ -87,14 +88,14 @@ private:
         if (!_chunks.empty()) {
             auto c = _chunks.front();
             _chunks.pop_front();
-            _size_available -= chunk::chunk_size;
+            _size_available -= _chunk_size;
             c->reset();
             return c;
         }
         if (_size_total < _size_limit) {
             try {
-                auto c = ss::make_lw_shared<chunk>(alignment);
-                _size_total += chunk::chunk_size;
+                auto c = ss::make_lw_shared<chunk>(alignment, _chunk_size);
+                _size_total += _chunk_size;
                 return c;
             } catch (const std::bad_alloc& e) {
                 vlog(stlog.debug, "chunk allocation failed: {}", e);
@@ -109,6 +110,8 @@ private:
     size_t _size_total{0};
     const size_t _size_target;
     const size_t _size_limit;
+
+    const size_t _chunk_size{0};
 };
 
 inline chunk_cache& chunks() {

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -36,9 +36,6 @@ public:
     using chunk = segment_appender_chunk;
 
     static constexpr const size_t write_behind_memory = 1_MiB;
-    static constexpr const size_t chunks_no_buffer = write_behind_memory
-                                                     / chunk::chunk_size;
-    static constexpr const size_t chunk_size = chunk::chunk_size;
     static constexpr const size_t fallocation_step = 32_MiB;
 
     struct options {
@@ -51,7 +48,7 @@ public:
           , falloc_step(step) {}
 
         ss::io_priority_class priority;
-        size_t number_of_chunks{chunks_no_buffer};
+        size_t number_of_chunks;
         size_t falloc_step{fallocation_step};
     };
 
@@ -143,6 +140,8 @@ private:
 
     ss::timer<ss::lowres_clock> _inactive_timer;
     void handle_inactive_timer();
+
+    size_t _chunk_size{0};
 
     friend std::ostream& operator<<(std::ostream&, const segment_appender&);
 };

--- a/src/v/storage/tests/appender_chunk_manipulations.cc
+++ b/src/v/storage/tests/appender_chunk_manipulations.cc
@@ -22,11 +22,16 @@ static constexpr size_t alignment = 4096;
 
 SEASTAR_THREAD_TEST_CASE(chunk_manipulation) {
     const auto b = random_generators::gen_alphanum_string(1024 * 1024);
-    chunk c(alignment);
+    const auto chunk_size = config::shard_local_cfg().append_chunk_size();
+    chunk c(alignment, chunk_size);
+
+    // Unit tests should be running with default config
+    assert(chunk_size == 16_KiB);
+
     {
         c.append(b.data(), c.space_left());
         BOOST_REQUIRE(c.is_full());
-        BOOST_REQUIRE_EQUAL(c.size(), storage::segment_appender::chunk_size);
+        BOOST_REQUIRE_EQUAL(c.size(), chunk_size);
         c.reset();
     }
     {
@@ -49,7 +54,6 @@ SEASTAR_THREAD_TEST_CASE(chunk_manipulation) {
         BOOST_REQUIRE_EQUAL(c.flushed_pos() % alignment, 10);
         BOOST_TEST_MESSAGE("10 bytes spill over: " << c);
         c.append(b.data() + i, alignment + 10);
-        static_assert(chunk::chunk_size == 16_KiB);
         BOOST_TEST_MESSAGE("Should be full: " << c.is_full() << ", " << c);
         BOOST_REQUIRE(c.is_full());
         // we flushed after 3 pages. so the dma_size() should be 1 page left

--- a/src/v/storage/tests/half_page_concurrent_dispatch.cc
+++ b/src/v/storage/tests/half_page_concurrent_dispatch.cc
@@ -29,7 +29,8 @@ struct fixture {
 FIXTURE_TEST(half_next_page, fixture) {
     using namespace storage; // NOLINT
     // gurantee next half page on 4096 segments(default)
-    constexpr size_t data_size = (segment_appender::chunk_size / 2) + 1;
+    const size_t data_size = (config::shard_local_cfg().append_chunk_size() / 2)
+                             + 1;
     ss::temporary_buffer<char> data(data_size);
     auto key = iobuf();
     auto value = iobuf();


### PR DESCRIPTION
## Cover letter

Where as previously a hardcoded 16kB write size was used, make this size configurable so that it can be tuned for storage devices that are less good at tiny writes, and/or heavily loaded systems where the sheer number of writes in flight can be an issue. 

Fixes: https://github.com/vectorizedio/redpanda/issues/272

## Release notes

A new configuration setting `append_chunk_size` enables tuning the disk write size (default is 16kB, same as what was previously hardcoded).  No change to behavior unless the setting is actively changed by the operator.
