### PR TITLE
Fixed reading from topics after cleanup policy was updated from compaction to deletion

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -321,6 +321,7 @@ ss::future<> disk_log_impl::do_compact(compaction_config cfg) {
         vlog(
           gclog.debug,
           "[{}] segment {} compaction result: {}",
+          config().ntp(),
           seg->reader().filename(),
           result);
         _compaction_ratio.update(result.compaction_ratio());

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -27,11 +27,9 @@ batch_consumer::consume_result skipping_consumer::accept_batch_start(
   const model::record_batch_header& header) const {
     // check for holes in the offset range on disk
     // skip check for compacted logs
-    if (unlikely(
-          !_reader._seg.is_compacted_segment() && _expected_next_batch() >= 0
-          && header.base_offset != _expected_next_batch)) {
+    if (unlikely(header.base_offset < _expected_next_batch)) {
         throw std::runtime_error(fmt::format(
-          "hole encountered reading from disk log: "
+          "incorrect offset encountered reading from disk log: "
           "expected batch offset {} (actual {})",
           _expected_next_batch,
           header.base_offset()));


### PR DESCRIPTION
## Cover letter
Updated logic checking if holes were encountered in a log to be independent from cleanup policy. When cleanup policy changes from `compaction` to `deletion` holes may exists in a topic that is not longer compacted. Relaxed hole checking logic to still validate if offsets are monotonic but made it independent from cleanup policy.

Fixes: #2214