### PR TITLE
kafka/client: Fix concurrency bug with retry mitigation function

### DIFF
--- a/src/v/kafka/client/retry_with_mitigation.h
+++ b/src/v/kafka/client/retry_with_mitigation.h
@@ -43,7 +43,7 @@ auto retry_with_mitigation(
             [&func, &errFunc, &eptr]() {
                 auto fut = ss::now();
                 if (eptr) {
-                    auto fut = errFunc(eptr).handle_exception(
+                    fut = errFunc(eptr).handle_exception(
                       [](const std::exception_ptr&) {
                           // ignore failed mitigation
                       });


### PR DESCRIPTION
This was leading to all sorts of confusing to debug issues. The behavior that was observed was invocations of `func` and `errFunc` interleaving instead of occurring synchronously with respect to each other.

The fact that eptr was being set meant that `errFunc` will be invoked, however the erroneous reset to another local var that would never be used meant that it was no longer to be invoked within the chain of calls with the futures returned from the method.