### PR TITLE
Change helm e2e tests in operator

### DIFF
--- a/src/go/k8s/README.md
+++ b/src/go/k8s/README.md
@@ -99,3 +99,8 @@ please run the following command:
 ```
 kubectl delete -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/default
 ```
+
+#### Running e2e tests
+
+Before you execute any kuttl tests, that are defined in e2e test Makefile target,
+please create kind cluster.

--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
-startKIND: true
 kindContainers:
   - vectorized/redpanda-operator:latest
   - vectorized/configurator:latest


### PR DESCRIPTION
## Cover letter

To align both kuttl test suites helm and e2e requires kind cluster to be created before executing them. 