### PR TITLE
tests: fix disabling test_changing_topic_retention_with_restart

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -97,7 +97,7 @@ class RetentionPolicyTest(RedpandaTest):
                    backoff_sec=5,
                    err_msg="Segments were not removed")
 
-    @ignore()  # https://github.com/vectorizedio/redpanda/issues/2406
+    @ignore  # https://github.com/vectorizedio/redpanda/issues/2406
     @cluster(num_nodes=3)
     def test_changing_topic_retention_with_restart(self):
         """


### PR DESCRIPTION
## Cover letter

Turns out that `@ignore` works, and `@ignore(param=val)` works, but `@ignore()` does nothing.

Related: https://github.com/vectorizedio/redpanda/issues/2406

## Release notes

None
