### PR TITLE
Add missing enumeration to switch statement

### DIFF
--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -41,6 +41,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::replication_error:
     case cluster::errc::shutting_down:
     case cluster::errc::join_request_dispatch_error:
+    case cluster::errc::source_topic_not_exists:
     case cluster::errc::seed_servers_exhausted:
     case cluster::errc::auto_create_topics_exception:
     case cluster::errc::partition_not_exists:


### PR DESCRIPTION
Build is broken due to a enumeration value not handed in a switch statement.