### PR TITLE
Fix offset translation after log eviction

### DIFF
--- a/src/v/kafka/server/offset_translator.h
+++ b/src/v/kafka/server/offset_translator.h
@@ -53,10 +53,19 @@ public:
 private:
     int64_t delta(model::offset o) const {
         auto it = _cfg_mgr.lower_bound(o);
-        if (it != _cfg_mgr.begin()) {
-            --it;
+
+        if (it == _cfg_mgr.begin()) {
+            /**
+             * iterator points to the first configuration with offset greater
+             * than then requsted one. Knowing an index of that configuration we
+             * know that there was exactly (index -1) configurations with offset
+             * lower than the current one. We can simply subtract one from
+             * index.
+             */
+            return std::max<int64_t>(0, it->second.idx() - 1);
         }
-        return it->second.idx();
+
+        return std::prev(it)->second.idx();
     }
 
     const raft::configuration_manager& _cfg_mgr;

--- a/src/v/raft/configuration_bootstrap_state.cc
+++ b/src/v/raft/configuration_bootstrap_state.cc
@@ -31,15 +31,14 @@ void configuration_bootstrap_state::process_configuration(
           "Compressed configuration records are unsupported");
     }
     auto last_offset = b.last_offset();
-    if (_log_config_offset_tracker < last_offset) {
-        _config_batches_seen++;
-        _log_config_offset_tracker = last_offset;
-        process_offsets(b.base_offset(), last_offset);
-        b.for_each_record([this](model::record rec) {
-            _config = reflection::from_iobuf<raft::group_configuration>(
-              rec.release_value());
-        });
-    }
+
+    process_offsets(b.base_offset(), last_offset);
+    b.for_each_record([this, o = b.base_offset()](model::record rec) {
+        _configurations.emplace_back(
+          o,
+          reflection::from_iobuf<raft::group_configuration>(
+            rec.release_value()));
+    });
 }
 void configuration_bootstrap_state::process_data_offsets(
   model::record_batch b) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1036,7 +1036,7 @@ ss::future<> consensus::do_start() {
               if (st.config_batches_seen() > 0) {
                   f = f.then([this, st = std::move(st)]() mutable {
                       return _configuration_manager.add(
-                        st.prev_log_index(), st.release_config());
+                        std::move(st).release_configurations());
                   });
               }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1818,20 +1818,12 @@ consensus::do_write_snapshot(model::offset last_included_index, iobuf&& data) {
 
     return details::persist_snapshot(
              _snapshot_mgr, std::move(md), std::move(data))
-      .then([this,
-             last_included_index,
-             term = *last_included_term,
-             cfg = std::move(*config)]() mutable {
+      .then([this, last_included_index, term = *last_included_term]() mutable {
           // update consensus state
           _last_snapshot_index = last_included_index;
           _last_snapshot_term = term;
           // update configuration manager
-          return _configuration_manager
-            .add(_last_snapshot_index, std::move(cfg))
-            .then([this] {
-                return _configuration_manager.prefix_truncate(
-                  _last_snapshot_index);
-            });
+          return _configuration_manager.prefix_truncate(_last_snapshot_index);
       });
 }
 

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -17,6 +17,7 @@
 #include "raft/append_entries_buffer.h"
 #include "raft/configuration_manager.h"
 #include "raft/consensus_client_protocol.h"
+#include "raft/consensus_utils.h"
 #include "raft/event_manager.h"
 #include "raft/follower_stats.h"
 #include "raft/group_configuration.h"
@@ -257,7 +258,9 @@ public:
         return _log.timequery(cfg);
     }
 
-    model::offset start_offset() const { return _log.offsets().start_offset; }
+    model::offset start_offset() const {
+        return details::next_offset(_last_snapshot_index);
+    }
 
     model::offset dirty_offset() const { return _log.offsets().dirty_offset; }
 

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -87,12 +87,12 @@ FIXTURE_TEST(write_configs, bootstrap_fixture) {
       cfg.data_batches_seen(),
       cfg.config_batches_seen());
 
-    cfg.config().for_each_voter([](raft::vnode rni) {
+    cfg.configurations().back().cfg.for_each_voter([](raft::vnode rni) {
         BOOST_REQUIRE(
           rni.id() >= 0 && rni.id() <= bootstrap_fixture::active_nodes);
     });
 
-    cfg.config().for_each_learner([](raft::vnode rni) {
+    cfg.configurations().back().cfg.for_each_learner([](raft::vnode rni) {
         BOOST_REQUIRE(rni.id() > bootstrap_fixture::active_nodes);
     });
 

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -173,9 +173,11 @@ FIXTURE_TEST(test_prefix_truncation, config_manager_fixture) {
 
     validate_recovery();
     // try to truncate whole
-    BOOST_CHECK_THROW(
-      _cfg_mgr.prefix_truncate(model::offset(3003)).get0(),
-      std::invalid_argument);
+    _cfg_mgr.prefix_truncate(model::offset(3003)).get0();
+    validate_recovery();
+    // last known config is preserved
+    BOOST_REQUIRE_EQUAL(_cfg_mgr.get(model::offset(3003)), configurations[5]);
+    BOOST_REQUIRE_EQUAL(_cfg_mgr.get_latest_index()(), 6);
 }
 
 FIXTURE_TEST(test_truncation, config_manager_fixture) {

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -25,7 +25,7 @@ from ducktape.utils.util import wait_until
 from rptest.services.redpanda import RedpandaService
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.services.verifiable_consumer import VerifiableConsumer
-from rptest.services.verifiable_producer import VerifiableProducer
+from rptest.services.verifiable_producer import VerifiableProducer, is_int_with_prefix
 
 TopicPartition = namedtuple('TopicPartition', ['topic', 'partition'])
 
@@ -84,16 +84,18 @@ class EndToEndTest(Test):
     def start_producer(self, num_nodes=1, throughput=1000):
         assert self.redpanda
         assert self.topic
-        self.producer = VerifiableProducer(self.test_context,
-                                           num_nodes=num_nodes,
-                                           redpanda=self.redpanda,
-                                           topic=self.topic,
-                                           throughput=throughput)
+        self.producer = VerifiableProducer(
+            self.test_context,
+            num_nodes=num_nodes,
+            redpanda=self.redpanda,
+            topic=self.topic,
+            throughput=throughput,
+            message_validator=is_int_with_prefix)
         self.producer.start()
 
     def on_record_consumed(self, record, node):
         partition = TopicPartition(record["topic"], record["partition"])
-        record_id = int(record["value"])
+        record_id = record["value"]
         offset = record["offset"]
         self.last_consumed_offsets[partition] = offset
         self.records_consumed.append(record_id)

--- a/tests/rptest/tests/end_to_end.py
+++ b/tests/rptest/tests/end_to_end.py
@@ -61,7 +61,11 @@ class EndToEndTest(Test):
         self.redpanda = None
         self.topic = None
 
-    def start_redpanda(self, num_nodes=1):
+    def start_redpanda(self, num_nodes=1, extra_rp_conf=None):
+        if extra_rp_conf is not None:
+            # merge both configurations, the extra_rp_conf passed in
+            # paramter takes the precedence
+            self._extra_rp_conf = {**self._extra_rp_conf, **extra_rp_conf}
         assert self.redpanda is None
         self.redpanda = RedpandaService(self.test_context,
                                         num_nodes,

--- a/tests/rptest/tests/simple_e2e_test.py
+++ b/tests/rptest/tests/simple_e2e_test.py
@@ -1,0 +1,37 @@
+import random
+import time
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+import requests
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.end_to_end import EndToEndTest
+
+
+class SimpleEndToEndTest(EndToEndTest):
+    @cluster(num_nodes=9)
+    def test_correctness_while_evicitng_log(self):
+        '''
+        Validate that all the records will be delivered to consumers when there 
+        are multiple producers and log is evicted
+        '''
+        # use small segment size to enable log eviction
+        self.start_redpanda(num_nodes=3,
+                            extra_rp_conf={
+                                "log_segment_size": 1048576,
+                                "retention_bytes": 5242880,
+                                "default_topic_replications": 3,
+                            })
+
+        spec = TopicSpec(name="topic", partition_count=1, replication_factor=1)
+        self.redpanda.create_topic(spec)
+        self.topic = spec.name
+
+        self.start_producer(5, throughput=10000)
+        self.start_consumer(1)
+        self.await_startup()
+
+        self.run_validation(min_records=100000,
+                            producer_timeout_sec=120,
+                            consumer_timeout_sec=120)


### PR DESCRIPTION
## Cover letter

Fixed offset translation immutability issues. In redpanda we translate internal offsets to Kafka layer offset. The translation must be deterministic and offsets have to be immutable.  Fixed problem causing of by one error in offset translation. 

Fixes: #2326 