### PR TITLE
kafka: print ip on auth fail

### DIFF
--- a/src/v/security/sasl_authentication.h
+++ b/src/v/security/sasl_authentication.h
@@ -12,6 +12,7 @@
 #include "vassert.h"
 
 #include <memory>
+#include <string_view>
 
 namespace security {
 
@@ -70,5 +71,23 @@ private:
     std::unique_ptr<sasl_mechanism> _mechanism;
     bool _handshake_v0{false};
 };
+
+// inline because the function is pretty small and clang complains about
+// duplicate symbol since sasl_authentication.h is included in several
+// locations.
+inline std::string_view sasl_state_to_str(sasl_server::sasl_state state) {
+    switch (state) {
+    case sasl_server::sasl_state::initial:
+        return "initial";
+    case sasl_server::sasl_state::handshake:
+        return "handshake";
+    case sasl_server::sasl_state::authenticate:
+        return "authenticate";
+    case sasl_server::sasl_state::complete:
+        return "complete";
+    case sasl_server::sasl_state::failed:
+        return "failed";
+    }
+}
 
 }; // namespace security


### PR DESCRIPTION
## Cover letter

Print the source ip on auth failure.

Changes from force-push [320d49e](https://github.com/vectorizedio/redpanda/commit/320d49ebc14d9025febb740dcafe206391f739ae):
- added more info to generic catch log
- created context logger for connection_context
- used the new logger to print info on authorization failures

Changes from force-push [b7334c4](https://github.com/vectorizedio/redpanda/commit/b7334c4f68bba8ee0a68be2804853cdcea6182ba):
- rebase dev for updated code in connection_context
- removed unnecessary includes
- added comments
- changed client_port to be a member function only

Fixes: #2307 