### PR TITLE
Backport #2441: schema_registry: Sanitize type names and namespaces

### DIFF
--- a/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/sanitize_avro.cc
@@ -32,6 +32,12 @@ pps::schema_definition leading_dot{
 pps::schema_definition leading_dot_sanitized{
   R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"fields":[{"name":"f1","type":["null","string"]}],"name":"r1","type":"record"}]},{"name":"two","type":["null","r1"]}]})"};
 
+pps::schema_definition leading_dot_ns{
+  R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"fields":[{"name":"f1","type":["null","string"]}],"name":".ns.r1","type":"record"}]},{"name":"two","type":["null",".ns.r1"]}]})"};
+
+pps::schema_definition leading_dot_ns_sanitized{
+  R"({"type":"record","name":"record","fields":[{"name":"one","type":["null",{"fields":[{"name":"f1","type":["null","string"]}],"name":"r1","type":"record","namespace":".ns"}]},{"name":"two","type":["null",".ns.r1"]}]})"};
+
 BOOST_AUTO_TEST_CASE(test_sanitize_avro_minify) {
     BOOST_REQUIRE_EQUAL(
       pps::sanitize_avro_schema_definition(not_minimal).value()(),
@@ -42,4 +48,19 @@ BOOST_AUTO_TEST_CASE(test_sanitize_avro_name) {
     BOOST_REQUIRE_EQUAL(
       pps::sanitize_avro_schema_definition(leading_dot).value()(),
       leading_dot_sanitized());
+}
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_name_ns) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(leading_dot_ns).value(),
+      leading_dot_ns_sanitized);
+}
+
+pps::schema_definition debezium_schema{
+  R"({"type":"record","name":"SchemaChangeKey","namespace":"io.debezium.connector.mysql","fields":[{"name":"databaseName","type":"string"}],"connect.name":"io.debezium.connector.mysql.SchemaChangeKey"})"};
+
+BOOST_AUTO_TEST_CASE(test_sanitize_avro_debzium) {
+    BOOST_REQUIRE_EQUAL(
+      pps::sanitize_avro_schema_definition(debezium_schema).value(),
+      debezium_schema);
 }


### PR DESCRIPTION
Backport #2441 

## Cover letter

The name field for complex type (record, union, fixed), should
have a leading dot removed iff it's the only one. Otherwise it
should be split on the last dot into a name and namespace.

The name of a type referred to in a union should have the leading
dot removed iff it's the only one.

Signed-off-by: Ben Pope <ben@vectorized.io>
(cherry picked from commit 4aac62cfae6f8ac29d30518c943378ff60455996)

## Release notes

Release note: Avro name sanitization is now namespace aware.