### PR TITLE
k8s: run produce-consume in default namespace

### DIFF
--- a/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-assert.yaml
@@ -1,14 +1,16 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: cluster-sample
+  name: cluster-sample-produceconsume
+  namespace: default
 status:
   readyReplicas: 3
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: cluster-sample
+  name: cluster-sample-produceconsume
+  namespace: default
 spec:
   clusterIP: None
   ports:
@@ -25,6 +27,7 @@ spec:
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: cluster-sample
+  name: cluster-sample-produceconsume
+  namespace: default
 status:
   replicas: 3

--- a/src/go/k8s/tests/e2e/produce-consume/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/00-redpanda-cluster.yaml
@@ -1,7 +1,8 @@
 apiVersion: redpanda.vectorized.io/v1alpha1
 kind: Cluster
 metadata:
-  name: cluster-sample
+  name: cluster-sample-produceconsume
+  namespace: default
 spec:
   image: "localhost/redpanda"
   version: "dev"

--- a/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-assert.yaml
@@ -1,7 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: create-test-topic
+  name: create-test-topic-produceconsume
+  namespace: default
 status:
   conditions:
     - status: "True"

--- a/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/01-create-topic.yaml
@@ -1,7 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: create-test-topic
+  name: create-test-topic-produceconsume
+  namespace: default
 spec:
   template:
     spec:
@@ -17,7 +18,7 @@ spec:
             - /bin/bash
             - -c
           args:
-            - sleep 10 ; rpk topic create -r 3 test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
+            - sleep 10 ; rpk topic create -r 3 test --brokers cluster-sample-produceconsume-0.cluster-sample-produceconsume.$POD_NAMESPACE.svc.cluster.local:9092 -v
       restartPolicy: Never
   backoffLimit: 12
   parallelism: 1

--- a/src/go/k8s/tests/e2e/produce-consume/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/02-assert.yaml
@@ -1,7 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: produce-message
+  name: produce-message-produceconsume
+  namespace: default
 status:
   conditions:
     - status: "True"

--- a/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/02-produce-message.yaml
@@ -1,7 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: produce-message
+  name: produce-message-produceconsume
+  namespace: default
 spec:
   template:
     spec:
@@ -20,7 +21,7 @@ spec:
             - >
               echo {"test":"message"} |
               rpk topic produce test
-              --brokers "cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-1.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-2.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092"
+              --brokers "cluster-sample-produceconsume-0.cluster-sample-produceconsume.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-1.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-2.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092"
               -v -n 1 -k "test-key"
       restartPolicy: Never
   backoffLimit: 12

--- a/src/go/k8s/tests/e2e/produce-consume/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/03-assert.yaml
@@ -1,7 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: consume-message
+  name: consume-message-produceconsume
+  namespace: default
 status:
   conditions:
     - status: "True"

--- a/src/go/k8s/tests/e2e/produce-consume/03-consume-message.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/03-consume-message.yaml
@@ -1,7 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: consume-message
+  name: consume-message-produceconsume
+  namespace: default
 spec:
   template:
     spec:
@@ -18,7 +19,7 @@ spec:
             - -c
           args:
             - >
-              kafkacat -b cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092
+              kafkacat -b cluster-sample-produceconsume-0.cluster-sample-produceconsume.$POD_NAMESPACE.svc.cluster.local:9092
               -C -t test -c1
               -f '\nKey (%K bytes): %k\t\nValue (%S bytes): %s\nTimestamp: %T\tPartition: %p\tOffset: %o\n--\n'
       restartPolicy: Never

--- a/src/go/k8s/tests/e2e/produce-consume/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/04-assert.yaml
@@ -1,7 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: delete-test-topic
+  name: delete-test-topic-produceconsume
+  namespace: default
 status:
   conditions:
     - status: "True"

--- a/src/go/k8s/tests/e2e/produce-consume/04-delete-topic.yaml
+++ b/src/go/k8s/tests/e2e/produce-consume/04-delete-topic.yaml
@@ -1,7 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: delete-test-topic
+  name: delete-test-topic-produceconsume
+  namespace: default
 spec:
   template:
     spec:
@@ -17,7 +18,7 @@ spec:
             - /bin/bash
             - -c
           args:
-            - rpk topic delete test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
+            - rpk topic delete test --brokers cluster-sample-produceconsume-0.cluster-sample-produceconsume.$POD_NAMESPACE.svc.cluster.local:9092 -v
       restartPolicy: Never
   backoffLimit: 6
   parallelism: 1


### PR DESCRIPTION
To debug build failures