### PR TITLE
licenses/third_party.md: Update the licenses for rpk & k8s

### DIFF
--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -39,41 +39,82 @@ please keep this up to date with every new library use.
 | CRoaring        | Apache License 2                   |
 | base64          | BSD 2                              |
  
-# Golang deps _used_ in production (exclude all test dependencies)
+# GO deps _used_ in production in RPK (exclude all test dependencies)
 
-| software                             | license          |
-| :----------                          | :------------:   |
-| github.com/Azure/go-ansiterm         | MIT              |
-| github.com/Azure/go-winio            | MIT              |
-| github.com/Shopify/sarama            | MIT              |
-| github.com/docker/distribution       | Apache License 2 |
-| github.com/docker/docker             | Apache License 2 |
-| github.com/docker/go-connections     | Apache License 2 |
-| github.com/docker/go-units           | Apache License 2 |
-| github.com/fatih/color               | MI               |
-| github.com/gobuffalo/packr           | MIT              |
-| github.com/gogo/protobuf             | BSD 3            |
-| github.com/gorilla/mux               | BSD 3            |
-| github.com/lorenzosaino/go-sysctl    | BSD 3            |
-| github.com/mattn/go-colorable        | MIT              |
-| github.com/mattn/go-isatty           | MIT              |
-| github.com/mattn/go-runewidth        | MIT              |
-| github.com/mitchellh/go-homedir      | MIT              |
-| github.com/morikuni/aec              | MIT              |
-| github.com/olekukonko/tablewriter    | MIT              |
-| github.com/opencontainers/go-digest  | Apache License 2 |
-| github.com/opencontainers/image-spec | Apache License 2 |
-| github.com/pkg/errors                | BSD 2            |
-| github.com/safchain/ethtool          | Apache License 2 |
-| github.com/sirupsen/logrus           | MIT              |
-| github.com/spf13/afero               | Apache License 2 |
-| github.com/spf13/cobra               | Apache License 2 |
-| github.com/spf13/viper               | Apache License 2 |
-| gopkg.in/jcmturner/goidentity.v3     | Apache License 2 |
-| gopkg.in/yaml.v2                     | Apache License 2 |
-| github.com/aws/aws-sdk-go            | Apache License 2 |
-| github.com/jmespath/go-jmespath      | Apache License 2 |
+| software                                              | license                   |
+| :----------                                           | :------------:            |
+| cloud.google.com/go                                   | Apache License 2          |
+| github.com/AlecAivazis/survey/v2                      | Apache License 2          |
+| github.com/Microsoft/go-winio                         | MIT License               |
+| github.com/Shopify/sarama                             | MIT License               |
+| github.com/avast/retry-go                             | MIT License               |
+| github.com/aws/aws-sdk-go                             | Apache License 2.0        |
+| github.com/beevik/ntp                                 | BSD 2-Clause License      |
+| github.com/burdiyan/kafkautil                         | MIT License               |
+| github.com/cespare/xxhash                             | MIT License               |
+| github.com/containerd/containerd                      | Apache License 2.0        |
+| github.com/coreos/go-systemd/v22                      | Apache License 2.0        |
+| github.com/docker/distribution                        | Apache License 2.0        |
+| github.com/docker/docker                              | Apache License 2.0        |
+| github.com/docker/go-connections                      | Apache License 2.0        |
+| github.com/docker/go-units                            | Apache License 2.0        |
+| github.com/fatih/color                                | MIT License               |
+| github.com/golang/snappy                              | BSD 3-Clause License      |
+| github.com/google/go-cmp                              | BSD 3-Clause License      |
+| github.com/google/uuid                                | BSD 3-Clause License      |
+| github.com/hashicorp/go-multierror                    | Mozilla Public License 2.0|
+| github.com/icza/dyno                                  | Apache License 2.0        |
+| github.com/konsorten/go-windows-terminal-sequences    | MIT License               |
+| github.com/lorenzosaino/go-sysctl                     | BSD 3-Clause License      |
+| github.com/lovoo/goka                                 | BSD 3-Clause License      |
+| github.com/mattn/go-colorable                         | MIT License               |
+| github.com/mattn/go-isatty                            | MIT License               |
+| github.com/mattn/go-runewidth                         | MIT License               |
+| github.com/mgutz/ansi                                 | MIT License               |
+| github.com/mitchellh/mapstructure                     | MIT License               |
+| github.com/moby/term                                  | Apache License 2.0        |
+| github.com/morikuni/aec                               | MIT License               |
+| github.com/olekukonko/tablewriter                     | MIT License               |
+| github.com/opencontainers/go-digest                   | Apache License 2.0        |
+| github.com/opencontainers/image-spec                  | Apache License 2.0        |
+| github.com/pkg/errors                                 | BSD 2-Clause License      |
+| github.com/prometheus/client_model                    | Apache License 2.0        |
+| github.com/prometheus/common                          | Apache License 2.0        |
+| github.com/safchain/ethtool                           | Apache License 2.0        |
+| github.com/sirupsen/logrus                            | MIT License               |
+| github.com/spf13/afero                                | Apache License 2.0        |
+| github.com/spf13/cobra                                | Apache License 2.0        |
+| github.com/spf13/pflag                                | BSD 3-Clause License      |
+| github.com/spf13/viper                                | MIT License               |
+| github.com/stretchr/testify                           | MIT License               |
+| github.com/tklauser/go-sysconf                        | BSD 3-Clause License      |
+| github.com/twmb/franz-go                              | BSD 3-Clause License      |
+| github.com/twmb/tlscfg                                | BSD 3-Clause License      |
+| github.com/xdg/scram                                  | Apache License 2.0        |
+| golang.org/x/crypto                                   | BSD 3-Clause License      |
+| golang.org/x/mod                                      | BSD 3-Clause License      |
+| golang.org/x/sync                                     | BSD 3-Clause License      |
+| golang.org/x/sys                                      | BSD 3-Clause License      |
+| golang.org/x/tools                                    | BSD 3-Clause License      |
+| gopkg.in/yaml.v2                                      | Apache License 2.0        |
+| mvdan.cc/sh/v3                                        | BSD 3-Clause License      |
 
+# GO deps _used_ in production in K8S (exclude all test dependencies)
+
+| software                                  | license                   |
+| :----------                               | :------------:            |
+| github.com/banzaicloud/k8s-objectmatcher  | Apache License 2          |
+| github.com/go-logr/logr                   | Apache License 2          |
+| github.com/hashicorp/go-multierror        | Mozilla Public License 2.0|
+| github.com/jetstack/cert-manager          | Apache License 2          |
+| github.com/prometheus/client_golang       | Apache License 2          |
+| github.com/spf13/afero                    | Apache License 2          |
+| gopkg.in/yaml.v3                          | Apache License 2          |
+| k8s.io/api                                | Apache License 2          |
+| k8s.io/apimachinery                       | Apache License 2          |
+| k8s.io/client-go                          | Apache License 2          |
+| k8s.io/utils                              | Apache License 2          |
+| sigs.k8s.io/controller-runtime            | Apache License 2          |
 
 # Javascript deps _used_ in production (exclude all test dependencies)
 


### PR DESCRIPTION
Update the licenses for rpk & k8s.
Generated using the GitHub API (/repositories endpoint) where possible.