### PR TITLE
serde: add version check (version < compat_version)

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -306,6 +306,16 @@ header read_header(iobuf_parser& in, std::size_t const bytes_left_limit) {
           static_cast<int>(Type::redpanda_serde_version)));
     }
 
+    if (unlikely(version < Type::redpanda_serde_compat_version)) {
+        throw serde_exception(fmt_with_ctx(
+          ssx::sformat,
+          "read {}: version={} < {}::compat_version={}",
+          type_str<Type>(),
+          static_cast<int>(version),
+          type_str<T>(),
+          static_cast<int>(Type::redpanda_serde_compat_version)));
+    }
+
     return header{
       ._version = version,
       ._compat_version = compat_version,

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -615,7 +615,7 @@ struct old_cs
 };
 struct new_no_cs
   : public serde::
-      envelope<new_cs, serde::version<4>, serde::compat_version<4>> {
+      envelope<new_cs, serde::version<4>, serde::compat_version<3>> {
     serde::checksum_t unchecked_dummy_checksum_{0U};
     std::vector<test_msg1_new_manual> data_;
 };

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -57,6 +57,11 @@ struct test_msg1
     int _b, _c;
 };
 
+struct test_msg1_imcompatible
+  : serde::envelope<test_msg1, serde::version<5>, serde::compat_version<5>> {
+    test_msg0 _m;
+};
+
 struct test_msg1_new
   : serde::
       envelope<test_msg1_new, serde::version<10>, serde::compat_version<5>> {
@@ -84,6 +89,12 @@ static_assert(serde::inherits_from_envelope_v<test_msg1_new>);
 static_assert(!serde::inherits_from_envelope_v<test_msg1_new_manual>);
 static_assert(test_msg1::redpanda_serde_version == 4);
 static_assert(test_msg1::redpanda_serde_compat_version == 0);
+
+SEASTAR_THREAD_TEST_CASE(incompatible_version_throws) {
+    BOOST_CHECK_THROW(
+      serde::from_iobuf<test_msg1_imcompatible>(serde::to_iobuf(test_msg1{})),
+      serde::serde_exception);
+}
 
 SEASTAR_THREAD_TEST_CASE(manual_and_envelope_equal) {
     auto const roundtrip = serde::from_iobuf<test_msg1_new_manual>(


### PR DESCRIPTION
Before, a new version would try to read old data, even if `version < Type::compat_version`. This PR adds a check to `read_header` that throws an exception in this case.