### PR TITLE
cloud_storage: Add remote_partition class

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -11,6 +11,7 @@ v_cc_library(
     partition_recovery_manager.cc
     types.cc
     remote_segment.cc
+    remote_partition.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1,0 +1,612 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/remote_partition.h"
+
+#include "cloud_storage/logger.h"
+#include "cloud_storage/offset_translation_layer.h"
+#include "cloud_storage/remote_segment.h"
+#include "cloud_storage/types.h"
+#include "storage/parser_errc.h"
+#include "storage/types.h"
+#include "utils/retry_chain_node.h"
+#include "utils/stream_utils.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/queue.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/temporary_buffer.hh>
+
+#include <chrono>
+#include <exception>
+#include <variant>
+
+using namespace std::chrono_literals;
+
+namespace cloud_storage {
+
+using data_t = model::record_batch_reader::data_t;
+using storage_t = model::record_batch_reader::storage_t;
+
+/// This function returns segment base offset as kafka offset
+static model::offset get_kafka_base_offset(const manifest::segment_meta& m) {
+    // Manifests created with the old version of redpanda won't have the
+    // delta_offset field. In this case the value will be initialized to
+    // model::offset::min(). In this case offset translation couldn't be
+    // performed.
+    auto delta = m.delta_offset == model::offset::min() ? model::offset(0)
+                                                        : m.delta_offset;
+    return m.base_offset - delta;
+}
+
+class partition_record_batch_reader_impl final
+  : public model::record_batch_reader::impl {
+public:
+    explicit partition_record_batch_reader_impl(
+      const log_reader_config& config,
+      ss::lw_shared_ptr<remote_partition> part) noexcept
+      : _ctxlog(cst_log, _rtc, part->get_ntp().path())
+      , _partition(std::move(part))
+      , _it(_partition->_segments.begin())
+      , _end(_partition->_segments.end()) {
+        if (config.abort_source) {
+            vlog(_ctxlog.debug, "abort_source is set");
+            auto sub = config.abort_source->get().subscribe([this]() noexcept {
+                vlog(_ctxlog.debug, "abort requested via config.abort_source");
+                _partition->evict_reader(std::move(_reader));
+                _it = _end;
+            });
+            if (sub) {
+                _as_sub = std::move(*sub);
+            } else {
+                vlog(_ctxlog.debug, "abort_source is triggered in c-tor");
+                _it = _end;
+                _reader = {};
+            }
+        }
+        if (!is_end_of_stream()) {
+            initialize_reader_state(config);
+        }
+    }
+
+    ~partition_record_batch_reader_impl() override = default;
+    partition_record_batch_reader_impl(
+      partition_record_batch_reader_impl&& o) noexcept = delete;
+    partition_record_batch_reader_impl&
+    operator=(partition_record_batch_reader_impl&& o) noexcept = delete;
+    partition_record_batch_reader_impl(
+      const partition_record_batch_reader_impl& o)
+      = delete;
+    partition_record_batch_reader_impl&
+    operator=(const partition_record_batch_reader_impl& o)
+      = delete;
+
+    bool is_end_of_stream() const override { return _it == _end; }
+
+    ss::future<storage_t>
+    do_load_slice(model::timeout_clock::time_point deadline) override {
+        try {
+            if (is_end_of_stream()) {
+                vlog(
+                  _ctxlog.debug,
+                  "partition_record_batch_reader_impl do_load_slice - empty");
+                co_return storage_t{};
+            }
+            if (_reader->config().over_budget) {
+                vlog(_ctxlog.debug, "We're overbudget, stopping");
+                // We need to stop in such way that will keep the
+                // reader in the reusable state, so we could reuse
+                // it on next itertaion
+
+                // The existing state have to be rebuilt
+                _partition->return_reader(std::move(_reader), _it->second);
+                _it = _end;
+                co_return storage_t{};
+            }
+            while (co_await maybe_reset_reader()) {
+                vlog(
+                  _ctxlog.debug,
+                  "Invoking 'read_some' on current log reader {}",
+                  _reader->config());
+                auto result = co_await _reader->read_some(deadline);
+                if (
+                  !result
+                  && result.error() == storage::parser_errc::end_of_stream) {
+                    vlog(_ctxlog.debug, "EOF error while reading from stream");
+                    _reader->config().next_offset_redpanda
+                      = _reader->max_rp_offset() + model::offset(1);
+                    // Next iteration will trigger transition in
+                    // 'maybe_reset_reader'
+                    continue;
+                } else if (!result) {
+                    vlog(_ctxlog.debug, "Unexpected error");
+                    throw std::system_error(result.error());
+                }
+                // empty result will also be propagated here
+                data_t d = std::move(result.value());
+                co_return storage_t{std::move(d)};
+            }
+        } catch (const ss::gate_closed_exception&) {
+            vlog(
+              _ctxlog.debug,
+              "gate_closed_exception while reading from remote_partition");
+            _it = _end;
+            _reader = {};
+        }
+        vlog(
+          _ctxlog.debug,
+          "EOS reached, reader available: {}, is end of stream: {}",
+          static_cast<bool>(_reader),
+          is_end_of_stream());
+        co_return storage_t{};
+    }
+
+    void print(std::ostream& o) override {
+        o << "cloud_storage_partition_record_batch_reader";
+    }
+
+private:
+    // Initialize object using remote_partition as a source
+    void initialize_reader_state(const log_reader_config& config) {
+        vlog(
+          _ctxlog.debug,
+          "partition_record_batch_reader_impl initialize reader state");
+        auto lookup_result = find_cached_reader(config);
+        if (lookup_result) {
+            auto&& [reader, it] = lookup_result.value();
+            _reader = std::move(reader);
+            _it = it;
+            return;
+        }
+        vlog(
+          _ctxlog.debug,
+          "partition_record_batch_reader_impl initialize reader state - "
+          "segment not "
+          "found");
+        _it = _end;
+        _reader = {};
+    }
+
+    struct cache_reader_lookup_result {
+        std::unique_ptr<remote_segment_batch_reader> reader;
+        remote_partition::segment_map_t::iterator iter;
+    };
+
+    std::optional<cache_reader_lookup_result>
+    find_cached_reader(const log_reader_config& config) {
+        if (!_partition || _partition->_segments.empty()) {
+            return std::nullopt;
+        }
+        auto it = _partition->_segments.upper_bound(config.start_offset);
+        if (it != _partition->_segments.begin()) {
+            it = std::prev(it);
+        }
+        auto reader = _partition->borrow_reader(config, it->first, it->second);
+        // Here we know the exact type of the reader_state because of
+        // the invariant of the borrow_reader
+        const auto& segment
+          = std::get<remote_partition::materialized_segment_ptr>(it->second)
+              ->segment;
+        vlog(
+          _ctxlog.debug,
+          "segment offset range {}-{}, delta: {}",
+          segment->get_base_rp_offset(),
+          segment->get_max_rp_offset(),
+          segment->get_base_offset_delta());
+        return {{.reader = std::move(reader), .iter = it}};
+    }
+
+    /// Reset reader if current segment is fully consumed.
+    /// The object may transition onto a next segment or
+    /// it will transtion into completed state with no reader
+    /// attached.
+    ss::future<bool> maybe_reset_reader() {
+        vlog(_ctxlog.debug, "maybe_reset_reader called");
+        if (!_reader) {
+            co_return false;
+        }
+        if (_reader->config().start_offset > _reader->config().max_offset) {
+            vlog(
+              _ctxlog.debug,
+              "maybe_reset_stream called - stream already consumed, start "
+              "{}, "
+              "max {}",
+              _reader->config().start_offset,
+              _reader->config().max_offset);
+            // Entire range is consumed, detach from remote_partition and
+            // close the reader.
+            co_await set_end_of_stream();
+            co_return false;
+        }
+        vlog(
+          _ctxlog.debug,
+          "maybe_reset_reader, config next_offset_redpanda: {}, start_offset: "
+          "{}, reader max_offset: {}",
+          _reader->config().next_offset_redpanda,
+          _reader->config().start_offset,
+          _reader->max_rp_offset());
+        if (_reader->config().next_offset_redpanda > _reader->max_rp_offset()) {
+            // move to the next segment
+            vlog(_ctxlog.debug, "maybe_reset_stream condition triggered");
+            _it++;
+            // We're comparing to the cached _end instead of
+            // _partition->_segments.end() to avoid the following pitfall. If
+            // the currently referenced segment has no data batches and we get
+            // to this point, but at the same time the new segment with the same
+            // base_offset (in kafka terms) was added to the map this new
+            // segment will replace the current one and we won't read it (since
+            // we're already done with the segment). This isn't a problem since
+            // we will just stop and the next fetch request will be able to read
+            // the data. But if not one but two or more segments were added to
+            // the _segments map we will just skip the segment with the same
+            // base_offset and proceed with the next one. The client will see a
+            // gap. The caching of the _segments.end() prevents this.
+            if (_it == _end) {
+                co_await set_end_of_stream();
+            } else {
+                // reuse config but replace the reader
+                auto config = _reader->config();
+                _partition->evict_reader(std::move(_reader));
+                vlog(_ctxlog.debug, "initializing new segment reader");
+                _reader = _partition->borrow_reader(
+                  config, _it->first, _it->second);
+            }
+        }
+        vlog(
+          _ctxlog.debug,
+          "maybe_reset_stream completed {} {}",
+          static_cast<bool>(_reader),
+          is_end_of_stream());
+        co_return static_cast<bool>(_reader);
+    }
+
+    /// Transition reader to the completed state. Stop tracking state in
+    /// the 'remote_partition'
+    ss::future<> set_end_of_stream() {
+        co_await _reader->stop();
+        _it = _partition->_segments.end();
+        _reader = {};
+    }
+
+    retry_chain_node _rtc;
+    retry_chain_logger _ctxlog;
+
+    ss::lw_shared_ptr<remote_partition> _partition;
+    /// Currently accessed segment
+    remote_partition::segment_map_t::iterator _it;
+    remote_partition::segment_map_t::iterator _end;
+    /// Reader state that was borrowed from the materialized_segment_state
+    std::unique_ptr<remote_segment_batch_reader> _reader;
+    /// Cancelation subscription
+    ss::abort_source::subscription _as_sub;
+};
+
+remote_partition::remote_partition(
+  const manifest& m, remote& api, cache& c, s3::bucket_name bucket)
+  : _rtc()
+  , _ctxlog(cst_log, _rtc, m.get_ntp().path())
+  , _api(api)
+  , _cache(c)
+  , _manifest(m)
+  , _bucket(std::move(bucket))
+  , _stm_jitter(stm_jitter_duration) {}
+
+ss::future<> remote_partition::start() {
+    update_segments_incrementally();
+    (void)run_eviction_loop();
+
+    _stm_timer.set_callback([this] {
+        gc_stale_materialized_segments();
+        if (!_as.abort_requested()) {
+            _stm_timer.rearm(_stm_jitter());
+        }
+    });
+    _stm_timer.rearm(_stm_jitter());
+    co_return;
+}
+
+ss::future<> remote_partition::run_eviction_loop() {
+    // Evict readers asynchronously
+    gate_guard g(_gate);
+    try {
+        while (!_as.abort_requested()) {
+            co_await _cvar.wait([this] {
+                return _as.abort_requested() || !_eviction_list.empty();
+            });
+            auto tmp_list = std::exchange(_eviction_list, {});
+            for (auto& rs : tmp_list) {
+                co_await std::visit([](auto&& rs) { return rs->stop(); }, rs);
+            }
+        }
+    } catch (const ss::broken_condition_variable&) {
+    }
+    vlog(_ctxlog.debug, "remote partition eviction loop stopped");
+}
+
+void remote_partition::gc_stale_materialized_segments() {
+    vlog(
+      _ctxlog.debug,
+      "collecting stale materialized segments, {} segments materialized, {} "
+      "segments total",
+      _materialized.size(),
+      _segments.size());
+    auto now = ss::lowres_clock::now();
+    std::vector<model::offset> offsets;
+    for (auto& st : _materialized) {
+        if (
+          now - st.atime > stm_max_idle_time
+          && !st.segment->download_in_progress() && st.segment.owned()) {
+            vlog(
+              _ctxlog.debug,
+              "reader for segment with base offset {} is stale",
+              st.offset_key);
+            // this will delete and unlink the object from
+            // _materialized collection
+            offsets.push_back(st.offset_key);
+        }
+    }
+    vlog(_ctxlog.debug, "found {} eviction candidates ", offsets.size());
+    for (auto o : offsets) {
+        vlog(_ctxlog.debug, "about to offload segment {}", o);
+        auto it = _segments.find(o);
+        vassert(it != _segments.end(), "Can't find offset {}", o);
+        auto tmp = std::visit(
+          [this](auto&& st) { return st->offload(this); }, _segments[o]);
+        _segments[o] = std::move(tmp);
+    }
+}
+
+model::offset remote_partition::first_uploaded_offset() {
+    vassert(
+      _manifest.size() > 0,
+      "The manifest for {} is not expected to be empty",
+      _manifest.get_ntp());
+    try {
+        if (_first_uploaded_offset) {
+            return *_first_uploaded_offset;
+        }
+        model::offset starting_offset = model::offset::max();
+        for (const auto& m : _manifest) {
+            starting_offset = std::min(
+              starting_offset, get_kafka_base_offset(m.second));
+        }
+        _first_uploaded_offset = starting_offset;
+        vlog(
+          _ctxlog.debug,
+          "remote partition first_uploaded_offset set to {}",
+          starting_offset);
+        return starting_offset;
+    } catch (...) {
+        vlog(
+          _ctxlog.error,
+          "remote partition first_uploaded_offset error {}",
+          std::current_exception());
+
+        throw;
+    }
+}
+
+const model::ntp& remote_partition::get_ntp() const {
+    return _manifest.get_ntp();
+}
+
+bool remote_partition::is_data_available() const {
+    return _manifest.size() > 0;
+}
+
+ss::future<> remote_partition::stop() {
+    vlog(_ctxlog.debug, "remote partition stop {} segments", _segments.size());
+    _as.request_abort();
+    _stm_timer.cancel();
+    _cvar.broken();
+
+    co_await _gate.close();
+
+    for (auto& [offset, seg] : _segments) {
+        vlog(_ctxlog.debug, "remote partition stop {}", offset);
+        co_await std::visit([](auto&& st) { return st->stop(); }, seg);
+    }
+}
+
+void remote_partition::update_segments_incrementally() {
+    vlog(_ctxlog.debug, "remote partition update segments incrementally");
+    // find new segments
+    for (const auto& meta : _manifest) {
+        auto o = get_kafka_base_offset(meta.second);
+        auto prev_it = _segments.find(o);
+        if (prev_it != _segments.end()) {
+            // The key can be in the map in two cases:
+            // - we've already added the segment to the map
+            // - the key that we've added previously doesn't have data batches
+            //   in this case it can be safely replaced by the new one
+            auto prev_key = std::visit(
+              [](auto&& p) { return p->manifest_key; }, prev_it->second);
+            auto prev_meta = _manifest.get(prev_key);
+            vassert(prev_meta, "Can't find key in the manifest");
+            if (
+              meta.second == *prev_meta
+              || prev_meta->base_offset > meta.second.base_offset) {
+                // This path can be taken if we've already added the
+                // segment with data batches and the current segment
+                // that the loop is checking doesn't have any.
+                // The check works because if we have two segments and
+                // one of them doesn't have data batches, the one that
+                // have data batches will have larger base_offset (in
+                // redpanda terms). Note that the key in the map is a
+                // kafka offset.
+                continue;
+            }
+            vlog(
+              _ctxlog.debug,
+              "Segment with kafka-offset {} will be replaced. New segment "
+              "{{base: {}, max: {}, delta: {}}}, previous segment "
+              "{{base: {}, max: {}, delta: {}}}",
+              o,
+              meta.second.base_offset,
+              meta.second.committed_offset,
+              meta.second.delta_offset,
+              prev_meta->base_offset,
+              prev_meta->committed_offset,
+              prev_meta->delta_offset);
+
+            std::visit([this](auto&& p) { p->offload(this); }, prev_it->second);
+        }
+        _segments[o] = std::make_unique<offloaded_segment_state>(meta.first);
+    }
+}
+
+/// Materialize segment if needed and create a reader
+std::unique_ptr<remote_segment_batch_reader> remote_partition::borrow_reader(
+  log_reader_config config, model::offset key, segment_state& st) {
+    struct visit_materialize_make_reader {
+        segment_state& state;
+        remote_partition* part;
+        const log_reader_config& config;
+        const model::offset offset_key;
+
+        std::unique_ptr<remote_segment_batch_reader>
+        operator()(offloaded_segment_ptr& st) {
+            auto tmp = st->materialize(*part, offset_key);
+            auto res = tmp->borrow_reader(config, part->_ctxlog);
+            state = std::move(tmp);
+            return res;
+        }
+        std::unique_ptr<remote_segment_batch_reader>
+        operator()(materialized_segment_ptr& st) {
+            return st->borrow_reader(config, part->_ctxlog);
+        }
+    };
+    return std::visit(
+      visit_materialize_make_reader{
+        .state = st, .part = this, .config = config, .offset_key = key},
+      st);
+}
+
+/// Return reader back to segment_state
+void remote_partition::return_reader(
+  std::unique_ptr<remote_segment_batch_reader> reader, segment_state& st) {
+    struct visit_return_reader {
+        remote_partition* part;
+        std::unique_ptr<remote_segment_batch_reader> reader;
+
+        void operator()(offloaded_segment_ptr&) {
+            part->evict_reader(std::move(reader));
+        }
+        void operator()(materialized_segment_ptr& st) {
+            st->return_reader(std::move(reader));
+        }
+    };
+    std::visit(
+      visit_return_reader{.part = this, .reader = std::move(reader)}, st);
+}
+
+ss::future<model::record_batch_reader> remote_partition::make_reader(
+  storage::log_reader_config config,
+  std::optional<model::timeout_clock::time_point> deadline) {
+    std::ignore = deadline;
+    gate_guard g(_gate);
+    vlog(
+      _ctxlog.debug,
+      "remote partition make_reader invoked, config: {}, num segments {}",
+      config,
+      _segments.size());
+    if (_segments.size() < _manifest.size()) {
+        update_segments_incrementally();
+    }
+    auto impl = std::make_unique<partition_record_batch_reader_impl>(
+      log_reader_config(config), shared_from_this());
+    model::record_batch_reader rdr(std::move(impl));
+    co_return rdr;
+}
+
+remote_partition::offloaded_segment_state::offloaded_segment_state(
+  manifest::key key)
+  : manifest_key(std::move(key)) {}
+
+std::unique_ptr<remote_partition::materialized_segment_state>
+remote_partition::offloaded_segment_state::materialize(
+  remote_partition& p, model::offset offset_key) {
+    auto st = std::make_unique<materialized_segment_state>(
+      manifest_key, offset_key, p);
+    return st;
+}
+
+ss::future<> remote_partition::offloaded_segment_state::stop() {
+    return ss::now();
+}
+
+std::unique_ptr<remote_partition::offloaded_segment_state>
+remote_partition::offloaded_segment_state::offload(remote_partition*) {
+    auto st = std::make_unique<offloaded_segment_state>(manifest_key);
+    return st;
+}
+
+remote_partition::materialized_segment_state::materialized_segment_state(
+  manifest::key mk, model::offset off_key, remote_partition& p)
+  : manifest_key(std::move(mk))
+  , offset_key(off_key)
+  , segment(ss::make_lw_shared<remote_segment>(
+      p._api, p._cache, p._bucket, p._manifest, manifest_key, p._rtc))
+  , atime(ss::lowres_clock::now()) {
+    p._materialized.push_back(*this);
+}
+
+void remote_partition::materialized_segment_state::return_reader(
+  std::unique_ptr<remote_segment_batch_reader> state) {
+    atime = ss::lowres_clock::now();
+    readers.push_back(std::move(state));
+}
+
+/// Borrow reader or make a new one.
+/// In either case return a reader.
+std::unique_ptr<remote_segment_batch_reader>
+remote_partition::materialized_segment_state::borrow_reader(
+  const log_reader_config& cfg, retry_chain_logger& ctxlog) {
+    atime = ss::lowres_clock::now();
+    for (auto it = readers.begin(); it != readers.end(); it++) {
+        if ((*it)->config().start_offset == cfg.start_offset) {
+            // here we're reusing the existing reader
+            auto tmp = std::move(*it);
+            tmp->config() = cfg;
+            readers.erase(it);
+            vlog(
+              ctxlog.debug,
+              "reusing existing reader, config: {}",
+              tmp->config());
+            return tmp;
+        }
+    }
+    vlog(ctxlog.debug, "creating new reader, config: {}", cfg);
+    return std::make_unique<remote_segment_batch_reader>(segment, cfg);
+}
+
+ss::future<> remote_partition::materialized_segment_state::stop() {
+    for (auto& rs : readers) {
+        co_await rs->stop();
+    }
+    co_await segment->stop();
+}
+
+std::unique_ptr<remote_partition::offloaded_segment_state>
+remote_partition::materialized_segment_state::offload(
+  remote_partition* partition) {
+    _hook.unlink();
+    for (auto&& rs : readers) {
+        partition->evict_reader(std::move(rs));
+    }
+    partition->evict_segment(std::move(segment));
+    auto st = std::make_unique<offloaded_segment_state>(manifest_key);
+    return st;
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/offset_translation_layer.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/remote_segment.h"
+#include "cloud_storage/types.h"
+#include "model/metadata.h"
+#include "s3/client.h"
+#include "storage/ntp_config.h"
+#include "storage/types.h"
+#include "utils/intrusive_list_helpers.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/weak_ptr.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+namespace cloud_storage {
+
+class partition_record_batch_reader_impl;
+
+/// Remote partition manintains list of remote segments
+/// and list of active readers. Only one reader can be
+/// maintained per segment. The idea here is that the
+/// subsequent `make_reader` calls should reuse cached
+/// readers. We can expect that the historical reads
+/// won't conflict frequently. The conflict will result
+/// in rescan of the segment (since we don't have indexes
+/// for remote segments).
+class remote_partition
+  : public ss::enable_lw_shared_from_this<remote_partition> {
+    friend class partition_record_batch_reader_impl;
+
+    static constexpr ss::lowres_clock::duration stm_jitter_duration = 10s;
+    static constexpr ss::lowres_clock::duration stm_max_idle_time = 60s;
+
+public:
+    /// C-tor
+    ///
+    /// The manifest's lifetime should be bound to the lifetime of the owner
+    /// of the remote_partition.
+    remote_partition(
+      const manifest& m, remote& api, cache& c, s3::bucket_name bucket);
+
+    /// Start remote partition
+    ss::future<> start();
+
+    /// Stop remote partition
+    ///
+    /// This will stop all readers and background gc loop
+    ss::future<> stop();
+
+    /// Create a reader
+    ///
+    /// Note that config.start_offset and config.max_offset are kafka offsets.
+    /// All offset translation is done internally. The returned record batch
+    /// reader will produce batches with kafka offsets and the config will be
+    /// updated using kafka offsets.
+    ss::future<model::record_batch_reader> make_reader(
+      storage::log_reader_config config,
+      std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
+
+    /// Return first uploaded kafka offset
+    model::offset first_uploaded_offset();
+
+    /// Get partition NTP
+    const model::ntp& get_ntp() const;
+
+    /// Returns true if at least one segment is uploaded to the bucket
+    bool is_data_available() const;
+
+private:
+    /// Create new remote_segment instances for all new
+    /// items in the manifest.
+    void update_segments_incrementally();
+
+    ss::future<> run_eviction_loop();
+
+    void gc_stale_materialized_segments();
+
+    friend struct offloaded_segment_state;
+
+    struct materialized_segment_state;
+
+    /// State that have to be materialized before use
+    struct offloaded_segment_state {
+        explicit offloaded_segment_state(manifest::key key);
+
+        std::unique_ptr<materialized_segment_state>
+        materialize(remote_partition& p, model::offset offset_key);
+
+        ss::future<> stop();
+
+        std::unique_ptr<offloaded_segment_state> offload(remote_partition*);
+
+        manifest::key manifest_key;
+    };
+
+    /// State with materialized segment and cached reader
+    ///
+    /// The object represent the state in which there is(or was) at
+    /// least one active reader that consumes data from the
+    /// remote segment.
+    struct materialized_segment_state {
+        materialized_segment_state(
+          manifest::key mk, model::offset offk, remote_partition& p);
+
+        void return_reader(std::unique_ptr<remote_segment_batch_reader> reader);
+
+        /// Borrow reader or make a new one.
+        /// In either case return a reader.
+        std::unique_ptr<remote_segment_batch_reader>
+        borrow_reader(const log_reader_config& cfg, retry_chain_logger& ctxlog);
+
+        ss::future<> stop();
+
+        std::unique_ptr<offloaded_segment_state>
+        offload(remote_partition* partition);
+
+        /// Key of the segment metatdata in the manifest
+        manifest::key manifest_key;
+        /// Key of the segment in _segments collection of the remote_partition
+        model::offset offset_key;
+        ss::lw_shared_ptr<remote_segment> segment;
+        /// Batch readers that can be used to scan the segment
+        std::list<std::unique_ptr<remote_segment_batch_reader>> readers;
+        /// Reader access time
+        ss::lowres_clock::time_point atime;
+        /// List hook for the list of all materalized segments
+        intrusive_list_hook _hook;
+    };
+
+    using offloaded_segment_ptr = std::unique_ptr<offloaded_segment_state>;
+    using materialized_segment_ptr
+      = std::unique_ptr<materialized_segment_state>;
+    using segment_state
+      = std::variant<offloaded_segment_ptr, materialized_segment_ptr>;
+
+    /// Materialize segment if needed and create a reader
+    ///
+    /// \param config is a reader config
+    /// \param offset_key is an key of the segment state in the _segments
+    /// \param st is a segment state referenced by offset_key
+    std::unique_ptr<remote_segment_batch_reader> borrow_reader(
+      log_reader_config config, model::offset offset_key, segment_state& st);
+
+    /// Return reader back to segment_state
+    void return_reader(
+      std::unique_ptr<remote_segment_batch_reader>, segment_state& st);
+
+    /// Put reader into the eviction list which will
+    /// eventually lead to it being closed and deallocated
+    void evict_reader(std::unique_ptr<remote_segment_batch_reader> reader) {
+        _eviction_list.push_back(std::move(reader));
+        _cvar.signal();
+    }
+    void evict_segment(ss::lw_shared_ptr<remote_segment> segment) {
+        _eviction_list.push_back(std::move(segment));
+        _cvar.signal();
+    }
+
+    using segment_map_t = std::map<model::offset, segment_state>;
+
+    using evicted_resource_t = std::variant<
+      std::unique_ptr<remote_segment_batch_reader>,
+      ss::lw_shared_ptr<remote_segment>>;
+
+    using eviction_list_t = std::deque<evicted_resource_t>;
+
+    retry_chain_node _rtc;
+    retry_chain_logger _ctxlog;
+    ss::gate _gate;
+    ss::abort_source _as;
+    remote& _api;
+    cache& _cache;
+    const manifest& _manifest;
+    std::optional<model::offset> _first_uploaded_offset;
+    s3::bucket_name _bucket;
+    segment_map_t _segments;
+    eviction_list_t _eviction_list;
+    intrusive_list<
+      materialized_segment_state,
+      &materialized_segment_state::_hook>
+      _materialized;
+    ss::condition_variable _cvar;
+    /// Timer use to periodically evict stale readers
+    ss::timer<ss::lowres_clock> _stm_timer;
+    simple_time_jitter<ss::lowres_clock> _stm_jitter;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -25,7 +25,9 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/queue.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/timed_out_error.hh>
 #include <seastar/util/log.hh>
 
 #include <exception>
@@ -34,11 +36,8 @@ namespace cloud_storage {
 
 static constexpr size_t max_consume_size = 128_KiB;
 
-static const ss::lowres_clock::duration cache_hydration_timeout = 30s;
-static const ss::lowres_clock::duration cache_hydration_backoff = 250ms;
-static const ss::lowres_clock::duration cache_poll_timeout
-  = cache_hydration_timeout;
-static const ss::lowres_clock::duration cache_poll_interval = 100ms;
+static ss::lowres_clock::duration cache_hydration_timeout = 60s;
+static ss::lowres_clock::duration cache_hydration_backoff = 250ms;
 
 download_exception::download_exception(
   download_result r, std::filesystem::path p)
@@ -63,6 +62,10 @@ const char* download_exception::what() const noexcept {
     __builtin_unreachable();
 }
 
+inline void expiry_handler_impl(ss::promise<std::filesystem::path>& pr) {
+    pr.set_exception(ss::timed_out_error());
+}
+
 remote_segment::remote_segment(
   remote& r,
   cache& c,
@@ -76,7 +79,11 @@ remote_segment::remote_segment(
   , _manifest(m)
   , _path(std::move(path))
   , _rtc(&parent)
-  , _ctxlog(cst_log, _rtc, get_ntp().path()) {}
+  , _ctxlog(cst_log, _rtc, get_ntp().path())
+  , _wait_list(expiry_handler_impl) {
+    // run hydration loop in the background
+    (void)run_hydrate_bg();
+}
 
 const model::ntp& remote_segment::get_ntp() const {
     return _manifest.get_ntp();
@@ -125,62 +132,111 @@ const model::term_id remote_segment::get_term() const {
 
 ss::future<> remote_segment::stop() {
     vlog(_ctxlog.debug, "remote segment stop");
-    _as.request_abort();
+    _bg_cvar.broken();
     return _gate.close();
 }
 
 ss::future<ss::input_stream<char>>
-remote_segment::data_stream(size_t pos, ss::io_priority_class io_priority) {
+remote_segment::data_stream(size_t pos, ss::io_priority_class) {
     vlog(_ctxlog.debug, "remote segment file input stream at {}", pos);
     ss::gate::holder g(_gate);
     // Hydrate segment on disk
     auto full_path = co_await hydrate();
     // Create a file stream
-    auto opt = co_await _cache.get(full_path, pos, io_priority);
+    auto opt = co_await _cache.get(full_path, pos);
     if (opt) {
         co_return std::move(opt->body);
     }
     throw remote_segment_exception(
-      fmt::format("Segment {} is not in the cache", full_path));
+      fmt::format("Segment {} already evicted", full_path));
+}
+
+ss::future<> remote_segment::run_hydrate_bg() {
+    ss::gate::holder guard(_gate);
+    auto full_path = _manifest.get_remote_segment_path(_path);
+    try {
+        while (!_gate.is_closed()) {
+            co_await _bg_cvar.wait(
+              [this] { return !_wait_list.empty() || _gate.is_closed(); });
+            vlog(
+              _ctxlog.info,
+              "Start hydrating segment {}, {} consumers are awaiting",
+              full_path,
+              _wait_list.size());
+            auto status = co_await _cache.is_cached(full_path);
+            std::exception_ptr err;
+            switch (status) {
+            case cache_element_status::in_progress:
+                vassert(
+                  false,
+                  "Hydration of segment {} is already in progress, {} waiters",
+                  full_path,
+                  _wait_list.size());
+            case cache_element_status::available:
+                vlog(
+                  _ctxlog.debug,
+                  "Hydrated segment {} is already available, {} waiters will "
+                  "be invoked",
+                  full_path,
+                  _wait_list.size());
+                break;
+            case cache_element_status::not_available: {
+                vlog(_ctxlog.info, "Hydrating segment {}", full_path);
+                auto callback =
+                  [this, full_path](
+                    uint64_t size_bytes,
+                    ss::input_stream<char> s) -> ss::future<uint64_t> {
+                    co_await _cache.put(full_path, s).finally([&s] {
+                        return s.close();
+                    });
+                    co_return size_bytes;
+                };
+                retry_chain_node local_rtc(
+                  cache_hydration_timeout, cache_hydration_backoff, &_rtc);
+                auto res = co_await _api.download_segment(
+                  _bucket, _path, _manifest, callback, local_rtc);
+                if (res != download_result::success) {
+                    vlog(
+                      _ctxlog.debug,
+                      "Failed to hydrating a segment {}, {} waiter will be "
+                      "invoked",
+                      full_path,
+                      _wait_list.size());
+                    err = std::make_exception_ptr(
+                      download_exception(res, full_path));
+                }
+            } break;
+            }
+            while (!_wait_list.empty()) {
+                auto& p = _wait_list.front();
+                if (err) {
+                    p.set_exception(err);
+                } else {
+                    p.set_value(full_path);
+                }
+                _wait_list.pop_front();
+            }
+        }
+    } catch (const ss::broken_condition_variable&) {
+        vlog(_ctxlog.info, "Hydraton loop is stopped");
+    } catch (...) {
+        vlog(
+          _ctxlog.error,
+          "Error in hydraton loop: {}",
+          std::current_exception());
+    }
 }
 
 ss::future<std::filesystem::path> remote_segment::hydrate() {
-    ss::gate::holder g(_gate);
-    auto full_path = _manifest.get_remote_segment_path(_path);
-    vlog(_ctxlog.debug, "hydrating segment {}", full_path);
-    auto poll_deadline = ss::lowres_clock::now() + cache_poll_timeout;
-    while (co_await _cache.is_cached(full_path)
-           == cache_element_status::in_progress) {
-        vlog(
-          _ctxlog.debug,
-          "segment {} is being written to cache, waiting...",
-          full_path);
-        // poll cache periodically until status changes
-        co_await ss::sleep_abortable(cache_poll_interval, _as);
-        if (ss::lowres_clock::now() > poll_deadline) {
-            break;
-        }
-    }
-    if (
-      co_await _cache.is_cached(full_path) == cache_element_status::available) {
-        vlog(_ctxlog.debug, "{} is in the cache already", full_path);
-        co_return full_path;
-    }
-    vlog(_ctxlog.debug, "Hydrating a segment {}", full_path);
-    auto callback = [this, full_path](
-                      uint64_t size_bytes,
-                      ss::input_stream<char> s) -> ss::future<uint64_t> {
-        co_await _cache.put(full_path, s).finally([&s] { return s.close(); });
-        co_return size_bytes;
-    };
-    retry_chain_node local_rtc(
-      cache_hydration_timeout, cache_hydration_backoff, &_rtc);
-    auto res = co_await _api.download_segment(
-      _bucket, _path, _manifest, callback, local_rtc);
-    if (res != download_result::success) {
-        throw download_exception(res, full_path);
-    }
-    co_return full_path;
+    return ss::with_gate(_gate, [this] {
+        auto full_path = _manifest.get_remote_segment_path(_path);
+        vlog(_ctxlog.debug, "segment {} hydration requested", full_path);
+        ss::promise<std::filesystem::path> p;
+        auto fut = p.get_future();
+        _wait_list.push_back(std::move(p), ss::lowres_clock::time_point::max());
+        _bg_cvar.signal();
+        return fut;
+    });
 }
 
 /// Batch consumer that connects to remote_segment_batch_reader.
@@ -248,13 +304,18 @@ public:
     ///
     /// \param header is a record batch header with redpanda offset
     /// \note this can only be applied to current record batch
-    void advance_config_start_offset(
-      const model::record_batch_header& header) noexcept {
-        auto next = rp_to_kafka(header.last_offset()) + model::offset(1);
-        if (next > _config.start_offset) {
-            _config.start_offset = next;
-            _config.start_offset_redpanda = header.last_offset()
-                                            + model::offset(1);
+    void
+    advance_config_offsets(const model::record_batch_header& header) noexcept {
+        if (header.type == model::record_batch_type::raft_data) {
+            auto next = rp_to_kafka(header.last_offset()) + model::offset(1);
+            if (next > _config.start_offset) {
+                _config.start_offset = next;
+            }
+        }
+
+        auto next_rp = header.last_offset() + model::offset{1};
+        if (next_rp > _config.next_offset_redpanda) {
+            _config.next_offset_redpanda = next_rp;
         }
     }
 
@@ -292,7 +353,10 @@ public:
               rp_to_kafka(header.last_offset()) < _config.start_offset)) {
             vlog(
               _ctxlog.debug,
-              "accept_batch_start skip becuse {} < {}(kafka offset)",
+              "accept_batch_start skip because "
+              "last_kafka_offset {} (last_rp_offset: {}) < "
+              "config.start_offset: {}",
+              rp_to_kafka(header.last_offset()),
               header.last_offset(),
               _config.start_offset);
             return batch_consumer::consume_result::skip_batch;
@@ -341,10 +405,10 @@ public:
         // changing the _delta. The _delta that is be used for current record
         // batch can only account record batches in all previous batches.
         vlog(
-          _ctxlog.trace, "skip_batch_start called for {}", header.base_offset);
-        advance_config_start_offset(header);
+          _ctxlog.debug, "skip_batch_start called for {}", header.base_offset);
+        advance_config_offsets(header);
         if (header.type != model::record_batch_type::raft_data) {
-            ++_delta;
+            _delta += header.last_offset_delta + model::offset{1};
         }
     }
 
@@ -356,17 +420,12 @@ public:
           _header, std::move(_records), model::record_batch::tag_ctor_ng{}};
 
         _config.bytes_consumed += batch.size_bytes();
-        advance_config_start_offset(batch.header());
+        advance_config_offsets(batch.header());
 
         // NOTE: we need to translate offset of the batch after we updated
         // start offset of the config since it assumes that the header has
         // redpanda offset.
         batch.header().base_offset = rp_to_kafka(batch.base_offset());
-
-        vlog(
-          _ctxlog.trace,
-          "consume_batch_end called, produce {}",
-          batch.header());
 
         size_t sz = _parent.produce(std::move(batch));
 
@@ -393,46 +452,29 @@ private:
     model::term_id _term;
     model::offset _delta;
     retry_chain_node _rtc;
-    mutable retry_chain_logger _ctxlog;
+    retry_chain_logger _ctxlog;
 };
 
 remote_segment_batch_reader::remote_segment_batch_reader(
-  remote_segment& s, log_reader_config& config, model::term_id term) noexcept
-  : _rtc(s.get_retry_chain_node())
-  , _ctxlog(cst_log, _rtc, s.get_ntp().path())
-  , _seg(s)
+  ss::lw_shared_ptr<remote_segment> s, const log_reader_config& config) noexcept
+  : _seg(std::move(s))
   , _config(config)
-  , _term(term)
-  , _initial_delta(s.get_base_offset_delta()) {}
+  , _rtc(_seg->get_retry_chain_node())
+  , _ctxlog(cst_log, _rtc, _seg->get_ntp().path())
+  , _initial_delta(_seg->get_base_offset_delta()) {}
 
 ss::future<result<ss::circular_buffer<model::record_batch>>>
 remote_segment_batch_reader::read_some(
   model::timeout_clock::time_point deadline) {
-    vlog(
-      _ctxlog.debug,
-      "remote_segment_batch_reader::read_some(1) - done={}, ringbuf size={}",
-      _done,
-      _ringbuf.size());
-    if (_done) {
-        co_return storage::parser_errc::end_of_stream;
-    }
     if (_ringbuf.empty()) {
-        if (!_parser && !_done) {
+        if (!_parser) {
             _parser = co_await init_parser();
         }
         auto bytes_consumed = co_await _parser->consume();
         if (!bytes_consumed) {
             co_return bytes_consumed.error();
         }
-        if (bytes_consumed.value() == 0) {
-            _done = true;
-        }
     }
-    vlog(
-      _ctxlog.debug,
-      "remote_segment_batch_reader::read_some(2) - done={}, ringbuf size={}",
-      _done,
-      _ringbuf.size());
     _total_size = 0;
     co_return std::move(_ringbuf);
 }
@@ -440,11 +482,16 @@ remote_segment_batch_reader::read_some(
 ss::future<std::unique_ptr<storage::continuous_batch_parser>>
 remote_segment_batch_reader::init_parser() {
     vlog(_ctxlog.debug, "remote_segment_batch_reader::init_parser");
-    auto stream = co_await _seg.data_stream(
+    auto stream = co_await _seg->data_stream(
       0, priority_manager::local().shadow_indexing_priority());
     auto parser = std::make_unique<storage::continuous_batch_parser>(
       std::make_unique<remote_segment_batch_consumer>(
-        _config, *this, _term, _initial_delta, _seg.get_ntp(), _rtc),
+        _config,
+        *this,
+        _seg->get_term(),
+        _initial_delta,
+        _seg->get_ntp(),
+        *_seg->get_retry_chain_node()),
       std::move(stream));
     co_return parser;
 }

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ rp_test(
     cache_test.cc  
     offset_translation_layer_test.cc 
     remote_segment_test.cc 
+    remote_partition_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::cloud_storage v::storage_test_utils
   ARGS "-- -c 1"

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -1,0 +1,919 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "cloud_storage/manifest.h"
+#include "cloud_storage/offset_translation_layer.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/remote_partition.h"
+#include "cloud_storage/remote_segment.h"
+#include "cloud_storage/tests/cloud_storage_fixture.h"
+#include "cloud_storage/tests/common_def.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/types.h"
+#include "model/metadata.h"
+#include "model/record.h"
+#include "model/record_batch_types.h"
+#include "model/timeout_clock.h"
+#include "s3/client.h"
+#include "seastarx.h"
+#include "storage/log.h"
+#include "storage/log_manager.h"
+#include "storage/segment.h"
+#include "storage/types.h"
+#include "test_utils/async.h"
+#include "test_utils/fixture.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <exception>
+#include <numeric>
+#include <random>
+
+using namespace std::chrono_literals;
+using namespace cloud_storage;
+
+inline ss::logger test_log("test"); // NOLINT
+
+static std::unique_ptr<storage::continuous_batch_parser>
+make_recording_batch_parser(
+  iobuf buf,
+  std::vector<model::record_batch_header>& headers,
+  std::vector<iobuf>& records,
+  std::vector<uint64_t>& file_offsets) {
+    auto stream = make_iobuf_input_stream(std::move(buf));
+    auto parser = std::make_unique<storage::continuous_batch_parser>(
+      std::make_unique<recording_batch_consumer>(
+        headers, records, file_offsets),
+      std::move(stream));
+    return parser;
+}
+
+ss::sstring linearize_iobuf(iobuf io) {
+    ss::sstring bytes;
+    for (const auto& f : io) {
+        bytes.append(f.get(), f.size());
+    }
+    return bytes;
+}
+
+struct in_memory_segment {
+    ss::sstring bytes;
+    std::vector<model::record_batch_header> headers;
+    std::vector<iobuf> records;
+    std::vector<uint64_t> file_offsets;
+    model::offset base_offset, max_offset;
+    segment_name sname;
+    int num_config_batches{0};
+    int num_config_records{0};
+};
+
+static in_memory_segment make_segment(model::offset base, int num_batches) {
+    iobuf segment_bytes = generate_segment(base, num_batches);
+    std::vector<model::record_batch_header> hdr;
+    std::vector<iobuf> rec;
+    std::vector<uint64_t> off;
+    auto p1 = make_recording_batch_parser(
+      iobuf_deep_copy(segment_bytes), hdr, rec, off);
+    p1->consume().get();
+    in_memory_segment s;
+    s.bytes = linearize_iobuf(std::move(segment_bytes));
+    s.base_offset = hdr.front().base_offset;
+    s.max_offset = hdr.back().last_offset();
+    s.headers = std::move(hdr);
+    s.records = std::move(rec);
+    s.file_offsets = std::move(off);
+    s.sname = segment_name(fmt::format("{}-1-v1.log", s.base_offset()));
+    return s;
+}
+
+static in_memory_segment
+make_segment(model::offset base, const std::vector<batch_t>& batches) {
+    auto num_config_batches = std::count_if(
+      batches.begin(), batches.end(), [](batch_t t) {
+          return t.type != model::record_batch_type::raft_data;
+      });
+    auto num_config_records = std::accumulate(
+      batches.begin(), batches.end(), 0U, [](size_t acc, batch_t b) {
+          if (b.type == model::record_batch_type::raft_data) {
+              return acc;
+          }
+          return acc + b.num_records;
+      });
+    iobuf segment_bytes = generate_segment(base, batches);
+    std::vector<model::record_batch_header> hdr;
+    std::vector<iobuf> rec;
+    std::vector<uint64_t> off;
+    auto p1 = make_recording_batch_parser(
+      iobuf_deep_copy(segment_bytes), hdr, rec, off);
+    p1->consume().get();
+    in_memory_segment s;
+    s.bytes = linearize_iobuf(std::move(segment_bytes));
+    s.base_offset = hdr.front().base_offset;
+    s.max_offset = hdr.back().last_offset();
+    s.headers = std::move(hdr);
+    s.records = std::move(rec);
+    s.file_offsets = std::move(off);
+    s.sname = segment_name(fmt::format("{}-1-v1.log", s.base_offset()));
+    s.num_config_batches = num_config_batches;
+    s.num_config_records = num_config_records;
+    return s;
+}
+
+static std::vector<in_memory_segment>
+make_segments(int num_segments, int num_batches) {
+    std::vector<in_memory_segment> s;
+    model::offset base_offset{0};
+    for (int i = 0; i < num_segments; i++) {
+        s.push_back(make_segment(base_offset, num_batches));
+        base_offset = s.back().max_offset + model::offset(1);
+    }
+    return s;
+}
+
+static std::vector<in_memory_segment>
+make_segments(const std::vector<std::vector<batch_t>>& segments) {
+    std::vector<in_memory_segment> s;
+    model::offset base_offset{0};
+    for (int i = 0; i < segments.size(); i++) {
+        const auto& batches = segments[i];
+        s.push_back(make_segment(base_offset, batches));
+        base_offset = s.back().max_offset + model::offset(1);
+    }
+    return s;
+}
+
+static std::ostream& operator<<(std::ostream& o, const in_memory_segment& ims) {
+    fmt::print(
+      o,
+      "name {}, base-offset {}, max-offset {}\n",
+      ims.sname,
+      ims.base_offset,
+      ims.max_offset);
+    for (size_t i = 0; i < ims.headers.size(); i++) {
+        fmt::print(o, "\trecord-batch {}\n", ims.headers[i]);
+    }
+    return o;
+}
+
+static void print_segments(const std::vector<in_memory_segment>& segments) {
+    for (const auto& s : segments) {
+        vlog(test_log.debug, "segment: {}", s);
+    }
+}
+
+static std::vector<cloud_storage_fixture::expectation>
+make_imposter_expectations(
+  cloud_storage::manifest& m, const std::vector<in_memory_segment>& segments) {
+    std::vector<cloud_storage_fixture::expectation> results;
+    model::offset delta{0};
+    for (const auto& s : segments) {
+        // assume all segments has term=1
+        auto url = m.get_remote_segment_path(s.sname);
+        results.push_back(cloud_storage_fixture::expectation{
+          .url = "/" + url().string(), .body = s.bytes});
+        cloud_storage::manifest::segment_meta meta{
+          .is_compacted = false,
+          .size_bytes = s.bytes.size(),
+          .base_offset = s.base_offset,
+          .committed_offset = s.max_offset,
+          .base_timestamp = {},
+          .max_timestamp = {},
+          .delta_offset = model::offset(delta),
+        };
+        m.add(s.sname, meta);
+        delta = delta + model::offset(s.num_config_records);
+    }
+    std::stringstream ostr;
+    m.serialize(ostr);
+    results.push_back(cloud_storage_fixture::expectation{
+      .url = "/" + m.get_manifest_path()().string(),
+      .body = ss::sstring(ostr.str())});
+    return results;
+}
+
+/// Return vector<bool> which have a value for every recrod_batch_header in
+/// 'segments' If i'th value is true then the value are present in both
+/// 'headers' and 'segments' Otherwise the i'th value will be false.
+static std::vector<bool> get_coverage(
+  const std::vector<model::record_batch_header>& headers,
+  const std::vector<in_memory_segment>& segments,
+  int batches_per_segment) {
+    size_t num_record_batches = segments.size() * batches_per_segment;
+    std::vector<bool> result(num_record_batches, false);
+    size_t hix = 0;
+    size_t num_filtered = 0;
+    for (size_t i = 0; i < num_record_batches; i++) {
+        const auto& hh = headers[hix];
+        auto sh = segments.at(i / batches_per_segment)
+                    .headers.at(i % batches_per_segment);
+        if (sh.type != model::record_batch_type::raft_data) {
+            num_filtered++;
+            continue;
+        }
+        if (num_filtered != 0) {
+            // adjust base offset to compensate for removed record batches
+            // fix crc so comparison would work as expected
+            sh.base_offset = sh.base_offset - model::offset(num_filtered);
+            sh.header_crc = model::internal_header_only_crc(sh);
+        }
+        if (hh == sh) {
+            hix++;
+            result[i] = true;
+        }
+        if (hix == headers.size()) {
+            break;
+        }
+    }
+    return result;
+}
+
+using namespace cloud_storage;
+using namespace std::chrono_literals;
+
+class test_consumer final {
+public:
+    ss::future<ss::stop_iteration> operator()(model::record_batch b) {
+        headers.push_back(b.header());
+        co_return ss::stop_iteration::no;
+    }
+
+    std::vector<model::record_batch_header> end_of_stream() {
+        return std::move(headers);
+    }
+
+    std::vector<model::record_batch_header> headers;
+};
+
+static auto setup_s3_imposter(
+  cloud_storage_fixture& fixture,
+  int num_segments,
+  int num_batches_per_segment) {
+    // Create test data
+    auto segments = make_segments(num_segments, num_batches_per_segment);
+    cloud_storage::manifest manifest(manifest_ntp, manifest_revision);
+    auto expectations = make_imposter_expectations(manifest, segments);
+    fixture.set_expectations_and_listen(expectations);
+    return segments;
+}
+
+static auto setup_s3_imposter(
+  cloud_storage_fixture& fixture, std::vector<std::vector<batch_t>> batches) {
+    // Create test data
+    auto segments = make_segments(batches);
+    cloud_storage::manifest manifest(manifest_ntp, manifest_revision);
+    auto expectations = make_imposter_expectations(manifest, segments);
+    fixture.set_expectations_and_listen(expectations);
+    return segments;
+}
+
+static manifest hydrate_manifest(remote& api, const s3::bucket_name& bucket) {
+    manifest m(manifest_ntp, manifest_revision);
+    retry_chain_node rtc(1s, 200ms);
+    auto key = m.get_manifest_path();
+    auto res = api.download_manifest(bucket, key, m, rtc).get();
+    BOOST_REQUIRE(res == cloud_storage::download_result::success);
+    return m;
+}
+
+/// This test reads only a tip of the log
+static model::record_batch_header read_single_batch_from_remote_partition(
+  cloud_storage_fixture& fixture, model::offset target) {
+    auto conf = fixture.get_configuration();
+    static auto bucket = s3::bucket_name("bucket");
+    remote api(s3_connection_limit(10), conf);
+    auto action = ss::defer([&api] { api.stop().get(); });
+    auto m = ss::make_lw_shared<cloud_storage::manifest>(
+      manifest_ntp, manifest_revision);
+    offset_translator ot;
+    storage::log_reader_config reader_config(
+      target, target, ss::default_priority_class());
+
+    auto manifest = hydrate_manifest(api, bucket);
+
+    auto partition = ss::make_lw_shared<remote_partition>(
+      manifest, api, *fixture.cache, bucket);
+
+    auto reader = partition->make_reader(reader_config).get();
+
+    auto headers_read
+      = reader.consume(test_consumer(), model::no_timeout).get();
+
+    partition->stop().get();
+
+    vlog(test_log.debug, "num headers: {}", headers_read.size());
+    BOOST_REQUIRE(headers_read.size() == 1);
+    vlog(test_log.debug, "batch found: {}", headers_read.front());
+    return headers_read.front();
+}
+
+/// Similar to prev function but scans the range of offsets instead of
+/// returning a single one
+static std::vector<model::record_batch_header> scan_remote_partition(
+  cloud_storage_fixture& imposter, model::offset base, model::offset max) {
+    auto conf = imposter.get_configuration();
+    static auto bucket = s3::bucket_name("bucket");
+    remote api(s3_connection_limit(10), conf);
+    auto action = ss::defer([&api] { api.stop().get(); });
+    auto m = ss::make_lw_shared<cloud_storage::manifest>(
+      manifest_ntp, manifest_revision);
+    offset_translator ot;
+    storage::log_reader_config reader_config(
+      base, max, ss::default_priority_class());
+
+    auto manifest = hydrate_manifest(api, bucket);
+
+    auto partition = ss::make_lw_shared<remote_partition>(
+      manifest, api, *imposter.cache, bucket);
+
+    auto reader = partition->make_reader(reader_config).get();
+
+    auto headers_read
+      = reader.consume(test_consumer(), model::no_timeout).get();
+
+    partition->stop().get();
+    return headers_read;
+}
+
+FIXTURE_TEST(
+  test_remote_partition_single_batch_0, cloud_storage_fixture) { // NOLINT
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto hdr = read_single_batch_from_remote_partition(*this, model::offset(0));
+    BOOST_REQUIRE(hdr.base_offset == model::offset(0));
+}
+
+FIXTURE_TEST(
+  test_remote_partition_single_batch_1, cloud_storage_fixture) { // NOLINT
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto target = segments[0].max_offset;
+    vlog(test_log.debug, "target offset: {}", target);
+    print_segments(segments);
+    auto hdr = read_single_batch_from_remote_partition(*this, target);
+    BOOST_REQUIRE(hdr.last_offset() == target);
+}
+
+FIXTURE_TEST(
+  test_remote_partition_single_batch_2, cloud_storage_fixture) { // NOLINT
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto target = segments[1].base_offset;
+    vlog(test_log.debug, "target offset: {}", target);
+    print_segments(segments);
+    auto hdr = read_single_batch_from_remote_partition(*this, target);
+    BOOST_REQUIRE(hdr.base_offset == target);
+}
+
+FIXTURE_TEST(
+  test_remote_partition_single_batch_3, cloud_storage_fixture) { // NOLINT
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto target = segments[1].max_offset;
+    vlog(test_log.debug, "target offset: {}", target);
+    print_segments(segments);
+    auto hdr = read_single_batch_from_remote_partition(*this, target);
+    BOOST_REQUIRE(hdr.last_offset() == target);
+}
+
+FIXTURE_TEST(
+  test_remote_partition_single_batch_4, cloud_storage_fixture) { // NOLINT
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto target = segments[2].base_offset;
+    vlog(test_log.debug, "target offset: {}", target);
+    print_segments(segments);
+    auto hdr = read_single_batch_from_remote_partition(*this, target);
+    BOOST_REQUIRE(hdr.base_offset == target);
+}
+
+FIXTURE_TEST(test_remote_partition_single_batch_5, cloud_storage_fixture) {
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto target = segments[2].max_offset;
+    vlog(test_log.debug, "target offset: {}", target);
+    print_segments(segments);
+    auto hdr = read_single_batch_from_remote_partition(*this, target);
+    BOOST_REQUIRE(hdr.last_offset() == target);
+}
+
+/// This test scans the entire range of offsets
+FIXTURE_TEST(test_remote_partition_scan_full, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+
+    BOOST_REQUIRE_EQUAL(headers_read.size(), total_batches);
+    auto coverage = get_coverage(headers_read, segments, batches_per_segment);
+    auto nmatches = std::count(coverage.begin(), coverage.end(), true);
+    BOOST_REQUIRE_EQUAL(nmatches, coverage.size());
+}
+
+/// This test scans first half of batches
+FIXTURE_TEST(test_remote_partition_scan_first_half, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto base = segments[0].base_offset;
+    auto max = segments[1].headers[batches_per_segment / 2 - 1].last_offset();
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+
+    BOOST_REQUIRE_EQUAL(headers_read.size(), total_batches / 2);
+    auto coverage = get_coverage(headers_read, segments, batches_per_segment);
+    auto nmatches = std::count(coverage.begin(), coverage.end(), true);
+    BOOST_REQUIRE_EQUAL(nmatches, total_batches / 2);
+    const std::vector<bool> expected_coverage = {
+      true,  true,  true,  true,  true,  true,  true,  true,  true,  true,
+      true,  true,  true,  true,  true,  false, false, false, false, false,
+      false, false, false, false, false, false, false, false, false, false,
+    };
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      coverage.begin(),
+      coverage.end(),
+      expected_coverage.begin(),
+      expected_coverage.end());
+}
+
+/// This test scans last half of batches
+FIXTURE_TEST(test_remote_partition_scan_second_half, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto base = segments[1].headers[batches_per_segment / 2].last_offset();
+    auto max = segments[2].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+
+    BOOST_REQUIRE_EQUAL(headers_read.size(), total_batches / 2);
+    auto coverage = get_coverage(headers_read, segments, batches_per_segment);
+    auto nmatches = std::count(coverage.begin(), coverage.end(), true);
+    BOOST_REQUIRE_EQUAL(nmatches, total_batches / 2);
+    std::vector<bool> expected_coverage = {
+      false, false, false, false, false, false, false, false, false, false,
+      false, false, false, false, false, true,  true,  true,  true,  true,
+      true,  true,  true,  true,  true,  true,  true,  true,  true,  true,
+    };
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      coverage.begin(),
+      coverage.end(),
+      expected_coverage.begin(),
+      expected_coverage.end());
+}
+
+/// This test scans batches in the middle
+FIXTURE_TEST(test_remote_partition_scan_middle, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto base = segments[0].headers[batches_per_segment / 2].last_offset();
+    auto max = segments[2].headers[batches_per_segment / 2 - 1].last_offset();
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+    BOOST_REQUIRE_EQUAL(
+      headers_read.size(), total_batches - batches_per_segment);
+    auto coverage = get_coverage(headers_read, segments, batches_per_segment);
+    auto nmatches = std::count(coverage.begin(), coverage.end(), true);
+    BOOST_REQUIRE_EQUAL(nmatches, total_batches - batches_per_segment);
+    std::vector<bool> expected_coverage = {
+      false, false, false, false, false, true,  true,  true,  true,  true,
+      true,  true,  true,  true,  true,  true,  true,  true,  true,  true,
+      true,  true,  true,  true,  true,  false, false, false, false, false,
+    };
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      coverage.begin(),
+      coverage.end(),
+      expected_coverage.begin(),
+      expected_coverage.end());
+}
+
+/// This test scans batches in the middle
+FIXTURE_TEST(test_remote_partition_scan_off, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto base = segments[2].max_offset + model::offset(10);
+    auto max = base + model::offset(10);
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+    BOOST_REQUIRE_EQUAL(headers_read.size(), 0);
+}
+/// This test scans batches in the middle
+FIXTURE_TEST(test_remote_partition_lifetime_issue, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+
+    auto segments = setup_s3_imposter(*this, 3, 10);
+    auto base = segments[0].headers[batches_per_segment / 2].last_offset();
+    auto max = segments[2].headers[batches_per_segment / 2 - 1].last_offset();
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto conf = get_configuration();
+    static auto bucket = s3::bucket_name("bucket");
+    remote api(s3_connection_limit(10), conf);
+    auto action = ss::defer([&api] { api.stop().get(); });
+
+    auto manifest = hydrate_manifest(api, bucket);
+
+    auto partition = ss::make_lw_shared<remote_partition>(
+      manifest, api, *cache, bucket);
+
+    storage::log_reader_config reader_config(
+      base, max, ss::default_priority_class());
+    auto reader = partition->make_reader(reader_config).get();
+
+    partition->stop().get();
+    partition = {};
+
+    auto res = reader.consume(test_consumer(), model::no_timeout).get();
+    BOOST_REQUIRE_EQUAL(res.size(), 0);
+}
+
+/// This test scans the entire range of offsets
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_full_1, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+    constexpr batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    constexpr batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, data, data, data, data, data, data, data, data, data},
+    };
+
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+
+    BOOST_REQUIRE_EQUAL(headers_read.size(), total_batches - 3);
+    auto coverage = get_coverage(headers_read, segments, batches_per_segment);
+    std::vector<bool> expected_coverage = {
+      false, true, true, true, true, true, true, true, true, true,
+      false, true, true, true, true, true, true, true, true, true,
+      false, true, true, true, true, true, true, true, true, true,
+    };
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      coverage.begin(),
+      coverage.end(),
+      expected_coverage.begin(),
+      expected_coverage.end());
+}
+
+/// This test scans the entire range of offsets
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_full_2, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+    constexpr batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    constexpr batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, conf, conf, conf, conf, data, data, data, data, data},
+      {conf, conf, conf, conf, conf, data, data, data, data, data},
+      {conf, conf, conf, conf, conf, data, data, data, data, data},
+    };
+
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+
+    BOOST_REQUIRE_EQUAL(headers_read.size(), total_batches - 15);
+    auto coverage = get_coverage(headers_read, segments, batches_per_segment);
+    std::vector<bool> expected_coverage = {
+      false, false, false, false, false, true, true, true, true, true,
+      false, false, false, false, false, true, true, true, true, true,
+      false, false, false, false, false, true, true, true, true, true,
+    };
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      coverage.begin(),
+      coverage.end(),
+      expected_coverage.begin(),
+      expected_coverage.end());
+}
+
+/// This test scans the entire range of offsets
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_full_3, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+    constexpr batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    constexpr batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, data, data, data, data, data, data, data, data, data},
+      {conf, conf, conf, conf, conf, conf, conf, conf, conf, conf},
+      {conf, data, data, data, data, data, data, data, data, data},
+    };
+
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+
+    BOOST_REQUIRE_EQUAL(headers_read.size(), total_batches - 12);
+    auto coverage = get_coverage(headers_read, segments, batches_per_segment);
+    std::vector<bool> expected_coverage = {
+      false, true,  true,  true,  true,  true,  true,  true,  true,  true,
+      false, false, false, false, false, false, false, false, false, false,
+      false, true,  true,  true,  true,  true,  true,  true,  true,  true,
+    };
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      coverage.begin(),
+      coverage.end(),
+      expected_coverage.begin(),
+      expected_coverage.end());
+}
+
+/// This test scans the entire range of offsets
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_full_4, cloud_storage_fixture) {
+    constexpr int batches_per_segment = 10;
+    constexpr int num_segments = 3;
+    constexpr int total_batches = batches_per_segment * num_segments;
+    constexpr batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    constexpr batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, conf, conf, conf, conf, conf, conf, conf, conf, conf},
+      {conf, conf, conf, conf, conf, conf, conf, conf, conf, conf},
+      {conf, conf, conf, conf, conf, conf, conf, conf, conf, data},
+    };
+
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+
+    BOOST_REQUIRE_EQUAL(headers_read.size(), 1);
+    auto coverage = get_coverage(headers_read, segments, batches_per_segment);
+    std::vector<bool> expected_coverage = {
+      false, false, false, false, false, false, false, false, false, false,
+      false, false, false, false, false, false, false, false, false, false,
+      false, false, false, false, false, false, false, false, false, true,
+    };
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(
+      coverage.begin(),
+      coverage.end(),
+      expected_coverage.begin(),
+      expected_coverage.end());
+}
+
+/// This test scans the entire range of offsets
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_full_5, cloud_storage_fixture) {
+    constexpr int num_segments = 3;
+    constexpr batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    constexpr batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, conf, conf, conf, conf, conf, conf, conf, conf, data},
+      {conf},
+      {conf, conf, conf, conf, conf, conf, conf, conf, conf, conf},
+    };
+
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+
+    BOOST_REQUIRE_EQUAL(headers_read.size(), 1);
+}
+
+/// This test scans the entire range of offsets
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_full_6, cloud_storage_fixture) {
+    constexpr int num_segments = 3;
+    constexpr batch_t data = {
+      .num_records = 10, .type = model::record_batch_type::raft_data};
+    constexpr batch_t conf = {
+      .num_records = 1, .type = model::record_batch_type::raft_configuration};
+    const std::vector<std::vector<batch_t>> batch_types = {
+      {conf, conf, conf, conf, conf, conf, conf, conf, conf, conf},
+      {conf, conf, conf, conf, conf, conf, conf, conf, conf, conf},
+      {conf, conf, conf, conf, conf, conf, conf, conf, conf, conf},
+    };
+
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    print_segments(segments);
+
+    auto headers_read = scan_remote_partition(*this, base, max);
+
+    BOOST_REQUIRE_EQUAL(headers_read.size(), 0);
+}
+
+struct segment_layout {
+    std::vector<std::vector<batch_t>> segments;
+    size_t num_data_batches;
+};
+
+static segment_layout generate_segment_layout(int num_segments, int seed) {
+    static constexpr size_t max_segment_size = 20;
+    static constexpr size_t max_batch_size = 100;
+    std::seed_seq seq{seed};
+    std::mt19937 re(seq);
+    std::uniform_int_distribution<unsigned> dist;
+    size_t num_data_batches = 0;
+    auto gen_segment = [&re, &dist, &num_data_batches]() {
+        size_t sz = 1 + dist(re) % max_segment_size;
+        std::vector<batch_t> res;
+        res.reserve(sz);
+        for (size_t i = 0; i < sz; i++) {
+            size_t batch_size = 1 + dist(re) % max_batch_size;
+            size_t type = dist(re) % 2;
+            batch_t b{
+              .num_records = static_cast<int>(batch_size),
+              .type = type == 0 ? model::record_batch_type::raft_data
+                                : model::record_batch_type::raft_configuration,
+            };
+            if (b.type == model::record_batch_type::raft_data) {
+                num_data_batches++;
+            }
+            res.push_back(b);
+        }
+        return res;
+    };
+    std::vector<std::vector<batch_t>> all_batches;
+    all_batches.reserve(num_segments);
+    for (int i = 0; i < num_segments; i++) {
+        all_batches.push_back(gen_segment());
+    }
+    return {.segments = all_batches, .num_data_batches = num_data_batches};
+}
+
+/// This test scans the entire range of offsets
+FIXTURE_TEST(
+  test_remote_partition_scan_translate_full_random, cloud_storage_fixture) {
+    constexpr int num_segments = 1000;
+    const auto [batch_types, num_data_batches] = generate_segment_layout(
+      num_segments, 42);
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    auto headers_read = scan_remote_partition(*this, base, max);
+    model::offset expected_offset{0};
+    for (const auto& header : headers_read) {
+        vlog(
+          test_log.debug,
+          "Expected offset {}, actual header {}",
+          expected_offset,
+          header);
+        BOOST_REQUIRE_EQUAL(expected_offset, header.base_offset);
+        expected_offset = header.last_offset() + model::offset(1);
+    }
+    BOOST_REQUIRE_EQUAL(headers_read.size(), num_data_batches);
+}
+
+/// Similar to prev function but scans the range of offsets instead of
+/// returning a single one
+static std::vector<model::record_batch_header>
+scan_remote_partition_incrementally(
+  cloud_storage_fixture& imposter, model::offset base, model::offset max) {
+    auto conf = imposter.get_configuration();
+    static auto bucket = s3::bucket_name("bucket");
+    remote api(s3_connection_limit(10), conf);
+    auto action = ss::defer([&api] { api.stop().get(); });
+    auto m = ss::make_lw_shared<cloud_storage::manifest>(
+      manifest_ntp, manifest_revision);
+
+    auto manifest = hydrate_manifest(api, bucket);
+
+    auto partition = ss::make_lw_shared<remote_partition>(
+      manifest, api, *imposter.cache, bucket);
+
+    std::vector<model::record_batch_header> headers;
+
+    storage::log_reader_config reader_config(
+      base, max, ss::default_priority_class());
+    reader_config.max_bytes = 4_KiB;
+
+    auto next = base;
+
+    int num_fetches = 0;
+    while (next < max) {
+        reader_config.start_offset = next;
+        auto reader = partition->make_reader(reader_config).get();
+        auto headers_read
+          = reader.consume(test_consumer(), model::no_timeout).get();
+        if (headers_read.empty()) {
+            break;
+        }
+        next = headers_read.back().last_offset() + model::offset(1);
+        std::copy(
+          headers_read.begin(),
+          headers_read.end(),
+          std::back_inserter(headers));
+        num_fetches++;
+    }
+    BOOST_REQUIRE(num_fetches != 1);
+    partition->stop().get();
+    vlog(test_log.info, "{} fetch operations performed", num_fetches);
+    return headers;
+}
+
+FIXTURE_TEST(
+  test_remote_partition_scan_incrementally_random, cloud_storage_fixture) {
+    constexpr int num_segments = 1000;
+    const auto [batch_types, num_data_batches] = generate_segment_layout(
+      num_segments, 42);
+    auto segments = setup_s3_imposter(*this, batch_types);
+    auto base = segments[0].base_offset;
+    auto max = segments[num_segments - 1].max_offset;
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+    auto headers_read = scan_remote_partition_incrementally(*this, base, max);
+    model::offset expected_offset{0};
+    for (const auto& header : headers_read) {
+        vlog(
+          test_log.debug,
+          "Expected offset {}, actual header {}",
+          expected_offset,
+          header);
+        BOOST_REQUIRE_EQUAL(expected_offset, header.base_offset);
+        expected_offset = header.last_offset() + model::offset(1);
+    }
+    BOOST_REQUIRE_EQUAL(headers_read.size(), num_data_batches);
+}

