### PR TITLE
rpk: add group subcommand

### DIFF
--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -670,11 +670,9 @@ github.com/tklauser/go-sysconf v0.1.0/go.mod h1:h54uFIrVIJBr8RXt3F5JJdxVkmFeallW
 github.com/tklauser/numcpus v0.1.0/go.mod h1:i3up9VjARpkV00NkBbexuDd0RAVQz4rV5Gl8miYgd5k=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/twmb/franz-go v1.1.2/go.mod h1:KerrVhzNpasYrWJLr2Yj6Cui43f1BxH4U9SJEDVOjqQ=
+github.com/twmb/franz-go v1.2.3-0.20211104052441-7952375c09c0/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
 github.com/twmb/franz-go v1.2.3/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
-github.com/twmb/franz-go/pkg/kadm v0.0.0-20211102173559-4166d346389f/go.mod h1:IfPX6t+NBXmMhU5v4ewAJGhLpoEsQVkfNhXCTzBe0Ck=
-github.com/twmb/franz-go/pkg/kmsg v0.0.0-20210914042331-106aef61b693/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
-github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211010181717-11efd498dac5/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
+github.com/twmb/franz-go/pkg/kadm v0.0.0-20211110004707-9a9ce6a8d31a/go.mod h1:fuA2THFeFx/ms1w1R432uxWJqq7o3Q+olvJR4NFpWcM=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/twmb/go-rbtree v1.0.0/go.mod h1:UlIAI8gu3KRPkXSobZnmJfVwCJgEhD/liWzT5ppzIyc=
 github.com/twmb/tlscfg v1.2.0 h1:WCzLHtmnVJ94+veAO4TLTB1ENx7TPYLkTl4Q6WFF4Vo=

--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tklauser/go-sysconf v0.1.0
 	github.com/twmb/franz-go v1.2.3
-	github.com/twmb/franz-go/pkg/kadm v0.0.0-20211102173559-4166d346389f
+	github.com/twmb/franz-go/pkg/kadm v0.0.0-20211110004707-9a9ce6a8d31a
 	github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7
 	github.com/twmb/tlscfg v1.2.0
 	github.com/twmb/types v1.1.6

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -336,13 +336,11 @@ github.com/tklauser/go-sysconf v0.1.0/go.mod h1:h54uFIrVIJBr8RXt3F5JJdxVkmFeallW
 github.com/tklauser/numcpus v0.1.0 h1:BQeAuOQKZtytv8qblsFbi9mhTfXQdFFkyX0vaV6B4tc=
 github.com/tklauser/numcpus v0.1.0/go.mod h1:i3up9VjARpkV00NkBbexuDd0RAVQz4rV5Gl8miYgd5k=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/twmb/franz-go v1.1.2/go.mod h1:KerrVhzNpasYrWJLr2Yj6Cui43f1BxH4U9SJEDVOjqQ=
+github.com/twmb/franz-go v1.2.3-0.20211104052441-7952375c09c0/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
 github.com/twmb/franz-go v1.2.3 h1:K4Zommxo0qZuNnKEt4CcunHPLKdqDCUhcwoU+YdvQjo=
 github.com/twmb/franz-go v1.2.3/go.mod h1:e5ZOdNswX/wv+jebWNX49yc9U7zgR18Xovj9ckk6mx8=
-github.com/twmb/franz-go/pkg/kadm v0.0.0-20211102173559-4166d346389f h1:vq8+y3yTcNkDsjCoxBObH65fU0IbPG7caDfHNmSeM0Y=
-github.com/twmb/franz-go/pkg/kadm v0.0.0-20211102173559-4166d346389f/go.mod h1:IfPX6t+NBXmMhU5v4ewAJGhLpoEsQVkfNhXCTzBe0Ck=
-github.com/twmb/franz-go/pkg/kmsg v0.0.0-20210914042331-106aef61b693/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
-github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211010181717-11efd498dac5/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
+github.com/twmb/franz-go/pkg/kadm v0.0.0-20211110004707-9a9ce6a8d31a h1:rCny41X7HCiMpwa2TuXUhjFJ+ZuCC0sikYJ3Oh9DJtw=
+github.com/twmb/franz-go/pkg/kadm v0.0.0-20211110004707-9a9ce6a8d31a/go.mod h1:fuA2THFeFx/ms1w1R432uxWJqq7o3Q+olvJR4NFpWcM=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7 h1:YW4mW39H53O1qouKQnlrdNwyqAi5c4P10Oig8yndDKQ=
 github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/twmb/go-rbtree v1.0.0 h1:KxN7dXJ8XaZ4cvmHV1qqXTshxX3EBvX/toG5+UR49Mg=

