### PR TITLE
test: Fix prefix truncate recovery test

### DIFF
--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -84,3 +84,16 @@ class KafkaCat:
             return None, replicas
         else:
             return leader_id, replicas
+
+    def list_offsets(self, topic, partition):
+        def cmd(ts):
+            return ["-Q", "-t", f"{topic}:{partition}:{ts}"]
+
+        def offset(res):
+            # partition is a string in the output
+            return res[topic][f"{partition}"]["offset"]
+
+        oldest = offset(self._cmd(cmd(-2)))
+        newest = offset(self._cmd(cmd(-1)))
+
+        return (oldest, newest)

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -12,6 +12,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from ducktape.utils.util import wait_until
+from ducktape.cluster.cluster import ClusterNode
 
 DEFAULT_TIMEOUT = 30
 
@@ -206,12 +207,14 @@ class Admin:
         path = f"partitions/{namespace}/{topic}/{partition}/transfer_leadership?target={target_id}"
         self._request("POST", path)
 
-    def transfer_leadership_to(self, namespace, topic, partition, target_id):
+    def transfer_leadership_to(self, *, namespace, topic, partition, target):
         """
         Looks up current ntp leader and transfer leadership to target node, 
         this operations is NOP when current leader is the same as target. 
         If leadership transfer was performed this function return True
         """
+        target_id = self.redpanda.idx(target) if isinstance(
+            target, ClusterNode) else target
 
         #  check which node is current leader
 

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -62,7 +62,7 @@ class ListGroupsReplicationFactorTest(RedpandaTest):
                 admin.transfer_leadership_to(namespace=namespace,
                                              topic=topic,
                                              partition=partition,
-                                             target_id=target_id)
+                                             target=target_id)
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 503:
                     time.sleep(1)


### PR DESCRIPTION
The original intent of this test was to verify byte-for-byte equivalence
of a recovered replica from partitions that had undergone garbage
collection due to retention policy.

Since retention policy is applied independently on each node, this
turned out to be error prone / difficult to do. This patch rewrites the
test to verify higher level properties regarding under replication and
resulting offsets on the recovered replica.

Fixes: #2460