### PR TITLE
ducktape: retention_policy - wait for controller

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -114,6 +114,10 @@ class RetentionPolicyTest(RedpandaTest):
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
         kafka_tools = KafkaCliTools(self.redpanda)
+
+        # Wait for controller, alter configs doesn't have a retry loop
+        kafka_tools.describe_topic(self.topic)
+
         # change retention bytes to preserve 15 segments
         kafka_tools.alter_topic_config(
             self.topic, {


### PR DESCRIPTION
## Cover letter

PR #2428 changed the returned error code so that the error was
retriable with a metadata refresh, but kafka-configs.sh doesn't retry.

Call describe_topic to wait for the controller, as it performs a retry.

Fix #2406

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: none
