### PR TITLE
admin: redirect to leader on errc::not_leader & similar errors

### DIFF
--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/afero"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/net"
@@ -156,63 +155,6 @@ func (a *AdminAPI) sendOne(method, path string, body, into interface{}) error {
 		return err
 	}
 	return maybeUnmarshalRespInto(method, url, res, into)
-}
-
-// sendAll sends a request to all URLs in the admin client. The first successful
-// response will be unmarshaled into into if it is non-nil.
-//
-// As of v21.4.15, the Redpanda admin API doesn't do request forwarding, which
-// means that some requests (such as the ones made to /users) will fail unless
-// the reached node is the leader. Therefore, a request needs to be made to
-// each node, and of those requests at least one should succeed.
-// FIXME (@david): when https://github.com/vectorizedio/redpanda/issues/1265
-// is fixed.
-func (a *AdminAPI) sendAll(method, path string, body, into interface{}) error {
-	var (
-		once   sync.Once
-		resURL string
-		res    *http.Response
-		grp    multierror.Group
-
-		// When one request is successful, we want to cancel all other
-		// outstanding requests. We do not cancel the successful
-		// request's context, because the context is used all the way
-		// through reading a response body.
-		cancels      []func()
-		cancelExcept = func(except int) {
-			for i, cancel := range cancels {
-				if i != except {
-					cancel()
-				}
-			}
-		}
-	)
-
-	for i, url := range a.urlsWithPath(path) {
-		ctx, cancel := context.WithCancel(context.Background())
-		myURL := url
-		except := i
-		cancels = append(cancels, cancel)
-		grp.Go(func() error {
-			myRes, err := a.sendAndReceive(ctx, method, myURL, body)
-			if err != nil {
-				return err
-			}
-			cancelExcept(except) // kill all other requests
-
-			// Only one request should be successful, but for
-			// paranoia, we guard keeping the first successful
-			// response.
-			once.Do(func() { resURL, res = myURL, myRes })
-			return nil
-		})
-	}
-
-	err := grp.Wait()
-	if res != nil {
-		return maybeUnmarshalRespInto(method, resURL, res, into)
-	}
-	return err
 }
 
 // Unmarshals a response body into `into`, if it is non-nil.

--- a/src/go/rpk/pkg/api/admin/admin_test.go
+++ b/src/go/rpk/pkg/api/admin/admin_test.go
@@ -39,7 +39,6 @@ func TestCreateUser(t *testing.T) {
 	urls := []string{}
 
 	for i := 0; i < int(nNodes); i++ {
-		n := i
 		ts := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				b, err := ioutil.ReadAll(r.Body)
@@ -47,11 +46,7 @@ func TestCreateUser(t *testing.T) {
 				require.Exactly(t, bs, b)
 				// Have only one server return OK, to simulate a single
 				// node being the leader and being able to respond.
-				if n == 0 {
-					w.WriteHeader(http.StatusOK)
-				} else {
-					w.WriteHeader(http.StatusInternalServerError)
-				}
+				w.WriteHeader(http.StatusOK)
 			}),
 		)
 		defer ts.Close()
@@ -73,18 +68,11 @@ func TestDeleteUser(t *testing.T) {
 	urls := []string{}
 
 	for i := 0; i < int(nNodes); i++ {
-		n := i
 		ts := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Exactly(t, "/v1/security/users/Lola", r.URL.Path)
 
-				// Have only one server return OK, to simulate a single
-				// node being the leader and being able to respond.
-				if n == 0 {
-					w.WriteHeader(http.StatusOK)
-				} else {
-					w.WriteHeader(http.StatusInternalServerError)
-				}
+				w.WriteHeader(http.StatusOK)
 			}),
 		)
 		defer ts.Close()
