### PR TITLE
schema_registry: Initial support for protobuf

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -381,3 +381,14 @@ ExternalProject_Add(rapidjson
     -DRAPIDJSON_BUILD_DOC=OFF
     -DRAPIDJSON_HAS_STDSTRING=ON
 )
+
+ExternalProject_Add(protobuf
+  GIT_REPOSITORY https://github.com/protocolbuffers/protobuf
+  GIT_TAG v3.18.1
+  INSTALL_DIR   @REDPANDA_DEPS_INSTALL_DIR@
+  CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
+  SOURCE_SUBDIR cmake
+  CMAKE_ARGS
+    -Dprotobuf_BUILD_TESTS=OFF
+    ${common_cmake_args}
+)

--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -5,6 +5,8 @@ seastar_generate_swagger(
   OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/../api/api-doc/schema_registry.json.h
 )
 
+find_package(protobuf)
+
 v_cc_library(
   NAME pandaproxy_schema_registry
   SRCS
@@ -17,6 +19,7 @@ v_cc_library(
     sharded_store.cc
     types.cc
     avro.cc
+    protobuf.cc
   DEPS
     v::pandaproxy_common
     v::pandaproxy_parsing
@@ -26,6 +29,8 @@ v_cc_library(
     v::ssx
     v::utils
     avrocpp_s
+    protobuf::libprotobuf
+    protobuf::libprotoc
   )
 
 add_dependencies(v_pandaproxy_schema_registry schema_registry_swagger)

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -135,4 +135,9 @@ inline error_info invalid_subject_schema(const subject& sub) {
       fmt::format("Error while looking up schema under subject {}", sub())};
 }
 
+inline error_info invalid_schema(const canonical_schema& schema) {
+    return {
+      error_code::schema_invalid, fmt::format("Invalid schema {}", schema)};
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -306,6 +306,9 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     auto sub = parse::request_param<subject>(*rq.req, "subject");
     vlog(plog.debug, "post_subject_versions subject='{}'", sub);
+
+    co_await rq.service().writer().read_sync();
+
     auto unparsed = ppj::rjson_parse(
       rq.req->content.data(), post_subject_versions_request_handler<>{sub});
     rq.req.reset();

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -71,6 +71,12 @@ result<schema_version> parse_numerical_schema_version(const ss::sstring& ver) {
     return schema_version{static_cast<int32_t>(res.assume_value())};
 }
 
+result<std::optional<schema_version>>
+parse_schema_version(const ss::sstring& ver) {
+    return ver == "latest" ? std::optional<schema_version>{}
+                           : parse_numerical_schema_version(ver).value();
+}
+
 ss::future<server::reply_t>
 get_config(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
@@ -325,20 +331,9 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
         .value_or(include_deleted::no)};
     rq.req.reset();
 
-    auto version = invalid_schema_version;
-    if (ver == "latest") {
-        // We must sync to reliably say what is 'latest'
-        co_await rq.service().writer().read_sync();
+    co_await rq.service().writer().read_sync();
 
-        auto versions = co_await rq.service().schema_store().get_versions(
-          sub, inc_del);
-        if (versions.empty()) {
-            throw as_exception(not_found(sub, version));
-        }
-        version = versions.back();
-    } else {
-        version = parse_numerical_schema_version(ver).value();
-    }
+    auto version = parse_schema_version(ver).value();
 
     auto get_res = co_await get_or_load(rq, [&rq, sub, version, inc_del]() {
         return rq.service().schema_store().get_subject_schema(
@@ -348,7 +343,7 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
     auto json_rslt{json::rjson_serialize(post_subject_versions_version_response{
       .schema = std::move(get_res.schema),
       .id = get_res.id,
-      .version = version})};
+      .version = get_res.version})};
     rp.rep->write_body("json", json_rslt);
     co_return rp;
 }
@@ -363,20 +358,9 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version_schema(
         .value_or(include_deleted::no)};
     rq.req.reset();
 
-    auto version = invalid_schema_version;
-    if (ver == "latest") {
-        // We must sync to reliably say what is 'latest'
-        co_await rq.service().writer().read_sync();
+    co_await rq.service().writer().read_sync();
 
-        auto versions = co_await rq.service().schema_store().get_versions(
-          sub, inc_del);
-        if (versions.empty()) {
-            throw as_exception(not_found(sub, version));
-        }
-        version = versions.back();
-    } else {
-        version = parse_numerical_schema_version(ver).value();
-    }
+    auto version = parse_schema_version(ver).value();
 
     auto get_res = co_await rq.service().schema_store().get_subject_schema(
       sub, version, inc_del);

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/schema_registry/protobuf.h"
+
+#include <fmt/ostream.h>
+#include <google/protobuf/descriptor.h>
+
+namespace pandaproxy::schema_registry {
+
+namespace {
+
+namespace pb = google::protobuf;
+
+}
+
+struct protobuf_schema_definition::impl {
+    pb::DescriptorPool _dp;
+    const pb::FileDescriptor* fd{};
+};
+
+canonical_schema_definition::raw_string
+protobuf_schema_definition::raw() const {
+    return canonical_schema_definition::raw_string{_impl->fd->DebugString()};
+}
+
+bool operator==(
+  const protobuf_schema_definition& lhs,
+  const protobuf_schema_definition& rhs) {
+    return lhs.raw() == rhs.raw();
+}
+
+std::ostream&
+operator<<(std::ostream& os, const protobuf_schema_definition& def) {
+    fmt::print(
+      os, "type: {}, definition: {}", to_string_view(def.type()), def.raw()());
+    return os;
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -150,6 +150,9 @@ private:
     pb::FileDescriptorProto _fdp;
 };
 
+ss::future<const pb::FileDescriptor*> build_file_with_deps(
+  pb::DescriptorPool& dp, sharded_store& store, const canonical_schema& schema);
+
 ///\brief Build a FileDescriptor using the DescriptorPool.
 ///
 /// Dependencies are required to be in the DescriptorPool.
@@ -168,12 +171,41 @@ ss::future<const pb::FileDescriptor*> import_schema(
   sharded_store& store,
   const canonical_schema& schema) {
     try {
-        parser p;
-        auto fdp = p.parse(schema);
-        co_return build_file(dp, fdp);
+        co_return co_await build_file_with_deps(dp, store, schema);
     } catch (const exception& e) {
         throw as_exception(invalid_schema(schema));
     }
+}
+
+///\brief Build a FileDescriptor and import dependencies from the store.
+///
+/// Recursively import dependencies into the DescriptorPool, building the files
+/// on stack unwind.
+ss::future<const pb::FileDescriptor*> build_file_with_deps(
+  pb::DescriptorPool& dp,
+  sharded_store& store,
+  const canonical_schema& schema) {
+    parser p;
+    auto fdp = p.parse(schema);
+
+    const auto dependency_size = fdp.dependency_size();
+    for (int i = 0; i < dependency_size; ++i) {
+        auto sub = subject{fdp.dependency(i)};
+        if (auto fd = dp.FindFileByName(sub()); !fd) {
+            auto sub_schema = co_await store.get_subject_schema(
+              sub, std::nullopt, include_deleted::no);
+
+            co_await build_file_with_deps(
+              dp,
+              store,
+              canonical_schema{
+                sub,
+                std::move(sub_schema.schema).def(),
+                std::move(sub_schema.schema).refs()});
+        }
+    }
+
+    co_return build_file(dp, fdp);
 }
 
 struct protobuf_schema_definition::impl {

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -19,4 +19,10 @@ namespace pandaproxy::schema_registry {
 ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
   sharded_store& store, const canonical_schema& schema);
 
+ss::future<canonical_schema_definition>
+validate_protobuf_schema(sharded_store& store, const canonical_schema& schema);
+
+ss::future<canonical_schema>
+make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema);
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/schema_registry/types.h"
+
+namespace pandaproxy::schema_registry {
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -11,8 +11,12 @@
 
 #pragma once
 
+#include "pandaproxy/schema_registry/fwd.h"
 #include "pandaproxy/schema_registry/types.h"
 
 namespace pandaproxy::schema_registry {
+
+ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
+  sharded_store& store, const canonical_schema& schema);
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -71,6 +71,8 @@ sharded_store::make_canonical_schema(unparsed_schema schema) {
           std::move(schema.refs())};
     }
     case schema_type::protobuf:
+        co_return co_await make_canonical_protobuf_schema(
+          *this, std::move(schema));
     case schema_type::json:
         throw as_exception(invalid_schema_type(schema.type()));
     }
@@ -84,6 +86,8 @@ ss::future<> sharded_store::validate_schema(const canonical_schema& schema) {
         co_return;
     }
     case schema_type::protobuf:
+        co_await validate_protobuf_schema(*this, schema);
+        co_return;
     case schema_type::json:
         throw as_exception(invalid_schema_type(schema.type()));
     }
