### PR TITLE
[data-policy] script dispatcher

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -51,7 +51,8 @@ controller::controller(
   ss::sharded<shard_table>& st,
   ss::sharded<storage::api>& storage,
   ss::sharded<raft::group_manager>& raft_manager,
-  ss::sharded<v8_engine::data_policy_table>& data_policy_table)
+  ss::sharded<v8_engine::data_policy_table>& data_policy_table,
+  std::unique_ptr<v8_engine::api>& v8_engine_api)
   : _config_preload(std::move(config_preload))
   , _connections(ccache)
   , _partition_manager(pm)
@@ -59,7 +60,7 @@ controller::controller(
   , _storage(storage)
   , _tp_updates_dispatcher(_partition_allocator, _tp_state)
   , _security_manager(_credentials, _authorizer)
-  , _data_policy_manager(data_policy_table)
+  , _data_policy_manager(data_policy_table, v8_engine_api)
   , _raft_manager(raft_manager) {}
 
 ss::future<> controller::wire_up() {

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -40,7 +40,8 @@ public:
       ss::sharded<shard_table>& st,
       ss::sharded<storage::api>& storage,
       ss::sharded<raft::group_manager>&,
-      ss::sharded<v8_engine::data_policy_table>&);
+      ss::sharded<v8_engine::data_policy_table>&,
+      std::unique_ptr<v8_engine::api>&);
 
     model::node_id self() { return _raft0->self().id(); }
     ss::sharded<topics_frontend>& get_topics_frontend() { return _tp_frontend; }

--- a/src/v/cluster/data_policy_manager.h
+++ b/src/v/cluster/data_policy_manager.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "cluster/commands.h"
-#include "v8_engine/data_policy_table.h"
+#include "v8_engine/fwd.h"
 
 #include <absl/container/flat_hash_map.h>
 
