### PR TITLE
raft/cluster: shutdown fixes

### DIFF
--- a/src/v/raft/recovery_throttle.h
+++ b/src/v/raft/recovery_throttle.h
@@ -63,10 +63,9 @@ public:
         return _sem.wait(size);
     }
 
-    ss::future<> stop() {
+    void shutdown() {
         _refresh_timer.cancel();
         _sem.broken();
-        return ss::now();
     }
 
 private:

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -574,8 +574,10 @@ void application::wire_up_redpanda_services() {
     // that are being throttled are released so that they can make be quickly
     // shutdown by the group manager.
     _deferred.emplace_back([this] {
-        recovery_throttle.stop().get();
+        recovery_throttle.invoke_on_all(&raft::recovery_throttle::shutdown)
+          .get();
         raft_group_manager.stop().get();
+        recovery_throttle.stop().get();
     });
 
     syschecks::systemd_message("Adding partition manager").get();


### PR DESCRIPTION
## Cover letter

Fixed shutdown issues that were manifesting in CI making the tests to fail. 

Fixes: #2327, #2078