### PR TITLE
Fixed unavailability during follower & leader isolation

### DIFF
--- a/docs/rfcs/20200421_raft_recovery.md
+++ b/docs/rfcs/20200421_raft_recovery.md
@@ -210,7 +210,7 @@ In order to make it possible new fields have to be added to
             // next index to send to this follower
             model::offset next_index;
             // timestamp of last append_entries_rpc call
-            clock_type::time_point last_append_timestamp;
+            clock_type::time_point last_sent_append_entries_req_timesptamp;
             uint64_t failed_appends{0};
             bool is_learner = false;
             bool is_recovering = false;

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -115,6 +115,12 @@ metadata_cache::get_leader_id(const model::ntp& ntp) const {
     return _leaders.local().get_leader(ntp);
 }
 
+std::optional<model::node_id>
+metadata_cache::get_previous_leader_id(const model::ntp& ntp) const {
+    return _leaders.local().get_previous_leader(
+      model::topic_namespace_view(ntp), ntp.tp.partition);
+}
+
 /// If present returns a leader of raft0 group
 std::optional<model::node_id> metadata_cache::get_controller_leader_id() {
     return _leaders.local().get_leader(model::controller_ntp);

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -111,7 +111,7 @@ ss::future<model::node_id> metadata_cache::get_leader(
 }
 
 std::optional<model::node_id>
-metadata_cache::get_leader_id(const model::ntp& ntp) {
+metadata_cache::get_leader_id(const model::ntp& ntp) const {
     return _leaders.local().get_leader(ntp);
 }
 

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -101,6 +101,9 @@ public:
     }
 
     std::optional<model::node_id> get_leader_id(const model::ntp&) const;
+
+    std::optional<model::node_id>
+    get_previous_leader_id(const model::ntp&) const;
     /// Returns metadata of all topics in cache internal format
     // const cache_t& all_metadata() const { return _cache; }
 

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -100,7 +100,7 @@ public:
         return contains(model::topic_namespace_view(ntp), ntp.tp.partition);
     }
 
-    std::optional<model::node_id> get_leader_id(const model::ntp&);
+    std::optional<model::node_id> get_leader_id(const model::ntp&) const;
     /// Returns metadata of all topics in cache internal format
     // const cache_t& all_metadata() const { return _cache; }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2135,7 +2135,6 @@ consensus::last_sent_append_entries_req_timesptamp(vnode id) {
 void consensus::update_node_append_timestamp(vnode id) {
     if (auto it = _fstats.find(id); it != _fstats.end()) {
         it->second.last_sent_append_entries_req_timesptamp = clock_type::now();
-        update_node_hbeat_timestamp(id);
     }
 }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -164,7 +164,7 @@ clock_type::time_point consensus::majority_heartbeat() const {
         }
 
         if (auto it = _fstats.find(rni); it != _fstats.end()) {
-            return it->second.last_hbeat_timestamp;
+            return it->second.last_received_append_entries_reply_timestamp;
         }
 
         // if we do not know the follower state yet i.e. we have
@@ -2127,19 +2127,21 @@ model::term_id consensus::get_term(model::offset o) {
     return _log.get_term(o).value_or(model::term_id{});
 }
 
