### PR TITLE
cloud_storage: Various fixes from shadow-indexing-merged

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -23,8 +23,10 @@
 #include "storage/parser.h"
 #include "utils/gate_guard.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/file.hh>
+#include <seastar/core/gate.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/semaphore.hh>
@@ -381,19 +383,31 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
   retry_chain_node& parent,
   std::optional<model::offset> lso_override) {
     retry_chain_logger ctxlog(archival_log, parent, _ntp.path());
-    vlog(ctxlog.debug, "uploading next candidates...");
+    vlog(ctxlog.debug, "Uploading next candidates called for {}", _ntp);
+    if (_gate.is_closed()) {
+        return ss::make_ready_future<batch_result>(batch_result{});
+    }
     auto last_stable_offset = lso_override ? *lso_override
                                            : _partition->last_stable_offset();
-    return ss::with_gate(_gate, [this, &lm, last_stable_offset, &parent] {
-        return ss::with_semaphore(
-          _mutex, 1, [this, &lm, last_stable_offset, &parent] {
-              return schedule_uploads(lm, last_stable_offset, parent)
-                .then([this, &parent](std::vector<scheduled_upload> scheduled) {
-                    return wait_all_scheduled_uploads(
-                      std::move(scheduled), parent);
-                });
-          });
-    });
+    return ss::with_gate(
+             _gate,
+             [this, &lm, last_stable_offset, &parent] {
+                 return ss::with_semaphore(
+                   _mutex, 1, [this, &lm, last_stable_offset, &parent] {
+                       return schedule_uploads(lm, last_stable_offset, parent)
+                         .then([this, &parent](
+                                 std::vector<scheduled_upload> scheduled) {
+                             return wait_all_scheduled_uploads(
+                               std::move(scheduled), parent);
+                         });
+                   });
+             })
+      .handle_exception_type([](const ss::gate_closed_exception&) {
+          return ss::make_ready_future<batch_result>(batch_result{});
+      })
+      .handle_exception_type([](const ss::abort_requested_exception&) {
+          return ss::make_ready_future<batch_result>(batch_result{});
+      });
 }
 
 } // namespace archival

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -494,8 +494,12 @@ ss::future<> scheduler_service_impl::run_uploads() {
         vlog(_rtclog.debug, "Upload loop aborted (abort requested)");
     } catch (...) {
         vlog(_rtclog.error, "Upload loop error: {}", std::current_exception());
-        throw;
     }
