### PR TITLE
Fix "rpk wasm generate" error

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -62,6 +62,26 @@ const defApiVersion = "21.8.2"
 
 var inTests bool
 
+func getWasmApiVersion(wasmApi string) string {
+	var result []map[string]interface{}
+	if err := json.Unmarshal([]byte(wasmApi), &result); err != nil {
+		fmt.Printf("Can not parse json from npm search: '%s', Error: %s\n", wasmApi, err)
+		return defApiVersion
+	}
+
+	if len(result) != 1 {
+		fmt.Printf("Wrong npm search result: %v", result)
+		return defApiVersion
+	}
+
+	version, ok := result[0]["version"].(string)
+	if !ok {
+		fmt.Printf("Can not get version from npm search result: %s\n", result)
+		return defApiVersion
+	}
+	return version
+}
+
 // Looks up the latest version of our client library using npm, defaulting
 // if anything fails.
 func latestClientApiVersion() string {
@@ -83,23 +103,7 @@ func latestClientApiVersion() string {
 
 	wasmApi := strings.Join(output, "")
 
-	var result []map[string]interface{}
-	if err = json.Unmarshal([]byte(wasmApi), &result); err != nil {
-		fmt.Printf("Can not parse json from npm search: '%s', Error: %s\n", wasmApi, err)
-		return defApiVersion
-	}
-
-	if len(result) != 1 {
-		fmt.Printf("Wrong npm search result: %v", result)
-		return defApiVersion
-	}
-
-	version, ok := result[0]["version"].(string)
-	if !ok {
-		fmt.Printf("Can not get version from npm search result: %s\n", result)
-		return defApiVersion
-	}
-	return version
+	return getWasmApiVersion(wasmApi)
 }
 
 func executeGenerate(fs afero.Fs, path string) error {

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -80,15 +81,21 @@ func latestClientApiVersion() string {
 		return defApiVersion
 	}
 
-	var result map[string]interface{}
-	if err := json.Unmarshal([]byte(output[2]), &result); err != nil {
+	wasmApi := strings.Join(output, "")
+	var result []map[string]interface{}
+	if err := json.Unmarshal([]byte(wasmApi), &result); err != nil {
 		fmt.Println("Can not parse json from npm search: {}, Error: {}", output, err)
 		return defApiVersion
 	}
 
-	version, ok := result["version"].(string)
+	if len(result) != 1 {
+		fmt.Printf("Wrong npm search result: %v", result)
+		return defApiVersion
+	}
+
+	version, ok := result[0]["version"].(string)
 	if !ok {
-		fmt.Println("Can not get version from npm search result: {}", output)
+		fmt.Println("Can not get version from npm search result: {}", result)
 		return defApiVersion
 	}
 	return version

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate.go
@@ -82,9 +82,10 @@ func latestClientApiVersion() string {
 	}
 
 	wasmApi := strings.Join(output, "")
+
 	var result []map[string]interface{}
-	if err := json.Unmarshal([]byte(wasmApi), &result); err != nil {
-		fmt.Println("Can not parse json from npm search: {}, Error: {}", output, err)
+	if err = json.Unmarshal([]byte(wasmApi), &result); err != nil {
+		fmt.Printf("Can not parse json from npm search: '%s', Error: %s\n", wasmApi, err)
 		return defApiVersion
 	}
 
@@ -95,7 +96,7 @@ func latestClientApiVersion() string {
 
 	version, ok := result[0]["version"].(string)
 	if !ok {
-		fmt.Println("Can not get version from npm search result: {}", result)
+		fmt.Printf("Can not get version from npm search result: %s\n", result)
 		return defApiVersion
 	}
 	return version

--- a/src/go/rpk/pkg/cli/cmd/wasm/generate_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate_test.go
@@ -12,12 +12,56 @@ package wasm
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/wasm/template"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/testfs"
 )
 
 func init() {
 	inTests = true
+}
+
+func TestGetWasmApiVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		output string
+	}{
+		{
+			name: "should get correct vectorized WASM API version from npm search",
+			input: `[{"name":"@vectorizedio/wasm-api",
+		    "scope":"vectorizedio",
+		    "version":"21.10.1-si-beta13",
+		    "description":"wasm api helps to define wasm function",
+		    "date":"2021-10-27T17:00:30.090Z",
+		    "links":{"npm":"https://www.npmjs.com/package/%40vectorizedio%2Fwasm-api"},
+		    "publisher":{"username":"vectorizedio","email":"billing@vectorized.io"},
+		    "maintainers":[{"username":"vectorizedio","email":"billing@vectorized.io"}]}
+		    ]`,
+			output: "21.10.1-si-beta13",
+		},
+		{
+			name:   "should get default vectorized WASM API version if npm search returns random string",
+			input:  "Random string\n",
+			output: defApiVersion,
+		},
+		{
+			name:   "should get default vectorized WASM API version if npm search returns null string",
+			input:  "",
+			output: defApiVersion,
+		},
+		{
+			name:   "should get default vectorized WASM API version if npm search returns null JSON array",
+			input:  "[]",
+			output: defApiVersion,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			version := getWasmApiVersion(test.input)
+			require.Exactly(t, version, test.output)
+		})
+	}
 }
 
 func TestWasmCommand(t *testing.T) {


### PR DESCRIPTION
Fix #2527.
The cause of error is because older and newer version of npm have
different output format for "npm search @vectorizedio/wasm-api --json".
This fix changes how the output is handled so that "rpk wasm generate"
can work with different versions of npm.

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