@@ -96,6 +100,7 @@ sharded_store::make_valid_schema(const canonical_schema& schema) {
     case schema_type::avro:
         co_return make_avro_schema_definition(schema.def().raw()()).value();
     case schema_type::protobuf:
+        co_return co_await make_protobuf_schema_definition(*this, schema);
     case schema_type::json:
         throw as_exception(invalid_schema_type(schema.type()));
     }

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -206,7 +206,9 @@ sharded_store::get_schema_subject_versions(schema_id id) {
 }
 
 ss::future<subject_schema> sharded_store::get_subject_schema(
-  const subject& sub, schema_version version, include_deleted inc_del) {
+  const subject& sub,
+  std::optional<schema_version> version,
+  include_deleted inc_del) {
     auto v_id = (co_await _store.invoke_on(
                    shard_for(sub),
                    _smp_opts,

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -60,9 +60,11 @@ public:
     ss::future<std::vector<subject_version>>
     get_schema_subject_versions(schema_id id);
 
-    ///\brief Return a schema by subject and version.
+    ///\brief Return a schema by subject and version (or latest).
     ss::future<subject_schema> get_subject_schema(
-      const subject& sub, schema_version version, include_deleted inc_dec);
+      const subject& sub,
+      std::optional<schema_version> version,
+      include_deleted inc_dec);
 
     ///\brief Return a list of subjects.
     ss::future<std::vector<subject>> get_subjects(include_deleted inc_del);

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -20,6 +20,7 @@ rp_test(
     consume_to_store.cc
     compatibility_store.cc
     compatibility_3rdparty.cc
+    compatibility_protobuf.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v_pandaproxy_schema_registry
   ARGS "-- -c 1"

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -1,0 +1,77 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/test/compatibility_protobuf.h"
+
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/protobuf.h"
+#include "pandaproxy/schema_registry/sharded_store.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/unit_test.hpp>
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+struct simple_sharded_store {
+    simple_sharded_store() {
+        store.start(ss::default_smp_service_group()).get();
+    }
+    ~simple_sharded_store() { store.stop().get(); }
+    simple_sharded_store(const simple_sharded_store&) = delete;
+    simple_sharded_store(simple_sharded_store&&) = delete;
+    simple_sharded_store& operator=(const simple_sharded_store&) = delete;
+    simple_sharded_store& operator=(simple_sharded_store&&) = delete;
+
+    pps::schema_id
+    insert(const pps::canonical_schema& schema, pps::schema_version version) {
+        const auto id = next_id++;
+        store
+          .upsert(
+            pps::seq_marker{
+              std::nullopt,
+              std::nullopt,
+              version,
+              pps::seq_marker_key_type::schema},
+            schema,
+            id,
+            version,
+            pps::is_deleted::no)
+          .get();
+        return id;
+    }
+
+    pps::schema_id next_id{1};
+    pps::sharded_store store;
+};
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
+    simple_sharded_store store;
+
+    auto schema1 = pps::canonical_schema{pps::subject{"simple"}, simple};
+    auto sch1 = store.insert(schema1, pps::schema_version{1});
+    auto valid_simple
+      = pps::make_protobuf_schema_definition(store.store, schema1).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
+    simple_sharded_store store;
+
+    // imported depends on simple, which han't been inserted
+    auto schema1 = pps::canonical_schema{pps::subject{"imported"}, imported};
+    auto sch1 = store.insert(schema1, pps::schema_version{1});
+    BOOST_REQUIRE_EXCEPTION(
+      pps::make_protobuf_schema_definition(store.store, schema1).get(),
+      pps::exception,
+      [](const pps::exception& ex) {
+          return ex.code() == pps::error_code::schema_invalid;
+      });
+}

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -95,3 +95,28 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported) {
     auto valid_imported_again
       = pps::make_protobuf_schema_definition(store.store, schema3).get();
 }
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
+    simple_sharded_store store;
+
+    auto schema1 = pps::canonical_schema{pps::subject{"simple.proto"}, simple};
+    auto schema2 = pps::canonical_schema{
+      pps::subject{"imported.proto"},
+      imported,
+      {{"simple", pps::subject{"simple.proto"}, pps::schema_version{1}}}};
+    auto schema3 = pps::canonical_schema{
+      pps::subject{"imported-again.proto"},
+      imported_again,
+      {{"imported", pps::subject{"imported.proto"}, pps::schema_version{1}}}};
+
+    auto sch1 = store.insert(schema1, pps::schema_version{1});
+    auto sch2 = store.insert(schema2, pps::schema_version{1});
+    auto sch3 = store.insert(schema3, pps::schema_version{1});
+
+    auto valid_simple
+      = pps::make_protobuf_schema_definition(store.store, schema1).get();
+    auto valid_imported
+      = pps::make_protobuf_schema_definition(store.store, schema2).get();
+    auto valid_imported_again
+      = pps::make_protobuf_schema_definition(store.store, schema3).get();
+}

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -75,3 +75,23 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
           return ex.code() == pps::error_code::schema_invalid;
       });
 }
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_imported) {
+    simple_sharded_store store;
+
+    auto schema1 = pps::canonical_schema{pps::subject{"simple"}, simple};
+    auto schema2 = pps::canonical_schema{pps::subject{"imported"}, imported};
+    auto schema3 = pps::canonical_schema{
+      pps::subject{"imported-again"}, imported_again};
+
+    auto sch1 = store.insert(schema1, pps::schema_version{1});
+    auto sch2 = store.insert(schema2, pps::schema_version{1});
+    auto sch3 = store.insert(schema3, pps::schema_version{1});
+
+    auto valid_simple
+      = pps::make_protobuf_schema_definition(store.store, schema1).get();
+    auto valid_imported
+      = pps::make_protobuf_schema_definition(store.store, schema2).get();
+    auto valid_imported_again
+      = pps::make_protobuf_schema_definition(store.store, schema3).get();
+}

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
@@ -1,0 +1,35 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "pandaproxy/schema_registry/protobuf.h"
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+const auto simple = pps::canonical_schema_definition{
+  R"(
+syntax = "proto3";
+
+message Simple {
+  string id = 1;
+})",
+  pps::schema_type::protobuf};
+
+const auto imported = pps::canonical_schema_definition{
+  R"(
+syntax = "proto3";
+
+import "simple";
+
+message Test2 {
+  Simple id =  1;
+})",
+  pps::schema_type::protobuf};

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.h
@@ -33,3 +33,14 @@ message Test2 {
   Simple id =  1;
 })",
   pps::schema_type::protobuf};
