### PR TITLE
rpk: fix vectorized/wasm-api version for wasm generate

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -81,9 +81,9 @@ func checkIfExists(fs afero.Fs, path string) error {
 func GetLatestClientApiVersion() string {
 	/// Works by using npm to lookup the latest version of our library
 	timeout := 2 * time.Second
-	version := "1.0.0"
+	version := "21.8.2"
 	proc := vos.NewProc()
-	output, err := proc.RunWithSystemLdPath(timeout, "npm", "search", "'@vectorizedio/wasm-api'")
+	output, err := proc.RunWithSystemLdPath(timeout, "npm", "search", "@vectorizedio/wasm-api")
 	if err != nil {
 		log.Error(err)
 		return version

--- a/src/go/rpk/pkg/cli/cmd/wasm/template/package_json.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/template/package_json.go
@@ -11,7 +11,7 @@ package template
 
 const packageJson = `{
   "name": "wasm-panda",
-  "version": "1.0.0",
+  "version": ">= 21.8.2",
   "description": "inline wasm transforms sdk",
   "main": "bin/index.js",
   "bin": { "iwt": "./bin/index.js" },
@@ -23,7 +23,7 @@ const packageJson = `{
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@vectorizedio/wasm-api": "^%s"
+    "@vectorizedio/wasm-api": ">= %s"
   },
   "devDependencies": {
     "ts-loader": "8.0.4",


### PR DESCRIPTION
## Cover letter
Fix https://github.com/vectorizedio/redpanda/issues/2276

Use @vectorizedio/wasm-api version >= 21.8.2 in` rpk wasm generate
`
