### PR TITLE
Revert "k8s: remove tests failing when running on hand-created kind cluster"

### DIFF
--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: schema-registry
+status:
+  readyReplicas: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/00-redpanda-cluster.yaml
@@ -1,0 +1,27 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: schema-registry
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+      tls:
+        enabled: true
+    adminApi:
+    - port: 9644
+    schemaRegistry:
+      port: 8081
+    developerMode: true

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/01-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/01-create-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/01-create-schema.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          command:
+            - curl
+          args:
+            - --silent
+            - -X
+            - POST
+            - -H
+            - "Content-Type: application/vnd.schemaregistry.v1+json"
+            - --data
+            - '{"schema": "{\"type\": \"string\"}" }'
+            - http://schema-registry-cluster:8081/subjects/Kafka-value/versions
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/02-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: retrive-schema
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/02-retrieve-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/02-retrieve-schema.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: retrive-schema
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          command:
+            - curl
+          args:
+            - --silent
+            - -X
+            - GET
+            - http://schema-registry-cluster:8081/subjects/Kafka-value/versions/1
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/03-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-schema
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/03-delete-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/03-delete-schema.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-schema
+spec:
+  template:
+    spec:
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          command:
+            - curl
+          args:
+            - --silent
+            - -X
+            - DELETE
+            - http://schema-registry-cluster:8081/subjects/Kafka-value/versions/1
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/04-add-node-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/04-add-node-tls.yaml
@@ -1,0 +1,10 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: schema-registry
+spec:
+  configuration:
+    schemaRegistry:
+      port: 8081
+      tls:
+        enabled: true

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/04-assert.yaml
@@ -1,0 +1,44 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: schema-registry-schema-registry-selfsigned-issuer
+status:
+  conditions:
+    - reason: IsReady
+      status: "True"
+      type: Ready
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: schema-registry-schema-registry-root-issuer
+status:
+  conditions:
+    - reason: KeyPairVerified
+      status: "True"
+      type: Ready
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: schema-registry-schema-registry-root-certificate
+status:
+  conditions:
+    - reason: Ready
+      status: "True"
+      type: Ready
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: schema-registry-schema-registry-node
+status:
+  conditions:
+    - reason: Ready
+      status: "True"
+      type: Ready

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/05-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/05-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-tls
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/05-create-schema-with-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/05-create-schema-with-tls.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-tls
+spec:
+  template:
+    spec:
+      volumes:
+      - name: tlscert
+        secret:
+          defaultMode: 420
+          secretName: schema-registry-schema-registry-node
+      containers:
+      - name: rpk
+        image: localhost/redpanda:dev
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+        - /bin/bash
+        - -c
+        args:
+        - >
+          curl -vv --silent --cacert /etc/tls/certs/schema-registry/ca.crt
+          -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json"
+          --data '{"schema": "{\"type\": \"string\"}" }'
+          https://schema-registry-cluster.$POD_NAMESPACE.svc.cluster.local.:8081/subjects/Kafka-value/versions
+        volumeMounts:
+        - mountPath: /etc/tls/certs/schema-registry
+          name: tlscert
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/06-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/06-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: retrieve-schema-with-tls
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/06-retrieve-schema-with-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/06-retrieve-schema-with-tls.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: retrieve-schema-with-tls
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tlscert
+          secret:
+            defaultMode: 420
+            secretName: schema-registry-schema-registry-node
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              curl -vv --silent --cacert /etc/tls/certs/schema-registry/ca.crt
+              -X GET
+              https://schema-registry-cluster.$POD_NAMESPACE.svc.cluster.local.:8081/subjects/Kafka-value/versions/1
+          volumeMounts:
+            - mountPath: /etc/tls/certs/schema-registry
+              name: tlscert
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/07-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/07-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-schema-with-tls
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/07-delete-schema-with-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/07-delete-schema-with-tls.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-schema-with-tls
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tlscert
+          secret:
+            defaultMode: 420
+            secretName: schema-registry-schema-registry-node
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              curl -vv --silent --cacert /etc/tls/certs/schema-registry/ca.crt
+              -X DELETE
+              https://schema-registry-cluster.$POD_NAMESPACE.svc.cluster.local.:8081/subjects/Kafka-value/versions/1
+          volumeMounts:
+            - mountPath: /etc/tls/certs/schema-registry
+              name: tlscert
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/08-add-client-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/08-add-client-tls.yaml
@@ -1,0 +1,11 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: schema-registry
+spec:
+  configuration:
+    schemaRegistry:
+      port: 8081
+      tls:
+        enabled: true
+        requireClientAuth: true

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/08-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/08-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: schema-registry-schema-registry-client
+status:
+  conditions:
+    - reason: Ready
+      status: "True"
+      type: Ready

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/09-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/09-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-client-tls
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/09-create-schema-with-client-tls.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/09-create-schema-with-client-tls.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-client-tls
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tlscert
+          secret:
+            defaultMode: 420
+            secretName: schema-registry-schema-registry-node
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              curl -vv --silent --cacert /etc/tls/certs/schema-registry/ca.crt
+              --cert /etc/tls/certs/schema-registry/tls.crt --key /etc/tls/certs/schema-registry/tls.key
+              -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json"
+              --data '{"schema": "{\"type\": \"string\"}" }'
+              https://schema-registry-cluster.$POD_NAMESPACE.svc.cluster.local.:8081/subjects/Kafka-value/versions
+          volumeMounts:
+            - mountPath: /etc/tls/certs/schema-registry
+              name: tlscert
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/10-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/10-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: retrieve-schema-with-client-tls
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/10-retrieve-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/10-retrieve-schema.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: retrieve-schema-with-client-tls
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tlscert
+          secret:
+            defaultMode: 420
+            secretName: schema-registry-schema-registry-node
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              curl -vv --silent --cacert /etc/tls/certs/schema-registry/ca.crt
+              --cert /etc/tls/certs/schema-registry/tls.crt --key /etc/tls/certs/schema-registry/tls.key
+              -X GET
+              https://schema-registry-cluster.$POD_NAMESPACE.svc.cluster.local.:8081/subjects/Kafka-value/versions/1
+          volumeMounts:
+            - mountPath: /etc/tls/certs/schema-registry
+              name: tlscert
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/11-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/11-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-schema-with-client-tls
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/11-delete-schema.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/11-delete-schema.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-schema-with-client-tls
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tlscert
+          secret:
+            defaultMode: 420
+            secretName: schema-registry-schema-registry-node
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              curl -vv --silent --cacert /etc/tls/certs/schema-registry/ca.crt
+              --cert /etc/tls/certs/schema-registry/tls.crt --key /etc/tls/certs/schema-registry/tls.key
+              -X DELETE
+              https://schema-registry-cluster.$POD_NAMESPACE.svc.cluster.local.:8081/subjects/Kafka-value/versions/1
+          volumeMounts:
+            - mountPath: /etc/tls/certs/schema-registry
+              name: tlscert
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/update-conf-image/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/00-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - command: kubectl rollout status deployment redpanda-controller-manager -n redpanda-system
+  - command: hack/wait-for-webhook-ready.sh

