### PR TITLE
archival: cache eviction

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -2,9 +2,10 @@
 v_cc_library(
   NAME cloud_storage
   SRCS
-    manifest.cc
-    remote.cc
     cache_service.cc
+    manifest.cc
+    recursive_directory_walker.cc
+    remote.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cloud_storage/recursive_directory_walker.h"
+
+#include "cloud_storage/logger.h"
+#include "utils/gate_guard.h"
+#include "vassert.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sstring.hh>
+
+#include <algorithm>
+#include <chrono>
+#include <string_view>
+#include <vector>
+
+namespace cloud_storage {
+
+ss::future<std::pair<uint64_t, std::vector<file_list_item>>>
+recursive_directory_walker::walk(ss::sstring start_dir) {
+    gate_guard guard{_gate};
+
+    std::vector<file_list_item> files;
+    uint64_t current_cache_size(0);
+
+    std::deque<ss::sstring> dirlist = {start_dir};
+
+    while (!dirlist.empty()) {
+        auto target = dirlist.back();
+        dirlist.pop_back();
+        vassert(
+          std::string_view(target).starts_with(start_dir),
+          "Looking at directory {}, which is outside of initial dir {}.",
+          target,
+          start_dir);
+
+        try {
+            ss::file target_dir = co_await open_directory(target);
+            auto sub = target_dir.list_directory(
+              [&files, &current_cache_size, &dirlist, target](
+                ss::directory_entry entry) -> ss::future<> {
+                  vlog(cst_log.debug, "Looking at directory {}", target);
+
+                  auto entry_path = std::filesystem::path(target)
+                                    / std::filesystem::path(entry.name);
+                  if (
+                    entry.type
+                    && entry.type == ss::directory_entry_type::regular) {
+                      vlog(cst_log.debug, "Regular file found {}", entry_path);
+
+                      auto file_stats = co_await ss::file_stat(
+                        entry_path.string());
+
+                      auto last_access_timepoint = file_stats.time_accessed;
+
+                      current_cache_size += static_cast<uint64_t>(
+                        file_stats.size);
+                      files.push_back(
+                        {last_access_timepoint,
+                         (std::filesystem::path(target) / entry.name.data())
+                           .native(),
+                         static_cast<uint64_t>(file_stats.size)});
+                  } else if (
+                    entry.type
+                    && entry.type == ss::directory_entry_type::directory) {
+                      vlog(cst_log.debug, "Dir found {}", entry_path);
+                      dirlist.push_front(entry_path.string());
+                  }
+                  co_return;
+              });
+            co_await sub.done().finally(
+              [target_dir]() mutable { return target_dir.close(); });
+        } catch (std::filesystem::filesystem_error& e) {
+            if (e.code() == std::errc::no_such_file_or_directory) {
+                // skip this directory, move to the ext one
+            } else {
+                throw;
+            }
+        }
+    }
+    std::sort(files.begin(), files.end(), [](auto& a, auto& b) {
+        return a.access_time < b.access_time;
+    });
+
+    co_return std::make_pair(current_cache_size, files);
+}
+
+ss::future<> recursive_directory_walker::stop() {
+    vlog(cst_log.debug, "Stopping recursive directory walker");
+    return _gate.close();
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+
+#include <chrono>
+
+namespace cloud_storage {
+struct file_list_item {
+    std::chrono::system_clock::time_point access_time;
+    ss::sstring path;
+    uint64_t size;
+};
+class recursive_directory_walker {
+public:
+    ss::future<> stop();
+
+    // recursively walks start_dir, returns the total size of files in this
+    // directory and a list of files sorted by access time from oldest to newest
+    ss::future<std::pair<uint64_t, std::vector<file_list_item>>>
+    walk(ss::sstring start_dir);
+
+private:
+    ss::gate _gate;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -15,37 +15,26 @@
 #include "units.h"
 
 #include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
 
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <stdexcept>
+
 using namespace cloud_storage;
 
 FIXTURE_TEST(put_creates_file, cache_test_fixture) {
-    ss::sstring data_string;
-    while (data_string.length() < 4096) {
-        data_string += SAMPLE_STRING1;
-    }
-    iobuf buf;
-    buf.append(data_string.data(), data_string.length());
-
-    auto input = make_iobuf_input_stream(std::move(buf));
-    cache_service.put(KEY, input).get();
+    auto data_string = create_data_string('a', 1_MiB + 1_KiB);
+    put_into_cache(data_string, KEY);
 
     bool file_exists = ss::file_exists((CACHE_DIR / KEY).native()).get();
     BOOST_CHECK(file_exists);
 }
 
 FIXTURE_TEST(get_after_put, cache_test_fixture) {
-    ss::sstring data_string;
-    while (data_string.length() < 4096) {
-        data_string += SAMPLE_STRING1;
-    }
-    iobuf buf;
-    buf.append(data_string.data(), data_string.length());
-
-    auto input = make_iobuf_input_stream(std::move(buf));
-    cache_service.put(KEY, input).get();
+    auto data_string = create_data_string('a', 1_MiB + 1_KiB);
+    put_into_cache(data_string, KEY);
 
     std::optional<cloud_storage::cache_item> returned_item
       = cache_service.get(KEY).get();
@@ -60,22 +49,11 @@ FIXTURE_TEST(get_after_put, cache_test_fixture) {
 }
 
 FIXTURE_TEST(put_rewrites_file, cache_test_fixture) {
-    ss::sstring data_string1, data_string2;
-    while (data_string1.length() < 4096) {
-        data_string1 += SAMPLE_STRING1;
-    }
-    while (data_string2.length() < 4096) {
-        data_string2 += SAMPLE_STRING2;
-    }
-    iobuf buf1, buf2;
-    buf1.append(data_string1.data(), data_string1.length());
-    buf2.append(data_string2.data(), data_string2.length());
+    auto data_string1 = create_data_string('a', 1_MiB + 1_KiB);
+    put_into_cache(data_string1, KEY);
 
-    auto input1 = make_iobuf_input_stream(std::move(buf1));
-    cache_service.put(KEY, input1).get();
-
-    auto input2 = make_iobuf_input_stream(std::move(buf2));
-    cache_service.put(KEY, input2).get();
+    auto data_string2 = create_data_string('b', 1_MiB + 1_KiB);
+    put_into_cache(data_string2, KEY);
 
     std::optional<cloud_storage::cache_item> returned_item
       = cache_service.get(KEY).get();
@@ -113,16 +91,60 @@ FIXTURE_TEST(is_cached_after_put_success, cache_test_fixture) {
 }
 
 FIXTURE_TEST(after_invalidate_is_not_cached, cache_test_fixture) {
-    iobuf buf;
-    auto input = make_iobuf_input_stream(std::move(buf));
-    cache_service.put(KEY, input).get();
+    auto data_string1 = create_data_string('a', 1_MiB + 1_KiB);
+    put_into_cache(data_string1, KEY);
+
     cache_service.invalidate(KEY).get();
 
     bool is_cached = cache_service.is_cached(KEY).get();
-
     BOOST_CHECK(!is_cached);
 }
 
 FIXTURE_TEST(invalidate_missing_file_ok, cache_test_fixture) {
     BOOST_CHECK_NO_THROW(cache_service.invalidate(WRONG_KEY).get());
+}
+
+FIXTURE_TEST(empty_cache_nothing_deleted, cache_test_fixture) {
+    ss::sleep(ss::lowres_clock::duration(2s)).get();
+
+    BOOST_CHECK_EQUAL(0, cache_service.get_total_cleaned());
+}
+
+FIXTURE_TEST(files_up_to_max_cache_size_not_deleted, cache_test_fixture) {
+    auto data_string1 = create_data_string('a', 1_MiB + 1_KiB);
+    put_into_cache(data_string1, KEY);
+
+    ss::sleep(ss::lowres_clock::duration(2s)).get();
+
+    BOOST_CHECK_EQUAL(0, cache_service.get_total_cleaned());
+}
+
+FIXTURE_TEST(file_bigger_than_max_cache_size_deleted, cache_test_fixture) {
+    auto data_string1 = create_data_string('a', 2_MiB + 1_KiB);
+    put_into_cache(data_string1, KEY);
+
+    ss::sleep(ss::lowres_clock::duration(2s)).get();
+
+    BOOST_CHECK_EQUAL(2_MiB + 1_KiB, cache_service.get_total_cleaned());
+}
+
+FIXTURE_TEST(
+  files_bigger_than_max_cache_size_oldest_deleted, cache_test_fixture) {
+    auto data_string1 = create_data_string('a', 1_MiB + 1_KiB);
+    put_into_cache(data_string1, KEY);
+    auto data_string2 = create_data_string('b', 1_MiB + 1_KiB);
+    ss::sleep(1s).get();
+    put_into_cache(data_string1, KEY2);
+
+    ss::sleep(ss::lowres_clock::duration(2s)).get();
+
+    BOOST_CHECK_EQUAL(1_MiB + 1_KiB, cache_service.get_total_cleaned());
+    BOOST_REQUIRE(!ss::file_exists((CACHE_DIR / KEY).native()).get());
+    BOOST_REQUIRE(ss::file_exists((CACHE_DIR / KEY2).native()).get());
+}
+
+FIXTURE_TEST(cannot_put_tmp_file, cache_test_fixture) {
+    auto data_string1 = create_data_string('a', 1_KiB);
+    BOOST_CHECK_THROW(
+      put_into_cache(data_string1, TEMP_KEY), std::invalid_argument);
 }

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -9,36 +9,57 @@
  */
 
 #pragma once
+#include "bytes/iobuf.h"
 #include "cloud_storage/cache_service.h"
 #include "seastarx.h"
+#include "units.h"
 
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/seastar.hh>
+#include <seastar/core/sstring.hh>
 
 #include <boost/filesystem/operations.hpp>
 
+#include <chrono>
 #include <filesystem>
 
 using namespace cloud_storage;
+using namespace std::chrono_literals;
 
 class cache_test_fixture {
 public:
     const std::filesystem::path KEY{"abc001/test_topic/test_cache_file.txt"};
+    const std::filesystem::path KEY2{"abc002/test_topic2/test_cache_file2.txt"};
+    const std::filesystem::path TEMP_KEY{
+      "abc002/test_topic2/test_cache_file2.txt_0_0.part"};
     const std::filesystem::path WRONG_KEY{"abc001/test_topic/wrong_key.txt"};
-
     const std::filesystem::path CACHE_DIR{"test_cache_dir"};
-
-    const ss::sstring SAMPLE_STRING1 = ss::sstring("Test data");
-    const ss::sstring SAMPLE_STRING2 = ss::sstring("New test data!");
 
     cloud_storage::cache cache_service;
 
     cache_test_fixture()
-      : cache_service(CACHE_DIR) {
+      : cache_service(
+        CACHE_DIR, 1_MiB + 500_KiB, ss::lowres_clock::duration(1s)) {
         cache_service.start().get();
     }
 
     ~cache_test_fixture() {
-        boost::filesystem::remove_all(CACHE_DIR.native());
         cache_service.stop().get();
+        boost::filesystem::remove_all(CACHE_DIR.native());
+    }
+
+    ss::sstring create_data_string(char symbol_to_fill, uint64_t size) {
+        ss::sstring data_string;
+        data_string.resize(size, symbol_to_fill);
+
+        return data_string;
+    }
+
+    void put_into_cache(auto data_string, auto key) {
+        iobuf buf;
+        buf.append(data_string.data(), data_string.length());
+
+        auto input = make_iobuf_input_stream(std::move(buf));
+        cache_service.put(key, input).get();
     }
 };


### PR DESCRIPTION
Shadow indexing is a project to retrieve data from S3 storage in a transparent way for user. Fetched data will be stored in an archival cache. This PR implements eviction policy for archival cache. Usrs can configure the max_cache_size and an interval when eviction is triggered. Eviction deletes files from oldest to newest based on file access time, until cache size is not bigger than `0.8 * max_cache_size`. Only shard 0 cleans up cache.

In [force push](https://github.com/vectorizedio/redpanda/compare/a1d05e5465c4047a931e18581704f4e3faf19fd5..17877f9baf59df82ca93d18574059d577beb5cfc):
  - rebase
  
  In [force push](https://github.com/vectorizedio/redpanda/compare/14c8127193205be91b8f08bda43ae4730bf6b7c3..5ee89e065983d215c7780a554d502ab4baf05c2b):
 - get rid of `get_curr_cache_size()`, directory walker returns current cache size
 - return files sorted by access time
 - delete files
 
 In [force push](https://github.com/vectorizedio/redpanda/compare/5ee89e065983d215c7780a554d502ab4baf05c2b..2c7eae2d5570c9e8f817c750d5780bb4815b1549):
  - rebase
  - added unit tests
  - addressed comments
  - split directory walker into functions
  - added logging 
  
  In [force push](https://github.com/vectorizedio/redpanda/compare/372fd58d3629a59f2b7c78c63063b7b257bcc983..9489c01b044d7376cf188e3fad52b613ad4543a8):
 - split recursive_directory_walker into .h and .cc
 - add stop() method to recursive_directory_walker
 - protect `walk()` with gate
 - add `vassert`s that files are inside cache_dir
 
In [force push](https://github.com/vectorizedio/redpanda/compare/21e46288dfe687d5012c923f5eab1d84505a662b..418b77f1a7f8d9360727028950035fc5838f0945):
 - rebase
 - addressed comments