### PR TITLE
utils: Add stream utils

### DIFF
--- a/src/v/utils/stream_utils.h
+++ b/src/v/utils/stream_utils.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "utils/gate_guard.h"
+#include "vassert.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/temporary_buffer.hh>
+
+#include <exception>
+
+namespace detail {
+
+/// Helper template that wraps the input stream and consumes
+/// it to the cyclic buffer
+template<class Ch>
+class input_stream_fanout final {
+    struct data_item {
+        ss::temporary_buffer<Ch> buf;
+        ss::semaphore_units<> units;
+        unsigned mask;
+    };
+    using ring_buffer = ss::circular_buffer<data_item>;
+
+public:
+    /// C-tor
+    ///
+    /// \param i is a source input stream
+    /// \param num_clients is a number of consumers (fanout ratio)
+    /// \param read_ahead is a number of buffers that can be in-flight at the
+    /// same time
+    ///        (should be relatively low, e.g. 10)
+    /// \param max_size is an optional size limit for in-flight data
+    input_stream_fanout(
+      ss::input_stream<Ch> i,
+      size_t num_clients,
+      size_t read_ahead,
+      std::optional<size_t> max_size)
+      : _num_clients(num_clients)
+      , _bitmask(0)
+      , _max_size(max_size ? *max_size / read_ahead : 0)
+      , _in(std::move(i))
+      , _sem(read_ahead) {
+        vassert(
+          num_clients <= 10 && num_clients >= 2,
+          "input_stream_fanout can have up to 10 clients, {} were given",
+          num_clients);
+        vassert(
+          read_ahead != 0,
+          "input_stream_fanaout can't have zero readahead value");
+    }
+
+    /// Start consuming the input stream
+    void start() {
+        // Run produce in the background until stopped
+        // or produced everything.
+        (void)produce();
+    }
+
+    /// Stop consuming the input stream
+    ss::future<> stop() {
+        _pcond.broadcast();
+        co_await _gate.close();
+    }
+
+    /// Detach client with 'index' from the fanout
+    ///
+    /// The remaining clients can proceed as usual.
+    /// If the client is the last one, the stop method will be invoked.
+    ss::future<> detach(unsigned index) {
+        auto m = 1U << index;
+        _bitmask |= m;
+        if (_bitmask == (1U << _num_clients) - 1) {
+            // This is the last client, call stop
+            co_await stop();
+        }
+        // update all in-flight buffers
+        for (auto& it : _buffer) {
+            it.mask |= m;
+        }
+    }
+
+    /// Get next buffer from original input stream
+    ///
+    /// \param index is an index of the consumer
+    /// \return buffer
+    ss::future<ss::temporary_buffer<Ch>> get(unsigned index) {
+        gate_guard g(_gate);
+        while (!_gate.is_closed()) {
+            auto gen = _cnt;
+            if (auto ob = maybe_get(index); ob.has_value()) {
+                co_return std::move(ob.value());
+            }
+            // We need to wait for the data in the following scenarios:
+            // - The consumer is outrunning other consumers and the producer.
+            // - There is not data in the buffer because consumers are faster
+            // then the producer.
+            try {
+                co_await _pcond.wait([this, gen] { return _cnt != gen; });
+            } catch (const ss::broken_condition_variable&) {
+            }
+        }
+        co_return ss::temporary_buffer<Ch>();
+    }
+
+private:
+    /// Get next buffer from original input stream
+    ///
+    /// \return buffer or std::nullopt if the consumer need to repeat
+    std::optional<ss::temporary_buffer<Ch>> maybe_get(unsigned index) {
+        vassert(
+          index < _num_clients,
+          "Consumer index {} is too large. Only {} consumers allowed.",
+          index,
+          _num_clients);
+        unsigned mask = 1U << index;
+        std::optional<ss::temporary_buffer<Ch>> buf = std::nullopt;
+        auto next = _buffer.end();
+        for (auto it = _buffer.begin(); it != _buffer.end(); it++) {
+            if ((it->mask & mask) == 0) {
+                it->mask |= mask;
+                next = it;
+                break;
+            }
+        }
+        if (next != _buffer.end()) {
+            auto all_bits = (1U << _num_clients) - 1;
+            if (next->mask == all_bits) {
+                // The item is consumed by all clients
+                buf = std::move(next->buf);
+                vassert(
+                  next == _buffer.begin(),
+                  "broken input_stream_fanout invariant");
+                _buffer.pop_front();
+            } else {
+                // Other consumers will read this item
+                buf = next->buf.share();
+            }
+        }
+        return buf;
+    }
+    /// Constantly pull data from input stream and produce
+    /// the resulting buffers to clients
+    ss::future<> produce() {
+        gate_guard g(_gate);
+        while (!_in.eof() && !_gate.is_closed()) {
+            auto units = co_await ss::get_units(_sem, 1);
+            ss::temporary_buffer<Ch> buf;
+            if (_max_size == 0) {
+                buf = co_await _in.read();
+            } else {
+                buf = co_await _in.read_up_to(_max_size);
+            }
+            ++_cnt;
+            _buffer.push_back(data_item{
+              .buf = std::move(buf),
+              .units = std::move(units),
+              .mask = _bitmask});
+            _pcond.broadcast();
+        }
+    }
+
+    const size_t _num_clients;
+    unsigned _bitmask;
+    const size_t _max_size;
+    ss::input_stream<Ch> _in;
+    ss::semaphore _sem;
+    ss::condition_variable _pcond;
+    ring_buffer _buffer;
+    ss::gate _gate;
+    uint64_t _cnt{0};
+};
+
+template<class Ch>
+struct fanout_data_source final : ss::data_source_impl {
+    fanout_data_source(
+      ss::lw_shared_ptr<input_stream_fanout<Ch>> i, size_t source_id)
+      : _isf(std::move(i))
+      , _id{source_id} {}
+
+    ss::future<> close() final { co_await _isf->detach(_id); }
+
+    ss::future<ss::temporary_buffer<char>> skip(uint64_t) final {
+        vassert(false, "Not supported");
+    }
+    ss::future<ss::temporary_buffer<char>> get() final {
+        co_return co_await _isf->get(_id);
+    }
+    size_t _id;
+    ss::lw_shared_ptr<input_stream_fanout<Ch>> _isf;
+};
+
+template<typename Ch, size_t... ix>
+auto construct_data_sources(
+  ss::lw_shared_ptr<input_stream_fanout<Ch>> fanout,
+  std::integer_sequence<size_t, ix...>) {
+    return (
+      std::make_tuple(std::make_unique<fanout_data_source<Ch>>(fanout, ix)...));
+}
+
+} // namespace detail
+
+template<size_t N, typename Ch>
+auto input_stream_fanout(
+  ss::input_stream<Ch> in,
+  size_t read_ahead,
+  std::optional<size_t> memory_limit = std::nullopt) {
+    static_assert(N >= 2 && N <= 10, "N should be in 2..10 range");
+    auto f = ss::make_lw_shared<detail::input_stream_fanout<Ch>>(
+      std::move(in), N, read_ahead, memory_limit);
+    f->start();
+    auto ixseq = std::make_index_sequence<N>{};
+    auto fds = detail::construct_data_sources(f, ixseq);
+    auto is = std::apply(
+      [](auto&&... ds) {
+          return (std::make_tuple(
+            ss::input_stream<Ch>(ss::data_source(std::move(ds)))...));
+      },
+      fds);
+    return is;
+}

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ rp_test(
     base64_test.cc
     timed_mutex_test
     retry_chain_node_test.cc
+    input_stream_fanout_test.cc
   LIBRARIES v::seastar_testing_main v::utils v::bytes
   ARGS "-- -c 1"
   LABELS utils

--- a/src/v/utils/tests/input_stream_fanout_test.cc
+++ b/src/v/utils/tests/input_stream_fanout_test.cc
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "bytes/bytes.h"
+#include "bytes/iobuf.h"
+#include "random/generators.h"
+#include "utils/fragmented_vector.h"
+#include "utils/stream_utils.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <exception>
+#include <vector>
+
+template<typename... T>
+auto all_equal(const std::tuple<T...>& t) {
+    return std::apply(
+      [&t](auto&&... args) { return ((args == std::get<0>(t)) && ...); }, t);
+}
+
+template<size_t N>
+void test_sync_read(
+  size_t readahead, std::optional<size_t> limit = std::nullopt) {
+    iobuf input;
+    for (int i = 0; i < 20; i++) {
+        int sz = random_generators::get_int(100, 32 * 1024);
+        auto b = random_generators::get_bytes(sz);
+        input.append(bytes_to_iobuf(b));
+    }
+    auto szfull = input.size_bytes();
+    auto is = make_iobuf_input_stream(std::move(input));
+    auto streams = input_stream_fanout<N>(std::move(is), readahead, limit);
+    static_assert(
+      std::tuple_size_v<decltype(streams)> == N,
+      "Incorrect number of tuple elements");
+    int niter = 0;
+    while (true) {
+        auto buf = std::apply(
+          [](auto&&... s) { return (std::make_tuple(s.read().get()...)); },
+          streams);
+        BOOST_REQUIRE(all_equal(buf));
+        if (std::get<0>(buf).empty()) {
+            break;
+        }
+        niter++;
+    }
+    if (!limit) {
+        BOOST_REQUIRE(
+          niter != 0); // Check that there was at least one non empty batch
+    } else {
+        auto expected_iters = szfull / 1000;
+        BOOST_REQUIRE(niter >= expected_iters);
+    }
+    std::apply([](auto&&... s) { (s.close().get(), ...); }, streams);
+}
+
+template<size_t N>
+void test_async_read(
+  size_t readahead, std::optional<size_t> limit = std::nullopt) {
+    // Check the situation when we have one slow consumer
+    iobuf input;
+    iobuf copy;
+    int szfull = 0;
+    for (int i = 0; i < 20; i++) {
+        int sz = random_generators::get_int(100, 8 * 1024);
+        auto b = random_generators::get_bytes(sz);
+        input.append(bytes_to_iobuf(b));
+        copy.append(bytes_to_iobuf(b));
+        szfull += sz;
+    }
+    auto is = make_iobuf_input_stream(std::move(input));
+    auto streams = input_stream_fanout<N>(std::move(is), readahead, limit);
+    ss::gate g;
+    int cnt_a = 0;
+    auto dispatch_bg_read = [&g, &copy](auto sa) mutable {
+        auto cnt = ss::make_lw_shared<int>(0);
+        (void)ss::with_gate(g, [&copy, cnt, sa = std::move(sa)]() mutable {
+            return ss::async([&copy, cnt, sa = std::move(sa)]() mutable {
+                size_t top = 0;
+                while (true) {
+                    int r = random_generators::get_int(0, 20);
+                    if (r == 0) {
+                        ss::sleep(std::chrono::milliseconds(5)).get();
+                    }
+                    auto buf = sa.read().get();
+                    if (buf.empty()) {
+                        break;
+                    }
+                    size_t sz = buf.size();
+                    iobuf ib;
+                    ib.append(std::move(buf));
+                    auto actual = iobuf_to_bytes(ib);
+                    auto expected = iobuf_to_bytes(copy.share(top, sz));
+                    BOOST_REQUIRE(expected == actual);
+                    top += sz;
+                    ++(*cnt);
+                }
+                sa.close().get();
+                BOOST_REQUIRE_EQUAL(top, copy.size_bytes());
+            });
+        });
+        return cnt;
+    };
+    auto counters = std::apply(
+      [&dispatch_bg_read](auto&&... s) {
+          return (std::make_tuple(dispatch_bg_read(std::move(s))...));
+      },
+      streams);
+
+    /// Wait until all bg jobs are done
+    g.close().get();
+
+    auto deref_cnt = std::apply(
+      [](auto&&... cnt) { return (std::make_tuple(*cnt...)); }, counters);
+
+    BOOST_REQUIRE(all_equal(deref_cnt));
+}
+
+template<typename Head, typename... Tail>
+auto split_tuple(std::tuple<Head, Tail...>&& t) {
+    struct res_t {
+        Head head;
+        std::tuple<Tail...> tail;
+    };
+    return std::apply(
+      [](auto&& head, auto&&... tail) {
+          return res_t{
+            .head = std::forward<Head>(head),
+            .tail = std::make_tuple(std::forward<Tail>(tail)...),
+          };
+      },
+      t);
+}
+
+template<size_t N>
+void test_detached_consumer(
+  size_t readahead, std::optional<size_t> limit = std::nullopt) {
+    iobuf input;
+    for (int i = 0; i < 20; i++) {
+        int sz = random_generators::get_int(100, 32 * 1024);
+        auto b = random_generators::get_bytes(sz);
+        input.append(bytes_to_iobuf(b));
+    }
+    auto szfull = input.size_bytes();
+    auto is = make_iobuf_input_stream(std::move(input));
+    auto streams = input_stream_fanout<N>(std::move(is), readahead, limit);
+    static_assert(
+      std::tuple_size_v<decltype(streams)> == N,
+      "Incorrect number of tuple elements");
+
+    auto [head, tail] = split_tuple(std::move(streams));
+    // Stop first stream
+    head.close().get();
+
+    int niter = 0;
+    while (true) {
+        auto buf = std::apply(
+          [](auto&&... s) { return (std::make_tuple(s.read().get()...)); },
+          tail);
+        BOOST_REQUIRE(all_equal(buf));
+        if (std::get<0>(buf).empty()) {
+            break;
+        }
+        niter++;
+    }
+    if (!limit) {
+        BOOST_REQUIRE(
+          niter != 0); // Check that there was at least one non empty batch
+    } else {
+        auto expected_iters = szfull / 1000;
+        BOOST_REQUIRE(niter >= expected_iters);
+    }
+    std::apply([](auto&&... s) { (s.close().get(), ...); }, tail);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_2) { test_sync_read<2>(4); }
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_3) { test_sync_read<3>(4); }
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_4) { test_sync_read<4>(4); }
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_5) { test_sync_read<5>(4); }
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_6) { test_sync_read<6>(4); }
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_7) { test_sync_read<7>(4); }
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_8) { test_sync_read<8>(4); }
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_9) { test_sync_read<9>(4); }
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_10) { test_sync_read<10>(4); }
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_2_size_limit) {
+    test_sync_read<2>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_3_size_limit) {
+    test_sync_read<3>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_4_size_limit) {
+    test_sync_read<4>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_5_size_limit) {
+    test_sync_read<5>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_6_size_limit) {
+    test_sync_read<6>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_7_size_limit) {
+    test_sync_read<7>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_8_size_limit) {
+    test_sync_read<8>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_9_size_limit) {
+    test_sync_read<9>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_test_10_size_limit) {
+    test_sync_read<10>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_2_1) {
+    test_async_read<2>(1);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_3_1) {
+    test_async_read<3>(1);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_4_1) {
+    test_async_read<4>(1);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_5_1) {
+    test_async_read<5>(1);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_6_1) {
+    test_async_read<6>(1);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_7_1) {
+    test_async_read<7>(1);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_8_1) {
+    test_async_read<8>(1);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_9_1) {
+    test_async_read<9>(1);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_10_1) {
+    test_async_read<10>(1);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_2_4) {
+    test_async_read<2>(4);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_3_4) {
+    test_async_read<3>(4);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_4_4) {
+    test_async_read<4>(4);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_5_4) {
+    test_async_read<5>(4);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_6_4) {
+    test_async_read<6>(4);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_7_4) {
+    test_async_read<7>(4);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_8_4) {
+    test_async_read<8>(4);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_9_4) {
+    test_async_read<9>(4);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_10_4) {
+    test_async_read<10>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_2_size_limit) {
+    test_async_read<2>(4, 1000);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_3_size_limit) {
+    test_async_read<3>(4, 1000);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_4_size_limit) {
+    test_async_read<4>(4, 1000);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_5_size_limit) {
+    test_async_read<5>(4, 1000);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_6_size_limit) {
+    test_async_read<6>(4, 1000);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_7_size_limit) {
+    test_async_read<7>(4, 1000);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_8_size_limit) {
+    test_async_read<8>(4, 1000);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_9_size_limit) {
+    test_async_read<9>(4, 1000);
+}
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_async_10_size_limit) {
+    test_async_read<10>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_2) {
+    test_detached_consumer<2>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_3) {
+    test_detached_consumer<3>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_4) {
+    test_detached_consumer<4>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_5) {
+    test_detached_consumer<5>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_6) {
+    test_detached_consumer<6>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_7) {
+    test_detached_consumer<7>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_8) {
+    test_detached_consumer<8>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_9) {
+    test_detached_consumer<9>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_10) {
+    test_detached_consumer<10>(4);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_2_size_limit) {
+    test_detached_consumer<2>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_3_size_limit) {
+    test_detached_consumer<3>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_4_size_limit) {
+    test_detached_consumer<4>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_5_size_limit) {
+    test_detached_consumer<5>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_6_size_limit) {
+    test_detached_consumer<6>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_7_size_limit) {
+    test_detached_consumer<7>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_8_size_limit) {
+    test_detached_consumer<8>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_9_size_limit) {
+    test_detached_consumer<9>(4, 1000);
+}
+
+SEASTAR_THREAD_TEST_CASE(input_stream_fanout_detach_10_size_limit) {
+    test_detached_consumer<10>(4, 1000);
+}


