### PR TITLE
tests: reinstate tests that were silently not running

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -140,22 +140,24 @@ class RpkTool:
     def cluster_info(self, timeout=None):
         # Matches against `rpk cluster info`'s output & parses the brokers'
         # ID & address. Example:
-        #
-        #  Redpanda Cluster Info
-        #
-        #  1 (192.168.52.1:9092)  (No partitions)
-        #
-        #  2 (192.168.52.2:9092)  (No partitions)
-        #
-        #  3 (192.168.52.3:9092)  (No partitions)
-        #
+
+        # BROKERS
+        # =======
+        # ID    HOST  PORT
+        # 1*    n1    9092
+        # 2     n2    9092
+        # 3     n3    9092
+
         def _parse_out(line):
-            m = re.match(r" *(?P<id>\d) \((?P<addr>.+\:[0-9]+)\) *", line)
+            m = re.match(
+                r"^(?P<id>\d+)[\s*]+(?P<host>[^\s]+)\s+(?P<port>\d+)$",
+                line.strip())
             if m is None:
                 return None
 
-            return RpkClusterInfoNode(id=int(m.group('id')),
-                                      address=m.group('addr'))
+            address = f"{m.group('host')}:{m.group('port')}"
+
+            return RpkClusterInfoNode(id=int(m.group('id')), address=address)
 
         cmd = [
             self._rpk_binary(), 'cluster', 'info', '--brokers',

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -10,6 +10,7 @@ import random
 
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
+from ducktape.mark.resource import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -42,7 +42,7 @@ class DescribeTopicsTest(RedpandaTest):
                     return False
             # and targetted topic describe
             topics_described = [
-                client.describe_topic(topic) for topic in topics
+                client.describe_topic(topic.name) for topic in topics
             ]
             for meta in zip(topics, topics_described):
                 if meta[0].partition_count != meta[1].partition_count:

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -20,7 +20,7 @@ class DescribeTopicsTest(RedpandaTest):
     @cluster(num_nodes=3)
     def test_describe_topics(self):
         big = self.scale.ci or self.scale.release
-        num_topics = 100 if big else 2
+        num_topics = 20 if big else 2
 
         topics = [
             TopicSpec(partition_count=random.randint(1, 20),

--- a/tests/rptest/tests/kafka_client_compat_test.py
+++ b/tests/rptest/tests/kafka_client_compat_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -23,11 +23,14 @@ class LogLevelTest(RedpandaTest):
         admin = Admin(self.redpanda)
         node = self.redpanda.nodes[0]
 
-        # set to warn level. message seen at info
+        # This test assumes the default log level while testing is trace
+        default_log_level = "trace"
+
+        # set to warn level. message seen at trace
         with self.redpanda.monitor_log(node) as mon:
             admin.set_log_level("admin_api_server", "warn")
             mon.wait_until(
-                "Set log level for {admin_api_server}: info -> warn",
+                f"Set log level for {{admin_api_server}}: {default_log_level} -> warn",
                 timeout_sec=5,
                 backoff_sec=1,
                 err_msg="Never saw message")
@@ -56,7 +59,8 @@ class LogLevelTest(RedpandaTest):
 
         with self.redpanda.monitor_log(node) as mon:
             admin.set_log_level("admin_api_server", "debug", expires=5)
-            mon.wait_until("Expiring log level for {admin_api_server} to info",
-                           timeout_sec=10,
-                           backoff_sec=1,
-                           err_msg="Never saw message")
+            mon.wait_until(
+                f"Expiring log level for {{admin_api_server}} to {default_log_level}",
+                timeout_sec=10,
+                backoff_sec=1,
+                err_msg="Never saw message")

--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 import ducktape.errors
 from ducktape.utils.util import wait_until
+from ducktape.mark.resource import cluster
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -12,6 +12,7 @@ from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool
 from rptest.services.rpk_consumer import RpkConsumer
+from ducktape.mark.resource import cluster
 
 import threading
 import random

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -60,6 +60,7 @@ rpk:
   enable_usage_stats: false
   overprovisioned: false
   tune_aio_events: false
+  tune_ballast_file: false
   tune_clocksource: false
   tune_coredump: false
   tune_cpu: false
@@ -82,6 +83,12 @@ schema_registry: {}
                 # Delete 'node_uuid' so they can be compared (it's random so
                 # it's probably gonna be different each time)
                 del actual_config['node_uuid']
+
+                if actual_config != expected_config:
+                    self.logger.error("Configs differ")
+                    self.logger.error(
+                        f"Expected: {yaml.dump(expected_config)}")
+                    self.logger.error(f"Actual: {yaml.dump(actual_config)}")
 
                 assert actual_config == expected_config
 

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.utils.util import wait_until
+from ducktape.mark.resource import cluster
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk_remote import RpkRemoteTool


### PR DESCRIPTION
## Cover letter

Ducktape will ignore any test classes it can't import.  That
includes modules that don't import because of undefined names.

In a3a73c8eb3, `cluster` decorators were added to some functions
in modules where the name `cluster` was not in scope.

Ducktape logs these but does not fail the overall suite for it.

## Release notes

None