### PR TITLE
Make e2e tests more stable

### DIFF
--- a/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
@@ -19,6 +19,6 @@ spec:
           args:
             - rpk topic create test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
       restartPolicy: Never
-  backoffLimit: 6
+  backoffLimit: 12
   parallelism: 1
   completions: 1

--- a/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
@@ -17,7 +17,7 @@ spec:
             - /bin/bash
             - -c
           args:
-            - rpk topic create -r 3 test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
+            - sleep 10 ; rpk topic create -r 3 test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
       restartPolicy: Never
   backoffLimit: 12
   parallelism: 1

--- a/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
@@ -17,7 +17,7 @@ spec:
             - /bin/bash
             - -c
           args:
-            - rpk topic create test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
+            - rpk topic create -r 3 test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
       restartPolicy: Never
   backoffLimit: 12
   parallelism: 1

--- a/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
@@ -19,7 +19,8 @@ spec:
           args:
             - >
               echo {"test":"message"} |
-              rpk topic produce test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092
+              rpk topic produce test
+              --brokers "cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-1.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-2.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092"
               -v -n 1 -k "test-key"
       restartPolicy: Never
   backoffLimit: 12

--- a/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
@@ -22,6 +22,6 @@ spec:
               rpk topic produce test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092
               -v -n 1 -k "test-key"
       restartPolicy: Never
-  backoffLimit: 6
+  backoffLimit: 12
   parallelism: 1
   completions: 1


### PR DESCRIPTION
## Cover letter

Change the operator e2e to have more reliable outcome. The topic replication now will be equal to the number of nodes. All 3 brokers are used to exchange metadata information when rpk is trying to produce. Each job can now failed 12 times. 