### PR TITLE
.github: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -6,12 +6,18 @@ labels: "kind/bug"
 
 ### Version & Environment
 
-Redpanda Version:
+Redpanda version: (use `rpk version`):
 
 <!--
-Client libraries in use (e.g. rdkafka, franz-go)
-Operating system, container runtime, etc.
-Link to test failure for automated tests
+
+Please also give versions of other components:
+- Operating System (e.g. from `/etc/os-release`):
+- Any Kafka client libraries in use (e.g. rdkafka, franz-go)
+- Docker (use `docker info`):
+- Kubernetes (use `kubectl version`):
+
+Include link to test results for automated test failures
+
 -->
 
 ### What went wrong?

--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -1,0 +1,37 @@
+---
+name: 🔧 Bug report
+about: Something is not working
+labels: "kind/bug"
+---
+
+### Version & Environment
+
+Redpanda Version:
+
+<!--
+Client libraries in use (e.g. rdkafka, franz-go)
+Operating system, container runtime, etc.
+Link to test failure for automated tests
+-->
+
+### What went wrong?
+
+<!--
+  Describe the unexpected behavior
+-->
+
+### What should have happened instead?
+
+<!--
+  Describe what you wanted to happen.
+-->
+
+### How to reproduce the issue?
+
+1.
+2.
+3.
+
+### Additional information
+
+Please attach any relevant logs, backtraces, or metric charts.

--- a/.github/ISSUE_TEMPLATE/02_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.md
@@ -1,0 +1,34 @@
+---
+name: 🚀 Feature request
+about: Suggest an enhancement to Redpanda
+labels: "kind/enhancement"
+---
+
+### Who is this for and what problem do they have today?
+
+<!--
+Describe the user and relevant workflows
+Describe the current pain points the user has
+-->
+
+### What are the success criteria?
+
+<!--
+Describe what the desired outcome looks like
+Focus on user requirements, not technical implementation
+Note any requirements specifically out of scope
+-->
+
+### Why is solving this problem impactful?
+
+<!--
+Describe benefit and urgency for the user and Redpanda
+-->
+
+### Additional notes
+
+<!--
+Relevant GH issues and pull requests
+Dependencies on other features or components
+Link to PRD or Eng Proposal as needed
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 👋 Slack
+    url: https://vectorized.io/slack
+    about: Chat and ask questions in real time!
+  - name: ❓ Github Discussions
+    url: https://github.com/vectorizedio/redpanda/discussions
+    about: For longer, async, thoughtful discussions
+  - name: 💭 Product Feedback
+    url: https://vectorized.io/feedback/
+    about: Let us know how we can improve your experience
+
+


### PR DESCRIPTION
## Cover letter

Provide a guided path to:
- Guide questions to slack or discussions instead of issues
- Prompt for relevant details in bug reports and feature requests
- Auto-apply labels for bugs and features to reduce label-less issues

Preview here: https://github.com/jcsp/redpanda/issues/new/choose

I've left blank issues enabled for now, it's useful for internal tech debt tickets that aren't bugs or features, and also Projects might require blank issues enabled for doing things like creating issues inline there (not sure).

## Release notes

None