### PR TITLE
rpk topic describe: deref topic pointer

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/describe.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/describe.go
@@ -101,7 +101,7 @@ partitions section. By default, the summary and configs sections are printed.
 			header("SUMMARY", summary, func() {
 				tw := out.NewTabWriter()
 				defer tw.Flush()
-				tw.PrintColumn("NAME", t.Topic)
+				tw.PrintColumn("NAME", *t.Topic)
 				if t.IsInternal {
 					tw.PrintColumn("INTERNAL", t.IsInternal)
 				}


### PR DESCRIPTION
This is another location that was broken by kmsg changing the protocol;
this small commit is a quick fix. I'll be coming back and added tests
that ensure the args we are printing are what we want them to be.
