### PR TITLE
wasm engine ignores value for custom port and always chooses default

### DIFF
--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -179,7 +179,9 @@ export class ProcessBatchServer extends SupervisorServer {
         logger.info(`invalid topic on wasm script: ${handleDef.id}`);
         return errors.createResponseScriptInvalidTopic(handle);
       }
-      logger.info(`wasm script loaded on nodejs engine : ${handleDef.id}`);
+      logger.info(
+        `wasm script loaded on nodejs engine : ${handleDef.id} with topics ${handle.coprocessor.inputTopics}`
+      );
       this.repository.add(handle);
       return errors.createResponseSuccess(handle);
     }

--- a/src/js/modules/rpc/service.ts
+++ b/src/js/modules/rpc/service.ts
@@ -67,7 +67,7 @@ function main() {
 
   readConfigFile(configPath)
     .then((config) => {
-      const port = config?.redpanda?.coproc_supervisor_server || 43189;
+      const port = config?.redpanda?.coproc_supervisor_server?.port || 43189;
       const logFilePath = config?.coproc_engine?.logFilePath || defaultLogFile;
       LogService.setPath(logFilePath);
       const logger = LogService.createLogger("service");


### PR DESCRIPTION
The wasm engine parses ip/port values incorrectly. When a value exists for `coproc_supervisor_server` in the `redpanda.yaml` file, the wasm engine ignores it and always chooses the default.

The `coproc_supervisor_server` value is of type `unresolved_addr` https://github.com/vectorizedio/redpanda/blob/dev/src/v/config/configuration.cc#L117 as so in yaml it should be a dictionary where the keys are `address` and `port`.

