### PR TITLE
r/utils: fixed filling gaps with single batch missing

### DIFF
--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -202,7 +202,7 @@ model::record_batch make_ghost_batch(
 std::vector<model::record_batch> make_ghost_batches(
   model::offset start_offset, model::offset end_offset, model::term_id term) {
     std::vector<model::record_batch> batches;
-    while (start_offset < end_offset) {
+    while (start_offset <= end_offset) {
         static constexpr model::offset max_batch_size{
           std::numeric_limits<int32_t>::max()};
         // limit max batch size

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -193,7 +193,7 @@ class RedpandaService(Service):
         cmd = (f"nohup {self.find_binary('redpanda')}"
                f" --redpanda-cfg {RedpandaService.CONFIG_FILE}"
                f" --default-log-level {self._log_level}"
-               f" --logger-log-level=exception=debug:archival=debug "
+               f" --logger-log-level=exception=debug:archival=debug:io=debug "
                f" --kernel-page-cache=true "
                f" --overprovisioned "
                f" --smp {self._num_cores} "

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -524,5 +524,4 @@ class RedpandaService(Service):
         client.delete_topic(name)
 
     def cov_enabled(self):
-        return self._context.globals.get(self.COV_KEY,
-                                         self.DEFAULT_COV_OPT)
+        return self._context.globals.get(self.COV_KEY, self.DEFAULT_COV_OPT)


### PR DESCRIPTION
Fixed a bug introduced recently causing recovery to fail when there was
a gap consisting of exactly one record. In case a batch holds only
single record its base and end offsets are equal that wasn't correctly
taken into account when making ghost batches.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
