### PR TITLE
Bring back produce-consume tests

### DIFF
--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -111,16 +111,19 @@ push-to-kind: kind-create certmanager-install
 # Execute end to end tests
 e2e-tests: kuttl test docker-build docker-build-configurator
 	echo "~~~ Running kuttl tests :k8s:"
+	mkdir -p tests/_e2e_artifacts
 	$(KUTTL) test $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
 
 # Execute end to end tests using helm as an installation
 helm-e2e-tests: kuttl test docker-build docker-build-configurator
 	echo "~~~ Running kuttl tests :k8s:"
+	mkdir -p tests/_helm_e2e_artifacts
 	$(KUTTL) test --config kuttl-helm-test.yaml $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
 
 # Execute one consume produce end to end test
 produce-consume-e2e-tests: kuttl test docker-build docker-build-configurator
 	echo "~~~ Running kuttl tests :k8s:"
+	mkdir -p tests/_produce_consume_e2e_artifacts
 	$(KUTTL) test --config kuttl-produce-consume.yaml $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
 
 # Download controller-gen locally if necessary

--- a/src/go/k8s/Makefile
+++ b/src/go/k8s/Makefile
@@ -118,6 +118,11 @@ helm-e2e-tests: kuttl test docker-build docker-build-configurator
 	echo "~~~ Running kuttl tests :k8s:"
 	$(KUTTL) test --config kuttl-helm-test.yaml $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
 
+# Execute one consume produce end to end test
+produce-consume-e2e-tests: kuttl test docker-build docker-build-configurator
+	echo "~~~ Running kuttl tests :k8s:"
+	$(KUTTL) test --config kuttl-produce-consume.yaml $(TEST_ONLY_FLAG) $(KUTTL_TEST_FLAGS)
+
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen:

--- a/src/go/k8s/README.md
+++ b/src/go/k8s/README.md
@@ -99,3 +99,8 @@ please run the following command:
 ```
 kubectl delete -k https://github.com/vectorizedio/redpanda/src/go/k8s/config/default
 ```
+
+#### Running e2e tests
+
+Before you execute any kuttl tests, that are defined in e2e test Makefile target,
+please create kind cluster.

--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
-startKIND: true
 kindContainers:
   - vectorized/redpanda-operator:latest
   - vectorized/configurator:latest

--- a/src/go/k8s/kuttl-helm-test.yaml
+++ b/src/go/k8s/kuttl-helm-test.yaml
@@ -14,7 +14,6 @@ commands:
   - command: "helm dep up ./helm-chart/charts/redpanda-operator"
   - command: "helm install --set configurator.tag=latest --set image.tag=latest --namespace helm-test --create-namespace redpanda-operator ./helm-chart/charts/redpanda-operator"
   - command: "./hack/wait-for-webhook-ready.sh"
-  - command: "mkdir -p tests/_helm_e2e_artifacts"
 artifactsDir: tests/_helm_e2e_artifacts
 timeout: 300
 reportFormat: xml

--- a/src/go/k8s/kuttl-produce-consume.yaml
+++ b/src/go/k8s/kuttl-produce-consume.yaml
@@ -6,6 +6,7 @@ kindContainers:
 testDirs:
   - ./tests/produce-consume
 kindNodeCache: false
+skipDelete: true
 commands:
   - command: "kubectl taint nodes -l node-role.kubernetes.io/master= node-role.kubernetes.io/master:NoSchedule-"
   - command: "./hack/install-cert-manager.sh"

--- a/src/go/k8s/kuttl-produce-consume.yaml
+++ b/src/go/k8s/kuttl-produce-consume.yaml
@@ -12,7 +12,6 @@ commands:
   - command: "kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml"
   - command: "make deploy"
   - command: "./hack/wait-for-webhook-ready.sh"
-  - command: "mkdir -p tests/_produce_consume_e2e_artifacts"
 artifactsDir: tests/_produce_consume_e2e_artifacts
 timeout: 300
 reportFormat: xml

