### PR TITLE
Test interaction between archival and log eviction

### DIFF
--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -270,7 +270,7 @@ class ArchivalTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def test_single_partition_leadership_transfer(self):
-        """Start uploading data, restart leader node of the partition 0 to trigger the 
+        """Start uploading data, restart leader node of the partition 0 to trigger the
         leadership transfer, continue upload, verify S3 bucket content"""
         self.kafka_tools.produce(self.topic, 5000, 1024)
         time.sleep(5)
@@ -285,7 +285,7 @@ class ArchivalTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def test_all_partitions_leadership_transfer(self):
-        """Start uploading data, restart leader nodes of all partitions to trigger the 
+        """Start uploading data, restart leader nodes of all partitions to trigger the
         leadership transfer, continue upload, verify S3 bucket content"""
         self.kafka_tools.produce(self.topic, 5000, 1024)
         time.sleep(5)
@@ -453,9 +453,9 @@ class ArchivalTest(RedpandaTest):
     def _cross_node_verify(self):
         """Verify data on all nodes taking into account possible alignment issues
         caused by leadership transitions.
-        The verification algorithm is following: 
+        The verification algorithm is following:
         - Download and verify partition manifest;
-        - Partition manifest has all segments and metadata like committed offset 
+        - Partition manifest has all segments and metadata like committed offset
           and base offset. We can also retrieve MD5 hash of every segment;
         - Load segment metadata for every redpanda node.
         - Scan every node's metadata and match segments with manifest, on success
@@ -467,7 +467,7 @@ class ArchivalTest(RedpandaTest):
         - The base offset and md5 hashes are the same;
         - The committed offset of both segments are the same, md5 hashes are different,
           and base offset of the segment from manifest is larger than base offset of the
-          segment from redpanda node. In this case we should also compare the data 
+          segment from redpanda node. In this case we should also compare the data
           directly by scanning both segments.
         """
         nodes = {}

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -29,16 +29,15 @@ class EndToEndShadowIndexingTest(EndToEndTest):
     s3_secret_key = "panda-secret"
     s3_region = "panda-region"
     s3_topic_name = "panda-topic"
-    topics = (
-        TopicSpec(
-            name=s3_topic_name,
-            partition_count=1,
-            replication_factor=3,
-        ),
-    )
+    topics = (TopicSpec(
+        name=s3_topic_name,
+        partition_count=1,
+        replication_factor=3,
+    ), )
 
     def __init__(self, test_context):
-        super(EndToEndShadowIndexingTest, self).__init__(test_context=test_context)
+        super(EndToEndShadowIndexingTest,
+              self).__init__(test_context=test_context)
 
         self.s3_bucket_name = f"panda-bucket-{uuid.uuid1()}"
         self.topic = EndToEndShadowIndexingTest.s3_topic_name
@@ -98,13 +97,14 @@ class EndToEndShadowIndexingTest(EndToEndTest):
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 5
-                * EndToEndShadowIndexingTest.segment_size,
+                TopicSpec.PROPERTY_RETENTION_BYTES:
+                5 * EndToEndShadowIndexingTest.segment_size,
             },
         )
-        wait_for_segments_removal(
-            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=6
-        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=6)
 
         self.start_consumer()
         self.run_validation()

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -60,7 +60,10 @@ class RetentionPolicyTest(RedpandaTest):
         kafka_tools.alter_topic_config(self.topic, {
             property: 10000,
         })
-        self._wait_for_segments_removal(self.topic, 0, 5)
+        wait_for_segments_removal(self.redpanda,
+                                  self.topic,
+                                  partition_idx=0,
+                                  count=5)
 
     @cluster(num_nodes=3)
     def test_changing_topic_retention_with_restart(self):

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -18,6 +18,7 @@ from rptest.util import (
     wait_for_segments_removal,
 )
 