@@ -22,8 +22,11 @@ namespace cluster {
 
 class data_policy_manager {
 public:
-    explicit data_policy_manager(ss::sharded<v8_engine::data_policy_table>& dps)
-      : _dps(dps) {}
+    explicit data_policy_manager(
+      ss::sharded<v8_engine::data_policy_table>& dps,
+      std::unique_ptr<v8_engine::api>& v8_engine_api)
+      : _dps(dps)
+      , _v8_engine_api(v8_engine_api) {}
 
     static constexpr auto commands
       = make_commands_list<create_data_policy_cmd, delete_data_policy_cmd>();
@@ -37,6 +40,7 @@ public:
 
 private:
     ss::sharded<v8_engine::data_policy_table>& _dps;
+    std::unique_ptr<v8_engine::api>& _v8_engine_api;
 };
 
 } // namespace cluster

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -53,6 +53,7 @@ enum class errc : int16_t {
     partition_configuration_differs,
     data_policy_already_exists,
     data_policy_not_exists,
+    data_policy_js_code_not_exists,
     source_topic_not_exists,
     source_topic_still_in_use,
     wating_for_partition_shutdown,
@@ -147,6 +148,8 @@ struct errc_category final : public std::error_category {
             return "Data-policy already exists";
         case errc::data_policy_not_exists:
             return "Data-policy does not exist";
+        case errc::data_policy_js_code_not_exists:
+            return "Code for data-policy does not exist";
         case errc::source_topic_not_exists:
             return "Attempted to create a non_replicable log for a source "
                    "topic "

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -116,6 +116,18 @@ configuration::configuration()
       "Interval for which all coprocessor offsets are flushed to disk",
       required::no,
       300000ms) // five minutes
+  , enable_v8(
+      *this,
+      "enable_v8",
+      "Enable v8 engine for inline transformation or data-policy",
+      required::no,
+      false)
+  , executor_queue_size(
+      *this,
+      "executor_queue_size",
+      "Queue size for waiting tasks in executor",
+      required::no,
+      ss::smp::count)
   , seed_server_meta_topic_partitions(
       *this,
       "seed_server_meta_topic_partitions",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -55,6 +55,10 @@ struct configuration final : public config_store {
     property<std::size_t> coproc_max_batch_size;
     property<std::chrono::milliseconds> coproc_offset_flush_interval_ms;
 
+    // V8 engine
+    property<bool> enable_v8;
+    property<std::size_t> executor_queue_size;
+
     // Raft
     property<int32_t> seed_server_meta_topic_partitions;
     property<std::chrono::milliseconds> raft_heartbeat_interval_ms;

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -40,21 +40,10 @@ ss::future<> api::start() {
     co_await _mt_frontend.start_single(std::ref(_rs.topics_frontend));
     co_await _pacemaker.start(_engine_addr, std::ref(_rs));
     co_await _pacemaker.invoke_on_all(&coproc::pacemaker::start);
-    _listener = std::make_unique<wasm::event_listener>();
-
-    _wasm_async_handler = std::make_unique<coproc::wasm::async_event_handler>(
-      _listener->get_abort_source(), std::ref(_pacemaker));
-    _listener->register_handler(
-      coproc::wasm::event_type::async, _wasm_async_handler.get());
-
-    co_await _listener->start();
 }
 
 ss::future<> api::stop() {
     auto f = ss::now();
-    if (_listener) {
-        f = _listener->stop();
-    }
     return f.then([this] { return _pacemaker.stop(); }).then([this] {
         return _mt_frontend.stop();
     });

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -38,13 +38,9 @@ private:
     unresolved_address _engine_addr;
     sys_refs _rs;
 
-    std::unique_ptr<wasm::event_listener> _listener; /// one instance
-    ss::sharded<pacemaker> _pacemaker;               /// one per core
+    ss::sharded<pacemaker> _pacemaker; /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
-
-    // Event handlers
-    std::unique_ptr<wasm::async_event_handler> _wasm_async_handler;
 };
 
 } // namespace coproc

--- a/src/v/coproc/event_handler.cc
+++ b/src/v/coproc/event_handler.cc
@@ -11,6 +11,7 @@
 #include "coproc/event_handler.h"
 
 #include "utils/gate_guard.h"
+#include "v8_engine/code_database.h"
 #include "vlog.h"
 
 namespace coproc::wasm {
@@ -125,17 +126,17 @@ async_event_handler::process(absl::btree_map<script_id, parsed_event> wsas) {
     }
 }
 
-ss::future<> data_policy_event_handler::start() { return _scripts.start(); }
+ss::future<> data_policy_event_handler::start() { co_return; }
 
-ss::future<> data_policy_event_handler::stop() { return _scripts.stop(); }
+ss::future<> data_policy_event_handler::stop() { co_return; }
 
 // event_listener run this method from 0-core
 ss::future<> data_policy_event_handler::process(
   absl::btree_map<script_id, parsed_event> wsas) {
     for (auto& [id, event] : wsas) {
         co_await _scripts.invoke_on_all(
-          [id = id, &event = event](
-            absl::btree_map<script_id, iobuf>& _local_scripts) mutable {
+          [id = id,
+           &event = event](v8_engine::code_database& _local_scripts) mutable {
               if (event.header.action == event_action::deploy) {
                   _local_scripts.insert_or_assign(id, event.data.copy());
               } else {
@@ -144,18 +145,6 @@ ss::future<> data_policy_event_handler::process(
           });
     }
     co_return;
-}
-
-std::optional<iobuf>
-data_policy_event_handler::get_code(std::string_view name) {
-    // rpk use xxhash_64 for create script_is from script name
-    script_id id(xxhash_64(name.data(), name.size()));
-    auto code = _scripts.local().find(id);
-    if (code == _scripts.local().end()) {
-        return std::nullopt;
-    }
-
-    return code->second.copy();
 }
 
 } // namespace coproc::wasm

--- a/src/v/coproc/event_handler.h
+++ b/src/v/coproc/event_handler.h
@@ -14,6 +14,7 @@
 #include "coproc/script_dispatcher.h"
 #include "coproc/wasm_event.h"
 #include "seastarx.h"
+#include "v8_engine/fwd.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
@@ -91,6 +92,10 @@ private:
 
 class data_policy_event_handler final : public event_handler {
 public:
+    explicit data_policy_event_handler(
+      ss::sharded<v8_engine::code_database>& scripts)
+      : _scripts(scripts) {}
+
     ss::future<> start() override;
     ss::future<> stop() override;
 
@@ -102,11 +107,9 @@ public:
     ss::future<>
     process(absl::btree_map<script_id, parsed_event> wsas) override;
 
-    std::optional<iobuf> get_code(std::string_view name);
-
 private:
     /// Map of known script ids to their code
-    ss::sharded<absl::btree_map<script_id, iobuf>> _scripts;
+    ss::sharded<v8_engine::code_database>& _scripts;
 };
 
 } // namespace coproc::wasm

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -66,6 +66,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::partition_configuration_differs:
     case cluster::errc::data_policy_already_exists:
     case cluster::errc::data_policy_not_exists:
+    case cluster::errc::data_policy_js_code_not_exists:
     case cluster::errc::wating_for_partition_shutdown:
     case cluster::errc::error_collecting_health_report:
         break;

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -69,6 +69,7 @@ v_cc_library(
     v::pandaproxy_rest
     v::pandaproxy_schema_registry
     v::archival
+    v::v8_engine
   )
 
 add_executable(redpanda

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -174,6 +174,7 @@ int application::run(int ac, char** av) {
       ".yaml file config for redpanda");
 
     return app.run(ac, av, [this, &app] {
+        vassert(ss::smp::count > 0, "Seastar core count must be more 0");
         auto& cfg = app.configuration();
         log_system_resources(_log, cfg);
         validate_arguments(cfg);

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
+#include "coproc/event_handler.h"
 #include "coproc/event_listener.h"
 #include "coproc/fwd.h"
 #include "kafka/client/configuration.h"
@@ -111,6 +112,11 @@ private:
         return cfg.developer_mode() && cfg.enable_coproc();
     }
 
+    bool v8_enabled() {
+        const auto& cfg = config::shard_local_cfg();
+        return cfg.developer_mode() && cfg.enable_v8();
+    }
+
     bool archival_storage_enabled();
 
     template<typename Service, typename... Args>
@@ -153,9 +159,13 @@ private:
     // run these first on destruction
     deferred_actions _deferred;
 
+    std::unique_ptr<v8_engine::api> _v8_engine;
+
     // Coproc stuff
     std::unique_ptr<coproc::wasm::event_listener> _coproc_event_listener;
     std::unique_ptr<coproc::wasm::async_event_handler> _async_event_handler;
+    std::unique_ptr<coproc::wasm::data_policy_event_handler>
+      _data_policy_event_handler;
 };
 
 namespace debug {

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
+#include "coproc/event_listener.h"
 #include "coproc/fwd.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
@@ -151,6 +152,10 @@ private:
     std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;
     // run these first on destruction
     deferred_actions _deferred;
+
+    // Coproc stuff
+    std::unique_ptr<coproc::wasm::event_listener> _coproc_event_listener;
+    std::unique_ptr<coproc::wasm::async_event_handler> _async_event_handler;
 };
 
 namespace debug {

--- a/src/v/v8_engine/CMakeLists.txt
+++ b/src/v/v8_engine/CMakeLists.txt
@@ -7,6 +7,7 @@ v_cc_library(
     script.cc
     data_policy.cc
     data_policy_table.cc
+    logger.cc
   DEPS
     Seastar::seastar
     v8_monolith

--- a/src/v/v8_engine/CMakeLists.txt
+++ b/src/v/v8_engine/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
   DEPS
     Seastar::seastar
     v8_monolith
-    v_reflection)
+    absl::node_hash_map
+    v::rphashing)
 
 add_subdirectory(tests)

--- a/src/v/v8_engine/CMakeLists.txt
+++ b/src/v/v8_engine/CMakeLists.txt
@@ -1,6 +1,7 @@
 v_cc_library(
   NAME v8_engine
   SRCS
+    api.cc
     environment.cc
     executor.cc
     script.cc

--- a/src/v/v8_engine/api.cc
+++ b/src/v/v8_engine/api.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "v8_engine/api.h"
+
+namespace v8_engine {
+
+executor_service::executor_service(ss::alien::instance& instance, int64_t size)
+  : _instance(instance)
+  , _size(size) {}
+
+ss::future<> executor_service::start() {
+    return _executor.start_single(
+      std::ref(_instance), _core_for_std_thread, _size);
+}
+
+ss::future<> executor_service::stop() { return _executor.stop(); }
+
+api::api(ss::alien::instance& instance, int64_t size)
+  : _executor_service(instance, size) {}
+
+ss::future<> api::start() { return _executor_service.start(); }
+
+ss::future<> api::stop() { return _executor_service.stop(); }
+
+executor_service& api::get_executor() { return _executor_service; }
+
+} // namespace v8_engine

--- a/src/v/v8_engine/api.cc
+++ b/src/v/v8_engine/api.cc
@@ -46,4 +46,8 @@ code_database& api::get_code_database_local() {
     return _dp_code_database.local();
 }
 
+api::script_dispatcher_t& api::get_script_dispatcher() {
+    return _script_dispatcher.local();
+}
+
 } // namespace v8_engine

--- a/src/v/v8_engine/api.cc
+++ b/src/v/v8_engine/api.cc
@@ -26,10 +26,24 @@ ss::future<> executor_service::stop() { return _executor.stop(); }
 api::api(ss::alien::instance& instance, int64_t size)
   : _executor_service(instance, size) {}
 
-ss::future<> api::start() { return _executor_service.start(); }
+ss::future<> api::start() {
+    co_await _executor_service.start();
+    co_await _dp_code_database.start();
+}
 
-ss::future<> api::stop() { return _executor_service.stop(); }
+ss::future<> api::stop() {
+    co_await _dp_code_database.stop();
+    co_await _executor_service.stop();
+}
 
 executor_service& api::get_executor() { return _executor_service; }
+
+ss::sharded<code_database>& api::get_code_database() {
+    return _dp_code_database;
+}
+
+code_database& api::get_code_database_local() {
+    return _dp_code_database.local();
+}
 
 } // namespace v8_engine

--- a/src/v/v8_engine/api.h
+++ b/src/v/v8_engine/api.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "v8_engine/code_database.h"
 #include "v8_engine/environment.h"
 #include "v8_engine/executor.h"
 
@@ -62,10 +63,13 @@ public:
     ss::future<> stop();
 
     executor_service& get_executor();
+    ss::sharded<code_database>& get_code_database();
+    code_database& get_code_database_local();
 
 private:
     enviroment _env;
     executor_service _executor_service;
+    ss::sharded<code_database> _dp_code_database;
 };
 
 } // namespace v8_engine

--- a/src/v/v8_engine/api.h
+++ b/src/v/v8_engine/api.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "v8_engine/environment.h"
+#include "v8_engine/executor.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace v8_engine {
+
+// This class implements wrapper for executor.
+// In current design executor exist on one core
+// And for submit tasks you need to run invoke_on
+// So this class wrap this logic for v8_engine::script
+class executor_service {
+    static constexpr size_t _home_core = 0;
+    static constexpr unsigned _core_for_std_thread = 0;
+
+public:
+    executor_service(ss::alien::instance& instance, int64_t size);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    // We do not need use gate there, because executor has gate inside submit
+    // function
+    template<typename WrapperFuncForExecutor>
+    ss::future<> submit(
+      WrapperFuncForExecutor&& func_for_executor,
+      std::chrono::milliseconds timeout) {
+        return _executor.invoke_on(
+          _home_core,
+          [func_for_executor = std::forward<WrapperFuncForExecutor>(
+             func_for_executor),
+           timeout](executor& exec) mutable {
+              return exec.submit(
+                std::forward<WrapperFuncForExecutor>(func_for_executor),
+                timeout);
+          });
+    }
+
+private:
+    ss::alien::instance& _instance;
+    size_t _size;
+    ss::sharded<executor> _executor;
+};
+
+class api {
+public:
+    api(ss::alien::instance& instance, int64_t size);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    executor_service& get_executor();
+
+private:
+    enviroment _env;
+    executor_service _executor_service;
+};
+
+} // namespace v8_engine