--- a/src/go/k8s/kuttl-produce-consume.yaml
+++ b/src/go/k8s/kuttl-produce-consume.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+kindContainers:
+  - vectorized/redpanda-operator:latest
+  - vectorized/configurator:latest
+testDirs:
+  - ./tests/produce-consume
+kindNodeCache: false
+commands:
+  - command: "kubectl taint nodes -l node-role.kubernetes.io/master= node-role.kubernetes.io/master:NoSchedule-"
+  - command: "./hack/install-cert-manager.sh"
+  - command: "kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml"
+  - command: "make deploy"
+  - command: "./hack/wait-for-webhook-ready.sh"
+  - command: "mkdir -p tests/_produce_consume_e2e_artifacts"
+artifactsDir: tests/_produce_consume_e2e_artifacts
+timeout: 300
+reportFormat: xml
+parallel: 1

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -13,7 +13,6 @@ commands:
   - command: "kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml"
   - command: "make deploy"
   - command: "./hack/wait-for-webhook-ready.sh"
-  - command: "mkdir -p tests/_e2e_artifacts"
 artifactsDir: tests/_e2e_artifacts
 timeout: 300
 reportFormat: xml

--- a/src/go/k8s/tests/produce-consume/produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/00-assert.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cluster-sample
+status:
+  readyReplicas: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-sample
+spec:
+  clusterIP: None
+  ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: kafka
+      port: 9092
+      protocol: TCP
+      targetPort: 9092
+  type: ClusterIP
+---
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster-sample
+status:
+  replicas: 3
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/produce-consume/produce-consume/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/00-redpanda-cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster-sample
+  labels:
+    test: produce-consume
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 3
+  resources:
+    requests:
+      cpu: 1
+      memory: 2Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    adminApi:
+    - port: 9644
+    developerMode: false

--- a/src/go/k8s/tests/produce-consume/produce-consume/01-assert.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/01-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-test-topic
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/produce-consume/produce-consume/01-create-topic.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/01-create-topic.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-test-topic
+  labels:
+    test: produce-consume
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - sleep 10 ; rpk topic create -r 3 test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
+      restartPolicy: Never
+  backoffLimit: 12
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/produce-consume/produce-consume/02-assert.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/02-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: produce-message
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/produce-consume/produce-consume/02-produce-message.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/02-produce-message.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: produce-message
+  labels:
+    test: produce-consume
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              echo {"test":"message"} |
+              rpk topic produce test
+              --brokers "cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-1.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092,cluster-sample-2.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092"
+              -v -n 1 -k "test-key"
+      restartPolicy: Never
+  backoffLimit: 12
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/produce-consume/produce-consume/03-assert.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/03-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: consume-message
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/produce-consume/produce-consume/03-consume-message.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/03-consume-message.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: consume-message
+  labels:
+    test: produce-consume
+spec:
+  template:
+    spec:
+      containers:
+        - name: kafkacat
+          image: confluentinc/cp-kafkacat:5.5.3
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              kafkacat -b cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092
+              -C -t test -c1
+              -f '\nKey (%K bytes): %k\t\nValue (%S bytes): %s\nTimestamp: %T\tPartition: %p\tOffset: %o\n--\n'
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/produce-consume/produce-consume/04-assert.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/04-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-test-topic
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    selector: test=produce-consume

--- a/src/go/k8s/tests/produce-consume/produce-consume/04-delete-topic.yaml
+++ b/src/go/k8s/tests/produce-consume/produce-consume/04-delete-topic.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-test-topic
+  labels:
+    test: produce-consume
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - rpk topic delete test --brokers cluster-sample-0.cluster-sample.$POD_NAMESPACE.svc.cluster.local:9092 -v
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1


### PR DESCRIPTION
## Cover letter

This PR:
* create new kuttl configuration for produce consume e2e tests
* create new makefile target for produce consume e2e tests
* create test artifacts folder before kuttl is invoked 

The produce consume kuttl configuration will not delete resources created by tests. This will help with kind export logs as containers will still be there for later inspection.