### PR TITLE
kafka/server: Improve kafka::map_topic_error_code

### DIFF
--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -27,6 +27,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::notification_wait_timeout:
         return error_code::request_timed_out;
     case cluster::errc::not_leader_controller:
+    case cluster::errc::no_leader_controller:
         return error_code::not_controller;
     case cluster::errc::topic_already_exists:
         return error_code::topic_already_exists;

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -37,9 +37,36 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
         return error_code::request_timed_out;
     case cluster::errc::invalid_topic_name:
         return error_code::invalid_topic_exception;
-    default:
-        return error_code::unknown_server_error;
+    case cluster::errc::replication_error:
+    case cluster::errc::shutting_down:
+    case cluster::errc::join_request_dispatch_error:
+    case cluster::errc::seed_servers_exhausted:
+    case cluster::errc::auto_create_topics_exception:
+    case cluster::errc::partition_not_exists:
+    case cluster::errc::not_leader:
+    case cluster::errc::partition_already_exists:
+    case cluster::errc::waiting_for_recovery:
+    case cluster::errc::update_in_progress:
+    case cluster::errc::user_exists:
+    case cluster::errc::user_does_not_exist:
+    case cluster::errc::invalid_producer_epoch:
+    case cluster::errc::sequence_out_of_order:
+    case cluster::errc::generic_tx_error:
+    case cluster::errc::node_does_not_exists:
+    case cluster::errc::invalid_node_operation:
+    case cluster::errc::invalid_configuration_update:
+    case cluster::errc::topic_operation_error:
+    case cluster::errc::no_eligible_allocation_nodes:
+    case cluster::errc::allocation_error:
+    case cluster::errc::partition_configuration_revision_not_updated:
+    case cluster::errc::partition_configuration_in_joint_mode:
+    case cluster::errc::partition_configuration_leader_config_not_committed:
+    case cluster::errc::partition_configuration_differs:
+    case cluster::errc::data_policy_already_exists:
+    case cluster::errc::data_policy_not_exists:
+        break;
     }
