### PR TITLE
tools: catch memory leak backtraces in unit tests

### DIFF
--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -41,7 +41,8 @@ class BacktraceCapture(threading.Thread):
     """
 
     BACKTRACE_START = re.compile(
-        "(^Backtrace:|.+Sanitizer.*|.+Backtrace below:$)")
+        "(^Backtrace:|.+Sanitizer.*|.+Backtrace below:$|^Direct leak.+|^Indirect leak.+)"
+    )
     BACKTRACE_BODY = re.compile("^(  |==|0x)")
 
     def __init__(self, binary, process):
@@ -95,7 +96,9 @@ class BacktraceCapture(threading.Thread):
                     if accumulator:
                         blocks.append(accumulator)
                     accumulator = None
-                elif self.BACKTRACE_START.search(line):
+
+                # A start of backtrace line, which may also have been an end of backtrace line above
+                if accumulator is None and self.BACKTRACE_START.search(line):
                     accumulator = []
             else:
                 break


### PR DESCRIPTION
## Cover letter

The LeakSanitizer line was getting picked up, but
in these cases the actual marker for start of
a backtrace is the "Direct leak of..." type line
that precedes each exemplar.

Related: https://github.com/vectorizedio/redpanda/issues/2909

## Release notes

None