### PR TITLE
Archival metadata STM

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -344,12 +344,27 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
     if (total.num_succeded != 0) {
         vlog(
           ctxlog.debug,
-          "Uploading next candidates for {}, re-uploading manifest file",
+          "Uploaded next candidates for {}, re-uploading manifest file",
           _ntp);
+
         auto res = co_await upload_manifest(parent);
         if (res != cloud_storage::upload_result::success) {
-            vlog(ctxlog.debug, "Manifest upload for {} failed", _ntp);
+            vlog(ctxlog.warn, "Manifest upload for {} failed", _ntp);
         }
+
+        // TODO: error handling
+        if (_partition->archival_meta_stm()) {
+            retry_chain_node rc_node(
+              _manifest_upload_timeout, _initial_backoff, &parent);
+            if (!co_await _partition->archival_meta_stm()->add_segments(
+                  _manifest, rc_node)) {
+                vlog(
+                  ctxlog.warn,
+                  "archival metadata STM update for {} failed",
+                  _ntp);
+            }
+        }
+
         _last_upload_time = ss::lowres_clock::now();
     }
     co_return total;

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -45,7 +45,7 @@ using namespace std::chrono_literals;
 
 inline ss::logger fixt_log("fixture"); // NOLINT
 
-static constexpr uint16_t httpd_port_number = 4430;
+static constexpr int16_t httpd_port_number = 4430;
 static constexpr const char* httpd_host_name = "127.0.0.1";
 
 static cloud_storage::manifest load_manifest_from_str(std::string_view v) {
@@ -419,3 +419,22 @@ void segment_matcher<Fixture>::verify_manifest_content(
 }
 
 template class segment_matcher<archiver_fixture>;
+
+enable_cloud_storage_fixture::enable_cloud_storage_fixture() {
+    auto& cfg = config::shard_local_cfg();
+    cfg.cloud_storage_enabled.set_value(true);
+    cfg.cloud_storage_api_endpoint.set_value(
+      std::optional<ss::sstring>{httpd_host_name});
+    cfg.cloud_storage_api_endpoint_port.set_value(httpd_port_number);
+    cfg.cloud_storage_access_key.set_value(
+      std::optional<ss::sstring>{"access-key"});
+    cfg.cloud_storage_secret_key.set_value(
+      std::optional<ss::sstring>{"secret-key"});
+    cfg.cloud_storage_region.set_value(std::optional<ss::sstring>{"us-east1"});
+    cfg.cloud_storage_bucket.set_value(
+      std::optional<ss::sstring>{"test-bucket"});
+}
+
+enable_cloud_storage_fixture::~enable_cloud_storage_fixture() {
+    config::shard_local_cfg().cloud_storage_enabled.set_value(false);
+}

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -146,9 +146,17 @@ public:
     /// find matching segments and check the fields.
     void verify_manifest_content(const ss::sstring& manifest_content);
 };
+
+class enable_cloud_storage_fixture {
+public:
+    enable_cloud_storage_fixture();
+    ~enable_cloud_storage_fixture();
+};
+
 /// Archiver fixture that contains S3 mock and full redpanda stack.
 class archiver_fixture
   : public s3_imposter_fixture
