### PR TITLE
Logging remote client address in kafka trace logs

### DIFF
--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -45,6 +45,7 @@ public:
       , _sasl(std::move(sasl))
       // tests may build a context without a live connection
       , _client_addr(_rs.conn ? _rs.conn->addr.addr() : ss::net::inet_address{})
+      , _client_port(_rs.conn ? _rs.conn->addr.port() : 0)
       , _enable_authorizer(enable_authorizer) {}
 
     ~connection_context() noexcept = default;
@@ -75,6 +76,7 @@ public:
     ss::future<> process_one_request();
     bool is_finished_parsing() const;
     ss::net::inet_address client_host() const { return _client_addr; }
+    uint16_t client_port() const { return _client_port; }
 
 private:
     // used to track number of pending requests
@@ -127,6 +129,7 @@ private:
     map_t _responses;
     security::sasl_server _sasl;
     const ss::net::inet_address _client_addr;
+    const uint16_t _client_port{0};
     const bool _enable_authorizer;
 };
 

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -144,7 +144,9 @@ public:
     ss::future<response_ptr> respond(ResponseType r) {
         vlog(
           klog.trace,
-          "sending {}:{} response {}",
+          "[{}:{}] sending {}:{} response {}",
+          _conn->client_host(),
+          _conn->client_port(),
           ResponseType::api_type::key,
           ResponseType::api_type::name,
           r);

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -80,7 +80,9 @@ process_result_stages
   do_process(request_context&& ctx, ss::smp_service_group g) {
     vlog(
       klog.trace,
-      "Processing name:{}, key:{}, version:{} for {}",
+      "[{}:{}] processing name:{}, key:{}, version:{} for {}",
+      ctx.connection()->client_host(),
+      ctx.connection()->client_port(),
       Request::api::name,
       ctx.header().key,
       ctx.header().version,


### PR DESCRIPTION
Added remote client address to kafka requests processing trace logs. This way it will be possible to identify client requests stream in redpanda logs.
