### PR TITLE
Archival: avoid unwanted timebox uploads

### DIFF
--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -13,6 +13,7 @@
 #include "archival/probe.h"
 #include "archival/types.h"
 #include "model/fundamental.h"
+#include "raft/fwd.h"
 #include "storage/log_manager.h"
 #include "storage/ntp_config.h"
 #include "storage/segment_set.h"
@@ -55,7 +56,8 @@ public:
     ss::future<upload_candidate> get_next_candidate(
       model::offset begin_inclusive,
       model::offset end_exclusive,
-      storage::log_manager& lm);
+      storage::log,
+      const raft::offset_translator&);
 
 private:
     /// Check if the upload have to be forced due to timeout
@@ -74,7 +76,8 @@ private:
     lookup_result find_segment(
       model::offset last_offset,
       model::offset adjusted_lso,
-      storage::log_manager& lm);
+      storage::log,
+      const raft::offset_translator&);
 
     model::ntp _ntp;
     service_probe& _svc_probe;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -111,7 +111,10 @@ ntp_archiver::upload_manifest(retry_chain_node& parent) {
     gate_guard guard{_gate};
     retry_chain_node fib(_manifest_upload_timeout, _initial_backoff, &parent);
     retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
-    vlog(ctxlog.debug, "Uploading manifest for {}", _ntp);
+    vlog(
+      ctxlog.debug,
+      "Uploading manifest, path: {}",
+      _manifest.get_manifest_path());
     co_return co_await _remote.upload_manifest(_bucket, _manifest, fib);
 }
 
@@ -141,20 +144,20 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
 
 ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
   storage::log_manager& lm,
