### PR TITLE
Added group state cleanup when leadership is lost

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -100,6 +100,11 @@ ss::future<model::node_id> metadata_cache::get_leader(
     return _leaders.local().wait_for_leader(ntp, tout, as);
 }
 
+std::optional<model::node_id>
+metadata_cache::get_leader_id(const model::ntp& ntp) {
+    return _leaders.local().get_leader(ntp);
+}
+
 /// If present returns a leader of raft0 group
 std::optional<model::node_id> metadata_cache::get_controller_leader_id() {
     return _leaders.local().get_leader(model::controller_ntp);

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -96,6 +96,7 @@ public:
         return contains(model::topic_namespace_view(ntp), ntp.tp.partition);
     }
 
+    std::optional<model::node_id> get_leader_id(const model::ntp&);
     /// Returns metadata of all topics in cache internal format
     // const cache_t& all_metadata() const { return _cache; }
 

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -222,6 +222,8 @@ private:
       ss::lw_shared_ptr<attached_partition>,
       recovery_batch_consumer_state);
 
+    ss::future<> gc_partition_state(ss::lw_shared_ptr<attached_partition>);
+
     ss::future<> inject_noop(
       ss::lw_shared_ptr<cluster::partition> p,
       ss::lowres_clock::time_point timeout);

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -158,6 +158,10 @@
                     "type": "long",
                     "description": "leader node id"
                 },
+                "raft_group_id": {
+                    "type": "long",
+                    "description": "partition raft group id"
+                },
                 "replicas": {
                     "type": "array",
                     "items": {

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -154,6 +154,10 @@
                     "type": "string",
                     "description": "status"
                 },
+                "leader_id": {
+                    "type": "long",
+                    "description": "leader node id"
+                },
                 "replicas": {
                     "type": "array",
                     "items": {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -783,7 +783,8 @@ void admin_server::register_partition_routes() {
                   p.replicas.push(a);
                   p.leader_id = *leader_opt;
               }
-
+              // special case, controller is raft group 0
+              p.raft_group_id = 0;
               for (const auto& i : _metadata_cache.local().all_broker_ids()) {
                   if (!leader_opt.has_value() || leader_opt.value() != i) {
                       ss::httpd::partition_json::assignment a;
@@ -814,6 +815,7 @@ void admin_server::register_partition_routes() {
                       a.core = r.shard;
                       p.replicas.push(a);
                   }
+                  p.raft_group_id = assignment->group;
               }
               auto leader = _metadata_cache.local().get_leader_id(ntp);
               if (leader) {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -767,6 +767,7 @@ void admin_server::register_partition_routes() {
           p.ns = ntp.ns;
           p.topic = ntp.tp.topic;
           p.partition_id = ntp.tp.partition;
+          p.leader_id = -1;
 
           // Logic for fetching replicas+status is different for normal
           // topics vs. the special controller topic.
@@ -780,6 +781,7 @@ void admin_server::register_partition_routes() {
                   a.node_id = leader_opt.value();
                   a.core = cluster::controller_stm_shard;
                   p.replicas.push(a);
+                  p.leader_id = *leader_opt;
               }
 
               for (const auto& i : _metadata_cache.local().all_broker_ids()) {
@@ -813,6 +815,11 @@ void admin_server::register_partition_routes() {
                       p.replicas.push(a);
                   }
               }
+              auto leader = _metadata_cache.local().get_leader_id(ntp);
+              if (leader) {
+                  p.leader_id = *leader;
+              }
+
               return _controller->get_api()
                 .local()
                 .get_reconciliation_state(ntp)


### PR DESCRIPTION
Previously when `kafka_internal/group` topic partition leadership was
lost we did nothing more than resetting `is_loading` flag on the
partition. Added group state cleanup when group topic partition
leadership is lost. When node will become a leader again state will be
recovered in loading phase.

Fixes: #2528, #2217

Release notes:
- `ListGroups` for each broker will only return those groups for which node is a leader.

[force push](https://github.com/vectorizedio/redpanda/compare/d11836f8d52868d54bc5847aaf77e2709563585c..4bcb341a91920b6da482248e52cdfabd3505be04):

- added duckate test validating that consumer groups are not duplicated
   - added `transfer_leadership_to` in ducktape admin
   - added missing fields to `partition_details` returned by admin API
 - fixed possible group access after it being removed from `_groups` map