### PR TITLE
application: log file handle limit on startup

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -67,6 +67,7 @@
 #include <seastar/util/conversions.hh>
 #include <seastar/util/defer.hh>
 
+#include <sys/resource.h>
 #include <sys/utsname.h>
 
 #include <chrono>
@@ -138,6 +139,17 @@ static void log_system_resources(
       ss::smp::count,
       human::bytes(total_mem),
       human::bytes(reserve));
+
+    struct rlimit nofile = {0, 0};
+    if (getrlimit(RLIMIT_NOFILE, &nofile) == 0) {
+        vlog(
+          log.info,
+          "File handle limit: {}/{}",
+          nofile.rlim_cur,
+          nofile.rlim_max);
+    } else {
+        vlog(log.warn, "Error {} querying file handle limit", errno);
+    }
 }
 
 int application::run(int ac, char** av) {


### PR DESCRIPTION
## Cover letter

Useful for test/support if we're in any doubt
about the system's configuration & risk of hitting
issues with large numbers of partitions.

## Release notes

Redpanda now logs the system file handle limit on startup, to help diagnose issues on systems where the limit may be too small for the number of log segments.
