### PR TITLE
storage/test: Fix filename to elimate cmake warning

### DIFF
--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ rp_test(
     segment_size_jitter_test.cc
     log_segment_reader_test.cc
     log_manager_test.cc
-    offset_assignment_test
+    offset_assignment_test.cc
     storage_e2e_test.cc
     log_truncate_test.cc
     offset_index_utils_tests.cc


### PR DESCRIPTION
## Cover letter

The test was working but produced a warning:
```
CMake Warning (dev) at cmake/testing.cmake:79 (add_executable):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  File:

    /home/ben/development/src/github.com/BenPope/redpanda-v21.10.x/src/v/storage/tests/offset_assignment_test.cc
Call Stack (most recent call first):
  src/v/storage/tests/CMakeLists.txt:14 (rp_test)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Signed-off-by: Ben Pope <ben@vectorized.io>
## Release notes

[none]