### PR TITLE
Cluster health monitor

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -81,6 +81,7 @@ v_cc_library(
     scheduling/constraints.cc
     scheduling/leader_balancer.cc
     scheduling/leader_balancer_probe.cc
+    health_monitor_types.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -82,6 +82,8 @@ v_cc_library(
     scheduling/leader_balancer.cc
     scheduling/leader_balancer_probe.cc
     health_monitor_types.cc
+    health_monitor_backend.cc
+    health_monitor_frontend.cc
   DEPS
     Seastar::seastar
     controller_rpc

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -16,6 +16,7 @@
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
 #include "cluster/health_manager.h"
+#include "cluster/health_monitor_frontend.h"
 #include "cluster/scheduling/leader_balancer.h"
 #include "cluster/topic_updates_dispatcher.h"
 #include "raft/group_manager.h"
@@ -81,6 +82,10 @@ public:
         return _members_frontend;
     }
 
+    ss::sharded<health_monitor_frontend>& get_health_monitor() {
+        return _hm_frontend;
+    }
+
     ss::future<> wire_up();
 
     ss::future<> start();
@@ -119,6 +124,8 @@ private:
     ss::sharded<data_policy_frontend> _data_policy_frontend;
     ss::sharded<security::authorizer> _authorizer;
     ss::sharded<raft::group_manager>& _raft_manager;
+    ss::sharded<health_monitor_frontend> _hm_frontend; // instance per core
+    ss::sharded<health_monitor_backend> _hm_backend;   // single instance
     ss::sharded<health_manager> _health_manager;
     std::unique_ptr<leader_balancer> _leader_balancer;
     consensus_ptr _raft0;

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -2,7 +2,8 @@
     "namespace": "cluster",
     "service_name": "controller",
     "includes": [
-        "cluster/types.h"
+        "cluster/types.h",
+        "cluster/health_monitor_types.h"
     ],
     "methods": [
         {
@@ -64,6 +65,16 @@
             "name": "config_status",
             "input_type": "config_status_request",
             "output_type": "config_status_reply"
+        },
+        {
+            "name": "collect_node_health_report",
+            "input_type": "get_node_health_request",
+            "output_type": "get_node_health_reply"
+        },
+        {
+            "name": "get_cluster_health_report",
+            "input_type": "get_cluster_health_request",
+            "output_type": "get_cluster_health_reply"
         }
     ]
 }

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -55,7 +55,8 @@ enum class errc : int16_t {
     data_policy_not_exists,
     source_topic_not_exists,
     source_topic_still_in_use,
-    wating_for_partition_shutdown
+    wating_for_partition_shutdown,
+    error_collecting_health_report,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -157,6 +158,8 @@ struct errc_category final : public std::error_category {
             return "Partition update on current core can not be finished since "
                    "backend is waiting for the partition to be shutdown on its "
                    "originating core";
+        case errc::error_collecting_health_report:
+            return "Error requesting health monitor update";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -39,5 +39,7 @@ class data_policy_frontend;
 class tx_gateway;
 class rm_group_proxy;
 class non_replicable_topics_frontend;
+class health_monitor_frontend;
+class health_monitor_backend;
 
 } // namespace cluster

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -1,0 +1,507 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/health_monitor_backend.h"
+
+#include "cluster/controller_service.h"
+#include "cluster/errc.h"
+#include "cluster/fwd.h"
+#include "cluster/health_monitor_types.h"
+#include "cluster/logger.h"
+#include "cluster/members_table.h"
+#include "config/configuration.h"
+#include "config/node_config.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "rpc/connection_cache.h"
+#include "version.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/timed_out_error.hh>
+#include <seastar/core/with_timeout.hh>
+#include <seastar/util/log.hh>
+
+namespace cluster {
+
+health_monitor_backend::health_monitor_backend(
+  ss::lw_shared_ptr<raft::consensus> raft0,
+  ss::sharded<members_table>& mt,
+  ss::sharded<rpc::connection_cache>& connections,
+  ss::sharded<partition_manager>& partition_manager,
+  ss::sharded<ss::abort_source>& as)
+  : _raft0(std::move(raft0))
+  , _members(mt)
+  , _connections(connections)
+  , _partition_manager(partition_manager)
+  , _as(as) {
+    _tick_timer.set_callback([this] { tick(); });
+    _tick_timer.arm(tick_interval());
+}
+
+ss::future<> health_monitor_backend::stop() {
+    _tick_timer.cancel();
+    co_await _gate.close();
+}
+
+cluster_health_report health_monitor_backend::build_cluster_report(
+  const cluster_report_filter& filter) {
+    std::vector<node_health_report> reports;
+    std::vector<node_state> statuses;
+    // refreshing node status is not expensive on leader, we can refresh it
+    // every time
+    if (_raft0->is_leader()) {
+        refresh_nodes_status();
+    }
+
+    auto nodes = filter.nodes.empty() ? _members.local().all_broker_ids()
+                                      : filter.nodes;
+    reports.reserve(nodes.size());
+    statuses.reserve(nodes.size());
+    for (const auto& node_id : nodes) {
+        auto r = build_node_report(node_id, filter.node_report_filter);
+        if (r) {
+            reports.push_back(std::move(r.value()));
+        }
+
+        auto it = _status.find(node_id);
+        if (it != _status.end()) {
+            statuses.push_back(it->second);
+        }
+    }
+
+    return cluster_health_report{
+      .raft0_leader = _raft0->get_leader_id(),
+      .node_states = std::move(statuses),
+      .node_reports = std::move(reports)};
+}
+
+void health_monitor_backend::refresh_nodes_status() {
+    // remove all nodes not longer present in members collection
+    absl::erase_if(
+      _status, [this](auto& e) { return !_members.local().contains(e.first); });
+
+    for (auto& b : _members.local().all_brokers()) {
+        node_state status;
+        status.id = b->id();
+        status.membership_state = b->get_membership_state();
+
+        // current node is always alive
+        if (b->id() == _raft0->self().id()) {
+            status.is_alive = alive::yes;
+        }
+        auto res = _raft0->get_follower_metrics(b->id());
+        if (res) {
+            status.is_alive = alive(res.value().is_live);
+        }
+        _status.insert_or_assign(b->id(), status);
+    }
+}
+
+std::vector<topic_status> filter_topic_status(
+  const std::vector<topic_status>& topics, const partitions_filter& filter) {
+    // empty filter matches all
+    if (filter.namespaces.empty()) {
+        return topics;
+    }
+
+    std::vector<topic_status> filtered;
+
+    for (auto& tl : topics) {
+        topic_status filtered_topic_status{.tp_ns = tl.tp_ns};
+        for (auto& pl : tl.partitions) {
+            if (filter.matches(tl.tp_ns, pl.id)) {
+                filtered_topic_status.partitions.push_back(pl);
+            }
+        }
+        if (!filtered_topic_status.partitions.empty()) {
+            filtered.push_back(std::move(filtered_topic_status));
+        }
+    }
+
+    return filtered;
+}
+
+std::optional<node_health_report> health_monitor_backend::build_node_report(
+  model::node_id id, const node_report_filter& f) {
+    auto it = _reports.find(id);
+    if (it == _reports.end()) {
+        return std::nullopt;
+    }
+
+    node_health_report report;
+    report.id = id;
+
+    report.disk_space = it->second.disk_space;
+    report.redpanda_version = it->second.redpanda_version;
+
+    if (f.include_partitions) {
+        report.topics = filter_topic_status(it->second.topics, f.ntp_filters);
+    }
+
+    return report;
+}
+
+ss::future<std::error_code>
+health_monitor_backend::refresh_cluster_health_cache(force_refresh force) {
+    auto leader_id = _raft0->get_leader_id();
+
+    // if we are a leader, do nothing
+    if (leader_id == _raft0->self().id()) {
+        co_return errc::success;
+    }
+
+    auto units = co_await _refresh_mutex.get_units();
+    // no leader controller
+    if (!leader_id) {
+        vlog(
+          clusterlog.debug,
+          "unable to refresh health metadata, no leader controller");
+        // TODO: maybe we should try to ping other members in this case ?
+        co_return errc::no_leader_controller;
+    }
+    // check under semaphore if we need to force refresh, otherwise we will just
+    // skip refresh request since current state is 'fresh enough' i.e. not older
+    // than max metadata age
+    auto now = model::timeout_clock::now();
+    if (!force && now - _last_refresh < max_metadata_age()) {
+        vlog(
+          clusterlog.trace,
+          "skipping metadata refresh request current metadata age: {} ms",
+          (now - _last_refresh) / 1ms);
+        co_return errc::success;
+    }
+
+    vlog(clusterlog.debug, "refreshing health cache, leader id: {}", leader_id);
+    const auto timeout = now + max_metadata_age();
+    auto reply = co_await _connections.local()
+                   .with_node_client<controller_client_protocol>(
+                     _raft0->self().id(),
+                     ss::this_shard_id(),
+                     *leader_id,
+                     max_metadata_age(),
+                     [timeout](controller_client_protocol client) mutable {
+                         get_cluster_health_request req{
+                           .filter = cluster_report_filter{}};
+                         return client.get_cluster_health_report(
+                           std::move(req), rpc::client_opts(timeout));
+                     })
+                   .then(&rpc::get_ctx_data<get_cluster_health_reply>);
+    if (!reply) {
+        vlog(
+          clusterlog.warn,
+          "unable to get cluster health metadata from {} - {}",
+          leader_id,
+          reply.error().message());
+        co_return reply.error();
+    }
+
+    if (!reply.value().report) {
+        vlog(
+          clusterlog.warn,
+          "unable to get cluster health metadata from {} - {}",
+          leader_id,
+          reply.value().error);
+        co_return reply.value().error;
+    }
+
+    _status.clear();
+    for (auto& n_status : reply.value().report->node_states) {
+        _status.emplace(n_status.id, n_status);
+    }
+
+    _reports.clear();
+    for (auto& n_report : reply.value().report->node_reports) {
+        const auto id = n_report.id;
+        _reports.emplace(id, std::move(n_report));
+    }
+
+    _last_refresh = ss::lowres_clock::now();
+    co_return errc::success;
+}
+
+ss::future<result<cluster_health_report>>
+health_monitor_backend::get_cluster_health(
+  cluster_report_filter filter,
+  force_refresh refresh,
+  model::timeout_clock::time_point deadline) {
+    vlog(
+      clusterlog.debug,
+      "requesing cluster state report with filter: {}, force refresh: {}",
+      filter,
+      refresh);
+    auto const need_refresh = refresh
+                              || _last_refresh + max_metadata_age()
+                                   < ss::lowres_clock::now();
+
+    // if current node is not the controller leader and we need a refresh we
+    // refresh metadata cache
+    if (!_raft0->is_leader() && need_refresh) {
+        try {
+            auto f = refresh_cluster_health_cache(refresh);
+            auto err = co_await ss::with_timeout(deadline, std::move(f));
+            if (err) {
+                vlog(
+                  clusterlog.info,
+                  "error refreshing cluster health state - {}",
+                  err.message());
+                co_return err;
+            }
+        } catch (const ss::timed_out_error&) {
+            vlog(
+              clusterlog.info,
+              "timed out when refreshing cluster health state, falling back to "
+              "previous cluster health snapshot");
+            co_return errc::timeout;
+        }
+    }
+
+    co_return build_cluster_report(filter);
+}
+
+cluster_health_report
+health_monitor_backend::get_current_cluster_health_snapshot(
+  const cluster_report_filter& f) {
+    return build_cluster_report(f);
+}
+
+void health_monitor_backend::tick() {
+    if (!_raft0->is_leader()) {
+        vlog(clusterlog.trace, "skipping tick, not leader");
+        _tick_timer.arm(tick_interval());
+        return;
+    }
+
+    (void)ss::with_gate(_gate, [this] {
+        // make sure that ticks will have fixed interval
+        auto next_tick = ss::lowres_clock::now() + tick_interval();
+        return collect_cluster_health().finally([this, next_tick] {
+            if (!_as.local().abort_requested()) {
+                _tick_timer.arm(next_tick);
+            }
+        });
+    });
+}
+
+ss::future<result<node_health_report>>
+health_monitor_backend::collect_remote_node_health(model::node_id id) {
+    const auto timeout = model::timeout_clock::now() + max_metadata_age();
+    return _connections.local()
+      .with_node_client<controller_client_protocol>(
+        _raft0->self().id(),
+        ss::this_shard_id(),
+        id,
+        max_metadata_age(),
+        [timeout](controller_client_protocol client) mutable {
+            return client.collect_node_health_report(
+              get_node_health_request{.filter = node_report_filter{}},
+              rpc::client_opts(timeout));
+        })
+      .then(&rpc::get_ctx_data<get_node_health_reply>)
+      .then([this, id](result<get_node_health_reply> reply) {
+          return process_node_reply(id, std::move(reply));
+      });
+}
+
+result<node_health_report>
+map_reply_result(result<get_node_health_reply> reply) {
+    if (!reply) {
+        return result<node_health_report>(reply.error());
+    }
+    if (!reply.value().report.has_value()) {
+        return result<node_health_report>(reply.value().error);
+    }
+    return result<node_health_report>(std::move(*reply.value().report));
+}
+
+result<node_health_report> health_monitor_backend::process_node_reply(
+  model::node_id id, result<get_node_health_reply> reply) {
+    auto it = _last_replies.find(id);
+    if (it == _last_replies.end()) {
+        auto [inserted, _] = _last_replies.emplace(id, reply_status{});
+        it = inserted;
+    }
+
+    auto res = map_reply_result(reply);
+    if (!res) {
+        vlog(
+          clusterlog.trace,
+          "unable to get node health report from {} - {}",
+          id,
+          res.error().message());
+        /**
+         * log only once node state transition from alive to down
+         */
+        if (it->second.is_alive) {
+            vlog(
+              clusterlog.warn,
+              "unable to get node health report from {} - {}, marking node as "
+              "down",
+              id,
+              res.error().message());
+        }
+        return result<node_health_report>(reply.error());
+    }
+
+    it->second.last_reply_timestamp = ss::lowres_clock::now();
+    if (!it->second.is_alive && clusterlog.is_enabled(ss::log_level::info)) {
+        vlog(
+          clusterlog.info,
+          "received node {} health report, marking node as up");
+    }
+
+    return res;
+}
+
+ss::future<> health_monitor_backend::collect_cluster_health() {
+    /**
+     * We are collecting cluster health on raft 0 leader only
+     */
+    vlog(clusterlog.trace, "collecting cluster health statistics");
+    // collect all reports
+    auto ids = _members.local().all_broker_ids();
+    auto reports = co_await ssx::async_transform(
+      ids.begin(), ids.end(), [this](model::node_id id) {
+          if (id == _raft0->self().id()) {
+              return collect_current_node_health(node_report_filter{});
+          }
+          return collect_remote_node_health(id);
+      });
+    // update nodes reports
+    _reports.clear();
+    for (auto& r : reports) {
+        if (r) {
+            const auto id = r.value().id;
+            vlog(
+              clusterlog.debug,
+              "collected node {} health report: {}",
+              id,
+              r.value());
+            _reports.emplace(id, std::move(r.value()));
+        }
+    }
+}
+
+ss::future<result<node_health_report>>
+health_monitor_backend::collect_current_node_health(node_report_filter filter) {
+    vlog(clusterlog.debug, "collecting health report with filter: {}", filter);
+    node_health_report ret;
+    ret.id = _raft0->self().id();
+
+    ret.disk_space = get_disk_space();
+    ret.redpanda_version = cluster::application_version(
+      (std::string)redpanda_version());
+
+    if (filter.include_partitions) {
+        ret.topics = co_await collect_topic_status(
+          std::move(filter.ntp_filters));
+    }
+
+    co_return ret;
+}
+
+struct ntp_leader {
+    model::ntp ntp;
+    model::term_id term;
+    std::optional<model::node_id> leader_id;
+};
+
+partition_status to_partition_leader(const ntp_leader& ntpl) {
+    return partition_status{
+      .id = ntpl.ntp.tp.partition,
+      .term = ntpl.term,
+      .leader_id = ntpl.leader_id,
+    };
+}
+
+std::vector<ntp_leader> collect_shard_local_leaders(
+  partition_manager& pm, const partitions_filter& filters) {
+    std::vector<ntp_leader> leaders;
+    // empty filter, collect all
+    if (filters.namespaces.empty()) {
+        leaders.reserve(pm.partitions().size());
+        std::transform(
+          pm.partitions().begin(),
+          pm.partitions().end(),
+          std::back_inserter(leaders),
+          [](auto& p) {
+              return ntp_leader{
+                .ntp = p.first,
+                .term = p.second->term(),
+                .leader_id = p.second->get_leader_id(),
+              };
+          });
+    } else {
+        for (const auto& [ntp, partition] : pm.partitions()) {
+            if (filters.matches(ntp)) {
+                leaders.push_back(ntp_leader{
+                  .ntp = ntp,
+                  .term = partition->term(),
+                  .leader_id = partition->get_leader_id(),
+                });
+            }
+        }
+    }
+
+    return leaders;
+}
+using leaders_acc_t
+  = absl::node_hash_map<model::topic_namespace, std::vector<partition_status>>;
+
+leaders_acc_t
+reduce_leaders_map(leaders_acc_t acc, std::vector<ntp_leader> current_leaders) {
+    for (auto& ntpl : current_leaders) {
+        model::topic_namespace tp_ns(
+          std::move(ntpl.ntp.ns), std::move(ntpl.ntp.tp.topic));
+
+        acc[tp_ns].push_back(to_partition_leader(ntpl));
+    }
+    return acc;
+}
+
+ss::future<std::vector<topic_status>>
+health_monitor_backend::collect_topic_status(partitions_filter filters) {
+    auto leaders_map = co_await _partition_manager.map_reduce0(
+      [&filters](partition_manager& pm) {
+          return collect_shard_local_leaders(pm, filters);
+      },
+      leaders_acc_t{},
+      &reduce_leaders_map);
+
+    std::vector<topic_status> topics;
+    topics.reserve(leaders_map.size());
+    for (auto& [tp_ns, partitions] : leaders_map) {
+        topics.push_back(
+          topic_status{.tp_ns = tp_ns, .partitions = std::move(partitions)});
+    }
+
+    co_return topics;
+}
+
+std::vector<node_disk_space> health_monitor_backend::get_disk_space() {
+    auto space_info = std::filesystem::space(
+      config::node().data_directory().path);
+
+    return {node_disk_space{
+      .path = config::node().data_directory().as_sstring(),
+      .free = space_info.free,
+      .total = space_info.capacity,
+    }};
+}
+
+std::chrono::milliseconds health_monitor_backend::tick_interval() {
+    return config::shard_local_cfg().health_monitor_tick_interval();
+}
+
+std::chrono::milliseconds health_monitor_backend::max_metadata_age() {
+    return config::shard_local_cfg().health_monitor_max_metadata_age();
+}
+
+} // namespace cluster

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -1,0 +1,114 @@
+
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "cluster/fwd.h"
+#include "cluster/health_monitor_types.h"
+#include "cluster/members_table.h"
+#include "cluster/partition_manager.h"
+#include "model/metadata.h"
+#include "raft/consensus.h"
+
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sharded.hh>
+
+#include <absl/container/node_hash_map.h>
+
+#include <chrono>
+#include <vector>
+namespace cluster {
+/**
+ * Health monitor backend is responsible for collecting cluster health status
+ * and caching cluster health information.
+ *
+ * Health monitor status collection is active only on the node which is a
+ * controller partition leader. When any other node is requesting a cluster
+ * report it either uses locally cached state or asks controller leader for
+ * new report.
+ */
+class health_monitor_backend {
+public:
+    static constexpr ss::shard_id shard{0};
+
+    health_monitor_backend(
+      ss::lw_shared_ptr<raft::consensus>,
+      ss::sharded<members_table>&,
+      ss::sharded<rpc::connection_cache>&,
+      ss::sharded<partition_manager>&,
+      ss::sharded<ss::abort_source>&);
+
+    ss::future<> stop();
+
+    ss::future<result<cluster_health_report>> get_cluster_health(
+      cluster_report_filter, force_refresh, model::timeout_clock::time_point);
+
+    cluster_health_report
+    get_current_cluster_health_snapshot(const cluster_report_filter&);
+
+    ss::future<result<node_health_report>>
+      collect_current_node_health(node_report_filter);
+
+private:
+    struct reply_status {
+        ss::lowres_clock::time_point last_reply_timestamp
+          = ss::lowres_clock::time_point::min();
+        alive is_alive = alive::no;
+    };
+
+    using status_cache_t = absl::node_hash_map<model::node_id, node_state>;
+    using report_cache_t
+      = absl::node_hash_map<model::node_id, node_health_report>;
+
+    using last_reply_cache_t
+      = absl::node_hash_map<model::node_id, reply_status>;
+
+    void tick();
+    ss::future<> collect_cluster_health();
+    ss::future<result<node_health_report>>
+      collect_remote_node_health(model::node_id);
+
+    ss::future<std::error_code> refresh_cluster_health_cache(force_refresh);
+
+    cluster_health_report build_cluster_report(const cluster_report_filter&);
+
+    std::optional<node_health_report>
+    build_node_report(model::node_id, const node_report_filter&);
+
+    ss::future<std::vector<topic_status>>
+      collect_topic_status(partitions_filter);
+
+    std::vector<node_disk_space> get_disk_space();
+
+    void refresh_nodes_status();
+
+    result<node_health_report>
+      process_node_reply(model::node_id, result<get_node_health_reply>);
+
+    std::chrono::milliseconds tick_interval();
+    std::chrono::milliseconds max_metadata_age();
+
+    ss::lw_shared_ptr<raft::consensus> _raft0;
+    ss::sharded<members_table>& _members;
+    ss::sharded<rpc::connection_cache>& _connections;
+    ss::sharded<partition_manager>& _partition_manager;
+    ss::sharded<ss::abort_source>& _as;
+
+    ss::lowres_clock::time_point _last_refresh;
+
+    status_cache_t _status;
+    report_cache_t _reports;
+    last_reply_cache_t _last_replies;
+
+    ss::timer<ss::lowres_clock> _tick_timer;
+    ss::gate _gate;
+    mutex _refresh_mutex;
+};
+} // namespace cluster

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/health_monitor_frontend.h"
+
+#include "cluster/errc.h"
+
+namespace cluster {
+
+health_monitor_frontend::health_monitor_frontend(
+  ss::sharded<health_monitor_backend>& backend)
+  : _backend(backend) {}
+
+ss::future<result<cluster_health_report>>
+health_monitor_frontend::get_cluster_health(
+  cluster_report_filter f,
+  force_refresh force_refresh,
+  model::timeout_clock::time_point deadline) {
+    return dispatch_to_backend(
+      [f = std::move(f), force_refresh, deadline](health_monitor_backend& be) {
+          return be.get_cluster_health(f, force_refresh, deadline);
+      });
+}
+
+ss::future<cluster_health_report>
+health_monitor_frontend::get_current_cluster_health_snapshot(
+  cluster_report_filter f) {
+    return dispatch_to_backend([f = std::move(f)](health_monitor_backend& be) {
+        return be.get_current_cluster_health_snapshot(f);
+    });
+}
+
+// Collcts and returns current node health report according to provided
+// filters list
+ss::future<result<node_health_report>>
+health_monitor_frontend::collect_node_health(node_report_filter f) {
+    return dispatch_to_backend(
+      [f = std::move(f)](health_monitor_backend& be) mutable {
+          return be.collect_current_node_health(std::move(f));
+      });
+}
+
+// Return status of single node
+ss::future<result<std::vector<node_state>>>
+health_monitor_frontend::get_nodes_status(
+  model::timeout_clock::time_point deadline) {
+    return dispatch_to_backend([deadline](health_monitor_backend& be) {
+        // build filter
+        cluster_report_filter filter{
+          .node_report_filter = node_report_filter{
+            .include_partitions = include_partitions_info::no,
+          }};
+        return be.get_cluster_health(filter, force_refresh::no, deadline)
+          .then([](result<cluster_health_report> res) {
+              using ret_t = result<std::vector<node_state>>;
+              if (!res) {
+                  return ret_t(res.error());
+              }
+
+              return ret_t(std::move(res.value().node_states));
+          });
+    });
+}
+} // namespace cluster

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "cluster/controller_backend.h"
+#include "cluster/fwd.h"
+#include "cluster/health_monitor_backend.h"
+#include "cluster/health_monitor_types.h"
+#include "model/metadata.h"
+#include "model/timeout_clock.h"
+
+#include <seastar/core/sharded.hh>
+
+#include <utility>
+
+namespace cluster {
+
+/**
+ * The health_monitor_frontend is cluster health monitor entry point.
+ * It provides interaface that allow caller
+ * to query cluster health and request current node state collection proccess.
+ * Health monitor frontend is available on every node and dispatches requests to
+ * health monitor backend which lives on single shard.
+ */
+class health_monitor_frontend {
+public:
+    explicit health_monitor_frontend(ss::sharded<health_monitor_backend>&);
+    // Reports cluster health. Cluster health is based on the cluster health
+    // state that is cached on current node. If force_refresh flag is set. It
+    // will always refresh cluster health metadata
+    ss::future<result<cluster_health_report>> get_cluster_health(
+      cluster_report_filter, force_refresh, model::timeout_clock::time_point);
+
+    // Returns currently available cluster health report snapshot
+    ss::future<cluster_health_report>
+      get_current_cluster_health_snapshot(cluster_report_filter);
+
+    // Collcts and returns current node health report according to provided
+    // filters list
+    ss::future<result<node_health_report>>
+      collect_node_health(node_report_filter);
+
+    // Return status of all nodes
+    ss::future<result<std::vector<node_state>>>
+      get_nodes_status(model::timeout_clock::time_point);
+
+private:
+    template<typename Func>
+    auto dispatch_to_backend(Func&& f) {
+        return _backend.invoke_on(
+          health_monitor_backend::shard, std::forward<Func>(f));
+    }
+
+    ss::sharded<health_monitor_backend>& _backend;
+};
+} // namespace cluster

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/health_monitor_types.h"
+
+#include "cluster/errc.h"
+#include "model/adl_serde.h"
+#include "utils/human.h"
+#include "utils/to_string.h"
+
+#include <fmt/ostream.h>
+
+namespace cluster {
+
+std::ostream& operator<<(std::ostream& o, const node_state& s) {
+    fmt::print(
+      o,
+      "{{membership_state: {}, is_alive: {}}}",
+      s.membership_state,
+      s.is_alive);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const node_health_report& r) {
+    fmt::print(
+      o,
+      "{{id: {}, disk_space: {}, topics: {}, redpanda_version: {}}}",
+      r.id,
+      r.disk_space,
+      r.topics,
+      r.redpanda_version);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const cluster_health_report& r) {
+    fmt::print(
+      o,
+      "{{raft0_leader: {}, node_states: {}, node_reports: {} }}",
+      r.raft0_leader,
+      r.node_states,
+      r.node_reports);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const node_disk_space& s) {
+    fmt::print(
+      o,
+      "{{path: {}, free: {}, total: {}}}",
+      s.path,
+      human::bytes(s.free),
+      human::bytes(s.total));
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const partition_status& pl) {
+    fmt::print(
+      o, "{{id: {}, term: {}, leader_id: {}}}", pl.id, pl.term, pl.leader_id);
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const topic_status& tl) {
+    fmt::print(o, "{{topic: {}, leaders: {}}}", tl.tp_ns, tl.partitions);
+    return o;
+}
+} // namespace cluster
+namespace reflection {
+
+template<typename T>
+void read_and_assert_version(std::string_view type, iobuf_parser& parser) {
+    auto version = adl<int8_t>{}.from(parser);
+    vassert(
+      version <= T::current_version,
+      "unsupported version of {}, max_supported version: {}, read version: {}",
+      type,
+      version,
+      T::current_version);
+}
+
+void adl<cluster::node_disk_space>::to(
+  iobuf& out, cluster::node_disk_space&& s) {
+    serialize(out, s.current_version, s.path, s.free, s.total);
+}
+
+cluster::node_disk_space adl<cluster::node_disk_space>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::node_disk_space>(
+      "cluster::node_disk_space", p);
+
+    auto path = adl<ss::sstring>{}.from(p);
+    auto free = adl<uint64_t>{}.from(p);
+    auto total = adl<uint64_t>{}.from(p);
+
+    return cluster::node_disk_space{
+      .path = path,
+      .free = free,
+      .total = total,
+    };
+}
+
+void adl<cluster::node_state>::to(iobuf& out, cluster::node_state&& s) {
+    serialize(out, s.current_version, s.id, s.membership_state, s.is_alive);
+}
+
+cluster::node_state adl<cluster::node_state>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::node_state>("cluster::node_state", p);
+
+    auto id = adl<model::node_id>{}.from(p);
+    auto m_state = adl<model::membership_state>{}.from(p);
+    auto is_alive = adl<cluster::alive>{}.from(p);
+
+    return cluster::node_state{
+      .id = id,
+      .membership_state = m_state,
+      .is_alive = is_alive,
+    };
+}
+
+void adl<cluster::partition_status>::to(
+  iobuf& out, cluster::partition_status&& s) {
+    serialize(out, s.current_version, s.id, s.term, s.leader_id);
+}
+
+cluster::partition_status
+adl<cluster::partition_status>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::partition_status>(
+      "cluster::partition_status", p);
+
+    auto id = adl<model::partition_id>{}.from(p);
+    auto term = adl<model::term_id>{}.from(p);
+    auto leader = adl<std::optional<model::node_id>>{}.from(p);
+
+    return cluster::partition_status{
+      .id = id,
+      .term = term,
+      .leader_id = leader,
+    };
+}
+
+void adl<cluster::topic_status>::to(iobuf& out, cluster::topic_status&& l) {
+    return serialize(
+      out,
+      l.current_version,
+      std::move(l.tp_ns.ns),
+      std::move(l.tp_ns.tp),
+      std::move(l.partitions));
+}
+
+cluster::topic_status adl<cluster::topic_status>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::topic_status>("cluster::topic_status", p);
+
+    auto ns = adl<model::ns>{}.from(p);
+    auto topic = adl<model::topic>{}.from(p);
+    auto partitions = adl<std::vector<cluster::partition_status>>{}.from(p);
+
+    return cluster::topic_status{
+      .tp_ns = model::topic_namespace(std::move(ns), std::move(topic)),
+      .partitions = std::move(partitions),
+    };
+}
+
+void adl<cluster::node_health_report>::to(
+  iobuf& out, cluster::node_health_report&& r) {
+    reflection::serialize(
+      out,
+      r.current_version,
+      r.id,
+      std::move(r.redpanda_version),
+      std::move(r.disk_space),
+      std::move(r.topics));
+}
+
+cluster::node_health_report
+adl<cluster::node_health_report>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::node_health_report>(
+      "cluster::node_health_report", p);
+
+    auto id = adl<model::node_id>{}.from(p);
+    auto redpanda_version = adl<cluster::application_version>{}.from(p);
+    auto disk_space = adl<std::vector<cluster::node_disk_space>>{}.from(p);
+    auto topics = adl<std::vector<cluster::topic_status>>{}.from(p);
+
+    return cluster::node_health_report{
+      .id = id,
+      .redpanda_version = std::move(redpanda_version),
+      .disk_space = std::move(disk_space),
+      .topics = std::move(topics),
+    };
+}
+
+void adl<cluster::cluster_health_report>::to(
+  iobuf& out, cluster::cluster_health_report&& r) {
+    reflection::serialize(
+      out,
+      r.current_version,
+      r.raft0_leader,
+      std::move(r.node_states),
+      std::move(r.node_reports));
+}
+
+cluster::cluster_health_report
+adl<cluster::cluster_health_report>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::cluster_health_report>(
+      "cluster::cluster_health_report", p);
+
+    auto raft0_leader = adl<std::optional<model::node_id>>{}.from(p);
+    auto node_states = adl<std::vector<cluster::node_state>>{}.from(p);
+    auto node_reports = adl<std::vector<cluster::node_health_report>>{}.from(p);
+
+    return cluster::cluster_health_report{
+      .raft0_leader = raft0_leader,
+      .node_states = std::move(node_states),
+      .node_reports = std::move(node_reports),
+    };
+}
+} // namespace reflection

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -377,4 +377,77 @@ adl<cluster::cluster_report_filter>::from(iobuf_parser& p) {
     };
 }
 
