### PR TITLE
Try to fix JS tests CI failure

### DIFF
--- a/src/js/test/rpc/server.test.ts
+++ b/src/js/test/rpc/server.test.ts
@@ -43,7 +43,7 @@ let sinonInstance: SinonSandbox;
 let server: ProcessBatchServer;
 let client: SupervisorClient;
 let writeError: SinonStub;
-let portNumber = 43000;
+let portNumber: number;
 
 const createStubs = (sandbox: SinonSandbox) => {
   const watchMock = sandbox.stub(chokidar, "watch");
@@ -108,36 +108,18 @@ describe("Server", function () {
         // @ts-ignore
         error: writeError,
       });
+
       server = new ProcessBatchServer();
-
-      // Sometimes JS tests fail in CI because "port already in use"
-      // error when the server tries to listen. The problem maybe
-      // because previous instance of the test didn't shutdown completely.
-      // Here we tried to fix it by catching the EADDRINUSE exception and
-      // try to listen a different port number when the exception happens.
-      for (let index = 0; index < 10; index++) {
-        try {
-          server.listen(portNumber);
-          break;
-        } catch (err) {
-          if (err.code === "EADDRINUSE") {
-            console.log(
-              "Port %d is already in use, try another port.",
-              portNumber
-            );
-            portNumber++;
-            continue;
-          } else throw err;
-        }
-      }
-
-      return new Promise<void>((resolve, reject) => {
-        return SupervisorClient.create(portNumber)
-          .then((c) => {
-            client = c;
-            resolve();
-          })
-          .catch((e) => reject(e));
+      return server.listenRandomPort().then((port) => {
+        portNumber = port;
+        return new Promise<void>((resolve, reject) => {
+          return SupervisorClient.create(portNumber)
+            .then((c) => {
+              client = c;
+              resolve();
+            })
+            .catch((e) => reject(e));
+        });
       });
     });
 


### PR DESCRIPTION
Fix #2339
Modified the SupervisorServer's listen() function to catch error
and retry if it's EADDRINUSE error.

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
