### PR TITLE
Correct allow-host param name in ACL creation docs

### DIFF
--- a/docs/www/acls.md
+++ b/docs/www/acls.md
@@ -207,7 +207,7 @@ Please note that you may have to add the `--tls-key`, `--tls-cert` and `--tls-tr
 ```cmd
 $ rpk acl create \
   --allow-principal 'User:Charlie' \
-  --allow-hosts '*' \
+  --allow-host '*' \
   --operation all \
   --resource topic \
   --resource-name pings


### PR DESCRIPTION
## Cover letter

param name is slightly incorrect in the ACL creation guide

## Release notes

Correct allow-host param name in ACL creation docs