### PR TITLE
id_allocator_stm: add handle_eviction

### DIFF
--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -93,8 +93,10 @@ id_allocator_stm::allocate_id_and_wait(
 
         return replicate_and_wait(allocation_cmd{seq, range}, timeout, seq)
           .then([this](log_allocation_result r) {
-              _last_allocated_base = r.base + 1;
-              _last_allocated_range = r.range - 1;
+              if (r.raft_status == raft::errc::success) {
+                  _last_allocated_base = r.base + 1;
+                  _last_allocated_range = r.range - 1;
+              }
               return stm_allocation_result{r.base, r.raft_status};
           });
     });

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -92,6 +92,9 @@ public:
     ss::future<stm_allocation_result>
     allocate_id_and_wait(model::timeout_clock::time_point timeout);
 
+protected:
+    ss::future<> handle_eviction() override;
+
 private:
     struct sequence_id {
         model::run_id run_id;


### PR DESCRIPTION
## Cover letter

Updates id allocator state machine (id_allocator_stm) to support trucations happening after the start of a state_machine. When a truncation event happens id_allocator_stm resets its state and reconstructs it by reading the log.

How was it tested? Reproduced the error and checked that the fix fixes it.
    
Reproduction steps:
    
Run local 3 node cluster with low id_allocator_stm retention
    
    id_allocator_batch_size: 3
    id_allocator_log_capacity: 5
    
Create / close kafka producer with idempotency enabled in a loop 30x times to trigger log truncation.
    
Stop one of the nodes.
    
Repeat the create / close loop.
    
Restart the stopped node.
    
Observe the error / lack of the error
    
    WARN  2021-09-23 11:01:37,400 [shard 1] cluster - state_machine.cc:43 - {kafka_internal/id_allocator/0} state_machine should support handle_eviction
    
Fixes https://github.com/vectorizedio/redpanda/issues/2416

