### PR TITLE
rpc/server: wait_for_shutdown should initiate shutdown sequence

### DIFF
--- a/src/v/rpc/server.cc
+++ b/src/v/rpc/server.cc
@@ -181,6 +181,10 @@ void server::shutdown_input() {
 }
 
 ss::future<> server::wait_for_shutdown() {
+    if (!_as.abort_requested()) {
+        shutdown_input();
+    }
+
     return _conn_gate.close().then([this] {
         return seastar::do_for_each(
           _connections, [](connection& c) { return c.shutdown(); });
@@ -195,7 +199,6 @@ ss::future<> server::stop() {
     }
     // if shutdown_input wasn't called fallback to previous behavior i.e. stop()
     // waits for shutdown
-    shutdown_input();
     return wait_for_shutdown();
 }
 


### PR DESCRIPTION
Fixed shutting down of `rpc::server`. When `wait_for_shutdown` is called it should start the shutdown sequence.

`rpc::server` shutdown may be done in two phases in first phase initiated with `rpc::server::shutdown_input()` method call server stops accepting new requests and connections. Second phase is initiated with `rpc::server::wait_for_shutdown()` method call. Second phases finishes when all pending request are completed and connections are closed. The problem this PR is fixing is related with the `wait_for_shutdown()` method being called without calling `shutdown_input()` first. Changed the behavior so that it is safe to call `wait_for_shutdown()` without stopping the input first. 