--- a/src/v/utils/retry_chain_node.cc
+++ b/src/v/utils/retry_chain_node.cc
@@ -301,3 +301,9 @@ ss::abort_source* retry_chain_node::find_abort_source() {
     }
     return root->get_abort_source();
 }
+
+void retry_chain_logger::do_log(
+  ss::log_level lvl,
+  ss::noncopyable_function<void(ss::logger&, ss::log_level)> fn) const {
+    fn(_log, lvl);
+}


### PR DESCRIPTION
## Cover letter

This PR adds `remote_partition` class with tests.
The class is used to fetch data from S3. It provides regular `model::record_batch_reader` interface.
The remote segments are created lazily and periodically deallocated (when not in use) to save memory when we have a lot of segments in the bucket.

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/7f89d04edd65e66077d0cebc12bb17f6320fe236..85214176e59b1b607f4a1d12068adda2ca98bca7)
- Fix code review issue
- Add fix for `remote_segment` eviction

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/85214176e59b1b607f4a1d12068adda2ca98bca7..222cdf37a8af0921c0f0a424da07b55cf2be6bfa)
- Rebase dev
- Rearrange commits (`remote_segment` update comes first)
- Updated the commit message for `remote_segment` commit
- Add changes to `test/remote_segment_test.cc` that were skipped and caused the build to fail

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/222cdf37a8af0921c0f0a424da07b55cf2be6bfa..367435ddfe3ac2d03158373becced2e475b6a87f)
- Add availability check to `remote_partition`
- Update commit messages
- Fix #2898

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/367435ddfe3ac2d03158373becced2e475b6a87f..7d69f6062813bf7da7470558f59fbaef8e4bc4b8)
- Fix code review issues

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/7d69f6062813bf7da7470558f59fbaef8e4bc4b8..64e2989eaf4ecbbde9565788a99c91133c489166)
- Fix code review issues
- Limit range that the `partition_record_batch_reader_impl` can access

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/64e2989eaf4ecbbde9565788a99c91133c489166..a8f501be9505e0547a59073026d9cabd506a6cfd)
- Add workaround for the compiler bug

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/a8f501be9505e0547a59073026d9cabd506a6cfd..d82a5414f3aa880f63e889680fde23199dea0264)
- Code review fixes

## Release notes

N/A