+void adl<cluster::get_node_health_request>::to(
+  iobuf& out, cluster::get_node_health_request&& req) {
+    reflection::serialize(out, req.current_version, std::move(req.filter));
+}
+
+cluster::get_node_health_request
+adl<cluster::get_node_health_request>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::get_node_health_request>(
+      "cluster::get_node_health_request", p);
+
+    auto filter = adl<cluster::node_report_filter>{}.from(p);
+
+    return cluster::get_node_health_request{
+      .filter = std::move(filter),
+    };
+}
+
+void adl<cluster::get_node_health_reply>::to(
+  iobuf& out, cluster::get_node_health_reply&& reply) {
+    reflection::serialize(out, reply.current_version, std::move(reply.report));
+}
+
+cluster::get_node_health_reply
+adl<cluster::get_node_health_reply>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::get_node_health_reply>(
+      "cluster::get_node_health_reply", p);
+
+    auto report = adl<std::optional<cluster::node_health_report>>{}.from(p);
+
+    return cluster::get_node_health_reply{
+      .report = std::move(report),
+    };
+}
+
+void adl<cluster::get_cluster_health_request>::to(
+  iobuf& out, cluster::get_cluster_health_request&& req) {
+    reflection::serialize(
+      out, req.current_version, std::move(req.filter), req.refresh);
+}
+
+cluster::get_cluster_health_request
+adl<cluster::get_cluster_health_request>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::get_cluster_health_request>(
+      "cluster::get_cluster_health_request", p);
+
+    auto filter = adl<cluster::cluster_report_filter>{}.from(p);
+    auto refresh = adl<cluster::force_refresh>{}.from(p);
+
+    return cluster::get_cluster_health_request{
+      .filter = std::move(filter),
+      .refresh = refresh,
+    };
+}
+
+void adl<cluster::get_cluster_health_reply>::to(
+  iobuf& out, cluster::get_cluster_health_reply&& reply) {
+    reflection::serialize(
+      out, reply.current_version, reply.error, reply.report);
+}
+
+cluster::get_cluster_health_reply
+adl<cluster::get_cluster_health_reply>::from(iobuf_parser& p) {
+    read_and_assert_version<cluster::get_cluster_health_reply>(
+      "cluster::get_cluster_health_reply", p);
+    auto err = adl<cluster::errc>{}.from(p);
+    auto report = adl<std::optional<cluster::cluster_health_report>>{}.from(p);
+
+    return cluster::get_cluster_health_reply{
+      .error = err,
+      .report = std::move(report),
+    };
+}
+
 } // namespace reflection

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "bytes/iobuf_parser.h"
+#include "cluster/errc.h"
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "reflection/adl.h"
+#include "utils/named_type.h"
+
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
+
+namespace cluster {
+
+/**
+ * Health reports
+ */
+
+using alive = ss::bool_class<struct node_alive_tag>;
+using application_version = named_type<ss::sstring, struct version_number_tag>;
+/**
+ * node state is determined from controller, and it doesn't require contacting
+ * with the node directly
+ */
+struct node_state {
+    static constexpr int8_t current_version = 0;
+
+    model::node_id id;
+    model::membership_state membership_state;
+    alive is_alive;
+    friend std::ostream& operator<<(std::ostream&, const node_state&);
+};
+
+struct node_disk_space {
+    static constexpr int8_t current_version = 0;
+
+    ss::sstring path;
+    uint64_t free;
+    uint64_t total;
+    friend std::ostream& operator<<(std::ostream&, const node_disk_space&);
+    friend bool operator==(const node_disk_space&, const node_disk_space&)
+      = default;
+};
+
+struct partition_status {
+    static constexpr int8_t current_version = 0;
+
+    model::partition_id id;
+    model::term_id term;
+    std::optional<model::node_id> leader_id;
+    friend std::ostream& operator<<(std::ostream&, const partition_status&);
+    friend bool operator==(const partition_status&, const partition_status&)
+      = default;
+};
+
+struct topic_status {
+    static constexpr int8_t current_version = 0;
+
+    model::topic_namespace tp_ns;
+    std::vector<partition_status> partitions;
+    friend std::ostream& operator<<(std::ostream&, const topic_status&);
+    friend bool operator==(const topic_status&, const topic_status&) = default;
+};
+/**
+ * Node health report is collected built based on node local state at given
+ * instance of time
+ */
+struct node_health_report {
+    static constexpr int8_t current_version = 0;
+
+    model::node_id id;
+    application_version redpanda_version;
+    // we store a vector to be ready to operate with multiple data
+    // directories
+    std::vector<node_disk_space> disk_space;
+    std::vector<topic_status> topics;
+
+    friend std::ostream& operator<<(std::ostream&, const node_health_report&);
+};
+
+struct cluster_health_report {
+    static constexpr int8_t current_version = 0;
+
+    std::optional<model::node_id> raft0_leader;
+    // we split node status from node health reports since node status is a
+    // cluster wide property (currently based on raft0 follower state)
+    std::vector<node_state> node_states;
+
+    // node reports are node specific information collected directly on a
+    // node
+    std::vector<node_health_report> node_reports;
+    friend std::ostream&
+    operator<<(std::ostream&, const cluster_health_report&);
+};
+
+
+} // namespace cluster
+
+namespace reflection {
+
+template<>
+struct adl<cluster::node_health_report> {
+    void to(iobuf&, cluster::node_health_report&&);
+    cluster::node_health_report from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::cluster_health_report> {
+    void to(iobuf&, cluster::cluster_health_report&&);
+    cluster::cluster_health_report from(iobuf_parser&);
+};
+template<>
+struct adl<cluster::node_disk_space> {
+    void to(iobuf&, cluster::node_disk_space&&);
+    cluster::node_disk_space from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::node_state> {
+    void to(iobuf&, cluster::node_state&&);
+    cluster::node_state from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::partition_status> {
+    void to(iobuf&, cluster::partition_status&&);
+    cluster::partition_status from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::topic_status> {
+    void to(iobuf&, cluster::topic_status&&);
+    cluster::topic_status from(iobuf_parser&);
+};
+} // namespace reflection

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -144,6 +144,38 @@ struct cluster_report_filter {
 
 using force_refresh = ss::bool_class<struct hm_force_refresh_tag>;
 
+/**
+ * RPC requests
+ */
+
+struct get_node_health_request {
+    static constexpr int8_t current_version = 0;
+
+    node_report_filter filter;
+};
+
+struct get_node_health_reply {
+    static constexpr int8_t current_version = 0;
+
+    errc error = cluster::errc::success;
+    std::optional<node_health_report> report;
+};
+
+struct get_cluster_health_request {
+    static constexpr int8_t current_version = 0;
+
+    cluster_report_filter filter;
+    // if set to true will force node health metadata refresh
+    force_refresh refresh = force_refresh::no;
+};
+
+struct get_cluster_health_reply {
+    static constexpr int8_t current_version = 0;
+
+    errc error = cluster::errc::success;
+    std::optional<cluster_health_report> report;
+};
+
 } // namespace cluster
 
 namespace reflection {
@@ -210,4 +242,29 @@ struct adl<cluster::cluster_report_filter> {
     void to(iobuf&, cluster::cluster_report_filter&&);
     cluster::cluster_report_filter from(iobuf_parser&);
 };
+
+template<>
+struct adl<cluster::get_node_health_request> {
+    void to(iobuf&, cluster::get_node_health_request&&);
+    cluster::get_node_health_request from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::get_node_health_reply> {
+    void to(iobuf&, cluster::get_node_health_reply&&);
+    cluster::get_node_health_reply from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::get_cluster_health_request> {
+    void to(iobuf&, cluster::get_cluster_health_request&&);
+    cluster::get_cluster_health_request from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::get_cluster_health_reply> {
+    void to(iobuf&, cluster::get_cluster_health_reply&&);
+    cluster::get_cluster_health_reply from(iobuf_parser&);
+};
+
 } // namespace reflection

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "cluster/fwd.h"
+#include "cluster/health_monitor_types.h"
 #include "cluster/types.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
@@ -52,7 +54,8 @@ public:
     metadata_cache(
       ss::sharded<topic_table>&,
       ss::sharded<members_table>&,
-      ss::sharded<partition_leaders_table>&);
+      ss::sharded<partition_leaders_table>&,
+      ss::sharded<health_monitor_frontend>&);
 
     ss::future<> stop() { return ss::now(); }
 
@@ -86,6 +89,9 @@ public:
 
     /// Returns all brokers, returns copy as the content of broker can change
     std::vector<broker_ptr> all_brokers() const;
+
+    /// Returns all brokers, returns copy as the content of broker can change
+    ss::future<std::vector<broker_ptr>> all_alive_brokers() const;
 
     /// Returns all broker ids
     std::vector<model::node_id> all_broker_ids() const;
@@ -136,5 +142,6 @@ private:
     ss::sharded<topic_table>& _topics_state;
     ss::sharded<members_table>& _members_table;
     ss::sharded<partition_leaders_table>& _leaders;
+    ss::sharded<health_monitor_frontend>& _health_monitor;
 };
 } // namespace cluster

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -158,6 +158,10 @@ public:
         return _raft->config().revision_id();
     }
 
+    std::optional<model::node_id> get_leader_id() const {
+        return _raft->get_leader_id();
+    }
+
     model::offset get_latest_configuration_offset() const {
         return _raft->get_latest_configuration_offset();
     }

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -31,7 +31,8 @@ public:
       ss::sharded<security_frontend>&,
       ss::sharded<controller_api>&,
       ss::sharded<members_frontend>&,
-      ss::sharded<config_frontend>&);
+      ss::sharded<config_frontend>&,
+      ss::sharded<health_monitor_frontend>&);
 
     virtual ss::future<join_reply>
     join(join_request&&, rpc::streaming_context&) override;
@@ -68,6 +69,12 @@ public:
     ss::future<config_status_reply>
     config_status(config_status_request&&, rpc::streaming_context&) final;
 
+    ss::future<get_node_health_reply> collect_node_health_report(
+      get_node_health_request&&, rpc::streaming_context&) final;
+
+    ss::future<get_cluster_health_reply> get_cluster_health_report(
+      get_cluster_health_request&&, rpc::streaming_context&) final;
+
 private:
     std::
       pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
@@ -85,6 +92,12 @@ private:
     ss::future<finish_reallocation_reply>
       do_finish_reallocation(finish_reallocation_request);
 
+    ss::future<get_node_health_reply>
+      do_collect_node_health_report(get_node_health_request);
+
+    ss::future<get_cluster_health_reply>
+      do_get_cluster_health_report(get_cluster_health_request);
+
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<metadata_cache>& _md_cache;
@@ -92,5 +105,6 @@ private:
     ss::sharded<controller_api>& _api;
     ss::sharded<members_frontend>& _members_frontend;
     ss::sharded<config_frontend>& _config_frontend;
+    ss::sharded<health_monitor_frontend>& _hm_frontend;
 };
 } // namespace cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(srcs
     create_partitions_test.cc
     id_allocator_stm_test.cc
     data_policy_controller_test.cc
