### PR TITLE
Fix expiring promise to prevent double set

### DIFF
--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -7,7 +7,8 @@ rp_test(
     directory_walker_test.cc
     outcome_utils_test.cc
     base64_test.cc
-    timed_mutex_test
+    timed_mutex_test.cc
+    expiring_promise_test.cc
     retry_chain_node_test.cc
     input_stream_fanout_test.cc
   LIBRARIES v::seastar_testing_main v::utils v::bytes

--- a/src/v/utils/tests/expiring_promise_test.cc
+++ b/src/v/utils/tests/expiring_promise_test.cc
@@ -1,0 +1,25 @@
+#include "seastarx.h"
+#include "utils/expiring_promise.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_future.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+// testing that shared_promise doesn't immediately become available after set
+SEASTAR_THREAD_TEST_CASE(test_shared_promise_availability) {
+    ss::shared_promise<int32_t> promise;
+    auto future = promise.get_shared_future();
+    BOOST_REQUIRE_EQUAL(promise.available(), false);
+    promise.set_value(42);
+    BOOST_REQUIRE_EQUAL(promise.available(), false);
+    future.get();
+    BOOST_REQUIRE_EQUAL(promise.available(), true);
+}
+
+// testing that expiring_promise immediately becomes available after set
+SEASTAR_THREAD_TEST_CASE(test_expiring_promise_availability) {
+    expiring_promise<int32_t> promise;
+    BOOST_REQUIRE_EQUAL(promise.available(), false);
+    promise.set_value(42);
+    BOOST_REQUIRE_EQUAL(promise.available(), true);
+}


### PR DESCRIPTION
It takes time before a promise becomes unavailable after setting a value of an exception. It may lead to setting a promise twice and getting an exception. Fixing this behavior by explicitly tracking availability.