### PR TITLE
Serde ADL + Auto Skip of Bytes for Custom Read Functions

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -402,6 +402,29 @@ ss::future<> write_async(iobuf& out, T const& t) {
     }
 }
 
+/**
+ * Only use this method for enums specifying the underlying datatype explicitly.
+ * Otherwise, the serialization format might change depending on the compiler.
+ */
+template<
+  typename T,
+  std::enable_if_t<std::is_enum_v<std::decay_t<T>>, void*> = nullptr>
+void read_enum(iobuf_parser& in, T& el, size_t const bytes_left_limit) {
+    serde::read_nested(
+      in, *reinterpret_cast<std::underlying_type_t<T>*>(&el), bytes_left_limit);
+}
+
+/**
+ * Only use this method for enums specifying the underlying datatype explicitly.
+ * Otherwise, the serialization format might change depending on the compiler.
+ */
+template<
+  typename T,
+  std::enable_if_t<std::is_enum_v<std::decay_t<T>>, void*> = nullptr>
+void write_enum(iobuf& out, T const el) {
+    serde::write(out, static_cast<std::underlying_type_t<T>>(el));
+}
+
 template<typename T>
 iobuf to_iobuf(T&& t) {
     iobuf b;

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -281,9 +281,9 @@ void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
                 f = read_nested<FieldType>(in, bytes_left_limit);
                 return true;
             });
-            if (in.bytes_left() > h._bytes_left_limit) {
-                in.skip(in.bytes_left() - h._bytes_left_limit);
-            }
+        }
+        if (in.bytes_left() > h._bytes_left_limit) {
+            in.skip(in.bytes_left() - h._bytes_left_limit);
         }
     } else if constexpr (std::is_same_v<Type, bool>) {
         t = read_nested<int8_t>(in, bytes_left_limit) != 0;

--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -254,12 +254,10 @@ header read_header(iobuf_parser& in, std::size_t const bytes_left_limit) {
 }
 
 template<typename T>
-std::decay_t<T>
-read_nested(iobuf_parser& in, std::size_t const bytes_left_limit) {
+void read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit) {
     using Type = std::decay_t<T>;
     static_assert(has_serde_read<T> || is_serde_compatible_v<Type>);
 
-    auto t = Type();
     if constexpr (is_envelope_v<Type>) {
         auto const h = read_header<Type>(in, bytes_left_limit);
         if constexpr (has_serde_read<Type>) {
@@ -317,19 +315,26 @@ read_nested(iobuf_parser& in, std::size_t const bytes_left_limit) {
         t = std::chrono::milliseconds{
           read_nested<int64_t>(in, bytes_left_limit)};
     } else if constexpr (std::is_same_v<Type, iobuf>) {
-        return in.share(read_nested<serde_size_t>(in, bytes_left_limit));
+        t = in.share(read_nested<serde_size_t>(in, bytes_left_limit));
     } else if constexpr (std::is_same_v<Type, ss::sstring>) {
         auto str = ss::uninitialized_string(
           read_nested<serde_size_t>(in, bytes_left_limit));
         in.consume_to(str.size(), str.begin());
-        return str;
+        t = str;
     } else if constexpr (reflection::is_std_optional_v<Type>) {
-        return read_nested<bool>(in, bytes_left_limit)
-                 ? Type{read_nested<typename Type::value_type>(
-                   in, bytes_left_limit)}
-                 : std::nullopt;
+        t = read_nested<bool>(in, bytes_left_limit)
+              ? Type{read_nested<typename Type::value_type>(
+                in, bytes_left_limit)}
+              : std::nullopt;
     }
+}
 
+template<typename T>
+std::decay_t<T>
+read_nested(iobuf_parser& in, std::size_t const bytes_left_limit) {
+    using Type = std::decay_t<T>;
+    auto t = Type();
+    read_nested(in, t, bytes_left_limit);
     return t;
 }
 

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -34,6 +34,15 @@ struct custom_read_write {
     int _x;
 };
 
+enum class my_enum : uint8_t { x, y, z };
+
+inline void
+read_nested(iobuf_parser& in, my_enum& el, size_t const bytes_left_limit) {
+    serde::read_enum(in, el, bytes_left_limit);
+}
+
+inline void write(iobuf& out, my_enum el) { serde::write_enum(out, el); }
+
 SEASTAR_THREAD_TEST_CASE(custom_read_write_test) {
     BOOST_CHECK(
       serde::from_iobuf<custom_read_write>(

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -19,6 +19,29 @@
 #include <chrono>
 #include <limits>
 
+struct custom_read_write {
+    friend inline void read_nested(
+      iobuf_parser& in, custom_read_write& el, size_t const bytes_left_limit) {
+        serde::read_nested(in, el._x, bytes_left_limit);
+        ++el._x;
+    }
+
+    friend inline void write(iobuf& out, custom_read_write el) {
+        ++el._x;
+        serde::write(out, el._x);
+    }
+
+    int _x;
+};
+
+SEASTAR_THREAD_TEST_CASE(custom_read_write_test) {
+    BOOST_CHECK(
+      serde::from_iobuf<custom_read_write>(
+        serde::to_iobuf(custom_read_write{123}))
+        ._x
+      == 125);
+}
+
 struct test_msg0
   : serde::envelope<test_msg0, serde::version<1>, serde::compat_version<0>> {
     char _i, _j;


### PR DESCRIPTION
Before, the only signature of `read_nested` was this:

```cpp
read_nested(iobuf_parser& in, std::size_t const bytes_left_limit)
```

Now, I added another signature:

```cpp
read_nested(iobuf_parser& in, T& t, std::size_t const bytes_left_limit)
```

The first one calls the second one. So it's possible to make a specialization for one of the above (what fits).

The new one enables to skip stating the type to deserialize because the C++ compiler will figure it out through ADL on the second argument of `read_nested`. This should make it more convenient to use serde.

Additionally, this PR adds convenience functions to ease the implementation of enum (de)serialization and skips bytes at the end of custom deserialization.