### PR TITLE
rpk topic alter-config: separate Short and Long

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/topic/config.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/config.go
@@ -32,8 +32,9 @@ func NewAlterConfigCommand(fs afero.Fs) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use: "alter-config [TOPICS...] --set key=value --del key2,key3",
-		Short: `Set, delete, add, and remove key/value configs for a topic.
+		Use:   "alter-config [TOPICS...] --set key=value --del key2,key3",
+		Short: `Set, delete, add, and remove key/value configs for a topic.`,
+		Long: `Set, delete, add, and remove key/value configs for a topic.
 
 This command allows you to incrementally alter the configuration for multiple
 topics at a time.


### PR DESCRIPTION
When changing to alter-config, the Short text was accidentally lost and
replaced with the Long text. This makes `rpk topic -h` ridiculously
verbose.

We re-add the short text by just copying the first line of the long
text.

Closes #2355

The new help text looks like:
```
$ rpk topic -h
Create, delete, produce to and consume from Redpanda topics.

Usage:
  rpk topic [command]

Available Commands:
  alter-config Set, delete, add, and remove key/value configs for a topic.
  consume      Consume (read) records from a topic
  create       Create topics.
  delete       Delete a topic
  describe     Describe a topic.
  list         List topics
  produce      Produce a record from data entered in stdin.
```