--- a/src/go/k8s/tests/e2e/update-conf-image/00-configurator.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/00-configurator.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# Set specific configurator version - this will be reflected in all configurator containers of managed redpanda clusters (new or old)
+- command: kubectl patch deployment redpanda-controller-manager -n redpanda-system --type='json' -p='[{"op":"add", "path":"/spec/template/spec/containers/1/args/-", "value":"--configurator-tag=v21.6.6"}]'
+- command: kubectl get deployment redpanda-controller-manager -n redpanda-system -o json

--- a/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-image-cluster
+spec:
+  template:
+    spec:
+      initContainers:
+        - image: "vectorized/configurator:v21.6.6"
+      containers:
+        - image: "localhost/redpanda:dev"
+        - image: "localhost/redpanda:dev"
+status:
+  readyReplicas: 2

--- a/src/go/k8s/tests/e2e/update-conf-image/01-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/01-current-image.yaml
@@ -1,0 +1,23 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-image-cluster
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    adminApi:
+    - port: 9644
+    developerMode: true

--- a/src/go/k8s/tests/e2e/update-conf-image/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/02-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - command: kubectl rollout status deployment redpanda-controller-manager -n redpanda-system
+  - command: hack/wait-for-webhook-ready.sh

--- a/src/go/k8s/tests/e2e/update-conf-image/02-new-configurator.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/02-new-configurator.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# Configurator version will become default (latest) and all redpanda configurators (one here) get updated to latest
+- command: kubectl patch deployment redpanda-controller-manager -n redpanda-system --type='json' -p='[{"op":"remove", "path":"/spec/template/spec/containers/1/args/4"}]'

