### PR TITLE
Fix controller api race

### DIFF
--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -128,6 +128,12 @@ controller_api::get_reconciliation_state(model::ntp ntp) {
           std::move(ntp), std::move(ops), reconciliation_status::in_progress);
     }
 
+    // if update is in progress return
+    if (_topics.local().is_update_in_progress(ntp)) {
+        co_return ntp_reconciliation_state(
+          std::move(ntp), std::move(ops), reconciliation_status::in_progress);
+    }
+
     // deltas are empty, make sure that local node partitions are in align with
     // expected cluster state
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/cluster_utils.h"
 #include "cluster/commands.h"
+#include "cluster/fwd.h"
 #include "cluster/logger.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
@@ -392,6 +393,10 @@ topic_table::get_partition_assignment(const model::ntp& ntp) const {
     }
 
     return *p_it;
+}
+
+bool topic_table::is_update_in_progress(const model::ntp& ntp) const {
+    return _update_in_progress.contains(ntp);
 }
 
 } // namespace cluster

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -132,6 +132,8 @@ public:
 
     const underlying_t& topics_map() const { return _topics; }
 
+    bool is_update_in_progress(const model::ntp&) const;
+
 private:
     struct waiter {
         explicit waiter(uint64_t id)


### PR DESCRIPTION
## Cover letter
Previously when we reported the reconciliation state we didn't query for update in progress flag from topics table. This might lead to situation in which we incorrectly reported that partition operation is already done while it wasn't yet even started. 

Fixes: N/A

## Release notes

Provide user reliable way for querying partition movement status. 
