### PR TITLE
Improved logging from the process of applying cleanup policy

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -511,7 +511,7 @@ ss::future<> disk_log_impl::compact(compaction_config cfg) {
         f = f.then([this, cfg] { return do_compact(cfg); });
     }
     return f.then(
-      [this] { _probe.set_compaction_ration(_compaction_ratio.get()); });
+      [this] { _probe.set_compaction_ratio(_compaction_ratio.get()); });
 }
 
 ss::future<> disk_log_impl::gc(compaction_config cfg) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -13,6 +13,7 @@
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "model/timeout_clock.h"
+#include "model/timestamp.h"
 #include "reflection/adl.h"
 #include "storage/disk_log_appender.h"
 #include "storage/fwd.h"
@@ -150,12 +151,28 @@ model::offset disk_log_impl::time_based_gc_max_offset(model::timestamp time) {
     // files so that size-based retention eventually evicts the problematic
     // segment, preventing a crash.
     //
+
+    // if the segment max timestamp is bigger than now plus threshold we
+    // will report the segment max timestamp as bogus timestamp
+    static constexpr auto const_threshold = 1min;
+    auto bogus_threshold = model::timestamp(
+      model::timestamp::now().value() + const_threshold / 1ms);
+
     auto it = std::find_if(
       std::cbegin(_segs),
       std::cend(_segs),
-      [time](const ss::lw_shared_ptr<segment>& s) {
+      [time, bogus_threshold](const ss::lw_shared_ptr<segment>& s) {
+          auto max_ts = s->index().max_timestamp();
           // first that is not going to be collected
-          return s->index().max_timestamp() > time;
+          if (max_ts > bogus_threshold) {
+              vlog(
+                gclog.warn,
+                "[{}] found segment with bogus max timestamp: {} - {}",
+                max_ts,
+                s);
+          }
+
+          return max_ts > time;
       });
 
     if (it == _segs.cbegin()) {
@@ -191,6 +208,8 @@ disk_log_impl::monitor_eviction(ss::abort_source& as) {
 }
 
 void disk_log_impl::set_collectible_offset(model::offset o) {
+    vlog(
+      gclog.debug, "[{}] setting max collectible offset {}", config().ntp(), o);
     _max_collectible_offset = o;
 }
 
@@ -201,6 +220,12 @@ bool disk_log_impl::is_front_segment(const segment_set::type& ptr) const {
 
 ss::future<> disk_log_impl::garbage_collect_segments(
   model::offset max_offset, ss::abort_source* as, std::string_view ctx) {
+    vlog(
+      gclog.debug,
+      "[{}] {} requested to remove segments up to {} offset",
+      config().ntp(),
+      ctx,
+      max_offset);
     // we only notify eviction monitor if there are segments to evict
     auto have_segments_to_evict = _segs.size() > 1
                                   && _segs.front()->offsets().committed_offset
@@ -258,11 +283,23 @@ ss::future<> disk_log_impl::garbage_collect_max_partition_size(
 
 ss::future<> disk_log_impl::garbage_collect_oldest_segments(
   model::timestamp time, ss::abort_source* as) {
+    vlog(
+      gclog.debug,
+      "[{}] time retention timestamp: {}, first segment max timestamp: {}",
+      config().ntp(),
+      time,
+      _segs.empty() ? model::timestamp::min()
+                    : _segs.front()->index().max_timestamp());
     model::offset max_offset = time_based_gc_max_offset(time);
     return garbage_collect_segments(max_offset, as, "gc[time_based_retention]");
 }
 
 ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
+    vlog(
+      gclog.trace,
+      "[{}] applying 'compaction' log cleanup policy with config: {}",
+      config().ntp(),
+      cfg);
     // find first not compacted segment
     auto segit = std::find_if(
       _segs.begin(), _segs.end(), [](ss::lw_shared_ptr<segment>& s) {
@@ -281,8 +318,8 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
         auto result = co_await storage::internal::self_compact_segment(
           seg, cfg, _probe, *_readers_cache);
         vlog(
-          stlog.debug,
-          "segment {} compaction result: {}",
+          gclog.debug,
+          "[{}] segment {} compaction result: {}",
           seg->reader().filename(),
           result);
         _compaction_ratio.update(result.compaction_ratio());
@@ -493,6 +530,11 @@ disk_log_impl::apply_overrides(compaction_config defaults) const {
 }
 
 ss::future<> disk_log_impl::compact(compaction_config cfg) {
+    vlog(
+      gclog.trace,
+      "[{}] houskeeping with configuration from manager: {}",
+      config().ntp(),
+      cfg);
     cfg = apply_overrides(cfg);
     ss::future<> f = ss::now();
     if (config().is_collectable()) {
@@ -516,7 +558,11 @@ ss::future<> disk_log_impl::compact(compaction_config cfg) {
 
 ss::future<> disk_log_impl::gc(compaction_config cfg) {
     vassert(!_closed, "gc on closed log - {}", *this);
-
+    vlog(
+      gclog.trace,
+      "[{}] applying 'deletion' log cleanup policy with config: {}",
+      config().ntp(),
+      cfg);
     if (unlikely(cfg.asrc->abort_requested())) {
         return ss::make_ready_future<>();
     }
@@ -531,10 +577,20 @@ ss::future<> disk_log_impl::gc(compaction_config cfg) {
                              && config().ntp().tp.topic
                                   == model::tx_manager_topic;
     if (!is_tx_manager_ntp && is_internal_namespace) {
+        vlog(
+          gclog.trace,
+          "[{}] skipped log deletion, internal topic",
+          config().ntp());
         return ss::make_ready_future<>();
     }
     if (cfg.max_bytes) {
         size_t max = cfg.max_bytes.value();
+        vlog(
+          gclog.debug,
+          "[{}] retention max bytes: {}, current partition size: {}",
+          config().ntp(),
+          max,
+          _probe.partition_size());
         if (!_segs.empty() && _probe.partition_size() > max) {
             return garbage_collect_max_partition_size(max, cfg.asrc);
         }

--- a/src/v/storage/logger.cc
+++ b/src/v/storage/logger.cc
@@ -11,4 +11,5 @@
 
 namespace storage {
 ss::logger stlog("storage");
+ss::logger gclog("storage-gc");
 } // namespace storage

--- a/src/v/storage/logger.h
+++ b/src/v/storage/logger.h
@@ -17,4 +17,5 @@
 
 namespace storage {
 extern ss::logger stlog;
+extern ss::logger gclog;
 } // namespace storage

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -67,7 +67,7 @@ public:
     size_t partition_size() const { return _partition_bytes; }
     void add_initial_segment(const segment&);
     void remove_partition_bytes(size_t remove) { _partition_bytes -= remove; }
-    void set_compaction_ration(double r) { _compaction_ratio = r; }
+    void set_compaction_ratio(double r) { _compaction_ratio = r; }
 
 private:
     uint64_t _partition_bytes = 0;


### PR DESCRIPTION
## Cover letter

Added separate logger to log events related with applying cleanup policy. This way we will have an easy way to trace the cleanup problems as we can use dynamic log severity control for the single `storage-gc` logger. 

## Release notes
- Improved logging in for readpanda logs cleanup
