### PR TITLE
schema_registry: sanitize avro schema

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -12,12 +12,22 @@
 #include "pandaproxy/schema_registry/avro.h"
 
 #include "pandaproxy/schema_registry/error.h"
+#include "utils/string_switch.h"
 
 #include <avro/Compiler.hh>
 #include <avro/Exception.hh>
 #include <avro/GenericDatum.hh>
 #include <avro/Types.hh>
 #include <avro/ValidSchema.hh>
+#include <boost/outcome/std_result.hpp>
+#include <boost/outcome/success_failure.hpp>
+#include <fmt/core.h>
+#include <rapidjson/allocators.h>
+#include <rapidjson/document.h>
+#include <rapidjson/encodings.h>
+#include <rapidjson/error/en.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 
 namespace pandaproxy::schema_registry {
 
@@ -112,6 +122,132 @@ bool check_compatible(avro::Node& reader, avro::Node& writer) {
     return writer.resolve(reader) != avro::RESOLVE_NO_MATCH;
 }
 
+result<void> sanitize(
+  rapidjson::GenericValue<rapidjson::UTF8<>>& v,
+  rapidjson::MemoryPoolAllocator<>& alloc);
+result<void> sanitize(
+  rapidjson::GenericValue<rapidjson::UTF8<>>::Object& o,
+  rapidjson::MemoryPoolAllocator<>& alloc);
+result<void> sanitize(
+  rapidjson::GenericValue<rapidjson::UTF8<>>::Array& a,
+  rapidjson::MemoryPoolAllocator<>& alloc);
+
+result<void> sanitize_name(
+  rapidjson::GenericValue<rapidjson::UTF8<>>& name,
+  rapidjson::MemoryPoolAllocator<>& alloc) {
+    if (!name.IsString() || name.GetStringLength() == 0) {
+        return error_info{
+          error_code::schema_invalid, "Invalid JSON Field \"name\""};
+    }
+
+    auto name_sv = std::string_view{name.GetString(), name.GetStringLength()};
+    name_sv = name_sv.substr(name_sv.find_last_of('.') + 1);
+    if (name_sv.length() != name.GetStringLength()) {
+        // SetString uses memcpy, take a copy so the range doesn't overlap.
+        auto new_name = ss::sstring{name_sv};
+        name.SetString(new_name.data(), new_name.length(), alloc);
+    }
+    return outcome::success();
+}
+
+result<void> sanitize_record(
+  rapidjson::GenericValue<rapidjson::UTF8<>>::Object& v,
+  rapidjson::MemoryPoolAllocator<>& alloc) {
+    auto f_it = v.FindMember("fields");
+    if (f_it == v.MemberEnd()) {
+        return error_info{
+          error_code::schema_invalid, "Missing JSON field \"fields\""};
+    }
+    if (!f_it->value.IsArray()) {
+        return error_info{
+          error_code::schema_invalid, "JSON field \"fields\" is not an array"};
+    }
+    return sanitize(f_it->value, alloc);
+}
+
+result<void> sanitize_avro_type(
+  rapidjson::GenericValue<rapidjson::UTF8<>>::Object& o,
+  std::string_view type_sv,
+  rapidjson::MemoryPoolAllocator<>& alloc) {
+    auto type = string_switch<std::optional<avro::Type>>(type_sv)
+                  .match("record", avro::Type::AVRO_RECORD)
+                  .default_match(std::nullopt);
+    if (!type.has_value()) {
+        return outcome::success();
+    }
+
+    switch (type.value()) {
+    case avro::AVRO_RECORD: {
+        return sanitize_record(o, alloc);
+    }
+    default:
+        break;
+    }
+    return outcome::success();
+}
+
+result<void> sanitize(
+  rapidjson::GenericValue<rapidjson::UTF8<>>& v,
+  rapidjson::MemoryPoolAllocator<>& alloc) {
+    switch (v.GetType()) {
+    case rapidjson::Type::kObjectType: {
+        auto o = v.GetObject();
+        return sanitize(o, alloc);
+    }
+    case rapidjson::Type::kArrayType: {
+        auto a = v.GetArray();
+        return sanitize(a, alloc);
+    }
+    case rapidjson::Type::kFalseType:
+    case rapidjson::Type::kTrueType:
+    case rapidjson::Type::kNullType:
+    case rapidjson::Type::kNumberType:
+    case rapidjson::Type::kStringType:
+        return outcome::success();
+    }
+    __builtin_unreachable();
+}
+
+result<void> sanitize(
+  rapidjson::GenericValue<rapidjson::UTF8<>>::Object& o,
+  rapidjson::MemoryPoolAllocator<>& alloc) {
+    if (auto it = o.FindMember("name"); it != o.MemberEnd()) {
+        auto res = sanitize_name(it->value, alloc);
+        if (res.has_error()) {
+            return res.assume_error();
+        }
+    }
+
+    if (auto t_it = o.FindMember("type"); t_it != o.MemberEnd()) {
+        auto res = sanitize(t_it->value, alloc);
+        if (res.has_error()) {
+            return res.assume_error();
+        }
+
+        if (t_it->value.GetType() == rapidjson::Type::kStringType) {
+            std::string_view type_sv = {
+              t_it->value.GetString(), t_it->value.GetStringLength()};
+            auto res = sanitize_avro_type(o, type_sv, alloc);
+            if (res.has_error()) {
+                return res.assume_error();
+            }
+        }
+    }
+    return outcome::success();
+}
+
+result<void> sanitize(
+  rapidjson::GenericValue<rapidjson::UTF8<>>::Array& a,
+  rapidjson::MemoryPoolAllocator<>& alloc) {
+    for (auto& m : a) {
+        auto s = sanitize(m, alloc);
+        if (s.has_error()) {
+            return s.assume_error();
+        }
+    }
+    return outcome::success();
+}
+
 } // namespace
 
 result<avro_schema_definition>
