### PR TITLE
tests: fix RpkTool.produce to partition 0 

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -90,7 +90,7 @@ class RpkTool:
         ]
         if headers:
             cmd += ['-H ' + h for h in headers]
-        if partition:
+        if partition is not None:
             cmd += ['-p', str(partition)]
         out = self._run_topic(cmd, stdin=msg, timeout=timeout)
 

--- a/tests/rptest/tests/rpk_topic_test.py
+++ b/tests/rptest/tests/rpk_topic_test.py
@@ -163,7 +163,6 @@ class RpkToolTest(RedpandaTest):
                    backoff_sec=20,
                    err_msg="Message didn't appear.")
 
-    @ignore
     @cluster(num_nodes=4)
     def test_consume_from_partition(self):
         topic = 'topic_partition'


### PR DESCRIPTION
## Cover letter

Previously this would omit the partition argument and
tests intending to write to partition 0 would write
in an un-partition-aware way.

Fixes: #1899 

## Release notes

None