### PR TITLE
coproc: add support for moving materialized partitions

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -431,6 +431,14 @@ std::vector<model::topic_namespace> topic_table::all_topics() const {
       [](const topic_configuration_assignment& td) { return td.cfg.tp_ns; });
 }
 
+std::optional<topic_table::topic_metadata>
+topic_table::get_topic_table_metadata(model::topic_namespace_view tp) const {
+    if (auto it = _topics.find(tp); it != _topics.end()) {
+        return it->second;
+    }
+    return {};
+}
+
 std::optional<model::topic_metadata>
 topic_table::get_topic_metadata(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -155,6 +155,8 @@ public:
 
     const underlying_t& topics_map() const { return _topics; }
 
+    const hierarchy_t& hierarchy_map() const { return _topics_hierarchy; }
+
     bool is_update_in_progress(const model::ntp&) const;
 
 private:

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -110,6 +110,15 @@ public:
 
     /// Delta API
 
+    /**
+     * NOTE: There can only be one entity at a time consuming from this API.
+     *
+     * Even though many entities could call this method and register for an
+     * update, in the case there are already pending updates ready by the time
+     * this method is called, the first caller to this method will recieve the
+     * updates; consume them and the next caller will observe no updates and
+     * register for future updates.
+     */
     ss::future<std::vector<delta>> wait_for_changes(ss::abort_source&);
 
     bool has_pending_changes() const { return !_pending_deltas.empty(); }

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -131,6 +131,9 @@ public:
     std::optional<topic_configuration>
       get_topic_cfg(model::topic_namespace_view) const;
 
+    std::optional<topic_metadata>
+      get_topic_table_metadata(model::topic_namespace_view) const;
+
     ///\brief Returns topics timestamp type
     ///
     /// If topic does not exists it returns an empty optional

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -12,6 +12,7 @@ v_cc_library(
     api.cc
     types.cc
     logger.cc
+    reconciliation_backend.cc
     script_context.cc
     script_context_frontend.cc
     script_context_backend.cc

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -39,10 +39,10 @@ ss::future<> api::start() {
     co_await _mt_frontend.start_single(std::ref(_rs.topics_frontend));
     co_await _pacemaker.start(_engine_addr, std::ref(_rs));
     co_await _pacemaker.invoke_on_all(&coproc::pacemaker::start);
-    _listener = std::make_unique<wasm::event_listener>();
-
+    _listener = std::make_unique<wasm::event_listener>(_as);
+    _dispatcher = std::make_unique<wasm::script_dispatcher>(_pacemaker, _as);
     _wasm_async_handler = std::make_unique<coproc::wasm::async_event_handler>(
-      _listener->get_abort_source(), std::ref(_pacemaker));
+      std::ref(*_dispatcher));
     _listener->register_handler(
       coproc::wasm::event_type::async, _wasm_async_handler.get());
 

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -45,7 +45,7 @@ api::~api() = default;
 ss::future<> api::start() {
     co_await _sdb.start_single();
     co_await _mt_frontend.start_single(std::ref(_rs.topics_frontend));
-    co_await _pacemaker.start(_engine_addr, std::ref(_rs));
+    co_await _pacemaker.start(_engine_addr, std::ref(_sdb), std::ref(_rs));
     co_await _pacemaker.invoke_on_all(&coproc::pacemaker::start);
     _listener = std::make_unique<wasm::event_listener>(_as);
     _dispatcher = std::make_unique<wasm::script_dispatcher>(

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -16,6 +16,8 @@
 #include "coproc/fwd.h"
 #include "coproc/sys_refs.h"
 #include "utils/unresolved_address.h"
+
+#include <seastar/core/abort_source.hh>
 namespace coproc {
 
 class api {
@@ -38,13 +40,14 @@ public:
 private:
     unresolved_address _engine_addr;
     sys_refs _rs;
+    ss::abort_source _as;
 
-    std::unique_ptr<wasm::event_listener> _listener; /// one instance
-    ss::sharded<pacemaker> _pacemaker;               /// one per core
+    ss::sharded<pacemaker> _pacemaker; /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
 
-    // Event handlers
+    std::unique_ptr<wasm::script_dispatcher> _dispatcher;
+    std::unique_ptr<wasm::event_listener> _listener;
     std::unique_ptr<wasm::async_event_handler> _wasm_async_handler;
 };
 

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -25,6 +25,8 @@ public:
     api(
       unresolved_address,
       ss::sharded<storage::api>&,
+      ss::sharded<cluster::topic_table>&,
+      ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::topics_frontend>&,
       ss::sharded<cluster::metadata_cache>&,
       ss::sharded<cluster::partition_manager>&) noexcept;
@@ -41,11 +43,14 @@ private:
     unresolved_address _engine_addr;
     sys_refs _rs;
     ss::abort_source _as;
+    ss::sharded<cluster::topic_table>& _topics; /// pass to _backend
 
     ss::sharded<wasm::script_database> _sdb; // one instance
     ss::sharded<pacemaker> _pacemaker;       /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
+    ss::sharded<reconciliation_backend> _backend;
+    ss::sharded<cluster::shard_table>& _shard_table;
 
     std::unique_ptr<wasm::script_dispatcher> _dispatcher;
     std::unique_ptr<wasm::event_listener> _listener;

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -42,7 +42,8 @@ private:
     sys_refs _rs;
     ss::abort_source _as;
 
-    ss::sharded<pacemaker> _pacemaker; /// one per core
+    ss::sharded<wasm::script_database> _sdb; // one instance
+    ss::sharded<pacemaker> _pacemaker;       /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
 

--- a/src/v/coproc/errc.h
+++ b/src/v/coproc/errc.h
@@ -65,7 +65,8 @@ enum class errc {
     materialized_topic,
     script_id_does_not_exist,
     partition_has_pending_update,
-    partition_input_already_exists
+    partition_input_already_exists,
+    partition_input_not_exists
 };
 
 struct errc_category final : public std::error_category {
@@ -89,6 +90,8 @@ struct errc_category final : public std::error_category {
             return "attempted to move a partition that is already pending";
         case errc::partition_input_already_exists:
             return "attempted to add a partition that already exists";
+        case errc::partition_input_not_exists:
+            return "attempted to remove a partition that doesn't exist";
         default:
             return "Undefined coprocessor error encountered";
         }

--- a/src/v/coproc/errc.h
+++ b/src/v/coproc/errc.h
@@ -63,7 +63,9 @@ enum class errc {
     topic_does_not_exist,
     invalid_topic,
     materialized_topic,
-    script_id_does_not_exist
+    script_id_does_not_exist,
+    partition_has_pending_update,
+    partition_input_already_exists
 };
 
 struct errc_category final : public std::error_category {
@@ -83,6 +85,10 @@ struct errc_category final : public std::error_category {
             return "Topic is already a materialized topic";
         case errc::script_id_does_not_exist:
             return "Could not find coprocessor with matching script_id";
+        case errc::partition_has_pending_update:
+            return "attempted to move a partition that is already pending";
+        case errc::partition_input_already_exists:
+            return "attempted to add a partition that already exists";
         default:
             return "Undefined coprocessor error encountered";
         }

--- a/src/v/coproc/event_handler.cc
+++ b/src/v/coproc/event_handler.cc
@@ -40,19 +40,9 @@ async_event_handler::preparation_before_process() {
               "interval");
             co_return cron_finish_status::skip_pull;
         }
-    } else if (heartbeat.value().data != _active_ids.size()) {
-        /// There is a discrepency between the number of registered coprocs
-        /// according to redpanda and according to the wasm engine.
-        /// Reconcile all state from offset 0.
-        vlog(coproclog.info, "Replaying coprocessor state...");
-        if (co_await _dispatcher.disable_all_coprocessors()) {
-            vlog(
-              coproclog.error,
-              "Failed to reset wasm_engine state, will keep retrying...");
-        } else {
-            _active_ids.clear();
-            co_return cron_finish_status::replay_topic;
-        }
+    } else if (!heartbeat.value()) {
+        vlog(coproclog.warn, "Replaying coprocessor state...");
+        co_return cron_finish_status::replay_topic;
     }
     co_return cron_finish_status::none;
 }
@@ -63,64 +53,33 @@ async_event_handler::process(absl::btree_map<script_id, parsed_event> wsas) {
     std::vector<enable_copros_request::data> enables;
     std::vector<script_id> disables;
     for (auto& [id, event] : wsas) {
-        /// Keeping the active_ids cache up to date solves the issue of
-        /// issuing a bunch of remove commands for scripts that aren't
-        /// deployed (this could occur during bootstrapping)
-        auto found = _active_ids.find(id);
         if (event.header.action == event_action::remove) {
-            if (found != _active_ids.end()) {
-                disables.emplace_back(id);
-            }
+            disables.emplace_back(id);
         } else {
-            /// ... or in the case if deploys are performed using the same
-            /// key. This would normally be resolved if the events came in
-            /// the same record batch by the reconcile events function, but
-            /// not if they arrived in separate batches.
-            if (found == _active_ids.end()) {
-                enables.emplace_back(enable_copros_request::data{
-                  .id = id, .source_code = std::move(event.data)});
-            }
+            enables.emplace_back(enable_copros_request::data{
+              .id = id, .source_code = std::move(event.data)});
         }
     }
     /// TODO: In the future, maybe it would be cleaner to have a add/remove
     /// endpoint, instead of two seperate RPC endpoints
     if (!enables.empty()) {
         enable_copros_request req{.inputs = std::move(enables)};
-        auto resp = co_await _dispatcher.enable_coprocessors(std::move(req));
-        if (resp.has_error()) {
+        auto ec = co_await _dispatcher.enable_coprocessors(std::move(req));
+        if (ec) {
             throw async_event_handler_exception(fmt_with_ctx(
               fmt::format,
               "Failed to register coprocessors with the wasm engine: {}",
-              resp.error()));
-            co_return;
-        } else {
-            for (script_id id : resp.value()) {
-                vlog(
-                  coproclog.info,
-                  "Successfully registered script with id: {}",
-                  id);
-                _active_ids.insert(id);
-            }
+              ec));
         }
     }
     if (!disables.empty()) {
         disable_copros_request req{.ids = std::move(disables)};
-        auto resp = co_await _dispatcher.disable_coprocessors(std::move(req));
-        if (resp.has_error()) {
-            /// In this case the code will follow a path that re-enters this
-            /// method with the same inputs, and the call to enable_copros
-            /// above succeeded but the call to disable_coprocessors failed,
-            /// double registrations will be avoided because the ids have
-            /// entered the \ref active_ids cache and will not be queued for
-            /// re-registration
+        auto ec = co_await _dispatcher.disable_coprocessors(std::move(req));
+        if (ec) {
             throw async_event_handler_exception(fmt_with_ctx(
               fmt::format,
-              "Failed to make disable request to the wasm engine: {}",
-              resp.error()));
-        } else {
-            for (script_id id : resp.value()) {
-                _active_ids.erase(id);
-            }
+              "Failed to deregister coprocessors with the wasm engine: {}",
+              ec));
         }
     }
 }

--- a/src/v/coproc/event_handler.cc
+++ b/src/v/coproc/event_handler.cc
@@ -11,15 +11,14 @@
 #include "coproc/event_handler.h"
 
 #include "coproc/ntp_context.h"
+#include "coproc/script_dispatcher.h"
 #include "utils/gate_guard.h"
 #include "vlog.h"
 
 namespace coproc::wasm {
 
-async_event_handler::async_event_handler(
-  ss::abort_source& abort_source, ss::sharded<pacemaker>& pacemaker)
-  : _abort_source(abort_source)
-  , _dispatcher(pacemaker, _abort_source) {}
+async_event_handler::async_event_handler(script_dispatcher& dispatcher)
+  : _dispatcher(dispatcher) {}
 
 ss::future<> async_event_handler::start() { co_return; }
 

--- a/src/v/coproc/event_handler.h
+++ b/src/v/coproc/event_handler.h
@@ -77,9 +77,6 @@ public:
     process(absl::btree_map<script_id, parsed_event> wsas) override;
 
 private:
-    /// Set of known script ids to be active
-    absl::btree_set<script_id> _active_ids;
-
     ss::gate _gate;
 
     /// Used to make requests to the wasm engine

--- a/src/v/coproc/event_handler.h
+++ b/src/v/coproc/event_handler.h
@@ -10,13 +10,14 @@
 
 #pragma once
 
+#include "coproc/fwd.h"
 #include "coproc/logger.h"
-#include "coproc/script_dispatcher.h"
 #include "coproc/wasm_event.h"
 #include "seastarx.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
 
 #include <absl/container/btree_map.h>
 #include <absl/container/btree_set.h>
@@ -64,8 +65,7 @@ public:
 
 class async_event_handler final : public event_handler {
 public:
-    explicit async_event_handler(
-      ss::abort_source& abort_source, ss::sharded<pacemaker>& pacemaker);
+    explicit async_event_handler(script_dispatcher&);
 
     ss::future<> start() override;
     ss::future<> stop() override;
@@ -80,13 +80,10 @@ private:
     /// Set of known script ids to be active
     absl::btree_set<script_id> _active_ids;
 
-    /// Pass it tot script_dispatcher
-    ss::abort_source& _abort_source;
-
     ss::gate _gate;
 
     /// Used to make requests to the wasm engine
-    script_dispatcher _dispatcher;
+    script_dispatcher& _dispatcher;
 };
 
 class data_policy_event_handler final : public event_handler {

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -59,8 +59,9 @@ ss::future<> event_listener::stop() {
       });
 }
 
-event_listener::event_listener()
-  : _client(make_client()) {}
+event_listener::event_listener(ss::abort_source& as)
+  : _client(make_client())
+  , _abort_source(as) {}
 
 ss::future<> event_listener::start() {
     co_await ss::parallel_for_each(
@@ -97,8 +98,6 @@ void event_listener::register_handler(event_type type, event_handler* handler) {
       "Register new handler for wasm_event_type: {}",
       coproc_type_as_string_view(type));
 }
-
-ss::abort_source& event_listener::get_abort_source() { return _abort_source; }
 
 static ss::future<std::vector<model::record_batch>>
 decompress_wasm_events(model::record_batch_reader::data_t events) {

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -35,7 +35,7 @@ namespace coproc::wasm {
 class event_listener {
 public:
     /// class constructor
-    event_listener();
+    explicit event_listener(ss::abort_source&);
 
     /// To be invoked once on redpanda::application startup
     ///
@@ -68,7 +68,7 @@ private:
 
     /// Primitives used to manage the poll loop
     ss::gate _gate;
-    ss::abort_source _abort_source;
+    ss::abort_source& _abort_source;
 
     /// Current offset into the 'coprocessor_internal_topic'
     model::offset _offset{0};

--- a/src/v/coproc/exception.h
+++ b/src/v/coproc/exception.h
@@ -31,6 +31,21 @@ private:
     ss::sstring _msg;
 };
 
+/// Not necessarily a fatal error, explicity handle these events as theres no
+/// way to ensure handles to partitions aren't in use before
+/// partition::shutdown() is called
+class partition_shutdown_exception final : public exception {
+public:
+    partition_shutdown_exception(model::ntp ntp, ss::sstring msg) noexcept
+      : exception(std::move(msg))
+      , _ntp(std::move(ntp)) {}
+
+    const model::ntp& ntp() const { return _ntp; }
+
+private:
+    model::ntp _ntp;
+};
+
 /// Root exception type for classes of exceptions that are only thrown by
 /// actions interpreted by coprocessors themselves
 class script_exception : public exception {

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -16,6 +16,7 @@ namespace coproc {
 class api;
 class pacemaker;
 class script_context;
+class reconciliation_backend;
 
 namespace wasm {
 

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -19,6 +19,7 @@ class script_context;
 
 namespace wasm {
 
+class script_database;
 class script_dispatcher;
 class event_listener;
 

--- a/src/v/coproc/offset_storage_utils.cc
+++ b/src/v/coproc/offset_storage_utils.cc
@@ -64,9 +64,9 @@ ss::future<ntp_context_cache> recover_offsets(
         auto partition = pm.get(key);
         if (!partition) {
             vlog(
-              coproclog.error,
-              "Coult not recover ntp {}, for some reason it does not exist in "
-              "the partition_manager",
+              coproclog.debug,
+              "Coult not recover ntp {}, its possible it was from a moved "
+              "partition",
               key);
         } else {
             auto [itr, _] = recovered.emplace(

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -118,6 +118,22 @@ public:
     ss::future<> wait_idle_state(script_id);
 
     /**
+     * Restarts a partition. Useful after source partition is moved.
+     */
+    ss::future<absl::flat_hash_map<script_id, errc>> restart_partition(
+      model::ntp,
+      std::vector<std::pair<script_id, std::vector<topic_namespace_policy>>>,
+      ntp_context::offset_tracker&&);
+
+    /**
+     * Removes partition from any active scripts that may be processing it
+     *
+     * @returns Ids of scripts that were reading from this partition
+     */
+    ss::future<std::variant<errc, ntp_context::offset_tracker>>
+      shutdown_partition(model::ntp);
+
+    /**
      * @returns true if a matching script id exists on 'this' shard
      */
     bool local_script_id_exists(script_id);
@@ -136,6 +152,8 @@ private:
       const std::vector<topic_namespace_policy>&);
 
     void fire_updates(script_id, errc);
+
+    void install_failure_handler(script_id);
 
     struct offset_flush_fiber_state {
         ss::timer<ss::lowres_clock> timer;

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -138,9 +138,6 @@ public:
      */
     bool local_script_id_exists(script_id);
 
-    /// returns the number of running / registered fibers
-    size_t n_registered_scripts() const { return _scripts.size(); }
-
     /// returns a handle to the reconnect transport
     shared_script_resources& resources() { return _shared_res; }
 

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -16,6 +16,7 @@
 #include "cluster/topics_frontend.h"
 #include "config/configuration.h"
 #include "coproc/exception.h"
+#include "coproc/fwd.h"
 #include "coproc/ntp_context.h"
 #include "coproc/offset_storage_utils.h"
 #include "coproc/script_context.h"
@@ -63,7 +64,8 @@ public:
      * @param address of coprocessor engine
      * @param reference to the storage layer
      */
-    pacemaker(unresolved_address, sys_refs&);
+    pacemaker(
+      unresolved_address, ss::sharded<wasm::script_database>&, sys_refs&);
 
     /**
      * Begins the offset tracking fiber
@@ -179,6 +181,10 @@ private:
 
     /// Data to be referenced by script_contexts on the current shard
     shared_script_resources _shared_res;
+
+    /// Global script database cache. Only used by pacemaker to remove scripts
+    /// that should be permanently removed, due to a fatal error
+    ss::sharded<wasm::script_database>& _sdb;
 
     /// Main datastructure containing all active script_contexts
     absl::node_hash_map<script_id, std::unique_ptr<script_context>> _scripts;

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/reconciliation_backend.h"
+
+#include "cluster/cluster_utils.h"
+#include "cluster/shard_table.h"
+#include "coproc/logger.h"
+#include "coproc/pacemaker.h"
+#include "coproc/script_database.h"
+#include "ssx/future-util.h"
+#include "storage/log_manager.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace coproc {
+
+reconciliation_backend::reconciliation_backend(
+  ss::sharded<wasm::script_database>& sdb,
+  ss::sharded<storage::api>& storage,
+  ss::sharded<cluster::topic_table>& topics,
+  ss::sharded<cluster::shard_table>& shard_table,
+  ss::sharded<pacemaker>& pacemaker) noexcept
+  : _self(config::shard_local_cfg().node_id())
+  , _sdb(sdb)
+  , _storage(storage)
+  , _topics(topics)
+  , _shard_table(shard_table)
+  , _pacemaker(pacemaker) {}
+
+ss::future<> reconciliation_backend::start() {
+    _id_cb = _topics.local().register_delta_notification(
+      [this](const std::vector<cluster::topic_table::delta>& deltas) {
+          (void)process_updates(deltas);
+      });
+    return ss::now();
+}
+
+ss::future<> reconciliation_backend::stop() {
+    _topics.local().unregister_delta_notification(_id_cb);
+    return _gate.close();
+}
+
+ss::future<> reconciliation_backend::process_updates(
+  std::vector<cluster::topic_table::delta> deltas) {
+    return ss::do_with(std::move(deltas), [this](auto& deltas) {
+        return ss::with_gate(_gate, [this, &deltas]() {
+            return ss::with_semaphore(_sem, 1, [this, &deltas]() mutable {
+                return ss::do_for_each(deltas, [this](auto& d) {
+                    return process_update(std::move(d));
+                });
+            });
+        });
+    });
+}
+
+static std::optional<ss::shard_id>
+new_shard(model::node_id self, std::vector<model::broker_shard> new_replicas) {
+    auto rep = std::find_if(
+      std::cbegin(new_replicas),
+      std::cend(new_replicas),
+      [self](const model::broker_shard& bs) { return bs.node_id == self; });
+    return rep == new_replicas.end() ? std::nullopt
+                                     : std::optional<ss::shard_id>(rep->shard);
+}
+
+static std::vector<storage::ntp_config> child_configs(
+  const cluster::topic_table& topics,
+  const storage::api& storage,
+  const model::ntp& ntp) {
+    std::vector<storage::ntp_config> configs;
+    auto found = topics.hierarchy_map().find(model::topic_namespace_view{ntp});
+    vassert(
+      found != topics.hierarchy_map().end() && !found->second.empty(),
+      "Missing corresponding hierarchy for source topic {}",
+      ntp);
+    for (const auto& c : found->second) {
+        auto log = storage.log_mgr().get(
+          model::ntp(ntp.ns, c.tp, ntp.tp.partition));
+        if (log) {
+            configs.emplace_back(log->config());
+        }
+    }
+    return configs;
+}
+
+ss::future<> reconciliation_backend::process_shutdown(
+  model::ntp ntp,
+  model::revision_id rev,
+  std::vector<model::broker_shard> new_replicas,
+  std::vector<storage::ntp_config> configs) {
+    vlog(coproclog.info, "Processing shutdown of: {}", ntp);
+    auto errc_or_ctx = co_await _pacemaker.local().shutdown_partition(ntp);
+    if (std::holds_alternative<errc>(errc_or_ctx)) {
+        vlog(
+          coproclog.error,
+          "Failed to process shutdown of: {} reason: {}",
+          ntp,
+          std::get<errc>(errc_or_ctx));
+        co_return;
+    }
+    auto offsets = std::move(
+      std::get<ntp_context::offset_tracker>(errc_or_ctx));
+
+    /// Remove from shard table so ntp is effectively deregistered
+    co_await _shard_table.invoke_on_all(
+      [configs, ntp, rev](cluster::shard_table& st) {
+          for (const auto& c : configs) {
+              st.erase(c.ntp(), rev);
+          }
+      });
+
+    /// Either remove from disk or move...
+    std::optional<ss::shard_id> shard = new_shard(_self, new_replicas);
+    if (!shard) {
+        /// Move is occuring on a new node, just remove the log on this node
+        for (const auto& c : configs) {
+            co_await _storage.local().log_mgr().remove(c.ntp());
+            vlog(coproclog.info, "Materialized log {} removed", c.ntp());
+        }
+    } else {
+        /// Move is occuring to a new shard on this node, call shutdown instead
+        /// of remove to avoid erasing all log data
+        for (const auto& c : configs) {
+            co_await _storage.local().log_mgr().shutdown(c.ntp());
+            vlog(coproclog.info, "Materialized log {} shutdown", c.ntp());
+        }
+        /// Store information needed to re-create the log on new shard
+        co_await this->container().invoke_on(
+          *shard,
+          [ntp,
+           rev,
+           configs = std::move(configs),
+           offsets = std::move(offsets)](reconciliation_backend& be) mutable {
+              auto [itr, success] = be._saved_ctxs.emplace(
+                std::move(ntp),
+                state_revision{std::move(offsets), std::move(configs), rev});
+              if (!success) {
+                  if (itr->second.r_id < rev) {
+                      itr->second = state_revision{
+                        .offsets = std::move(offsets),
+                        .configs = std::move(configs),
+                        .r_id = rev};
+                  } else {
+                      vlog(
+                        coproclog.warn,
+                        "Ignoring older request ntp: {} old: {} new: {}",
+                        ntp,
+                        itr->second.r_id,
+                        rev);
+                  }
+              }
+          });
+    }
+}
+
+static std::vector<std::pair<script_id, std::vector<topic_namespace_policy>>>
+grab_metadata(wasm::script_database& sdb, model::topic_namespace_view tn_view) {
+    std::vector<std::pair<script_id, std::vector<topic_namespace_policy>>>
+      results;
+    auto found = sdb.find(tn_view);
+    auto& ids = found->second;
+    for (auto id : ids) {
+        auto id_found = sdb.find(id);
+        results.emplace_back(id, id_found->second.inputs);
+    }
+    return results;
+}
+
+ss::future<> reconciliation_backend::process_restart(
+  model::ntp ntp, model::revision_id rev) {
+    vlog(coproclog.info, "Processing restart of: {}", ntp);
+
+    state_revision sr;
+    auto found = _saved_ctxs.extract(ntp);
+    vassert(!found.empty(), "missing matching op_t::update event {}", ntp);
+    sr = std::move(found.mapped());
+    vassert(
+      sr.r_id < rev, "Older rev - ntp: {} old: {} new: {}", ntp, sr.r_id, rev);
+
+    /// Obtain all matching script_ids for the shutdown partition, they must all
+    /// be restarted
+    auto meta = co_await _sdb.invoke_on(
+      wasm::script_database_main_shard, [ntp](wasm::script_database& sdb) {
+          return grab_metadata(sdb, model::topic_namespace_view{ntp});
+      });
+
+    std::vector<model::ntp> ntps;
+    for (auto& c : sr.configs) {
+        ntps.push_back(c.ntp());
+        vlog(coproclog.info, "Re-creating materialized log: {}", c.ntp());
+        co_await _storage.local()
+          .log_mgr()
+          .manage(std::move(c))
+          .discard_result();
+    }
+
+    auto shard = ss::this_shard_id();
+    co_await _shard_table.invoke_on_all(
+      [ntps = std::move(ntps), shard, ntp, rev](
+        cluster::shard_table& shard_table) mutable {
+          for (auto& ntp : ntps) {
+              shard_table.update_shard(std::move(ntp), shard, rev);
+          }
+      });
+
+    /// Ensure that materialized log creation occurs before this line, as
+    /// restart_partition will start processing and coprocessors would find
+    /// themselves in an odd state (i.e. non_replicated topic exists in topic
+    /// metadata but no associated storage::log exists)
+    auto results = co_await _pacemaker.local().restart_partition(
+      ntp, std::move(meta), std::move(sr.offsets));
+    for (const auto& [id, errc] : results) {
+        vlog(
+          coproclog.info,
+          "Upon restart of '{}' script_id '{}' reported status: {}",
+          ntp,
+          errc);
+    }
+}
+
+ss::future<>
+reconciliation_backend::process_update(cluster::topic_table::delta d) {
+    using op_t = cluster::topic_table::delta::op_type;
+    if (!(d.type == op_t::update || d.type == op_t::update_finished)) {
+        /// ignore requests that have nothing to do with moving topics
+        co_return;
+    }
+    const auto& tmap = _topics.local().topics_map();
+    auto tp_md = tmap.find(model::topic_namespace_view{d.ntp});
+    vassert(tp_md != tmap.end(), "ntp missing topic metadata: {}", d.ntp);
+    if (!tp_md->second.is_topic_replicable()) {
+        /// ignore requests that have nothing to do with replicable_topics
+        co_return;
+    }
+    model::revision_id rev(d.offset());
+    if (d.type == op_t::update) {
+        if (cluster::has_local_replicas(
+              _self, d.previous_assignment->replicas)) {
+            /// Grab the topic hierarchy of the source topic
+            auto configs = child_configs(
+              _topics.local(), _storage.local(), d.ntp);
+            vassert(
+              !configs.empty(), "Missing config source hierarchy: {}", d.ntp);
+            co_await process_shutdown(
+              d.ntp,
+              rev,
+              std::move(d.new_assignment.replicas),
+              std::move(configs));
+        }
+    } else if (d.type == op_t::update_finished) {
+        if (cluster::has_local_replicas(_self, d.new_assignment.replicas)) {
+            co_await process_restart(d.ntp, rev);
+        }
+    }
+}
+
+} // namespace coproc

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/fwd.h"
+#include "cluster/topic_table.h"
+#include "coproc/fwd.h"
+#include "coproc/ntp_context.h"
+#include "coproc/types.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
+
+namespace coproc {
+
+class reconciliation_backend
+  : public ss::peering_sharded_service<reconciliation_backend> {
+public:
+    explicit reconciliation_backend(
+      ss::sharded<wasm::script_database>&,
+      ss::sharded<storage::api>&,
+      ss::sharded<cluster::topic_table>&,
+      ss::sharded<cluster::shard_table>&,
+      ss::sharded<pacemaker>&) noexcept;
+
+    ss::future<> start();
+    ss::future<> stop();
+
+private:
+    ss::future<> process_shutdown(
+      model::ntp,
+      model::revision_id,
+      std::vector<model::broker_shard>,
+      std::vector<storage::ntp_config>);
+    ss::future<> process_restart(model::ntp, model::revision_id);
+    ss::future<> process_update(cluster::topic_table::delta);
+    ss::future<> process_updates(std::vector<cluster::topic_table::delta>);
+
+private:
+    cluster::notification_id_type _id_cb;
+    model::node_id _self;
+
+    ss::gate _gate;
+    ss::abort_source _as;
+    ss::semaphore _sem{1};
+
+    ss::sharded<wasm::script_database>& _sdb;
+    ss::sharded<storage::api>& _storage;
+    ss::sharded<cluster::topic_table>& _topics;
+    ss::sharded<cluster::shard_table>& _shard_table;
+    ss::sharded<pacemaker>& _pacemaker;
+
+    /// If xcore moves occur, also move in-memory state
+    struct state_revision {
+        ntp_context::offset_tracker offsets;
+        std::vector<storage::ntp_config> configs;
+        model::revision_id r_id;
+    };
+    absl::node_hash_map<model::ntp, state_revision> _saved_ctxs;
+};
+
+} // namespace coproc

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -85,12 +85,11 @@ public:
 private:
     ss::future<> do_execute();
 
-    ss::future<>
-      send_request(supervisor_client_protocol, process_batch_request);
-
     ss::future<> process_reply(process_batch_reply);
 
     void process_idle_callbacks();
+
+    ss::future<ss::stop_iteration> process_send_write(rpc::transport*);
 
 private:
     /// Idle state promises

--- a/src/v/coproc/script_database.h
+++ b/src/v/coproc/script_database.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "coproc/types.h"
+
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
+
+#include <vector>
+
+namespace coproc::wasm {
+/// In memory cache of all coprocessors of all coprocessors
+///
+/// Useful when its necessary to redeploy or reference a shutdown or partitally
+/// shutdown coprocessor for its metadata
+class script_database {
+public:
+    struct script_metadata {
+        iobuf source;
+        std::vector<topic_namespace_policy> inputs;
+    };
+
+    using underlying_t = absl::node_hash_map<script_id, script_metadata>;
+    using inverted_lookup_t = absl::node_hash_map<
+      model::topic_namespace,
+      absl::node_hash_set<script_id>,
+      model::topic_namespace_hash,
+      model::topic_namespace_eq>;
+    using const_iterator = underlying_t::const_iterator;
+    using const_inv_iterator = inverted_lookup_t::const_iterator;
+
+    /// Querying
+    /// ... by scripts
+    bool exists(script_id id) { return _db.find(id) != _db.end(); }
+    const const_iterator find(script_id id) const { return _db.find(id); }
+    const const_iterator cbegin() const { return _db.cbegin(); }
+    const const_iterator cend() const { return _db.cend(); }
+
+    /// ... by topic/namespace
+    bool exists(const model::topic_namespace& tn) const {
+        return _by_input.find(tn) != _by_input.cend();
+    }
+    const const_inv_iterator find(model::topic_namespace_view tnv) const {
+        return _by_input.find(tnv);
+    }
+    const const_inv_iterator inv_cbegin() const { return _by_input.cbegin(); }
+    const const_inv_iterator inv_cend() const { return _by_input.cend(); }
+
+    underlying_t::size_type size() const { return _db.size(); }
+    inverted_lookup_t::size_type unique_inputs() const {
+        return _by_input.size();
+    }
+
+    /// Removal
+    bool remove_script(script_id id) {
+        auto found = _db.find(id);
+        if (found == _db.end()) {
+            return false;
+        }
+        for (const auto& e : found->second.inputs) {
+            _by_input.erase(e.tn);
+        }
+        _db.erase(found);
+        return true;
+    }
+    void clear() {
+        _db.clear();
+        _by_input.clear();
+    }
+
+    /// Addition
+    bool add_script(
+      script_id id, iobuf source, std::vector<topic_namespace_policy> inputs) {
+        script_metadata meta{.source = std::move(source), .inputs = inputs};
+        auto [_, success] = _db.emplace(id, std::move(meta));
+        if (!success) {
+            return false;
+        }
+        for (auto& input : inputs) {
+            auto found = _by_input.find(input.tn);
+            if (found == _by_input.end()) {
+                absl::node_hash_set<script_id> ns;
+                ns.emplace(id);
+                _by_input.emplace(std::move(input.tn), std::move(ns));
+            } else {
+                found->second.emplace(id);
+            }
+        }
+        return true;
+    }
+
+private:
+    underlying_t _db;
+    inverted_lookup_t _by_input;
+};
+
+/// \brief script_database is a sharded service that only exists on shard 0.
+/// Use this as its 'home_shard' when calling 'invoke_on'
+static constexpr ss::shard_id script_database_main_shard = 0;
+
+} // namespace coproc::wasm

--- a/src/v/coproc/script_dispatcher.h
+++ b/src/v/coproc/script_dispatcher.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "coproc/pacemaker.h"
+#include "coproc/script_database.h"
 #include "coproc/supervisor.h"
 #include "coproc/types.h"
 
@@ -26,33 +27,35 @@ namespace coproc::wasm {
 /// retrival of the reply, invokes the appropriate action within the pacemaker.
 class script_dispatcher {
 public:
-    explicit script_dispatcher(ss::sharded<pacemaker>&, ss::abort_source&);
+    script_dispatcher(
+      ss::sharded<pacemaker>&,
+      ss::sharded<script_database>&,
+      ss::abort_source&) noexcept;
 
     /// Called when new coprocessors arrive on the coproc_internal_topic
     ///
     /// The wasm engine will be sent the list of coprocessors to enable
     /// Upon retrival of each successful ack, the script will be registered with
     /// the pacemaker.
-    ss::future<result<std::vector<script_id>>>
-      enable_coprocessors(enable_copros_request);
+    ss::future<std::error_code> enable_coprocessors(enable_copros_request);
 
     /// Called when removal commands arrive on the coproc_internal_topic
     ///
     /// The wasm engine will be send the list of coprocessor ids to remove from
     /// its internal map. Upon retrival of each successful ack, the script will
     /// be deregistered from the pacemaker.
-    ss::future<result<std::vector<script_id>>>
-      disable_coprocessors(disable_copros_request);
+    ss::future<std::error_code> disable_coprocessors(disable_copros_request);
 
     /// Invoke this after fatal error has occurred and its desired to clear all
     /// state from the wasm engine.
     ss::future<std::error_code> disable_all_coprocessors();
 
     /// Invoke this to query weather the wasm engine is up or not
-    ss::future<result<rpc::client_context<state_size_t>>>
-    heartbeat(int8_t connect_attempts = 3);
+    ss::future<result<bool>> heartbeat(int8_t connect_attempts = 3);
 
 private:
+    ss::future<result<rpc::client_context<state_size_t>>> do_heartbeat(int8_t);
+
     /// The following methods are introduced to sidestep an issue detected when
     /// using .map/invoke_on_all within the context of a coroutine
     ss::future<std::vector<std::vector<coproc::errc>>>
@@ -71,6 +74,9 @@ private:
     /// remove_source to add and remove coprocessors. It must do them however
     /// across all shards
     ss::sharded<pacemaker>& _pacemaker;
+
+    /// TODO: leave impotant comment here
+    ss::sharded<script_database>& _sdb;
 
     /// Reference to the script_listeners abort source. This class uses this
     /// abort source to know when to abort the transports retry loop in order to

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ rp_test(
   BINARY_NAME coproc_fixture
   SOURCES
     ${fixture_srcs}
+    input_partition_movement_tests.cc
     topic_ingestion_policy_tests.cc
     failure_recovery_tests.cc
     pacemaker_tests.cc

--- a/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
@@ -14,6 +14,7 @@
 #include "config/configuration.h"
 #include "coproc/api.h"
 #include "coproc/logger.h"
+#include "coproc/pacemaker.h"
 #include "coproc/tests/utils/event_publisher_utils.h"
 #include "coproc/tests/utils/kafka_publish_consumer.h"
 #include "kafka/client/client.h"

--- a/src/v/coproc/tests/input_partition_movement_tests.cc
+++ b/src/v/coproc/tests/input_partition_movement_tests.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/tests/fixtures/coproc_bench_fixture.h"
+#include "coproc/tests/utils/coprocessor.h"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test_log.hpp>
+
+using copro_typeid = coproc::registry::type_identifier;
+
+FIXTURE_TEST(test_move_source_topic, coproc_test_fixture) {
+    model::topic mvp("mvp");
+    setup({{mvp, 4}}).get();
+
+    auto id = coproc::script_id(443920);
+    enable_coprocessors(
+      {{.id = id(),
+        .data{
+          .tid = copro_typeid::identity_coprocessor,
+          .topics = {{mvp, coproc::topic_ingestion_policy::latest}}}}})
+      .get();
+
+    /// Push sample data onto all partitions
+    std::vector<ss::future<>> fs;
+    for (auto i = 0; i < 4; ++i) {
+        model::ntp input_ntp(
+          model::kafka_namespace, mvp, model::partition_id(i));
+        auto f = push(
+                   input_ntp,
+                   storage::test::make_random_memory_record_batch_reader(
+                     model::offset(0), 40, 1, false))
+                   .discard_result();
+        fs.emplace_back(std::move(f));
+    }
+    ss::when_all_succeed(fs.begin(), fs.end()).get();
+
+    /// Wait until the materialized topic has come into existance
+    model::ntp origin_ntp(model::kafka_namespace, mvp, model::partition_id(0));
+    model::ntp target_ntp = origin_ntp;
+    target_ntp.tp.topic = to_materialized_topic(
+      mvp, identity_coprocessor::identity_topic);
+    auto r = consume(target_ntp, model::offset{0}, model::offset{1}).get();
+    BOOST_REQUIRE(r.size() >= 1);
+    auto shard = root_fixture()->app.shard_table.local().shard_for(target_ntp);
+    BOOST_REQUIRE(shard);
+
+    /// Choose target and calculate where to move it to
+    const ss::shard_id next_shard = (*shard + 1) / ss::smp::count;
+    info("Current target shard {} and next shard {}", *shard, next_shard);
+    model::broker_shard bs{.node_id = model::node_id(1), .shard = next_shard};
+
+    /// Move the input onto the new desired target
+    auto& topics_fe = root_fixture()->app.controller->get_topics_frontend();
+    auto ec = topics_fe.local()
+                .move_partition_replicas(origin_ntp, {bs}, model::no_timeout)
+                .get();
+    info("Error code: {}", ec);
+    BOOST_REQUIRE(!ec);
+
+    /// Wait until the shard table is updated with the new shard
+    tests::cooperative_spin_wait_with_timeout(
+      10s,
+      [this, target_ntp, next_shard] {
+          auto s = root_fixture()->app.shard_table.local().shard_for(
+            target_ntp);
+          return s && *s == next_shard;
+      })
+      .get();
+
+    /// Issue a read from the target shard, and expect the topic content
+    info("Draining from shard....{}", bs.shard);
+    r = consume(target_ntp).get();
+    BOOST_REQUIRE_EQUAL(r.size(), 40);
+
+    /// Finally, ensure there is no materialized partition on original shard
+    auto logf = root_fixture()->app.storage.invoke_on(
+      *shard, [origin_ntp](storage::api& api) {
+          return api.log_mgr().get(origin_ntp).has_value();
+      });
+    BOOST_REQUIRE(!logf.get0());
+}

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -701,6 +701,8 @@ void application::wire_up_redpanda_services() {
           coprocessing,
           config::shard_local_cfg().coproc_supervisor_server(),
           std::ref(storage),
+          std::ref(controller->get_topics_state()),
+          std::ref(shard_table),
           std::ref(controller->get_topics_frontend()),
           std::ref(metadata_cache),
           std::ref(partition_manager));

--- a/src/v/storage/api.h
+++ b/src/v/storage/api.h
@@ -43,6 +43,7 @@ public:
 
     kvstore& kvs() { return *_kvstore; }
     log_manager& log_mgr() { return *_log_mgr; }
+    const log_manager& log_mgr() const { return *_log_mgr; }
 
 private:
     kvstore_config _kv_conf;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -203,7 +203,7 @@ public:
     size_t size() const { return _logs.size(); }
 
     /// Returns the log for the specified ntp.
-    std::optional<log> get(const model::ntp& ntp) {
+    std::optional<log> get(const model::ntp& ntp) const {
         if (auto it = _logs.find(ntp); it != _logs.end()) {
             return it->second.handle;
         }

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -71,6 +71,19 @@ public:
       , _overrides(std::move(overrides))
       , _revision_id(id) {}
 
+    ntp_config(const ntp_config& o)
+      : _ntp(o._ntp)
+      , _base_dir(o._base_dir)
+      , _overrides(nullptr)
+      , _revision_id(o._revision_id) {
+        if (o._overrides) {
+            _overrides = std::make_unique<default_overrides>(*o._overrides);
+        }
+    }
+
+    ntp_config(ntp_config&&) = default;
+    ntp_config& operator=(ntp_config&&) = default;
+
     const model::ntp& ntp() const { return _ntp; }
     model::ntp& ntp() { return _ntp; }
 


### PR DESCRIPTION
Materialized partitions will follow the broker/shard of its source topic. Therefore one cannot make a request to explicitly move a materialized partition, however it will be automatically moved if a request to move its parent/source was made.

To support this a new service called `coproc/reconciliation_backend.h/cc` was created that listens for updates from the topic table. Its explicitly only listening for `movement`/`finish movement` events. When the event is detected, the necessary work will be performed to either shutdown the partition for each coproc or restart it.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/d9868b062d813b81add67c122e44d2590891e1c4..efcfa4aab79fcf260e01f846baea426036b434a5)
- Fixed a bug which caused the cluster tests to fail