### PR TITLE
cloud_storage: Limit memory use by tests

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -827,7 +827,7 @@ static segment_layout generate_segment_layout(int num_segments, int seed) {
 /// This test scans the entire range of offsets
 FIXTURE_TEST(
   test_remote_partition_scan_translate_full_random, cloud_storage_fixture) {
-    constexpr int num_segments = 1000;
+    constexpr int num_segments = 400;
     const auto [batch_types, num_data_batches] = generate_segment_layout(
       num_segments, 42);
     auto segments = setup_s3_imposter(*this, batch_types);
@@ -897,7 +897,7 @@ scan_remote_partition_incrementally(
 
 FIXTURE_TEST(
   test_remote_partition_scan_incrementally_random, cloud_storage_fixture) {
-    constexpr int num_segments = 1000;
+    constexpr int num_segments = 400;
     const auto [batch_types, num_data_batches] = generate_segment_layout(
       num_segments, 42);
     auto segments = setup_s3_imposter(*this, batch_types);

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -123,7 +123,7 @@ FIXTURE_TEST(test_upload_segment_timeout, s3_imposter_fixture) { // NOLINT
         out.append(manifest_payload.data(), manifest_payload.size());
         return make_iobuf_input_stream(std::move(out));
     };
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(20ms, 10ms);
     auto res = remote
                  .upload_segment(
                    s3::bucket_name("bucket"), name, clen, reset_stream, m, fib)
@@ -180,7 +180,7 @@ FIXTURE_TEST(test_download_segment_timeout, s3_imposter_fixture) { // NOLINT
         return ss::make_ready_future<uint64_t>(0);
     };
 
-    retry_chain_node fib(100ms, 20ms);
+    retry_chain_node fib(20ms, 10ms);
     auto dnl_res
       = remote.download_segment(bucket, name, m, try_consume, fib).get();
     BOOST_REQUIRE(dnl_res == download_result::timedout);


### PR DESCRIPTION

## Cover letter

Randomized tests for shadow-indexing use a lot of memory to generate the
data. As result the docker container gets killed by OOM.



## Release notes

N/A