### PR TITLE
tests: refinements to raft ducktape tests

### DIFF
--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -106,6 +106,8 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
         args = ["--describe", "--topic", topic]
         res = self._run("kafka-topics.sh", args)
         self._redpanda.logger.debug("Describe topics result: %s", res)
+        if res is None:
+            raise RuntimeError(f"Error describing topic {topic}")
 
         # parse/extract the topic configuration
         configs = None

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -78,7 +78,7 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
         args = ['--alter']
         args += ["--topic", topic]
         args += ["--partitions", f"{partitions}"]
-        return self._run("kafka-topics.sh", args)
+        return self._run_strict("kafka-topics.sh", args)
 
     def delete_topic(self, topic):
         self._redpanda.logger.debug("Deleting topic: %s", topic)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -336,7 +336,8 @@ class RedpandaService(Service):
         self.logger.debug("Controller reported with id: {}".format(cid))
         if cid != -1:
             node = self.get_node(cid)
-            self.logger.debug("Controller node found: {}".format(node))
+            self.logger.debug("Controller node found: {}".format(
+                node.account.hostname))
             return node
 
     def node_storage(self, node):

--- a/tests/rptest/tests/create_partitions_test.py
+++ b/tests/rptest/tests/create_partitions_test.py
@@ -27,6 +27,10 @@ class CreatePartitionsTest(RedpandaTest):
         client = KafkaCliTools(self.redpanda)
         client.add_topic_partitions(topic, count)
 
+    def _delete_topic(self, topic_name):
+        client = KafkaCliTools(self.redpanda)
+        client.delete_topic(topic_name)
+
     def _create_add_verify(self, topic, new_parts):
         self.logger.info(
             f"Testing topic {topic.name} with partitions {topic.partition_count} replicas {topic.replication_factor} additional partitions {new_parts}"
@@ -63,3 +67,6 @@ class CreatePartitionsTest(RedpandaTest):
                               replication_factor=random.choice((1, 3)))
             new_parts = random.randint(1, 30)
             self._create_add_verify(topic, new_parts)
+            self._delete_topic(topic.name)
+
+            # todo delete the topic to avoid running out of file handles

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -50,8 +50,12 @@ class EndToEndTest(Test):
       - Perform some action (e.g. partition movement)
       - Run validation
     """
-    def __init__(self, test_context):
+    def __init__(self, test_context, extra_rp_conf=None):
         super(EndToEndTest, self).__init__(test_context=test_context)
+        if extra_rp_conf is None:
+            self._extra_rp_conf = {}
+        else:
+            self._extra_rp_conf = extra_rp_conf
         self.records_consumed = []
         self.last_consumed_offsets = {}
         self.redpanda = None
@@ -59,8 +63,10 @@ class EndToEndTest(Test):
 
     def start_redpanda(self, num_nodes=1):
         assert self.redpanda is None
-        self.redpanda = RedpandaService(self.test_context, num_nodes,
-                                        KafkaCliTools)
+        self.redpanda = RedpandaService(self.test_context,
+                                        num_nodes,
+                                        KafkaCliTools,
+                                        extra_rp_conf=self._extra_rp_conf)
         self.redpanda.start()
 
     def start_consumer(self, num_nodes=1, group_id="test_group"):

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -26,6 +26,16 @@ class LeadershipTransferTest(RedpandaTest):
     """
     topics = (TopicSpec(partition_count=3, replication_factor=3), )
 
+    def __init__(self, *args, **kwargs):
+        super(LeadershipTransferTest, self).__init__(
+            *args,
+            extra_rp_conf={
+                # Disable leader balancer, as this test is doing its own
+                # partition movement and the balancer would interfere
+                'enable_leader_balancer': False
+            },
+            **kwargs)
+
     @cluster(num_nodes=3)
     def test_controller_recovery(self):
         kc = KafkaCat(self.redpanda)

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -134,7 +134,8 @@ class NodeOperationFuzzyTest(EndToEndTest):
         def decommission(node_id):
             self.logger.info(f"decommissioning node: {node_id}")
             admin = Admin(self.redpanda)
