### PR TITLE
Reduce the number of includes brought into application.h by coproc

### DIFF
--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -13,6 +13,7 @@ v_cc_library(
     logger.cc
     script_context.cc
     script_context_frontend.cc
+    script_context_backend.cc
     pacemaker.cc
     offset_storage_utils.cc
     wasm_event.cc

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -9,6 +9,7 @@ rpcgen(
 v_cc_library(
   NAME coproc
   SRCS
+    api.cc
     types.cc
     logger.cc
     script_context.cc

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/api.h"
+
+#include "coproc/event_listener.h"
+#include "coproc/pacemaker.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace coproc {
+
+api::api(
+  unresolved_address addr,
+  ss::sharded<storage::api>& storage,
+  ss::sharded<cluster::partition_manager>& partition_manager) noexcept
+  : _engine_addr(std::move(addr))
+  , _rs(sys_refs{.storage = storage, .partition_manager = partition_manager}) {}
+
+api::~api() = default;
+
+ss::future<> api::start() {
+    co_await _pacemaker.start(_engine_addr, std::ref(_rs));
+    co_await _pacemaker.invoke_on_all(&coproc::pacemaker::start);
+    _listener = std::make_unique<wasm::event_listener>(_pacemaker);
+    co_await _listener->start();
+}
+
+ss::future<> api::stop() {
+    auto f = ss::now();
+    if (_listener) {
+        f = _listener->stop();
+    }
+    return f.then([this] { return _pacemaker.stop(); });
+}
+
+} // namespace coproc

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "coproc/fwd.h"
+#include "coproc/sys_refs.h"
+#include "utils/unresolved_address.h"
+namespace coproc {
+
+class api {
+public:
+    api(
+      unresolved_address,
+      ss::sharded<storage::api>&,
+      ss::sharded<cluster::partition_manager>&) noexcept;
+
+    ~api();
+
+    ss::future<> start();
+
+    ss::future<> stop();
+
+    ss::sharded<pacemaker>& get_pacemaker() { return _pacemaker; }
+
+private:
+    unresolved_address _engine_addr;
+    sys_refs _rs;
+    std::unique_ptr<wasm::event_listener> _listener; /// one instance
+    ss::sharded<pacemaker> _pacemaker;               /// one per core
+};
+
+} // namespace coproc

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace coproc {
+
+class pacemaker;
+class script_context;
+
+namespace wasm {
+
+class script_dispatcher;
+class event_listener;
+
+} // namespace wasm
+
+} // namespace coproc

--- a/src/v/coproc/offset_storage_utils.cc
+++ b/src/v/coproc/offset_storage_utils.cc
@@ -79,10 +79,6 @@ ss::future<ntp_context_cache> recover_offsets(
 
 ss::future<> save_offsets(
   storage::simple_snapshot_manager& snap, const ntp_context_cache& ntp_cache) {
-    vlog(
-      coproclog.info,
-      "Saving {} coprocessor offsets to disk....",
-      ntp_cache.size());
     /// Create the metadata, and data iobuffers
     iobuf metadata = reflection::to_iobuf(static_cast<int8_t>(1));
     iresults_map irm_map;

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -11,11 +11,14 @@
 
 #pragma once
 
+#include "cluster/metadata_cache.h"
 #include "cluster/partition_manager.h"
+#include "cluster/topics_frontend.h"
 #include "config/configuration.h"
 #include "coproc/ntp_context.h"
 #include "coproc/offset_storage_utils.h"
 #include "coproc/script_context.h"
+#include "coproc/sys_refs.h"
 #include "coproc/types.h"
 #include "rpc/reconnect_transport.h"
 #include "storage/fwd.h"
@@ -42,10 +45,7 @@ public:
      * @param address of coprocessor engine
      * @param reference to the storage layer
      */
-    pacemaker(
-      unresolved_address,
-      ss::sharded<storage::api>&,
-      ss::sharded<cluster::partition_manager>&);
+    pacemaker(unresolved_address, sys_refs&);
 
     /**
      * Begins the offset tracking fiber

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -13,6 +13,7 @@
 
 #include "coproc/logger.h"
 #include "coproc/reference_window_consumer.hpp"
+#include "coproc/script_context_backend.h"
 #include "coproc/script_context_frontend.h"
 #include "coproc/types.h"
 #include "model/record_batch_reader.h"
@@ -117,149 +118,19 @@ ss::future<> script_context::send_request(
         std::move(r), rpc::client_opts(rpc::clock_type::now() + 5s))
       .then([this](reply_t reply) {
           if (reply) {
-              return process_reply(std::move(reply.value().data));
+              output_write_args args{
+                .id = _id,
+                .log_manager = _resources.api.log_mgr(),
+                .inputs = _ntp_ctxs,
+                .locks = _resources.log_mtx};
+              return write_materialized(
+                std::move(reply.value().data.resps), args);
           }
           vlog(
             coproclog.warn,
             "Error upon attempting to perform RPC to wasm engine, code: {}",
             reply.error());
           return ss::now();
-      });
-}
-
-ss::future<> script_context::process_reply(process_batch_reply reply) {
-    if (reply.resps.empty()) {
-        vlog(
-          coproclog.error, "Wasm engine interpreted the request as erraneous");
-        return ss::now();
-    }
-    return ss::do_with(std::move(reply), [this](process_batch_reply& reply) {
-        return ss::do_for_each(
-          reply.resps, [this](process_batch_reply::data& e) {
-              return process_one_reply(std::move(e));
-          });
-    });
-}
-
-ss::future<> script_context::process_one_reply(process_batch_reply::data e) {
-    /// Ensure this 'script_context' instance is handling the correct reply
-    if (e.id != _id) {
-        /// TODO: Maybe in the future errors of these type should mean redpanda
-        /// kill -9's the wasm engine.
-        vlog(
-          coproclog.error,
-          "erranous reply from wasm engine, mismatched id observed, expected: "
-          "{} and observed {}",
-          _id,
-          e.id);
-        return ss::now();
-    }
-    if (!e.reader) {
-        return ss::make_exception_future<>(script_failed_exception(
-          e.id,
-          fmt::format(
-            "script id {} will auto deregister due to an internal syntax "
-            "error",
-            e.id)));
-    }
-    /// Use the source topic portion of the materialized topic to perform a
-    /// lookup for the relevent 'ntp_context'
-    auto materialized_ntp = model::materialized_ntp(e.ntp);
-    auto found = _ntp_ctxs.find(materialized_ntp.source_ntp());
-    if (found == _ntp_ctxs.end()) {
-        vlog(
-          coproclog.warn,
-          "script {} unknown source ntp: {}",
-          _id,
-          materialized_ntp.source_ntp());
-        return ss::now();
-    }
-    auto ntp_ctx = found->second;
-    return write_materialized(materialized_ntp, std::move(*e.reader))
-      .then([this, ntp_ctx](bool success) {
-          if (!success) {
-              vlog(coproclog.warn, "record_batch failed to pass crc checks");
-              return;
-          }
-          auto ofound = ntp_ctx->offsets.find(_id);
-          vassert(
-            ofound != ntp_ctx->offsets.end(),
-            "Offset not found for script id {} for ntp owning context: {}",
-            _id,
-            ntp_ctx->ntp());
-          /// Reset the acked offset so that progress can be made
-          ofound->second.last_acked = ofound->second.last_read;
-      });
-}
-
-ss::future<storage::log> get_log(storage::api& api, const model::ntp& ntp) {
-    auto found = api.log_mgr().get(ntp);
-    if (found) {
-        return ss::make_ready_future<storage::log>(*found);
-    }
-    vlog(coproclog.info, "Making new log: {}", ntp);
-    return api.log_mgr().manage(
-      storage::ntp_config(ntp, api.log_mgr().config().base_dir));
-}
-
-class set_term_id_to_one {
-public:
-    ss::future<ss::stop_iteration> operator()(model::record_batch& b) {
-        b.header().ctx.term = model::term_id(0);
-        _batches.push_back(std::move(b));
-        co_return ss::stop_iteration::no;
-    }
-
-    model::record_batch_reader end_of_stream() {
-        return model::make_memory_record_batch_reader(std::move(_batches));
-    }
-
-private:
-    model::record_batch_reader::data_t _batches;
-};
-
-ss::future<bool> script_context::write_checked(
-  storage::log log, model::record_batch_reader reader) {
-    /// Re-write all batch term_ids to 1, otherwise they will carry the
-    /// term ids of records coming from parent batches
-    auto [success, batch_w_correct_terms]
-      = co_await std::move(reader).for_each_ref(
-        reference_window_consumer(
-          model::record_batch_crc_checker(), set_term_id_to_one()),
-        model::no_timeout);
-    if (!success) {
-        /// In the case crc checks failed, do NOT write records to storage
-        co_return false;
-    }
-    /// Compress the data before writing...
-    auto compressed = co_await std::move(batch_w_correct_terms)
-                        .for_each_ref(
-                          storage::internal::compress_batch_consumer(
-                            model::compression::zstd, 512),
-                          model::no_timeout);
-    const storage::log_append_config write_cfg{
-      .should_fsync = storage::log_append_config::fsync::no,
-      .io_priority = ss::default_priority_class(),
-      .timeout = model::no_timeout};
-    /// Finally, write the batch
-    co_await std::move(compressed)
-      .for_each_ref(log.make_appender(write_cfg), model::no_timeout)
-      .discard_result();
-    co_return true;
-}
-
-ss::future<bool> script_context::write_materialized(
-  const model::materialized_ntp& m_ntp, model::record_batch_reader reader) {
-    auto found = _resources.log_mtx.find(m_ntp.input_ntp());
-    if (found == _resources.log_mtx.end()) {
-        found = _resources.log_mtx.emplace(m_ntp.input_ntp(), mutex()).first;
-    }
-    return found->second.with(
-      [this, m_ntp, reader = std::move(reader)]() mutable {
-          return get_log(_resources.api, m_ntp.input_ntp())
-            .then([this, reader = std::move(reader)](storage::log log) mutable {
-                return write_checked(std::move(log), std::move(reader));
-            });
       });
 }
 

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -120,7 +120,7 @@ ss::future<> script_context::send_request(
           if (reply) {
               output_write_args args{
                 .id = _id,
-                .log_manager = _resources.api.log_mgr(),
+                .rs = _resources.rs,
                 .inputs = _ntp_ctxs,
                 .locks = _resources.log_mtx};
               return write_materialized(

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -75,10 +75,6 @@ private:
       send_request(supervisor_client_protocol, process_batch_request);
 
     ss::future<> process_reply(process_batch_reply);
-    ss::future<> process_one_reply(process_batch_reply::data);
-    ss::future<bool> write_materialized(
-      const model::materialized_ntp&, model::record_batch_reader);
-    ss::future<bool> write_checked(storage::log, model::record_batch_reader);
 
 private:
     /// Killswitch for in-process reads

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -87,7 +87,7 @@ static ss::future<bool> write_materialized_partition(
     }
     return found->second.with(
       [m_ntp, args, reader = std::move(reader)]() mutable {
-          return get_log(args.log_manager, m_ntp.input_ntp())
+          return get_log(args.rs.storage.local().log_mgr(), m_ntp.input_ntp())
             .then([reader = std::move(reader)](storage::log log) mutable {
                 return do_write_materialized_partition(
                   std::move(log), std::move(reader));

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "script_context_backend.h"
+
+#include "coproc/logger.h"
+#include "coproc/reference_window_consumer.hpp"
+#include "storage/parser_utils.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace coproc {
+/// Sets all of the term_ids in a batch of record batches to be a newly
+/// desired term.
+class set_term_id_to_zero {
+public:
+    ss::future<ss::stop_iteration> operator()(model::record_batch& b) {
+        b.header().ctx.term = model::term_id(0);
+        _batches.push_back(std::move(b));
+        co_return ss::stop_iteration::no;
+    }
+
+    model::record_batch_reader end_of_stream() {
+        return model::make_memory_record_batch_reader(std::move(_batches));
+    }
+
+private:
+    model::record_batch_reader::data_t _batches;
+};
+
+static ss::future<bool> do_write_materialized_partition(
+  storage::log log, model::record_batch_reader reader) {
+    /// Re-write all batch term_ids to 1, otherwise they will carry the
+    /// term ids of records coming from parent batches
+    auto [success, batch_w_correct_terms]
+      = co_await std::move(reader).for_each_ref(
+        reference_window_consumer(
+          model::record_batch_crc_checker(), set_term_id_to_zero()),
+        model::no_timeout);
+    if (!success) {
+        /// In the case crc checks failed, do NOT write records to storage
+        co_return false;
+    }
+    /// Compress the data before writing...
+    auto compressed = co_await std::move(batch_w_correct_terms)
+                        .for_each_ref(
+                          storage::internal::compress_batch_consumer(
+                            model::compression::zstd, 512),
+                          model::no_timeout);
+    const storage::log_append_config write_cfg{
+      .should_fsync = storage::log_append_config::fsync::no,
+      .io_priority = ss::default_priority_class(),
+      .timeout = model::no_timeout};
+    /// Finally, write the batch
+    co_await std::move(compressed)
+      .for_each_ref(log.make_appender(write_cfg), model::no_timeout)
+      .discard_result();
+    co_return true;
+}
+
+static ss::future<storage::log>
+get_log(storage::log_manager& log_mgr, const model::ntp& ntp) {
+    auto found = log_mgr.get(ntp);
+    if (found) {
+        return ss::make_ready_future<storage::log>(*found);
+    }
+    vlog(coproclog.info, "Making new log: {}", ntp);
+    return log_mgr.manage(storage::ntp_config(ntp, log_mgr.config().base_dir));
+}
+
+static ss::future<bool> write_materialized_partition(
+  const model::materialized_ntp& m_ntp,
+  model::record_batch_reader reader,
+  output_write_args args) {
+    auto found = args.locks.find(m_ntp.input_ntp());
+    if (found == args.locks.end()) {
+        found = args.locks.emplace(m_ntp.input_ntp(), mutex()).first;
+    }
+    return found->second.with(
+      [m_ntp, args, reader = std::move(reader)]() mutable {
+          return get_log(args.log_manager, m_ntp.input_ntp())
+            .then([reader = std::move(reader)](storage::log log) mutable {
+                return do_write_materialized_partition(
+                  std::move(log), std::move(reader));
+            });
+      });
+}
+
+static ss::future<>
+process_one_reply(process_batch_reply::data e, output_write_args args) {
+    /// Ensure this 'script_context' instance is handling the correct reply
+    if (e.id != args.id()) {
+        /// TODO: Maybe in the future errors of these type should mean redpanda
+        /// kill -9's the wasm engine.
+        vlog(
+          coproclog.error,
+          "erranous reply from wasm engine, mismatched id observed, expected: "
+          "{} and observed {}",
+          args.id,
+          e.id);
+        co_return;
+    }
+    if (!e.reader) {
+        throw script_failed_exception(
+          e.id,
+          fmt::format(
+            "script id {} will auto deregister due to an internal syntax "
+            "error",
+            e.id));
+    }
+    /// Use the source topic portion of the materialized topic to perform a
+    /// lookup for the relevent 'ntp_context'
+    auto materialized_ntp = model::materialized_ntp(e.ntp);
+    auto found = args.inputs.find(materialized_ntp.source_ntp());
+    if (found == args.inputs.end()) {
+        vlog(
+          coproclog.warn,
+          "script {} unknown source ntp: {}",
+          args.id,
+          materialized_ntp.source_ntp());
+        co_return;
+    }
+    auto ntp_ctx = found->second;
+    auto success = co_await write_materialized_partition(
+      materialized_ntp, std::move(*e.reader), args);
+    if (!success) {
+        vlog(coproclog.warn, "record_batch failed to pass crc checks");
+        co_return;
+    }
+    auto ofound = ntp_ctx->offsets.find(args.id);
+    vassert(
+      ofound != ntp_ctx->offsets.end(),
+      "Offset not found for script id {} for ntp owning context: {}",
+      args.id,
+      ntp_ctx->ntp());
+    /// Reset the acked offset so that progress can be made
+    ofound->second.last_acked = ofound->second.last_read;
+}
+
+ss::future<>
+write_materialized(output_write_inputs replies, output_write_args args) {
+    if (replies.empty()) {
+        vlog(
+          coproclog.error, "Wasm engine interpreted the request as erraneous");
+    } else {
+        for (auto& e : replies) {
+            co_await process_one_reply(std::move(e), args);
+        }
+    }
+}
+
+} // namespace coproc

--- a/src/v/coproc/script_context_backend.h
+++ b/src/v/coproc/script_context_backend.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "coproc/ntp_context.h"
+#include "coproc/types.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/future.hh>
+
+#include <absl/container/node_hash_map.h>
+
+namespace coproc {
+/// The outputs from a 'process_batch' call to a wasm engine
+using output_write_inputs = std::vector<process_batch_reply::data>;
+
+/// Arugments to pass to 'write_materialized', trivially copyable
+struct output_write_args {
+    coproc::script_id id;
+    storage::log_manager& log_manager;
+    ntp_context_cache& inputs;
+    absl::node_hash_map<model::ntp, mutex>& locks;
+};
+
+/**
+ * Process the wasm engines response may produce side effects within storage
+ *
+ * The output of a wasm engine may be one of three types:
+ * 1. Filter - an ack without an associated transform, bump offset & move on.
+ * 2. Normal - create/write transform to a set of materialized logs.
+ * 3. Error - Re-try or deregister script depending on error + policy.
+ *
+ * @params inputs - Output from wasm engine
+ * @params args - associated coproc state needed
+ */
+ss::future<> write_materialized(output_write_inputs, output_write_args);
+} // namespace coproc

--- a/src/v/coproc/script_context_backend.h
+++ b/src/v/coproc/script_context_backend.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "coproc/ntp_context.h"
+#include "coproc/sys_refs.h"
 #include "coproc/types.h"
 #include "utils/mutex.h"
 
@@ -26,7 +27,7 @@ using output_write_inputs = std::vector<process_batch_reply::data>;
 /// Arugments to pass to 'write_materialized', trivially copyable
 struct output_write_args {
     coproc::script_id id;
-    storage::log_manager& log_manager;
+    sys_refs& rs;
     ntp_context_cache& inputs;
     absl::node_hash_map<model::ntp, mutex>& locks;
 };

--- a/src/v/coproc/script_dispatcher.cc
+++ b/src/v/coproc/script_dispatcher.cc
@@ -178,12 +178,12 @@ script_dispatcher::enable_coprocessors(enable_copros_request req) {
     for (enable_copros_reply::data& r : reply.value().data.acks) {
         /// 1. Only continue on success
         script_id id = r.script_meta.id;
-        vlog(coproclog.debug, "Request complete: {}", id);
         if (r.ack != enable_response_code::success) {
             vlog(
               coproclog.info,
-              "wasm engine failed to register script, returned with code: "
+              "wasm engine failed to register script {}, returned with code: "
               "{}",
+              id,
               r.ack);
             continue;
         }

--- a/src/v/coproc/sys_refs.h
+++ b/src/v/coproc/sys_refs.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "seastarx.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace coproc {
+
+/// Struct of references of external layers of redpanda that coproc will
+/// leverage
+struct sys_refs {
+    ss::sharded<storage::api>& storage;
+    ss::sharded<cluster::partition_manager>& partition_manager;
+};
+
+} // namespace coproc

--- a/src/v/coproc/tests/pacemaker_tests.cc
+++ b/src/v/coproc/tests/pacemaker_tests.cc
@@ -8,6 +8,7 @@
  * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "coproc/pacemaker.h"
 #include "coproc/tests/fixtures/coproc_test_fixture.h"
 #include "coproc/tests/utils/coprocessor.h"
 #include "coproc/types.h"
@@ -178,7 +179,7 @@ FIXTURE_TEST(test_copro_auto_deregister_function, coproc_test_fixture) {
 
     /// Assert that the coproc does not exist in memory
     auto n_registered = root_fixture()
-                          ->app.pacemaker
+                          ->app.coprocessing->get_pacemaker()
                           .map_reduce0(
                             [id](coproc::pacemaker& p) {
                                 return p.local_script_id_exists(id);

--- a/src/v/coproc/tests/topic_ingestion_policy_tests.cc
+++ b/src/v/coproc/tests/topic_ingestion_policy_tests.cc
@@ -123,5 +123,5 @@ FIXTURE_TEST(test_copro_tip_stored, coproc_test_fixture) {
 
     auto results = drain(output_ntp, 80).get();
     BOOST_CHECK(results);
-    BOOST_CHECK(results->size() == 80);
+    BOOST_CHECK(results->size() >= 80);
 }

--- a/src/v/coproc/tests/topic_ingestion_policy_tests.cc
+++ b/src/v/coproc/tests/topic_ingestion_policy_tests.cc
@@ -8,6 +8,7 @@
  * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "coproc/pacemaker.h"
 #include "coproc/tests/fixtures/coproc_test_fixture.h"
 #include "coproc/tests/utils/coprocessor.h"
 #include "model/namespace.h"
@@ -44,12 +45,14 @@ public:
         /// Wait for the coprocessor to startup before next batch
         coproc::script_id id(78);
         tests::cooperative_spin_wait_with_timeout(60s, [this, id]() {
-            return root_fixture()->app.pacemaker.map_reduce0(
-              [id](coproc::pacemaker& p) {
-                  return p.local_script_id_exists(id);
-              },
-              false,
-              std::logical_or<>());
+            return root_fixture()
+              ->app.coprocessing->get_pacemaker()
+              .map_reduce0(
+                [id](coproc::pacemaker& p) {
+                    return p.local_script_id_exists(id);
+                },
+                false,
+                std::logical_or<>());
         }).get();
 
         push(

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -15,8 +15,7 @@
 #include "cluster/controller.h"
 #include "cluster/fwd.h"
 #include "cluster/rm_partition_frontend.h"
-#include "coproc/event_listener.h"
-#include "coproc/pacemaker.h"
+#include "coproc/api.h"
 #include "kafka/server/fwd.h"
 #include "kafka/server/rm_group_frontend.h"
 #include "pandaproxy/rest/configuration.h"
@@ -77,7 +76,7 @@ public:
     ss::sharded<kafka::group_router> group_router;
     ss::sharded<cluster::shard_table> shard_table;
     ss::sharded<storage::api> storage;
-    ss::sharded<coproc::pacemaker> pacemaker;
+    std::unique_ptr<coproc::api> coprocessing;
     ss::sharded<cluster::partition_manager> partition_manager;
     ss::sharded<raft::recovery_throttle> recovery_throttle;
     ss::sharded<raft::group_manager> raft_group_manager;
@@ -135,7 +134,6 @@ private:
     scheduling_groups _scheduling_groups;
     ss::logger _log;
 
-    std::unique_ptr<coproc::wasm::event_listener> _wasm_event_listener;
     ss::sharded<rpc::connection_cache> _raft_connection_cache;
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<rpc::server> _rpc;


### PR DESCRIPTION
Introducing coproc/api.h which only includes forwarding references to copro types. Application.h now only includes coproc::api therefore greatly reducing the number of includes brought into the application by coproc.

Included in the PR is a small refactoring effort brought in by another PR to spread the logical responsibilities of some coproc entities around to make things easier to understand.