### PR TITLE
docs: Fix EOL for Windows network creation

### DIFF
--- a/docs/www/quick-start-windows.md
+++ b/docs/www/quick-start-windows.md
@@ -52,9 +52,9 @@ but still allow for the Kafka API to be available on the localhost.
 We'll also create the persistent volumes that let the Redpanda instances keep state during instance restarts.
 
 ```bash
-docker network create -d bridge redpandanet && \
-docker volume create redpanda1 && \
-docker volume create redpanda2 && \
+docker network create -d bridge redpandanet && ^
+docker volume create redpanda1 && ^
+docker volume create redpanda2 && ^
 docker volume create redpanda3
 ```
 


### PR DESCRIPTION
## Cover letter

The Windows EOL was incorrect for the command to create the Docker network.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