--- a/src/go/k8s/tests/e2e/update-conf-image/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/03-assert.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-image-cluster
+spec:
+  template:
+    spec:
+      initContainers:
+        - image: "vectorized/configurator:latest"
+status:
+  readyReplicas: 2
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: update-image-cluster-0
+spec:
+  initContainers:
+    - name: redpanda-configurator
+      image: "vectorized/configurator:latest" 
+status:
+  phase: "Running"
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: update-image-cluster-1
+status:
+  phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-image-cluster-and-node-port
+status:
+  readyReplicas: 2
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    pod: update-image-cluster-and-node-port-0
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - type: pod
+    pod: update-image-cluster-and-node-port-1
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: update-image-cluster-and-node-port-external
+spec:
+  externalTrafficPolicy: Local
+  ports:
+    - name: kafka-external
+      nodePort: 32748
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: admin-external
+      nodePort: 31178
+      port: 9645
+      protocol: TCP
+      targetPort: 9645
+  type: NodePort

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/00-current-image.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: update-image-cluster-and-node-port-external
+spec:
+  externalTrafficPolicy: Local
+  ports:
+    - name: kafka-different-name
+      nodePort: 32748
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: admin-different-name
+      nodePort: 31178
+      port: 9645
+      protocol: TCP
+      targetPort: 9645
+  type: NodePort
+---
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-image-cluster-and-node-port
+spec:
+  image: "vectorized/redpanda"
+  version: "v21.6.6"
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    - external:
+        enabled: true
+    adminApi:
+    - port: 9644
+    - external:
+        enabled: true
+    developerMode: true

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-image-cluster-and-node-port
+status:
+  readyReplicas: 2
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: update-image-cluster-and-node-port-0
+spec:
+  containers:
+    - name: redpanda
+      image: "localhost/redpanda:dev"
+    - name: rpk-status
+      image: "localhost/redpanda:dev"
+status:
+  phase: "Running"
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: update-image-cluster-and-node-port-1
+spec:
+  containers:
+    - name: redpanda
+      image: "localhost/redpanda:dev"
+    - name: rpk-status
+      image: "localhost/redpanda:dev"
+status:
+  phase: "Running"
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: update-image-cluster-and-node-port-external
+spec:
+  externalTrafficPolicy: Local
+  ports:
+    - name: kafka-external
+      nodePort: 32748
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+    - name: admin-external
+      nodePort: 31178
+      port: 9645
+      protocol: TCP
+      targetPort: 9645
+  type: NodePort

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-new-image.yaml
@@ -1,0 +1,7 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-image-cluster-and-node-port
+spec:
+  image: "localhost/redpanda"
+  version: "dev"

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: up-img
+status:
+  readyReplicas: 2
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name:  up-img-admin-selfsigned-issuer
+status:
+  conditions:
+    - reason: IsReady
+      status: "True"
+      type: Ready
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name:  up-img-admin-root-issuer
+status:
+  conditions:
+    - reason: KeyPairVerified
+      status: "True"
+      type: Ready
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name:  up-img-admin-root-certificate
+status:
+  conditions:
+    - reason: Ready
+      status: "True"
+      type: Ready
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name:  up-img-admin-api-node
+status:
+  conditions:
+    - reason: Ready
+      status: "True"
+      type: Ready
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name:  up-img-admin-api-client
+status:
+  conditions:
+    - reason: Ready
+      status: "True"
+      type: Ready

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
@@ -1,0 +1,27 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: up-img
+spec:
+  image: "vectorized/redpanda"
+  version: "v21.6.6"
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    adminApi:
+    - port: 9644
+      tls:
+        enabled: true
+        requireClientAuth: true
+    developerMode: true
+

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: up-img
+status:
+  readyReplicas: 2
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: up-img-0
+spec:
+  containers:
+    - name: redpanda
+      image: "localhost/redpanda:dev"
+    - name: rpk-status
+      image: "localhost/redpanda:dev"
+status:
+  phase: "Running"
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: up-img-1
+spec:
+  containers:
+    - name: redpanda
+      image: "localhost/redpanda:dev"
+    - name: rpk-status
+      image: "localhost/redpanda:dev"
+status:
+  phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image.yaml
@@ -1,0 +1,7 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: up-img
+spec:
+  image: "localhost/redpanda"
+  version: "dev"

--- a/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: up-img
+status:
+  readyReplicas: 2
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name:  up-img-admin-selfsigned-issuer
+status:
+  conditions:
+    - reason: IsReady
+      status: "True"
+      type: Ready
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name:  up-img-admin-root-issuer
+status:
+  conditions:
+    - reason: KeyPairVerified
+      status: "True"
+      type: Ready
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: up-img-admin-root-certificate
+status:
+  conditions:
+    - reason: Ready
+      status: "True"
+      type: Ready
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: up-img-admin-api-node
+status:
+  conditions:
+    - reason: Ready
+      status: "True"
+      type: Ready

