### PR TITLE
cluster: fix update_properties overlapping with updates

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -516,7 +516,8 @@ controller_backend::execute_partitition_op(const topic_table::delta& delta) {
         return finish_partition_update(delta.ntp, delta.new_assignment, rev);
     case op_t::update_properties:
         return process_partition_properties_update(
-          delta.ntp, delta.new_assignment);
+                 delta.ntp, delta.new_assignment)
+          .then([] { return std::error_code(errc::success); });
     }
     __builtin_unreachable();
 }
@@ -719,26 +720,25 @@ ss::future<std::error_code> controller_backend::process_partition_update(
     co_return ec;
 }
 
-ss::future<std::error_code>
-controller_backend::process_partition_properties_update(
+ss::future<> controller_backend::process_partition_properties_update(
   model::ntp ntp, partition_assignment assignment) {
     /**
      * No core local replicas are expected to exists, do nothing
      */
     if (!has_local_replicas(_self, assignment.replicas)) {
-        co_return errc::success;
+        co_return;
     }
 
     auto partition = _partition_manager.local().get(ntp);
 
     // partition doesn't exists, it must already have been removed, do nothing
     if (!partition) {
-        co_return errc::success;
+        co_return;
     }
     auto cfg = _topics.local().get_topic_cfg(model::topic_namespace_view(ntp));
     // configuration doesn't exists, topic was removed
     if (!cfg) {
-        co_return errc::success;
+        co_return;
     }
     vlog(
       clusterlog.trace,
@@ -746,7 +746,6 @@ controller_backend::process_partition_properties_update(
       ntp,
       cfg->properties);
     co_await partition->update_configuration(cfg->properties);
-    co_return errc::success;
 }
 
 /**

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -92,7 +92,7 @@ private:
     ss::future<std::error_code> finish_partition_update(
       model::ntp, const partition_assignment&, model::revision_id);
 
-    ss::future<std::error_code>
+    ss::future<>
       process_partition_properties_update(model::ntp, partition_assignment);
 
     ss::future<std::error_code> create_partition(

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -89,7 +89,7 @@ private:
       const partition_assignment&,
       const partition_assignment&,
       model::revision_id);
-    ss::future<std::error_code> finish_partition_update(
+    ss::future<> finish_partition_update(
       model::ntp, const partition_assignment&, model::revision_id);
 
     ss::future<>
@@ -104,8 +104,7 @@ private:
       model::ntp, raft::group_id, ss::shard_id, model::revision_id);
     ss::future<>
       remove_from_shard_table(model::ntp, raft::group_id, model::revision_id);
-    ss::future<std::error_code>
-      delete_partition(model::ntp, model::revision_id);
+    ss::future<> delete_partition(model::ntp, model::revision_id);
     ss::future<std::error_code> update_partition_replica_set(
       const model::ntp&,
       const std::vector<model::broker_shard>&,

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -54,6 +54,10 @@ class RpkTool:
             cmd += ["--partitions", str(partitions)]
         return self._run_topic(cmd)
 
+    def delete_topic(self, topic):
+        cmd = ["delete", topic]
+        return self._run_topic(cmd)
+
     def list_topics(self):
         cmd = ["list"]
 
@@ -113,6 +117,10 @@ class RpkTool:
                                 hw=int(m.group('hw')))
 
         return filter(lambda p: p != None, map(partition_line, lines))
+
+    def alter_topic_config(self, topic, set_key, set_value):
+        cmd = ['alter-config', topic, "--set", f"{set_key}={set_value}"]
+        self._run_topic(cmd)
 
     def wasm_deploy(self, script, name, description):
         cmd = [

--- a/tests/rptest/services/rpk_producer.py
+++ b/tests/rptest/services/rpk_producer.py
@@ -1,0 +1,24 @@
+from ducktape.services.background_thread import BackgroundThreadService
+
+
+class RpkProducer(BackgroundThreadService):
+    """
+    Wrap the `rpk topic produce` command.  This is useful if you need
+    to write a simple repeated value to a topic, for example to increase
+    the topic's size on disk when testing recovery.
+    """
+    def __init__(self, context, redpanda, topic, msg_size, msg_count):
+        super(RpkProducer, self).__init__(context, num_nodes=1)
+        self._redpanda = redpanda
+        self._topic = topic
+        self._msg_size = msg_size
+        self._msg_count = msg_count
+
+    def _worker(self, _idx, node):
+        rpk_binary = self._redpanda.find_binary("rpk")
+        cmd = f"dd if=/dev/zero bs={self._msg_size} count=1 | {rpk_binary} topic --brokers {self._redpanda.brokers()} produce -n {self._msg_count} --key test {self._topic}"
+        for line in node.account.ssh_capture(cmd, timeout_sec=10):
+            self.logger.debug(line.rstrip())
+
+    def stop_node(self, node):
+        node.account.kill_process("rpk", clean_shutdown=False)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -17,9 +17,11 @@ from rptest.clients.kafka_cat import KafkaCat
 import requests
 
 from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
 from rptest.services.honey_badger import HoneyBadger
+from rptest.services.rpk_producer import RpkProducer
 from kafka import KafkaProducer
 from kafka import KafkaConsumer
 
@@ -35,8 +37,9 @@ class PartitionMovementTest(EndToEndTest):
     - Add settings for scaling up tests
     - Add tests guarnateeing multiple segments
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, ctx, *args, **kwargs):
         super(PartitionMovementTest, self).__init__(
+            ctx,
             *args,
             extra_rp_conf={
                 # Disable leader balancer, as this test is doing its own
@@ -44,6 +47,7 @@ class PartitionMovementTest(EndToEndTest):
                 'enable_leader_balancer': False
             },
             **kwargs)
+        self._ctx = ctx
 
     @staticmethod
     def _random_partition(metadata):
@@ -366,3 +370,79 @@ class PartitionMovementTest(EndToEndTest):
         assignments = [{"node_id": valid_dest, "core": 0}]
         r = admin.set_partition_replicas(topic, partition, assignments)
         assert r.status_code == 200
+
+    @cluster(num_nodes=5)
+    def test_overlapping_changes(self):
+        """
+        Check that while a movement is in flight, rules about
+        overlapping operations are properly enforced.
+        """
+
+        self.start_redpanda(num_nodes=4)
+        node_ids = {1, 2, 3, 4}
+
+        # Create topic with enough data that inter-node movement
+        # will take a while.
+        name = f"movetest"
+        spec = TopicSpec(name=name, partition_count=1, replication_factor=3)
+        self.redpanda.create_topic(spec)
+
+        # Wait for the partition to have a leader (`rpk produce` errors
+        # out if it tries to write data before this)
+        def partition_ready():
+            return KafkaCat(self.redpanda).get_partition_leader(
+                name, 0)[0] is not None
+
+        wait_until(partition_ready, timeout_sec=10, backoff_sec=0.5)
+
+        # Write a substantial amount of data to the topic
+        msg_size = 512 * 1024
+        write_bytes = 512 * 1024 * 1024
+        producer = RpkProducer(self._ctx,
+                               self.redpanda,
+                               name,
+                               msg_size=msg_size,
+                               msg_count=int(write_bytes / msg_size))
+        t1 = time.time()
+        producer.start()
+
+        # This is an absurdly low expected throughput, but necessarily
+        # so to run reliably on current test runners, which share an EBS
+        # backend among many parallel tests.  10MB/s has been empirically
+        # shown to be too high an expectation.
+        expect_bps = 1 * 1024 * 1024
+        expect_runtime = write_bytes / expect_bps
+        producer.wait(timeout_sec=expect_runtime)
+
+        self.logger.info(
+            f"Write complete {write_bytes} in {time.time() - t1} seconds")
+
+        # Start an inter-node move, which should take some time
+        # to complete because of recovery network traffic
+        admin = Admin(self.redpanda)
+        assignments = self._get_assignments(admin, name, 0)
+        new_node = list(node_ids - set([a['node_id'] for a in assignments]))[0]
+        self.logger.info(f"old assignments: {assignments}")
+        old_assignments = assignments
+        assignments = assignments[1:] + [{'node_id': new_node, 'core': 0}]
+        self.logger.info(f"new assignments: {assignments}")
+        r = admin.set_partition_replicas(name, 0, assignments)
+        r.raise_for_status()
+        assert admin.get_partitions(name, 0)['status'] == "in_progress"
+
+        # Another move should fail
+        assert admin.get_partitions(name, 0)['status'] == "in_progress"
+        r = admin.set_partition_replicas(name, 0, old_assignments)
+        assert r.status_code == 400
+
+        # An update to partition properties should succeed
+        # (issue https://github.com/vectorizedio/redpanda/issues/2300)
+        rpk = RpkTool(self.redpanda)
+        assert admin.get_partitions(name, 0)['status'] == "in_progress"
+        rpk.alter_topic_config(name, "retention.ms", "3600000")
+
+        # A deletion should succeed
+        assert name in rpk.list_topics()
+        assert admin.get_partitions(name, 0)['status'] == "in_progress"
+        rpk.delete_topic(name)
+        assert name not in rpk.list_topics()

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -131,30 +131,7 @@ class RaftAvailabilityTest(RedpandaTest):
         """
         :returns: 2 tuple of (leader, [replica ids])
         """
-        kc = KafkaCat(self.redpanda)
-
-        topic_meta = None
-        all_metadata = kc.metadata()
-        for t in all_metadata['topics']:
-            if t['topic'] != self.topic:
-                self.logger.warning(f"Unexpected topic {t['topic']}")
-            else:
-                topic_meta = t
-                break
-
-        if topic_meta is None:
-            self.logger.error(f"Topic {self.topic} not found!")
-            self.logger.error(
-                f"KafkaCat metadata: {json.dumps(all_metadata,indent=2)}")
-            assert topic_meta is not None
-
-        partition = topic_meta['partitions'][0]
-        leader_id = partition['leader']
-        replicas = [p['id'] for p in partition['replicas']]
-        if leader_id == -1:
-            return None, replicas
-        else:
-            return leader_id, replicas
+        return KafkaCat(self.redpanda).get_partition_leader(self.topic, 0)
 
     def _wait_for_leader(self, condition=None, timeout=None):
         if timeout is None:


### PR DESCRIPTION
## Cover letter

Redpanda could assert out when a topic's properties were updated while a partition movement was ongoing.

The previous assertion assumed that no other operations
could come between the `update` and `update_finished` for
a partition.

`update_properties` is permitted here.  Remove the failing
assertion, and add code to execute these messages while skipping
to the update_finished.

Fixes: https://github.com/vectorizedio/redpanda/issues/2300

## Release notes

A bug is fixed where redpanda could stop unexpectedly when topic properties were modified at the same time as a partition within the topic was being moved between nodes.
