### PR TITLE
Fix removing config when prefix truncating

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -96,3 +96,83 @@ class RetentionPolicyTest(RedpandaTest):
                    timeout_sec=120,
                    backoff_sec=5,
                    err_msg="Segments were not removed")
+
+    @cluster(num_nodes=3)
+    def test_changing_topic_retention_with_restart(self):
+        """
+        Test changing topic retention duration for topics with data produced 
+        with ACKS=1 and ACKS=-1. This test produces data until 10 segments 
+        appear, then it changes retention topic property and waits for some 
+        segmetnts to be removed
+        """
+        segment_size = 1048576
+
+        # produce until segments have been compacted
+        self._produce_until_segments(self.topic, 0, 20, -1)
+
+        # restart all nodes to force replicating raft configuration
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        kafka_tools = KafkaCliTools(self.redpanda)
+        # change retention bytes to preserve 15 segments
+        kafka_tools.alter_topic_config(
+            self.topic, {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 15 * segment_size,
+            })
+        self._wait_for_segments_removal(self.topic, 0, 16)
+
+        # change retention bytes again to preserve 10 segments
+        kafka_tools.alter_topic_config(
+            self.topic, {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 10 * segment_size,
+            })
+        self._wait_for_segments_removal(self.topic, 0, 11)
+
+        # change retention bytes again to preserve 5 segments
+        kafka_tools.alter_topic_config(
+            self.topic, {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 4 * segment_size,
+            })
+        self._wait_for_segments_removal(self.topic, 0, 5)
+
+    def _segments_count(self, topic, partition_idx):
+        storage = self.redpanda.storage()
+        topic_partitions = storage.partitions("kafka", topic)
+
+        return map(lambda p: len(p.segments),
+                   filter(lambda p: p.num == partition_idx, topic_partitions))
+
+    def _produce_until_segments(self, topic, partition_idx, count, acks):
+        """
+        Produce into the topic until given number of segments will appear 
+        """
+        kafka_tools = KafkaCliTools(self.redpanda)
+
+        def done():
+            kafka_tools.produce(topic, 10000, 1024, acks=acks)
+            topic_partitions = self._segments_count(topic, partition_idx)
+            partitions = []
+            for p in topic_partitions:
+                partitions.append(p >= count)
+            return all(partitions)
+
+        wait_until(done,
+                   timeout_sec=120,
+                   backoff_sec=2,
+                   err_msg="Segments were not created")
+
+    def _wait_for_segments_removal(self, topic, partition_idx, count):
+        """
+        Wait until only given number of segments will left in a partitions
+        """
+        def done():
+            topic_partitions = self._segments_count(topic, partition_idx)
+            partitions = []
+            for p in topic_partitions:
+                partitions.append(p <= count)
+            return all(partitions)
+
+        wait_until(done,
+                   timeout_sec=120,
+                   backoff_sec=5,
+                   err_msg="Segments were not removed")


### PR DESCRIPTION
## Cover Letter
Recently introduced changes in configuration manager were intended to solve the problem of not being required to add the configuration to manager before prefix truncation. Recently introduced configuration insert related with prefix truncate was incomplete. We correctly handled situation in which prefix truncate offset was larger than the last one stored in configuration manager, but we missed inserting configuration at prefix truncate offset when prefix truncation happened in between existing configurations. This way configuration manager was missing configuration for part of the log which triggered an assertion when trying to create a snapshot.

### Example

#### Legend
Each `[<offset>]` denotes single configuration stored in configuration manager at `offset`


##### Previously correctly handled case

configuration in manager before prefix truncate:

```
[0][100][200]
```

prefix truncate at `400`, after:

```
[400] <-- configuration from offset 200
```

##### Case triggering an error

configuration in manager before prefix truncate:

```
[0][1000][4000]
```

prefix truncate at `1500`, after

```
[4000] <-- error we do not have configuration for range [1500,4000)
```

#### After applying the fix
```
[1500][4000] <-- correct, configuration from offset 1000 is valid for [1500,4000)
```