### PR TITLE
k8s/test: add KUTLL_TEST_FLAGS variable

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -114,7 +114,7 @@ push-to-kind: kind-create certmanager-install
 
 # Execute end to end tests
 e2e-tests: kuttl test docker-build docker-build-configurator
-	$(KUTTL) test $(TEST_ONLY_FLAG) --kind-context $(BUILDKITE_JOB_ID)
+	$(KUTTL) test $(TEST_ONLY_FLAG) $(KUTLL_TEST_FLAGS) --kind-context $(BUILDKITE_JOB_ID)
 
 # Execute end to end tests using helm as an installation
 helm-e2e-tests: kuttl test docker-build docker-build-configurator


### PR DESCRIPTION
Allow passing arbitrary flags to `kuttl`. One specific flag that is needed is `--skip-delete-cluster` for not executing `kind delete`