### PR TITLE
tests/docker: use latest librdkafka release

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFK
     mkdir -p "/opt/kafka-2.5.0" && chmod a+rw /opt/kafka-2.5.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.5.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.5.0" && \
     mkdir -p "/opt/kafka-2.7.0" && chmod a+rw /opt/kafka-2.7.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.7.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.7.0" && \
     mkdir /opt/librdkafka && \
-    curl -SL "https://github.com/edenhill/librdkafka/archive/v1.6.1.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka && \
+    curl -SL "https://github.com/edenhill/librdkafka/archive/v1.8.0.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka && \
     cd /opt/librdkafka && \
     ./configure && \
     make -j$(nproc) && \

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir -p /usr/local/go/ && \
     curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 https://golang.org/dl/go1.17.linux-${ARCHID}.tar.gz | tar -xz -C /usr/local/go/ --strip 1'
 ENV PATH="${PATH}:/usr/local/go/bin"
 
-# install kafka binary dependencies, librdkafka dev, kafkacat and kaf tools
+# install kafka binary dependencies, librdkafka dev, kcat and kaf tools
 ENV KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
 RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.3.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.3.1" && \
     mkdir -p "/opt/kafka-2.4.1" && chmod a+rw /opt/kafka-2.4.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.4.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.4.1" && \
@@ -61,9 +61,9 @@ RUN mkdir -p "/opt/kafka-2.3.1" && chmod a+rw /opt/kafka-2.3.1 && curl -s "$KAFK
     make build -j$(nproc) && \
     go get github.com/birdayz/kaf/cmd/kaf && \
     mv /root/go/bin/kaf /usr/local/bin/ && \
-    mkdir /tmp/kafkacat && \
-    curl -SL "https://github.com/edenhill/kafkacat/archive/1.6.0.tar.gz" | tar -xz --strip-components=1 -C /tmp/kafkacat && \
-    cd /tmp/kafkacat && \
+    mkdir /tmp/kcat && \
+    curl -SL "https://github.com/edenhill/kcat/archive/1.7.0.tar.gz" | tar -xz --strip-components=1 -C /tmp/kcat && \
+    cd /tmp/kcat && \
     ./configure && \
     make -j$(nproc) && \
     make install && \

--- a/tests/rptest/chaos/redpanda_muservice.py
+++ b/tests/rptest/chaos/redpanda_muservice.py
@@ -100,7 +100,7 @@ class RedpandaMuService(MuService):
     def api_meta(self, service, node):
         topic = KafkaKVMuService.TOPIC
         return node.account.ssh_output(
-            f"kafkacat -L -b {node.account.hostname} -t {topic} -J",
+            f"kcat -L -b {node.account.hostname} -t {topic} -J",
             allow_fail=False)
 
     def api_is_running(self, service, node):

--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -14,7 +14,7 @@ import json
 
 class KafkaCat:
     """
-    Wrapper around the kafkacat utility.
+    Wrapper around the kcat utility.
 
     This tools is useful because it offers a JSON output format.
     """
@@ -34,7 +34,7 @@ class KafkaCat:
         for retry in reversed(range(10)):
             try:
                 res = subprocess.check_output(
-                    ["kafkacat", "-b",
+                    ["kcat", "-b",
                      self._redpanda.brokers(), "-J"] + cmd)
                 res = json.loads(res)
                 self._redpanda.logger.debug(json.dumps(res, indent=2))
@@ -43,6 +43,6 @@ class KafkaCat:
                 if retry == 0:
                     raise
                 self._redpanda.logger.debug(
-                    "kafkacat retrying after exit code {}: {}".format(
+                    "kcat retrying after exit code {}: {}".format(
                         e.returncode, e.output))
                 time.sleep(2)

--- a/tests/rptest/services/compatibility/compat_producer.py
+++ b/tests/rptest/services/compatibility/compat_producer.py
@@ -26,11 +26,11 @@ class CompatProducer(BackgroundThreadService):
         self._topic = topic
 
     def _worker(self, idx, node):
-        cmd = f"echo \"redpanda is fast\" | kafkacat -b {self._redpanda.brokers()} -t {self._topic}"
+        cmd = f"echo \"redpanda is fast\" | kcat -b {self._redpanda.brokers()} -t {self._topic}"
         node.account.ssh_output(cmd, timeout_sec=10)
 
     def stop_node(self, node):
-        node.account.kill_process("kafkacat", clean_shutdown=False)
+        node.account.kill_process("kcat", clean_shutdown=False)
 
     def clean_node(self, nodes):
         pass


### PR DESCRIPTION
## Cover letter

Keep kafkacat (now called `kcat`) up to date at the same time.

Fixes: https://github.com/vectorizedio/redpanda/issues/2404

## Release notes

None
