### PR TITLE
admin: fix crash & cluster unavailability from moving partition to nonexistent shard

### DIFF
--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -34,6 +34,15 @@ int16_t allocation_state::available_nodes() const {
       });
 }
 
+bool allocation_state::validate_shard(
+  model::node_id node, uint32_t shard) const {
+    if (auto node_i = _nodes.find(node); node_i != _nodes.end()) {
+        return shard < node_i->second->cpus();
+    } else {
+        return false;
+    }
+}
+
 raft::group_id allocation_state::next_group_id() { return ++_highest_group; }
 
 void allocation_state::apply_update(

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -43,6 +43,8 @@ public:
     void rollback(const std::vector<partition_assignment>& pa);
     void rollback(const std::vector<model::broker_shard>& v);
 
+    bool validate_shard(model::node_id node, uint32_t shard) const;
+
     // Raft group id
     raft::group_id next_group_id();
     raft::group_id last_group_id() const { return _highest_group; }

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -516,6 +516,14 @@ ss::future<std::vector<topic_result>> topics_frontend::create_partitions(
     co_return result;
 }
 
+ss::future<bool>
+topics_frontend::validate_shard(model::node_id node, uint32_t shard) const {
+    return _allocator.invoke_on(
+      partition_allocator::shard, [node, shard](partition_allocator& al) {
+          return al.state().validate_shard(node, shard);
+      });
+}
+
 allocation_request make_allocation_request(
   int16_t replication_factor, const create_partititions_configuration& cfg) {
     allocation_request req;

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -66,6 +66,8 @@ public:
       std::vector<create_partititions_configuration>,
       model::timeout_clock::time_point);
 
+    ss::future<bool> validate_shard(model::node_id node, uint32_t shard) const;
+
 private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -296,3 +296,44 @@ class PartitionMovementTest(EndToEndTest):
         for _ in range(25):
             self._move_and_verify()
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
+
+    @cluster(num_nodes=3)
+    def test_invalid_destination(self):
+        """
+        Check that requuests to move to non-existent locations are properly rejected.
+        """
+
+        self.start_redpanda(num_nodes=3)
+        spec = TopicSpec(name="topic", partition_count=1, replication_factor=1)
+        self.redpanda.create_topic(spec)
+        topic = spec.name
+        partition = 0
+
+        admin = Admin(self.redpanda)
+        brokers = admin.get_brokers()
+        assignments = self._get_assignments(admin, topic, partition)
+
+        # Pick a node id where the topic currently isn't allocated
+        valid_dest = list(
+            set([b['node_id']
+                 for b in brokers]) - set([a['node_id']
+                                           for a in assignments]))[0]
+
+        # This test will need updating on far-future hardware when core counts go higher
+        invalid_shard = 1000
+        invalid_dest = 30
+
+        # A valid node but an invalid core
+        assignments = [{"node_id": valid_dest, "core": invalid_shard}]
+        r = admin.set_partition_replicas(topic, partition, assignments)
+        assert r.status_code == 400
+
+        # An invalid node but a valid core
+        assignments = [{"node_id": invalid_dest, "core": 0}]
+        r = admin.set_partition_replicas(topic, partition, assignments)
+        assert r.status_code == 400
+
+        # Finally a valid move
+        assignments = [{"node_id": valid_dest, "core": 0}]
+        r = admin.set_partition_replicas(topic, partition, assignments)
+        assert r.status_code == 200


### PR DESCRIPTION
## Cover letter

Using a core number beyond what exists on the node breaks the cluster - more detail in the ticket.  The fix is simply to validate those arguments before committing the change to the log.

Fixes: https://github.com/vectorizedio/redpanda/issues/2287

## Release notes

An admin API bug is fixed where invalid 'core' arguments to the /partitions/<namespace>/<topic>/<partition>/replicas endpoint could lead to crashes.  These arguments are now properly validated.
