### PR TITLE
tests: enable parameterizing cluster resource config on tests

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -41,7 +41,7 @@ class ResourceSettings:
     of these into your RedpandaTest constructor if you want to e.g.
     create low-memory situations.
     """
-    def __init__(self, num_cpus=None, memory_mb=None):
+    def __init__(self, num_cpus=None, memory_mb=None, bypass_fsync=None):
         if num_cpus is None:
             num_cpus = 3
 
@@ -51,12 +51,18 @@ class ResourceSettings:
         self._num_cpus = num_cpus
         self._memory_mb = memory_mb
 
+        if bypass_fsync is None:
+            self._bypass_fsync = False
+        else:
+            self._bypass_fsync = bypass_fsync
+
     def to_cli(self):
         return ("--kernel-page-cache=true "
                 "--overprovisioned "
                 "--reserve-memory 0M "
                 f"--memory {self._memory_mb}M "
-                f"--smp {self._num_cpus}")
+                f"--smp {self._num_cpus} "
+                f"--unsafe-bypass-fsync={'1' if self._bypass_fsync else '0'}")
 
 
 class RedpandaService(Service):

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -18,6 +18,7 @@ from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import redpanda_cluster
 import random
 
 ELECTION_TIMEOUT = 10
@@ -222,7 +223,12 @@ class RaftAvailabilityTest(RedpandaTest):
         self._ping_pong()
         self.logger.info("Cluster is available as expected")
 
-    @cluster(num_nodes=3)
+    def setUp(self):
+        # Disable default RedpandaTest startup so that `redpanda_cluster`
+        # can change resource settings before starting cluster.
+        pass
+
+    @redpanda_cluster()
     def test_one_node_down(self):
         """
         Simplest HA test.  Stop the leader for our partition.  Validate that
@@ -303,7 +309,7 @@ class RaftAvailabilityTest(RedpandaTest):
              lambda a, b: b == a),
         ])
 
-    @cluster(num_nodes=3)
+    @redpanda_cluster()
     def test_two_nodes_down(self):
         """
         Validate that when two nodes are down, the cluster becomes unavailable, and
@@ -347,7 +353,7 @@ class RaftAvailabilityTest(RedpandaTest):
         # 1/3 nodes down, cluster should be available
         self._expect_available()
 
-    @cluster(num_nodes=3)
+    @redpanda_cluster()
     def test_leader_restart(self):
         """
         Validate that when a leader node is stopped and restarted,

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -29,7 +29,7 @@ class RedpandaTest(Test):
                  extra_rp_conf=dict(),
                  enable_pp=False,
                  enable_sr=False,
-                 num_cores=3):
+                 resource_settings=None):
         super(RedpandaTest, self).__init__(test_context)
         self.scale = Scale(test_context)
         self.redpanda = RedpandaService(test_context,
@@ -39,7 +39,7 @@ class RedpandaTest(Test):
                                         enable_pp=enable_pp,
                                         enable_sr=enable_sr,
                                         topics=self.topics,
-                                        num_cores=num_cores)
+                                        resource_settings=resource_settings)
 
     @property
     def topic(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -22,6 +22,7 @@ from ducktape.services.background_thread import BackgroundThreadService
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import ResourceSettings
 
 
 def create_topic_names(count):
@@ -52,7 +53,7 @@ class SchemaRegistryTest(RedpandaTest):
             enable_pp=True,
             enable_sr=True,
             extra_rp_conf={"auto_create_topics_enabled": False},
-            num_cores=1)
+            resource_settings=ResourceSettings(num_cpus=1))
 
         http.client.HTTPConnection.debuglevel = 1
         http.client.print = lambda *args: self.logger.debug(" ".join(args))


### PR DESCRIPTION
## Cover letter

This change makes a `redpanda_cluster` decorator (replaces generic ducktape `cluster`) that includes parameterizing test across multiple resource (cpu, memory) configurations.

The idea is that we will eventually use this everywhere, but for the moment I'm using it on the recently added RaftAvailabilityTest.  It won't make sense for all tests, so `redpanda_cluster` takes a resource_configs argument, this can be set to [ResourceSettings()] to just run the test with the defaults.

The default parameters are 'normal' (3 cores, 6GB memory) and 'tiny' (1 core, 200MB memory, fsync off).  The fsync disabling part is to increase stress on the system by making sure it isn't just idly waiting around for fsyncs most of the time, which can happen on slow drives on test systems.

## Release notes

None