### PR TITLE
tests: Remove tolerance for ntp query errors

### DIFF
--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -86,10 +86,6 @@ class RpkClusterTest(RedpandaTest):
                 # dmidecode doesn't work in ducktape containers, ignore
                 # errors about it.
                 continue
-            elif "pool.ntp.org" in l:
-                # rpk's NTP queries frequently fail
-                # https://github.com/vectorizedio/redpanda/issues/2802
-                continue
             else:
                 self.logger.error(f"Bad output line: {l}")
                 filtered_errors.append(l)


### PR DESCRIPTION
After https://github.com/vectorizedio/redpanda/pull/2841 was merged, NTP query errors should decrease. Therefore, the tests should fail again if there was an error retrieving or saving NTP data.