### PR TITLE
3rdparty: Update abseil to 20210324.2

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -184,7 +184,7 @@ ExternalProject_Add(HdrHistogram
 
 ExternalProject_Add(abseil
   GIT_REPOSITORY https://github.com/vectorizedio/abseil-cpp.git
-  GIT_TAG e1d388e7e74803050423d035e4374131b9b57919
+  GIT_TAG 20210324.2
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   DEPENDS ${default_depends}


### PR DESCRIPTION
## Cover letter

Fix a compilation error:
```
build/debug/clang/v_deps_build/abseil-prefix/src/abseil/absl/debugging/failure_signal_handler.cc:139:24: error: no matching function for call to 'max'
  size_t stack_size = (std::max(SIGSTKSZ, 65536) + page_mask) & ~page_mask;
                       ^~~~~~~~
```

Signed-off-by: Ben Pope <ben@vectorized.io>

Related: #2760 

## Release notes

[none]