+
 class RetentionPolicyTest(RedpandaTest):
     topics = (TopicSpec(partition_count=1,
                         replication_factor=3,
@@ -40,9 +41,9 @@ class RetentionPolicyTest(RedpandaTest):
             acks=[1, -1])
     def test_changing_topic_retention(self, property, acks):
         """
-        Test changing topic retention duration for topics with data produced 
-        with ACKS=1 and ACKS=-1. This test produces data until 10 segments 
-        appear, then it changes retention topic property and waits for 
+        Test changing topic retention duration for topics with data produced
+        with ACKS=1 and ACKS=-1. This test produces data until 10 segments
+        appear, then it changes retention topic property and waits for
         segments to be removed
         """
         kafka_tools = KafkaCliTools(self.redpanda)
@@ -64,9 +65,9 @@ class RetentionPolicyTest(RedpandaTest):
     @cluster(num_nodes=3)
     def test_changing_topic_retention_with_restart(self):
         """
-        Test changing topic retention duration for topics with data produced 
-        with ACKS=1 and ACKS=-1. This test produces data until 10 segments 
-        appear, then it changes retention topic property and waits for some 
+        Test changing topic retention duration for topics with data produced
+        with ACKS=1 and ACKS=-1. This test produces data until 10 segments
+        appear, then it changes retention topic property and waits for some
         segmetnts to be removed
         """
         segment_size = 1048576
@@ -92,24 +93,27 @@ class RetentionPolicyTest(RedpandaTest):
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 15 * segment_size,
             })
-        wait_for_segments_removal(
-            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=16
-        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=16)
 
         # change retention bytes again to preserve 10 segments
         kafka_tools.alter_topic_config(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 10 * segment_size,
             })
-        wait_for_segments_removal(
-            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=11
-        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=11)
 
         # change retention bytes again to preserve 5 segments
         kafka_tools.alter_topic_config(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 4 * segment_size,
             })
-        wait_for_segments_removal(
-            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=5
-        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=5)

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -43,7 +43,7 @@ class Scale:
         return self._scale == Scale.RELEASE
 
 
-def _segments_count(redpanda, topic, partition_idx):
+def segments_count(redpanda, topic, partition_idx):
     storage = redpanda.storage()
     topic_partitions = storage.partitions("kafka", topic)
 
@@ -61,7 +61,7 @@ def produce_until_segments(redpanda, topic, partition_idx, count, acks=-1):
 
     def done():
         kafka_tools.produce(topic, 10000, 1024, acks=acks)
-        topic_partitions = _segments_count(redpanda, topic, partition_idx)
+        topic_partitions = segments_count(redpanda, topic, partition_idx)
         partitions = []
         for p in topic_partitions:
             partitions.append(p >= count)
@@ -78,7 +78,7 @@ def wait_for_segments_removal(redpanda, topic, partition_idx, count):
     Wait until only given number of segments will left in a partitions
     """
     def done():
-        topic_partitions = _segments_count(redpanda, topic, partition_idx)
+        topic_partitions = segments_count(redpanda, topic, partition_idx)
         partitions = []
         for p in topic_partitions:
             partitions.append(p <= count)

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -44,7 +44,8 @@ class Scale:
 
 
 def _segments_count(redpanda, topic, partition_idx):
-    topic_partitions = redpanda.storage.partitions("kafka", topic)
+    storage = redpanda.storage()
+    topic_partitions = storage.partitions("kafka", topic)
 
     return map(
         lambda p: len(p.segments),

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
@@ -67,16 +66,16 @@ def produce_until_segments(redpanda, topic, partition_idx, count, acks=-1):
             partitions.append(p >= count)
         return all(partitions)
 
-    wait_until(
-        done, timeout_sec=120, backoff_sec=2, err_msg="Segments were not created"
-    )
+    wait_until(done,
+               timeout_sec=120,
+               backoff_sec=2,
+               err_msg="Segments were not created")
 
 
 def wait_for_segments_removal(redpanda, topic, partition_idx, count):
     """
     Wait until only given number of segments will left in a partitions
     """
-
     def done():
         topic_partitions = _segments_count(redpanda, topic, partition_idx)
         partitions = []
@@ -84,6 +83,7 @@ def wait_for_segments_removal(redpanda, topic, partition_idx, count):
             partitions.append(p <= count)
         return all(partitions)
 
-    wait_until(
-        done, timeout_sec=120, backoff_sec=5, err_msg="Segments were not removed"
-    )
+    wait_until(done,
+               timeout_sec=120,
+               backoff_sec=5,
+               err_msg="Segments were not removed")


### PR DESCRIPTION
## Cover letter

Add ducktape test that checks that that only archived segments can be evicted and that eviction restarts once the segments have been archived.

Also fix errors introduced by the previous ducktape PR.