+    // The loop can be stopped by gate or abort_source (if it was waiting inside
+    // sleep_abortable)
+    vassert(
+      _as.abort_requested() || _gate.is_closed(),
+      "Upload loop is not stopped properly");
 }
 
 } // namespace archival::internal

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -74,7 +74,7 @@ static error_outcome categorize_error(
         } else if (err.code() == s3::s3_error_code::slow_down) {
             // This can happen when we're dealing with high request rate to
             // the manifest's prefix. Backoff algorithm should be applied.
-            vlog(ctxlog.debug, "SlowDown response received {}", path);
+            vlog(ctxlog.warn, "SlowDown response received {}", path);
             result = error_outcome::retry_slowdown;
         } else {
             // Unexpected REST API error, we can't recover from this
@@ -108,7 +108,7 @@ static error_outcome categorize_error(
             result = error_outcome::fail;
         } else {
             vlog(
-              ctxlog.debug,
+              ctxlog.warn,
               "System error susceptible for retry {}",
               cerr.what());
         }
@@ -183,17 +183,10 @@ ss::future<download_result> remote::download_manifest(
         } catch (...) {
             eptr = std::current_exception();
         }
+        co_await client->shutdown();
         auto outcome = categorize_error(eptr, fib, bucket, path);
         switch (outcome) {
         case error_outcome::retry_slowdown:
-            // We have to close the connection upon receiving the 'SlowDown'
-            // response from S3. If we won't do this and just sleep the required
-            // number of milliseconds the next request that will use this
-            // connection will trigger a 'short read' error. The error means
-            // that the S3 forcibly closes the connection. This doesn't happen
-            // when we close and then reestablish the connection upon receiving
-            // the 'SlowDown' response (if long enough backoff period is used).
-            co_await client->shutdown();
             [[fallthrough]];
         case error_outcome::retry:
             vlog(
@@ -207,8 +200,10 @@ ss::future<download_result> remote::download_manifest(
             break;
         case error_outcome::fail:
             result = download_result::failed;
+            break;
         case error_outcome::notfound:
             result = download_result::notfound;
+            break;
         }
     }
     _probe.failed_manifest_download();
@@ -265,10 +260,10 @@ ss::future<upload_result> remote::upload_manifest(
         } catch (...) {
             eptr = std::current_exception();
         }
+        co_await client->shutdown();
         auto outcome = categorize_error(eptr, fib, bucket, path);
         switch (outcome) {
         case error_outcome::retry_slowdown:
-            co_await client->shutdown();
             [[fallthrough]];
         case error_outcome::retry:
             vlog(
@@ -285,6 +280,7 @@ ss::future<upload_result> remote::upload_manifest(
             // not expected during upload
         case error_outcome::fail:
             result = upload_result::failed;
+            break;
         }
     }
     _probe.failed_manifest_upload();
@@ -352,10 +348,10 @@ ss::future<upload_result> remote::upload_segment(
         } catch (...) {
             eptr = std::current_exception();
         }
+        co_await client->shutdown();
         auto outcome = categorize_error(eptr, fib, bucket, path);
         switch (outcome) {
         case error_outcome::retry_slowdown:
-            co_await client->shutdown();
             [[fallthrough]];
         case error_outcome::retry:
             vlog(
@@ -372,6 +368,7 @@ ss::future<upload_result> remote::upload_segment(
             // not expected during upload
         case error_outcome::fail:
             result = upload_result::failed;
+            break;
         }
     }
     _probe.failed_upload();
@@ -424,10 +421,10 @@ ss::future<download_result> remote::download_segment(
         } catch (...) {
             eptr = std::current_exception();
         }
+        co_await client->shutdown();
         auto outcome = categorize_error(eptr, fib, bucket, path);
         switch (outcome) {
         case error_outcome::retry_slowdown:
-            co_await client->shutdown();
             [[fallthrough]];
         case error_outcome::retry:
             vlog(
@@ -441,8 +438,10 @@ ss::future<download_result> remote::download_segment(
             break;
         case error_outcome::fail:
             result = download_result::failed;
+            break;
         case error_outcome::notfound:
             result = download_result::notfound;
+            break;
         }
     }
     _probe.failed_download();

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -21,6 +21,7 @@
 #include "rpc/transport.h"
 #include "rpc/types.h"
 #include "seastarx.h"
+#include "utils/prefix_logger.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/circular_buffer.hh>
@@ -96,7 +97,7 @@ public:
     /// Return immediately if connected or make connection attempts
     /// until success, timeout or error
     ss::future<reconnect_result_t>
-    get_connected(ss::lowres_clock::duration timeout);
+    get_connected(ss::lowres_clock::duration timeout, prefix_logger ctxlog);
 
     void fail_outstanding_futures() noexcept override;
 
@@ -106,7 +107,7 @@ public:
     public:
         using verb = boost::beast::http::verb;
         /// C-tor can only be called by http_request
-        explicit response_stream(client* client, verb v);
+        explicit response_stream(client* client, verb v, ss::sstring target);
 
         response_stream(response_stream&&) = delete;
         response_stream(response_stream const&) = delete;
@@ -148,6 +149,7 @@ public:
 
     private:
         client* _client;
+        prefix_logger _ctxlog;
         response_parser _parser;
         iobuf _buffer; /// store incomplete tail elements
         iobuf _prefetch;
@@ -187,6 +189,7 @@ public:
 
     private:
         client* _client;
+        prefix_logger _ctxlog;
         http_request _request;
         http_serializer _serializer;
         chunked_encoder _chunk_encode;

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -827,7 +827,8 @@ SEASTAR_THREAD_TEST_CASE(test_http_cancel_reconnect) {
     auto config = transport_configuration();
     ss::abort_source as;
     http::client client(config, as);
-    auto fut = client.get_connected(10s);
+    auto fut = client.get_connected(
+      10s, prefix_logger(http::http_log, "test-url"));
     ss::sleep(10ms).get();
     BOOST_REQUIRE(fut.failed() == false);
     BOOST_REQUIRE(fut.available() == false);
@@ -839,7 +840,8 @@ SEASTAR_THREAD_TEST_CASE(test_http_reconnect_graceful_shutdown) {
     auto config = transport_configuration();
     ss::abort_source as;
     http::client client(config, as);
-    auto fut = client.get_connected(10s);
+    auto fut = client.get_connected(
+      10s, prefix_logger(http::http_log, "test-url"));
     ss::sleep(10ms).get();
     BOOST_REQUIRE(fut.failed() == false);
     BOOST_REQUIRE(fut.available() == false);

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -350,7 +350,7 @@ public:
       , _node(node)
       , _ctx(std::move(context)) {}
     template<typename... Args>
-    void log(ss::log_level lvl, const char* format, Args&&... args) {
+    void log(ss::log_level lvl, const char* format, Args&&... args) const {
         if (_log.is_enabled(lvl)) {
             auto msg = ssx::sformat(format, std::forward<Args>(args)...);
             if (_ctx) {
@@ -362,23 +362,23 @@ public:
         }
     }
     template<typename... Args>
-    void error(const char* format, Args&&... args) {
+    void error(const char* format, Args&&... args) const {
         log(ss::log_level::error, format, std::forward<Args>(args)...);
     }
     template<typename... Args>
-    void warn(const char* format, Args&&... args) {
+    void warn(const char* format, Args&&... args) const {
         log(ss::log_level::warn, format, std::forward<Args>(args)...);
     }
     template<typename... Args>
-    void info(const char* format, Args&&... args) {
+    void info(const char* format, Args&&... args) const {
         log(ss::log_level::info, format, std::forward<Args>(args)...);
     }
     template<typename... Args>
-    void debug(const char* format, Args&&... args) {
+    void debug(const char* format, Args&&... args) const {
         log(ss::log_level::debug, format, std::forward<Args>(args)...);
     }
     template<typename... Args>
-    void trace(const char* format, Args&&... args) {
+    void trace(const char* format, Args&&... args) const {
         log(ss::log_level::trace, format, std::forward<Args>(args)...);
     }
 


### PR DESCRIPTION
## Cover letter

This PR brings fixes and improvements from shadow-indexing-merged branch that have to be merged before the actual feature.

The improvements:
- Logging in http package uses prefixed_logger to add context to messages
- The `retry_chain_logger` is now const friendly
- Find ca-certificates automatically if the path to cert is not specified in the config explicitly
- Improved logging in `cloud_storage::remote`. 

Bugfixes:
- In `cloud_storage::remote` force reconnection after any error. Without this the connection can be reused via connection pool which leads to crazy behaviour. 
- Fix bug in archival upload. The bug is caused by `gate_closed_exception` thrown out of `ntp_archiver`. The upload loop can't tell then difference between its own gate being closed and the one from `ntp_archiver` and stops early. This causes the node to run out of disk space (since nothing gets uploaded on the shard).

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/6efb33cbc77174263fd123846b69d9a3784486f9..4274948c1150d0ea2b413d421a3ea4cd04b0eadc)
- rebase dev
- fix format string in http `prefix_logger`

## Release notes

N/A