### PR TITLE
Adjusting incorrectly persisted configuration indices. 

### DIFF
--- a/src/v/kafka/server/offset_translator.h
+++ b/src/v/kafka/server/offset_translator.h
@@ -51,22 +51,7 @@ public:
     }
 
 private:
-    int64_t delta(model::offset o) const {
-        auto it = _cfg_mgr.lower_bound(o);
-
-        if (it == _cfg_mgr.begin()) {
-            /**
-             * iterator points to the first configuration with offset greater
-             * than then requsted one. Knowing an index of that configuration we
-             * know that there was exactly (index -1) configurations with offset
-             * lower than the current one. We can simply subtract one from
-             * index.
-             */
-            return std::max<int64_t>(0, it->second.idx() - 1);
-        }
-
-        return std::prev(it)->second.idx();
-    }
+    int64_t delta(model::offset o) const { return _cfg_mgr.offset_delta(o); }
 
     const raft::configuration_manager& _cfg_mgr;
 };

--- a/src/v/raft/configuration_manager.cc
+++ b/src/v/raft/configuration_manager.cc
@@ -433,6 +433,22 @@ model::revision_id configuration_manager::get_latest_revision() const {
     return _configurations.rbegin()->second.cfg.revision_id();
 }
 
+int64_t configuration_manager::offset_delta(model::offset o) const {
+    auto it = lower_bound(o);
+
+    if (it == begin()) {
+        /**
+         * iterator points to the first configuration with offset greater
+         * than then requsted one. Knowing an index of that configuration we
+         * know that there was exactly (index -1) configurations with offset
+         * lower than the current one. We can simply subtract one from
+         * index.
+         */
+        return std::max<int64_t>(0, it->second.idx() - 1);
+    }
+
+    return std::prev(it)->second.idx();
+}
 std::ostream& operator<<(std::ostream& o, const configuration_manager& m) {
     o << "{configurations: ";
     for (const auto& p : m._configurations) {

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -161,6 +161,7 @@ public:
         return _configurations.lower_bound(o);
     }
 
+    int64_t offset_delta(model::offset) const;
     friend std::ostream&
     operator<<(std::ostream&, const configuration_manager&);
 

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -162,6 +162,9 @@ public:
     }
 
     int64_t offset_delta(model::offset) const;
+
+    ss::future<> adjust_configuration_idx(configuration_idx);
+
     friend std::ostream&
     operator<<(std::ostream&, const configuration_manager&);
 


### PR DESCRIPTION
## Cover letter

Issue related with incorrectly assigned configuration indices (#2326) lead to the situation in which persisted `_initial_configuration_idx` was incorrect. This may lead to corrupted offset translation in Kafka layer and render
negative offsets. Implemented fix, based on adjusting configuration indices based on available information to fix offset translation.
If partition start offset is rendered as negative one we adjust configuration indexing in a way that partition will start with offset 0.
