### PR TITLE
tests: raise on errors by default in admin, kafka clients

### DIFF
--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -135,7 +135,6 @@ class NodeOperationFuzzyTest(EndToEndTest):
             self.logger.info(f"decommissioning node: {node_id}")
             admin = Admin(self.redpanda)
             r = admin.decommission_broker(id=node_id)
-            r.raise_for_status()
 
             def node_removed():
                 admin = Admin(self.redpanda)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -9,6 +9,7 @@
 
 import random
 import time
+import requests
 
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
@@ -138,7 +139,6 @@ class PartitionMovementTest(EndToEndTest):
             f"new assignments for {topic}-{partition}: {assignments}")
 
         r = admin.set_partition_replicas(topic, partition, assignments)
-        r.raise_for_status()
 
         def status_done():
             info = admin.get_partitions(topic, partition)
@@ -197,7 +197,6 @@ class PartitionMovementTest(EndToEndTest):
             f"new assignments for {topic}-{partition}: {assignments}")
 
         r = admin.set_partition_replicas(topic, partition, assignments)
-        r.raise_for_status()  # Expect success
 
         def status_done():
             info = admin.get_partitions(topic, partition)
@@ -352,13 +351,21 @@ class PartitionMovementTest(EndToEndTest):
 
         # A valid node but an invalid core
         assignments = [{"node_id": valid_dest, "core": invalid_shard}]
-        r = admin.set_partition_replicas(topic, partition, assignments)
-        assert r.status_code == 400
+        try:
+            r = admin.set_partition_replicas(topic, partition, assignments)
+        except requests.exceptions.HTTPError as e:
+            assert e.response.status_code == 400
+        else:
+            raise RuntimeError(f"Expected 400 but got {r.status_code}")
 
         # An invalid node but a valid core
         assignments = [{"node_id": invalid_dest, "core": 0}]
-        r = admin.set_partition_replicas(topic, partition, assignments)
-        assert r.status_code == 400
+        try:
+            r = admin.set_partition_replicas(topic, partition, assignments)
+        except requests.exceptions.HTTPError as e:
+            assert e.response.status_code == 400
+        else:
+            raise RuntimeError(f"Expected 400 but got {r.status_code}")
 
         # Finally a valid move
         assignments = [{"node_id": valid_dest, "core": 0}]


### PR DESCRIPTION
## Cover letter

These client classes swallowed errors by default.  This risks hiding failures, and making failures harder to diagnose when they show up as timeouts after a failed API call, rather than as an exception from the failed API call.

Fixes: https://github.com/vectorizedio/redpanda/issues/2318

## Release notes

None
