### PR TITLE
Fixed partition not being writable during recovery when moving from one node to another

### DIFF
--- a/src/v/raft/group_configuration.h
+++ b/src/v/raft/group_configuration.h
@@ -272,6 +272,14 @@ auto group_configuration::quorum_match(Func&& f) const {
     if (!_old) {
         return details::quorum_match(std::forward<Func>(f), _current.voters);
     }
+    /**
+     * relay only on the old configuration if current configuration doesn't yet
+     * have any voters
+     */
+    if (_current.voters.empty()) {
+        return details::quorum_match(f, _old->voters);
+    }
+
     return std::min(
       details::quorum_match(f, _current.voters),
       details::quorum_match(f, _old->voters));


### PR DESCRIPTION
## Cover letter

When there are no voters in new raft group configuration we must use only old configuration quorum to calculate majorities since learners are not included into decision process. Previously when new configuration contained no voters
`configuration::quorum_match` always returned not initialized `model::offset` preventing committed offset from being updated and making writes on the leader impossible.

Fixes: #2289 