### PR TITLE
Fixed shutting down log

### DIFF
--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -146,6 +146,9 @@ ss::future<> readers_cache::stop() {
      */
     co_await wait_for_no_inuse_readers();
     /**
+     * At this poit we are sure that all cached readers are not used anymore and
+     * no new readers will be added to _readers list.
+     *
      * Close and dispose cached readers
      */
     for (auto& r : _readers) {
@@ -300,8 +303,19 @@ void readers_cache::dispose_in_background(entry* e) {
                 delete e; // NOLINT
             });
         });
-    } catch (const ss::gate_closed_exception& e) {
+    } catch (const ss::gate_closed_exception& ex) {
         vlog(stlog.debug, "gate closed while disposing reader");
+        /**
+         * since gate is closed and we failed to call finally on the reader we
+         * add it back to _readers list, it will be gracefully closed in
+         * `readers_cache::close`.
+         * NOTE:
+         * _readers intrusive list is supposed to keep resusable readers but
+         * when gate closed exception is thrwon we are certain that no more
+         * oprations will be executed on the cache so we can reuse the _readers
+         * list to gracefully shutdown readers.
+         */
+        _readers.push_back(*e);
     }
 }
 

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -81,6 +81,9 @@ readers_cache::put(std::unique_ptr<log_reader> reader) {
 
 std::optional<model::record_batch_reader>
 readers_cache::get_reader(const log_reader_config& cfg) {
+    if (_gate.is_closed()) {
+        return std::nullopt;
+    }
     vlog(stlog.trace, "{} - trying to get reader for: {}", _ntp, cfg);
     intrusive_list<entry, &entry::_hook> to_evict;
     /**


### PR DESCRIPTION
## Cover letter

An error in `storage::readers_cache` implementation may lead to the situation in which closing the log might stuck and never return. The issue was caused by the fact that background reader disposal was not executed when `readers_cache` was closed. This way the not reusable reader was never deleted and hold the `log` lock lease preventing log
from being closed. Fixed an issue by making sure that reader will be gracefully closed and disposed during `readers_cache` shutdown.

Related to: 
#2385 

Fixes: N/A

## Release notes
