### PR TITLE
tests: fix storage import in prefix_truncate_recovery_test

### DIFF
--- a/tests/rptest/tests/prefix_truncate_recovery_test.py
+++ b/tests/rptest/tests/prefix_truncate_recovery_test.py
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import os
-import collections
 import tempfile
 from ducktape.mark import matrix
 from ducktape.mark.resource import cluster
@@ -18,7 +16,7 @@ from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
-from storage import storage as vstorage
+import storage as vstorage
 
 
 class PrefixTruncateRecoveryTest(RedpandaTest):

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -17,6 +17,7 @@ setup(
         'prometheus-client==0.9.0',
         'pyyaml==5.3.1',
         'kafka-python==2.0.2',
+        'crc32c==2.2',
         'confluent-kafka==1.6.1',
     ],
     scripts=[],


### PR DESCRIPTION
## Cover letter

* Fix the import of storage itself (this depends on a vtools
change to bring tools/ into PYTHONPATH)
* Add crc32c as a requirement, because storage requires it.

Fixes: https://github.com/vectorizedio/redpanda/issues/2460

## Release notes

None