### PR TITLE
Protecting log operations with gate

### DIFF
--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -157,6 +157,7 @@ private:
         ss::abort_source::subscription subscription;
     };
     bool _closed{false};
+    ss::gate _compaction_gate;
     log_manager& _manager;
     segment_set _segs;
     kvstore& _kvstore;


### PR DESCRIPTION
Added gate to protect compaction operation in log. Previous it may happen that log
was deleted before compaction was finished. This lead to UAF failure and segmentation fault.

Signed-off-by: Michal Maslanka <michal@vectorized.io>