--- a/src/go/rpk/pkg/cli/cmd/check.go
+++ b/src/go/rpk/pkg/cli/cmd/check.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package cmd

--- a/src/go/rpk/pkg/cli/cmd/cluster.go
+++ b/src/go/rpk/pkg/cli/cmd/cluster.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/cluster"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/group"
 )
 
 func NewClusterCommand(fs afero.Fs) *cobra.Command {
@@ -46,7 +47,12 @@ func NewClusterCommand(fs afero.Fs) *cobra.Command {
 		&brokers,
 	)
 	command.AddCommand(cluster.NewMetadataCommand(fs))
-	command.AddCommand(cluster.NewOffsetsCommand(fs))
+
+	offsets := group.NewDescribeCommand(fs)
+	offsets.Deprecated = "replaced by 'rpk group describe'"
+	offsets.Hidden = true
+	offsets.Use = "offsets"
+	command.AddCommand(offsets)
 
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/config.go
+++ b/src/go/rpk/pkg/cli/cmd/config.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package cmd

--- a/src/go/rpk/pkg/cli/cmd/group/describe.go
+++ b/src/go/rpk/pkg/cli/cmd/group/describe.go
@@ -6,7 +6,8 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
-package cluster
+
+package group
 
 import (
 	"context"
@@ -22,57 +23,34 @@ import (
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/out"
 )
 
-func NewOffsetsCommand(fs afero.Fs) *cobra.Command {
-	var printEmpty bool
+func NewDescribeCommand(fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "offsets",
-		Short: "Print group offset status & lag.",
-		Long: `Print group offset status & lag.
+		Use:   "describe [GROUPS...]",
+		Short: "Describe group offset status & lag.",
+		Long: `Describe group offset status & lag.
 
 This command describes group members, calculates their lag, and prints detailed
-information about the members. By default, if no groups are explicitly listed,
-this command describes all groups. Specific groups to describe can be passed as
-arguments.
-
-By default, offsets are only printed for non-empty groups. If you are managing
-groups manually outside of the context of consumer groups but are using
-Redpanda to store offsets, you can use the --print-empty flag to print offsets
-for empty groups. If you specify any groups directly, their lag is printed even
-if the groups are empty.
+information about the members.
 `,
-
+		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, groups []string) {
 			p := config.ParamsFromCommand(cmd)
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "unable to load config: %v", err)
 
-			cl, err := kafka.NewFranzClient(fs, p, cfg)
+			adm, err := kafka.NewAdmin(fs, p, cfg)
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
-			defer cl.Close()
-
-			adm := kadm.NewClient(cl)
+			defer adm.Close()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-
-			printEmpty = printEmpty || len(groups) > 0
-
-			if len(groups) == 0 {
-				kgroups, err := adm.ListGroups(ctx)
-				out.HandleShardError("ListGroups", err)
-				groups = kgroups.Groups()
-			}
-
-			if len(groups) == 0 {
-				out.Exit("There are no groups to describe!")
-			}
 
 			described, err := adm.DescribeGroups(ctx, groups...)
 			out.HandleShardError("DescribeGroups", err)
 
 			fetched := adm.FetchManyOffsets(ctx, groups...)
 			fetched.EachError(func(r kadm.FetchOffsetsResponse) {
-				fmt.Printf("unable to fetch offsets for group %q: %v", r.Group, r.Err)
+				fmt.Printf("unable to fetch offsets for group %q: %v\n", r.Group, r.Err)
 				delete(fetched, r.Group)
 			})
 			if fetched.AllFailed() {
@@ -86,11 +64,9 @@ if the groups are empty.
 				described,
 				fetched,
 				listed,
-				printEmpty,
 			)
 		},
 	}
-	cmd.Flags().BoolVarP(&printEmpty, "print-empty", "e", false, "print lag for empty groups if printing all groups")
 	return cmd
 }
 
@@ -117,7 +93,6 @@ func printDescribed(
 	groups kadm.DescribedGroups,
 	fetched map[string]kadm.FetchOffsetsResponse,
 	listed kadm.ListedOffsets,
-	printEmpty bool,
 ) {
 	for _, group := range groups.Sorted() {
 		lag := kadm.CalculateGroupLag(group, fetched[group.Group].Fetched, listed)
@@ -125,14 +100,11 @@ func printDescribed(
 		var rows []describeRow
 		var useInstanceID, useErr bool
 		for _, l := range lag.Sorted() {
-			if l.IsEmpty() && !printEmpty {
-				continue
-			}
 			row := describeRow{
 				topic:     l.End.Topic,
 				partition: l.End.Partition,
 
-				currentOffset: strconv.FormatInt(l.Commit.Offset, 10),
+				currentOffset: strconv.FormatInt(l.Commit.At, 10),
 				logEndOffset:  l.End.Offset,
 				lag:           strconv.FormatInt(l.Lag, 10),
 
@@ -146,7 +118,7 @@ func printDescribed(
 				row.host = l.Member.ClientHost
 			}
 
-			if l.Commit.Offset == -1 { // nothing committed
+			if l.Commit.At == -1 { // nothing committed
 				row.currentOffset = "-"
 			}
 			if l.End.Offset == 0 { // nothing produced yet

--- a/src/go/rpk/pkg/cli/cmd/group/group.go
+++ b/src/go/rpk/pkg/cli/cmd/group/group.go
@@ -1,0 +1,197 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+// Package group contains group related subcommands.
+package group
+
+import (
+	"context"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/out"
+)
+
+func NewCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "group",
+		Aliases: []string{"g"},
+		Short:   `Describe, list, and delete consumer groups and manage their offsets.`,
+		Long: `Describe, list, and delete consumer groups and manage their offsets.
+
+Consumer groups allow you to horizontally scale consuming from topics. A
+non-group consumer consumes all records from all partitions you assign it. In
+contrast, consumer groups allow many consumers to coordinate and divide work.
+If you have two members in a group consuming topics A and B, each with three
+partitions, then both members consume three partitions. If you add another
+member to the group, then each of the three members will consume two
+partitions. This allows you to horizontally scale consuming of topics.
+
+The unit of scaling is a single partition. If you add more consumers to a group
+than there are are total partitions to consume, then some consumers will be
+idle. More commonly, you have many more partitions than consumer group members
+and each member consumes a chunk of available partitions. One scenario where
+you may want more members than partitions is if you want active standby's to
+take over load immediately if any consuming member dies.
+
+How group members divide work is entirely client driven (the "partition
+assignment strategy" or "balancer" depending on the client). Brokers know
+nothing about how consumers are assigning partitions. A broker's role in group
+consuming is to choose which member is the leader of a group, forward that
+member's assignment to every other member, and ensure all members are alive
+through heartbeats.
+
+Consumers periodically commit their progress when consuming partitions. Through
+these commits, you can monitor just how far behind a consumer is from the
+latest messages in a partition. This is called "lag". Large lag implies that
+the client is having problems, which could be from the server being too slow,
+or the client being oversubscribed in the number of partitions it is consuming,
+or the server being in a bad state that requires restarting or removing from
+the server pool, and so on.
+
+You can manually manage offsets for a group, which allows you to rewind or
+forward commits. If you notice that a recent deploy of your consumers had a
+bug, you may want to stop all members, rewind the commits to before the latest
+deploy, and restart the members with a patch.
+
+This command allows you to list all groups, describe a group (to view the
+members and their lag), and manage offsets.
+`,
+		Args: cobra.ExactArgs(0),
+	}
+
+	var (
+		brokers        []string
+		configFile     string
+		user           string
+		password       string
+		mechanism      string
+		enableTLS      bool
+		certFile       string
+		keyFile        string
+		truststoreFile string
+	)
+	// backcompat: until we switch to -X, we need these flags.
+	common.AddKafkaFlags(
+		cmd,
+		&configFile,
+		&user,
+		&password,
+		&mechanism,
+		&enableTLS,
+		&certFile,
+		&keyFile,
+		&truststoreFile,
+		&brokers,
+	)
+
+	cmd.AddCommand(
+		newDeleteCommand(fs),
+		NewDescribeCommand(fs),
+		newListCommand(fs),
+		newSeekCommand(fs),
+	)
+
+	return cmd
+}
+
+func newListCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List all groups.",
+		Long: `List all groups.
+
+This command lists all groups currently known to Redpanda, including empty
+groups that have not yet expired. The BROKER column is which broker node is the
+coordinator for the group. This command can be used to track down unknown
+groups, or to list groups that need to be cleaned up.
+`,
+		Args: cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, _ []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p, cfg)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			listed, err := adm.ListGroups(context.Background())
+			out.HandleShardError("ListGroups", err)
+
+			tw := out.NewTable("BROKER", "GROUP")
+			defer tw.Flush()
+			for _, g := range listed.Sorted() {
+				tw.PrintStructFields(struct {
+					Broker int32
+					Group  string
+				}{g.Coordinator, g.Group})
+			}
+		},
+	}
+}
+
+func newDeleteCommand(fs afero.Fs) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete [GROUPS...]",
+		Short: "Delete groups from brokers.",
+		Long: `Delete groups from brokers.
+
+Older versions of the Kafka protocol included a retention_millis field in
+offset commit requests. Group commits persisted for this retention and then
+eventually expired. Once all commits for a group expired, the group would be
+considered deleted.
+
+The retention field was removed because it proved problematic for infrequently
+committing consumers: the offsets could be expired for a group that was still
+active. If clients use new enough versions of OffsetCommit (versions that have
+removed the retention field), brokers expire offsets only when the group is
+empty for offset.retention.minutes. Redpanda does not currently support that
+configuration (see #2904), meaning offsets for empty groups expire only when
+they are explicitly deleted.
+
+You may want to delete groups to clean up offsets sooner than when they
+automatically are cleaned up, such as when you create temporary groups for
+quick investigation or testing. This command helps you do that.
+`,
+		Args: cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p, cfg)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			deleted, err := adm.DeleteGroups(context.Background(), args...)
+			out.HandleShardError("DeleteGroups", err)
+
+			tw := out.NewTable("GROUP", "STATUS")
+			defer tw.Flush()
+			for _, g := range deleted.Sorted() {
+				status := "OK"
+				if g.Err != nil {
+					status = g.Err.Error()
+				}
+				tw.PrintStructFields(struct {
+					Group  string
+					Status string
+				}{
+					g.Group,
+					status,
+				})
+			}
+		},
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/group/seek.go
+++ b/src/go/rpk/pkg/cli/cmd/group/seek.go
@@ -1,0 +1,294 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package group
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/out"
+)
+
+func newSeekCommand(fs afero.Fs) *cobra.Command {
+	var (
+		to             string
+		toGroup        string
+		toFile         string
+		topics         []string
+		allowNewTopics bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "seek [GROUP] --to (start|end|timestamp) --to-group ... --topics ...",
+		Short: "Modify a group's current offsets.",
+		Long: `Modify a group's current offsets.
+
+This command allows you to modify a group's offsets. Sometimes, you may need to
+rewind a group if you had a mistaken deploy, or fast-forward a group if it is
+falling behind on messages that can be skipped.
+
+The --to option allows you to seek to the start of partitions, end of
+partitions, or after a specific timestamp. The default is to seek any topic
+previously committed. Using --topics allows to you set commits for only the
+specified topics; all other commits will remain untouched. Topics with no
+commits will not be committed unless allowed with --allow-new-topics.
+
+The --to-group option allows you to seek to commits that are in another group.
+This is a merging operation: if g1 is consuming topics A and B, and g2 is
+consuming only topic B, "rpk group seek g1 --to-group g2" will update g1's
+commits for topic B only. The --topics flag can be used to further narrow which
+topics are updated. Unlike --to, all non-filtered topics are committed, even
+topics not yet being consumed, meaning --allow-new-topics is not needed.
+
+The --to-file option allows to seek to offsets specified in a text file with
+the following format:
+    [TOPIC] [PARTITION] [OFFSET]
+    [TOPIC] [PARTITION] [OFFSET]
+    ...
+Each line contains the topic, the partition, and the offset to seek to. As with
+the prior options, --topics allows filtering which topics are updated. Similar
+to --to-group, all non-filtered topics are committed, even topics not yet being
+consumed, meaning --allow-new-topics is not needed.
+
+The --to, --to-group, and --to-file options are mutually exclusive. If you are
+not authorized to describe or read some topics used in a group, you will not be
+able to modify offsets for those topics.
+
+EXAMPLES
+
+Seek group G to June 1st, 2021:
+    rpk group seek g --to 1622505600
+    or, rpk group seek g --to 1622505600000
+    or, rpk group seek g --to 1622505600000000000
+Seek group X to the commits of group Y topic foo:
+    rpk group seek X --to-group Y --topics foo
+Seek group G's topics foo, bar, and biz to the end:
+    rpk group seek G --to end --topics foo,bar,biz
+Seek group G to the beginning of a topic it was not previously consuming:
+    rpk group seek G --to start --topics foo --allow-new-topics
+`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p, cfg)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			var n int
+			for _, f := range []string{to, toGroup, toFile} {
+				if f != "" {
+					n++
+				}
+			}
+			switch {
+			case n == 0:
+				out.Die("Must specify one --to flag.")
+			case n == 1:
+			default:
+				out.Die("Cannot specify multiple --to flags.")
+			}
+
+			tset := make(map[string]bool)
+			for _, topic := range topics {
+				tset[topic] = true
+			}
+
+			group := args[0]
+
+			seek(fs, adm, group, to, toGroup, toFile, tset, allowNewTopics)
+		},
+	}
+
+	cmd.Flags().StringVar(&to, "to", "", "where to seek (start, end, unix second|millisecond|nanosecond)")
+	cmd.Flags().StringVar(&toGroup, "to-group", "", "seek to the commits of another group")
+	cmd.Flags().StringVar(&toFile, "to-file", "", "seek to offsets as specified in the file")
+	cmd.Flags().StringArrayVar(&topics, "topics", nil, "only seek these topics, if any are specified")
+	cmd.Flags().BoolVar(&allowNewTopics, "allow-new-topics", false, "allow seeking to new topics not currently consumed (implied with --to-group or --to-file)")
+
+	return cmd
+}
+
+func parseSeekFile(
+	fs afero.Fs, file string, topics map[string]bool,
+) (kadm.Offsets, error) {
+	f, err := fs.Open(file)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open %q: %v", file, err)
+	}
+
+	o := make(kadm.Offsets)
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := s.Text()
+		if len(line) == 0 {
+			continue
+		}
+		fields := strings.Split(line, " ")
+		if len(fields) == 1 {
+			fields = strings.Split(line, "\t")
+		}
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("unable to split line %q by space or tab into three fields", line)
+		}
+
+		topic := fields[0]
+		partition, err := strconv.ParseInt(fields[1], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse partition on line %q: %v", line, err)
+		}
+		offset, err := strconv.ParseInt(fields[2], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse offset on line %q: %v", line, err)
+		}
+
+		o.Add(kadm.Offset{
+			Topic:       topic,
+			Partition:   int32(partition),
+			At:          offset,
+			LeaderEpoch: -1,
+		})
+	}
+	if err := s.Err(); err != nil {
+		return nil, fmt.Errorf("file %q scan error: %v", file, err)
+	}
+
+	// If we have a filter, keep only what is in the filter.
+	if len(topics) > 0 {
+		o.KeepFunc(func(o kadm.Offset) bool { return topics[o.Topic] })
+	}
+
+	return o, nil
+}
+
+func seekFetch(
+	adm *kadm.Client, group string, topics map[string]bool,
+) kadm.Offsets {
+	resps, err := adm.FetchOffsets(context.Background(), group)
+	if err == nil {
+		err = resps.Error()
+	}
+	out.MaybeDie(err, "unable to fetch offsets for %q: %v", group, err)
+	// If we have a filter, keep only what is in the filter.
+	if len(topics) > 0 {
+		resps.KeepFunc(func(o kadm.OffsetResponse) bool { return topics[o.Topic] })
+	}
+	return resps.Into()
+}
+
+func seek(
+	fs afero.Fs,
+	adm *kadm.Client,
+	group string,
+	to string,
+	toGroup string,
+	toFile string,
+	topics map[string]bool,
+	allowNewTopics bool,
+) {
+	current := seekFetch(adm, group, topics)
+	var commitTo kadm.Offsets
+	if toFile != "" {
+		var err error
+		commitTo, err = parseSeekFile(fs, toFile, topics)
+		out.MaybeDieErr(err)
+	} else if toGroup != "" {
+		commitTo = seekFetch(adm, toGroup, topics)
+	} else { // --to, we need to list offsets currently used, as well as any extra
+		tps := current.TopicsSet()
+		for topic := range topics {
+			if _, exists := tps[topic]; !exists && !allowNewTopics {
+				out.Die("Cannot commit new topic %q without --allow-new-topics.", topic)
+			}
+			tps[topic] = map[int32]struct{}{} // ensure exists
+		}
+		topics := tps.Topics()
+
+		var listed kadm.ListedOffsets
+		var err error
+		switch to {
+		case "start":
+			listed, err = adm.ListStartOffsets(context.Background(), topics...)
+		case "end":
+			listed, err = adm.ListEndOffsets(context.Background(), topics...)
+		default:
+			var milli int64
+			milli, err = strconv.ParseInt(to, 10, 64)
+			out.MaybeDie(err, "unable to parse millisecond %q: %v", to, err)
+			switch len(to) {
+			case 10: // e.g. "1622505600"; sec to milli
+				milli *= 1000
+			case 13: // e.g. "1622505600000", already in milli
+			case 19: // e.g. "1622505600000000000"; nano to milli
+				milli /= 1e6
+			default:
+				out.Die("--to timestamp %q is not a second, nor a millisecond, nor a nanosecond", to)
+			}
+			listed, err = adm.ListOffsetsAfterMilli(context.Background(), milli, topics...)
+		}
+		if err == nil { // ListOffsets can return ShardErrors, but we want to be entirely successful
+			err = listed.Error()
+		}
+		out.MaybeDie(err, "unable to list all offsets successfully: %v", err)
+		commitTo = listed.Into()
+	}
+
+	// Finally, we commit.
+	committed, err := adm.CommitOffsets(context.Background(), group, commitTo)
+	out.MaybeDie(err, "unable to commit offsets: %v", err)
+
+	useErr := committed.Error() != nil
+	headers := []string{"topic", "partition", "prior-offset", "current-offset"}
+	if useErr {
+		headers = append(headers, "error")
+	}
+	tw := out.NewTable(headers...)
+	defer tw.Flush()
+	for _, c := range committed.Sorted() {
+		s := seekCommit{c.Topic, c.Partition, -1, -1}
+		if o, exists := current.Lookup(c.Topic, c.Partition); exists {
+			s.Prior = o.At
+		}
+		if o, exists := commitTo.Lookup(c.Topic, c.Partition); exists {
+			s.Current = o.At
+		}
+		se := seekCommitErr{s, ""}
+		if c.Err != nil {
+			se.Error = c.Err.Error()
+		}
+		if useErr {
+			tw.PrintStructFields(se)
+		} else {
+			tw.PrintStructFields(s)
+		}
+	}
+}
+
+type seekCommit struct {
+	Topic     string
+	Partition int32
+	Prior     int64
+	Current   int64
+}
+
+type seekCommitErr struct {
+	seekCommit
+	Error string
+}

--- a/src/go/rpk/pkg/cli/cmd/group/seek_test.go
+++ b/src/go/rpk/pkg/cli/cmd/group/seek_test.go
@@ -1,0 +1,126 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package group
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/testfs"
+)
+
+func TestParseSeekFile(t *testing.T) {
+	keep := map[string]bool{"foo": true}
+	o0 := kadm.Offset{
+		Topic:       "foo",
+		Partition:   0,
+		At:          1,
+		LeaderEpoch: -1,
+	}
+	o2 := kadm.Offset{
+		Topic:       "foo",
+		Partition:   2,
+		At:          3,
+		LeaderEpoch: -1,
+	}
+	expBoth := kadm.Offsets{"foo": map[int32]kadm.Offset{0: o0, 2: o2}}
+
+	for _, test := range []struct {
+		name     string
+		contents string
+
+		exp    kadm.Offsets
+		expErr bool
+	}{
+		{
+			name:     "standard",
+			contents: "foo 0 1\nfoo 2 3\n",
+			exp:      expBoth,
+		},
+
+		{
+			name:     "empty_line",
+			contents: "\nfoo 0 1\nfoo 2 3\n",
+			exp:      expBoth,
+		},
+
+		{
+			name:     "bar_skipped",
+			contents: "\nfoo 0 1\nfoo 2 3\nbar 0 2\n",
+			exp:      expBoth,
+		},
+
+		{
+			name:     "tabs",
+			contents: "foo\t0\t1\nfoo\t2\t3\n",
+			exp:      expBoth,
+		},
+
+		{
+			name:     "tab_space_mix",
+			contents: "foo 0 1\nfoo\t2\t3\n",
+			exp:      expBoth,
+		},
+
+		{
+			name:     "nothing_is_fine",
+			contents: "",
+			exp:      make(kadm.Offsets),
+		},
+
+		{
+			name:     "bad_part_num",
+			contents: "foo asdf 1\n",
+			expErr:   true,
+		},
+
+		{
+			name:     "bad_offset_num",
+			contents: "foo 0 asdf\n",
+			expErr:   true,
+		},
+
+		{
+			name:     "too_many_fields",
+			contents: "foo 0 1 2\n",
+			expErr:   true,
+		},
+
+		{
+			name:     "part_too_large",
+			contents: "foo 99999999999999999999999 1\n",
+			expErr:   true,
+		},
+
+		{
+			name:     "offset_too_large",
+			contents: "foo 1 99999999999999999999999n",
+			expErr:   true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fs := testfs.FromMap(map[string]testfs.Fmode{
+				test.name: {0o444, test.contents},
+			})
+
+			got, err := parseSeekFile(fs, test.name, keep)
+			gotErr := err != nil
+
+			if gotErr != test.expErr {
+				t.Errorf("got err? %v, exp err? %v", gotErr, test.expErr)
+			}
+			if gotErr || test.expErr {
+				return
+			}
+			require.Equal(t, got, test.exp)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/mode.go
+++ b/src/go/rpk/pkg/cli/cmd/mode.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package cmd

--- a/src/go/rpk/pkg/cli/cmd/redpanda.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package cmd

--- a/src/go/rpk/pkg/cli/cmd/redpanda/check.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/check.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/config_test.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda_test

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/start_test.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/stop_test.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda_test

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda

--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune_test.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package redpanda

--- a/src/go/rpk/pkg/cli/cmd/root.go
+++ b/src/go/rpk/pkg/cli/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/group"
 	plugincmd "github.com/vectorizedio/redpanda/src/go/rpk/pkg/cli/cmd/plugin"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/plugin"
@@ -69,6 +70,7 @@ func Execute() {
 	rootCmd.AddCommand(NewTopicCommand(fs, mgr))
 	rootCmd.AddCommand(NewClusterCommand(fs))
 	rootCmd.AddCommand(NewACLCommand(fs, mgr))
+	rootCmd.AddCommand(group.NewCommand(fs, mgr))
 
 	rootCmd.AddCommand(plugincmd.NewCommand(fs))
 

--- a/src/go/rpk/pkg/cli/cmd/start.go
+++ b/src/go/rpk/pkg/cli/cmd/start.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package cmd

--- a/src/go/rpk/pkg/cli/cmd/stop.go
+++ b/src/go/rpk/pkg/cli/cmd/stop.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package cmd

--- a/src/go/rpk/pkg/cli/cmd/topic/consume.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/consume.go
@@ -155,17 +155,6 @@ func (c *consumer) consume() {
 			for _, t := range f.Topics {
 				for _, p := range t.Partitions {
 					for _, r := range p.Records {
-						// We've seen a new record: if this pushes us
-						// past the --num flag (if non-zero), we return.
-						// We have to mark any seen records so that when
-						// we LeaveGroup on return, the autocommit will
-						// commit what we want.
-						n++
-						if c.num > 0 && n > c.num {
-							c.cl.MarkCommitRecords(marks...)
-							return
-						}
-
 						if c.f == nil {
 							c.writeRecordJSON(r)
 						} else {
@@ -176,6 +165,15 @@ func (c *consumer) consume() {
 						// Track this record to be "marked" once this loop
 						// is over.
 						marks = append(marks, r)
+						n++
+
+						// If this pushes us to the --num flag,
+						// we return. We mark any seen records so that
+						// LeaveGroup will autocommit properly.
+						if c.num > 0 && n >= c.num {
+							c.cl.MarkCommitRecords(marks...)
+							return
+						}
 					}
 				}
 			}

--- a/src/go/rpk/pkg/cli/cmd/topic/produce.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/produce.go
@@ -91,6 +91,9 @@ func NewProduceCommand(fs afero.Fs) *cobra.Command {
 				defaultTopic = args[0]
 				opts = append(opts, kgo.DefaultProduceTopic(defaultTopic))
 			}
+			if len(inFormat) == 0 {
+				out.Die("invalid empty format")
+			}
 
 			// Parse our input/output formats.
 			inf, err := kgo.NewRecordReader(os.Stdin, inFormat)

--- a/src/go/rpk/pkg/cli/cmd/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/tune.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package cmd

--- a/src/go/rpk/pkg/tools.go
+++ b/src/go/rpk/pkg/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package main

--- a/src/go/rpk/pkg/tuners/ballast/tuner.go
+++ b/src/go/rpk/pkg/tuners/ballast/tuner.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package ballast

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package commands

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file_test.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file_test.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package commands_test

--- a/src/go/rpk/pkg/tuners/factory/factory.go
+++ b/src/go/rpk/pkg/tuners/factory/factory.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package factory

--- a/src/go/rpk/pkg/tuners/factory/factory_test.go
+++ b/src/go/rpk/pkg/tuners/factory/factory_test.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package factory_test

--- a/src/go/rpk/pkg/tuners/redpanda_checkers_test.go
+++ b/src/go/rpk/pkg/tuners/redpanda_checkers_test.go
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+//go:build linux
 // +build linux
 
 package tuners_test


### PR DESCRIPTION
This has four leading commits for tiny things I noticed leading up to the main commit.

rpk cluster offsets always described groups. We should move it to the
rpk group command.

There have been many asks for the group command space. We now add it,
immediately adding:

* delete
* describe (formerly cluster offsets)
* list
* seek

Delete and list are obvious. Describe prints all lag for any requested
topics. We now remove printing all groups by default; this was just too
noisy.

Seek allows for modifying a group's offsets, seeking to the start, end,
or after a specified timestamp. We also allow committing from a
different group. By default, we only allow commits for topics the group
is currently consuming; passing `--allow-new-topic` opts in to commit
for new topics as well.

Due to how often this has been asked for, this commit adds the command
without ducktape tests. I have opened #2906 to ensure we add ducktape
tests eventually.

Examples:

```
$ rpk group list
BROKER  GROUP
3       group

$ rpk group describe g
GROUP        g
COORDINATOR  3
STATE        Empty
BALANCER
MEMBERS      0
TOPIC  PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG     MEMBER-ID  CLIENT-ID  HOST
foo    0          49              162545          162496
foo    1          40              58010           57970
foo    2          47              127297          127250
foo    3          46              82749           82703
foo    4          33              104496          104463
foo    5          41              101486          101445
foo    6          40              57147           57107
foo    7          43              82554           82511
foo    8          33              121628          121595
foo    9          40              113169          113129
foo    10         35              170661          170626
foo    11         34              82916           82882
foo    12         51              114607          114556
foo    13         51              91827           91776
foo    14         33              91775           91742
foo    15         28              147500          147472
foo    16         34              78888           78854
foo    17         49              75043           74994
foo    18         35              92288           92253
foo    19         38              91387           91349

$ rpk group seek g --to end
TOPIC  PARTITION  PRIOR-OFFSET  CURRENT-OFFSET
foo    0          49            162545
foo    1          40            58010
foo    2          47            127297
foo    3          46            82749
foo    4          33            104496
foo    5          41            101486
foo    6          40            57147
foo    7          43            82554
foo    8          33            121628
foo    9          40            113169
foo    10         35            170661
foo    11         34            82916
foo    12         51            114607
foo    13         51            91827
foo    14         33            91775
foo    15         28            147500
foo    16         34            78888
foo    17         49            75043
foo    18         35            92288
foo    19         38            91387

$ rpk group seek g --to start
TOPIC  PARTITION  PRIOR-OFFSET  CURRENT-OFFSET
foo    0          162545        0
foo    1          58010         0
foo    2          127297        0
foo    3          82749         0
foo    4          104496        0
foo    5          101486        0
foo    6          57147         0
foo    7          82554         0
foo    8          121628        0
foo    9          113169        0
foo    10         170661        0
foo    11         82916         0
foo    12         114607        0
foo    13         91827         0
foo    14         91775         0
foo    15         147500        0
foo    16         78888         0
foo    17         75043         0
foo    18         92288         0
foo    19         91387         0

$ cat offsets
foo 0 3
foo 1 4

$ rpk group seek g --to-file offsets
TOPIC  PARTITION  PRIOR-OFFSET  CURRENT-OFFSET
foo    0          0             3
foo    1          0             4

$ rpk group delete g
GROUP  STATUS
g      OK

$ rpk group list
BROKER  GROUP
```

# Release notes

* The new `rpk group` command can be used to list groups, delete groups, describe groups, and modify group offsets.
* `rpk cluster offsets` has been deprecated.