### PR TITLE
cloud_storage: Prevent in-progress remote_segment from being evicted

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -385,7 +385,9 @@ void remote_partition::gc_stale_materialized_segments() {
     auto now = ss::lowres_clock::now();
     std::vector<model::offset> offsets;
     for (auto& st : _materialized) {
-        if (now - st.atime > stm_max_idle_time && st.segment.owned()) {
+        if (
+          now - st.atime > stm_max_idle_time
+          && !st.segment->download_in_progress() && st.segment.owned()) {
             vlog(
               _ctxlog.debug,
               "reader for segment with base offset {} is stale",

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -94,6 +94,8 @@ public:
 
     retry_chain_node* get_retry_chain_node() { return &_rtc; }
 
+    bool download_in_progress() const noexcept { return !_wait_list.empty(); }
+
 private:
     /// Hydrates segment in the background if there is any consumer
     ss::future<> run_hydrate_bg();


### PR DESCRIPTION

## Cover letter

Disable eviction for in-progress downloads. This might break the
invariant of the hydration loop if the evicted in-progress download
is re-created when still in-progress.

Fix #2893


## Release notes

N/A