### PR TITLE
cloud_storage: Availability check

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -437,6 +437,8 @@ const model::ntp& remote_partition::get_ntp() const {
     return _manifest.get_ntp();
 }
 
+bool remote_partition::is_available() const { return _manifest.size() > 0; }
+
 ss::future<> remote_partition::stop() {
     vlog(_ctxlog.debug, "remote partition stop {} segments", _segments.size());
     _as.request_abort();

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -79,6 +79,9 @@ public:
     /// Get partition NTP
     const model::ntp& get_ntp() const;
 
+    /// Returns true if at least one segment is uploaded to the bucket
+    bool is_available() const;
+
 private:
     /// Create new remote_segment instances for all new
     /// items in the manifest.

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -205,7 +205,8 @@ public:
     /// The remaining 'cloud' methods can only be called if this
     /// method returned 'true'.
     bool cloud_data_available() const {
-        return static_cast<bool>(_cloud_storage_partition);
+        return static_cast<bool>(_cloud_storage_partition)
+               && _cloud_storage_partition->is_available();
     }
 
     /// Starting offset in the object store


### PR DESCRIPTION
## Cover letter


Add 'is_available' method to check that 'remote_parition' has data. Use
the check in 'cloud_data_available' method to prevent calling
'remote_partition' when it's empty.

## Release notes

N/A