### PR TITLE
Changed semantics of `partition_count` in CreatePartitions API

### DIFF
--- a/src/v/cluster/tests/create_partitions_test.cc
+++ b/src/v/cluster/tests/create_partitions_test.cc
@@ -15,13 +15,20 @@ model::topic_namespace make_tp_ns(const ss::sstring& tp) {
 
 FIXTURE_TEST(test_creating_partitions, rebalancing_tests_fixture) {
     start_cluster(3);
+    /**
+     * Test setup:
+     * topic test-1, 3 paritions, replication factor 1
+     * topic test-2, 4 paritions, replication factor 3
+     */
     create_topic(create_topic_cfg("test-1", 3, 1));
     create_topic(create_topic_cfg("test-2", 4, 3));
 
+    // topic test-1, increase partition count to 6
     cluster::create_partititions_configuration cfg_test_1(
-      make_tp_ns("test-1"), 3);
+      make_tp_ns("test-1"), 6);
+    // topic test-2, increase partition count to 9
     cluster::create_partititions_configuration cfg_test_2(
-      make_tp_ns("test-2"), 5);
+      make_tp_ns("test-2"), 9);
 
     auto res = (*get_leader_node_application())
                  ->controller->get_topics_frontend()
@@ -38,14 +45,38 @@ FIXTURE_TEST(test_creating_partitions, rebalancing_tests_fixture) {
     auto tp_2_md = topics.local().get_topic_metadata(make_tp_ns("test-2"));
 
     // total 6 partitions
-    BOOST_REQUIRE_EQUAL(tp_1_md->partitions.size(), 3 + 3);
+    BOOST_REQUIRE_EQUAL(tp_1_md->partitions.size(), 6);
     for (auto i = 0; i < 6; ++i) {
         BOOST_REQUIRE_EQUAL(tp_1_md->partitions[i].id, model::partition_id(i));
     }
 
     // total 9 partitions
-    BOOST_REQUIRE_EQUAL(tp_2_md->partitions.size(), 4 + 5);
+    BOOST_REQUIRE_EQUAL(tp_2_md->partitions.size(), 9);
     for (auto i = 0; i < 9; ++i) {
         BOOST_REQUIRE_EQUAL(tp_2_md->partitions[i].id, model::partition_id(i));
     }
+}
+
+FIXTURE_TEST(test_error_handling, rebalancing_tests_fixture) {
+    start_cluster(3);
+    /**
+     * Test setup:
+     * topic test-1, 3 paritions, replication factor 1
+     */
+    create_topic(create_topic_cfg("test-1", 3, 1));
+
+    // topic test-1, try decreasing partition count
+    cluster::create_partititions_configuration cfg_test_1(
+      make_tp_ns("test-1"), 2);
+
+    auto res = (*get_leader_node_application())
+                 ->controller->get_topics_frontend()
+                 .local()
+                 .create_partitions({cfg_test_1}, model::no_timeout)
+                 .get();
+
+    BOOST_REQUIRE_EQUAL(res.size(), 1);
+    BOOST_REQUIRE_EQUAL(
+      res[0].ec,
+      cluster::make_error_code(cluster::errc::topic_invalid_partitions));
 }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -91,9 +91,10 @@ topic_table::apply(create_partition_cmd cmd, model::offset offset) {
 
     // add partitions
     auto prev_partition_count = tp->second.configuration.cfg.partition_count;
+    // update partitions count
     tp->second.configuration.cfg.partition_count
-      += cmd.value.cfg.new_total_partition_count;
-    // add assignments
+      = cmd.value.cfg.new_total_partition_count;
+    // add assignments of newly created partitions
     for (auto& p_as : cmd.value.assignments) {
         p_as.id += model::partition_id(prev_partition_count);
         tp->second.configuration.assignments.push_back(p_as);

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -92,7 +92,7 @@ topic_table::apply(create_partition_cmd cmd, model::offset offset) {
     // add partitions
     auto prev_partition_count = tp->second.configuration.cfg.partition_count;
     tp->second.configuration.cfg.partition_count
-      += cmd.value.cfg.partition_count;
+      += cmd.value.cfg.new_total_partition_count;
     // add assignments
     for (auto& p_as : cmd.value.assignments) {
         p_as.id += model::partition_id(prev_partition_count);

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -553,10 +553,14 @@ topics_frontend::validate_shard(model::node_id node, uint32_t shard) const {
 }
 
 allocation_request make_allocation_request(
-  int16_t replication_factor, const create_partititions_configuration& cfg) {
+  int16_t replication_factor,
+  const int32_t current_partitions_count,
+  const create_partititions_configuration& cfg) {
+    const auto new_partitions_cnt = cfg.new_total_partition_count
+                                    - current_partitions_count;
     allocation_request req;
-    req.partitions.reserve(cfg.partition_count);
-    for (auto p = 0; p < cfg.partition_count; ++p) {
+    req.partitions.reserve(new_partitions_cnt);
+    for (auto p = 0; p < new_partitions_cnt; ++p) {
         req.partitions.emplace_back(model::partition_id(p), replication_factor);
     }
     return req;
@@ -569,10 +573,18 @@ ss::future<topic_result> topics_frontend::do_create_partition(
     if (!tp_cfg) {
         co_return make_error_result(p_cfg.tp_ns, errc::topic_not_exists);
     }
+    // we only support increasing number of partitions
+    if (p_cfg.new_total_partition_count <= tp_cfg->partition_count) {
+        co_return make_error_result(
+          p_cfg.tp_ns, errc::topic_invalid_partitions);
+    }
+
     auto units = co_await _allocator.invoke_on(
       partition_allocator::shard,
-      [p_cfg, rf = tp_cfg->replication_factor](partition_allocator& al) {
-          return al.allocate(make_allocation_request(rf, p_cfg));
+      [p_cfg,
+       current = tp_cfg->partition_count,
+       rf = tp_cfg->replication_factor](partition_allocator& al) {
+          return al.allocate(make_allocation_request(rf, current, p_cfg));
       });
 
     // no assignments, error

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -142,7 +142,7 @@ ntp_reconciliation_state::ntp_reconciliation_state(
 create_partititions_configuration::create_partititions_configuration(
   model::topic_namespace tp_ns, int32_t cnt)
   : tp_ns(std::move(tp_ns))
-  , partition_count(cnt) {}
+  , new_total_partition_count(cnt) {}
 
 std::ostream& operator<<(std::ostream& o, const topic_configuration& cfg) {
     fmt::print(
@@ -268,9 +268,9 @@ std::ostream&
 operator<<(std::ostream& o, const create_partititions_configuration& cfg) {
     fmt::print(
       o,
-      "{{topic: {}, partition count: {}, custom assignments: {}}}",
+      "{{topic: {}, new total partition count: {}, custom assignments: {}}}",
       cfg.tp_ns,
-      cfg.partition_count,
+      cfg.new_total_partition_count,
       cfg.custom_assignments);
     return o;
 }
@@ -747,7 +747,8 @@ adl<cluster::ntp_reconciliation_state>::from(iobuf_parser& in) {
 
 void adl<cluster::create_partititions_configuration>::to(
   iobuf& out, cluster::create_partititions_configuration&& pc) {
-    return serialize(out, pc.tp_ns, pc.partition_count, pc.custom_assignments);
+    return serialize(
+      out, pc.tp_ns, pc.new_total_partition_count, pc.custom_assignments);
 }
 
 cluster::create_partititions_configuration

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -396,7 +396,9 @@ struct create_partititions_configuration {
     create_partititions_configuration(model::topic_namespace, int32_t);
 
     model::topic_namespace tp_ns;
-    int32_t partition_count;
+
+    // This is new total number of partitions in topic.
+    int32_t new_total_partition_count;
 
     // TODO: use when we will start supporting custom partitions assignment
     std::vector<custom_assignment> custom_assignments;

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -72,7 +72,7 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
             ]
         return self._run("kafka-topics.sh", args)
 
-    def add_topic_partitions(self, topic, partitions):
+    def create_topic_partitions(self, topic, partitions):
         self._redpanda.logger.debug("Adding %d partitions to topic: %s",
                                     partitions, topic)
         args = ['--alter']

--- a/tests/rptest/tests/create_partitions_test.py
+++ b/tests/rptest/tests/create_partitions_test.py
@@ -23,9 +23,9 @@ class CreatePartitionsTest(RedpandaTest):
         meta = client.describe_topic(topic)
         return meta.partition_count
 
-    def _add_topic_partitions(self, topic, count):
+    def _create_topic_partitions(self, topic, count):
         client = KafkaCliTools(self.redpanda)
-        client.add_topic_partitions(topic, count)
+        client.create_topic_partitions(topic, count)
 
     def _delete_topic(self, topic_name):
         client = KafkaCliTools(self.redpanda)
@@ -33,7 +33,7 @@ class CreatePartitionsTest(RedpandaTest):
 
     def _create_add_verify(self, topic, new_parts):
         self.logger.info(
-            f"Testing topic {topic.name} with partitions {topic.partition_count} replicas {topic.replication_factor} additional partitions {new_parts}"
+            f"Testing topic {topic.name} with partitions {topic.partition_count} replicas {topic.replication_factor} expected partitions {new_parts}"
         )
 
         self.redpanda.create_topic(topic)
@@ -46,15 +46,15 @@ class CreatePartitionsTest(RedpandaTest):
             f"Initial topic doesn't have expected {topic.partition_count} partitions, found {self._partition_count(topic.name)}"
         )
 
-        self._add_topic_partitions(topic.name, new_parts)
+        self._create_topic_partitions(topic.name, new_parts)
 
-        expected_parts = topic.partition_count + new_parts
+        expected_parts = new_parts
         wait_until(
             lambda: self._partition_count(topic.name) == expected_parts,
             timeout_sec=20,
             backoff_sec=2,
             err_msg=
-            f"Initial topic doesn't have expected {expected_parts} partitions, found {self._partition_count(topic.name)}"
+            f"Error waiting for partitions to be created, expected {expected_parts} partitions, found {self._partition_count(topic.name)}"
         )
 
     @cluster(num_nodes=3)
@@ -63,10 +63,11 @@ class CreatePartitionsTest(RedpandaTest):
         iterations = 12 if big else 2
 
         for _ in range(iterations):
-            topic = TopicSpec(partition_count=random.randint(1, 20),
+            partition_count = random.randint(1, 10)
+            new_partition_count = random.randint(partition_count + 1, 20)
+            topic = TopicSpec(partition_count=partition_count,
                               replication_factor=random.choice((1, 3)))
-            new_parts = random.randint(1, 30)
-            self._create_add_verify(topic, new_parts)
+            self._create_add_verify(topic, new_partition_count)
             self._delete_topic(topic.name)
 
             # todo delete the topic to avoid running out of file handles


### PR DESCRIPTION
## Cover letter

Previous implementation of create partitions API assumed that requested number of partitions will be added to current topic partition count. This assumption is incorrect since requested number of partitions is the new total number of partitions for given topic. Adjusted implementation and tests to account for that change in semantics.

Fixes: #2393
## Release notes

- Fully functional create partitions support.