### PR TITLE
raft: fix catching timed_out_error by value

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2507,7 +2507,7 @@ consensus::prepare_transfer_leadership(vnode target_rni) {
         meta.follower_state_change.broadcast();
         try {
             co_await meta.recovery_finished.wait(timeout);
-        } catch (ss::timed_out_error) {
+        } catch (const ss::timed_out_error&) {
             vlog(
               _ctxlog.warn,
               "transfer leadership: timed out waiting on node {} "


### PR DESCRIPTION
## Cover letter[

Our current clang version didn't mind this, but other compilers did:

src/v/raft/consensus.cc:2495:22: error: catching polymorphic type ‘class seastar::timed_out_error’ by value [-Werror=catch-value=]
2495 |         } catch (ss::timed_out_error) {
     |                      ^~~~~~~~~~~~~~~

## Release notes

None