### PR TITLE
redpanda: Move kafka/server header deps from .h to cpp

### DIFF
--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -18,6 +18,7 @@ class fetch_session_cache;
 class group_manager;
 class group_router;
 class rm_group_frontend;
+class rm_group_proxy_impl;
 class request_context;
 class quota_manager;
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -17,7 +17,6 @@
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
 #include "kafka/server/fwd.h"
-#include "kafka/server/rm_group_frontend.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/rest/fwd.h"
 #include "pandaproxy/schema_registry/configuration.h"
@@ -141,7 +140,7 @@ private:
     ss::sharded<storage::compaction_controller> _compaction_controller;
 
     ss::metrics::metric_groups _metrics;
-    kafka::rm_group_proxy_impl _rm_group_proxy;
+    std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;
     // run these first on destruction
     deferred_actions _deferred;
 };


### PR DESCRIPTION
## Cover letter

Also defer construction of `_rm_group_proxy` to just before it's needed, and after its dependencies are constructed.

It now won't be constructed in standalone mode of Pandaproxy REST and Schema Registry.

**Note**
`construct_single_service` can't be used as there's no `stop()` member.

There are lifetime implications to that, for example `_rm_group_frontend` is destructed before `_rm_group_proxy`, @rystsov can you take a look and open a separate PR if required?

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

Release note: none
