### PR TITLE
Revert "kafka/client: Fix concurrency bug with retry fn"

### DIFF
--- a/src/v/kafka/client/retry_with_mitigation.h
+++ b/src/v/kafka/client/retry_with_mitigation.h
@@ -43,7 +43,7 @@ auto retry_with_mitigation(
             [&func, &errFunc, &eptr]() {
                 auto fut = ss::now();
                 if (eptr) {
-                    fut = errFunc(eptr).handle_exception(
+                    auto fut = errFunc(eptr).handle_exception(
                       [](const std::exception_ptr&) {
                           // ignore failed mitigation
                       });


### PR DESCRIPTION
## Cover letter

This reverts commit ee285530e20b025532ae9c077409ce316fefbb9d.

This PR (https://github.com/vectorizedio/redpanda/pull/2910) was merged past CI failures which are now recurring on dev.

## Release notes

None