-            admin.decommission_broker(id=node_id)
+            r = admin.decommission_broker(id=node_id)
+            r.raise_for_status()
 
             def node_removed():
                 admin = Admin(self.redpanda)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -34,6 +34,16 @@ class PartitionMovementTest(EndToEndTest):
     - Add settings for scaling up tests
     - Add tests guarnateeing multiple segments
     """
+    def __init__(self, *args, **kwargs):
+        super(PartitionMovementTest, self).__init__(
+            *args,
+            extra_rp_conf={
+                # Disable leader balancer, as this test is doing its own
+                # partition movement and the balancer would interfere
+                'enable_leader_balancer': False
+            },
+            **kwargs)
+
     @staticmethod
     def _random_partition(metadata):
         topic = random.choice(metadata)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -219,7 +219,7 @@ class PartitionMovementTest(EndToEndTest):
 
         topics = []
         for partition_count in range(1, 5):
-            for replication_factor in (3, 3):
+            for replication_factor in (1, 3):
                 name = f"topic{len(topics)}"
                 spec = TopicSpec(name=name,
                                  partition_count=partition_count,
@@ -241,7 +241,7 @@ class PartitionMovementTest(EndToEndTest):
 
         topics = []
         for partition_count in range(1, 5):
-            for replication_factor in (3, 3):
+            for replication_factor in (1, 3):
                 name = f"topic{len(topics)}"
                 spec = TopicSpec(name=name,
                                  partition_count=partition_count,

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -127,7 +127,8 @@ class PartitionMovementTest(EndToEndTest):
         self.logger.info(
             f"new assignments for {topic}-{partition}: {assignments}")
 
-        admin.set_partition_replicas(topic, partition, assignments)
+        r = admin.set_partition_replicas(topic, partition, assignments)
+        r.raise_for_status()
 
         def status_done():
             info = admin.get_partitions(topic, partition)
@@ -185,7 +186,8 @@ class PartitionMovementTest(EndToEndTest):
         self.logger.info(
             f"new assignments for {topic}-{partition}: {assignments}")
 
-        admin.set_partition_replicas(topic, partition, assignments)
+        r = admin.set_partition_replicas(topic, partition, assignments)
+        r.raise_for_status()  # Expect success
 
         def status_done():
             info = admin.get_partitions(topic, partition)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -275,11 +275,23 @@ class PartitionMovementTest(EndToEndTest):
                 auto_offset_reset='earliest',
                 request_timeout_ms=5000,
                 consumer_timeout_ms=10000)
-            consumed = []
+            consumed = set()
             for msg in consumer:
-                consumed.append((msg.key, msg.value))
-            self.logger.info(f"Finished verifying records in {spec}")
-            assert set(consumed) == produced
+                consumed.add((msg.key, msg.value))
+            if consumed != produced:
+                self.logger.error(
+                    f"Validation failed for topic {spec.name}.  Produced {len(produced)}, consumed {len(consumed)}"
+                )
+                self.logger.error(
+                    f"Messages consumed but not produced: {sorted(consumed - produced)}"
+                )
+                self.logger.error(
+                    f"Messages produced but not consumed: {sorted(produced - consumed)}"
+                )
+
+                assert set(consumed) == produced
+            else:
+                self.logger.info(f"Finished verifying records in {spec}")
 
     @cluster(num_nodes=5)
     def test_dynamic(self):


### PR DESCRIPTION
## Cover letter

There are still unresolved issues within redpanda that can fail partition_movement_test, but I already have a few fixes to the test itself, so I think it makes sense to get those into dev so that as/when we see more failures they'll be better formed (especially the change to check for errors on the admin API POST instead of just timing out)

Related: https://github.com/vectorizedio/redpanda/issues/2246, https://github.com/vectorizedio/redpanda/issues/2282

## Release notes

None
