### PR TITLE
k8s/helm-chart: skip kind teardown on helm chart tests

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -118,7 +118,7 @@ e2e-tests: kuttl test docker-build docker-build-configurator
 
 # Execute end to end tests using helm as an installation
 helm-e2e-tests: kuttl test docker-build docker-build-configurator
-	$(KUTTL) test --config kuttl-helm-test.yaml $(TEST_ONLY_FLAG) --kind-context $(BUILDKITE_JOB_ID)-helm
+	$(KUTTL) test --config kuttl-helm-test.yaml $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS) --kind-context $(BUILDKITE_JOB_ID)-helm
 
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen

--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -114,7 +114,7 @@ push-to-kind: kind-create certmanager-install
 
 # Execute end to end tests
 e2e-tests: kuttl test docker-build docker-build-configurator
-	$(KUTTL) test $(TEST_ONLY_FLAG) $(KUTLL_TEST_FLAGS) --kind-context $(BUILDKITE_JOB_ID)
+	$(KUTTL) test $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS) --kind-context $(BUILDKITE_JOB_ID)
 
 # Execute end to end tests using helm as an installation
 helm-e2e-tests: kuttl test docker-build docker-build-configurator


### PR DESCRIPTION
A previous PR (#2296) introduced the use of a "`KUTLL_TEST_FLAG` variable [sic]" variable that is passed to `kuttl`. This variable was not being passed to `kuttl` when running helm chart tests (only k8s operator tests). This PR fixes the typo in the name of the flag and passes it to kuttl when invoking helm chart tests.

corresponding vtools pr: https://github.com/vectorizedio/vtools/pull/270

fixes #2439