@@ -104,16 +92,11 @@ func TestListUsers(t *testing.T) {
 	urls := []string{}
 
 	for i := 0; i < int(nNodes); i++ {
-		n := i
 		ts := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if n == 0 {
-					w.Write([]byte(
-						`["Joss", "lola", "jeff", "tobias"]`,
-					))
-				} else {
-					w.WriteHeader(http.StatusInternalServerError)
-				}
+				w.Write([]byte(
+					`["Joss", "lola", "jeff", "tobias"]`,
+				))
 			}),
 		)
 		defer ts.Close()

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -35,7 +35,7 @@ func (a *AdminAPI) Brokers() ([]Broker, error) {
 
 // DecommissionBroker issues a decommission request for the given broker.
 func (a *AdminAPI) DecommissionBroker(node int) error {
-	return a.sendAll(
+	return a.sendAny(
 		http.MethodPut,
 		fmt.Sprintf("%s/%d/decommission", brokersEndpoint, node),
 		nil,
@@ -45,7 +45,7 @@ func (a *AdminAPI) DecommissionBroker(node int) error {
 
 // RecommissionBroker issues a recommission request for the given broker.
 func (a *AdminAPI) RecommissionBroker(node int) error {
-	return a.sendAll(
+	return a.sendAny(
 		http.MethodPut,
 		fmt.Sprintf("%s/%d/recommission", brokersEndpoint, node),
 		nil,

--- a/src/go/rpk/pkg/api/admin/api_user.go
+++ b/src/go/rpk/pkg/api/admin/api_user.go
@@ -47,7 +47,7 @@ func (a *AdminAPI) CreateUser(username, password, mechanism string) error {
 		Password:  password,
 		Algorithm: mechanism,
 	}
-	return a.sendAll(http.MethodPost, usersEndpoint, u, nil)
+	return a.sendAny(http.MethodPost, usersEndpoint, u, nil)
 }
 
 // DeleteUser deletes the given username, if it exists.
@@ -56,11 +56,11 @@ func (a *AdminAPI) DeleteUser(username string) error {
 		return errors.New("invalid empty username")
 	}
 	path := usersEndpoint + "/" + url.PathEscape(username)
-	return a.sendAll(http.MethodDelete, path, nil, nil)
+	return a.sendAny(http.MethodDelete, path, nil, nil)
 }
 
 // ListUsers returns the current users.
 func (a *AdminAPI) ListUsers() ([]string, error) {
 	var users []string
-	return users, a.sendAll(http.MethodGet, usersEndpoint, nil, &users)
+	return users, a.sendAny(http.MethodGet, usersEndpoint, nil, &users)
 }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1049,17 +1049,14 @@ void admin_server::register_partition_routes() {
                   model::timeout_clock::now()
                     + 10s); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 
-          if (err) {
-              vlog(
-                logger.error,
-                "Error changing ntp {} replicas: {}:{}",
-                ntp,
-                err,
-                err.message());
-              throw ss::httpd::bad_request_exception(
-                fmt::format("Error moving partition: {}", err.message()));
-          }
+          vlog(
+            logger.debug,
+            "Request to change ntp {} replica set to {}: err={}",
+            ntp,
+            replicas,
+            err);
 
+          co_await throw_on_error(*req, err, model::controller_ntp);
           co_return ss::json::json_void();
       });
 }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -84,9 +84,10 @@ private:
     ss::future<> throw_on_error(
       ss::httpd::request& req,
       std::error_code ec,
+      model::ntp const& ntp,
       model::node_id id = model::node_id{-1}) const;
     ss::future<ss::httpd::redirect_exception>
-    redirect_to_leader(ss::httpd::request& req) const;
+    redirect_to_leader(ss::httpd::request& req, model::ntp const& ntp) const;
 
     struct level_reset {
         using time_point = ss::timer<>::clock::time_point;

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -17,6 +17,7 @@
 
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/http/exception.hh>
 #include <seastar/http/file_handler.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/util/log.hh>
@@ -79,6 +80,13 @@ private:
     void register_broker_routes();
     void register_partition_routes();
     void register_hbadger_routes();
+
+    ss::future<> throw_on_error(
+      ss::httpd::request& req,
+      std::error_code ec,
+      model::node_id id = model::node_id{-1}) const;
+    ss::future<ss::httpd::redirect_exception>
+    redirect_to_leader(ss::httpd::request& req) const;
 
     struct level_reset {
         using time_point = ss::timer<>::clock::time_point;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -34,7 +34,8 @@ class Admin:
 
     def _request(self, verb, path, node=None, **kwargs):
         if node is None:
-            node = self.redpanda.controller()
+            node = random.choice(self.redpanda.nodes)
+
         r = requests.request(verb, self._url(node, path), **kwargs)
 
         # Log the response

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -10,7 +10,6 @@
 import sys
 import time
 import re
-import requests
 import random
 
 from ducktape.mark.resource import cluster
@@ -23,6 +22,7 @@ from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.kaf_producer import KafProducer
+from rptest.services.admin import Admin
 
 ELECTION_TIMEOUT = 10
 
@@ -451,29 +451,23 @@ class RaftAvailabilityTest(RedpandaTest):
         # reactor stalls and corresponding nondeterministic behaviour/failures.
         # This appears unrelated to the functionality under test, something else
         # is tripping up the cluster when we have so many leadership transfers.
+        # https://github.com/vectorizedio/redpanda/issues/2623
+
+        admin = Admin(self.redpanda)
 
         initial_leader_id = leader_node_id
         for n in range(0, transfer_count):
             target_idx = (initial_leader_id + n) % len(self.redpanda.nodes)
             target_node_id = target_idx + 1
 
-            api_host = self.redpanda.nodes[leader_node_id - 1].account.hostname
-
-            url = "http://{}:9644/v1/partitions/kafka/{}/{}/transfer_leadership?target={}".format(
-                api_host, self.topic, 0, target_node_id)
             self.logger.info(f"Starting transfer to {target_node_id}")
-
-            # Leadership transfer is a blocking API endpoint, important to use a timeout
-            # to avoid a test hang if something goes hangs on the server side.
-            r = requests.post(url, timeout=30)
-            if r.status_code not in (200, 500):
-                r.raise_for_status()
+            admin.partition_transfer_leadership("kafka", self.topic, 0,
+                                                target_node_id)
 
             self._wait_for_leader(
                 lambda l: l is not None and l == target_node_id,
                 timeout=ELECTION_TIMEOUT * 2)
             self.logger.info(f"Completed transfer to {target_node_id}")
-            leader_node_id = target_node_id
 
         self.logger.info(f"Completed {transfer_count} transfers successfully")
 


### PR DESCRIPTION
## Cover letter

Depends on seastar changes to flesh out the redirect_exception functionality:
- https://github.com/vectorizedio/seastar/pull/13
- https://github.com/vectorizedio/seastar/pull/14

This is not entirely robust, it assumes that all nodes are using the same port for the admin service, and that the client can directly connect to redpanda nodes (i.e. it is not coming via a reverse proxy).

However, it is a step forward compared with the status quo:
- Currently we return 400s in these cases, if the client did not know they were supposed to find the leader and send the request there
- It's already not possible to use a reverse proxy, because clients have to steer their requests to the leader.

Fixes: https://github.com/vectorizedio/redpanda/issues/1265

## Release notes

For admin API requests that must be submitted to the controller leader node, or to the leader for a particular partition, other nodes will now respond with an HTTP 307 redirect to the leader rather than an HTTP 400 error.