### PR TITLE
cmake: Update OSS build seastar version

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -151,7 +151,7 @@ ExternalProject_Add(boost
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/vectorizedio/seastar.git
-  GIT_TAG d8313208857d8362d68b769ec03f338bbcbf482d
+  GIT_TAG a65207afcbaae84d4bc720a7d22995f21f5ff7b2
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS


### PR DESCRIPTION

## Cover letter

Update to match vtools & enable building latest admin-redirects bits.

## Release notes

None