### PR TITLE
ducky: parametrized output path in cluster file generating script

### DIFF
--- a/tests/docker/ducktape_cluster.py
+++ b/tests/docker/ducktape_cluster.py
@@ -7,10 +7,10 @@ import os
 # of nodes (i.e. the --scale parameter to docker-compose)
 
 scale = int(sys.argv[1])
+out_file = sys.argv[2]
 template_file = os.path.join(os.path.dirname(__file__),
                              'ducktape_cluster.json.j2')
 template = jinja2.Template(open(template_file).read())
-out_file = os.path.join(os.path.dirname(__file__), 'ducktape_cluster.json')
 
 print(f"Writing ducktape config for {scale} nodes to {out_file}")
 open(out_file, 'w').write(template.render(scale=scale))


### PR DESCRIPTION
When cluster file is generated we want it to be in build directory to
prevent modifying source tree when running tests locally.