-  model::offset last_uploaded_offset,
+  model::offset start_upload_offset,
   model::offset last_stable_offset,
   retry_chain_node& parent) {
     retry_chain_logger ctxlog(archival_log, parent, _ntp.path());
 
     auto upload = co_await _policy.get_next_candidate(
-      last_uploaded_offset, last_stable_offset, lm);
+      start_upload_offset, last_stable_offset, lm);
 
     if (upload.source.get() == nullptr) {
         vlog(
           ctxlog.debug,
-          "Uploading next candidates, last_uploaded_offset: {}, "
-          "last_stable_offset: {} ...skip",
-          last_uploaded_offset,
+          "upload candidate not found, start_upload_offset: {}, "
+          "last_stable_offset: {}",
+          start_upload_offset,
           last_stable_offset);
         // Indicate that the upload is not started
         co_return scheduled_upload{
@@ -194,25 +197,23 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
         if (meta->committed_offset < dirty_offset) {
             vlog(
               ctxlog.info,
-              "Uploading next candidates for {}, attempt to re-upload "
-              "{}, manifest committed offset {}, upload dirty offset {}",
-              _ntp,
+              "will re-upload {}, last offset in the manifest {}, "
+              "candidate dirty offset {}",
               upload,
               meta->committed_offset,
               dirty_offset);
         } else if (meta->committed_offset >= dirty_offset) {
             vlog(
               ctxlog.warn,
-              "Skip upload for {} because it's already in the manifest "
-              "{}, manifest committed offset {}, upload dirty offset {}",
-              _ntp,
+              "skip upload {} because it's already in the manifest, "
+              "last offset in the manifest {}, candidate dirty offset {}",
               upload,
               meta->committed_offset,
               dirty_offset);
-            last_uploaded_offset = meta->committed_offset;
+            start_upload_offset = meta->committed_offset;
             co_return scheduled_upload{
               .result = std::nullopt,
-              .inclusive_last_offset = last_uploaded_offset,
+              .inclusive_last_offset = start_upload_offset,
               .meta = std::nullopt,
               .name = std::nullopt,
               .delta = std::nullopt,
@@ -222,7 +223,7 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
     }
     auto offset = upload.final_offset;
     auto base = upload.starting_offset;
-    last_uploaded_offset = offset + model::offset(1);
+    start_upload_offset = offset + model::offset(1);
     auto delta = base
                  - _partition->get_offset_translator()->from_log_offset(base);
     co_return scheduled_upload{
@@ -254,30 +255,27 @@ ntp_archiver::schedule_uploads(
     // latest uploaded segment but '_policy' requires offset that
     // belongs to the next offset or the gap. No need to do this
     // if there is no segments.
-    auto last_uploaded_offset = _manifest.size() ? _manifest.get_last_offset()
-                                                     + model::offset(1)
-                                                 : model::offset(0);
-
-    vlog(ctxlog.debug, "Uploading next candidates called for {}", _ntp);
+    auto start_upload_offset = _manifest.size() ? _manifest.get_last_offset()
+                                                    + model::offset(1)
+                                                : model::offset(0);
 
     vlog(
       ctxlog.debug,
-      "Uploading next candidates for {}, trying offset {}, LSO {}",
-      _ntp,
-      last_uploaded_offset,
+      "scheduling uploads, start_upload_offset: {}, last_stable_offset: {}",
+      start_upload_offset,
       last_stable_offset);
 
     return ss::do_with(
       std::vector<scheduled_upload>(),
       size_t(0),
-      last_uploaded_offset,
+      start_upload_offset,
       [this, &lm, last_stable_offset, &parent](
         std::vector<scheduled_upload>& scheduled,
         size_t& ix,
-        model::offset& last_uploaded_offset) {
+        model::offset& start_upload_offset) {
           return ss::repeat([this,
                              &lm,
-                             &last_uploaded_offset,
+                             &start_upload_offset,
                              last_stable_offset,
                              &parent,
                              &scheduled,
@@ -289,14 +287,14 @@ ntp_archiver::schedule_uploads(
                      ++ix;
                      return schedule_single_upload(
                               lm,
-                              last_uploaded_offset,
+                              start_upload_offset,
                               last_stable_offset,
                               parent)
                        .then([&scheduled,
-                              &last_uploaded_offset](scheduled_upload upload) {
+                              &start_upload_offset](scheduled_upload upload) {
                            auto res = upload.stop;
-                           last_uploaded_offset = upload.inclusive_last_offset
-                                                  + model::offset(1);
+                           start_upload_offset = upload.inclusive_last_offset
+                                                 + model::offset(1);
                            scheduled.push_back(std::move(upload));
                            return ss::make_ready_future<ss::stop_iteration>(
                              res);
@@ -323,10 +321,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
         }
     }
     if (flist.empty()) {
-        vlog(
-          ctxlog.debug,
-          "Uploading next candidates for {}, no uploads started ...skip",
-          _ntp);
+        vlog(ctxlog.debug, "no uploads started, returning");
         co_return total;
     }
     auto results = co_await ss::when_all_succeed(begin(flist), end(flist));
@@ -344,12 +339,17 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
     if (total.num_succeded != 0) {
         vlog(
           ctxlog.debug,
-          "Uploaded next candidates for {}, re-uploading manifest file",
-          _ntp);
+          "successfully uploaded {} segments (failed {} uploads), "
+          "re-uploading manifest file",
+          total.num_succeded,
+          total.num_failed);
 
         auto res = co_await upload_manifest(parent);
         if (res != cloud_storage::upload_result::success) {
-            vlog(ctxlog.warn, "Manifest upload for {} failed", _ntp);
+            vlog(
+              ctxlog.warn,
+              "manifest upload to {} failed",
+              _manifest.get_manifest_path());
         }
 
         // TODO: error handling
@@ -358,10 +358,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
               _manifest_upload_timeout, _initial_backoff, &parent);
             if (!co_await _partition->archival_meta_stm()->add_segments(
                   _manifest, rc_node)) {
-                vlog(
-                  ctxlog.warn,
-                  "archival metadata STM update for {} failed",
-                  _ntp);
+                vlog(ctxlog.warn, "archival metadata STM update failed");
             }
         }
 
@@ -375,7 +372,7 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
   retry_chain_node& parent,
   std::optional<model::offset> lso_override) {
     retry_chain_logger ctxlog(archival_log, parent, _ntp.path());
-    vlog(ctxlog.debug, "Uploading next candidates called for {}", _ntp);
+    vlog(ctxlog.debug, "uploading next candidates...");
     auto last_stable_offset = lso_override ? *lso_override
                                            : _partition->last_stable_offset();
     return ss::with_gate(_gate, [this, &lm, last_stable_offset, &parent] {

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -149,8 +149,17 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
   retry_chain_node& parent) {
     retry_chain_logger ctxlog(archival_log, parent, _ntp.path());
 
+    std::optional<storage::log> log = lm.get(_ntp);
+    if (!log) {
+        vlog(ctxlog.warn, "couldn't find log in log manager");
+        co_return scheduled_upload{.stop = ss::stop_iteration::yes};
+    }
+
     auto upload = co_await _policy.get_next_candidate(
-      start_upload_offset, last_stable_offset, lm);
+      start_upload_offset,
+      last_stable_offset,
+      *log,
+      *_partition->get_offset_translator());
 
     if (upload.source.get() == nullptr) {
         vlog(

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -433,10 +433,6 @@ ss::future<> scheduler_service_impl::run_uploads() {
                   auto archiver = _queue.get_upload_candidate();
                   storage::api& api = _storage_api.local();
                   storage::log_manager& lm = api.log_mgr();
-                  vlog(
-                    _rtclog.debug,
-                    "Checking {} for S3 upload candidates",
-                    archiver->get_ntp());
                   return archiver->upload_next_candidates(lm, _rtcnode);
               });
 
@@ -464,7 +460,7 @@ ss::future<> scheduler_service_impl::run_uploads() {
             } else if (total.num_succeded != 0) {
                 vlog(
                   _rtclog.debug,
-                  "Successfuly upload {} segments",
+                  "Successfuly uploaded {} segments",
                   total.num_succeded);
             }
 

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -16,9 +16,11 @@
 #include "cloud_storage/types.h"
 #include "cluster/types.h"
 #include "model/metadata.h"
+#include "raft/offset_translator.h"
 #include "ssx/sformat.h"
 #include "storage/disk_log_impl.h"
 #include "storage/parser.h"
+#include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/fixture.h"
 #include "utils/retry_chain_node.h"
 #include "utils/unresolved_address.h"
@@ -312,17 +314,25 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     archival::archival_policy policy(manifest_ntp, svc_probe, ntp_probe);
 
     log_segment_set(lm);
+
+    auto log = lm.get(manifest_ntp);
+    BOOST_REQUIRE(log);
+
+    auto partition = app.partition_manager.local().get(manifest_ntp);
+    BOOST_REQUIRE(partition);
+    const raft::offset_translator& tr = *partition->get_offset_translator();
+
     // Starting offset is lower than offset1
-    auto upload1 = policy.get_next_candidate(model::offset(0), lso, lm).get();
+    auto upload1
+      = policy.get_next_candidate(model::offset(0), lso, *log, tr).get();
     log_upload_candidate(upload1);
     BOOST_REQUIRE(upload1.source.get() != nullptr);
     BOOST_REQUIRE(upload1.starting_offset == offset1);
 
-    auto upload2
-      = policy
-          .get_next_candidate(
-            upload1.source->offsets().dirty_offset + model::offset(1), lso, lm)
-          .get();
+    model::offset start_offset;
+
+    start_offset = upload1.source->offsets().dirty_offset + model::offset(1);
+    auto upload2 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload2);
     BOOST_REQUIRE(upload2.source.get() != nullptr);
     BOOST_REQUIRE(upload2.starting_offset() == offset2);
@@ -330,11 +340,8 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload2.source != upload1.source);
     BOOST_REQUIRE(upload2.source->offsets().base_offset == offset2);
 
-    auto upload3
-      = policy
-          .get_next_candidate(
-            upload2.source->offsets().dirty_offset + model::offset(1), lso, lm)
-          .get();
+    start_offset = upload2.source->offsets().dirty_offset + model::offset(1);
+    auto upload3 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload3);
     BOOST_REQUIRE(upload3.source.get() != nullptr);
     BOOST_REQUIRE(upload3.starting_offset() == offset3);
@@ -342,16 +349,74 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload3.source != upload2.source);
     BOOST_REQUIRE(upload3.source->offsets().base_offset == offset3);
 
-    auto upload4
-      = policy
-          .get_next_candidate(
-            upload3.source->offsets().dirty_offset + model::offset(1), lso, lm)
-          .get();
+    start_offset = upload3.source->offsets().dirty_offset + model::offset(1);
+    auto upload4 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
     BOOST_REQUIRE(upload4.source.get() == nullptr);
 
-    auto upload5
-      = policy.get_next_candidate(lso + model::offset(1), lso, lm).get();
+    start_offset = lso + model::offset(1);
+    auto upload5 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
     BOOST_REQUIRE(upload5.source.get() == nullptr);
+}
+
+// NOLINTNEXTLINE
+SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
+    storage::disk_log_builder b;
+    b | storage::start(manifest_ntp) | storage::add_segment(model::offset{0})
+      | storage::add_random_batch(
+        model::offset{0},
+        1,
+        storage::maybe_compress_batches::no,
+        model::record_batch_type::raft_configuration)
+      | storage::add_random_batch(model::offset{1}, 10)
+      | storage::add_random_batch(
+        model::offset{11},
+        3,
+        storage::maybe_compress_batches::no,
+        model::record_batch_type::archival_metadata);
+
+    ntp_level_probe ntp_probe(per_ntp_metrics_disabled::yes, manifest_ntp);
+    service_probe svc_probe(service_metrics_disabled::yes);
+    archival::archival_policy policy(
+      manifest_ntp, svc_probe, ntp_probe, segment_time_limit{0s});
+
+    auto log = b.get_log();
+
+    raft::offset_translator tr(
+      {model::record_batch_type::raft_configuration,
+       model::record_batch_type::archival_metadata},
+      raft::group_id{0},
+      manifest_ntp,
+      b.storage());
+    tr.start(raft::offset_translator::must_reset::yes, {}).get();
+    tr.sync_with_log(log, std::nullopt).get();
+
+    auto start_offset = model::offset{0};
+    auto last_stable_offset = log.offsets().dirty_offset + model::offset{1};
+    auto upload1
+      = policy.get_next_candidate(start_offset, last_stable_offset, log, tr)
+          .get();
+    BOOST_REQUIRE(upload1.source);
+    BOOST_REQUIRE_EQUAL(upload1.exposed_name, "0-0-v1.log");
+    BOOST_REQUIRE_EQUAL(upload1.starting_offset, start_offset);
+    BOOST_REQUIRE_EQUAL(upload1.final_offset, log.offsets().dirty_offset);
+
+    b
+      | storage::add_random_batch(
+        model::offset{14},
+        2,
+        storage::maybe_compress_batches::no,
+        model::record_batch_type::archival_metadata);
+
+    tr.sync_with_log(log, std::nullopt).get();
+
+    start_offset = upload1.final_offset + model::offset{1};
+    last_stable_offset = log.offsets().dirty_offset + model::offset{1};
+    auto upload2
+      = policy.get_next_candidate(start_offset, last_stable_offset, log, tr)
+          .get();
+    BOOST_REQUIRE(!upload2.source);
+
+    b.stop().get();
 }
 
 // NOLINTNEXTLINE
@@ -783,18 +848,24 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     // Every segment should be returned once as we're calling the
     // policy to get next candidate.
     log_segment_set(lm);
+
+    auto log = lm.get(manifest_ntp);
+    BOOST_REQUIRE(log);
+
+    auto partition = app.partition_manager.local().get(manifest_ntp);
+    BOOST_REQUIRE(partition);
+    const raft::offset_translator& tr = *partition->get_offset_translator();
+
+    model::offset start_offset{0};
     model::offset lso{9999};
     // Starting offset is lower than offset1
-    auto upload1 = policy.get_next_candidate(model::offset(0), lso, lm).get();
+    auto upload1 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload1);
     BOOST_REQUIRE(upload1.source.get() != nullptr);
     BOOST_REQUIRE(upload1.starting_offset == offset1);
 
-    auto upload2
-      = policy
-          .get_next_candidate(
-            upload1.source->offsets().dirty_offset + model::offset(1), lso, lm)
-          .get();
+    start_offset = upload1.source->offsets().dirty_offset + model::offset(1);
+    auto upload2 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload2);
     BOOST_REQUIRE(upload2.source.get() != nullptr);
     BOOST_REQUIRE(upload2.starting_offset == offset2);
@@ -802,11 +873,8 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload2.source != upload1.source);
     BOOST_REQUIRE(upload2.source->offsets().base_offset == offset2);
 
-    auto upload3
-      = policy
-          .get_next_candidate(
-            upload2.source->offsets().dirty_offset + model::offset(1), lso, lm)
-          .get();
+    start_offset = upload2.source->offsets().dirty_offset + model::offset(1);
+    auto upload3 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
     log_upload_candidate(upload3);
     BOOST_REQUIRE(upload3.source.get() != nullptr);
     BOOST_REQUIRE(upload3.starting_offset == offset3);
@@ -814,10 +882,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload3.source != upload2.source);
     BOOST_REQUIRE(upload3.source->offsets().base_offset == offset3);
 
-    auto upload4
-      = policy
-          .get_next_candidate(
-            upload3.source->offsets().dirty_offset + model::offset(1), lso, lm)
-          .get();
+    start_offset = upload3.source->offsets().dirty_offset + model::offset(1);
+    auto upload4 = policy.get_next_candidate(start_offset, lso, *log, tr).get();
     BOOST_REQUIRE(upload4.source.get() == nullptr);
 }

--- a/src/v/raft/fwd.h
+++ b/src/v/raft/fwd.h
@@ -16,5 +16,6 @@ namespace raft {
 class consensus;
 class group_manager;
 class recovery_throttle;
+class offset_translator;
 
 } // namespace raft

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -323,6 +323,8 @@ public:
 
     size_t bytes_written() const { return _bytes_written; }
 
+    storage::api& storage() { return _storage; }
+
 private:
     template<typename Consumer>
     auto consume_impl(Consumer c, log_reader_config config) {


### PR DESCRIPTION
## Cover letter

If timeboxed uploads are enabled and there is no producer activity, we can get into a nasty loop where we upload a segment, add an archival metadata batch, upload a segment containing that batch, add another archival metadata batch, etc. This leads to lots of small segments that don't contain data being uploaded. To avoid it, we check that kafka (translated) offset increases.