-clock_type::time_point consensus::last_append_timestamp(vnode id) {
-    return _fstats.get(id).last_append_timestamp;
+clock_type::time_point
+consensus::last_sent_append_entries_req_timesptamp(vnode id) {
+    return _fstats.get(id).last_sent_append_entries_req_timesptamp;
 }
 
 void consensus::update_node_append_timestamp(vnode id) {
     if (auto it = _fstats.find(id); it != _fstats.end()) {
-        it->second.last_append_timestamp = clock_type::now();
+        it->second.last_sent_append_entries_req_timesptamp = clock_type::now();
         update_node_hbeat_timestamp(id);
     }
 }
 
 void consensus::update_node_hbeat_timestamp(vnode id) {
-    _fstats.get(id).last_hbeat_timestamp = clock_type::now();
+    _fstats.get(id).last_received_append_entries_reply_timestamp
+      = clock_type::now();
 }
 
 follower_req_seq consensus::next_follower_sequence(vnode id) {
@@ -2811,7 +2813,7 @@ bool consensus::should_reconnect_follower(vnode id) {
     }
 
     if (auto it = _fstats.find(id); it != _fstats.end()) {
-        auto last_at = it->second.last_hbeat_timestamp;
+        auto last_at = it->second.last_received_append_entries_reply_timestamp;
         const auto fail_count = it->second.heartbeats_failed;
 
         auto is_live = last_at + _jit.base_duration() > clock_type::now();
@@ -2882,7 +2884,7 @@ std::vector<follower_metrics> consensus::get_follower_metrics() const {
     ret.reserve(_fstats.size());
     auto dirty_offset = _log.offsets().dirty_offset;
     for (const auto& f : _fstats) {
-        auto last_hbeat = f.second.last_hbeat_timestamp;
+        auto last_hbeat = f.second.last_received_append_entries_reply_timestamp;
         auto is_live = last_hbeat + _jit.base_duration() > clock_type::now();
         ret.push_back(follower_metrics{
           .id = f.first.id(),

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -154,7 +154,7 @@ public:
     const model::ntp& ntp() const { return _log.config().ntp(); }
     clock_type::time_point last_heartbeat() const { return _hbeat; };
 
-    clock_type::time_point last_append_timestamp(vnode);
+    clock_type::time_point last_sent_append_entries_req_timesptamp(vnode);
     /**
      * \brief Persist snapshot with given data and start offset
      *

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -83,9 +83,10 @@ static heartbeat_requests requests_for_range(
             if (ptr->are_heartbeats_suppressed(rni)) {
                 return;
             }
-            auto last_append_timestamp = ptr->last_append_timestamp(rni);
+            auto last_sent_append_entries_req_timesptamp
+              = ptr->last_sent_append_entries_req_timesptamp(rni);
 
-            if (last_append_timestamp > last_heartbeat) {
+            if (last_sent_append_entries_req_timesptamp > last_heartbeat) {
                 vlog(
                   hbeatlog.trace,
                   "Skipping sending beat to {} gr: {} last hb {}, last append "
@@ -93,7 +94,8 @@ static heartbeat_requests requests_for_range(
                   rni,
                   ptr->group(),
                   last_heartbeat.time_since_epoch().count(),
-                  last_append_timestamp.time_since_epoch().count());
+                  last_sent_append_entries_req_timesptamp.time_since_epoch()
+                    .count());
                 // we already sent heartbeat, skip it
                 return;
             }

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -208,7 +208,7 @@ inline bool replicate_entries_stm::should_skip_follower_request(vnode id) {
         const auto timeout = clock_type::now()
                              - _ptr->_replicate_append_timeout;
 
-        return it->second.last_hbeat_timestamp < timeout
+        return it->second.last_received_append_entries_reply_timestamp < timeout
                || it->second.is_recovering;
     }
 

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -79,8 +79,8 @@ struct follower_index_metadata {
     // next index to send to this follower
     model::offset next_index;
     // timestamp of last append_entries_rpc call
-    clock_type::time_point last_append_timestamp;
-    clock_type::time_point last_hbeat_timestamp;
+    clock_type::time_point last_sent_append_entries_req_timesptamp;
+    clock_type::time_point last_received_append_entries_reply_timestamp;
     uint32_t heartbeats_failed{0};
     // The pair of sequences used to track append entries requests sent and
     // received by the follower. Every time append entries request is created

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -175,11 +175,13 @@ class RaftAvailabilityTest(RedpandaTest):
         rpk = RpkTool(self.redpanda)
 
         payload = str(random.randint(0, 1000))
-
+        start = time.time()
         offset = rpk.produce(self.topic, "tkey", payload, timeout=5)
         consumed = kc.consume_one(self.topic, 0, offset)
+        latency = time.time() - start
         self.logger.info(
-            f"_ping_pong produced '{payload}' consumed '{consumed}'")
+            f"_ping_pong produced '{payload}' consumed '{consumed}' in {(latency)*1000.0:.2f} ms"
+        )
         if consumed['payload'] != payload:
             raise RuntimeError(f"expected '{payload}' got '{consumed}'")
 


### PR DESCRIPTION
## Cover letter

Fixed availability issue occurring during follower isolation. Follower isolation chaos test isolates one of the followers from other group members (it uses `iptables` to drop all the packets targeting isolated follower). In this situation leader is supposed to stop trying sending requests to isolated follower. The bug that has been fixed caused leader to always try to send append entries to follower even tho the follower is unreachable. This triggered backpressure propagation (based on constant number of in-flight requests per follower). The backpressure was propagated to the client which resulted in timeouts. 

## Metadata response heuristics

We use simple heuristic to tolerate isolation of a node hosting both partition leader and follower.  Kafka clients request metadata refresh in case they receive error that is related with stale metadata - f.e. NOT_LEADER. Metadata request can be processed by any broker and there is no general rule for that which broker to choose to refresh metadata from. (f.e. Java kafka client uses the broker with active least loaded connection.) This may lead to the situation in which client will ask for metadata always the same broker. When that broker is isolated from rest of the cluster it will never update its metadata view. This way the client will always receive stale metadata.  

This behavior may lead to a live lock in an event of network partition. If current partition leader is isolated from the cluster it will keep answering with its id in the leader_id field for that partition (according to policy where we return a former leader - there is no leader for that broker, it is a candidate). Client will retry produce or fetch request and receive NOT_LEADER error, this will force client to request metadata update, broker will respond with the same metadata and the whole cycle will loop indefinitely.  

In order to break the loop and force client to make progress we use following heuristics: 

1. when current leader is unknown, return former leader (Kafka behavior) 
2. when current leader is unknown and previous leader is equal to current node id select random replica_id as a leader (indicate leader isolation)  

With those heuristics we will always force the client to communicate with the nodes that may not be partitioned.

## Release notes


Release note: [1-2 sentences of what this PR changes]