--- a/src/v/v8_engine/api.h
+++ b/src/v/v8_engine/api.h
@@ -13,6 +13,7 @@
 #include "v8_engine/code_database.h"
 #include "v8_engine/environment.h"
 #include "v8_engine/executor.h"
+#include "v8_engine/script_dispatcher.h"
 
 #include <seastar/core/sharded.hh>
 
@@ -66,10 +67,14 @@ public:
     ss::sharded<code_database>& get_code_database();
     code_database& get_code_database_local();
 
+    using script_dispatcher_t = script_dispatcher<executor_service>;
+    script_dispatcher_t& get_script_dispatcher();
+
 private:
     enviroment _env;
     executor_service _executor_service;
     ss::sharded<code_database> _dp_code_database;
+    ss::sharded<script_dispatcher_t> _script_dispatcher;
 };
 
 } // namespace v8_engine

--- a/src/v/v8_engine/code_database.h
+++ b/src/v/v8_engine/code_database.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "coproc/types.h"
+#include "hashing/xx.h"
+#include "model/metadata.h"
+
+#include <absl/container/node_hash_map.h>
+
+namespace v8_engine {
+
+class code_database {
+public:
+    void insert_or_assign(coproc::script_id id, iobuf code) {
+        _code_db.insert_or_assign(id, std::move(code));
+    }
+
+    void erase(coproc::script_id id) { _code_db.erase(id); }
+
+    std::optional<iobuf> get_code(std::string_view name) {
+        // rpk use xxhash_64 for create script_is from script name
+        size_t id(xxhash_64(name.data(), name.size()));
+        auto code = _code_db.find(coproc::script_id(id));
+        if (code == _code_db.end()) {
+            return std::nullopt;
+        }
+
+        return code->second.share(0, code->second.size_bytes());
+    }
+
+private:
+    absl::node_hash_map<coproc::script_id, iobuf> _code_db;
+};
+
+} // namespace v8_engine