### PR DESCRIPTION
## Cover letter

Add the 'input_stream_fanout' template that takes a single seastar `input_stream` instance and returns multiple.

Number of returned input_stream instances depend on template parameter:

```cpp
auto [s1, s2, s3] = inpust_stream_fanout<3>(std::move(s), 4, 128_KiB);
```

The function also accepts 'readahead' and 'memory_limit' parameters. The 'readahead' limits number of buffers that can be in-flight at the same time. The 'memory_limit' limits total amount of memory used for buffers which are in-flight at the same time.

It is possible to crate from 2 to 10 streams. The high end limit of 10 is not technically a limit. It is possible to create more. We just
don't need that.

Internally, the fanout input stream has a collection of in-flight buffers. The background fiber constantly reads new buffers from the supplied input stream and adds these buffers to the collection. Every buffer has associated mask and semaphore unit. The semaphore units are acquired before reading from the stream. The max-count property of the sempahore is equal to 'readahead' value.

The cosumers are scanning the collection from the begining. Every consumer has a unique id and associated bit in the mask. If this bit is not set the consumer will consume the buffer (by sharing it) and set the bit. If the mask after that is full (all bits are set which means that the buffer is consumed by all consumers) the consumer will remove the buffer from the collection.

If the collection is full the producer waits until the consumers will free up some space. If the consumer can't find an element to consume because either the collection is empty or it's fully consumed by that particular consumer, it will wait on the condition variable. The condition variable is trigered on produce.

The component is going to be used in the `cloud_storage` component to integrate `remote` and `cache`. It will allow the `remote` to stream data from the cloud storage to the user and at the same time to the cache.

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/8d9303a2d3e5a0675df81ff64b1dd4b787e2d409..0e039e060e6293954bf03d719be6760a564b5f1f)
- Implemented detach operation which allows to close arbitrary number of streams without creating a deadlock

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/0e039e060e6293954bf03d719be6760a564b5f1f..5a0034d38fc0b71d483c17c59be83cdb9a899206)
- Switch from deque to circular_buffer
- Make `maybe_get` return value and not a future<>
- Fix other code review issues

## Release notes

N/A
