### PR TITLE
Re-enable ducktape tests for wasm

### DIFF
--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -65,7 +65,6 @@ class WasmIdentityTest(WasmTest):
         """ How to interpret PASS/FAIL between two sets of returned results"""
         return materialized_result_set_compare
 
-    @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
     @cluster(num_nodes=3)
     def verify_materialized_topics_test(self):
         """


### PR DESCRIPTION
Draft PR not intended to merge, we want to test the wasm ducktape changes on CI. The top commit in this PR differs from dev only by re-enabling the wasm tests

Link to relevant issue: https://github.com/vectorizedio/redpanda/issues/2514

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/4f3b7e8013270f458ba665e8fcfc073b693b394d..1b3a33b923288e89998d6c2c4c3ffe74ab425503)
- Changed commit title