@@ -124,6 +260,40 @@ make_avro_schema_definition(std::string_view sv) {
           error_code::schema_invalid,
           fmt::format("Invalid schema {}", e.what())};
     }
+}
+
+result<schema_definition>
+sanitize_avro_schema_definition(schema_definition def) {
+    rapidjson::GenericDocument<rapidjson::UTF8<>> doc;
+    constexpr auto flags = rapidjson::kParseDefaultFlags
+                           | rapidjson::kParseStopWhenDoneFlag;
+    doc.Parse<flags>(def().data(), def().size());
+    if (doc.HasParseError()) {
+        return error_info{
+          error_code::schema_invalid,
+          fmt::format(
+            "Invalid schema: {} at offset {}",
+            rapidjson::GetParseError_En(doc.GetParseError()),
+            doc.GetErrorOffset())};
+    }
+
+    auto res = sanitize(doc, doc.GetAllocator());
+    if (res.has_error()) {
+        return error_info{
+          res.assume_error().code(),
+          fmt::format("{} {}", res.assume_error().message(), def())};
+    }
+
+    rapidjson::GenericStringBuffer<rapidjson::UTF8<>> str_buf;
+    str_buf.Reserve(def().size());
+    rapidjson::Writer<rapidjson::StringBuffer> w{str_buf};
+
+    if (!doc.Accept(w)) {
+        return error_info{error_code::schema_invalid, "Invalid schema"};
+    }
+
+    return schema_definition{
+      ss::sstring{str_buf.GetString(), str_buf.GetSize()}};
 }
 
 bool check_compatible(

--- a/src/v/pandaproxy/schema_registry/avro.h
+++ b/src/v/pandaproxy/schema_registry/avro.h
@@ -30,6 +30,9 @@ struct avro_schema_definition
 
 result<avro_schema_definition> make_avro_schema_definition(std::string_view sv);
 
+result<schema_definition>
+sanitize_avro_schema_definition(schema_definition def);
+
 bool check_compatible(
   const avro_schema_definition& reader, const avro_schema_definition& writer);
 

--- a/src/v/pandaproxy/schema_registry/schema_util.cc
+++ b/src/v/pandaproxy/schema_registry/schema_util.cc
@@ -29,4 +29,14 @@ result<void> validate(std::string_view def, schema_type type) {
     }
 }
 
+result<schema_definition> sanitize(schema_definition def, schema_type type) {
+    switch (type) {
+    case schema_type::avro: {
+        return sanitize_avro_schema_definition(std::move(def));
+    }
+    default:
+        return invalid_schema_type(type);
+    }
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/schema_util.h
+++ b/src/v/pandaproxy/schema_registry/schema_util.h
@@ -18,4 +18,6 @@ namespace pandaproxy::schema_registry {
 
 result<void> validate(std::string_view def, schema_type type);
 
+result<schema_definition> sanitize(schema_definition def, schema_type type);
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -3,6 +3,7 @@ rp_test(
   BINARY_NAME pandaproxy_schema_registry_unit
   SOURCES
     compatibility_avro.cc
+    sanitize_avro.cc
     util.cc
     storage.cc
     store.cc

--- a/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
@@ -1,0 +1,45 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/avro.h"
+#include "pandaproxy/schema_registry/test/compatibility_avro.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+pps::schema_definition not_minimal{
+  R"({
+   "type": "record",
+   "name": "myrecord",
+   "fields": [{"type":"string","name":"f1"}]
+})"};
+
+pps::schema_definition not_minimal_sanitized{
+  R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]})"};
+
+pps::schema_definition leading_dot{
+  R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":".f1"}]})"};
+
+pps::schema_definition leading_dot_sanitized{
+  R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]})"};
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_minify) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(not_minimal).value()(),
+      not_minimal_sanitized());
+}
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_name) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(leading_dot).value()(),
+      leading_dot_sanitized());
+}


### PR DESCRIPTION
## Cover letter

Avro schema should be sanitized before being stored into the topic:
 * Minify the JSON
 * Strip leading namespace from names

It should be possible to store additional fields, and to some degree, invalid schema in the topic, so _[parsing canonical form](https://avro.apache.org/docs/current/spec.html#Parsing+Canonical+Form+for+Schemas)_ is not suitable, and neither is roundtripping it through libavrocpp.

E.g. this will minify and fix the field `.f1` -> `f1`:
```json
{
  "type": "record",
  "name": "myrecord",
  "fields": [
    {
      "type": "string",
      "name": ".f1"
    }
  ]
}
```
Into
```json
{"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]}
```

## Release notes

Schema Registry: Sanitize Avro schema before adding to the topic.
