### PR TITLE
Use corect timeout handling for tx tests

### DIFF
--- a/tests/java/tx-verifier/src/main/java/io/vectorized/kafka/TxConsumer.java
+++ b/tests/java/tx-verifier/src/main/java/io/vectorized/kafka/TxConsumer.java
@@ -15,6 +15,9 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 
 public class TxConsumer {
+  public static class TimeoutException extends Exception {
+    public TimeoutException(String msg) { super(msg); }
+  }
 
   String topic;
   TopicPartition tp;
@@ -82,7 +85,7 @@ public class TxConsumer {
       }
     }
 
-    throw new Exception(
+    throw new TimeoutException(
         "can't read up to " + last_offset + " in " + attempts + " tries");
   }
 
@@ -117,7 +120,7 @@ public class TxConsumer {
       }
     }
 
-    throw new Exception(
+    throw new TimeoutException(
         "can't read " + n + " records in " + attempts + " tries");
   }
 }

--- a/tests/java/tx-verifier/src/main/java/io/vectorized/kafka/Verifier.java
+++ b/tests/java/tx-verifier/src/main/java/io/vectorized/kafka/Verifier.java
@@ -67,6 +67,13 @@ class Verifier {
             "Executing " + name + " test, retries left: " + retries);
         action.run(connection);
         return;
+      } catch (TxConsumer.TimeoutException e) {
+        if (retries > 0) {
+          e.printStackTrace();
+          Thread.sleep(Duration.ofSeconds(1).toMillis());
+          continue;
+        }
+        throw e;
       } catch (KafkaException e) {
         if (retries > 0) {
           e.printStackTrace();

--- a/tests/java/tx-verifier/src/main/java/io/vectorized/kafka/Verifier.java
+++ b/tests/java/tx-verifier/src/main/java/io/vectorized/kafka/Verifier.java
@@ -306,7 +306,7 @@ class Verifier {
       }
       assertLess(last_offset, consumer.position());
 
-      var records = consumer.read(first_offset, last_offset, 1);
+      var records = consumer.read(first_offset, last_offset, 500, 10);
       consumer.close();
       consumer = null;
       assertEquals(records.size(), offsets.size());
@@ -350,7 +350,7 @@ class Verifier {
       }
       assertLess(last_offset, consumer.position());
 
-      var records = consumer.read(first_offset, last_offset, 1);
+      var records = consumer.read(first_offset, last_offset, 500, 10);
       consumer.close();
       consumer = null;
       assertEquals(records.size(), 2);
@@ -558,7 +558,7 @@ class Verifier {
       stream = null;
 
       consumer = new TxConsumer(connection, topic2, true);
-      var transformed = consumer.readN(target_offset + 1, 3, 1);
+      var transformed = consumer.readN(target_offset + 1, 3, 500, 10);
 
       for (var target : transformed) {
         assertTrue(mapping.containsKey(target.offset));


### PR DESCRIPTION
Fixes transaction tests to reduce the rate of false positive errors:

 - it used request batch (1) as a timeout (1ms): replaced to 500ms
 - it didn't retry a test on timeout: changed to retry it up to three times

Fixes https://github.com/vectorizedio/redpanda/issues/2490