### PR TITLE
Create a wrapper for materialized logs, so shutdown can be controlled

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -71,6 +71,7 @@ v_cc_library(
     members_backend.cc
     health_manager.cc
     non_replicable_partition.cc
+    non_replicable_partition_manager.cc
     non_replicable_topics_frontend.cc
     scheduling/allocation_node.cc
     scheduling/types.cc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -70,6 +70,7 @@ v_cc_library(
     members_frontend.cc
     members_backend.cc
     health_manager.cc
+    non_replicable_partition.cc
     non_replicable_topics_frontend.cc
     scheduling/allocation_node.cc
     scheduling/types.cc

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -45,12 +45,14 @@ namespace cluster {
 controller::controller(
   ss::sharded<rpc::connection_cache>& ccache,
   ss::sharded<partition_manager>& pm,
+  ss::sharded<non_replicable_partition_manager>& nr_pm,
   ss::sharded<shard_table>& st,
   ss::sharded<storage::api>& storage,
   ss::sharded<raft::group_manager>& raft_manager,
   ss::sharded<v8_engine::data_policy_table>& data_policy_table)
   : _connections(ccache)
   , _partition_manager(pm)
+  , _nr_partition_manager(nr_pm)
   , _shard_table(st)
   , _storage(storage)
   , _tp_updates_dispatcher(_partition_allocator, _tp_state)
@@ -150,6 +152,7 @@ ss::future<> controller::start() {
             std::ref(_tp_state),
             std::ref(_shard_table),
             std::ref(_partition_manager),
+            std::ref(_nr_partition_manager),
             std::ref(_members_table),
             std::ref(_partition_leaders),
             std::ref(_tp_frontend),

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -33,6 +33,7 @@ public:
     controller(
       ss::sharded<rpc::connection_cache>& ccache,
       ss::sharded<partition_manager>& pm,
+      ss::sharded<non_replicable_partition_manager>& nr_pm,
       ss::sharded<shard_table>& st,
       ss::sharded<storage::api>& storage,
       ss::sharded<raft::group_manager>&,
@@ -95,6 +96,7 @@ private:
     ss::sharded<members_backend> _members_backend;   // single instance
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_manager>& _partition_manager;
+    ss::sharded<non_replicable_partition_manager>& _nr_partition_manager;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<storage::api>& _storage;
     topic_updates_dispatcher _tp_updates_dispatcher;

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -164,6 +164,7 @@ controller_backend::controller_backend(
   ss::sharded<topic_table>& tp_state,
   ss::sharded<shard_table>& st,
   ss::sharded<partition_manager>& pm,
+  ss::sharded<non_replicable_partition_manager>& nrpm,
   ss::sharded<members_table>& members,
   ss::sharded<partition_leaders_table>& leaders,
   ss::sharded<topics_frontend>& frontend,
@@ -172,6 +173,7 @@ controller_backend::controller_backend(
   : _topics(tp_state)
   , _shard_table(st)
   , _partition_manager(pm)
+  , _nr_partition_manager(nrpm)
   , _members_table(members)
   , _partition_leaders_table(leaders)
   , _topics_frontend(frontend)

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster/logger.h"
 #include "cluster/members_table.h"
+#include "cluster/non_replicable_partition_manager.h"
 #include "cluster/partition.h"
 #include "cluster/partition_leaders_table.h"
 #include "cluster/partition_manager.h"
@@ -953,24 +954,38 @@ ss::future<> controller_backend::delete_non_replicable_partition(
     vlog(clusterlog.trace, "removing {} from shard table at {}", ntp, rev);
     co_await _shard_table.invoke_on_all(
       [ntp, rev](shard_table& st) { st.erase(ntp, rev); });
-    auto log = _storage.local().log_mgr().get(ntp);
-    if (log && log->config().get_revision() < rev) {
-        co_await _storage.local().log_mgr().remove(ntp);
+    auto nr_partition = _nr_partition_manager.local().get(ntp);
+    if (nr_partition && nr_partition->get_revision_id() < rev) {
+        co_await _nr_partition_manager.local().remove(ntp);
     }
 }
 
 ss::future<std::error_code> controller_backend::create_non_replicable_partition(
   model::ntp ntp, model::revision_id rev) {
-    auto cfg = _topics.local().get_topic_cfg(model::topic_namespace_view(ntp));
-    if (!cfg) {
+    auto& topics_map = _topics.local().topics_map();
+    auto tt_md = topics_map.find(model::topic_namespace_view(ntp));
+    if (tt_md == topics_map.end()) {
         // partition was already removed, do nothing
         co_return errc::success;
     }
     vassert(
-      !_storage.local().log_mgr().get(ntp),
-      "Log exists for missing entry in topics_table");
-    auto ntp_cfg = cfg->make_ntp_config(_data_directory, ntp.tp.partition, rev);
-    co_await _storage.local().log_mgr().manage(std::move(ntp_cfg));
+      !tt_md->second.is_topic_replicable(),
+      "Replicable topic reached non-replicable API");
+    auto nr_partition = _nr_partition_manager.local().get(ntp);
+    if (likely(!nr_partition)) {
+        // get_source_topic will assert if incorrect API is used
+        auto src_partition = _partition_manager.local().get(model::ntp(
+          ntp.ns, tt_md->second.get_source_topic(), ntp.tp.partition));
+        if (!src_partition) {
+            co_return errc::partition_not_exists;
+        }
+        auto ntp_cfg = tt_md->second.get_configuration().cfg.make_ntp_config(
+          _data_directory, ntp.tp.partition, rev);
+        co_await _nr_partition_manager.local().manage(
+          std::move(ntp_cfg), src_partition);
+    } else if (nr_partition->get_revision_id() < rev) {
+        co_return errc::partition_already_exists;
+    }
     co_await add_to_shard_table(std::move(ntp), ss::this_shard_id(), rev);
     co_return errc::success;
 }

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -40,6 +40,7 @@ public:
       ss::sharded<cluster::topic_table>&,
       ss::sharded<shard_table>&,
       ss::sharded<partition_manager>&,
+      ss::sharded<non_replicable_partition_manager>&,
       ss::sharded<members_table>&,
       ss::sharded<cluster::partition_leaders_table>&,
       ss::sharded<topics_frontend>&,
@@ -132,6 +133,7 @@ private:
     ss::sharded<topic_table>& _topics;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;
+    ss::sharded<non_replicable_partition_manager>& _nr_partition_manager;
     ss::sharded<members_table>& _members_table;
     ss::sharded<partition_leaders_table>& _partition_leaders_table;
     ss::sharded<topics_frontend>& _topics_frontend;

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -38,5 +38,6 @@ class data_policy_frontend;
 class tx_gateway;
 class rm_group_proxy;
 class non_replicable_topics_frontend;
+class non_replicable_partition_manager;
 
 } // namespace cluster

--- a/src/v/cluster/non_replicable_partition.cc
+++ b/src/v/cluster/non_replicable_partition.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/non_replicable_partition.h"
+
+#include "storage/log.h"
+
+namespace {
+
+/// Ensures that operations on a model::record_batch_reader occur within the
+/// context of a gate for safe shutdown. If operations are observed while the
+/// gate is closed the caller will observe the ss::gate_closed_exception
+class gated_shutdown_reader final : public model::record_batch_reader::impl {
+public:
+    gated_shutdown_reader(
+      ss::gate& g,
+      std::unique_ptr<model::record_batch_reader::impl> impl) noexcept
+      : _gate(g)
+      , _impl(std::move(impl)) {}
+
+    bool is_end_of_stream() const final {
+        return _gate.is_closed() || _impl->is_end_of_stream();
+    }
+
+    ss::future<model::record_batch_reader::storage_t>
+    do_load_slice(model::timeout_clock::time_point t) final {
+        auto holder = _gate.hold();
+        return _impl->do_load_slice(t).finally([holder] {});
+    }
+
+    void print(std::ostream& os) final { os << "gated_shutdown_reader"; }
+
+private:
+    ss::gate& _gate;
+    std::unique_ptr<model::record_batch_reader::impl> _impl;
+};
+
+} // namespace
+
+namespace cluster {
+/// Not neccessary to hold gate open until all processing completes, as that can
+/// be done by invoking the write within the context of the \ref
+/// non_replicable_partition gate. This class just makes the operation
+/// cancellable
+safe_shutdown_appender::safe_shutdown_appender(
+  ss::gate& g, storage::log_appender&& appender) noexcept
+  : _gate(g)
+  , _appender(std::move(appender)) {}
+
+ss::future<ss::stop_iteration>
+safe_shutdown_appender::operator()(model::record_batch& rb) {
+    if (_gate.is_closed()) {
+        return ss::make_ready_future<ss::stop_iteration>(
+          ss::stop_iteration::yes);
+    }
+    return _appender.operator()(rb);
+}
+
+ss::future<storage::append_result> safe_shutdown_appender::end_of_stream() {
+    return _appender.end_of_stream();
+}
+
+non_replicable_partition::non_replicable_partition(
+  storage::log log, ss::lw_shared_ptr<partition> source) noexcept
+  : _log(log)
+  , _source(source) {}
+
+ss::future<model::record_batch_reader>
+non_replicable_partition::make_reader(storage::log_reader_config config) {
+    return ss::with_gate(_gate, [this, config = std::move(config)] {
+        return _log.make_reader(config).then(
+          [this](model::record_batch_reader rdr) {
+              return model::make_record_batch_reader<gated_shutdown_reader>(
+                _gate, std::move(rdr).release());
+          });
+    });
+}
+
+safe_shutdown_appender
+non_replicable_partition::make_appender(storage::log_append_config write_cfg) {
+    auto appender = _log.make_appender(write_cfg);
+    return safe_shutdown_appender(_gate, std::move(appender));
+}
+
+ss::future<std::optional<storage::timequery_result>>
+non_replicable_partition::timequery(storage::timequery_config cfg) {
+    return ss::with_gate(
+      _gate, [this, cfg = std::move(cfg)] { return _log.timequery(cfg); });
+}
+} // namespace cluster

--- a/src/v/cluster/non_replicable_partition.h
+++ b/src/v/cluster/non_replicable_partition.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/partition.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/gate.hh>
+
+namespace cluster {
+
+class safe_shutdown_appender {
+public:
+    safe_shutdown_appender(
+      ss::gate& g, storage::log_appender&& appender) noexcept;
+
+    ss::future<ss::stop_iteration> operator()(model::record_batch&);
+    ss::future<storage::append_result> end_of_stream();
+
+private:
+    ss::gate& _gate;
+    storage::log_appender _appender;
+};
+
+class non_replicable_partition {
+public:
+    non_replicable_partition(
+      storage::log, ss::lw_shared_ptr<partition>) noexcept;
+
+    ss::future<> start() { return ss::now(); }
+    ss::future<> stop() { return _gate.close(); }
+
+    const model::ntp& source() const { return _source->ntp(); }
+    const model::ntp& ntp() const { return _log.config().ntp(); }
+    const storage::ntp_config& config() const { return _log.config(); }
+    bool is_leader() const { return _source->is_leader(); }
+    model::revision_id get_revision_id() const {
+        return _log.config().get_revision();
+    }
+
+    /// \brief Returns a reader that enters the \ref _gate when it performs
+    /// operations
+    ss::future<model::record_batch_reader>
+      make_reader(storage::log_reader_config);
+
+    /// \brief Returns an appender that ensures appends will not occur after
+    /// future returned from stop() resolves
+    safe_shutdown_appender make_appender(storage::log_append_config);
+
+    /// \brief Invokes the timequey method on the \ref _log within the context
+    /// of the \ref gate
+    ss::future<std::optional<storage::timequery_result>>
+      timequery(storage::timequery_config);
+
+private:
+    ss::gate _gate;
+    storage::log _log;
+    ss::lw_shared_ptr<partition> _source;
+};
+
+} // namespace cluster

--- a/src/v/cluster/non_replicable_partition_manager.cc
+++ b/src/v/cluster/non_replicable_partition_manager.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/logger.h"
+#include "cluster/non_replicable_partition_manager.h"
+#include "storage/api.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace cluster {
+
+non_replicable_partition_manager::non_replicable_partition_manager(
+  ss::sharded<storage::api>& storage) noexcept
+  : _storage(storage.local()) {}
+
+ss::lw_shared_ptr<non_replicable_partition>
+non_replicable_partition_manager::get(const model::ntp& ntp) const {
+    if (auto it = _ntp_table.find(ntp); it != _ntp_table.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+ss::future<> non_replicable_partition_manager::manage(
+  storage::ntp_config ntp_cfg, ss::lw_shared_ptr<partition> src) {
+    auto holder = _gate.hold();
+    storage::log log = co_await _storage.log_mgr().manage(std::move(ntp_cfg));
+    vlog(
+      clusterlog.info,
+      "Non replicable log created manage completed, ntp: {}, rev: {}, {} "
+      "segments, {} bytes",
+      log.config().ntp(),
+      log.config().get_revision(),
+      log.segment_count(),
+      log.size_bytes());
+
+    auto nrp = ss::make_lw_shared<non_replicable_partition>(log, src);
+    _ntp_table.emplace(log.config().ntp(), nrp);
+    co_await nrp->start();
+}
+
+ss::future<> non_replicable_partition_manager::stop_partitions() {
+    co_await _gate.close();
+    auto partitions = std::exchange(_ntp_table, {});
+    co_await ss::parallel_for_each(
+      partitions, [this](ntp_table_container::value_type& e) {
+          return do_shutdown(e.second);
+      });
+}
+
+ss::future<> non_replicable_partition_manager::remove(const model::ntp& ntp) {
+    auto nr_partition = get(ntp);
+
+    if (!nr_partition) {
+        throw std::invalid_argument(fmt_with_ctx(
+          ssx::sformat,
+          "Can not remove non_replicable partition. NTP {} is not "
+          "present in partition manager: ",
+          ntp));
+    }
+
+    _ntp_table.erase(ntp);
+    co_await nr_partition->stop();
+    co_await _storage.log_mgr().remove(ntp);
+}
+
+ss::future<> non_replicable_partition_manager::do_shutdown(
+  ss::lw_shared_ptr<non_replicable_partition> nr_partition) {
+    try {
+        auto ntp = nr_partition->ntp();
+        co_await nr_partition->stop();
+        co_await _storage.log_mgr().shutdown(nr_partition->ntp());
+    } catch (...) {
+        vassert(
+          false,
+          "error shutting down non replicable partition {},  "
+          "non_replicable partition manager state: {}, error: {} - "
+          "terminating redpanda",
+          nr_partition->ntp(),
+          *this,
+          std::current_exception());
+    }
+}
+
+std::ostream&
+operator<<(std::ostream& o, const non_replicable_partition_manager& nr_pm) {
+    return o << "{shard:" << ss::this_shard_id() << ", mngr:{}"
+             << nr_pm._storage.log_mgr()
+             << ", ntp_table.size:" << nr_pm._ntp_table.size() << "}";
+}
+
+} // namespace cluster

--- a/src/v/cluster/non_replicable_partition_manager.h
+++ b/src/v/cluster/non_replicable_partition_manager.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/non_replicable_partition.h"
+#include "cluster/partition.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/gate.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+namespace cluster {
+
+class non_replicable_partition_manager {
+public:
+    using ntp_table_container = absl::
+      flat_hash_map<model::ntp, ss::lw_shared_ptr<non_replicable_partition>>;
+
+    explicit non_replicable_partition_manager(
+      ss::sharded<storage::api>& storage) noexcept;
+
+    ss::future<> start() { return ss::now(); }
+    ss::future<> stop_partitions();
+
+    ss::lw_shared_ptr<non_replicable_partition>
+    get(const model::ntp& ntp) const;
+    ss::future<> manage(storage::ntp_config, ss::lw_shared_ptr<partition>);
+
+    ss::future<> remove(const model::ntp&);
+
+private:
+    ss::future<> do_shutdown(ss::lw_shared_ptr<non_replicable_partition>);
+
+private:
+    ntp_table_container _ntp_table;
+    ss::gate _gate;
+    storage::api& _storage;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const non_replicable_partition_manager&);
+};
+
+} // namespace cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ rp_test(
 )
 
 set(srcs
+    non_replicable_topic_tests.cc
     partition_allocator_tests.cc
     simple_batch_builder_test.cc
     serialization_rt_test.cc

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -99,6 +99,10 @@ public:
         return &_instances[id]->app;
     }
 
+    fixture_ptr::pointer get_node_fixture(model::node_id id) {
+        return _instances[id].get();
+    }
+
     cluster::metadata_cache& get_local_cache(model::node_id id) {
         return _instances[id]->app.metadata_cache.local();
     }

--- a/src/v/cluster/tests/non_replicable_topic_tests.cc
+++ b/src/v/cluster/tests/non_replicable_topic_tests.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/metadata_cache.h"
+#include "cluster/non_replicable_partition_manager.h"
+#include "cluster/tests/cluster_test_fixture.h"
+#include "model/metadata.h"
+#include "storage/tests/utils/random_batch.h"
+#include "storage/types.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/core/coroutine.hh>
+
+using namespace std::chrono_literals; // NOLINT
+
+namespace {
+class sleep_once_consumer {
+public:
+    explicit sleep_once_consumer(model::timeout_clock::duration d) noexcept
+      : _timeout(d) {}
+
+    ss::future<ss::stop_iteration> operator()(const model::record_batch& rb) {
+        if (_first_run) {
+            _first_run = false;
+            _started.set_value();
+            co_await ss::sleep(_timeout);
+        }
+        co_return ss::stop_iteration::no;
+    }
+
+    void end_of_stream() {}
+
+    /// Used to know when actual consumption will begin
+    ss::future<> started() { return _started.get_future(); }
+
+private:
+    bool _first_run{true};
+    ss::promise<> _started;
+    model::timeout_clock::duration _timeout;
+};
+
+model::topic_namespace to_tpns(const model::ntp& ntp) {
+    return model::topic_namespace(model::topic_namespace_view{ntp});
+}
+
+template<typename T>
+ss::future<bool>
+partition_exists(ss::sharded<T>& pm, ss::shard_id shard, model::ntp ntp) {
+    return pm.invoke_on(
+      shard, [ntp](T& local_pm) { return (bool)local_pm.get(ntp); });
+}
+
+ss::future<model::timeout_clock::duration> timed_delete_partition(
+  model::timeout_clock::duration timeout,
+  cluster::topics_frontend& topics_frontend,
+  cluster::non_replicable_partition_manager& local,
+  model::ntp tp2_ntp) {
+    auto partition = local.get(tp2_ntp);
+    BOOST_REQUIRE(partition);
+    /// Begin by writing some sample data into the partition/log
+    auto batches = storage::test::make_random_batches(model::offset{0});
+    const storage::log_append_config write_cfg{
+      .should_fsync = storage::log_append_config::fsync::no,
+      .io_priority = ss::default_priority_class(),
+      .timeout = model::no_timeout};
+    auto rbr = model::make_memory_record_batch_reader(std::move(batches));
+    auto rs = co_await std::move(rbr).for_each_ref(
+      partition->make_appender(write_cfg), model::no_timeout);
+    auto reader_cfg = storage::log_reader_config(
+      model::offset{0},
+      model::model_limits<model::offset>::max(),
+      ss::default_priority_class());
+    rbr = co_await partition->make_reader(reader_cfg);
+
+    /// Start the tests by consuming the pushed data, using the
+    /// sleep_once_consumer to hold up consumption for at least some known
+    /// duration
+    auto soc = sleep_once_consumer(timeout);
+    auto start_consume = soc.started();
+    auto finished = std::move(rbr).consume(std::move(soc), model::no_timeout);
+    /// To avoid deletion occuring before the stream actually started, wait on
+    /// the 'start_consume' future to known when consume has started
+    co_await std::move(start_consume);
+
+    /// Attempt to close while consume is in progress. Expected behavior
+    /// should be no crashes, and the close taking at least as long as the
+    /// sleep_once_consumers sleep.
+    auto start = model::timeout_clock::now();
+    co_await local.remove(tp2_ntp);
+    auto end = model::timeout_clock::now();
+
+    /// Wait on end of stream, even though by this time it has resolved, this
+    /// future must be waited on to prevent stranded future exceptions
+    co_await std::move(finished);
+    co_return(end - start);
+}
+
+} // namespace
+
+/// Tests that streams via non_replicated_partitions can be properly aborted
+FIXTURE_TEST(test_non_replicated_shutdown, cluster_test_fixture) {
+    model::node_id id{0};
+    auto app = create_node_application(id);
+    wait_for_controller_leadership(id).get();
+    wait_for_all_members(3s).get();
+    auto* fixture = get_node_fixture(id);
+
+    /// Test has 2 partitions, 1 normal, 1 non_replicable
+    model::ntp tp_ntp = model::ntp(
+      model::kafka_namespace, model::topic("abc"), model::partition_id(0));
+    model::ntp tp2_ntp = model::ntp(
+      model::kafka_namespace, model::topic("def"), model::partition_id(0));
+
+    /// Create underlying topics
+    fixture->add_topic(to_tpns(tp_ntp)).get();
+    fixture->add_non_replicable_topic(to_tpns(tp_ntp), to_tpns(tp2_ntp)).get();
+
+    /// Wait until the partitions are created
+    std::optional<ss::shard_id> home_shard;
+    tests::cooperative_spin_wait_with_timeout(
+      3s,
+      [fixture, tp2_ntp, &home_shard]() mutable {
+          home_shard = fixture->app.shard_table.local().shard_for(tp2_ntp);
+          return home_shard.has_value();
+      })
+      .get();
+    BOOST_REQUIRE(home_shard);
+    info("tp_ntp shard: {}", *home_shard);
+
+    /// Delete partition while its in use, assert that the configured time has
+    /// passed between the two calls.
+    auto& nr_pm = fixture->app.nr_partition_manager;
+    auto delete_time
+      = nr_pm
+          .invoke_on(
+            *home_shard,
+            [fixture,
+             tp2_ntp](cluster::non_replicable_partition_manager& local) {
+                return timed_delete_partition(
+                  1s,
+                  fixture->app.controller->get_topics_frontend().local(),
+                  local,
+                  tp2_ntp);
+            })
+          .get();
+
+    /// Assert that the deletion did occur...
+    bool exists = partition_exists(nr_pm, *home_shard, tp2_ntp).get();
+    BOOST_REQUIRE(!exists);
+
+    /// ... and that the total time took included the sleep_once_consumers sleep
+    /// duration
+    BOOST_REQUIRE(delete_time >= 1s);
+}

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -74,6 +74,7 @@ public:
     ss::sharded<storage::api> storage;
     std::unique_ptr<coproc::api> coprocessing;
     ss::sharded<cluster::partition_manager> partition_manager;
+    ss::sharded<cluster::non_replicable_partition_manager> nr_partition_manager;
     ss::sharded<raft::recovery_throttle> recovery_throttle;
     ss::sharded<raft::group_manager> raft_group_manager;
     ss::sharded<cluster::metadata_dissemination_service>


### PR DESCRIPTION
Currently `cluster::partition`s are `ss::lw_shared_ptr` instances where it is not known which shared_ptr copy will be the last holder before destruction. Therefore when a partition is deleted, `stop()` is called without waiting for all consumers of the interface to stop whatever they are doing. Upon next invocation of some method `ss::gate_closed_exception` will be called, and the shutdown can safely occur.

Materialized logs have no abstraction, they are literally writes to a `storage::log` instance. Due to the introduction of the ability to delete materialized logs, there now needs to be a way to safely shut them down. If `close()` is called twice on a `storage::log` assertions will be called. Also there are assertions that fire during writes if `close()` is being concurrently performed.

This PR attempts to solve these problems by creating an abstraction called `cluster::non_replicable_partition`. The solution works in the same way `cluster::partition`s are shut down. This class looks and feels like a normal `cluster::partition`, however its much simpler. It simply contains a gate that allows for safe shutdown of the `storage::log`. Reads & writes are wrapped with code that knows when the gate is closed, so a `record_batch_reader::impl` or consumer impl can stop iteration when the gate has been closed. Just like `cluster::partition` if usage is performed to the class while the gate is closed the class throws `ss::gate_closed_exception`.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/8951d47477500c1324659d9509de7b0ff15ae191..45077fba5d69307ac2c9d50d85d0fc64a490107f)
- Rebased dev for CI fixes

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/45077fba5d69307ac2c9d50d85d0fc64a490107f..ac2ac3892d8c19b4a1ee72aa5f929a4b89213b1d)
- Added missing #pragma once
- Modified `write` api for `non_replicable_partition` to return a `log_appender` instead of directly handling write.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/ac2ac3892d8c19b4a1ee72aa5f929a4b89213b1d..b9cf4d403e08d376f7f186575c093aca2ae7c976)
- re-added removed assertion one that makes more sense
- Ensured `stop_partitions` is called during shutdown