+    return error_code::unknown_server_error;
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -499,7 +499,8 @@ recovery_batch_consumer::operator()(model::record_batch batch) {
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::no);
     } else {
-        klog.trace("ignorning batch with type {}", int(batch.header().type));
+        vlog(
+          klog.trace, "ignorning batch with type {}", int(batch.header().type));
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::no);
     }

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -56,7 +56,7 @@ void group_stm::commit(model::producer_identity pid) {
     auto prepared_it = _prepared_txs.find(pid.get_id());
     if (prepared_it == _prepared_txs.end()) {
         // missing prepare may happen when the consumer log gets truncated
-        klog.trace("can't find ongoing tx {}", pid);
+        vlog(klog.trace, "can't find ongoing tx {}", pid);
         return;
     } else if (prepared_it->second.pid.epoch != pid.epoch) {
         klog.warn(

--- a/src/v/kafka/server/handlers/create_acls.cc
+++ b/src/v/kafka/server/handlers/create_acls.cc
@@ -36,7 +36,7 @@ ss::future<response_ptr> create_acls_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     create_acls_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     if (!ctx.authorized(
           security::acl_operation::alter, security::default_cluster_name)) {

--- a/src/v/kafka/server/handlers/delete_acls.cc
+++ b/src/v/kafka/server/handlers/delete_acls.cc
@@ -60,7 +60,7 @@ ss::future<response_ptr> delete_acls_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     delete_acls_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     if (!ctx.authorized(
           security::acl_operation::alter, security::default_cluster_name)) {

--- a/src/v/kafka/server/handlers/describe_acls.cc
+++ b/src/v/kafka/server/handlers/describe_acls.cc
@@ -70,7 +70,7 @@ ss::future<response_ptr> describe_acls_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     describe_acls_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     if (!ctx.authorized(
           security::acl_operation::describe, security::default_cluster_name)) {

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -306,7 +306,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     describe_configs_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     describe_configs_response response;
     response.data.results.reserve(request.data.resources.size());

--- a/src/v/kafka/server/handlers/describe_groups.cc
+++ b/src/v/kafka/server/handlers/describe_groups.cc
@@ -27,7 +27,7 @@ ss::future<response_ptr>
 describe_groups_handler::handle(request_context ctx, ss::smp_service_group) {
     describe_groups_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     auto unauthorized_it = std::partition(
       request.data.groups.begin(),

--- a/src/v/kafka/server/handlers/describe_log_dirs.cc
+++ b/src/v/kafka/server/handlers/describe_log_dirs.cc
@@ -97,7 +97,7 @@ ss::future<response_ptr> describe_log_dirs_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     describe_log_dirs_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     describe_log_dirs_response response;
 

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -243,7 +243,7 @@ ss::future<response_ptr> incremental_alter_configs_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {
     incremental_alter_configs_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     auto groupped = group_alter_config_resources(
       std::move(request.data.resources));

--- a/src/v/kafka/server/handlers/list_groups.cc
+++ b/src/v/kafka/server/handlers/list_groups.cc
@@ -24,7 +24,7 @@ ss::future<response_ptr> list_groups_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     list_groups_request request{};
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     auto&& [error, groups] = co_await ctx.groups().list_groups();
 

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -227,7 +227,7 @@ list_offsets_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     list_offsets_request request;
     request.decode(ctx.reader(), ctx.header().version);
     request.compute_duplicate_topics();
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     auto unauthorized_it = std::partition(
       request.data.topics.begin(),

--- a/src/v/kafka/server/handlers/offset_commit.cc
+++ b/src/v/kafka/server/handlers/offset_commit.cc
@@ -57,7 +57,7 @@ process_result_stages
 offset_commit_handler::handle(request_context ctx, ss::smp_service_group ssg) {
     offset_commit_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     if (request.data.group_instance_id) {
         return process_result_stages::single_stage(ctx.respond(

--- a/src/v/kafka/server/handlers/offset_fetch.cc
+++ b/src/v/kafka/server/handlers/offset_fetch.cc
@@ -42,7 +42,7 @@ ss::future<response_ptr>
 offset_fetch_handler::handle(request_context ctx, ss::smp_service_group) {
     offset_fetch_request request;
     request.decode(ctx.reader(), ctx.header().version);
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     if (!ctx.authorized(
           security::acl_operation::describe, request.data.group_id)) {

--- a/src/v/kafka/server/handlers/txn_offset_commit.cc
+++ b/src/v/kafka/server/handlers/txn_offset_commit.cc
@@ -83,7 +83,7 @@ ss::future<response_ptr> txn_offset_commit_handler::handle(
     txn_offset_commit_request request;
     request.decode(ctx.reader(), ctx.header().version);
 
-    klog.trace("Handling request {}", request);
+    vlog(klog.trace, "Handling request {}", request);
 
     txn_offset_commit_ctx octx(std::move(ctx), std::move(request), ssg);
 

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -97,7 +97,6 @@ class RetentionPolicyTest(RedpandaTest):
                    backoff_sec=5,
                    err_msg="Segments were not removed")
 
-    @ignore()  # https://github.com/vectorizedio/redpanda/issues/2406
     @cluster(num_nodes=3)
     def test_changing_topic_retention_with_restart(self):
         """


### PR DESCRIPTION
**Note**: Let's wait for this to bake on `test-staging` for a bit before merge.

## Cover letter

Map `cluster::errc::no_leader_controller` to `kafka::error_code::not_controller` so that the error is retriable, with metadata refresh.

Fixes #2406 

Also:
* Improve logging by using `vlog`
* Improve switch case to force compilation error when new `cluster::errc` is introduced.

See https://github.com/vectorizedio/redpanda/issues/2425 for followup work.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/7618d016cea291560ec2db16ac3ddd1f4675fc1e..629ca10a8554a358f7ec024e4e0c04a73d273428)
* Change the mapping to `cluster::errc::not_controller`
* Change base to dev

## Release notes

Release note: redpanda/kafka: leader_not_available is now a retriable error.
