### PR TITLE
cluster: add centralized config service

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -36,6 +36,8 @@ v_cc_library(
     partition_manager.cc
     scheduling/partition_allocator.cc
     logger.cc
+    config_frontend.cc
+    config_manager.cc
     cluster_utils.cc
     id_allocator.cc
     id_allocator_frontend.cc

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -77,6 +77,10 @@ static constexpr int8_t decommission_node_cmd_type = 0;
 static constexpr int8_t recommission_node_cmd_type = 1;
 static constexpr int8_t finish_reallocations_cmd_type = 2;
 
+// cluster config commands
+static constexpr int8_t cluster_config_delta_cmd_type = 0;
+static constexpr int8_t cluster_config_status_cmd_type = 1;
+
 using create_topic_cmd = controller_command<
   model::topic_namespace,
   topic_configuration_assignment,
@@ -176,6 +180,19 @@ using finish_reallocations_cmd = controller_command<
   int8_t, // unused
   finish_reallocations_cmd_type,
   model::record_batch_type::node_management_cmd>;
+
+// Cluster configuration deltas
+using cluster_config_delta_cmd = controller_command<
+  config_version,
+  cluster_config_delta_cmd_data,
+  cluster_config_delta_cmd_type,
+  model::record_batch_type::cluster_config_cmd>;
+
+using cluster_config_status_cmd = controller_command<
+  model::node_id,
+  cluster_config_status_cmd_data,
+  cluster_config_status_cmd_type,
+  model::record_batch_type::cluster_config_cmd>;
 
 // typelist utils
 // clang-format off

--- a/src/v/cluster/config_frontend.cc
+++ b/src/v/cluster/config_frontend.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "config_frontend.h"
+
+#include "cluster/cluster_utils.h"
+
+namespace cluster {
+
+config_frontend::config_frontend(
+  ss::sharded<controller_stm>& stm, ss::sharded<ss::abort_source>& as)
+  : _stm(stm)
+  , _as(as) {}
+
+ss::future<> config_frontend::start() { return ss::now(); }
+ss::future<> config_frontend::stop() { return ss::now(); }
+
+/**
+ * Issue a write of new configuration to the raft0 log.  Any pre-write
+ * validation of the content should have been done already (e.g. in admin API
+ * handler).  This function will naively write the config values through,
+ * so any invalid settings will show up in the config_manager (and as 'invalid'
+ * entries in the config_status to nodes they propagate to).
+ *
+ * Must be called on `version_shard` to enable serialized generation of
+ * version numbers.
+ */
+ss::future<std::error_code> config_frontend::patch(
+  config_update& update, model::timeout_clock::time_point timeout) {
+    vassert(
+      ss::this_shard_id() == version_shard, "Must be called on version_shard");
+
+    if (_next_version == config_version_unset) {
+        // Race with config_manager initialization which is responsible for
+        // setting _next_version once loaded.
+        co_return errc::waiting_for_recovery;
+    }
+
+    auto data = cluster_config_delta_cmd_data();
+
+    data.upsert = std::move(update.upsert);
+    data.remove = std::move(update.remove);
+
+    // Take _write_lock to serialize updates to _next_version
+    co_return co_await _write_lock.with([this, data, timeout] {
+        auto cmd = cluster_config_delta_cmd(_next_version, data);
+        vlog(
+          clusterlog.trace,
+          "patch: writing delta with version {}",
+          _next_version);
+        return replicate_and_wait(_stm, _as, std::move(cmd), timeout);
+    });
+}
+
+/**
+ * Called with the content of an incoming config_status_request: a
+ * remote node is informing us of its status.  Write it into the log,
+ * from whence config_manager will read it back into their in-memory
+ * map of node statuses.
+ */
+ss::future<std::error_code> config_frontend::set_status(
+  config_status& status, model::timeout_clock::time_point timeout) {
+    vlog(clusterlog.trace, "set_status from node {}: {}", status.node, status);
+    if (status.node < 0) {
+        co_return errc::node_does_not_exists;
+    }
+
+    auto data = cluster_config_status_cmd_data();
+    data.status = status;
+    auto cmd = cluster_config_status_cmd(status.node, data);
+    co_return co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
+}
+
+/**
+ * For config_manager to notify the frontend of what the next version
+ * number should be.
+ *
+ * Must be called on version_shard (the shard where writes are
+ * serialized to generate version numbers).
+ */
+void config_frontend::set_next_version(config_version v) {
+    vassert(
+      ss::this_shard_id() == version_shard, "Must be called on version_shard");
+    vlog(clusterlog.trace, "set_next_version: {}", v);
+    _next_version = v;
+}
+
+} // namespace cluster

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/controller_stm.h"
+
+namespace cluster {
+
+struct config_update final {
+    std::vector<std::pair<ss::sstring, ss::sstring>> upsert;
+    std::vector<ss::sstring> remove;
+};
+
+class config_frontend final {
+public:
+    // Shard ID that will track the next available version and serialize
+    // writes to hand out sequential versions.
+    // Setting this to the same as controller_stm shard simplfies implementation
+    // by letting all state machine appliers assume they are running
+    // on the same shard that should keep its version state up to date.
+    static constexpr ss::shard_id version_shard = cluster::controller_stm_shard;
+
+    config_frontend(
+      ss::sharded<controller_stm>&, ss::sharded<ss::abort_source>&);
+
+    ss::future<std::error_code>
+    patch(config_update&, model::timeout_clock::time_point);
+
+    ss::future<std::error_code>
+    set_status(config_status&, model::timeout_clock::time_point);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    void set_next_version(config_version v);
+
+private:
+    ss::sharded<controller_stm>& _stm;
+    ss::sharded<ss::abort_source>& _as;
+
+    // Initially unset, frontend is not writeable until backend finishes
+    // init and calls set_next_version.
+    config_version _next_version{
+      config_version_unset}; // Only maintained on `version_shard`
+
+    // Serialize writes to generate version numbers.
+    mutex _write_lock;
+};
+} // namespace cluster

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -1,0 +1,725 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "config_manager.h"
+
+#include "cluster/config_frontend.h"
+#include "cluster/controller_service.h"
+#include "cluster/errc.h"
+#include "cluster/logger.h"
+#include "cluster/partition_leaders_table.h"
+#include "config/configuration.h"
+#include "config/node_config.h"
+#include "resource_mgmt/io_priority.h"
+#include "utils/file_io.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace cluster {
+
+// After failure to send status to leader, how long to
+// wait before retrying.
+static constexpr std::chrono::seconds status_retry = 5s;
+
+// During first start bootstrap, if we are not leader then
+// check again after this long.
+static constexpr std::chrono::seconds bootstrap_retry = 5s;
+
+// Timeout for raft write of bootstrap delta
+static constexpr std::chrono::seconds bootstrap_write_timeout = 5s;
+
+// In on-disk cache, the key used to store config version number
+static constexpr std::string_view version_key = "_version";
+
+// The filename within the data directory to use for config cache
+static constexpr std::string_view cache_file = "config_cache.yaml";
+
+config_manager::config_manager(
+  config_manager::preload_result preload,
+  ss::sharded<config_frontend>& cf,
+  ss::sharded<rpc::connection_cache>& cc,
+  ss::sharded<partition_leaders_table>& pl,
+  ss::sharded<ss::abort_source>& as)
+  : _self(config::node().node_id())
+  , _frontend(cf)
+  , _connection_cache(cc)
+  , _leaders(pl)
+  , _as(as) {
+    if (ss::this_shard_id() == controller_stm_shard) {
+        // Only the controller stm shard handles updates: leave these
+        // members in default initialized state on other shards.
+        _seen_version = preload.version;
+        my_latest_status.node = _self;
+        my_latest_status.version = preload.version;
+        _raw_values = preload.raw_values;
+        my_latest_status.invalid = preload.invalid;
+        my_latest_status.unknown = preload.unknown;
+    }
+}
+
+/**
+ * Start a background fiber that waits for a leader, then on the leader
+ * primes the cluster config from its current local configuration.
+ *
+ * That current local configuration was set earlier by application.cc
+ * from a local yaml file.
+ *
+ * This is the code path for upgrades from pre-central-config redpanda
+ * clusters, and for first startup on new clusters/nodes, if the new
+ * nodes have a bootstrap yaml file.
+ */
+void config_manager::start_bootstrap() {
+    // Detach fiber
+    (void)ss::try_with_gate(
+      _gate,
+      [this] {
+          return ss::do_until(
+            [this] {
+                return _as.local().abort_requested() || _bootstrap_complete;
+            },
+            [this]() -> ss::future<> {
+                if (_seen_version != config_version_unset) {
+                    vlog(
+                      clusterlog.info,
+                      "Bootstrap complete (version {})",
+                      _seen_version);
+                    _bootstrap_complete = true;
+                    co_return;
+                } else {
+                    auto leader = co_await _leaders.local().wait_for_leader(
+                      model::controller_ntp,
+                      model::timeout_clock::now() + bootstrap_retry,
+                      _as.local());
+                    if (leader == _self) {
+                        // We are the leader.  Proceed to bootstrap cluster
+                        // configuration from our local configuration.
+                        co_await do_bootstrap();
+                        vlog(clusterlog.info, "Completed bootstrap as leader");
+                    } else {
+                        // Someone else got leadership.  Maybe they
+                        // successfully bootstrap config, maybe they don't.
+                        // Wait a short time before checking again.
+                        co_await ss::sleep_abortable(
+                          bootstrap_retry, _as.local());
+                    }
+                }
+            });
+      })
+      .handle_exception_type([](ss::sleep_aborted const&) {})
+      .handle_exception_type([](ss::gate_closed_exception const&) {})
+      .handle_exception([](const std::exception_ptr&) {
+          // Explicitly handle exception so that we do not risk an
+          // 'ignored exceptional future' error.  The only exceptions
+          // we expect here are things like sleep_aborted during shutdown.
+          vlog(
+            clusterlog.warn,
+            "Exception during bootstrap: {}",
+            std::current_exception());
+      });
+}
+
+/**
+ * For all non-default values in the current runtime configuration,
+ * inject them into the raft0 cluster configuration as a single delta.
+ *
+ {* This is done once on the first startup (first overall, or first
+ * since upgrading to a redpanda version with central config)
+ */
+ss::future<> config_manager::do_bootstrap() {
+    config_update update;
+
+    config::shard_local_cfg().for_each([&update](
+                                         const config::base_property& p) {
+        if (!p.is_default()) {
+            rapidjson::StringBuffer buf;
+            rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+            p.to_json(writer);
+            ss::sstring key_str(p.name());
+            ss::sstring val_str = buf.GetString();
+            vlog(clusterlog.info, "Importing property {}={}", key_str, val_str);
+            update.upsert.push_back({key_str, val_str});
+        }
+    });
+
+    // Version of the first write
+    _frontend.local().set_next_version(config_version{1});
+
+    try {
+        co_await _frontend.local().patch(
+          update, model::timeout_clock::now() + bootstrap_write_timeout);
+    } catch (...) {
+        // On errors, just drop out: start_bootstrap will go around
+        // its loop again.
+        vlog(
+          clusterlog.warn,
+          "Failed to write bootstrap delta: {}",
+          std::current_exception());
+    }
+}
+
+ss::future<> config_manager::start() {
+    if (_seen_version == config_version_unset) {
+        vlog(clusterlog.trace, "Starting config_manager... (initial)");
+
+        // Background: wait til we have a leader. If this node is leader
+        // then bootstrap cluster configuration from local config.
+        start_bootstrap();
+    } else {
+        vlog(
+          clusterlog.trace,
+          "Starting config_manager... (seen version {})",
+          _seen_version);
+        _frontend.local().set_next_version(_seen_version + config_version{1});
+    }
+
+    vlog(clusterlog.trace, "Starting reconcile_status...");
+
+    // Detach fiber
+    (void)ss::try_with_gate(
+      _gate,
+      [this] {
+          return ss::do_until(
+            [this] { return _as.local().abort_requested(); },
+            [this] { return reconcile_status(); });
+      })
+      .handle_exception_type([](ss::gate_closed_exception const&) {})
+      .handle_exception([](std::exception_ptr const& e) {
+          vlog(clusterlog.warn, "Exception from reconcile_status: {}", e);
+      });
+
+    return ss::now();
+}
+
+ss::future<> config_manager::stop() {
+    vlog(clusterlog.info, "stopping cluster::config_manager...");
+    _reconcile_wait.broken();
+    co_await _gate.close();
+}
+
+/**
+ * For mux_state_machine: indicate which record types we handle
+ */
+bool config_manager::is_batch_applicable(const model::record_batch& b) {
+    return b.header().type == model::record_batch_type::cluster_config_cmd;
+}
+
+/**
+ * True if our status in the raft0-populated map of node statuses
+ * differs from our actual status.
+ */
+bool config_manager::should_send_status() {
+    if (auto status_i = status.find(_self); status_i != status.end()) {
+        return my_latest_status.version > config_version_unset
+               && my_latest_status != status_i->second;
+    } else {
+        return my_latest_status.version > config_version_unset;
+    }
+}
+
+/**
+ * Local filesystem location where we write out the most recently
+ * seen configuration.  Does not have to exist.
+ */
+std::filesystem::path config_manager::cache_path() {
+    return config::node().data_directory().path / cache_file;
+}
+
+static void preload_local(
+  ss::sstring const& key,
+  YAML::Node const& value,
+  std::optional<std::reference_wrapper<config_manager::preload_result>>
+    result) {
+    auto& cfg = config::shard_local_cfg();
+    if (cfg.contains(key)) {
+        try {
+            // Cache values are string-ized yaml.  In many cases this
+            // is the same as the underlying value (e.g. integers, bools),
+            // but for strings it's not (the literal value in the cache is
+            // "\"foo\"").
+            auto decoded = YAML::Load(value.as<std::string>());
+            cfg.get(key).set_value(decoded);
+
+            // Because we are in preload, it doesn't matter if the property
+            // requires restart.  We are setting it before anything else
+            // can be using it.
+
+            if (result.has_value()) {
+                vlog(
+                  clusterlog.trace,
+                  "Loaded property {}={} from local cache",
+                  key,
+                  YAML::Dump(decoded));
+            }
+        } catch (...) {
+            if (result.has_value()) {
+                vlog(
+                  clusterlog.info,
+                  "Ignoring invalid property: {}={}",
+                  key,
+                  YAML::Dump(value));
+                result.value().get().invalid.push_back(key);
+            }
+        }
+    } else {
+        if (result.has_value()) {
+            vlog(clusterlog.info, "Ignoring unknown property: {}", key);
+            result.value().get().unknown.push_back(key);
+        }
+    }
+}
+
+/**
+ * Before other redpanda subsystems are initialized, read the config
+ * cache and use it to bring the global cluster configuration somewhat
+ * up to date before the raft0 log is replayed.
+ */
+ss::future<config_manager::preload_result> config_manager::preload() {
+    // TODO: refactor yaml load workaround for lack of string view,
+    // it's also used in node_config load.
+
+    // TODO: legacy path: if cache isn't present, load from redpanda-cfg
+    // (currently we rely on application.cc to do this)
+
+    // TODO: assert that node_config was already loaded (we rely on
+    // data_directory)
+
+    preload_result result;
+
+    YAML::Node config;
+    try {
+        auto buf = co_await read_fully(cache_path());
+        auto workaround = ss::uninitialized_string(buf.size_bytes());
+        auto in = iobuf::iterator_consumer(buf.cbegin(), buf.cend());
+        in.consume_to(buf.size_bytes(), workaround.begin());
+        config = YAML::Load(workaround);
+    } catch (std::filesystem::filesystem_error const& e) {
+        // This is normal on upgrade from pre-config_manager version or
+        // on newly added node.  Also permitted later if user
+        // chooses to e.g. blow away config cache during disaster recovery.
+        vlog(clusterlog.info, "Can't load config cache: {}", e);
+        co_return result;
+    }
+
+    for (const auto& i : config) {
+        ss::sstring key = i.first.as<std::string>();
+        auto& value = i.second;
+        if (key == version_key) {
+            result.version = value.as<config_version>();
+            continue;
+        }
+
+        // Run locally to get validation fields of result
+        preload_local(key, value, std::ref(result));
+
+        // Store raw values in the result
+        result.raw_values[key] = YAML::Dump(value);
+
+        // Broadcast value to all shards
+        co_await ss::smp::invoke_on_all(
+          [&key, &value]() { preload_local(key, value, std::nullopt); });
+    }
+
+    co_return result;
+}
+
+/**
+ * Call this function iteratively on each node to check if it needs
+ * to send a config_status_request update to the controller leader.
+ *
+ * If no update is needed, sleeps on _reconcile_status, the condition
+ * variable that is signalled when our local status changes.
+ */
+ss::future<> config_manager::reconcile_status() {
+    bool failed = false;
+    if (should_send_status()) {
+        auto timeout = 5s;
+
+        auto leader = _leaders.local().get_leader(model::controller_ntp);
+        if (!leader) {
+            vlog(
+              clusterlog.trace,
+              "reconcile_status: no leader to send status to");
+            failed = true;
+        } else {
+            vlog(
+              clusterlog.trace,
+              "reconcile_status: sending status update to leader");
+            if (_self == *leader) {
+                auto err = co_await _frontend.local().set_status(
+                  my_latest_status, model::timeout_clock::now() + timeout);
+                if (err) {
+                    vlog(
+                      clusterlog.info,
+                      "reconcile_status: failed applying local status update: "
+                      "{}",
+                      err.message());
+                    failed = true;
+                }
+            } else {
+                auto r
+                  = co_await _connection_cache.local()
+                      .with_node_client<cluster::controller_client_protocol>(
+                        _self,
+                        ss::this_shard_id(),
+                        *leader,
+                        timeout,
+                        [this, timeout](controller_client_protocol cp) mutable {
+                            return cp.config_status(
+                              config_status_request{.status = my_latest_status},
+                              rpc::client_opts(
+                                model::timeout_clock::now() + timeout));
+                        });
+                if (r.has_error()) {
+                    // This is not logged as warning/error because it's expected
+                    // in certain situations like transferring leadership of
+                    // the raft0 partition
+                    vlog(
+                      clusterlog.info,
+                      "reconcile_status: failed sending status update to "
+                      "leader: "
+                      "{}",
+                      r.error().message());
+                    failed = true;
+                }
+            }
+        }
+    } else {
+        vlog(clusterlog.trace, "reconcile_status: up to date, sleeping");
+    }
+
+    try {
+        if (failed) {
+            // If we were dirty & failed to send our update, sleep until retry
+            co_await ss::sleep_abortable(status_retry, _as.local());
+        } else if (should_send_status()) {
+            // Our status updated while we were sending, proceed
+            // immediately to next iteration of loop.
+        } else {
+            // We are clean: sleep until signalled.
+            co_await _reconcile_wait.wait();
+        }
+    } catch (ss::condition_variable_timed_out) {
+        // Wait complete - proceed around next loop of do_until
+    } catch (ss::broken_condition_variable) {
+        // Shutting down - nextiteration will drop out
+    } catch (ss::sleep_aborted) {
+        // Shutting down - next iteration will drop out
+    }
+}
+
+/**
+ * Apply a configuration delta to the local shard's configuration
+ * object.  This delta is already persistent, and now being replayed
+ * from raft0 into our in memory state.
+ *
+ * @param silent if true, do not log issues with properties.  Useful
+ *               when invoking on N shards to avoid spamming the
+ *               same errors to the log N times.
+ *
+ * @return an `apply_result` indicating any issues, to be fed back
+ *         into cluster_status by the caller.
+ */
+config_manager::apply_result
+apply_local(cluster_config_delta_cmd_data const& data, bool silent) {
+    auto& cfg = config::shard_local_cfg();
+    auto result = config_manager::apply_result{};
+    for (const auto& u : data.upsert) {
+        if (!cfg.contains(u.first)) {
+            // We never heard of this property.  Record it as unknown
+            // in our config_status.
+            if (!silent) {
+                vlog(clusterlog.info, "Unknown property {}", u.first);
+            }
+            result.unknown.push_back(u.first);
+            continue;
+        }
+        auto& val_yaml = u.second;
+        try {
+            auto val = YAML::Load(val_yaml);
+            auto& property = cfg.get(u.first);
+            bool changed = property.set_value(val);
+            result.restart |= (property.needs_restart() && changed);
+        } catch (YAML::ParserException) {
+            if (!silent) {
+                vlog(
+                  clusterlog.warn,
+                  "Invalid syntax in property {}: {}",
+                  u.first,
+                  val_yaml);
+            }
+            result.invalid.push_back(u.first);
+            continue;
+        } catch (YAML::BadConversion) {
+            if (!silent) {
+                vlog(
+                  clusterlog.warn,
+                  "Invalid value for property {}: {}",
+                  u.first,
+                  val_yaml);
+            }
+            result.invalid.push_back(u.first);
+            continue;
+        } catch (std::bad_alloc) {
+            // Don't include bad_alloc in the catch-all below
+            throw;
+        } catch (...) {
+            // Because `property` is subclassed, it's hard to predict
+            // what other exceptions specific property subclasses
+            // might emit when trying to parse their values.  We definitely
+            // don't want to let those exceptions jam up the controller,
+            // so catch-all as an invalid property value.
+            if (!silent) {
+                vlog(
+                  clusterlog.warn,
+                  "Unexpected error setting property {}={}: {}",
+                  u.first,
+                  val_yaml,
+                  std::current_exception());
+            }
+            result.invalid.push_back(u.first);
+            continue;
+        }
+    }
+
+    for (const auto& r : data.remove) {
+        if (!cfg.contains(r)) {
+            // Ignore: if we have never heard of the property, removing
+            // its value is a no-op.
+            continue;
+        }
+
+        auto& property = cfg.get(r);
+        result.restart |= property.needs_restart();
+        property.reset();
+    }
+
+    return result;
+}
+
+void config_manager::merge_apply_result(
+  config_status& status,
+  cluster_config_delta_cmd_data const& data,
+  apply_result const& r) {
+    vlog(
+      clusterlog.trace,
+      "merge_apply_result: data {} {}",
+      fmt::ptr(&data),
+      data.upsert.size());
+    status.restart |= r.restart;
+
+    std::set<ss::sstring> errored_properties;
+    for (const auto& i : r.unknown) {
+        errored_properties.insert(i);
+    }
+    for (const auto& i : r.invalid) {
+        errored_properties.insert(i);
+    }
+
+    // Clear status for any OK or removed properties from this delta
+    std::set<ss::sstring> ok_properties;
+    for (const auto& i : data.remove) {
+        ok_properties.insert(i);
+    }
+    for (const auto& i : data.upsert) {
+        if (!errored_properties.contains(i.first)) {
+            ok_properties.insert(i.first);
+        }
+    }
+
+    // Filter out any previously errored properties that are now OK
+    std::erase_if(status.unknown, [&ok_properties](const ss::sstring& p) {
+        return ok_properties.contains(p);
+    });
+    std::erase_if(status.invalid, [&ok_properties](const ss::sstring& p) {
+        return ok_properties.contains(p);
+    });
+
+    // Add any newly errored properties
+    for (const auto& i : r.unknown) {
+        if (
+          std::find(status.unknown.begin(), status.unknown.end(), i)
+          == status.unknown.end()) {
+            status.unknown.push_back(i);
+        }
+    }
+    for (const auto& i : r.invalid) {
+        if (
+          std::find(status.invalid.begin(), status.invalid.end(), i)
+          == status.invalid.end()) {
+            status.invalid.push_back(i);
+        }
+    }
+}
+
+/**
+ * Update persistent local cache of config.
+ *
+ * This cache is for early loading during startup.  It is NOT required
+ * to be strictly up to date when we finish processing a delta.
+ *
+ * @param version
+ * @param data
+ * @return
+ */
+ss::future<> config_manager::store_delta(
+  config_version const& delta_version,
+  cluster_config_delta_cmd_data const& data) {
+    _seen_version = delta_version;
+
+    // version_shard is chosen to match controller_stm_shard, so
+    // our raft0 stm apply operations do not need a core jump to
+    // update the frontend version state.
+    vassert(
+      ss::this_shard_id() == config_frontend::version_shard,
+      "Must be called on frontend version_shard");
+    _frontend.local().set_next_version(_seen_version + config_version{1});
+
+    for (const auto& u : data.upsert) {
+        _raw_values[u.first] = u.second;
+    }
+    for (const auto& d : data.remove) {
+        _raw_values.erase(d);
+    }
+
+    // Assumption: configuration objects are small.
+    // Marshal the whole thing in a single buffer.
+    // TODO: enforce a length limit on config
+    // settings to avoid malicious users making
+    // this buffer/file huge.
+
+    // Construct a YAML document of raw values: the
+    // values are whatever we were sent in a delta,
+    // so they are stored string-ized.  This file
+    // format looks different to a YAML config file
+    // -- it is only proximately human readable,
+    // for use in disaster recovery, not ordinary
+    // hand editing.
+    YAML::Emitter out;
+    out << YAML::Comment("Auto-generated, do not edit this file "
+                         "unless Redpanda will not start");
+    out << YAML::BeginMap;
+    out << YAML::Key << std::string(version_key) << YAML::Value
+        << _seen_version;
+    for (const auto& i : _raw_values) {
+        out << YAML::Key << i.first << YAML::Value << i.second;
+    }
+    out << YAML::EndMap;
+
+    try {
+        // TODO: do a clean write tmp + mv, to
+        // avoid possibility of torn writes.  Note
+        // that an fsync is not necessary as long
+        // as the write is atomic: it is safe for
+        // the cache to be a little behind.
+        iobuf buf;
+        buf.append(out.c_str(), out.size());
+        co_await write_fully(cache_path(), std::move(buf));
+    } catch (...) {
+        // Failure to write the cache (maybe we're
+        // out of disk space?) is not fatal.  It
+        // just means that on next restart we'll
+        // apply the deltas since the last time we
+        // successfully wrote it.
+        vlog(
+          clusterlog.warn,
+          "Failed writing config cache: {}",
+          std::current_exception());
+    }
+}
+
+ss::future<std::error_code>
+config_manager::apply_delta(cluster_config_delta_cmd&& cmd_in) {
+    // Explicitly move onto stack, because the input argument
+    // may be invalidated after first coroutine sleep
+    auto cmd = std::move(cmd_in);
+
+    const config_version delta_version = cmd.key;
+    if (delta_version <= _seen_version) {
+        vlog(
+          clusterlog.trace,
+          "apply delta: ignore {} <= {}",
+          delta_version,
+          _seen_version);
+        co_return errc::success;
+    }
+
+    const cluster_config_delta_cmd_data& data = cmd.value;
+    vlog(
+      clusterlog.trace,
+      "apply_delta: {} upserts, {} removes",
+      data.upsert.size(),
+      data.remove.size());
+    for (const auto& u : data.upsert) {
+        vlog(clusterlog.trace, "apply_delta: upsert {}={}", u.first, u.second);
+    }
+
+    for (const auto& d : data.remove) {
+        vlog(clusterlog.trace, "apply_delta: delete {}", d);
+    }
+
+    // Update shard-local copies of configuration.  Use our local shard's
+    // apply to learn of any bad properties (all copies will have the same
+    // errors, so only need to check the errors on one)
+    auto apply_r = apply_local(data, false);
+
+    co_await ss::smp::invoke_on_all([&data] { apply_local(data, true); });
+
+    // Merge results from this delta into our status.
+    my_latest_status.version = delta_version;
+    merge_apply_result(my_latest_status, data, apply_r);
+
+    // Store the raw values (irrespective of any issues applying them) for
+    // early replay on next startup.
+    co_await store_delta(delta_version, data);
+
+    // Signal status update loop to wake up
+    _reconcile_wait.signal();
+
+    co_return errc::success;
+}
+
+ss::future<std::error_code>
+config_manager::apply_status(cluster_config_status_cmd&& cmd) {
+    auto node_id = cmd.key;
+    auto data = std::move(cmd.value);
+
+    // TODO: hook into node decom to remove nodes from
+    // the status map.
+
+    vlog(
+      clusterlog.trace,
+      "apply_status: updating node {}: {}",
+      node_id,
+      data.status);
+
+    status[node_id] = data.status;
+
+    co_return errc::success;
+}
+ss::future<std::error_code>
+config_manager::apply_update(model::record_batch b) {
+    auto cmd_var = co_await cluster::deserialize(
+      std::move(b), accepted_commands);
+
+    auto gate_holder = _gate.hold();
+
+    co_return co_await ss::visit(
+      cmd_var,
+      [this](cluster_config_delta_cmd cmd) {
+          return apply_delta(std::move(cmd));
+      },
+      [this](cluster_config_status_cmd cmd) {
+          return apply_status(std::move(cmd));
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/config_manager.h
+++ b/src/v/cluster/config_manager.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/commands.h"
+#include "model/record.h"
+#include "rpc/connection_cache.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+
+namespace cluster {
+
+/// This state machine receives updates to the global cluster config,
+/// and uses them to update the per-shard configuration objects
+/// that are consumed by other services within redpanda.
+class config_manager final {
+    static constexpr auto accepted_commands = make_commands_list<
+      cluster_config_delta_cmd,
+      cluster_config_status_cmd>{};
+
+public:
+    static constexpr ss::shard_id shard = 0;
+
+    struct preload_result {
+        config_version version{config_version_unset};
+        std::map<ss::sstring, ss::sstring> raw_values;
+        std::vector<ss::sstring> unknown;
+        std::vector<ss::sstring> invalid;
+    };
+
+    using status_map = std::map<model::node_id, config_status>;
+
+    config_manager(
+      preload_result preload,
+      ss::sharded<config_frontend>&,
+      ss::sharded<rpc::connection_cache>&,
+      ss::sharded<partition_leaders_table>&,
+      ss::sharded<ss::abort_source>&);
+
+    static ss::future<preload_result> preload();
+    ss::future<> start();
+    ss::future<> stop();
+
+    // mux_state_machine interface
+    bool is_batch_applicable(const model::record_batch& b);
+    ss::future<std::error_code> apply_update(model::record_batch);
+
+    // Result of trying to apply a delta to a configuration
+    struct apply_result {
+        bool restart{false};
+        std::vector<ss::sstring> unknown;
+        std::vector<ss::sstring> invalid;
+    };
+
+    status_map const& get_status() const { return status; }
+
+    config_version get_version() const noexcept { return _seen_version; }
+
+private:
+    void merge_apply_result(
+      config_status&,
+      cluster_config_delta_cmd_data const&,
+      apply_result const&);
+
+    bool should_send_status();
+    ss::future<> reconcile_status();
+    ss::future<std::error_code> apply_delta(cluster_config_delta_cmd&&);
+    ss::future<> store_delta(
+      config_version const& version, cluster_config_delta_cmd_data const& data);
+
+    bool _bootstrap_complete{false};
+    void start_bootstrap();
+    ss::future<> do_bootstrap();
+
+    ss::future<std::error_code> apply_status(cluster_config_status_cmd&& cmd);
+
+    static std::filesystem::path cache_path();
+
+    config_status my_latest_status;
+    status_map status;
+
+    model::node_id _self;
+    config_version _seen_version{config_version_unset};
+    std::map<ss::sstring, ss::sstring> _raw_values;
+
+    ss::sharded<config_frontend>& _frontend;
+    ss::sharded<rpc::connection_cache>& _connection_cache;
+    ss::sharded<partition_leaders_table>& _leaders;
+
+    ss::condition_variable _reconcile_wait;
+    ss::sharded<ss::abort_source>& _as;
+    ss::gate _gate;
+};
+
+} // namespace cluster

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -43,13 +43,15 @@
 namespace cluster {
 
 controller::controller(
+  config_manager::preload_result&& config_preload,
   ss::sharded<rpc::connection_cache>& ccache,
   ss::sharded<partition_manager>& pm,
   ss::sharded<shard_table>& st,
   ss::sharded<storage::api>& storage,
   ss::sharded<raft::group_manager>& raft_manager,
   ss::sharded<v8_engine::data_policy_table>& data_policy_table)
-  : _connections(ccache)
+  : _config_preload(std::move(config_preload))
+  , _connections(ccache)
   , _partition_manager(pm)
   , _shard_table(st)
   , _storage(storage)
@@ -94,6 +96,17 @@ ss::future<> controller::start() {
           return _members_manager.local().validate_configuration_invariants();
       })
       .then([this] {
+          return _config_frontend.start(std::ref(_stm), std::ref(_as));
+      })
+      .then([this] {
+          return _config_manager.start(
+            std::ref(_config_preload),
+            std::ref(_config_frontend),
+            std::ref(_connections),
+            std::ref(_partition_leaders),
+            std::ref(_as));
+      })
+      .then([this] {
           return _stm.start_single(
             std::ref(clusterlog),
             _raft0.get(),
@@ -101,7 +114,8 @@ ss::future<> controller::start() {
             std::ref(_tp_updates_dispatcher),
             std::ref(_security_manager),
             std::ref(_members_manager),
-            std::ref(_data_policy_manager));
+            std::ref(_data_policy_manager),
+            std::ref(_config_manager));
       })
       .then([this] {
           return _members_frontend.start(
@@ -198,6 +212,10 @@ ss::future<> controller::start() {
             members_manager::shard, &members_backend::start);
       })
       .then([this] {
+          return _config_manager.invoke_on(
+            config_manager::shard, &config_manager::start);
+      })
+      .then([this] {
           if (!config::shard_local_cfg().enable_leader_balancer()) {
               return ss::now();
           }
@@ -254,12 +272,14 @@ ss::future<> controller::stop() {
         return stop_leader_balancer
           .then([this] { return _health_manager.stop(); })
           .then([this] { return _members_backend.stop(); })
+          .then([this] { return _config_manager.stop(); })
           .then([this] { return _api.stop(); })
           .then([this] { return _backend.stop(); })
           .then([this] { return _tp_frontend.stop(); })
           .then([this] { return _security_frontend.stop(); })
           .then([this] { return _data_policy_frontend.stop(); })
           .then([this] { return _members_frontend.stop(); })
+          .then([this] { return _config_frontend.stop(); })
           .then([this] { return _stm.stop(); })
           .then([this] { return _authorizer.stop(); })
           .then([this] { return _credentials.stop(); })

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -212,8 +212,12 @@ ss::future<> controller::start() {
             members_manager::shard, &members_backend::start);
       })
       .then([this] {
-          return _config_manager.invoke_on(
-            config_manager::shard, &config_manager::start);
+          if (config::node().enable_central_config()) {
+              return _config_manager.invoke_on(
+                config_manager::shard, &config_manager::start);
+          } else {
+              return ss::now();
+          }
       })
       .then([this] {
           if (!config::shard_local_cfg().enable_leader_balancer()) {

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "cluster/config_frontend.h"
+#include "cluster/config_manager.h"
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
 #include "cluster/health_manager.h"
@@ -31,6 +33,7 @@ namespace cluster {
 class controller {
 public:
     controller(
+      cluster::config_manager::preload_result&& config_preload,
       ss::sharded<rpc::connection_cache>& ccache,
       ss::sharded<partition_manager>& pm,
       ss::sharded<shard_table>& st,
@@ -42,6 +45,13 @@ public:
     ss::sharded<topics_frontend>& get_topics_frontend() { return _tp_frontend; }
     ss::sharded<members_manager>& get_members_manager() {
         return _members_manager;
+    }
+
+    ss::sharded<config_frontend>& get_config_frontend() {
+        return _config_frontend;
+    }
+    ss::sharded<config_manager>& get_config_manager() {
+        return _config_manager;
     }
 
     ss::sharded<members_table>& get_members_table() { return _members_table; }
@@ -79,6 +89,8 @@ public:
     ss::future<> stop();
 
 private:
+    config_manager::preload_result _config_preload;
+
     ss::sharded<ss::abort_source> _as;                     // instance per core
     ss::sharded<partition_allocator> _partition_allocator; // single instance
     ss::sharded<topic_table> _tp_state;                    // instance per core
@@ -93,6 +105,8 @@ private:
     ss::sharded<controller_api> _api;                // instance per core
     ss::sharded<members_frontend> _members_frontend; // instance per core
     ss::sharded<members_backend> _members_backend;   // single instance
+    ss::sharded<config_frontend> _config_frontend;   // instance per core
+    ss::sharded<config_manager> _config_manager;     // single instance
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_manager>& _partition_manager;
     ss::sharded<shard_table>& _shard_table;

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -59,6 +59,11 @@
             "name": "finish_reallocation",
             "input_type": "finish_reallocation_request",
             "output_type": "finish_reallocation_reply"
+        },
+        {
+            "name": "config_status",
+            "input_type": "config_status_request",
+            "output_type": "config_status_reply"
         }
     ]
 }

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/config_manager.h"
 #include "cluster/data_policy_manager.h"
 #include "cluster/members_manager.h"
 #include "cluster/security_manager.h"
@@ -24,7 +25,8 @@ using controller_stm = raft::mux_state_machine<
   topic_updates_dispatcher,
   security_manager,
   members_manager,
-  data_policy_manager>;
+  data_policy_manager,
+  config_manager>;
 
 static constexpr ss::shard_id controller_stm_shard = 0;
 

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -33,6 +33,7 @@ class metadata_dissemination_service;
 class security_frontend;
 class controller_api;
 class members_frontend;
+class config_frontend;
 class members_backend;
 class data_policy_frontend;
 class tx_gateway;

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -30,7 +30,8 @@ public:
       ss::sharded<metadata_cache>&,
       ss::sharded<security_frontend>&,
       ss::sharded<controller_api>&,
-      ss::sharded<members_frontend>&);
+      ss::sharded<members_frontend>&,
+      ss::sharded<config_frontend>&);
 
     virtual ss::future<join_reply>
     join(join_request&&, rpc::streaming_context&) override;
@@ -64,6 +65,9 @@ public:
     ss::future<finish_reallocation_reply> finish_reallocation(
       finish_reallocation_request&&, rpc::streaming_context&) final;
 
+    ss::future<config_status_reply>
+    config_status(config_status_request&&, rpc::streaming_context&) final;
+
 private:
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
@@ -87,5 +91,6 @@ private:
     ss::sharded<security_frontend>& _security_frontend;
     ss::sharded<controller_api>& _api;
     ss::sharded<members_frontend>& _members_frontend;
+    ss::sharded<config_frontend>& _config_frontend;
 };
 } // namespace cluster

--- a/src/v/config/base_property.cc
+++ b/src/v/config/base_property.cc
@@ -18,10 +18,10 @@ base_property::base_property(
   config_store& conf,
   std::string_view name,
   std::string_view desc,
-  required req)
+  base_property::metadata meta)
   : _name(name)
   , _desc(desc)
-  , _required(req) {
+  , _meta(meta) {
     conf._properties.emplace(name, this);
 }
 

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -49,6 +49,7 @@ public:
     virtual void print(std::ostream&) const = 0;
     virtual void set_value(YAML::Node) = 0;
     virtual void set_value(std::any) = 0;
+    virtual void reset() = 0;
     virtual std::optional<validation_error> validate() const = 0;
     virtual base_property& operator=(const base_property&) = 0;
     virtual ~base_property() noexcept = default;

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -54,7 +54,7 @@ public:
     to_json(rapidjson::Writer<rapidjson::StringBuffer>& w) const = 0;
 
     virtual void print(std::ostream&) const = 0;
-    virtual void set_value(YAML::Node) = 0;
+    virtual bool set_value(YAML::Node) = 0;
     virtual void set_value(std::any) = 0;
     virtual void reset() = 0;
     virtual bool is_default() const = 0;

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -57,6 +57,7 @@ public:
     virtual void set_value(YAML::Node) = 0;
     virtual void set_value(std::any) = 0;
     virtual void reset() = 0;
+    virtual bool is_default() const = 0;
     virtual std::optional<validation_error> validate() const = 0;
     virtual base_property& operator=(const base_property&) = 0;
     virtual ~base_property() noexcept = default;

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -26,19 +26,26 @@ namespace config {
 
 class config_store;
 using required = ss::bool_class<struct required_tag>;
+using needs_restart = ss::bool_class<struct needs_restart_tag>;
 
 class base_property {
 public:
+    struct metadata {
+        required required{required::no};
+        needs_restart needs_restart{needs_restart::yes};
+    };
+
     base_property(
       config_store& conf,
       std::string_view name,
       std::string_view desc,
-      required req);
+      metadata meta);
 
     const std::string_view& name() const { return _name; }
     const std::string_view& desc() const { return _desc; }
 
-    const required is_required() const { return _required; }
+    const required is_required() const { return _meta.required; }
+    bool needs_restart() { return bool(_meta.needs_restart); }
 
     // this serializes the property value. a full configuration serialization is
     // performed in config_store::to_json where the json object key is taken
@@ -58,6 +65,6 @@ private:
     friend std::ostream& operator<<(std::ostream&, const base_property&);
     std::string_view _name;
     std::string_view _desc;
-    required _required;
+    metadata _meta;
 };
 }; // namespace config

--- a/src/v/config/config_store.h
+++ b/src/v/config/config_store.h
@@ -22,6 +22,8 @@
 namespace config {
 class config_store {
 public:
+    bool contains(std::string_view name) { return _properties.contains(name); }
+
     base_property& get(const std::string_view& name) {
         return *_properties.at(name);
     }
@@ -104,7 +106,6 @@ inline YAML::Node to_yaml(const config_store& cfg) {
     cfg.to_json(writer);
     return YAML::Load(buf.GetString());
 }
-
 }; // namespace config
 
 namespace std {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -284,19 +284,19 @@ configuration::configuration()
       *this,
       "log_cleanup_policy",
       "Default topic cleanup policy",
-      required::no,
+      {required::no, needs_restart::no},
       model::cleanup_policy_bitflags::deletion)
   , log_message_timestamp_type(
       *this,
       "log_message_timestamp_type",
       "Default topic messages timestamp type",
-      required::no,
+      {required::no, needs_restart::no},
       model::timestamp_type::create_time)
   , log_compression_type(
       *this,
       "log_compression_type",
       "Default topic compression type",
-      required::no,
+      {required::no, needs_restart::no},
       model::compression::producer)
   , fetch_max_bytes(
       *this,

--- a/src/v/config/endpoint_tls_config.h
+++ b/src/v/config/endpoint_tls_config.h
@@ -28,6 +28,8 @@ struct endpoint_tls_config {
         return o;
     }
 
+    bool operator==(endpoint_tls_config const& rhs) const = default;
+
     static std::optional<ss::sstring> validate(const endpoint_tls_config& ec) {
         return tls_config::validate(ec.config);
     }

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -97,6 +97,12 @@ node_config::node_config() noexcept
       "`cloud_storage_enabled` is present",
       required::no,
       (data_directory.value().path / "archival_cache").native())
+  , enable_central_config(
+      *this,
+      "enable_central_config",
+      "Enable central storage + sync of cluster configuration",
+      required::no,
+      false)
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -47,6 +47,9 @@ public:
     // Shadow indexing/S3 cache location
     property<std::optional<ss::sstring>> cloud_storage_cache_directory;
 
+    // Feature flag for central config
+    property<bool> enable_central_config;
+
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {
         return data_directory().path / "pid.lock";

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -75,6 +75,8 @@ public:
 
     void set_value(YAML::Node n) override { _value = std::move(n.as<T>()); }
 
+    void reset() override { _value = default_value(); }
+
     property<T>& operator()(T v) {
         _value = std::move(v);
         return *this;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -31,10 +31,22 @@ public:
       config_store& conf,
       std::string_view name,
       std::string_view desc,
-      required req = required::yes,
+      base_property::metadata meta = {},
       T def = T{},
       property::validator validator = property::noop_validator)
-      : base_property(conf, name, desc, req)
+      : base_property(conf, name, desc, meta)
+      , _value(def)
+      , _default(std::move(def))
+      , _validator(std::move(validator)) {}
+
+    property(
+      config_store& conf,
+      std::string_view name,
+      std::string_view desc,
+      required req = {},
+      T def = T{},
+      property::validator validator = property::noop_validator)
+      : base_property(conf, name, desc, {.required = req})
       , _value(def)
       , _default(std::move(def))
       , _validator(std::move(validator)) {}

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -59,6 +59,8 @@ public:
 
     bool is_overriden() const { return is_required() || _value != _default; }
 
+    bool is_default() const override { return _value == _default; }
+
     const T& operator()() { return value(); }
 
     const T& operator()() const { return value(); }

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -40,7 +40,11 @@ struct test_config : public config::config_store {
         "An optional int value",
         config::required::no,
         100)
-      , required_string(*this, "required_string", "Required string value")
+      , required_string(
+          *this,
+          "required_string",
+          "Required string value",
+          config::base_property::metadata{})
       , an_int64_t(
           *this, "an_int64_t", "Some other int type", config::required::no, 200)
       , an_aggregate(
@@ -49,7 +53,11 @@ struct test_config : public config::config_store {
           "Aggregate type",
           config::required::no,
           custom_aggregate{"str", 10})
-      , strings(*this, "strings", "Required strings vector")
+      , strings(
+          *this,
+          "strings",
+          "Required strings vector",
+          config::base_property::metadata{})
       , nullable_int(
           *this,
           "nullable_int",

--- a/src/v/config/tests/custom_aggregate.h
+++ b/src/v/config/tests/custom_aggregate.h
@@ -18,4 +18,8 @@
 struct custom_aggregate {
     ss::sstring string_value;
     int int_value;
+
+    bool operator==(const custom_aggregate& rhs) const {
+        return string_value == rhs.string_value && int_value == rhs.int_value;
+    }
 };

--- a/src/v/config/tls_config.h
+++ b/src/v/config/tls_config.h
@@ -33,6 +33,10 @@ namespace config {
 struct key_cert {
     ss::sstring key_file;
     ss::sstring cert_file;
+
+    bool operator==(const key_cert& rhs) const {
+        return key_file == rhs.key_file && cert_file == rhs.cert_file;
+    }
 };
 
 class tls_config {
@@ -110,6 +114,8 @@ public:
 
         return std::nullopt;
     }
+
+    bool operator==(const tls_config& rhs) const = default;
 
 private:
     bool _enabled{false};

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -346,6 +346,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::data_policy_management_cmd";
     case record_batch_type::archival_metadata:
         return o << "batch_type::archival_metadata";
+    case record_batch_type::cluster_config_cmd:
+        return o << "batch_type::cluster_config_cmd";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -37,6 +37,7 @@ enum class record_batch_type : int8_t {
     node_management_cmd = 17, // controller node management
     data_policy_management_cmd = 18, // data-policy management
     archival_metadata = 19,          // archival metadata updates
+    cluster_config_cmd = 20,         // cluster config deltas and status
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -6,6 +6,14 @@ seastar_generate_swagger(
 )
 
 seastar_generate_swagger(
+  TARGET  cluster_config_swagger
+  VAR cluster_config_swagger_file
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/cluster_config.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/admin/api-doc/cluster_config.json.h
+
+)
+
+seastar_generate_swagger(
   TARGET raft_swagger
   VAR raft_swagger_file
   IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/admin/api-doc/raft.json
@@ -68,7 +76,7 @@ add_executable(redpanda
   )
 target_link_libraries(redpanda PUBLIC v::application v::raft v::kafka)
 set_property(TARGET redpanda PROPERTY POSITION_INDEPENDENT_CODE ON)
-add_dependencies(v_application config_swagger raft_swagger
+add_dependencies(v_application config_swagger cluster_config_swagger raft_swagger
     security_swagger status_swagger broker_swagger partition_swagger hbadger_swagger)
 
 if(CMAKE_BUILD_TYPE MATCHES Release)

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -1,0 +1,84 @@
+{
+  "apiVersion": "0.0.1",
+  "swaggerVersion": "1.2",
+  "basePath": "/v1",
+  "resourcePath": "/cluster_config",
+  "produces": [
+    "application/json"
+  ],
+  "apis": [
+    {
+      "path": "/v1/cluster_config",
+      "operations": [
+        {"method": "PUT",
+          "summary": "Update cluster configuration",
+          "type": "void",
+          "nickname": "patch_cluster_config",
+          "produces": ["application/json"],
+          "parameters": [
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/v1/cluster_config/status",
+      "operations": [
+        {"method": "GET",
+          "summary": "Get configuration status of nodes",
+          "type": "array",
+          "items": {
+            "type": "cluster_config_status"
+          },
+          "nickname": "get_cluster_config_status",
+          "produces": ["application/json"],
+          "parameters": [
+          ]
+        }
+      ]
+    }
+  ],
+  "models": {
+    "cluster_config_status": {
+      "id": "cluster_config_status",
+      "description": "Per-node configuration status",
+      "properties": {
+        "node_id": {
+          "type": "long",
+          "description": "node id"
+        },
+        "restart": {
+          "type": "boolean",
+          "description": "Restart required to apply pending configuration"
+        },
+        "version": {
+          "type": "long",
+          "description": "Configuration version number, for cross referencing with PUT results"
+        },
+        "invalid": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of properties with invalid values"
+        },
+        "unknown": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of properties unknown to this node"
+        }
+      }
+    },
+    "cluster_config_write_result": {
+      "id": "cluster_config_write_result",
+      "description": "Result of writing changes to cluster configuration",
+      "properties": {
+        "version": {
+          "type": "long",
+          "description": "Configuration version number, for cross referencing with node config status"
+        }
+      }
+    }
+  }
+}

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -585,6 +585,10 @@ void admin_server::register_cluster_config_routes() {
       _server._routes,
       [this](std::unique_ptr<ss::httpd::request> req)
         -> ss::future<ss::json::json_return_type> {
+          if (!config::node().enable_central_config) {
+              throw ss::httpd::bad_request_exception(
+                "Requires enable_central_config=True in node configuration");
+          }
 
           auto doc = parse_json_body(*req);
           apply_validator(cluster_config_validator, doc);

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -73,6 +73,7 @@ private:
     void configure_metrics_route();
     void configure_admin_routes();
     void register_config_routes();
+    void register_cluster_config_routes();
     void register_raft_routes();
     void register_kafka_routes();
     void register_security_routes();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -335,7 +335,10 @@ void application::hydrate_config(const po::variables_map& cfg) {
             config::node().load(config);
         }).get0();
 
-        _config_preload = cluster::config_manager::preload().get0();
+        if (config::node().enable_central_config) {
+            _config_preload = cluster::config_manager::preload().get0();
+        }
+
         if (_config_preload.version == cluster::config_version_unset) {
             // This node has never seen a cluster configuration message.
             // Bootstrap configuration from local yaml file.

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -332,12 +332,17 @@ void application::hydrate_config(const po::variables_map& cfg) {
     _redpanda_enabled = config["redpanda"];
     if (_redpanda_enabled) {
         ss::smp::invoke_on_all([&config] {
-            config::shard_local_cfg().load(config);
-        }).get0();
-
-        ss::smp::invoke_on_all([&config] {
             config::node().load(config);
         }).get0();
+
+        _config_preload = cluster::config_manager::preload().get0();
+        if (_config_preload.version == cluster::config_version_unset) {
+            // This node has never seen a cluster configuration message.
+            // Bootstrap configuration from local yaml file.
+            ss::smp::invoke_on_all([&config] {
+                config::shard_local_cfg().load(config);
+            }).get0();
+        }
 
         config::shard_local_cfg().for_each(config_printer("redpanda"));
         config::node().for_each(config_printer("redpanda"));
@@ -612,6 +617,7 @@ void application::wire_up_redpanda_services() {
 
     construct_single_service(
       controller,
+      std::move(_config_preload),
       _raft_connection_cache,
       partition_manager,
       shard_table,
@@ -1008,7 +1014,8 @@ void application::start_redpanda() {
             std::ref(metadata_cache),
             std::ref(controller->get_security_frontend()),
             std::ref(controller->get_api()),
-            std::ref(controller->get_members_frontend()));
+            std::ref(controller->get_members_frontend()),
+            std::ref(controller->get_config_frontend()));
           proto->register_service<cluster::metadata_dissemination_handler>(
             _scheduling_groups.cluster_sg(),
             smp_service_groups.cluster_smp_sg(),

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -13,6 +13,7 @@
 
 #include "archival/fwd.h"
 #include "cloud_storage/partition_recovery_manager.h"
+#include "cluster/config_manager.h"
 #include "cluster/fwd.h"
 #include "coproc/fwd.h"
 #include "kafka/client/configuration.h"
@@ -125,6 +126,7 @@ private:
     void setup_metrics();
     std::unique_ptr<ss::app_template> _app;
     bool _redpanda_enabled{true};
+    cluster::config_manager::preload_result _config_preload;
     std::optional<pandaproxy::rest::configuration> _proxy_config;
     std::optional<kafka::client::configuration> _proxy_client_config;
     std::optional<pandaproxy::schema_registry::configuration>

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -119,8 +119,24 @@ class Admin:
         r.raise_for_status()
         return r
 
-    def get_config(self):
-        return self._request("GET", "config").json()
+    def get_cluster_config(self, node=None):
+        return self._request("GET", "config", node=node).json()
+
+    def patch_cluster_config(self, upsert=None, remove=None):
+        if upsert is None:
+            upsert = {}
+        if remove is None:
+            remove = []
+
+        return self._request("PUT",
+                             "cluster_config",
+                             json={
+                                 'upsert': upsert,
+                                 'remove': remove
+                             }).json()
+
+    def get_cluster_config_status(self):
+        return self._request("GET", "cluster_config/status").json()
 
     def get_node_config(self):
         return self._request("GET", "node_config").json()

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -7,14 +7,34 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import time
+
 from rptest.services.admin import Admin
 from rptest.tests.redpanda_test import RedpandaTest
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+
+BOOTSTRAP_CONFIG = {
+    # A non-default value for checking bootstrap import works
+    'enable_idempotence': True
+}
 
 
 class ClusterConfigTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super(ClusterConfigTest, self).__init__(*args,
+                                                extra_rp_conf=BOOTSTRAP_CONFIG,
+                                                **kwargs)
+
+        self.admin = Admin(self.redpanda)
+
+    @cluster(num_nodes=3)
     def test_get_config(self):
+        """
+        Verify that the config GET endpoint serves valid json with some options in it.
+        """
         admin = Admin(self.redpanda)
-        config = admin.get_config()
+        config = admin.get_cluster_config()
 
         # Pick an arbitrary config property to verify that the result
         # contained some properties
@@ -24,3 +44,200 @@ class ClusterConfigTest(RedpandaTest):
 
         # Some arbitrary property to check syntax of result
         assert 'kafka_api' in node_config
+
+    @cluster(num_nodes=3)
+    def test_bootstrap(self):
+        """
+        Verify that config settings present in redpanda.cfg are imported on
+        first startup.
+        :return:
+        """
+        admin = Admin(self.redpanda)
+        config = admin.get_cluster_config()
+        for k, v in BOOTSTRAP_CONFIG.items():
+            assert config[k] == v
+
+        set_again = {'enable_idempotence': False}
+        assert BOOTSTRAP_CONFIG['enable_idempotence'] != set_again[
+            'enable_idempotence']
+
+        self.redpanda.restart_nodes(self.redpanda.nodes, set_again)
+
+        # Our attempt to set the value differently in the config file after first startup
+        # should have failed: the original config value should still be set.
+        config = admin.get_cluster_config()
+        for k, v in BOOTSTRAP_CONFIG.items():
+            assert config[k] == v
+
+    def _wait_for_version_sync(self, version):
+        wait_until(
+            lambda: set([
+                n['version'] for n in self.admin.get_cluster_config_status()
+            ]) == {version},
+            timeout_sec=10,
+            backoff_sec=0.5,
+            err_msg=f"Config status versions did not converge on {version}")
+
+    def _check_restart_clears(self):
+        """
+        After changing a setting with needs_restart=true, check that
+        nodes clear the flag after being restarted.
+        """
+        status = self.admin.get_cluster_config_status()
+        for n in status:
+            assert n['restart'] is True
+
+        first_node = self.redpanda.nodes[0]
+        other_nodes = self.redpanda.nodes[1:]
+        self.redpanda.restart_nodes(first_node)
+        wait_until(lambda: self.admin.get_cluster_config_status()[0]['restart']
+                   == False,
+                   timeout_sec=10,
+                   backoff_sec=0.5,
+                   err_msg=f"Restart flag did not clear after restart")
+
+        self.redpanda.restart_nodes(other_nodes)
+        wait_until(lambda: set(
+            [n['restart']
+             for n in self.admin.get_cluster_config_status()]) == {False},
+                   timeout_sec=10,
+                   backoff_sec=0.5,
+                   err_msg=f"Not all nodes cleared restart flag")
+
+    @cluster(num_nodes=3)
+    def test_restart(self):
+        """
+        Verify that a setting requiring restart is indicated as such in status,
+        and that status is cleared after we restart the node.
+        """
+        # An arbitrary restart-requiring setting with a non-default value
+        new_setting = ('kafka_qdc_idle_depth', 77)
+
+        patch_result = self.admin.patch_cluster_config(
+            upsert=dict([new_setting]))
+        new_version = patch_result['version']
+        self._wait_for_version_sync(new_version)
+
+        assert self.admin.get_cluster_config()[
+            new_setting[0]] == new_setting[1]
+        # Update of cluster status is not synchronous
+        self._check_restart_clears()
+
+        # Test that a reset to default triggers the restart flag the same way as
+        # an upsert does
+        patch_result = self.admin.patch_cluster_config(remove=[new_setting[0]])
+        new_version = patch_result['version']
+        self._wait_for_version_sync(new_version)
+        assert self.admin.get_cluster_config()[
+            new_setting[0]] != new_setting[1]
+        self._check_restart_clears()
+
+    def _check_propagated_and_persistent(self, key, expect_value):
+        """
+        Verify that a configuration value has successfully propagated to all
+        nodes, and that it persists after a restart.
+        """
+        def check_all():
+            for node in self.redpanda.nodes:
+                actual_value = self.admin.get_cluster_config(node)[key]
+                if actual_value != expect_value:
+                    self.logger.error(
+                        f"Wrong value on node {node.account.hostname}: {key}={actual_value} (!={expect_value})"
+                    )
+                assert self.admin.get_cluster_config(node)[key] == expect_value
+
+        check_all()
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        check_all()
+
+    @cluster(num_nodes=3)
+    def test_simple_live_change(self):
+        # An arbitrary non-restart-requiring setting
+        norestart_new_setting = ('log_message_timestamp_type', "LogAppendTime")
+        assert self.admin.get_cluster_config()[
+            norestart_new_setting[0]] == "CreateTime"  # Initially default
+        patch_result = self.admin.patch_cluster_config(
+            upsert=dict([norestart_new_setting]))
+        new_version = patch_result['version']
+        self._wait_for_version_sync(new_version)
+
+        assert self.admin.get_cluster_config()[
+            norestart_new_setting[0]] == norestart_new_setting[1]
+
+        # Status should not indicate restart needed
+        status = self.admin.get_cluster_config_status()
+        for n in status:
+            assert n['restart'] is False
+
+        # Setting should be propagated and survive a restart
+        self._check_propagated_and_persistent(norestart_new_setting[0],
+                                              norestart_new_setting[1])
+
+    @cluster(num_nodes=3)
+    def test_invalid_settings(self):
+        default_value = "CreateTime"
+        invalid_setting = ('log_message_timestamp_type', "rhubarb")
+        assert self.admin.get_cluster_config()[
+            invalid_setting[0]] == default_value
+        patch_result = self.admin.patch_cluster_config(
+            upsert=dict([invalid_setting]))
+        new_version = patch_result['version']
+        self._wait_for_version_sync(new_version)
+
+        assert self.admin.get_cluster_config()[
+            invalid_setting[0]] == default_value
+
+        # Status should not indicate restart needed
+        status = self.admin.get_cluster_config_status()
+        for n in status:
+            assert n['restart'] is False
+            assert n['invalid'] == [invalid_setting[0]]
+
+        # List of invalid properties in node status should not clear on restart.
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        # We have to sleep here because in the success case there is no status update
+        # being sent: it's a no-op after node startup when they realize their config
+        # status is the same as the one already reported.
+        time.sleep(10)
+
+        status = self.admin.get_cluster_config_status()
+        for n in status:
+            assert n['restart'] is False
+            assert n['invalid'] == [invalid_setting[0]]
+
+        # Reset the properties, check that it disappears from the list of invalid settings
+        patch_result = self.admin.patch_cluster_config(
+            remove=[invalid_setting[0]])
+        self._wait_for_version_sync(patch_result['version'])
+        assert self.admin.get_cluster_config()[
+            invalid_setting[0]] == default_value
+
+        status = self.admin.get_cluster_config_status()
+        for n in status:
+            assert n['restart'] is False
+            assert n['invalid'] == []
+
+        # TODO once API frontend does validation, this test will need a force
+        # flag to the API to get the invalid value past the frontend and
+        # to the nodes where it will show up in status.  That force flag
+        # will also be important IRL if we want to enable e.g. pre-setting a config
+        # for a future redpanda version before installing the new version.
+
+        # TODO as well as specific invalid examples, do a pass across the whole
+        # schema to check that
+        pass
+
+    @cluster(num_nodes=3)
+    def test_valid_settings(self):
+        # TODO
+        #  - for all properties in the schema, set them with a valid non-default value
+        #  - check the new values are reflected in config GET
+        #  - restart all nodes (prompt a reload from cache file)
+        #  - check the new values are reflected in config GET
+
+        # This is not just checking the central config infrastructure: it's also
+        # validating that all the property types are outputting the same format
+        # as their input (e.g. they have proper rjson_serialize implementations)
+
+        pass


### PR DESCRIPTION
## Cover letter

This PR corresponds to "Phase 2" in the design doc's task breakdown:
- Add the central store (config_manager/config_frontend)
- Add status reporting from nodes (config_status_request & config_status)
- Key REST endpoints for updating config & getting status back
- All disabled by default because it's not safe to auto-enable until we have cluster version status in the health monitor.

## Release notes

None -- this is not  ready for advertising to users yet.