+
+const auto imported_again = pps::canonical_schema_definition{
+  R"(
+syntax = "proto3";
+
+import "imported";
+
+message Test3 {
+  Test2 id =  1;
+})",
+  pps::schema_type::protobuf};

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -135,6 +135,35 @@ private:
     avro::ValidSchema _impl;
 };
 
+class protobuf_schema_definition {
+public:
+    struct impl;
+    using pimpl = ss::shared_ptr<const impl>;
+
+    explicit protobuf_schema_definition(pimpl p)
+      : _impl{std::move(p)} {}
+
+    canonical_schema_definition::raw_string raw() const;
+
+    const impl& operator()() const { return *_impl; }
+
+    friend bool operator==(
+      const protobuf_schema_definition& lhs,
+      const protobuf_schema_definition& rhs);
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const protobuf_schema_definition& rhs);
+
+    constexpr schema_type type() const { return schema_type::protobuf; }
+
+    explicit operator canonical_schema_definition() const {
+        return {raw(), type()};
+    }
+
+private:
+    pimpl _impl;
+};
+
 ///\brief A schema that has been validated.
 class valid_schema {
     using impl = std::variant<avro_schema_definition>;

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -166,7 +166,8 @@ private:
 
 ///\brief A schema that has been validated.
 class valid_schema {
-    using impl = std::variant<avro_schema_definition>;
+    using impl
+      = std::variant<avro_schema_definition, protobuf_schema_definition>;
 
     template<typename T>
     using disable_if_valid_schema = std::


### PR DESCRIPTION
## Cover letter

Support for importing and validating protobuf schema.

Compatibility checks and final wiring-up in the next PR.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/0b189de61167da4a9b11951fe4d73975a5ad741f..eb916d23fda77c94ee2cbebaeeb0219ee182230d)
 * Rebase past conflict in #2850 (`sharded_store::get_subject_schema`)
 * [vtools/305](https://github.com/vectorizedio/vtools/pull/305) is merged
 * Add commit: `build/oss: Add Protobuf 3.18.1`

## Release notes

Release note: none