--- a/src/v/v8_engine/errc.h
+++ b/src/v/v8_engine/errc.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include <ostream>
+#include <system_error>
+
+namespace v8_engine {
+
+enum class errc { success = 0, v8_runtimes_not_exist, v8_runtimes_compiling };
+
+struct errc_category final : public std::error_category {
+    const char* name() const noexcept final { return "coproc::errc"; }
+
+    std::string message(int c) const final {
+        switch (static_cast<errc>(c)) {
+        case errc::success:
+            return "Success";
+        case errc::v8_runtimes_not_exist:
+            return "V8 runtimes does not exist";
+        case errc::v8_runtimes_compiling:
+            return "V8 runtimes are compiling";
+        default:
+            return "Undefined coprocessor error encountered";
+        }
+    }
+};
+
+inline const std::error_category& error_category() noexcept {
+    static errc_category e;
+    return e;
+}
+
+inline std::error_code make_error_code(errc e) noexcept {
+    return std::error_code(static_cast<int>(e), error_category());
+}
+
+} // namespace v8_engine
+
+namespace std {
+template<>
+struct is_error_code_enum<v8_engine::errc> : true_type {};
+
+} // namespace std

--- a/src/v/v8_engine/fwd.h
+++ b/src/v/v8_engine/fwd.h
@@ -14,6 +14,7 @@
 namespace v8_engine {
 
 class api;
+class code_database;
 class data_policy_table;
 class executor_service;
 

--- a/src/v/v8_engine/fwd.h
+++ b/src/v/v8_engine/fwd.h
@@ -13,6 +13,8 @@
 
 namespace v8_engine {
 
+class api;
 class data_policy_table;
+class executor_service;
 
 } // namespace v8_engine

--- a/src/v/v8_engine/logger.cc
+++ b/src/v/v8_engine/logger.cc
@@ -1,0 +1,13 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Licensed as a Redpanda Enterprise file under the Redpanda Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+
+#include "logger.h"
+
+namespace v8_engine {
+ss::logger log{"v8_engine"};
+} // namespace v8_engine

--- a/src/v/v8_engine/logger.h
+++ b/src/v/v8_engine/logger.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/print.hh>
+#include <seastar/util/log.hh>
+
+namespace v8_engine {
+extern ss::logger log;
+} // namespace v8_engine

--- a/src/v/v8_engine/script.cc
+++ b/src/v/v8_engine/script.cc
@@ -10,6 +10,7 @@
 
 #include "v8_engine/script.h"
 
+#include "bytes/iobuf_parser.h"
 #include "utils/file_io.h"
 
 #include <seastar/core/future.hh>
@@ -43,7 +44,7 @@ script::~script() {
     _context.Reset();
 }
 
-void script::compile_script(ss::temporary_buffer<char> js_code) {
+void script::compile_script(iobuf js_code) {
     v8::Locker locker(_isolate.get());
     v8::Isolate::Scope isolate_scope(_isolate.get());
     v8::HandleScope handle_scope(_isolate.get());
@@ -51,12 +52,12 @@ void script::compile_script(ss::temporary_buffer<char> js_code) {
     v8::Local<v8::Context> local_ctx = v8::Context::New(_isolate.get());
     v8::Context::Scope context_scope(local_ctx);
 
-    v8::Local<v8::String> script_code = v8::String::NewFromUtf8(
-                                          _isolate.get(),
-                                          js_code.begin(),
-                                          v8::NewStringType::kNormal,
-                                          js_code.size())
-                                          .ToLocalChecked();
+    auto code = iobuf_const_parser(js_code).read_string(js_code.size_bytes());
+
+    v8::Local<v8::String> script_code
+      = v8::String::NewFromUtf8(
+          _isolate.get(), code.c_str(), v8::NewStringType::kNormal, code.size())
+          .ToLocalChecked();
     v8::Local<v8::Script> compiled_script;
     if (!v8::Script::Compile(local_ctx, script_code)
            .ToLocal(&compiled_script)) {

--- a/src/v/v8_engine/script_dispatcher.h
+++ b/src/v/v8_engine/script_dispatcher.h
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "model/metadata.h"
+#include "outcome.h"
+#include "v8_engine/errc.h"
+#include "v8_engine/logger.h"
+#include "v8_engine/script.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/shared_ptr.hh>
+
+#include <absl/container/node_hash_map.h>
+
+#include <atomic>
+#include <exception>
+#include <iostream>
+#include <variant>
+
+namespace v8_engine {
+
+struct script_compile_params {
+    model::topic_namespace topic;
+    ss::sstring function_name;
+    iobuf code;
+    size_t max_heap_size_bytes{10000};
+    size_t run_timeout_ms{200};
+
+    script_compile_params(
+      model::topic_namespace topic, ss::sstring function_name, iobuf code)
+      : topic(std::move(topic))
+      , function_name(std::move(function_name))
+      , code(std::move(code)) {}
+
+    script_compile_params(const script_compile_params& other)
+      : topic(other.topic)
+      , function_name(other.function_name)
+      , code(other.code.copy())
+      , max_heap_size_bytes(other.max_heap_size_bytes)
+      , run_timeout_ms(other.run_timeout_ms) {}
+};
+
+// This class implement database for v8_runtimes. It can be updated by
+// data_policy_manager. Fetch request will only run get for getting v8_runtimes
+
+// clang-format off
+template<typename Executor>
+CONCEPT(requires requires(Executor executor) {
+    { executor.submit() } -> ss::future<>;
+})
+// clang-format on
+class script_dispatcher {
+    constexpr static size_t _mutex_count{50};
+
+public:
+    explicit script_dispatcher(Executor& executor)
+      : _executor(executor) {}
+
+    ss::future<> start() {
+        (void)ss::with_gate(_gate, [this] {
+            return ss::do_until(
+              [this] { return _as.abort_requested(); },
+              [this]() -> ss::future<> { co_await update_runtimes(); });
+        });
+
+        co_return;
+    }
+
+    ss::future<> stop() {
+        _as.request_abort();
+        co_await _gate.close();
+    }
+
+    // Insert only put compilation params to map.
+    bool insert(
+      model::topic_namespace topic, ss::sstring function_name, iobuf code) {
+        return _compilation_params
+          .emplace(
+            topic,
+            script_compile_params(
+              topic, std::move(function_name), std::move(code)))
+          .second;
+    }
+
+    // Will delete information about dp from compilation_params map, Also delete
+    // runtime if it exists.
+    // If we change data_policy several times during compilation, we
+    // need to notify background workwe that his runtimes expired and background
+    // worker should not save this runtimes to map, because after that runtimes
+    // map will contain "old" v8.
+    bool remove(const model::topic_namespace& topic) {
+        bool res = _compilation_params.erase(topic) == 1;
+        if (!res) {
+            return res;
+        }
+
+        auto it = _runtimes.find(topic);
+        if (it == _runtimes.end()) {
+            return res;
+        }
+
+        ss::visit(
+          it->second,
+          [](runtimes_counter& counter) {
+              counter.is_compiled = false;
+              counter.deletion++;
+          },
+          [this, &it](const ss::lw_shared_ptr<script>&) {
+              _runtimes.erase(it);
+          });
+
+        return res;
+    }
+
+    /// This method return v8_runtimes for data-policy (aka topic on curent
+    /// moment). If task inside background queue it will return error.
+    result<ss::lw_shared_ptr<script>, errc>
+    get(const model::topic_namespace& topic) {
+        auto it = _compilation_params.find(topic);
+        if (it == _compilation_params.end()) {
+            return errc::v8_runtimes_not_exist;
+        }
+
+        auto runtimes_it = _runtimes.find(topic);
+        if (runtimes_it == _runtimes.end()) {
+            // Need to compile runtimes at first time.
+            auto [_, res] = _runtimes.emplace(topic, runtimes_counter());
+            _event_queue.emplace_back(it->second);
+            vassert(
+              res, "Can not update _runtimes database for topic{}", topic);
+            return errc::v8_runtimes_compiling;
+        }
+
+        return ss::visit(
+          runtimes_it->second,
+          [it, this](runtimes_counter& counter)
+            -> result<ss::lw_shared_ptr<script>, errc> {
+              if (!counter.is_compiled) {
+                  // Need to add task to compile v8_runtimes, because user
+                  // remove old data_policy and insert new dp for current topic
+                  counter.is_compiled = true;
+                  _event_queue.emplace_back(it->second);
+              }
+              return errc::v8_runtimes_compiling;
+          },
+          [](ss::lw_shared_ptr<script> script_ptr)
+            -> result<ss::lw_shared_ptr<script>, errc> { return script_ptr; });
+    }
+
+private:
+    // This method understand did user update data_policy for topic and we need
+    // to skip some compilation tasks
+    bool is_data_policy_changed(const model::topic_namespace& topic) {
+        auto runtimes_it = _runtimes.find(topic);
+        vassert(
+          runtimes_it != _runtimes.end(),
+          "On compilation moment runtimes database must contain info about "
+          "waiting runtimes request for topic({})",
+          topic);
+        return ss::visit(
+          runtimes_it->second,
+          [&runtimes_it, this](runtimes_counter& counter) -> bool {
+              // Need to skip this task;
+              if (counter.deletion > 0) {
+                  // We handle all compilation task and skip all of them.
+                  if (--counter.deletion == 0) {
+                      _runtimes.erase(runtimes_it);
+                  }
+                  return true;
+              }
+              return false;
+          },
+          [topic](const ss::lw_shared_ptr<script>&) -> bool {
+              vassert(
+                false,
+                "Task queue for update runtimes can not contain task if "
+                "runtime exists for topic({})",
+                topic);
+              return false;
+          });
+    }
+
+    // Internal function which read updates from queue and change hash_map with
+    // v8_runtimes.
+    ss::future<> update_runtimes() {
+        while (!_event_queue.empty()) {
+            auto& compilation_event = _event_queue.front();
+
+            // check before compilatioin do we need skip this task.
+            if (is_data_policy_changed(compilation_event.topic)) {
+                _event_queue.pop_front();
+                co_return;
+            }
+
+            auto script_ptr = ss::make_lw_shared<script>(
+              compilation_event.max_heap_size_bytes,
+              compilation_event.run_timeout_ms);
+
+            bool is_compiled = true;
+            try {
+                co_await script_ptr->init(
+                  compilation_event.function_name,
+                  std::move(compilation_event.code),
+                  _executor);
+            } catch (const std::exception& e) {
+                log.error(
+                  "Can not compile data_policy funtion({}) for topic({}). "
+                  "Error: ",
+                  compilation_event.function_name,
+                  compilation_event.topic,
+                  e.what());
+                is_compiled = false;
+            }
+
+            if (is_data_policy_changed(compilation_event.topic)) {
+                _event_queue.pop_front();
+                co_return;
+            }
+
+            if (is_compiled) {
+                _runtimes.insert_or_assign(compilation_event.topic, script_ptr);
+            } else {
+                vassert(
+                  _runtimes.erase(compilation_event.topic) == 0,
+                  "Inconsistency script_dispatcher on failed compilation. Can "
+                  "not find info about waiting runtime request for topic({})",
+                  compilation_event.topic);
+            }
+            _event_queue.pop_front();
+        }
+    }
+
+private:
+    absl::node_hash_map<model::topic_namespace, script_compile_params>
+      _compilation_params;
+
+    // Queue with updates for script_dispatcher;
+    std::list<script_compile_params> _event_queue;
+
+    // This struct can help to understand do we need to sckip compilation,
+    // because data_policy was updated. Scenario looks like [insert dp1] ->
+    // [get(push compilation task to queue)] -> [remove dp 1] -> [insert dp2] ->
+    // [get(we need to cancel first compilation, because user can get expared
+    // state)]
+    struct runtimes_counter {
+        bool is_compiled{true};
+        int64_t deletion{0};
+    };
+
+    using runtimes_db_val
+      = std::variant<runtimes_counter, ss::lw_shared_ptr<script>>;
+
+    // Database for v8_runtimes
+    absl::node_hash_map<model::topic_namespace, runtimes_db_val> _runtimes;
+
+    Executor& _executor;
+
+    ss::gate _gate;
+    ss::abort_source _as;
+};
+
+} // namespace v8_engine

--- a/src/v/v8_engine/tests/CMakeLists.txt
+++ b/src/v/v8_engine/tests/CMakeLists.txt
@@ -15,6 +15,21 @@ rp_test(
 
 rp_test(
   UNIT_TEST
+  BINARY_NAME v8_script_dispatcher
+  SOURCES
+    script_dispatcher_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::v8_engine v::model v::utils
+  INPUT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/scripts/sum.js
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/to_upper.js
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/compile_timeout.js
+              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run_timeout.js
+  ARGS "-- -c 1"
+  LABELS v8_engine
+)
+
+rp_test(
+  UNIT_TEST
   BINARY_NAME v8_executor
   SOURCES
     executor_test.cc

--- a/src/v/v8_engine/tests/script_dispatcher_test.cc
+++ b/src/v/v8_engine/tests/script_dispatcher_test.cc
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "seastarx.h"
+#include "utils/file_io.h"
+#include "v8_engine/executor.h"
+#include "v8_engine/script_dispatcher.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/test/tools/old/interface.hpp>
+
+#include <chrono>
+using namespace std::chrono_literals;
+
+class env_for_test {
+public:
+    env_for_test()
+      : _executor(ss::engine().alien(), 1, ss::smp::count)
+      , _dispatcher(_executor) {
+        _dispatcher.start().get();
+    }
+
+    ~env_for_test() {
+        _dispatcher.stop().get();
+        _executor.stop().get();
+    }
+
+    v8_engine::executor& get_executor() { return _executor; }
+    v8_engine::script_dispatcher<v8_engine::executor>& get_dispather() {
+        return _dispatcher;
+    }
+
+private:
+    v8_engine::executor _executor;
+    v8_engine::script_dispatcher<v8_engine::executor> _dispatcher;
+};
+
+v8_engine::enviroment env;
+
+SEASTAR_THREAD_TEST_CASE(simple_update_test) {
+    env_for_test env_wrapper;
+
+    auto& dispatcher = env_wrapper.get_dispather();
+
+    model::ns ns("test");
+    model::topic topic("1");
+    model::topic_namespace topic_ns(ns, topic);
+
+    auto js_code = read_fully("to_upper.js").get();
+    BOOST_REQUIRE(dispatcher.insert(topic_ns, "to_upper", std::move(js_code)));
+
+    while (dispatcher.get(topic_ns).has_error()) {
+        ss::sleep(10ms).get();
+    }
+
+    auto v8_runtime = dispatcher.get(topic_ns).value();
+
+    ss::sstring raw_data = "qwerty";
+    ss::temporary_buffer<char> data(raw_data.data(), raw_data.size());
+    v8_runtime->run(data.share(), env_wrapper.get_executor()).get();
+    boost::to_upper(raw_data);
+    auto res = std::string(data.get_write(), data.size());
+    BOOST_REQUIRE_EQUAL(raw_data, res);
+
+    BOOST_REQUIRE(dispatcher.remove(topic_ns));
+    auto get_res = dispatcher.get(topic_ns);
+    BOOST_REQUIRE(get_res.has_error());
+    BOOST_REQUIRE(get_res.error() == v8_engine::errc::v8_runtimes_not_exist);
+
+    js_code = read_fully("to_upper.js").get();
+    BOOST_REQUIRE(dispatcher.insert(topic_ns, "to_upper", std::move(js_code)));
+
+    while (dispatcher.get(topic_ns).has_error()) {
+        ss::sleep(10ms).get();
+    }
+    v8_runtime = dispatcher.get(topic_ns).value();
+
+    ss::sstring raw_data2 = "qwerty";
+    ss::temporary_buffer<char> data2(raw_data2.data(), raw_data2.size());
+    v8_runtime->run(data2.share(), env_wrapper.get_executor()).get();
+    boost::to_upper(raw_data2);
+    res = std::string(data2.get_write(), data2.size());
+    BOOST_REQUIRE_EQUAL(raw_data2, res);
+}

--- a/src/v/v8_engine/tests/script_test.cc
+++ b/src/v/v8_engine/tests/script_test.cc
@@ -44,7 +44,7 @@ SEASTAR_THREAD_TEST_CASE(to_upper_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code = read_fully_tmpbuf("to_upper.js").get();
+    auto js_code = read_fully("to_upper.js").get();
     script.init("to_upper", std::move(js_code), executor_wrapper.get_executor())
       .get();
 
@@ -61,7 +61,7 @@ SEASTAR_THREAD_TEST_CASE(sum_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code = read_fully_tmpbuf("sum.js").get();
+    auto js_code = read_fully("sum.js").get();
     script.init("sum", std::move(js_code), executor_wrapper.get_executor())
       .get();
 
@@ -88,8 +88,8 @@ SEASTAR_THREAD_TEST_CASE(exception_in_compile_script_test) {
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
     std::string error_script = "2lkb34poup3q94h";
-    ss::temporary_buffer<char> js_code(
-      error_script.data(), error_script.size());
+    iobuf js_code;
+    js_code.append(error_script.c_str(), error_script.size());
     BOOST_REQUIRE_EXCEPTION(
       script.init("sum", std::move(js_code), executor_wrapper.get_executor())
         .get(),
@@ -106,7 +106,7 @@ SEASTAR_THREAD_TEST_CASE(exception_in_get_script_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code = read_fully_tmpbuf("sum.js").get();
+    auto js_code = read_fully("sum.js").get();
     BOOST_REQUIRE_EXCEPTION(
       script.init("foo", std::move(js_code), executor_wrapper.get_executor())
         .get(),
@@ -122,8 +122,7 @@ SEASTAR_THREAD_TEST_CASE(compile_timeout_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code
-      = read_fully_tmpbuf("compile_timeout.js").get();
+    auto js_code = read_fully("compile_timeout.js").get();
     BOOST_REQUIRE_EXCEPTION(
       script.init("foo", std::move(js_code), executor_wrapper.get_executor())
         .get(),
@@ -139,8 +138,7 @@ SEASTAR_THREAD_TEST_CASE(run_timeout_test) {
 
     v8_engine::script script(100, TIMEOUT_FOR_TEST_MS);
 
-    ss::temporary_buffer<char> js_code
-      = read_fully_tmpbuf("run_timeout.js").get();
+    auto js_code = read_fully("run_timeout.js").get();
     script
       .init("run_timeout", std::move(js_code), executor_wrapper.get_executor())
       .get();


### PR DESCRIPTION
## Cover letter
* `executor` - is std::thread with spsc queue.
* `executor_service` - is sharded service, which provide some logic to put task from seastar core to `executor`. In v0 it is constructed on 0-core. Each core in apply method run `invoke_on(0...)`. 
In next iteration logic will be changed. For example each core will have the own executor.
* code_database - service to store js code from `rpk wasm deploy. It is sharded because each core can create task for compile v8 and need to provide js code for that. When `executor_service` will be sharded normally it will prevent cross-core communication.
* data_policy_table - database for data-policies. It contains mapping from topic to data-policy.
* script_dispatcher - the main service which store v8 runtimes for fetch request. `data_policy_fronted` create records in log about data_policy changes. `data_policy_manager` replicates and change script_dispatcher.
There are 3 methods for dp_manager: `insert`, `remove`, `get`. v8_runtimes need 0,5MB memory, and compilation time can be too long, so we will compile v8 only on `get`. Fetch request will run `get` and put compilation task to internal queue. In next version we can cache v8_runtimes, For example use LRU cache.

---
### from - to  10c3203 to 6e18f9a
* Added queue for v8_runtimes updates
* Added v8 stuff to api

### [force-pushed ](https://github.com/vectorizedio/redpanda/compare/6e18f9a95f9d085d0548293ebe8e3fdebaf3eea5..ab48e7fb7e5b2119f0423a6b81bcb76d36b6334c)  from 6e18f9a to ab48e7f
* script dispatcher compile runtimes in background

### [force-pushed](https://github.com/vectorizedio/redpanda/compare/ab48e7fb7e5b2119f0423a6b81bcb76d36b6334c..f570fa367389dde1e12002ba119632cdcfa7977d)  from ab48e7f to f570fa3
* add more coments

### [force-push](https://github.com/vectorizedio/redpanda/compare/f570fa367389dde1e12002ba119632cdcfa7977d..0cd545ced0002920f3dc2b7feb8277872bfda166)
- Fix Rob's review:
- Use concept
- Delte core for std::thread from executor
- e.t.c.

### [force-pushed](https://github.com/vectorizedio/redpanda/compare/0cd545ced0002920f3dc2b7feb8277872bfda166..8dd6249045c1543e08c7630d85031b0097294975) from 0cd545c to 8dd6249 and [force-pushed](https://github.com/vectorizedio/redpanda/compare/8dd6249045c1543e08c7630d85031b0097294975..e4099408915270aeef33bfc28b08021e2d1154b7) from 8dd6249 to e409940
* resolve conflicts

### [force-pushed](https://github.com/vectorizedio/redpanda/compare/e4099408915270aeef33bfc28b08021e2d1154b7..22753667ae748869b6c0f9516ae859a6a8be23b9) from e409940 to 2275366 
* Fix Noah review