### PR TITLE
Do not store data_policy with another properties in log

### DIFF
--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -202,7 +202,7 @@ SEASTAR_THREAD_TEST_CASE(config_update_req_resp_test) {
 }
 
 namespace old {
-struct incremental_topic_updates {
+struct incremental_topic_updates_v0 {
     cluster::property_update<std::optional<model::compression>> compression;
     cluster::property_update<std::optional<model::cleanup_policy_bitflags>>
       cleanup_policy_bitflags;
@@ -214,6 +214,22 @@ struct incremental_topic_updates {
     cluster::property_update<tristate<size_t>> retention_bytes;
     cluster::property_update<tristate<std::chrono::milliseconds>>
       retention_duration;
+};
+
+struct incremental_topic_updates_v1 {
+    static constexpr int8_t version = -1;
+    cluster::property_update<std::optional<model::compression>> compression;
+    cluster::property_update<std::optional<model::cleanup_policy_bitflags>>
+      cleanup_policy_bitflags;
+    cluster::property_update<std::optional<model::compaction_strategy>>
+      compaction_strategy;
+    cluster::property_update<std::optional<model::timestamp_type>>
+      timestamp_type;
+    cluster::property_update<std::optional<size_t>> segment_size;
+    cluster::property_update<tristate<size_t>> retention_bytes;
+    cluster::property_update<tristate<std::chrono::milliseconds>>
+      retention_duration;
+    cluster::property_update<std::optional<v8_engine::data_policy>> data_policy;
 };
 
 } // namespace old
@@ -292,13 +308,16 @@ SEASTAR_THREAD_TEST_CASE(incremental_topic_updates_rt_test) {
     auto result = serialize_roundtrip_rpc(std::move(updates));
 
     BOOST_CHECK(result == original);
+    BOOST_CHECK(
+      result.data_policy
+      == cluster::property_update<std::optional<v8_engine::data_policy>>{});
 }
 
 SEASTAR_THREAD_TEST_CASE(incremental_topic_updates_backward_compatibilty_test) {
     cluster::incremental_topic_updates updates
       = random_incremental_topic_updates();
 
-    old::incremental_topic_updates old_updates;
+    old::incremental_topic_updates_v0 old_updates;
     old_updates.cleanup_policy_bitflags = updates.cleanup_policy_bitflags;
     old_updates.compaction_strategy = updates.compaction_strategy;
     old_updates.compression = updates.compression;
@@ -325,4 +344,35 @@ SEASTAR_THREAD_TEST_CASE(incremental_topic_updates_backward_compatibilty_test) {
     BOOST_CHECK(
       cluster::property_update<std::optional<v8_engine::data_policy>>{}
       == result.data_policy);
+
+    old::incremental_topic_updates_v1 old_updates_with_dp;
+    old_updates_with_dp.cleanup_policy_bitflags
+      = updates.cleanup_policy_bitflags;
+    old_updates_with_dp.compaction_strategy = updates.compaction_strategy;
+    old_updates_with_dp.compression = updates.compression;
+    old_updates_with_dp.timestamp_type = updates.timestamp_type;
+    old_updates_with_dp.retention_bytes = updates.retention_bytes;
+    old_updates_with_dp.retention_duration = updates.retention_duration;
+    old_updates_with_dp.segment_size = updates.segment_size;
+    old_updates_with_dp.data_policy = updates.data_policy;
+
+    // serialize old version
+    buf = reflection::to_iobuf(old_updates_with_dp);
+    iobuf_parser parser_with_dp(std::move(buf));
+    // deserialize with new type
+    result = reflection::adl<cluster::incremental_topic_updates>{}.from(
+      parser_with_dp);
+
+    BOOST_CHECK(
+      old_updates_with_dp.cleanup_policy_bitflags
+      == result.cleanup_policy_bitflags);
+    BOOST_CHECK(
+      old_updates_with_dp.compaction_strategy == result.compaction_strategy);
+    BOOST_CHECK(old_updates_with_dp.compression == result.compression);
+    BOOST_CHECK(old_updates_with_dp.timestamp_type == result.timestamp_type);
+    BOOST_CHECK(old_updates_with_dp.retention_bytes == result.retention_bytes);
+    BOOST_CHECK(
+      old_updates_with_dp.retention_duration == result.retention_duration);
+    BOOST_CHECK(old_updates_with_dp.segment_size == result.segment_size);
+    BOOST_CHECK(old_updates_with_dp.data_policy == result.data_policy);
 }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -879,8 +879,7 @@ void adl<cluster::incremental_topic_updates>::to(
       t.timestamp_type,
       t.segment_size,
       t.retention_bytes,
-      t.retention_duration,
-      t.data_policy);
+      t.retention_duration);
 }
 
 cluster::incremental_topic_updates
@@ -928,7 +927,8 @@ adl<cluster::incremental_topic_updates>::from(iobuf_parser& in) {
       = adl<cluster::property_update<tristate<std::chrono::milliseconds>>>{}
           .from(in);
 
-    if (version < 0) {
+    if (
+      version == cluster::incremental_topic_updates::version_with_datapolicy) {
         updates.data_policy
           = adl<
               cluster::property_update<std::optional<v8_engine::data_policy>>>{}

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -347,9 +347,11 @@ struct property_update<tristate<T>> {
 };
 
 struct incremental_topic_updates {
+    static constexpr int8_t version_with_datapolicy = -1;
+
     // negative version indicating new format (with included data_policy
     // property)
-    static constexpr int8_t version = -1;
+    static constexpr int8_t version = -2;
     property_update<std::optional<model::compression>> compression;
     property_update<std::optional<model::cleanup_policy_bitflags>>
       cleanup_policy_bitflags;
@@ -361,7 +363,11 @@ struct incremental_topic_updates {
     property_update<tristate<std::chrono::milliseconds>> retention_duration;
 
     // Data-policy property is replicated by data_policy_frontend and handled by
-    // data_policy_manager.
+    // data_policy_manager. It is used only for parsing kafka request
+    //
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // !IT IS REPLICATED BY data_policy_frontend!
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     property_update<std::optional<v8_engine::data_policy>> data_policy;
 
     bool operator==(const incremental_topic_updates& other) const {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -364,9 +364,26 @@ struct incremental_topic_updates {
     // data_policy_manager.
     property_update<std::optional<v8_engine::data_policy>> data_policy;
 
-    friend bool operator==(
-      const incremental_topic_updates&, const incremental_topic_updates&)
-      = default;
+    bool operator==(const incremental_topic_updates& other) const {
+        return std::tie(
+                 version,
+                 compression,
+                 cleanup_policy_bitflags,
+                 compaction_strategy,
+                 timestamp_type,
+                 segment_size,
+                 retention_bytes,
+                 retention_duration)
+               == std::tie(
+                 other.version,
+                 other.compression,
+                 other.cleanup_policy_bitflags,
+                 other.compaction_strategy,
+                 other.timestamp_type,
+                 other.segment_size,
+                 other.retention_bytes,
+                 other.retention_duration);
+    }
 };
 
 /**


### PR DESCRIPTION
## Cover letter

data_policy is replicated by data_policy_frontend, so we do not need to store it together with another properties from incremental_topic_updates.

Fixes #2766