--- a/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
@@ -1,0 +1,25 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: up-img
+spec:
+  image: "vectorized/redpanda"
+  version: "v21.6.6"
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 100Mi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    adminApi:
+    - port: 9644
+      tls:
+        enabled: true
+    developerMode: true

--- a/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: up-img
+status:
+  readyReplicas: 2
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: up-img-0
+spec:
+  containers:
+    - name: redpanda
+      image: "localhost/redpanda:dev"
+    - name: rpk-status
+      image: "localhost/redpanda:dev"
+status:
+  phase: "Running"
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: up-img-1
+spec:
+  containers:
+    - name: redpanda
+      image: "localhost/redpanda:dev"
+    - name: rpk-status
+      image: "localhost/redpanda:dev"
+status:
+  phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls/01-new-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-new-image.yaml
@@ -1,0 +1,7 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: up-img
+spec:
+  image: "localhost/redpanda"
+  version: "dev"

--- a/src/go/k8s/tests/e2e/update/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/00-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-cluster
+  labels:
+    app.kubernetes.io/name: "redpanda"
+    app.kubernetes.io/instance: "update-cluster"
+    app.kubernetes.io/managed-by: redpanda-operator
+    app.kubernetes.io/part-of: redpanda
+status:
+  readyReplicas: 1

--- a/src/go/k8s/tests/e2e/update/00-one-replica.yaml
+++ b/src/go/k8s/tests/e2e/update/00-one-replica.yaml
@@ -1,0 +1,23 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster
+spec:
+  image: "localhost/redpanda"
+  version: "dev"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100M
+    limits:
+      cpu: 1
+      memory: 100M
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    adminApi:
+    - port: 9644
+    developerMode: true

--- a/src/go/k8s/tests/e2e/update/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-cluster
+status:
+  readyReplicas: 2

--- a/src/go/k8s/tests/e2e/update/01-two-replicas.yaml
+++ b/src/go/k8s/tests/e2e/update/01-two-replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster
+spec:
+  replicas: 2

--- a/src/go/k8s/tests/e2e/update/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/02-assert.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-cluster
+spec:
+  template:
+    spec:
+      containers:
+        - resources:
+            requests:
+              memory: 99M
+        - resources:
+            requests:
+              memory: 10M

--- a/src/go/k8s/tests/e2e/update/02-update-resources.yaml
+++ b/src/go/k8s/tests/e2e/update/02-update-resources.yaml
@@ -1,0 +1,8 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster
+spec:
+  resources:
+    requests:
+      memory: 99M

--- a/src/go/k8s/tests/e2e/update/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/03-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: update-cluster
+spec:
+  template:
+    spec:
+      volumes:
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+      - configMap:
+          defaultMode: 420
+          name: update-cluster-base
+        name: configmap-dir
+      - emptyDir: {}
+        name: config-dir
+      - name: tlscert
+        secret:
+          defaultMode: 420
+          secretName: update-cluster-redpanda

--- a/src/go/k8s/tests/e2e/update/03-enable-tls.yaml
+++ b/src/go/k8s/tests/e2e/update/03-enable-tls.yaml
@@ -1,0 +1,10 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster
+spec:
+  configuration:
+    kafkaApi:
+      - port: 9092
+        tls:
+          enabled: true

--- a/src/go/k8s/tests/e2e/update/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/04-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: update-cluster
+spec:
+  clusterIP: None
+  ports:
+    - name: admin
+      port: 9644
+      protocol: TCP
+      targetPort: 9644
+    - name: kafka
+      port: 9093
+      protocol: TCP
+      targetPort: 9093
+  type: ClusterIP

--- a/src/go/k8s/tests/e2e/update/04-change-port.yaml
+++ b/src/go/k8s/tests/e2e/update/04-change-port.yaml
@@ -1,0 +1,9 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster
+spec:
+  configuration:
+    kafkaApi:
+    - port: 9093
+      name: kafka


### PR DESCRIPTION
This reverts commit d1c6f07ef1e21af1af5af6569446d5e83048b033.

Triggered 6 times, 6/6 passed

[Builds](https://buildkite.com/vectorized/redpanda/builds?branch=dimitriscruz%3Arevert-k8s-tests-commmit)

Fixes: #2508