### PR TITLE
Fix rpc server exception handling

### DIFF
--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -33,6 +33,9 @@ struct server_context_impl final : streaming_context {
     ~server_context_impl() override { res.probe().request_completed(); }
     const header& get_header() const final { return hdr; }
     void signal_body_parse() final { pr.set_value(); }
+    void body_parse_exception(std::exception_ptr e) final {
+        pr.set_exception(std::move(e));
+    }
     server::resources res;
     header hdr;
     ss::promise<> pr;

--- a/src/v/rpc/test/response_handler_tests.cc
+++ b/src/v/rpc/test/response_handler_tests.cc
@@ -12,6 +12,8 @@
 #include "test_utils/fixture.h"
 
 #include <seastar/core/sleep.hh>
+
+#include <exception>
 using namespace std::chrono_literals; // NOLINT
 
 struct test_str_ctx final : public rpc::streaming_context {
@@ -22,6 +24,7 @@ struct test_str_ctx final : public rpc::streaming_context {
     virtual const rpc::header& get_header() const final { return hdr; }
 
     virtual void signal_body_parse() final {}
+    virtual void body_parse_exception(std::exception_ptr) final {}
 
     rpc::header hdr;
     ss::semaphore s{1};

--- a/src/v/rpc/test/rpc_gen_types.h
+++ b/src/v/rpc/test/rpc_gen_types.h
@@ -54,6 +54,8 @@ enum class failure_type { throw_exception, exceptional_future, none };
 
 using throw_req = failure_type;
 
-struct throw_resp {};
+struct throw_resp {
+    ss::sstring reply;
+};
 
 } // namespace echo

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -42,6 +42,9 @@ struct client_context_impl final : streaming_context {
     }
     const header& get_header() const final { return _h; }
     void signal_body_parse() final { pr.set_value(); }
+    void body_parse_exception(std::exception_ptr e) final {
+        pr.set_exception(std::move(e));
+    }
     std::reference_wrapper<transport> _c;
     header _h;
     ss::promise<> pr;

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -149,9 +149,7 @@ result<rpc::client_context<T>> map_result(const header& hdr, T data) {
     auto st = static_cast<status>(hdr.meta);
 
     if (st == status::success) {
-        rpc::client_context<T> ctx(hdr);
-        ctx.data = std::move(data);
-        return ret_t(std::move(ctx));
+        return ret_t(rpc::client_context<T>(hdr, std::move(data)));
     }
 
     if (st == status::request_timeout) {

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -143,29 +143,46 @@ private:
 };
 
 namespace internal {
+
+inline errc map_server_error(status status) {
+    switch (status) {
+    case status::success:
+        return errc::success;
+    case status::request_timeout:
+        return errc::client_request_timeout;
+    case rpc::status::server_error:
+        return errc::service_error;
+    case status::method_not_found:
+        return errc::method_not_found;
+    };
+};
+
 template<typename T>
-result<rpc::client_context<T>> map_result(const header& hdr, T data) {
+ss::future<result<rpc::client_context<T>>> parse_result(
+  ss::input_stream<char>& in, std::unique_ptr<streaming_context> sctx) {
     using ret_t = result<rpc::client_context<T>>;
-    auto st = static_cast<status>(hdr.meta);
+    // check status first
+    auto st = static_cast<status>(sctx->get_header().meta);
 
+    // success case
     if (st == status::success) {
-        return ret_t(rpc::client_context<T>(hdr, std::move(data)));
+        return parse_type<T>(in, sctx->get_header())
+          .then([sctx = std::move(sctx)](T data) {
+              sctx->signal_body_parse();
+              return ret_t(
+                rpc::client_context<T>(sctx->get_header(), std::move(data)));
+          });
     }
 
-    if (st == status::request_timeout) {
-        return ret_t(errc::client_request_timeout);
-    }
+    /**
+     * signal that request body is parsed since it is empty when status
+     * indicates server error.
+     */
+    sctx->signal_body_parse();
 
-    if (st == status::server_error) {
-        return ret_t(errc::service_error);
-    }
-
-    if (st == status::method_not_found) {
-        return ret_t(errc::method_not_found);
-    }
-
-    return ret_t(errc::service_error);
+    return ss::make_ready_future<ret_t>(map_server_error(st));
 }
+
 } // namespace internal
 
 template<typename Input, typename Output>
@@ -191,12 +208,7 @@ transport::send_typed(Input r, uint32_t method_id, rpc::client_opts opts) {
           if (!sctx) {
               return ss::make_ready_future<ret_t>(sctx.error());
           }
-          return parse_type<Output>(_in, sctx.value()->get_header())
-            .then([sctx = std::move(sctx)](Output o) {
-                sctx.value()->signal_body_parse();
-                return internal::map_result<Output>(
-                  sctx.value()->get_header(), std::move(o));
-            });
+          return internal::parse_result<Output>(_in, std::move(sctx.value()));
       });
 }
 

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -156,6 +156,7 @@ public:
     /// \brief because we parse the input as a _stream_ we need to signal
     /// to the dispatching thread that it can resume parsing for a new RPC
     virtual void signal_body_parse() = 0;
+    virtual void body_parse_exception(std::exception_ptr) = 0;
 
     /// \brief keep these units until destruction of context.
     /// usually, we want to keep the reservation of the memory size permanently

--- a/src/v/rpc/types.h
+++ b/src/v/rpc/types.h
@@ -233,8 +233,10 @@ struct method {
 /// \brief used in returned types for client::send_typed() calls
 template<typename T>
 struct client_context {
-    explicit client_context(header h)
-      : hdr(std::move(h)) {}
+    client_context(header h, T data)
+      : hdr(h)
+      , data(std::move(data)) {}
+
     header hdr;
     T data;
 };


### PR DESCRIPTION
## Cover letter

Our RPC implementation support propagating server errors to the client.
For this we use a `meta` field in RPC response header. The status that
is included into `header::meta` field indicates whether the request is
successful or its execution failed on the server side. When status
indicates an error response body is empty.

Fixed an error caused by the fact that we tried to parse response body
before we checked the status flag. This caused parsing error and broken
promise exception on the client side.