+    health_monitor_test.cc
     topic_configuration_compat_test.cc)
 
 rp_test(

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -1,0 +1,350 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/health_monitor_types.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/shard_table.h"
+#include "cluster/simple_batch_builder.h"
+#include "cluster/tests/cluster_test_fixture.h"
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/timeout_clock.h"
+#include "outcome.h"
+#include "test_utils/async.h"
+#include "test_utils/fixture.h"
+#include "utils/unresolved_address.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <boost/test/tools/interface.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <unordered_set>
+#include <vector>
+
+static cluster::cluster_report_filter get_all{};
+
+void check_reports_the_same(
+  std::vector<cluster::node_health_report>& lhs,
+  std::vector<cluster::node_health_report>& rhs) {
+    BOOST_TEST_REQUIRE(lhs.size() == rhs.size());
+    auto by_id = [](
+                   const cluster::node_health_report& lr,
+                   const cluster::node_health_report& rr) {
+        return lr.id < rr.id;
+    };
+    std::sort(lhs.begin(), lhs.end(), by_id);
+    std::sort(rhs.begin(), rhs.end(), by_id);
+
+    for (auto i = 0; i < lhs.size(); ++i) {
+        auto& lr = lhs[i];
+        auto& rr = rhs[i];
+        BOOST_TEST_REQUIRE(lr.redpanda_version == rr.redpanda_version);
+        BOOST_TEST_REQUIRE(lr.topics == rr.topics);
+        BOOST_TEST_REQUIRE(lr.disk_space == rr.disk_space);
+    }
+}
+
+void check_states_the_same(
+  std::vector<cluster::node_state>& lhs,
+  std::vector<cluster::node_state>& rhs) {
+    BOOST_TEST_REQUIRE(lhs.size() == rhs.size());
+
+    auto by_id = [](
+                   const cluster::node_state& lr,
+                   const cluster::node_state& rr) { return lr.id < rr.id; };
+    std::sort(lhs.begin(), lhs.end(), by_id);
+    std::sort(rhs.begin(), rhs.end(), by_id);
+
+    for (auto i = 0; i < lhs.size(); ++i) {
+        auto& lr = lhs[i];
+        auto& rr = rhs[i];
+        BOOST_TEST_REQUIRE(lr.is_alive == rr.is_alive);
+        BOOST_TEST_REQUIRE(lr.membership_state == rr.membership_state);
+    }
+}
+
+FIXTURE_TEST(data_are_consistent_across_nodes, cluster_test_fixture) {
+    auto n1 = create_node_application(model::node_id{0});
+    auto n2 = create_node_application(model::node_id{1});
+    auto n3 = create_node_application(model::node_id{2});
+
+    wait_for_all_members(3s).get();
+    // wait for disk space report to be present
+    tests::cooperative_spin_wait_with_timeout(10s, [&n1] {
+        return n1->controller->get_health_monitor()
+          .local()
+          .get_cluster_health(
+            get_all, cluster::force_refresh::yes, model::no_timeout)
+          .then([](result<cluster::cluster_health_report> res) {
+              if (!res) {
+                  return false;
+              }
+              if (res.value().node_reports.empty()) {
+                  return false;
+              }
+              if (res.value().node_reports[0].disk_space.empty()) {
+                  return false;
+              }
+              return true;
+          });
+    }).get();
+
+    // collect health report from node 1
+    auto r_1 = n1->controller->get_health_monitor()
+                 .local()
+                 .get_cluster_health(
+                   get_all, cluster::force_refresh::yes, model::no_timeout)
+                 .get0();
+    auto r_2 = n2->controller->get_health_monitor()
+                 .local()
+                 .get_cluster_health(
+                   get_all, cluster::force_refresh::yes, model::no_timeout)
+                 .get0();
+    auto r_3 = n2->controller->get_health_monitor()
+                 .local()
+                 .get_cluster_health(
+                   get_all, cluster::force_refresh::yes, model::no_timeout)
+                 .get0();
+
+    BOOST_TEST_REQUIRE(r_1.has_value());
+    BOOST_TEST_REQUIRE(r_2.has_value());
+    BOOST_TEST_REQUIRE(r_3.has_value());
+
+    auto report_1 = r_1.value();
+    auto report_2 = r_2.value();
+    auto report_3 = r_3.value();
+    BOOST_TEST_REQUIRE(report_1.raft0_leader == report_2.raft0_leader);
+    BOOST_TEST_REQUIRE(report_2.raft0_leader == report_3.raft0_leader);
+
+    check_reports_the_same(report_1.node_reports, report_2.node_reports);
+    check_reports_the_same(report_2.node_reports, report_3.node_reports);
+    check_states_the_same(report_1.node_states, report_2.node_states);
+    check_states_the_same(report_2.node_states, report_3.node_states);
+}
+
+cluster::topic_configuration topic_cfg(
+  const model::ns& ns,
+  const ss::sstring& name,
+  int16_t replication,
+  int paritions) {
+    return cluster::topic_configuration(
+      ns, model::topic(name), paritions, replication);
+}
+
+void contains_exactly_ntp_leaders(
+  const std::unordered_set<model::ntp>& expected,
+  const std::vector<cluster::topic_status>& topics) {
+    auto left = expected;
+    for (const auto& t_l : topics) {
+        for (const auto& p_l : t_l.partitions) {
+            model::ntp ntp(t_l.tp_ns.ns, t_l.tp_ns.tp, p_l.id);
+            BOOST_REQUIRE_MESSAGE(
+              left.erase(ntp) == 1,
+              fmt::format(
+                "ntp {} is present in report, but is not expected", ntp));
+        }
+    }
+    BOOST_REQUIRE_MESSAGE(
+      left.empty(),
+      fmt::format(
+        "ntps {} are expected but were not present in report", left.size()));
+}
+
+model::ntp ntp(model::ns ns, ss::sstring tp, int pid) {
+    return model::ntp(
+      std::move(ns), model::topic(std::move(tp)), model::partition_id(pid));
+}
+
+FIXTURE_TEST(test_ntp_filter, cluster_test_fixture) {
+    auto n1 = create_node_application(model::node_id{0});
+    auto n2 = create_node_application(model::node_id{1});
+    auto n3 = create_node_application(model::node_id{2});
+
+    wait_for_all_members(3s).get();
+    // wait for disk space report to be present
+    tests::cooperative_spin_wait_with_timeout(10s, [&n1] {
+        return n1->controller->get_health_monitor()
+          .local()
+          .get_cluster_health(
+            get_all, cluster::force_refresh::yes, model::no_timeout)
+          .then([](result<cluster::cluster_health_report> res) {
+              if (!res) {
+                  return false;
+              }
+              if (res.value().node_reports.empty()) {
+                  return false;
+              }
+              if (res.value().node_reports[0].disk_space.empty()) {
+                  return false;
+              }
+              return true;
+          });
+    }).get();
+
+    // create topics
+    std::vector<cluster::topic_configuration> topics;
+    topics.push_back(topic_cfg(model::kafka_namespace, "tp-1", 3, 3));
+    topics.push_back(topic_cfg(model::kafka_namespace, "tp-2", 3, 2));
+    topics.push_back(topic_cfg(model::kafka_namespace, "tp-3", 3, 1));
+    topics.push_back(
+      topic_cfg(model::kafka_internal_namespace, "internal-1", 3, 2));
+
+    n1->controller->get_topics_frontend()
+      .local()
+      .autocreate_topics(std::move(topics), 30s)
+      .get();
+
+    static auto filter_template = [] {
+        return cluster::cluster_report_filter{
+          .node_report_filter = cluster::node_report_filter{
+            .include_partitions = cluster::include_partitions_info::yes,
+          }};
+    };
+
+    tests::cooperative_spin_wait_with_timeout(10s, [&n1] {
+        auto all = filter_template();
+        // get all leaders
+        return n1->controller->get_health_monitor()
+          .local()
+          .get_cluster_health(
+            all, cluster::force_refresh::yes, model::no_timeout)
+          .then([](result<cluster::cluster_health_report> report) {
+              return report.has_value()
+                     && report.value().node_reports.size() == 3
+                     && report.value().node_reports.begin()->topics.size() == 5;
+          });
+    }).get();
+
+    auto f_1 = filter_template();
+    // test filtering by ntp
+    cluster::partitions_filter::topic_map_t kafka_topics_map;
+    kafka_topics_map.emplace(
+      model::topic("tp-1"),
+      cluster::partitions_filter::partitions_set_t{
+        model::partition_id(0), model::partition_id(2)});
+    kafka_topics_map.emplace(
+      model::topic("tp-2"),
+      cluster::partitions_filter::partitions_set_t{model::partition_id(0)});
+
+    f_1.node_report_filter.ntp_filters.namespaces.emplace(
+      model::kafka_namespace, std::move(kafka_topics_map));
+
+    // filter by namespace
+    f_1.node_report_filter.ntp_filters.namespaces.emplace(
+      model::redpanda_ns, cluster::partitions_filter::topic_map_t{});
+
+    // filter by topic
+    cluster::partitions_filter::topic_map_t internal_topic_map;
+    internal_topic_map.emplace(
+      model::topic("internal-1"),
+      cluster::partitions_filter::partitions_set_t{});
+
+    f_1.node_report_filter.ntp_filters.namespaces.emplace(
+      model::kafka_internal_namespace, std::move(internal_topic_map));
+    /**
+     * Requested kafka/tp-1/0, kafka/tp-1/2, kafka/tp-2/0,
+     * redpanda/controller/0, all partitions of kafka-internal/internal-1
+     */
+
+    auto report = n1->controller->get_health_monitor()
+                    .local()
+                    .get_cluster_health(
+                      f_1, cluster::force_refresh::yes, model::no_timeout)
+                    .get0();
+    BOOST_TEST_REQUIRE(report.has_value());
+
+    contains_exactly_ntp_leaders(
+      {
+        ntp(model::kafka_namespace, "tp-1", 0),
+        ntp(model::kafka_namespace, "tp-1", 2),
+        ntp(model::kafka_namespace, "tp-2", 0),
+        ntp(model::kafka_internal_namespace, "internal-1", 0),
+        ntp(model::kafka_internal_namespace, "internal-1", 1),
+        ntp(model::redpanda_ns, "controller", 0),
+      },
+      report.value().node_reports.begin()->topics);
+
+    // check filtering in node report
+    auto node_report = n1->controller->get_health_monitor()
+                         .local()
+                         .collect_node_health(f_1.node_report_filter)
+                         .get();
+
+    BOOST_TEST_REQUIRE(node_report.has_value());
+    contains_exactly_ntp_leaders(
+      {
+        ntp(model::kafka_namespace, "tp-1", 0),
+        ntp(model::kafka_namespace, "tp-1", 2),
+        ntp(model::kafka_namespace, "tp-2", 0),
+        ntp(model::kafka_internal_namespace, "internal-1", 0),
+        ntp(model::kafka_internal_namespace, "internal-1", 1),
+        ntp(model::redpanda_ns, "controller", 0),
+      },
+      node_report.value().topics);
+}
+
+FIXTURE_TEST(test_alive_status, cluster_test_fixture) {
+    auto n1 = create_node_application(model::node_id{0});
+    auto n2 = create_node_application(model::node_id{1});
+    auto n3 = create_node_application(model::node_id{2});
+
+    wait_for_all_members(3s).get();
+    // wait for disk space report to be present
+    tests::cooperative_spin_wait_with_timeout(10s, [&n1] {
+        return n1->controller->get_health_monitor()
+          .local()
+          .get_cluster_health(
+            get_all, cluster::force_refresh::yes, model::no_timeout)
+          .then([](result<cluster::cluster_health_report> res) {
+              if (!res) {
+                  return false;
+              }
+              if (res.value().node_reports.empty()) {
+                  return false;
+              }
+              if (res.value().node_reports[0].disk_space.empty()) {
+                  return false;
+              }
+              return true;
+          });
+    }).get();
+
+    // stop one of the nodes
+    remove_node_application(model::node_id{1});
+
+    // wait until the node will be reported as not alive
+    tests::cooperative_spin_wait_with_timeout(10s, [&n1] {
+        return n1->controller->get_health_monitor()
+          .local()
+          .get_cluster_health(
+            get_all, cluster::force_refresh::yes, model::no_timeout)
+          .then([](result<cluster::cluster_health_report> res) {
+              if (!res) {
+                  return false;
+              }
+              if (res.value().node_reports.empty()) {
+                  return false;
+              }
+              auto it = std::find_if(
+                res.value().node_states.begin(),
+                res.value().node_states.end(),
+                [](cluster::node_state& s) {
+                    return s.id == model::node_id(1);
+                });
+              return it->is_alive == cluster::alive::no;
+          });
+    }).get();
+}

--- a/src/v/cluster/tests/replicas_rebalancing_tests.cc
+++ b/src/v/cluster/tests/replicas_rebalancing_tests.cc
@@ -36,7 +36,7 @@ void wait_for_even_replicas_distribution(
   const cluster::metadata_cache& cache) {
     static ss::logger logger("test-log");
     tests::cooperative_spin_wait_with_timeout(
-      30s,
+      60s,
       [&cache, added_node, min_expected, max_expected] {
           auto per_node = calculate_replicas_per_node(cache);
           for (auto& [id, count] : per_node) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -304,6 +304,13 @@ configuration::configuration()
       "Maximum number of bytes returned in fetch request",
       required::no,
       55_MiB)
+  , metadata_status_wait_timeout_ms(
+      *this,
+      "metadata_status_wait_timeout_ms",
+      "Maximum time to wait in metadata request for cluster health to be "
+      "refreshed",
+      required::no,
+      2s)
   , transactional_id_expiration_ms(
       *this,
       "transactional_id_expiration_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -909,7 +909,19 @@ configuration::configuration()
       "health_manager_tick_interval",
       "How often the health manager runs",
       required::no,
-      3min) {}
+      3min)
+  , health_monitor_tick_interval(
+      *this,
+      "health_monitor_tick_interval",
+      "How often health monitor refresh cluster state",
+      required::no,
+      10s)
+  , health_monitor_max_metadata_age(
+      *this,
+      "health_monitor_max_metadata_age",
+      "Max age of metadata cached in the health monitor of non controller node",
+      required::no,
+      10s) {}
 
 void configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -217,6 +217,9 @@ struct configuration final : public config_store {
     property<int> internal_topic_replication_factor;
     property<std::chrono::milliseconds> health_manager_tick_interval;
 
+    // health monitor
+    property<std::chrono::milliseconds> health_monitor_tick_interval;
+    property<std::chrono::milliseconds> health_monitor_max_metadata_age;
     configuration();
 
     void load(const YAML::Node& root_node);

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -89,6 +89,7 @@ struct configuration final : public config_store {
     property<model::timestamp_type> log_message_timestamp_type;
     property<model::compression> log_compression_type;
     property<size_t> fetch_max_bytes;
+    property<std::chrono::milliseconds> metadata_status_wait_timeout_ms;
     // same as transactional.id.expiration.ms in kafka
     property<std::chrono::milliseconds> transactional_id_expiration_ms;
     property<bool> enable_idempotence;

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -67,6 +67,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::data_policy_already_exists:
     case cluster::errc::data_policy_not_exists:
     case cluster::errc::wating_for_partition_shutdown:
+    case cluster::errc::error_collecting_health_report:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -267,9 +267,8 @@ template<>
 ss::future<response_ptr> metadata_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group g) {
     metadata_response reply;
-    auto brokers = ctx.metadata_cache().all_brokers();
-
-    for (const auto& broker : brokers) {
+    auto alive_brokers = co_await ctx.metadata_cache().all_alive_brokers();
+    for (const auto& broker : alive_brokers) {
         for (const auto& listener : broker->kafka_advertised_listeners()) {
             // filter broker listeners by active connection
             if (listener.name == ctx.listener()) {

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -243,6 +243,9 @@ struct topic_namespace {
         return tp == other.tp && ns == other.ns;
     }
 
+    friend bool operator==(const topic_namespace&, const topic_namespace&)
+      = default;
+
     template<typename H>
     friend H AbslHashValue(H h, const topic_namespace& tp_ns) {
         return H::combine(std::move(h), tp_ns.ns, tp_ns.tp);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -321,6 +321,7 @@ public:
     bool should_reconnect_follower(vnode);
 
     std::vector<follower_metrics> get_follower_metrics() const;
+    result<follower_metrics> get_follower_metrics(model::node_id) const;
 
     const configuration_manager& get_configuration_manager() const {
         return _configuration_manager;

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -108,6 +108,38 @@
                 "membership_status": {
                     "type": "string",
                     "description": "Broker membership status"
+                },
+                "is_alive": {
+                    "type": "boolean",
+                    "description": "is node seen as alive by the cluster"
+                },
+                "disk_space": {
+                    "type": "array",
+                    "items": {
+                        "type": "disk_space_info"
+                    },
+                    "description": "Array of disk space information per directory path. If disk space information is not available the array may be empty"
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Redpanda version"
+                }
+            }
+        },
+        "disk_space_info": {
+            "id": "disk_space_info",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "data directory path"
+                },
+                "free": {
+                    "type": "long",
+                    "description": "free space bytes"
+                },
+                "total": {
+                    "type": "long",
+                    "description": "total space bytes"
                 }
             }
         }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -670,7 +670,8 @@ void application::wire_up_redpanda_services() {
       metadata_cache,
       std::ref(controller->get_topics_state()),
       std::ref(controller->get_members_table()),
-      std::ref(controller->get_partition_leaders()))
+      std::ref(controller->get_partition_leaders()),
+      std::ref(controller->get_health_monitor()))
       .get();
     /**
      * Wait for all requests to finish before removing critical redpanda

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1062,7 +1062,9 @@ void application::start_redpanda() {
             std::ref(controller->get_security_frontend()),
             std::ref(controller->get_api()),
             std::ref(controller->get_members_frontend()),
-            std::ref(controller->get_config_frontend()));
+            std::ref(controller->get_config_frontend()),
+            std::ref(controller->get_health_monitor()));
+
           proto->register_service<cluster::metadata_dissemination_handler>(
             _scheduling_groups.cluster_sg(),
             smp_service_groups.cluster_smp_sg(),

--- a/tests/rptest/tests/configuration_update_test.py
+++ b/tests/rptest/tests/configuration_update_test.py
@@ -108,14 +108,10 @@ class ConfigurationUpdateTest(RedpandaTest):
         def metadata_updated():
             client = PythonLibrdkafka(self.redpanda)
             brokers = client.brokers()
-            self.logger.debug(f"brokers metadata: {brokers}")
-            if brokers[1].port != 10091:
-                return False
-            if brokers[2].port != 10092:
-                return False
-            if brokers[3].port != 10093:
-                return False
-            return True
+            self.redpanda.logger.debug(f"brokers metadata: {brokers}")
+            ports = [b.port for _, b in brokers.items()]
+            ports.sort()
+            return ports == [10091, 10092, 10093]
 
         wait_until(lambda: metadata_updated(),
                    timeout_sec=60,


### PR DESCRIPTION
## Cover letter

### Health monitor

The Health Monitor is going to be a component with an API allowing the caller to query for cluster runtime parameters. It is going to be a point allowing access to a state that is distributed across the cluster and may normally be known only on the node which the state is related with. Health monitor is going to include different cluster parameters f.e. Node versions, node availability, node resources and raft group status. 
##### Data consistency

Since the main purpose of a health monitor is to provide cluster observability it will guarantee eventual consistency for all the data. For simplicity at the beginning we will guarantee that the data on each node will not be older than the given configurable interval (f.e. 2 seconds).


Fixes: #2188 

## Release notes


Release note:
- Being fully compatible with Kafka Metadata API in terms of returned brokers list.

Force push:
- simplified filtering
- additional timeout for metadata request
- tracking node response to limit logging