### PR TITLE
schema_registry: Sanitize Avro union fields

### DIFF
--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -232,6 +232,17 @@ result<void> sanitize(
                 return res.assume_error();
             }
         }
+        if (t_it->value.GetType() == rapidjson::Type::kArrayType) {
+            auto a = t_it->value.GetArray();
+            for (auto& m : a) {
+                if (m.IsString()) {
+                    auto res = sanitize_name(m, alloc);
+                    if (res.has_error()) {
+                        return res.assume_error();
+                    }
+                }
+            }
+        }
     }
     return outcome::success();
 }

--- a/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
@@ -27,10 +27,10 @@ pps::schema_definition not_minimal_sanitized{
   R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]})"};
 
 pps::schema_definition leading_dot{
-  R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":".f1"}]})"};
+  R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"fields":[{"name":"f1","type":["null","string"]}],"name":".r1","type":"record"}]},{"name":"two","type":["null",".r1"]}]})"};
 
 pps::schema_definition leading_dot_sanitized{
-  R"({"type":"record","name":"myrecord","fields":[{"type":"string","name":"f1"}]})"};
+  R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"fields":[{"name":"f1","type":["null","string"]}],"name":"r1","type":"record"}]},{"name":"two","type":["null","r1"]}]})"};
 
 BOOST_AUTO_TEST_CASE(test_sanitize_avro_minify) {
     BOOST_REQUIRE_EQUAL(


### PR DESCRIPTION
## Cover letter

Backport #2331 

Union fields can refer to types by name, sanitize those names.

Signed-off-by: Ben Pope <ben@vectorized.io>
(cherry picked from commit 1879b50fe0ba4a98ecda7bb834c95f5dd689ccc3)

## Release notes

schema_registry: Sanitize Avro union fields