### PR TITLE
Fix wasm crash bug when deploy unpackaged scripts.

### DIFF
--- a/src/js/modules/rpc/server.ts
+++ b/src/js/modules/rpc/server.ts
@@ -223,9 +223,10 @@ export class ProcessBatchServer extends SupervisorServer {
     const handle = module?.exports?.default;
     if (handle === undefined) {
       this.logger.error(
-        "Error on load script, script doesn't " + "export anything"
+        "Error on load script, script doesn't export anything. " +
+          "Possible cause: script not packaged using NPM."
       );
-      return undefined;
+      return [undefined, errors.validateLoadScriptError(null, id, script)];
     }
     if (!errors.validateWasmAttributes(handle, id, this.logger)) {
       return [undefined, errors.validateLoadScriptError(null, id, script)];


### PR DESCRIPTION
## Cover letter

Fix a bug that occurs and crashes the WASM engine when the script being deployed is not packaged using NPM.

Fixes: #2505

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [The PR changes the error message when script being deployed doesn't export anything, to hint a possible cause that the script is not packaged using NPM.]
