### PR TITLE
ducky: use 8 random characters in auto generated topic names

### DIFF
--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -76,6 +76,6 @@ class TopicSpec:
                 self.replication_factor == other.replication_factor and \
                 self.cleanup_policy == other.cleanup_policy
 
-    def _random_topic_suffix(self, size=4):
+    def _random_topic_suffix(self, size=10):
         return "".join(
             random.choice(string.ascii_lowercase) for _ in range(size))


### PR DESCRIPTION
We experience overlap of random topic names in some of the tests. Using
10 random characters instead of 4 to make overlap less probable.

Fixes: #2474

Signed-off-by: Michal Maslanka <michal@vectorized.io>
