### PR TITLE
ParamsFromConfig: return early on FlagConfig

### DIFF
--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -158,6 +158,7 @@ func ParamsFromCommand(cmd *cobra.Command) *Params {
 
 			case FlagConfig:
 				p.ConfigPath = f.Value.String()
+				return
 
 			case FlagBrokers:
 				key = xKafkaBrokers


### PR DESCRIPTION
FlagConfig sets a value directly in the params, it is not a config
override itself. We need to return early so that we do not add it to
FlagOverrides.