+  , public enable_cloud_storage_fixture
   , public redpanda_thread_fixture
   , public segment_matcher<archiver_fixture> {
 public:

--- a/src/v/cloud_storage/manifest.cc
+++ b/src/v/cloud_storage/manifest.cc
@@ -285,11 +285,16 @@ remote_manifest_path manifest::get_manifest_path() const {
     return generate_partition_manifest_path(_ntp, _rev);
 }
 
-remote_segment_path
-manifest::get_remote_segment_path(const segment_name& name) const {
-    auto path = ssx::sformat("{}_{}/{}", _ntp.path(), _rev(), name());
+remote_segment_path manifest::generate_remote_segment_path(
+  const model::ntp ntp, model::revision_id rev_id, const segment_name& name) {
+    auto path = ssx::sformat("{}_{}/{}", ntp.path(), rev_id(), name());
     uint32_t hash = xxhash_32(path.data(), path.size());
     return remote_segment_path(fmt::format("{:08x}/{}", hash, path));
+}
+
+remote_segment_path
+manifest::get_remote_segment_path(const segment_name& name) const {
+    return generate_remote_segment_path(_ntp, _rev, name);
 }
 
 remote_segment_path

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -18,6 +18,7 @@
 #include "model/metadata.h"
 #include "s3/client.h"
 #include "seastarx.h"
+#include "serde/serde.h"
 #include "tristate.h"
 
 #include <seastar/util/bool_class.hh>
@@ -130,6 +131,10 @@ public:
 class manifest final : public base_manifest {
 public:
     struct segment_meta {
+        using value_t = segment_meta;
+        static constexpr serde::version_t redpanda_serde_version = 0;
+        static constexpr serde::version_t redpanda_serde_compat_version = 0;
+
         bool is_compacted;
         size_t size_bytes;
         model::offset base_offset;
@@ -157,6 +162,8 @@ public:
     remote_manifest_path get_manifest_path() const override;
 
     /// Segment file name in S3
+    static remote_segment_path generate_remote_segment_path(
+      const model::ntp, model::revision_id, const segment_name&);
     remote_segment_path get_remote_segment_path(const segment_name& name) const;
     remote_segment_path get_remote_segment_path(const key& name) const;
 

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -31,6 +31,7 @@ rpcgen(
 v_cc_library(
   NAME cluster
   SRCS
+    archival_metadata_stm.cc
     metadata_cache.cc
     partition_manager.cc
     scheduling/partition_allocator.cc
@@ -89,5 +90,6 @@ v_cc_library(
     absl::flat_hash_map
     v::model
     v::v8_engine
+    v::cloud_storage
   )
 add_subdirectory(tests)

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -266,6 +266,10 @@ ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
     co_return stm_snapshot::create(0, _insync_offset, std::move(snap_data));
 }
 
+model::offset archival_metadata_stm::max_collectible_offset() {
+    return _last_offset;
+}
+
 void archival_metadata_stm::apply_add_segment(const segment& segment) {
     if (segment.ntp_revision == _manifest.get_revision_id()) {
         _manifest.add(segment.name, segment.meta);

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -1,0 +1,310 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/archival_metadata_stm.h"
+
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_types.h"
+#include "model/record_utils.h"
+#include "raft/consensus.h"
+#include "serde/envelope.h"
+#include "serde/serde.h"
+#include "storage/record_batch_builder.h"
+#include "utils/named_type.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+
+namespace cluster {
+
+namespace {
+
+using cmd_key = named_type<uint8_t, struct cmd_key_tag>;
+
+} // namespace
+
+struct archival_metadata_stm::segment
+  : public serde::
+      envelope<segment, serde::version<0>, serde::compat_version<0>> {
+    // ntp_revision is needed to reconstruct full remote path of
+    // the segment.
+    model::revision_id ntp_revision;
+    cloud_storage::segment_name name;
+    cloud_storage::manifest::segment_meta meta;
+};
+
+struct archival_metadata_stm::add_segment_cmd {
+    static constexpr cmd_key key{0};
+
+    using value = segment;
+};
+
+struct archival_metadata_stm::snapshot
+  : public serde::
+      envelope<snapshot, serde::version<0>, serde::compat_version<0>> {
+    std::vector<segment> segments;
+};
+
+std::vector<archival_metadata_stm::segment>
+archival_metadata_stm::segments_from_manifest(
+  const cloud_storage::manifest& manifest) {
+    std::vector<segment> segments;
+    segments.reserve(manifest.size());
+    for (const auto& [key, meta] : manifest) {
+        model::revision_id ntp_revision;
+        cloud_storage::segment_name segment_name;
+        ss::visit(
+          key,
+          [&](const cloud_storage::remote_segment_path& path) {
+              auto components = get_segment_path_components(path);
+              vassert(components, "can't parse remote segment path {}", path);
+              ntp_revision = components->_rev;
+              segment_name = components->_name;
+          },
+          [&](const cloud_storage::segment_name& name) {
+              ntp_revision = manifest.get_revision_id();
+              segment_name = name;
+          });
+
+        segments.push_back(segment{
+          .ntp_revision = ntp_revision, .name = segment_name, .meta = meta});
+    }
+
+    std::sort(
+      segments.begin(), segments.end(), [](const auto& s1, const auto& s2) {
+          return s1.meta.base_offset < s2.meta.base_offset;
+      });
+
+    return segments;
+}
+
+archival_metadata_stm::archival_metadata_stm(
+  raft::consensus* raft, cloud_storage::remote& remote, ss::logger& logger)
+  : cluster::persisted_stm("archival_metadata.snapshot", logger, raft)
+  , _logger(logger, ssx::sformat("ntp: {}", raft->ntp()))
+  , _manifest(raft->ntp(), raft->config().revision_id())
+  , _cloud_storage_api(remote) {}
+
+ss::future<bool> archival_metadata_stm::add_segments(
+  const cloud_storage::manifest& manifest, retry_chain_node& rc_node) {
+    return _lock.with(rc_node.get_timeout(), [this, &manifest, &rc_node] {
+        return do_add_segments(manifest, rc_node);
+    });
+}
+
+ss::future<bool> archival_metadata_stm::do_add_segments(
+  const cloud_storage::manifest& new_manifest, retry_chain_node& rc_node) {
+    if (!co_await sync(rc_node.get_timeout())) {
+        co_return false;
+    }
+
+    auto segments = segments_from_manifest(new_manifest.difference(_manifest));
+    if (segments.empty()) {
+        co_return true;
+    }
+
+    storage::record_batch_builder b(
+      model::record_batch_type::archival_metadata, model::offset(0));
+    for (const auto& segment : segments) {
+        iobuf key_buf = serde::to_iobuf(add_segment_cmd::key);
+        auto record_val = add_segment_cmd::value{segment};
+        iobuf val_buf = serde::to_iobuf(std::move(record_val));
+        b.add_raw_kv(std::move(key_buf), std::move(val_buf));
+    }
+
+    auto batch = std::move(b).build();
+    auto result = co_await _raft->replicate(
+      _insync_term,
+      model::make_memory_record_batch_reader(std::move(batch)),
+      raft::replicate_options{raft::consistency_level::quorum_ack});
+
+    if (!result) {
+        vlog(
+          _logger.warn,
+          "error on replicating remote segment metadata: {}",
+          result.error());
+        co_return false;
+    }
+
+    auto applied = co_await wait_no_throw(
+      result.value().last_offset, rc_node.get_timeout());
+
+    if (!applied) {
+        co_return false;
+    }
+
+    for (const auto& segment : segments) {
+        vlog(
+          _logger.info,
+          "new remote segment added (name: {}, base_offset: {} last_offset: "
+          "{}), "
+          "remote start_offset: {}, last_offset: {}",
+          segment.name,
+          segment.meta.base_offset,
+          segment.meta.committed_offset,
+          _start_offset,
+          _last_offset);
+    }
+
+    co_return result;
+}
+
+ss::future<> archival_metadata_stm::apply(model::record_batch b) {
+    if (b.header().type != model::record_batch_type::archival_metadata) {
+        _insync_offset = b.last_offset();
+        co_return;
+    }
+
+    b.for_each_record([this](model::record&& r) {
+        auto key = serde::from_iobuf<cmd_key>(r.release_key());
+        if (key == add_segment_cmd::key) {
+            auto value = serde::from_iobuf<add_segment_cmd::value>(
+              r.release_value());
+            apply_add_segment(value);
+        }
+    });
+
+    _insync_offset = b.last_offset();
+}
+
+ss::future<> archival_metadata_stm::handle_eviction() {
+    cloud_storage::manifest manifest;
+
+    auto bucket = config::shard_local_cfg().cloud_storage_bucket.value();
+    vassert(bucket, "configuration property cloud_storage_bucket must be set");
+
+    auto timeout
+      = config::shard_local_cfg().cloud_storage_manifest_upload_timeout_ms();
+    auto backoff = config::shard_local_cfg().cloud_storage_initial_backoff_ms();
+
+    retry_chain_node rc_node(_download_as, timeout, backoff);
+    auto res = co_await _cloud_storage_api.download_manifest(
+      s3::bucket_name{*bucket},
+      _manifest.get_manifest_path(),
+      manifest,
+      rc_node);
+
+    if (res != cloud_storage::download_result::success) {
+        // sleep to the end of timeout to avoid calling handle_eviction in a
+        // busy loop.
+        co_await ss::sleep_abortable(rc_node.get_timeout(), _download_as);
+        throw std::runtime_error{fmt::format(
+          "couldn't download manifest {}: {}",
+          _manifest.get_manifest_path(),
+          res)};
+    }
+
+    _manifest = std::move(manifest);
+    for (const auto& segment : _manifest) {
+        if (
+          _start_offset == model::offset{}
+          || segment.second.base_offset < _start_offset) {
+            _start_offset = segment.second.base_offset;
+        }
+    }
+    _last_offset = _manifest.get_last_offset();
+
+    // We can skip all offsets up to the _last_offset because we can be sure
+    // that in the skipped batches there won't be any new remote segments.
+    _insync_offset = _last_offset;
+    auto next_offset = std::max(
+      _raft->start_offset(), raft::details::next_offset(_insync_offset));
+    set_next(next_offset);
+
+    vlog(
+      _logger.info,
+      "handled log eviction, next offset: {}, remote start_offset: {}, "
+      "last_offset: {}",
+      next_offset,
+      _start_offset,
+      _last_offset);
+}
+
+ss::future<> archival_metadata_stm::apply_snapshot(
+  stm_snapshot_header header, iobuf&& data) {
+    auto snap = serde::from_iobuf<snapshot>(std::move(data));
+
+    _manifest = cloud_storage::manifest(
+      _raft->ntp(), _raft->config().revision_id());
+    for (const auto& segment : snap.segments) {
+        apply_add_segment(segment);
+    }
+
+    vlog(
+      _logger.info,
+      "applied snapshot at offset: {}, remote start_offset: {}, last_offset: "
+      "{}",
+      header.offset,
+      _start_offset,
+      _last_offset);
+
+    _last_snapshot_offset = header.offset;
+    _insync_offset = header.offset;
+    co_return;
+}
+
+ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
+    auto segments = segments_from_manifest(_manifest);
+    iobuf snap_data = serde::to_iobuf(
+      snapshot{.segments = std::move(segments)});
+
+    vlog(
+      _logger.info,
+      "creating snapshot at offset: {}, remote start_offset: {}, last_offset: "
+      "{}",
+      _insync_offset,
+      _start_offset,
+      _last_offset);
+    co_return stm_snapshot::create(0, _insync_offset, std::move(snap_data));
+}
+
+void archival_metadata_stm::apply_add_segment(const segment& segment) {
+    if (segment.ntp_revision == _manifest.get_revision_id()) {
+        _manifest.add(segment.name, segment.meta);
+    } else {
+        auto path = cloud_storage::manifest::generate_remote_segment_path(
+          _raft->ntp(), segment.ntp_revision, segment.name);
+        _manifest.add(path, segment.meta);
+    }
+
+    // NOTE: here we don't take into account possibility of holes in the
+    // remote offset range. Archival tries to upload segments in order, and
+    // if for some reason is a hole, there are no mechanisms for correcting it.
+
+    const cloud_storage::manifest::segment_meta& meta = segment.meta;
+
+    if (_start_offset == model::offset{} || meta.base_offset < _start_offset) {
+        _start_offset = meta.base_offset;
+    }
+
+    if (meta.committed_offset > _last_offset) {
+        if (meta.base_offset > raft::details::next_offset(_last_offset)) {
+            // To ensure forward progress, we print a warning and skip over the
+            // hole.
+
+            vlog(
+              _logger.warn,
+              "hole in the remote offset range detected! previous last offset: "
+              "{}, new segment base offset: {}",
+              _last_offset,
+              meta.base_offset);
+        }
+
+        _last_offset = meta.committed_offset;
+    }
+}
+
+ss::future<> archival_metadata_stm::stop() {
+    _download_as.request_abort();
+    co_await raft::state_machine::stop();
+}
+
+} // namespace cluster

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -54,6 +54,7 @@ private:
 
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
+    model::offset max_collectible_offset() override;
 
     struct segment;
     struct add_segment_cmd;

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cloud_storage/manifest.h"
+#include "cloud_storage/remote.h"
+#include "cluster/persisted_stm.h"
+#include "utils/mutex.h"
+#include "utils/prefix_logger.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/util/log.hh>
+
+namespace cluster {
+
+/// This replicated state machine allows storing archival manifest (a set of
+/// segments archived to cloud storage) in the archived partition log itself.
+/// This is needed to 1) avoid querying cloud storage on partition startup and
+/// 2) to replicate metadata to raft followers so that they can decide which
+/// segments can be safely evicted.
+class archival_metadata_stm final : public persisted_stm {
+public:
+    explicit archival_metadata_stm(
+      raft::consensus*, cloud_storage::remote& remote, ss::logger& logger);
+
+    /// Add the difference between manifests to the raft log, replicate it and
+    /// wait until it is applied to the STM.
+    ss::future<bool>
+    add_segments(const cloud_storage::manifest&, retry_chain_node&);
+
+    /// A set of archived segments. NOTE: manifest can be out-of-date if this
+    /// node is not leader; or if the STM hasn't yet performed sync; or if the
+    /// node has lost leadership. But it will contain segments successfully
+    /// added with `add_segments`.
+    const cloud_storage::manifest& manifest() const { return _manifest; }
+
+    ss::future<> stop() override;
+
+private:
+    ss::future<bool>
+    do_add_segments(const cloud_storage::manifest&, retry_chain_node&);
+
+    ss::future<> apply(model::record_batch batch) override;
+    ss::future<> handle_eviction() override;
+
+    ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
+    ss::future<stm_snapshot> take_snapshot() override;
+
+    struct segment;
+    struct add_segment_cmd;
+    struct snapshot;
+
+    static std::vector<segment>
+    segments_from_manifest(const cloud_storage::manifest& manifest);
+
+    void apply_add_segment(const segment& segment);
+
+private:
+    prefix_logger _logger;
+
+    mutex _lock;
+
+    cloud_storage::manifest _manifest;
+    model::offset _start_offset;
+    model::offset _last_offset;
+
+    cloud_storage::remote& _cloud_storage_api;
+    ss::abort_source _download_as;
+};
+
+} // namespace cluster

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -43,7 +43,7 @@ partition::partition(
           clusterlog, _raft.get());
     } else if (is_tx_manager_topic(_raft->ntp())) {
         if (_raft->log_config().is_collectable()) {
-            _nop_stm = ss::make_lw_shared<raft::log_eviction_stm>(
+            _log_eviction_stm = ss::make_lw_shared<raft::log_eviction_stm>(
               _raft.get(), clusterlog, stm_manager, _as);
         }
 
@@ -53,7 +53,7 @@ partition::partition(
         }
     } else {
         if (_raft->log_config().is_collectable()) {
-            _nop_stm = ss::make_lw_shared<raft::log_eviction_stm>(
+            _log_eviction_stm = ss::make_lw_shared<raft::log_eviction_stm>(
               _raft.get(), clusterlog, stm_manager, _as);
         }
 
@@ -287,8 +287,8 @@ ss::future<> partition::start() {
 
     if (is_id_allocator_topic(ntp)) {
         return f.then([this] { return _id_allocator_stm->start(); });
-    } else if (_nop_stm) {
-        f = f.then([this] { return _nop_stm->start(); });
+    } else if (_log_eviction_stm) {
+        f = f.then([this] { return _log_eviction_stm->start(); });
     }
 
     if (_rm_stm) {
@@ -315,8 +315,8 @@ ss::future<> partition::stop() {
         return _id_allocator_stm->stop();
     }
 
-    if (_nop_stm) {
-        f = _nop_stm->stop();
+    if (_log_eviction_stm) {
+        f = _log_eviction_stm->stop();
     }
 
     if (_rm_stm) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -204,7 +204,7 @@ private:
 
 private:
     consensus_ptr _raft;
-    ss::lw_shared_ptr<raft::log_eviction_stm> _nop_stm;
+    ss::lw_shared_ptr<raft::log_eviction_stm> _log_eviction_stm;
     ss::lw_shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<cluster::tm_stm> _tm_stm;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/archival_metadata_stm.h"
 #include "cluster/id_allocator_stm.h"
 #include "cluster/partition_probe.h"
 #include "cluster/rm_stm.h"
@@ -26,6 +27,8 @@
 #include "raft/types.h"
 #include "storage/types.h"
 
+#include <seastar/core/shared_ptr.hh>
+
 namespace cluster {
 class partition_manager;
 
@@ -33,7 +36,10 @@ class partition_manager;
 /// all raft logic is proxied transparently
 class partition {
 public:
-    partition(consensus_ptr r, ss::sharded<cluster::tx_gateway_frontend>&);
+    partition(
+      consensus_ptr r,
+      ss::sharded<cluster::tx_gateway_frontend>&,
+      ss::sharded<cloud_storage::remote>&);
 
     raft::group_id group() const { return _raft->group(); }
     ss::future<> start();
@@ -185,6 +191,11 @@ public:
         return _rm_stm->aborted_transactions(from, to);
     }
 
+    const ss::shared_ptr<cluster::archival_metadata_stm>&
+    archival_meta_stm() const {
+        return _archival_meta_stm;
+    }
+
 private:
     friend partition_manager;
     friend replicated_partition_probe;
@@ -197,6 +208,7 @@ private:
     ss::lw_shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<cluster::tm_stm> _tm_stm;
+    ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
     ss::abort_source _as;
     partition_probe _probe;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cloud_storage/partition_recovery_manager.h"
+#include "cloud_storage/remote.h"
 #include "cluster/ntp_callbacks.h"
 #include "cluster/partition.h"
 #include "model/metadata.h"
@@ -33,7 +34,8 @@ public:
       ss::sharded<storage::api>&,
       ss::sharded<raft::group_manager>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
-      ss::sharded<cloud_storage::partition_recovery_manager>&);
+      ss::sharded<cloud_storage::partition_recovery_manager>&,
+      ss::sharded<cloud_storage::remote>&);
 
     using manage_cb_t
       = ss::noncopyable_function<void(ss::lw_shared_ptr<partition>)>;
@@ -161,6 +163,7 @@ private:
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
     ss::sharded<cloud_storage::partition_recovery_manager>&
       _partition_recovery_mgr;
+    ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     ss::gate _gate;
 
     friend std::ostream& operator<<(std::ostream&, const partition_manager&);

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -245,12 +245,13 @@ ss::future<bool> persisted_stm::wait_no_throw(
     auto deadline = model::timeout_clock::now() + timeout;
     return wait(offset, deadline)
       .then([] { return true; })
-      .handle_exception([offset](std::exception_ptr e) {
+      .handle_exception([offset, ntp = _c->ntp()](std::exception_ptr e) {
           vlog(
             clusterlog.error,
-            "An error {} happened during waiting for offset:{}",
+            "An error {} happened during waiting for offset: {}, ntp: {}",
             e,
-            offset);
+            offset,
+            ntp);
           return false;
       });
 }

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -153,6 +153,10 @@ persisted_stm::ensure_snapshot_exists(model::offset target_offset) {
     });
 }
 
+model::offset persisted_stm::max_collectible_offset() {
+    return model::offset::max();
+}
+
 ss::future<> persisted_stm::wait_offset_committed(
   model::timeout_clock::duration timeout,
   model::offset offset,

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -37,6 +37,20 @@ struct stm_snapshot_header {
 struct stm_snapshot {
     stm_snapshot_header header;
     iobuf data;
+
+    static stm_snapshot
+    create(int8_t version, model::offset offset, iobuf data) {
+        stm_snapshot_header header;
+        header.version = version;
+        header.snapshot_size = data.size_bytes();
+        header.offset = offset;
+
+        stm_snapshot snapshot;
+        snapshot.header = header;
+        snapshot.data = std::move(data);
+
+        return snapshot;
+    }
 };
 
 /**

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -88,6 +88,7 @@ public:
 
     ss::future<> make_snapshot() final;
     ss::future<> ensure_snapshot_exists(model::offset) final;
+    model::offset max_collectible_offset() override;
 
     /*
      * Usually start() acts as a barrier and we don't call any methods on the

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1309,15 +1309,8 @@ ss::future<stm_snapshot> rm_stm::take_snapshot() {
     iobuf tx_ss_buf;
     reflection::adl<tx_snapshot>{}.to(tx_ss_buf, tx_ss);
 
-    stm_snapshot_header header;
-    header.version = tx_snapshot_version;
-    header.snapshot_size = tx_ss_buf.size_bytes();
-    header.offset = _insync_offset;
-
-    stm_snapshot stx_ss;
-    stx_ss.header = header;
-    stx_ss.data = std::move(tx_ss_buf);
-    co_return stx_ss;
+    co_return stm_snapshot::create(
+      tx_snapshot_version, _insync_offset, std::move(tx_ss_buf));
 }
 
 ss::future<> rm_stm::save_abort_snapshot(abort_snapshot snapshot) {

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -320,15 +320,8 @@ ss::future<stm_snapshot> tm_stm::take_snapshot() {
     iobuf tm_ss_buf;
     reflection::adl<tm_snapshot>{}.to(tm_ss_buf, tm_ss);
 
-    stm_snapshot_header header;
-    header.version = supported_version;
-    header.snapshot_size = tm_ss_buf.size_bytes();
-    header.offset = _insync_offset;
-
-    stm_snapshot stm_ss;
-    stm_ss.header = header;
-    stm_ss.data = std::move(tm_ss_buf);
-    co_return stm_ss;
+    co_return stm_snapshot::create(
+      supported_version, _insync_offset, std::move(tm_ss_buf));
 }
 
 ss::future<> tm_stm::apply(model::record_batch b) {

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -15,6 +16,7 @@
 #include "model/record_batch_types.h"
 #include "model/timestamp.h"
 #include "model/validation.h"
+#include "serde/serde.h"
 #include "utils/string_switch.h"
 #include "utils/to_string.h"
 
@@ -35,6 +37,13 @@ std::ostream& operator<<(std::ostream& os, timestamp ts) {
     }
     return os << "{timestamp: missing}";
 }
+
+void read_nested(
+  iobuf_parser& in, timestamp& ts, size_t const bytes_left_limit) {
+    serde::read_nested(in, ts._v, bytes_left_limit);
+}
+
+void write(iobuf& out, timestamp ts) { serde::write(out, ts._v); }
 
 std::ostream& operator<<(std::ostream& os, const topic_partition& tp) {
     return ss::fmt_print(

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -338,6 +338,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::node_management_cmd";
     case record_batch_type::data_policy_management_cmd:
         return o << "batch_type::data_policy_management_cmd";
+    case record_batch_type::archival_metadata:
+        return o << "batch_type::archival_metadata";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -36,6 +36,7 @@ enum class record_batch_type : int8_t {
     group_abort_tx = 16,      // group_abort_tx_batch_type
     node_management_cmd = 17, // controller node management
     data_policy_management_cmd = 18, // data-policy management
+    archival_metadata = 19,          // archival metadata updates
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/model/timestamp.h
+++ b/src/v/model/timestamp.h
@@ -21,6 +21,9 @@
 #include <iosfwd>
 #include <limits>
 
+class iobuf;
+class iobuf_parser;
+
 namespace model {
 
 enum class timestamp_type : uint8_t { create_time, append_time };
@@ -63,6 +66,11 @@ public:
     auto operator<=>(const timestamp&) const = default;
 
     friend std::ostream& operator<<(std::ostream&, timestamp);
+
+    // ADL helpers for interfacing with the serde library.
+    friend void write(iobuf& out, timestamp ts);
+    friend void
+    read_nested(iobuf_parser& in, timestamp& ts, size_t const bytes_left_limit);
 
     static timestamp now();
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -44,7 +44,9 @@ namespace raft {
 static std::vector<model::record_batch_type>
 offset_translator_batch_types(const model::ntp& ntp) {
     if (ntp.ns == model::kafka_namespace) {
-        return {model::record_batch_type::raft_configuration};
+        return {
+          model::record_batch_type::raft_configuration,
+          model::record_batch_type::archival_metadata};
     } else {
         return {};
     }

--- a/src/v/raft/log_eviction_stm.h
+++ b/src/v/raft/log_eviction_stm.h
@@ -25,7 +25,13 @@ class consensus;
 
 /**
  * Responsible for taking snapshots triggered by underlying log segments
- * eviction
+ * eviction.
+ *
+ * The process goes like this: storage layer will send a "deletion notification"
+ * - a request to evict log up to a certain offset. log_eviction_stm will then
+ * adjust that offset with _stm_manager->max_collectible_offset(), write the
+ * raft snapshot and notify the storage layer that log eviction can safely
+ * proceed up to the adjusted offset.
  */
 class log_eviction_stm {
 public:

--- a/src/v/raft/state_machine.h
+++ b/src/v/raft/state_machine.h
@@ -102,6 +102,8 @@ public:
 protected:
     void set_next(model::offset offset);
     virtual ss::future<> handle_eviction();
+
+    consensus* _raft;
     ss::gate _gate;
 
 private:
@@ -121,7 +123,6 @@ private:
     ss::future<> apply();
     bool stop_batch_applicator();
 
-    consensus* _raft;
     ss::io_priority_class _io_prio;
     ss::logger& _log;
     offset_monitor _waiters;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -593,7 +593,8 @@ void application::wire_up_redpanda_services() {
       std::ref(storage),
       std::ref(raft_group_manager),
       std::ref(tx_gateway_frontend),
-      std::ref(partition_recovery_manager))
+      std::ref(partition_recovery_manager),
+      std::ref(cloud_storage_api))
       .get();
     vlog(_log.info, "Partition manager started");
 


### PR DESCRIPTION
## Cover letter

This PR introduces `archival_metadata_stm` - a replicated state machine that allows storing archival manifest (a set of partition segments archived to cloud storage) in the archived partition log itself. This is needed to 1) avoid querying cloud storage on partition startup and 2) to replicate metadata to raft followers so that they can decide which segments can be safely evicted.

