### PR TITLE
rpk: Update `rpk mode prod` command suggestion

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
@@ -241,7 +241,7 @@ func tune(
 	if allDisabled {
 		log.Warn(
 			"All tuners were disabled, so none were applied. You may run " +
-				" `rpk mode prod` to enable the recommended set of tuners " +
+				" `rpk redpanda mode prod` to enable the recommended set of tuners " +
 				" for non-containerized production use.",
 		)
 	}


### PR DESCRIPTION
We instruct the user to type rpk mode prod, and then when they do so we also tell them it's deprecated.

## Release notes

None