### PR TITLE
rpc: fix exception on transport stop during shutdown

### DIFF
--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -467,7 +467,7 @@ struct raft_group {
         for (auto& [_, m] : _members) {
             close_futures.push_back(m.stop_node());
         }
-        ss::when_all(close_futures.begin(), close_futures.end()).get0();
+        ss::when_all_succeed(close_futures.begin(), close_futures.end()).get0();
     }
 
     members_t& get_members() { return _members; }


### PR DESCRIPTION
## Cover letter

Seastar's output_stream::stop can throw.  It never did this during testing on full redpanda instances, but we see it in a particular unit test, and presumably it could in principle happen in real systems too, so let's handle it.

This was a CI regression from https://github.com/vectorizedio/redpanda/pull/2215

Fixes: https://github.com/vectorizedio/redpanda/issues/2252

## Release notes

None