### PR TITLE
compatibility: setup flink test structure

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -87,7 +87,10 @@ RUN git -C /opt clone https://github.com/Shopify/sarama.git && \
     git -C /opt clone https://github.com/twmb/franz-go.git && cd /opt/franz-go && \
     cd /opt/franz-go/examples/bench && go mod tidy && go build && \
     git -C /opt clone --branch ducktape2 https://github.com/vectorizedio/kafka-streams-examples.git && \
-    cd /opt/kafka-streams-examples && mvn -DskipTests=true clean package
+    cd /opt/kafka-streams-examples && mvn -DskipTests=true clean package && \
+    curl -SL "https://dlcdn.apache.org/flink/flink-1.14.0/flink-1.14.0-bin-scala_2.11.tgz" | tar -xz -C /opt && \
+    git -C /opt clone https://github.com/vectorizedio/flink-kafka-examples.git && \
+    cd /opt/flink-kafka-examples && mvn clean package
 
 RUN go install github.com/twmb/kcl@latest && \
     mv /root/go/bin/kcl /usr/local/bin/

--- a/tests/rptest/services/compatibility/flink_cluster.py
+++ b/tests/rptest/services/compatibility/flink_cluster.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import sys
+import time
+
+from ducktape.services.service import Service
+from ducktape.utils.util import wait_until
+from ducktape.cluster.remoteaccount import RemoteCommandError
+import rptest.services.compatibility.flink_examples as FlinkExamples
+
+
+# Using a Ducktape Service instead of BackgroundThreadService
+# because the Flink cluster itself is run like a linux service
+class FlinkCluster(Service):
+    """
+    The service that runs a Flink cluster on a single ducktape node
+    """
+    def __init__(self, context):
+        super(FlinkCluster, self).__init__(context, num_nodes=1)
+
+        self._node = None
+
+    def is_start_line(self, line):
+        return "Starting cluster." in line or "Starting standalonesession daemon on host" in line or "Starting taskexecutor daemon on host" in line
+
+    def start_node(self, node):
+        cmd = f"{FlinkExamples.FLINK_BIN}/start-cluster.sh"
+        output_iter = node.account.ssh_capture(cmd, timeout_sec=10)
+        for line in output_iter:
+            line = line.strip()
+            self.logger.debug(f"Starting flink cluster: {line}")
+            assert self.is_start_line(line)
+
+        self._node = node
+
+    def stop_node(self, node):
+        cmd = f"{FlinkExamples.FLINK_BIN}/stop-cluster.sh"
+        output_iter = node.account.ssh_capture(cmd, timeout_sec=10)
+        for line in output_iter:
+            line = line.strip()
+            self.logger.debug(f"Stopping flink cluster: {line}")
+
+    def clean_node(self, node):
+        node.account.remove(f"{FlinkExamples.FLINK_DIR}/log/*",
+                            allow_fail=True)
+        # Remove all files in log
+        self.logger.debug(f"Cleaned flink log")
+
+    def run_flink_job(self, flink_job, timeout=60):
+        assert self._node
+
+        output_iter = self._node.account.ssh_capture(flink_job.cmd(),
+                                                     allow_fail=True,
+                                                     timeout_sec=10)
+
+        def check_job():
+            line = next(output_iter)
+            line = line.strip()
+            self.logger.debug(f"Running flink job: {line}")
+            flink_job.condition(line)
+            return flink_job.condition_met()
+
+        wait_until(check_job,
+                   timeout_sec=timeout,
+                   backoff_sec=5,
+                   err_msg=f"failed to run flink job {flink_job.name}")

--- a/tests/rptest/services/compatibility/flink_examples.py
+++ b/tests/rptest/services/compatibility/flink_examples.py
@@ -1,0 +1,44 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+from .example_base import ExampleBase
+
+# The flink-examples root directory which is made in the
+# Dockerfile
+TESTS_DIR = os.path.join("/opt", "flink-kafka-examples")
+
+# The flink dirs
+FLINK_DIR = os.path.join("/opt", "flink-1.14.0")
+FLINK_BIN = os.path.join(FLINK_DIR, "bin")
+
+
+class FlinkWithKafka(ExampleBase):
+    def __init__(self, redpanda):
+        super(FlinkWithKafka, self).__init__(redpanda)
+
+    # The internal condition to determine if the
+    # flink job was submitted successfully.
+    def _condition(self, line):
+        return "Job has been submitted with JobID" in line
+
+    # Return the command to call in the shell
+    def cmd(self):
+        # This will submit the flink app to the flink cluster
+        cmd = f"{FLINK_BIN}/flink run --detached {TESTS_DIR}/target/flink-kafka-examples-1.0.jar {self._redpanda.brokers()}"
+        return cmd
+
+
+class FlinkWordCountJob(FlinkWithKafka):
+    def __init__(self, redpanda):
+        super(FlinkWordCountJob, self).__init__(redpanda)
+
+    @property
+    def name(self):
+        return "FlinkWordCountJob"

