### PR TITLE
Disseminating materialized topics

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -60,6 +60,7 @@ static constexpr int8_t move_partition_replicas_cmd_type = 2;
 static constexpr int8_t finish_moving_partition_replicas_cmd_type = 3;
 static constexpr int8_t update_topic_properties_cmd_type = 4;
 static constexpr int8_t create_partition_cmd_type = 5;
+static constexpr int8_t create_non_replicable_topic_cmd_type = 6;
 
 static constexpr int8_t create_user_cmd_type = 5;
 static constexpr int8_t delete_user_cmd_type = 6;
@@ -110,6 +111,12 @@ using create_partition_cmd = controller_command<
   model::topic_namespace,
   create_partititions_configuration_assignment,
   create_partition_cmd_type,
+  model::record_batch_type::topic_management_cmd>;
+
+using create_non_replicable_topic_cmd = controller_command<
+  non_replicable_topic,
+  int8_t, // unused
+  create_non_replicable_topic_cmd_type,
   model::record_batch_type::topic_management_cmd>;
 
 using create_user_cmd = controller_command<

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -60,7 +60,6 @@ controller::controller(
 ss::future<> controller::wire_up() {
     return _as.start()
       .then([this] { return _members_table.start(); })
-      .then([this] { return _partition_leaders.start(); })
       .then([this] { return _partition_allocator.start_single(); })
       .then([this] { return _credentials.start(); })
       .then([this] { return _authorizer.start(); })
@@ -79,6 +78,7 @@ ss::future<> controller::start() {
              config::shard_local_cfg().data_directory().as_sstring(),
              std::move(initial_raft0_brokers))
       .then([this](consensus_ptr c) { _raft0 = c; })
+      .then([this] { return _partition_leaders.start(std::ref(_tp_state)); })
       .then([this] {
           return _members_manager.start_single(
             _raft0,

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -503,6 +503,11 @@ controller_backend::execute_partitition_op(const topic_table::delta& delta) {
           rev,
           create_brokers_set(
             delta.new_assignment.replicas, _members_table.local()));
+    case op_t::add_non_replicable:
+        if (!has_local_replicas(_self, delta.new_assignment.replicas)) {
+            return ss::make_ready_future<std::error_code>(errc::success);
+        }
+        return create_non_replicable_partition(delta.ntp, rev);
     case op_t::del:
         return delete_partition(delta.ntp, rev);
     case op_t::update:
@@ -853,6 +858,18 @@ ss::future<> controller_backend::add_to_shard_table(
       });
 }
 
+ss::future<> controller_backend::add_to_shard_table(
+  model::ntp ntp, ss::shard_id shard, model::revision_id revision) {
+    vlog(
+      clusterlog.trace, "adding {} to shard table at {}", revision, ntp, shard);
+    return _shard_table.invoke_on_all(
+      [ntp = std::move(ntp), shard, revision](shard_table& s) mutable {
+          vassert(
+            s.update_shard(ntp, shard, revision),
+            "Newer revision for non-replicable ntp exists");
+      });
+}
+
 ss::future<> controller_backend::remove_from_shard_table(
   model::ntp ntp, raft::group_id raft_group, model::revision_id revision) {
     // update shard_table: broadcast
@@ -861,6 +878,22 @@ ss::future<> controller_backend::remove_from_shard_table(
       [ntp = std::move(ntp), raft_group, revision](shard_table& s) mutable {
           s.erase(ntp, raft_group, revision);
       });
+}
+
+ss::future<std::error_code> controller_backend::create_non_replicable_partition(
+  model::ntp ntp, model::revision_id rev) {
+    auto cfg = _topics.local().get_topic_cfg(model::topic_namespace_view(ntp));
+    if (!cfg) {
+        // partition was already removed, do nothing
+        co_return errc::success;
+    }
+    vassert(
+      !_storage.local().log_mgr().get(ntp),
+      "Log exists for missing entry in topics_table");
+    auto ntp_cfg = cfg->make_ntp_config(_data_directory, ntp.tp.partition, rev);
+    co_await _storage.local().log_mgr().manage(std::move(ntp_cfg));
+    co_await add_to_shard_table(std::move(ntp), ss::this_shard_id(), rev);
+    co_return errc::success;
 }
 
 ss::future<std::error_code> controller_backend::create_partition(

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -100,6 +100,10 @@ private:
       raft::group_id,
       model::revision_id,
       std::vector<model::broker>);
+    ss::future<std::error_code>
+      create_non_replicable_partition(model::ntp, model::revision_id);
+    ss::future<>
+      add_to_shard_table(model::ntp, ss::shard_id, model::revision_id);
     ss::future<> add_to_shard_table(
       model::ntp, raft::group_id, ss::shard_id, model::revision_id);
     ss::future<>

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -53,7 +53,7 @@ enum class errc : int16_t {
     partition_configuration_differs,
     data_policy_already_exists,
     data_policy_not_exists,
-
+    source_topic_not_exists
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -144,6 +144,10 @@ struct errc_category final : public std::error_category {
             return "Data-policy already exists";
         case errc::data_policy_not_exists:
             return "Data-policy does not exist";
+        case errc::source_topic_not_exists:
+            return "Attempted to create a non_replicable log for a source "
+                   "topic "
+                   "that does not exist";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -53,7 +53,8 @@ enum class errc : int16_t {
     partition_configuration_differs,
     data_policy_already_exists,
     data_policy_not_exists,
-    source_topic_not_exists
+    source_topic_not_exists,
+    invalid_delete_topic_request
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -148,6 +149,8 @@ struct errc_category final : public std::error_category {
             return "Attempted to create a non_replicable log for a source "
                    "topic "
                    "that does not exist";
+        case errc::invalid_delete_topic_request:
+            return "Requested to delete a non replicable topic is invalid";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -11,10 +11,13 @@
 
 #pragma once
 
+#include "cluster/fwd.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "utils/concepts-enabled.h"
 #include "utils/expiring_promise.h"
+
+#include <seastar/core/sharded.hh>
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/node_hash_map.h>
@@ -28,7 +31,7 @@ namespace cluster {
 /// received by cluster::metadata_dissemination_service.
 class partition_leaders_table {
 public:
-    partition_leaders_table() = default;
+    explicit partition_leaders_table(ss::sharded<topic_table>&);
 
     ss::future<> stop();
 
@@ -141,6 +144,8 @@ private:
       absl::node_hash_map<int32_t, expiring_promise<model::node_id>>>;
 
     promises_t _leader_promises;
+
+    ss::sharded<topic_table>& _topic_table;
 };
 
 } // namespace cluster

--- a/src/v/cluster/shard_table.h
+++ b/src/v/cluster/shard_table.h
@@ -57,6 +57,17 @@ public:
         return success;
     }
 
+    bool update_shard(
+      const model::ntp& ntp, ss::shard_id i, model::revision_id rev) {
+        if (auto it = _ntp_idx.find(ntp); it != _ntp_idx.end()) {
+            if (it->second.revision > rev) {
+                return false;
+            }
+        }
+        _ntp_idx.insert_or_assign(ntp, shard_revision{i, rev});
+        return true;
+    }
+
     void update(
       const model::ntp& ntp,
       raft::group_id g,

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -304,6 +304,11 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     co_return make_error_code(errc::success);
 }
 
+ss::future<std::error_code>
+topic_table::apply(create_non_replicable_topic_cmd cmd, model::offset o) {
+    co_return make_error_code(errc::topic_operation_error);
+}
+
 void topic_table::notify_waiters() {
     if (_waiters.empty()) {
         return;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -97,6 +97,10 @@ ss::future<> topic_table::stop() {
 ss::future<std::error_code>
 topic_table::apply(delete_topic_cmd cmd, model::offset offset) {
     if (auto tp = _topics.find(cmd.value); tp != _topics.end()) {
+        if (tp->second.is_topic_replicable()) {
+            return ss::make_ready_future<std::error_code>(
+              errc::invalid_delete_topic_request);
+        }
         for (auto& p : tp->second.configuration.assignments) {
             auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, p.id);
             _pending_deltas.emplace_back(

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -37,6 +37,35 @@ topic_table::transform_topics(Func&& f) const {
     return ret;
 }
 
+topic_table::topic_metadata::topic_metadata(
+  topic_configuration_assignment c, model::revision_id rid) noexcept
+  : configuration(std::move(c))
+  , _id_or_topic(rid) {}
+
+topic_table::topic_metadata::topic_metadata(
+  topic_configuration_assignment c, model::topic st) noexcept
+  : configuration(std::move(c))
+  , _id_or_topic(std::move(st)) {}
+
+bool topic_table::topic_metadata::is_topic_replicable() const {
+    return std::holds_alternative<model::topic>(_id_or_topic);
+}
+model::revision_id topic_table::topic_metadata::get_revision() const {
+    vassert(
+      !is_topic_replicable(), "Query for revision_id on a replicable topic");
+    return std::get<model::revision_id>(_id_or_topic);
+}
+const model::topic& topic_table::topic_metadata::get_source_topic() const {
+    vassert(is_topic_replicable(), "Query for source_topic on a normal topic");
+    return std::get<model::topic>(_id_or_topic);
+}
+const topic_configuration_assignment&
+topic_table::topic_metadata::get_configuration() const {
+    vassert(
+      !is_topic_replicable(), "Query for configuration on a replicable topic");
+    return configuration;
+}
+
 ss::future<std::error_code>
 topic_table::apply(create_topic_cmd cmd, model::offset offset) {
     if (_topics.contains(cmd.key)) {
@@ -53,10 +82,7 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
 
     _topics.insert(
       {cmd.key,
-       topic_metadata{
-         .configuration = std::move(cmd.value),
-         .revision = model::revision_id(offset()),
-       }});
+       topic_metadata(std::move(cmd.value), model::revision_id(offset()))});
     notify_waiters();
     return ss::make_ready_future<std::error_code>(errc::success);
 }
@@ -85,7 +111,7 @@ topic_table::apply(delete_topic_cmd cmd, model::offset offset) {
 ss::future<std::error_code>
 topic_table::apply(create_partition_cmd cmd, model::offset offset) {
     auto tp = _topics.find(cmd.key);
-    if (tp == _topics.end()) {
+    if (tp == _topics.end() || tp->second.is_topic_replicable()) {
         co_return errc::topic_not_exists;
     }
 
@@ -110,7 +136,7 @@ topic_table::apply(create_partition_cmd cmd, model::offset offset) {
 ss::future<std::error_code>
 topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
     auto tp = _topics.find(model::topic_namespace_view(cmd.key));
-    if (tp == _topics.end()) {
+    if (tp == _topics.end() || tp->second.is_topic_replicable()) {
         return ss::make_ready_future<std::error_code>(errc::topic_not_exists);
     }
 
@@ -159,7 +185,7 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
 ss::future<std::error_code>
 topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
     auto tp = _topics.find(model::topic_namespace_view(cmd.key));
-    if (tp == _topics.end()) {
+    if (tp == _topics.end() || tp->second.is_topic_replicable()) {
         return ss::make_ready_future<std::error_code>(errc::topic_not_exists);
     }
 
@@ -240,7 +266,7 @@ void incremental_update(
 ss::future<std::error_code>
 topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     auto tp = _topics.find(cmd.key);
-    if (tp == _topics.end()) {
+    if (tp == _topics.end() || tp->second.is_topic_replicable()) {
         co_return make_error_code(errc::topic_not_exists);
     }
     auto& properties = tp->second.configuration.cfg.properties;
@@ -377,7 +403,7 @@ bool topic_table::contains(
 std::optional<cluster::partition_assignment>
 topic_table::get_partition_assignment(const model::ntp& ntp) const {
     auto it = _topics.find(model::topic_namespace_view(ntp));
-    if (it == _topics.end()) {
+    if (it == _topics.end() || it->second.is_topic_replicable()) {
         return {};
     }
 

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -34,9 +34,21 @@ namespace cluster {
 class topic_table {
 public:
     using delta = topic_table_delta;
-    struct topic_metadata {
+    class topic_metadata {
+    public:
+        topic_metadata(
+          topic_configuration_assignment, model::revision_id) noexcept;
+        topic_metadata(topic_configuration_assignment, model::topic) noexcept;
+
+        bool is_topic_replicable() const;
+        model::revision_id get_revision() const;
+        const model::topic& get_source_topic() const;
+        const topic_configuration_assignment& get_configuration() const;
+
+    private:
+        friend class topic_table;
         topic_configuration_assignment configuration;
-        model::revision_id revision;
+        std::variant<model::revision_id, model::topic> _id_or_topic;
     };
     using underlying_t = absl::flat_hash_map<
       model::topic_namespace,

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -86,7 +86,8 @@ public:
       move_partition_replicas_cmd,
       finish_moving_partition_replicas_cmd,
       update_topic_properties_cmd,
-      create_partition_cmd>{};
+      create_partition_cmd,
+      create_non_replicable_topic_cmd>{};
 
     /// State machine applies
     ss::future<std::error_code> apply(create_topic_cmd, model::offset);
@@ -98,6 +99,8 @@ public:
     ss::future<std::error_code>
       apply(update_topic_properties_cmd, model::offset);
     ss::future<std::error_code> apply(create_partition_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(create_non_replicable_topic_cmd, model::offset);
     ss::future<> stop();
 
     /// Delta API

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -95,6 +95,9 @@ topic_updates_dispatcher::apply_update(model::record_batch b) {
                       }
                       return ec;
                   });
+            },
+            [this, base_offset](create_non_replicable_topic_cmd cmd) {
+                return dispatch_updates_to_cores(std::move(cmd), base_offset);
             });
       });
 }

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -59,7 +59,8 @@ public:
       move_partition_replicas_cmd,
       finish_moving_partition_replicas_cmd,
       update_topic_properties_cmd,
-      create_partition_cmd>();
+      create_partition_cmd,
+      create_non_replicable_topic_cmd>();
 
     bool is_batch_applicable(const model::record_batch& batch) const {
         return batch.header().type

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -242,6 +242,60 @@ ss::future<topic_result> topics_frontend::do_update_topic_properties(
     }
 }
 
+ss::future<topic_result> topics_frontend::do_create_non_replicable_topic(
+  non_replicable_topic data, model::timeout_clock::time_point timeout) {
+    if (!validate_topic_name(data.name)) {
+        co_return topic_result(
+          topic_result(std::move(data.name), errc::invalid_topic_name));
+    }
+
+    create_non_replicable_topic_cmd cmd(data, 0);
+    try {
+        auto ec = co_await replicate_and_wait(
+          _stm, _as, std::move(cmd), timeout);
+        co_return topic_result(data.name, map_errc(ec));
+    } catch (const std::exception& ex) {
+        vlog(
+          clusterlog.warn,
+          "unable to create non replicated topic {} - source topic - {} "
+          "reason: "
+          "{}",
+          data.name,
+          data.source,
+          ex.what());
+        co_return topic_result(std::move(data.name), errc::replication_error);
+    }
+}
+
+ss::future<std::vector<topic_result>>
+topics_frontend::create_non_replicable_topics(
+  std::vector<non_replicable_topic> topics,
+  model::timeout_clock::time_point timeout) {
+    vlog(clusterlog.trace, "Create non_replicable topics {}", topics);
+    std::vector<ss::future<topic_result>> futures;
+    futures.reserve(topics.size());
+
+    std::transform(
+      std::begin(topics),
+      std::end(topics),
+      std::back_inserter(futures),
+      [this, timeout](non_replicable_topic& d) {
+          return do_create_non_replicable_topic(std::move(d), timeout);
+      });
+
+    return ss::when_all_succeed(futures.begin(), futures.end())
+      .then([this, timeout](std::vector<topic_result> results) {
+          if (needs_linearizable_barrier(results)) {
+              return stm_linearizable_barrier(timeout).then(
+                [results = std::move(results)](result<model::offset>) mutable {
+                    return results;
+                });
+          }
+          return ss::make_ready_future<std::vector<topic_result>>(
+            std::move(results));
+      });
+}
+
 topic_result
 make_error_result(const model::topic_namespace& tp_ns, std::error_code ec) {
     if (ec.category() == cluster::error_category()) {

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -68,6 +68,9 @@ public:
       std::vector<create_partititions_configuration>,
       model::timeout_clock::time_point);
 
+    ss::future<std::vector<topic_result>> create_non_replicable_topics(
+      std::vector<non_replicable_topic>, model::timeout_clock::time_point);
+
     ss::future<bool> validate_shard(model::node_id node, uint32_t shard) const;
 
 private:
@@ -81,6 +84,9 @@ private:
 
     ss::future<topic_result>
       do_delete_topic(model::topic_namespace, model::timeout_clock::time_point);
+
+    ss::future<topic_result> do_create_non_replicable_topic(
+      non_replicable_topic, model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_result>> dispatch_create_to_leader(
       model::node_id,

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -212,6 +212,8 @@ operator<<(std::ostream& o, const topic_table_delta::op_type& tp) {
         return o << "update_finished";
     case topic_table_delta::op_type::update_properties:
         return o << "update_properties";
+    case topic_table_delta::op_type::add_non_replicable:
+        return o << "add_non_replicable_addition";
     }
     __builtin_unreachable();
 }
@@ -242,7 +244,7 @@ std::ostream& operator<<(std::ostream& o, const backend_operation& op) {
 
 std::ostream& operator<<(std::ostream& o, const non_replicable_topic& d) {
     fmt::print(
-      o, "{{Source topic: {}, materialized topic: {}}}", d.source, d.name);
+      o, "{{Source topic: {}, non replicable topic: {}}}", d.source, d.name);
     return o;
 }
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -517,7 +517,14 @@ private:
 };
 // delta propagated to backend
 struct topic_table_delta {
-    enum class op_type { add, del, update, update_finished, update_properties };
+    enum class op_type {
+        add,
+        del,
+        update,
+        update_finished,
+        update_properties,
+        add_non_replicable
+    };
 
     topic_table_delta(
       model::ntp,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -586,6 +586,13 @@ struct create_data_policy_cmd_data {
     v8_engine::data_policy dp;
 };
 
+struct non_replicable_topic {
+    static constexpr int8_t current_version = 1;
+    model::topic_namespace source;
+    model::topic_namespace name;
+};
+std::ostream& operator<<(std::ostream&, const non_replicable_topic&);
+
 enum class reconciliation_status : int8_t {
     done,
     in_progress,
@@ -770,6 +777,12 @@ template<>
 struct adl<cluster::create_data_policy_cmd_data> {
     void to(iobuf&, cluster::create_data_policy_cmd_data&&);
     cluster::create_data_policy_cmd_data from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::non_replicable_topic> {
+    void to(iobuf& out, cluster::non_replicable_topic&&);
+    cluster::non_replicable_topic from(iobuf_parser&);
 };
 
 } // namespace reflection

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -31,6 +31,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::topic_already_exists:
         return error_code::topic_already_exists;
     case cluster::errc::topic_not_exists:
+    case cluster::errc::invalid_delete_topic_request:
         return error_code::unknown_topic_or_partition;
     case cluster::errc::timeout:
         return error_code::request_timed_out;

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -104,6 +104,43 @@ public:
         client.stop().then([&client] { client.shutdown(); }).get();
     }
 
+    void test_create_non_replicable_topic(
+      model::topic src, kafka::create_topics_request req) {
+        std::vector<cluster::non_replicable_topic> non_reps;
+        std::transform(
+          req.data.topics.begin(),
+          req.data.topics.end(),
+          std::back_inserter(non_reps),
+          [&src](const kafka::creatable_topic& t) {
+              return cluster::non_replicable_topic{
+                .source = model::topic_namespace{model::kafka_namespace, src},
+                .name = model::topic_namespace{model::kafka_namespace, t.name}};
+          });
+
+        // Creating a materialized topic is not part of the kafka API
+        // Must do this through the cluster::topics_frontend class
+        auto& topics_frontend = app.controller->get_topics_frontend();
+        const auto resp = topics_frontend.local()
+                            .create_non_replicable_topics(
+                              std::move(non_reps), model::no_timeout)
+                            .get();
+        BOOST_TEST(
+          std::all_of(
+            std::cbegin(resp),
+            std::cend(resp),
+            [](const cluster::topic_result& t) {
+                return t.ec == cluster::errc::success;
+            }),
+          fmt::format("expected no errors. received response: {}", resp));
+
+        auto client = make_kafka_client().get0();
+        client.connect().get();
+        for (auto& topic : req.data.topics) {
+            verify_metadata(client, req, topic);
+        }
+        client.stop().then([&client] { client.shutdown(); }).get();
+    }
+
     void verify_metadata(
       kafka::client::transport& client,
       kafka::create_topics_request& create_req,
@@ -230,4 +267,12 @@ FIXTURE_TEST_EXPECTED_FAILURES(create_topics, create_topic_fixture, 2) {
       topicReq("topic11", assignment = Map(0 -> List(0, 1), 1 -> List(1, 0), 2 -> List(1, 2)))),
       validateOnly = true))
 #endif
+}
+
+FIXTURE_TEST(create_non_replicable_topics, create_topic_fixture) {
+    wait_for_controller_leadership().get();
+
+    test_create_topic(make_req({make_topic("topic1")}));
+    test_create_non_replicable_topic(
+      model::topic("topic1"), make_req({make_topic("topic2")}));
 }

--- a/src/v/kafka/server/tests/delete_topics_test.cc
+++ b/src/v/kafka/server/tests/delete_topics_test.cc
@@ -55,6 +55,17 @@ public:
           = client.dispatch(std::move(req), kafka::api_version(2)).get0();
     }
 
+    void create_non_replicable_topic(ss::sstring src, ss::sstring name) {
+        cluster::non_replicable_topic nrt{
+          .source = model::
+            topic_namespace{model::kafka_namespace, model::topic(std::move(src))},
+          .name = model::topic_namespace{
+            model::kafka_namespace, model::topic(std::move(name))}};
+        auto& topics_frontend = app.controller->get_topics_frontend();
+        const auto resp = topics_frontend.local().create_non_replicable_topics(
+          {std::move(nrt)}, model::no_timeout);
+    }
+
     kafka::delete_topics_response
     send_delete_topics_request(kafka::delete_topics_request req) {
         auto client = make_kafka_client().get0();
@@ -153,6 +164,20 @@ FIXTURE_TEST(delete_valid_topics, delete_topics_request_fixture) {
     // Multi topic
     validate_valid_delete_topics_request(make_delete_topics_request(
       {model::topic("topic-2"), model::topic("topic-3")}, 10s));
+}
+
+FIXTURE_TEST(delete_non_replicable_topics, delete_topics_request_fixture) {
+    wait_for_controller_leadership().get();
+
+    // Until subsequent changes, its illegal to delete a non_replicable topic
+    create_topic("topic-1", 1, 1);
+    create_non_replicable_topic("topic-1", "topic-5");
+    auto resp = send_delete_topics_request(
+      make_delete_topics_request({model::topic("topic-5")}, 10s));
+    for (const auto& r : resp.data.responses) {
+        BOOST_REQUIRE_EQUAL(
+          r.error_code, kafka::error_code::unknown_topic_or_partition);
+    }
 }
 
 #if 0

--- a/src/v/kafka/server/tests/find_coordinator_test.cc
+++ b/src/v/kafka/server/tests/find_coordinator_test.cc
@@ -49,3 +49,28 @@ FIXTURE_TEST(find_coordinator, redpanda_thread_fixture) {
     BOOST_TEST(resp.data.host == "127.0.0.1");
     BOOST_TEST(resp.data.port == 9092);
 }
+
+FIXTURE_TEST(
+  find_coordinator_for_non_replicatable_topic, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get();
+    model::topic_namespace src{model::kafka_namespace, model::topic("src")};
+    model::topic_namespace dst{model::kafka_namespace, model::topic("dst")};
+    add_topic(src).get();
+    add_non_replicable_topic(std::move(src), std::move(dst)).get();
+
+    auto client = make_kafka_client().get0();
+    client.connect().get();
+    kafka::find_coordinator_request req("src");
+    kafka::find_coordinator_request req2("dst");
+    std::vector<kafka::find_coordinator_response> resps;
+    resps.push_back(client.dispatch(req, kafka::api_version(1)).get0());
+    resps.push_back(client.dispatch(req2, kafka::api_version(1)).get0());
+    client.stop().then([&client] { client.shutdown(); }).get();
+
+    for (const auto& r : resps) {
+        BOOST_TEST(r.data.error_code == kafka::error_code::none);
+        BOOST_TEST(r.data.node_id == model::node_id(1));
+        BOOST_TEST(r.data.host == "127.0.0.1");
+        BOOST_TEST(r.data.port == 9092);
+    }
+}

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -46,6 +46,14 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         }).get0();
     }
 
+    void start_non_replicable() {
+        start();
+        model::topic_namespace tp_ns_src(model::ns("kafka"), test_topic);
+        model::topic_namespace tp_ns(
+          model::ns("kafka"), model::topic("non_replicable_topic"));
+        add_non_replicable_topic(std::move(tp_ns_src), std::move(tp_ns)).get();
+    }
+
     std::vector<kafka::produce_request::partition> small_batches(size_t count) {
         storage::record_batch_builder builder(
           model::record_batch_type::raft_data, model::offset(0));
@@ -159,3 +167,23 @@ FIXTURE_TEST(test_produce_consume_small_batches, prod_consume_fixture) {
       resp_2.data.topics.begin()->partitions.begin()->records->last_offset(),
       offset_2);
 };
+
+FIXTURE_TEST(test_cannot_produce_onto_non_replicable, prod_consume_fixture) {
+    wait_for_controller_leadership().get0();
+    start_non_replicable();
+    std::vector<kafka::produce_request::topic> topics;
+    topics.push_back(kafka::produce_request::topic{
+      .name = model::topic("non_replicable_topic"),
+      .partitions = small_batches(1)});
+    kafka::produce_request req(std::nullopt, 1, std::move(topics));
+    req.data.timeout_ms = std::chrono::seconds(2);
+    req.has_idempotent = false;
+    req.has_transactional = false;
+    kafka::produce_response r = producer->dispatch(std::move(req)).get0();
+    BOOST_REQUIRE_EQUAL(r.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(r.data.responses[0].name(), "non_replicable_topic");
+    BOOST_REQUIRE_EQUAL(r.data.responses.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      r.data.responses[0].partitions[0].error_code,
+      kafka::error_code::unknown_topic_or_partition);
+}


### PR DESCRIPTION
This PR introduces changes to cluster that will aid in having materialized topics appear as first class citizens within redpanda. 

Previously materialized topics were just `storage::log`'s, with no visibility within the cluster level. The system worked because of a special naming schema for materialized topics. When this schema was detected, queries within the storage layer were made. This works in distributed deployments due to the fact that the same coprocessor is running and performing its transforms on all nodes.

 Its desirable to move away from this to have better integration within the kafka API. Things like list topics and topics offsets won't work because crucial data structures which contain topic metadata don't have any information about materialized topics.

This PR attempts to solve that by populating these core data structures with materialized topics/ntps, when applicable. A new command has also been created to explicitly disseminate the event of materialized topic creation. 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/3c7643925ee096b69e4b0407eaf24f02b033aa44..d7505aed722057224e34a11d3ba43540d8dcb4dc)
- Modified create_materialized_topic command to use an unused int8_t as its value, to prevent including unnecessary data in requests.
- Removed the necessity for the partition leaders table to be filled with materialized ntps
- This removed the necessity for the metadata_dissemention_service to be modified at all
- Removed the added `source_topic` field from `topic_properties`. As this structure gets serialized to disk and adding a field here will cause issues since our RPC doesn't yet contain a versioning schema. The solution was at add this property to `cluster::topic_metadata` instead.
- Removed the commit that edited produce.cc. It claimed to prevent users from producing onto materialized topics but all it really did was return an error code other then what would have been returned if the change wasn't there. Without this commit users will see `topic_or_partition_not_exists` as an error when attempting to produce onto a materialized topic.
- Added a unit test 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/d7505aed722057224e34a11d3ba43540d8dcb4dc..61076a4a2d150e9ec66f027297a3c0ae10e9d8b9)
- Mistake, added and removed the commit preceding the first commit in this PR.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/61076a4a2d150e9ec66f027297a3c0ae10e9d8b9..5c2c778ae8a4d9aa6c5d8f5f104a2cecf9e84903)
- Resolved conflicts with two files by rebasing against latest dev

Changes in [force-pushes 5c2c778 to fb23995](https://github.com/vectorizedio/redpanda/compare/5c2c778ae8a4d9aa6c5d8f5f104a2cecf9e84903..fb23995a51a90dfca6fca2d7d28fe5a42bda8c0c)
- Added this [commit](https://github.com/vectorizedio/redpanda/pull/2344/commits/aead604e8764f1a036a762467bf2e95e5f54a2bc) which addresses an issue Noah brought up with the type system around the `cluster::topic_metadata` type.
- Added additional error checking in controller_backend.cc
- Moved methods implementation (topic_table::materialized_children) out of a its header file into src

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/fb23995a51a90dfca6fca2d7d28fe5a42bda8c0c..f60dbdd7a0fde2e02a37625dd306710b11aee5f2)
- Removed commit about materialized topic hierarchy. Method added was unused after previous force pushes.
- Did a large rename. Removed all references to 'materialized_topics/partitions' and changed the name to 'non_replicated_topics/partitons'. Since cluster doesn't depend on v/coproc it should not contain these types of references to it, even if they are just naming schemes. Also if there is another need for non_replicated topics, it can reuse the same infra without having coproc* naming conventions attached. 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/f60dbdd7a0fde2e02a37625dd306710b11aee5f2..b3b5e04864e6df6243fcd034a407db89cf28de9e)
- Another name change. Changed `non_replicated_topics` -> `non_replicable_topics`
- Implemented much more testing, covered all of the cases Noah listed
- Changed the command integer number value from 10 to 6

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/b3b5e04864e6df6243fcd034a407db89cf28de9e..478e7ceec0a86a5f342bcff464a78cfeb155b8b3)
- Asserted on some conditions which shouldn't make sense to handle in controller backend
- Addressing Michal & Vadims comments

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/478e7ceec0a86a5f342bcff464a78cfeb155b8b3..8afb3ec56b22c686ce5337008b17a7b83c5fbbd2)
- New method to force public methods to query a topic config via an accessor which will throw if topic is of the new type `not_replicable`. The idea is to prevent any code paths from accidentally doing something to a non_replicable topic assuming its a normal one.  