### PR TITLE
k8s: bump rpk status sidecar limit to 30M

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -48,7 +48,7 @@ var (
 			corev1.ResourceCPU:    resource.MustParse("0.2"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("10M"),
+			corev1.ResourceMemory: resource.MustParse("30M"),
 			corev1.ResourceCPU:    resource.MustParse("0.2"),
 		},
 	}


### PR DESCRIPTION
## Cover letter
It looks like 10M might not be enough even on test clusters so bumping the limit.

Fixes: #2849

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
k8s: rpkStatus sidecar resource limits were increased from 10M to 30M