--- a/tests/rptest/tests/compatibility/flink_test.py
+++ b/tests/rptest/tests/compatibility/flink_test.py
@@ -1,0 +1,131 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.services.compatibility.example_runner import ExampleRunner
+from rptest.services.compatibility.flink_cluster import FlinkCluster
+import rptest.services.compatibility.flink_examples as FlinkExamples
+from rptest.services.kaf_producer import KafProducer
+from rptest.services.rpk_consumer import RpkConsumer
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+import math
+
+
+class FlinkTest(RedpandaTest):
+    """
+    Base class for Flink tests that contains all
+    shared objects between tests and starts the
+    Flink cluster
+    """
+
+    # The JOB is the java program that uses Flink with kafka connectors.
+    # The java program is represented by a wrapper in FlinkExamples.
+    JOB = None
+
+    # The producer should be an extension to KafProducer
+    PRODUCER = None
+
+    def __init__(self, test_context):
+        super(FlinkTest, self).__init__(test_context=test_context)
+
+        self._ctx = test_context
+
+        self._max_records = 10
+        self._timeout = 120
+
+        self._flink_cluster = FlinkCluster(test_context)
+
+    def is_valid_msg(self, msg):
+        raise NotImplementedError("is_valid_msg() is undefined")
+
+    def setUp(self):
+        self._flink_cluster.start()
+
+        super().setUp()
+
+    @cluster(num_nodes=6)
+    def test_flink(self):
+        # This will raise TypeError if JOB is undefined
+        flink_job = self.JOB(self.redpanda)
+
+        # This will raise TypeError if PRODUCER is undefined
+        producer = self.PRODUCER(self._ctx, self.redpanda, self.topics[0].name,
+                                 self._max_records)
+        consumer = RpkConsumer(self._ctx, self.redpanda, self.topics[1].name)
+
+        # Start the flink job on the
+        # cluster node
+        self._flink_cluster.run_flink_job(flink_job, self._timeout)
+
+        # Produce some messages
+        producer.start()
+        producer.wait()
+
+        # Consume the data
+        consumer.start()
+
+        def check_msgs():
+            msgs = consumer.messages
+            if len(msgs) < 1:
+                return False
+
+            # Check the last message consumed. A lot of messages may be
+            # produced or consumed but only the last message represents
+            # a successful test.
+            return self.is_valid_msg(msgs[-1])
+
+        wait_until(check_msgs,
+                   timeout_sec=self._timeout,
+                   backoff_sec=5,
+                   err_msg=f"{self._ctx.cls_name} consumer failed")
+
+        consumer.stop()
+        producer.stop()
+
+
+class WordProducer(KafProducer):
+    def __init__(self, context, redpanda, topic, records):
+        super(WordProducer, self).__init__(context,
+                                           redpanda,
+                                           topic,
+                                           num_records=records)
+
+    def value_gen(self):
+        # The WordCount job will see the randomly generated
+        # number as a seperate word.
+        return "redpanda $((1 + $RANDOM % 3))"
+
+
+class FlinkWordCount(FlinkTest):
+    """
+    Test Flink with Kafka using a simple streaming job that consumes
+    from an input topic and calculates the frequency for each word in
+    the topic.
+    """
+
+    # Topic names are hardcoded in the examples. Don't change them.
+    topics = (
+        TopicSpec(name="input-topic"),
+        TopicSpec(name="output-topic"),
+    )
+
+    JOB = FlinkExamples.FlinkWordCountJob
+    PRODUCER = WordProducer
+
+    def __init__(self, test_context):
+        super(FlinkWordCount, self).__init__(test_context=test_context)
+
+    def is_valid_msg(self, msg):
+        value = msg["value"]
+        # The WordCount job is successfull when the consumer
+        # reads "redpanda" max_records times.
+        return f"redpanda {self._max_records}" in value


### PR DESCRIPTION
## Cover letter

Providing Kafka compatibility via Kafka clients is an on-going effort. This PR creates the test structure in ducktape for testing [Apache Flink](https://github.com/apache/flink) with their [FlinkKafka connector](https://github.com/apache/flink/tree/master/flink-connectors/flink-connector-kafka). More tests to come in the next PR.

Changes from force-push [4ce84e4](https://github.com/vectorizedio/redpanda/commit/4ce84e4a372b75949729898a551221be66472f64):
- Change the message rate to create a better timeout for CI

Changes from force-push [9348011](https://github.com/vectorizedio/redpanda/commit/93480118fe0f9c0f20e8b89777401df18c505ac6):
- Change max_records and timeout
- Remove unused code

Changes from force-push [fced6449](https://github.com/vectorizedio/redpanda/commit/fced64491b1a9c6adcdb19e98ce45df559e8cfa5):
- Update comments to better reflect the code changes
- Change `WordProducer.value_gen` to use a random number as a word

Changes from force-push [4bd9cd3](https://github.com/vectorizedio/redpanda/commit/4bd9cd3ac5c88baba37ccfe72204c51a784d16be):
- Directly access last consumer message instead of using a loop

## Release notes

Release note: Created the WordCount test case by re-writing the apache flink [wordcount example](https://github.com/apache/flink/blob/master/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java) to use the kafka connector.
