### PR TITLE
r/mux_stm: wait for gate closed before invalidating pending promises

### DIFF
--- a/src/v/utils/expiring_promise.h
+++ b/src/v/utils/expiring_promise.h
@@ -81,7 +81,6 @@ public:
 
     void set_exception(std::exception_ptr&& ex) {
         if (_timer.cancel()) {
-            _promise.set_exception(ex);
             unlink_abort_source();
         }
 

--- a/src/v/utils/expiring_promise.h
+++ b/src/v/utils/expiring_promise.h
@@ -34,13 +34,13 @@ public:
             if (as) {
                 auto opt_sub = as.value().get().subscribe([this]() noexcept {
                     if (_timer.cancel()) {
-                        _promise.set_exception(ss::abort_requested_exception{});
+                        set_exception(ss::abort_requested_exception{});
                     }
                 });
                 if (opt_sub) {
                     _sub = std::move(*opt_sub);
                 } else {
-                    _promise.set_exception(ss::abort_requested_exception{});
+                    set_exception(ss::abort_requested_exception{});
                     return _promise.get_shared_future();
                 }
             }
@@ -54,9 +54,9 @@ public:
 
                   // if errors are encoded in values f.e. result<T> or errc
                   if constexpr (is_result || is_std_error_code) {
-                      _promise.set_value(ef());
+                      set_value(ef());
                   } else {
-                      _promise.set_exception(ef());
+                      set_exception(ef());
                   }
                   unlink_abort_source();
               });
@@ -98,6 +98,10 @@ public:
         if (!_promise.available()) {
             _promise.set_exception(ex);
         }
+    }
+
+    void set_exception(const std::exception& ex) {
+        set_exception(std::make_exception_ptr(ex));
     }
 
 private:


### PR DESCRIPTION
When mux state machine is being shut down we need to wait for all the
fibers protected by gate to finish since even if gate was closed it may
happen that new promises will be inserted into the promises map. Waiting
for gate to be closed before invalidating pending promises guarantees
that no new promises will be inserted into the map after pending
promises were invalidated and `set_value` will never be called twice on
the same promise

Signed-off-by: Michal Maslanka <michal@vectorized.io>
