### PR TITLE
Fixed recovery when there are gaps which are larger than max of `int32_t`

### DIFF
--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -42,6 +42,8 @@
 
 #include <algorithm>
 #include <iterator>
+#include <limits>
+#include <vector>
 
 namespace raft::details {
 [[gnu::cold]] void throw_out_of_range() {
@@ -193,6 +195,28 @@ model::record_batch make_ghost_batch(
     return batch;
 }
 
+/**
+ * makes multiple ghost batches required to fill the gap in a way that max batch
+ * size (max of int32_t) is not exceeded
+ */
+std::vector<model::record_batch> make_ghost_batches(
+  model::offset start_offset, model::offset end_offset, model::term_id term) {
+    std::vector<model::record_batch> batches;
+    while (start_offset < end_offset) {
+        static constexpr model::offset max_batch_size{
+          std::numeric_limits<int32_t>::max()};
+        // limit max batch size
+        const model::offset delta = std::min<model::offset>(
+          max_batch_size, end_offset - start_offset);
+
+        batches.push_back(
+          make_ghost_batch(start_offset, delta + start_offset, term));
+        start_offset = next_offset(batches.back().last_offset());
+    }
+
+    return batches;
+}
+
 ss::circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
   model::offset expected_start,
   ss::circular_buffer<model::record_batch>&& batches) {
@@ -201,8 +225,9 @@ ss::circular_buffer<model::record_batch> make_ghost_batches_in_gaps(
     for (auto& b : batches) {
         // gap
         if (b.base_offset() > expected_start) {
-            res.push_back(make_ghost_batch(
-              expected_start, prev_offset(b.base_offset()), b.term()));
+            auto gb = make_ghost_batches(
+              expected_start, prev_offset(b.base_offset()), b.term());
+            std::move(gb.begin(), gb.end(), std::back_inserter(res));
         }
         expected_start = next_offset(b.last_offset());
         res.push_back(std::move(b));

--- a/src/v/raft/tests/consensus_utils_test.cc
+++ b/src/v/raft/tests/consensus_utils_test.cc
@@ -7,6 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "random/generators.h"
+
+#include <iterator>
+#include <limits>
 #define BOOST_TEST_MODULE raft
 #include "raft/consensus_utils.h"
 #include "storage/tests/utils/disk_log_builder.h"
@@ -54,6 +58,39 @@ BOOST_AUTO_TEST_CASE(test_filling_gaps) {
         auto it = std::next(batches.begin(), idx);
         batches.erase(it, std::next(it));
     }
+
+    model::offset first_expected = model::offset(10);
+
+    auto without_gaps = raft::details::make_ghost_batches_in_gaps(
+      first_expected, std::move(batches));
+
+    for (auto& b : without_gaps) {
+        BOOST_REQUIRE_EQUAL(b.base_offset(), first_expected);
+        first_expected = raft::details::next_offset(b.last_offset());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_filling_gaps_larger_than_batch_size) {
+    auto batches = storage::test::make_random_batches(
+      model::offset(20), 50, true);
+
+    // cut some holes in log
+    for (size_t i = 0; i < 10; ++i) {
+        auto idx = random_generators::get_int(batches.size() - 1);
+        auto it = std::next(batches.begin(), idx);
+        batches.erase(it, std::next(it));
+    }
+
+    auto batches_after = storage::test::make_random_batches(
+      model::offset(
+        3 * static_cast<int64_t>(std::numeric_limits<int32_t>::max())
+        + random_generators::get_int<int64_t>(
+          std::numeric_limits<int32_t>::max())),
+      10,
+      true);
+
+    std::move(
+      batches_after.begin(), batches_after.end(), std::back_inserter(batches));
 
     model::offset first_expected = model::offset(10);
 


### PR DESCRIPTION
## Cover letter

Raft protocol doesn't tolerate gaps in log offset. In order to make recovery of compacted topics possible we use ghost batches (virtual batches that are not persisted to disk). Previously we always used single ghost batch per gap. If the gap was large enough it may lead to situation in which `batch_header::offset_delta` field was overflown. This may lead to crash on the node receiving append_entries requests since offsets are not monotonic, and assertion is triggered.

Fixes: #2310

