### PR TITLE
coproc: New abstraction for safe shutdown of materialized logs

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -200,4 +200,20 @@ ss::future<std::error_code> replicate_and_wait(
 std::vector<custom_assignable_topic_configuration>
   without_custom_assignments(std::vector<topic_configuration>);
 
+inline bool has_non_replicable_op_type(const topic_table_delta& d) {
+    using op_t = topic_table_delta::op_type;
+    switch (d.type) {
+    case op_t::add_non_replicable:
+    case op_t::del_non_replicable:
+        return true;
+    case op_t::add:
+    case op_t::del:
+    case op_t::update:
+    case op_t::update_finished:
+    case op_t::update_properties:
+        return false;
+    }
+    __builtin_unreachable();
+}
+
 } // namespace cluster

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -373,6 +373,14 @@ ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
     bool stop = false;
     auto it = deltas.begin();
     while (!(stop || it == deltas.end())) {
+        if (has_non_replicable_op_type(*it)) {
+            /// This if statement has nothing to do with correctness and is only
+            /// here to reduce the amount of uncessecary logging emitted by the
+            /// controller_backend for events that it eventually will not handle
+            /// anyway.
+            ++it;
+            continue;
+        }
         try {
             auto ec = co_await execute_partitition_op(*it);
             if (ec) {

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -100,17 +100,11 @@ private:
       raft::group_id,
       model::revision_id,
       std::vector<model::broker>);
-    ss::future<std::error_code>
-      create_non_replicable_partition(model::ntp, model::revision_id);
-    ss::future<>
-      add_to_shard_table(model::ntp, ss::shard_id, model::revision_id);
     ss::future<> add_to_shard_table(
       model::ntp, raft::group_id, ss::shard_id, model::revision_id);
     ss::future<>
       remove_from_shard_table(model::ntp, raft::group_id, model::revision_id);
     ss::future<> delete_partition(model::ntp, model::revision_id);
-    ss::future<>
-      delete_non_replicable_partition(model::ntp, model::revision_id);
     ss::future<std::error_code> update_partition_replica_set(
       const model::ntp&,
       const std::vector<model::broker_shard>&,

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -62,9 +62,6 @@ const model::topic& topic_table::topic_metadata::get_source_topic() const {
 }
 const topic_configuration_assignment&
 topic_table::topic_metadata::get_configuration() const {
-    vassert(
-      is_topic_replicable(),
-      "Query for configuration on a non-replicable topic");
     return configuration;
 }
 
@@ -393,9 +390,6 @@ topic_table::apply(create_non_replicable_topic_cmd cmd, model::offset o) {
 
     auto ca = tp->second.configuration;
     ca.cfg.tp_ns = new_non_rep_topic;
-    for (auto& assignment : ca.assignments) {
-        assignment.group = raft::group_id(-1);
-    }
 
     auto [itr, success] = _topics_hierarchy.try_emplace(
       source,
@@ -493,6 +487,14 @@ std::optional<topic_configuration>
 topic_table::get_topic_cfg(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {
         return it->second.configuration.cfg;
+    }
+    return {};
+}
+
+std::optional<std::vector<partition_assignment>>
+topic_table::get_topic_assignments(model::topic_namespace_view tp) const {
+    if (auto it = _topics.find(tp); it != _topics.end()) {
+        return it->second.configuration.assignments;
     }
     return {};
 }

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -137,6 +137,12 @@ public:
     std::optional<topic_configuration>
       get_topic_cfg(model::topic_namespace_view) const;
 
+    ///\brief Returns partition assignments of single topic.
+    ///
+    /// If topic does not exists it returns an empty optional
+    std::optional<std::vector<partition_assignment>>
+      get_topic_assignments(model::topic_namespace_view) const;
+
     ///\brief Returns topics timestamp type
     ///
     /// If topic does not exists it returns an empty optional

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -76,8 +76,7 @@ private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
     ss::future<> update_leaders_with_estimates(std::vector<ntp_leader> leaders);
-    void update_allocations(const create_topic_cmd&);
-    void update_allocations(const create_partition_cmd&);
+    void update_allocations(std::vector<partition_assignment>);
     void deallocate_topic(const model::topic_metadata&);
     void reallocate_partition(
       const std::vector<model::broker_shard>&,

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -23,6 +23,7 @@ v_cc_library(
     script_dispatcher.cc
     event_handler.cc
     partition.cc
+    partition_manager.cc
   DEPS
     v::rpc
     v::model

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -22,6 +22,7 @@ v_cc_library(
     event_listener.cc
     script_dispatcher.cc
     event_handler.cc
+    partition.cc
   DEPS
     v::rpc
     v::model

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -24,6 +24,7 @@ v_cc_library(
     event_handler.cc
     partition.cc
     partition_manager.cc
+    reconciliation_backend.cc
   DEPS
     v::rpc
     v::model

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -49,7 +49,8 @@ ss::future<> api::start() {
       std::ref(_rs.topic_table),
       std::ref(_rs.shard_table),
       std::ref(_rs.partition_manager),
-      std::ref(_rs.cp_partition_manager));
+      std::ref(_rs.cp_partition_manager),
+      std::ref(_pacemaker));
 
     co_await _reconciliation_backend.invoke_on_all(
       &coproc::reconciliation_backend::start);

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -15,6 +15,7 @@
 #include "coproc/event_handler.h"
 #include "coproc/event_listener.h"
 #include "coproc/pacemaker.h"
+#include "coproc/partition_manager.h"
 #include "coproc/reconciliation_backend.h"
 
 #include <seastar/core/coroutine.hh>
@@ -42,10 +43,15 @@ api::api(
 api::~api() = default;
 
 ss::future<> api::start() {
+    co_await _partition_manager.start(std::ref(_rs.storage));
+    co_await _partition_manager.invoke_on_all(
+      &coproc::partition_manager::start);
+
     co_await _reconciliation_backend.start(
       std::ref(_rs.topic_table),
       std::ref(_rs.shard_table),
-      std::ref(_rs.storage));
+      std::ref(_rs.partition_manager),
+      std::ref(_partition_manager));
     co_await _reconciliation_backend.invoke_on_all(
       &coproc::reconciliation_backend::start);
 
@@ -63,13 +69,13 @@ ss::future<> api::start() {
 }
 
 ss::future<> api::stop() {
-    auto f = ss::now();
     if (_listener) {
-        f = _listener->stop();
+        co_await _listener->stop();
     }
-    return f.then([this] { return _pacemaker.stop(); }).then([this] {
-        return _mt_frontend.stop();
-    });
+    co_await _pacemaker.stop();
+    co_await _mt_frontend.stop();
+    co_await _reconciliation_backend.stop();
+    co_await _partition_manager.stop();
 }
 
 } // namespace coproc

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -43,7 +43,8 @@ private:
     std::unique_ptr<wasm::event_listener> _listener; /// one instance
     ss::sharded<pacemaker> _pacemaker;               /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
-      _mt_frontend; /// one instance
+      _mt_frontend;                                    /// one instance
+    ss::sharded<partition_manager> _partition_manager; /// one per core
     ss::sharded<reconciliation_backend>
       _reconciliation_backend; /// one per core
 

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -39,7 +39,6 @@ public:
 
 private:
     unresolved_address _engine_addr;
-    sys_refs _rs;
 
     std::unique_ptr<wasm::event_listener> _listener; /// one instance
     ss::sharded<pacemaker> _pacemaker;               /// one per core
@@ -47,6 +46,8 @@ private:
       _mt_frontend; /// one instance
     ss::sharded<reconciliation_backend>
       _reconciliation_backend; /// one per core
+
+    sys_refs _rs;
 
     // Event handlers
     std::unique_ptr<wasm::async_event_handler> _wasm_async_handler;

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -26,7 +26,8 @@ public:
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::topics_frontend>&,
       ss::sharded<cluster::metadata_cache>&,
-      ss::sharded<cluster::partition_manager>&) noexcept;
+      ss::sharded<cluster::partition_manager>&,
+      ss::sharded<coproc::partition_manager>&) noexcept;
 
     ~api();
 
@@ -43,8 +44,7 @@ private:
     std::unique_ptr<wasm::event_listener> _listener; /// one instance
     ss::sharded<pacemaker> _pacemaker;               /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
-      _mt_frontend;                                    /// one instance
-    ss::sharded<partition_manager> _partition_manager; /// one per core
+      _mt_frontend; /// one instance
     ss::sharded<reconciliation_backend>
       _reconciliation_backend; /// one per core
 

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -22,6 +22,8 @@ public:
     api(
       unresolved_address,
       ss::sharded<storage::api>&,
+      ss::sharded<cluster::topic_table>&,
+      ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::topics_frontend>&,
       ss::sharded<cluster::metadata_cache>&,
       ss::sharded<cluster::partition_manager>&) noexcept;
@@ -42,6 +44,8 @@ private:
     ss::sharded<pacemaker> _pacemaker;               /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
+    ss::sharded<reconciliation_backend>
+      _reconciliation_backend; /// one per core
 
     // Event handlers
     std::unique_ptr<wasm::async_event_handler> _wasm_async_handler;

--- a/src/v/coproc/errc.h
+++ b/src/v/coproc/errc.h
@@ -63,7 +63,9 @@ enum class errc {
     topic_does_not_exist,
     invalid_topic,
     materialized_topic,
-    script_id_does_not_exist
+    script_id_does_not_exist,
+    partition_not_exists,
+    partition_already_exists
 };
 
 struct errc_category final : public std::error_category {
@@ -83,6 +85,10 @@ struct errc_category final : public std::error_category {
             return "Topic is already a materialized topic";
         case errc::script_id_does_not_exist:
             return "Could not find coprocessor with matching script_id";
+        case errc::partition_not_exists:
+            return "Partition missing from coproc::partition_manager";
+        case errc::partition_already_exists:
+            return "Partition alreday exists in coproc::partition_manager";
         default:
             return "Undefined coprocessor error encountered";
         }

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -17,6 +17,7 @@ class api;
 class pacemaker;
 class script_context;
 class partition_manager;
+class reconciliation_backend;
 
 namespace wasm {
 

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -16,6 +16,7 @@ namespace coproc {
 class api;
 class pacemaker;
 class script_context;
+class partition_manager;
 
 namespace wasm {
 

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -122,6 +122,30 @@ public:
     /// returns a handle to the reconnect transport
     shared_script_resources& resources() { return _shared_res; }
 
+    /// Calls the function while materialized topic is on the denylist
+    ///
+    /// Its not enough to add the topic to the denylist, it must also be
+    /// checked that all fibers are respecting this, i.e. don't have in-progress
+    /// writes to these topics. After the function has been invoked the topic
+    /// will be removed from the blacklist.
+    template<typename Fn>
+    ss::future<>
+    with_hold(const model::ntp& source, const model::ntp& materialized, Fn fn) {
+        _shared_res.in_progress_deletes.emplace(materialized);
+        std::vector<ss::future<>> fs;
+        for (auto& [_, script] : _scripts) {
+            fs.emplace_back(script->remove_output(source, materialized));
+        }
+        /// When this future completes, it can safely be assumed that all fibers
+        /// are respecting the new addition to the blacklist
+        co_await ss::when_all_succeed(fs.begin(), fs.end());
+        co_await fn();
+        _shared_res.log_mtx.erase(materialized);
+        /// Releases the barrier, if any fibers wish to recreate the topic its
+        /// safe to do so now
+        _shared_res.in_progress_deletes.erase(materialized);
+    }
+
 private:
     void do_add_source(
       script_id,

--- a/src/v/coproc/partition.cc
+++ b/src/v/coproc/partition.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/partition.h"
+
+#include "storage/log.h"
+
+namespace coproc {
+
+partition::partition(
+  storage::log log, ss::lw_shared_ptr<cluster::partition> source) noexcept
+  : _log(log)
+  , _source(source) {}
+
+ss::future<model::record_batch_reader>
+partition::make_reader(storage::log_reader_config config) {
+    return ss::try_with_gate(
+      _gate, [this, config] { return _log.make_reader(config); });
+}
+
+storage::log_appender
+partition::make_appender(storage::log_append_config write_cfg) {
+    _gate.check();
+    return _log.make_appender(write_cfg);
+}
+
+ss::future<std::optional<storage::timequery_result>>
+partition::timequery(storage::timequery_config cfg) {
+    return ss::try_with_gate(
+      _gate, [this, cfg] { return _log.timequery(cfg); });
+}
+
+} // namespace coproc

--- a/src/v/coproc/partition.h
+++ b/src/v/coproc/partition.h
@@ -50,6 +50,9 @@ public:
     ss::future<std::optional<storage::timequery_result>>
       timequery(storage::timequery_config);
 
+    /// \brief get a handle to the source partition
+    ss::lw_shared_ptr<cluster::partition> source_partition() { return _source; }
+
 private:
     ss::gate _gate;
     storage::log _log;

--- a/src/v/coproc/partition.h
+++ b/src/v/coproc/partition.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/partition.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/gate.hh>
+
+namespace coproc {
+
+class partition {
+public:
+    partition(storage::log, ss::lw_shared_ptr<cluster::partition>) noexcept;
+
+    ss::future<> start() { return ss::now(); }
+    ss::future<> stop() { return _gate.close(); }
+
+    model::offset start_offset() const { return _log.offsets().start_offset; }
+    model::offset dirty_offset() const { return _log.offsets().dirty_offset; }
+
+    const model::ntp& source() const { return _source->ntp(); }
+    const model::ntp& ntp() const { return _log.config().ntp(); }
+    const storage::ntp_config& config() const { return _log.config(); }
+    bool is_leader() const { return _source->is_leader(); }
+    model::revision_id get_revision_id() const {
+        return _log.config().get_revision();
+    }
+
+    /// \brief Returns a reader that enters the \ref _gate when it performs
+    /// operations
+    ss::future<model::record_batch_reader>
+      make_reader(storage::log_reader_config);
+
+    /// \brief Returns an appender that ensures appends will not occur after
+    /// future returned from stop() resolves
+    storage::log_appender make_appender(storage::log_append_config);
+
+    /// \brief Invokes the timequery method on the \ref _log within the context
+    /// of the \ref gate
+    ss::future<std::optional<storage::timequery_result>>
+      timequery(storage::timequery_config);
+
+private:
+    ss::gate _gate;
+    storage::log _log;
+    ss::lw_shared_ptr<cluster::partition> _source;
+};
+
+} // namespace coproc

--- a/src/v/coproc/partition_manager.cc
+++ b/src/v/coproc/partition_manager.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/partition_manager.h"
+
+#include "cluster/logger.h"
+#include "cluster/partition.h"
+#include "coproc/logger.h"
+#include "storage/api.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace coproc {
+
+partition_manager::partition_manager(
+  ss::sharded<storage::api>& storage) noexcept
+  : _storage(storage.local()) {}
+
+ss::lw_shared_ptr<partition>
+partition_manager::get(const model::ntp& ntp) const {
+    if (auto it = _ntp_table.find(ntp); it != _ntp_table.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+ss::future<> partition_manager::manage(
+  storage::ntp_config ntp_cfg, ss::lw_shared_ptr<cluster::partition> src) {
+    auto holder = _gate.hold();
+    storage::log log = co_await _storage.log_mgr().manage(std::move(ntp_cfg));
+    vlog(
+      coproclog.info,
+      "Non replicable log created manage completed, ntp: {}, rev: {}, {} "
+      "segments, {} bytes",
+      log.config().ntp(),
+      log.config().get_revision(),
+      log.segment_count(),
+      log.size_bytes());
+
+    auto nrp = ss::make_lw_shared<partition>(log, src);
+    auto [_, success] = _ntp_table.emplace(log.config().ntp(), nrp);
+    vassert(
+      success,
+      "coproc::partition_manager contained item for key that was expected to "
+      "not exist");
+    _manage_watchers.notify(nrp->ntp(), nrp);
+    co_await nrp->start();
+}
+
+ss::future<> partition_manager::stop_partitions() {
+    co_await _gate.close();
+    auto partitions = std::exchange(_ntp_table, {});
+    co_await ss::parallel_for_each(
+      partitions, [this](ntp_table_container::value_type& e) {
+          return do_shutdown(e.second);
+      });
+}
+
+ss::future<> partition_manager::remove(const model::ntp& ntp) {
+    auto holder = _gate.hold();
+    auto found = _ntp_table.find(ntp);
+
+    if (found == _ntp_table.end()) {
+        throw std::invalid_argument(fmt_with_ctx(
+          ssx::sformat,
+          "Can not remove non_replicable partition. NTP {} is not "
+          "present in partition manager: ",
+          ntp));
+    }
+
+    auto partition = found->second;
+    _ntp_table.erase(found);
+    _unmanage_watchers.notify(ntp, ntp.tp.partition);
+    co_await partition->stop();
+    co_await _storage.log_mgr().remove(ntp);
+}
+
+ss::future<>
+partition_manager::do_shutdown(ss::lw_shared_ptr<partition> partition) {
+    try {
+        auto ntp = partition->ntp();
+        co_await partition->stop();
+        co_await _storage.log_mgr().shutdown(std::move(ntp));
+    } catch (...) {
+        vassert(
+          false,
+          "error shutting down non replicable partition {},  "
+          "non_replicable partition manager state: {}, error: {} - "
+          "terminating redpanda",
+          partition->ntp(),
+          *this,
+          std::current_exception());
+    }
+}
+
+cluster::notification_id_type partition_manager::register_manage_notification(
+  const model::ns& ns, const model::topic& topic, manage_cb_t cb) {
+    cluster::ntp_callbacks<manage_cb_t> init;
+    init.register_notify(
+      ns, topic, [&cb](ss::lw_shared_ptr<partition> p) { cb(p); });
+    for (auto& e : _ntp_table) {
+        init.notify(e.first, e.second);
+    }
+    return _manage_watchers.register_notify(ns, topic, std::move(cb));
+}
+
+std::ostream& operator<<(std::ostream& os, const partition_manager& nr_pm) {
+    fmt::print(os, "{ntp_count: {}}", nr_pm._ntp_table.size());
+    return os;
+}
+
+} // namespace coproc

--- a/src/v/coproc/partition_manager.h
+++ b/src/v/coproc/partition_manager.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/ntp_callbacks.h"
+#include "cluster/partition.h"
+#include "coproc/partition.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/gate.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+namespace coproc {
+
+class partition_manager {
+public:
+    using ntp_table_container
+      = absl::flat_hash_map<model::ntp, ss::lw_shared_ptr<partition>>;
+    using manage_cb_t
+      = ss::noncopyable_function<void(ss::lw_shared_ptr<partition>)>;
+    using unmanage_cb_t = ss::noncopyable_function<void(model::partition_id)>;
+
+    explicit partition_manager(ss::sharded<storage::api>& storage) noexcept;
+
+    ss::future<> start() { return ss::now(); }
+    ss::future<> stop_partitions();
+
+    ss::lw_shared_ptr<partition> get(const model::ntp& ntp) const;
+    ss::future<>
+      manage(storage::ntp_config, ss::lw_shared_ptr<cluster::partition>);
+
+    ss::future<> remove(const model::ntp&);
+
+    /// Recieve updates when a partition with matching ns, topic is added
+    cluster::notification_id_type register_manage_notification(
+      const model::ns& ns, const model::topic& topic, manage_cb_t cb);
+
+    /// Recieve updates when a partition with matching ns, topic is removed
+    cluster::notification_id_type register_unmanage_notification(
+      const model::ns& ns, const model::topic& topic, unmanage_cb_t cb) {
+        return _unmanage_watchers.register_notify(ns, topic, std::move(cb));
+    }
+    void unregister_manage_notification(cluster::notification_id_type id) {
+        _manage_watchers.unregister_notify(id);
+    }
+    void unregister_unmanage_notification(cluster::notification_id_type id) {
+        _unmanage_watchers.unregister_notify(id);
+    }
+
+private:
+    ss::future<> do_shutdown(ss::lw_shared_ptr<partition>);
+
+private:
+    ntp_table_container _ntp_table;
+    cluster::ntp_callbacks<manage_cb_t> _manage_watchers;
+    cluster::ntp_callbacks<unmanage_cb_t> _unmanage_watchers;
+
+    ss::gate _gate;
+    storage::api& _storage;
+
+    friend std::ostream& operator<<(std::ostream&, const partition_manager&);
+};
+
+} // namespace coproc

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/reconciliation_backend.h"
+
+#include "cluster/cluster_utils.h"
+#include "cluster/shard_table.h"
+#include "cluster/topic_table.h"
+#include "coproc/logger.h"
+#include "coproc/pacemaker.h"
+#include "storage/api.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace coproc {
+
+reconciliation_backend::reconciliation_backend(
+  ss::sharded<cluster::topic_table>& topics,
+  ss::sharded<cluster::shard_table>& shard_table,
+  ss::sharded<storage::api>& storage) noexcept
+  : _self(model::node_id(config::node().node_id))
+  , _data_directory(config::node().data_directory().as_sstring())
+  , _topics(topics)
+  , _shard_table(shard_table)
+  , _storage(storage) {
+    _retry_timer.set_callback([this] {
+        (void)within_context([this]() { return fetch_and_reconcile(); });
+    });
+}
+
+template<typename Fn>
+ss::future<> reconciliation_backend::within_context(Fn&& fn) {
+    try {
+        return ss::with_gate(
+          _gate, [this, fn = std::forward<Fn>(fn)]() mutable {
+              if (!_as.abort_requested()) {
+                  return _mutex.with(
+                    [fn = std::forward<Fn>(fn)]() mutable { return fn(); });
+              }
+              return ss::now();
+          });
+    } catch (const ss::gate_closed_exception& ex) {
+        vlog(coproclog.debug, "Timer fired during shutdown: {}", ex);
+    }
+    return ss::now();
+}
+
+ss::future<> reconciliation_backend::start() {
+    _id_cb = _topics.local().register_delta_notification(
+      [this](std::vector<update_t> deltas) {
+          return within_context([this, deltas = std::move(deltas)]() mutable {
+              for (auto& d : deltas) {
+                  auto ntp = d.ntp;
+                  _topic_deltas[ntp].push_back(std::move(d));
+              }
+              return fetch_and_reconcile();
+          });
+      });
+    return ss::now();
+}
+
+ss::future<> reconciliation_backend::stop() {
+    _as.request_abort();
+    _topics.local().unregister_delta_notification(_id_cb);
+    return _gate.close();
+}
+
+ss::future<std::vector<reconciliation_backend::update_t>>
+reconciliation_backend::process_events_for_ntp(
+  model::ntp ntp, std::vector<update_t> updates) {
+    std::vector<update_t> retries;
+    for (auto& d : updates) {
+        vlog(coproclog.trace, "executing ntp: {} op: {}", d.ntp, d);
+        auto err = co_await process_update(d);
+        vlog(coproclog.info, "partition operation {} result {}", d, err);
+        if (err != errc::success) {
+            /// In this case the source topic exists but its
+            /// associated partition doesn't, so try again
+            retries.push_back(std::move(d));
+        }
+    }
+    co_return retries;
+}
+
+ss::future<> reconciliation_backend::fetch_and_reconcile() {
+    using deltas_cache = decltype(_topic_deltas);
+    auto deltas = std::exchange(_topic_deltas, {});
+    deltas_cache retry_cache;
+    co_await ss::parallel_for_each(
+      deltas.begin(),
+      deltas.end(),
+      [this, &retry_cache](deltas_cache::value_type& p) -> ss::future<> {
+          auto retries = co_await process_events_for_ntp(p.first, p.second);
+          if (!retries.empty()) {
+              retry_cache[p.first] = std::move(retries);
+          }
+      });
+    if (!retry_cache.empty()) {
+        vlog(
+          coproclog.warn,
+          "There were recoverable errors when processing events, retrying");
+        std::swap(_topic_deltas, retry_cache);
+        if (!_retry_timer.armed()) {
+            _retry_timer.arm(
+              model::timeout_clock::now() + retry_timeout_interval);
+        }
+    }
+}
+
+ss::future<std::error_code> reconciliation_backend::process_update(update_t) {
+    co_return errc::success;
+}
+
+} // namespace coproc

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/fwd.h"
+#include "cluster/topic_table.h"
+#include "coproc/fwd.h"
+#include "storage/fwd.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+
+#include <absl/container/node_hash_map.h>
+
+namespace coproc {
+
+class reconciliation_backend {
+public:
+    explicit reconciliation_backend(
+      ss::sharded<cluster::topic_table>&,
+      ss::sharded<cluster::shard_table>&,
+      ss::sharded<storage::api>&) noexcept;
+
+    /// Starts the reconciliation loop
+    ///
+    /// Listens for events emitted from the topics table
+    ss::future<> start();
+
+    /// Stops the reconciliation loop
+    ss::future<> stop();
+
+private:
+    using update_t = cluster::topic_table::delta;
+    ss::future<std::error_code> process_update(update_t);
+    ss::future<std::vector<update_t>>
+      process_events_for_ntp(model::ntp, std::vector<update_t>);
+
+    ss::future<> fetch_and_reconcile();
+
+    template<typename Fn>
+    ss::future<> within_context(Fn&&);
+
+private:
+    cluster::notification_id_type _id_cb;
+    model::node_id _self;
+    ss::sstring _data_directory;
+    absl::node_hash_map<model::ntp, std::vector<update_t>> _topic_deltas;
+
+    mutex _mutex;
+    ss::gate _gate;
+    ss::abort_source _as;
+    ss::timer<model::timeout_clock> _retry_timer;
+
+    ss::sharded<cluster::topic_table>& _topics;
+    ss::sharded<cluster::shard_table>& _shard_table;
+    ss::sharded<storage::api>& _storage;
+};
+
+} // namespace coproc

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -31,7 +31,8 @@ public:
       ss::sharded<cluster::topic_table>&,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::partition_manager>&,
-      ss::sharded<partition_manager>&) noexcept;
+      ss::sharded<partition_manager>&,
+      ss::sharded<pacemaker>&) noexcept;
 
     /// Starts the reconciliation loop
     ///
@@ -77,6 +78,7 @@ private:
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::partition_manager>& _cluster_pm;
     ss::sharded<partition_manager>& _coproc_pm;
+    ss::sharded<pacemaker>& _pacemaker;
 };
 
 } // namespace coproc

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -46,6 +46,13 @@ private:
 
     ss::future<> fetch_and_reconcile();
 
+    ss::future<>
+    delete_non_replicable_partition(model::ntp ntp, model::revision_id rev);
+    ss::future<std::error_code>
+    create_non_replicable_partition(model::ntp ntp, model::revision_id rev);
+    ss::future<> add_to_shard_table(
+      model::ntp ntp, ss::shard_id shard, model::revision_id revision);
+
     template<typename Fn>
     ss::future<> within_context(Fn&&);
 

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -21,6 +21,8 @@
 
 #include <absl/container/node_hash_map.h>
 
+#include <chrono>
+
 namespace coproc {
 
 class reconciliation_backend {
@@ -28,7 +30,8 @@ public:
     explicit reconciliation_backend(
       ss::sharded<cluster::topic_table>&,
       ss::sharded<cluster::shard_table>&,
-      ss::sharded<storage::api>&) noexcept;
+      ss::sharded<cluster::partition_manager>&,
+      ss::sharded<partition_manager>&) noexcept;
 
     /// Starts the reconciliation loop
     ///
@@ -57,6 +60,9 @@ private:
     ss::future<> within_context(Fn&&);
 
 private:
+    static constexpr auto retry_timeout_interval = std::chrono::milliseconds(
+      100);
+
     cluster::notification_id_type _id_cb;
     model::node_id _self;
     ss::sstring _data_directory;
@@ -69,7 +75,8 @@ private:
 
     ss::sharded<cluster::topic_table>& _topics;
     ss::sharded<cluster::shard_table>& _shard_table;
-    ss::sharded<storage::api>& _storage;
+    ss::sharded<cluster::partition_manager>& _cluster_pm;
+    ss::sharded<partition_manager>& _coproc_pm;
 };
 
 } // namespace coproc

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -122,6 +122,7 @@ ss::future<> script_context::send_request(
                 .frontend = _resources.rs.mt_frontend,
                 .pm = _resources.rs.cp_partition_manager,
                 .inputs = _routes,
+                .denylist = _resources.in_progress_deletes,
                 .locks = _resources.log_mtx};
               return write_materialized(
                 std::move(reply.value().data.resps), args);

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -118,7 +118,9 @@ ss::future<> script_context::send_request(
           if (reply) {
               output_write_args args{
                 .id = _id,
-                .rs = _resources.rs,
+                .metadata = _resources.rs.metadata_cache,
+                .frontend = _resources.rs.mt_frontend,
+                .storage = _resources.rs.storage,
                 .inputs = _routes,
                 .locks = _resources.log_mtx};
               return write_materialized(

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -120,7 +120,7 @@ ss::future<> script_context::send_request(
                 .id = _id,
                 .metadata = _resources.rs.metadata_cache,
                 .frontend = _resources.rs.mt_frontend,
-                .storage = _resources.rs.storage,
+                .pm = _resources.rs.cp_partition_manager,
                 .inputs = _routes,
                 .locks = _resources.log_mtx};
               return write_materialized(

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -240,6 +240,14 @@ static ss::future<> process_one_reply(
             "error",
             e.id));
     }
+    if (args.denylist.contains(e.ntp)) {
+        /// The script attempted to write to a blacklisted ntp, meaning that
+        /// this ntp has been marked for deletion. Ignore this particular
+        /// portion of the request, until the ntp leaves the denlylist (after it
+        /// has been fully torn down). If the script later responds with this
+        /// ntp, it will be eventually re-created.
+        co_return;
+    }
     /// Possible filter response
     if (e.ntp == e.source) {
         /// If the reader is empty, then the wasm engine returned a nil

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -122,7 +122,7 @@ static ss::future<> maybe_make_materialized_log(
   model::topic_namespace new_materialized,
   bool is_leader,
   output_write_args args) {
-    const auto& cache = args.rs.metadata_cache.local();
+    const auto& cache = args.metadata.local();
     if (cache.get_topic_cfg(new_materialized)) {
         if (cache.get_source_topic(new_materialized)) {
             /// Log already exists
@@ -153,7 +153,7 @@ static ss::future<> maybe_make_materialized_log(
     /// All requests are debounced, therefore if multiple entities attempt to
     /// create a materialzied topic, all requests will wait for the first to
     /// complete.
-    co_return co_await args.rs.mt_frontend.invoke_on(
+    co_return co_await args.frontend.invoke_on(
       cluster::non_replicable_topics_frontend_shard,
       [topics = std::move(topics)](
         cluster::non_replicable_topics_frontend& mtfe) mutable {
@@ -180,7 +180,7 @@ static ss::future<> write_materialized_partition(
           return maybe_make_materialized_log(
                    source, new_materialized, input->is_leader(), args)
             .then([args, ntp, reader = std::move(reader)]() mutable {
-                auto found = args.rs.storage.local().log_mgr().get(ntp);
+                auto found = args.storage.local().log_mgr().get(ntp);
                 if (found) {
                     return do_write_materialized_partition(
                       *found, std::move(reader));

--- a/src/v/coproc/script_context_backend.h
+++ b/src/v/coproc/script_context_backend.h
@@ -11,8 +11,9 @@
 
 #pragma once
 
+#include "cluster/fwd.h"
+#include "coproc/fwd.h"
 #include "coproc/script_context_router.h"
-#include "coproc/sys_refs.h"
 #include "coproc/types.h"
 #include "utils/mutex.h"
 
@@ -27,7 +28,9 @@ using output_write_inputs = std::vector<process_batch_reply::data>;
 /// Arugments to pass to 'write_materialized', trivially copyable
 struct output_write_args {
     coproc::script_id id;
-    sys_refs& rs;
+    ss::sharded<cluster::metadata_cache>& metadata;
+    ss::sharded<cluster::non_replicable_topics_frontend>& frontend;
+    ss::sharded<storage::api>& storage;
     routes_t& inputs;
     absl::node_hash_map<model::ntp, mutex>& locks;
 };

--- a/src/v/coproc/script_context_backend.h
+++ b/src/v/coproc/script_context_backend.h
@@ -20,6 +20,7 @@
 #include <seastar/core/future.hh>
 
 #include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
 
 namespace coproc {
 /// The outputs from a 'process_batch' call to a wasm engine
@@ -32,6 +33,7 @@ struct output_write_args {
     ss::sharded<cluster::non_replicable_topics_frontend>& frontend;
     ss::sharded<coproc::partition_manager>& pm;
     routes_t& inputs;
+    absl::node_hash_set<model::ntp>& denylist;
     absl::node_hash_map<model::ntp, mutex>& locks;
 };
 

--- a/src/v/coproc/script_context_backend.h
+++ b/src/v/coproc/script_context_backend.h
@@ -30,7 +30,7 @@ struct output_write_args {
     coproc::script_id id;
     ss::sharded<cluster::metadata_cache>& metadata;
     ss::sharded<cluster::non_replicable_topics_frontend>& frontend;
-    ss::sharded<storage::api>& storage;
+    ss::sharded<coproc::partition_manager>& pm;
     routes_t& inputs;
     absl::node_hash_map<model::ntp, mutex>& locks;
 };

--- a/src/v/coproc/shared_script_resources.h
+++ b/src/v/coproc/shared_script_resources.h
@@ -20,6 +20,7 @@
 #include <seastar/core/semaphore.hh>
 
 #include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
 
 #include <chrono>
 
@@ -49,6 +50,9 @@ struct shared_script_resources {
     /// NOTE: Pointer stability is explicity requested due to the way iterators
     /// to elements within the collection are used
     absl::node_hash_map<model::ntp, mutex> log_mtx;
+
+    /// Set partitions that are in the middle of being deleted
+    absl::node_hash_set<model::ntp> in_progress_deletes;
 
     /// References to other redpanda components
     sys_refs& rs;

--- a/src/v/coproc/sys_refs.h
+++ b/src/v/coproc/sys_refs.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/fwd.h"
+#include "coproc/fwd.h"
 #include "seastarx.h"
 #include "storage/fwd.h"
 
@@ -29,6 +30,7 @@ struct sys_refs {
     ss::sharded<cluster::topics_frontend>& topics_frontend;
     ss::sharded<cluster::metadata_cache>& metadata_cache;
     ss::sharded<cluster::partition_manager>& partition_manager;
+    ss::sharded<coproc::partition_manager>& cp_partition_manager;
 };
 
 } // namespace coproc

--- a/src/v/coproc/sys_refs.h
+++ b/src/v/coproc/sys_refs.h
@@ -23,6 +23,8 @@ namespace coproc {
 /// leverage
 struct sys_refs {
     ss::sharded<storage::api>& storage;
+    ss::sharded<cluster::topic_table>& topic_table;
+    ss::sharded<cluster::shard_table>& shard_table;
     ss::sharded<cluster::non_replicable_topics_frontend>& mt_frontend;
     ss::sharded<cluster::topics_frontend>& topics_frontend;
     ss::sharded<cluster::metadata_cache>& metadata_cache;

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -164,7 +164,7 @@ coproc::output_write_args fiber_mock_fixture::make_output_write_args(state& s) {
       .id = _id,
       .metadata = shared_res.rs.metadata_cache,
       .frontend = shared_res.rs.mt_frontend,
-      .storage = shared_res.rs.storage,
+      .pm = shared_res.rs.cp_partition_manager,
       .inputs = s.routes,
       .locks = shared_res.log_mtx};
 }

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -162,7 +162,9 @@ coproc::output_write_args fiber_mock_fixture::make_output_write_args(state& s) {
     auto& shared_res = app.coprocessing->get_pacemaker().local().resources();
     return coproc::output_write_args{
       .id = _id,
-      .rs = shared_res.rs,
+      .metadata = shared_res.rs.metadata_cache,
+      .frontend = shared_res.rs.mt_frontend,
+      .storage = shared_res.rs.storage,
       .inputs = s.routes,
       .locks = shared_res.log_mtx};
 }

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -166,6 +166,7 @@ coproc::output_write_args fiber_mock_fixture::make_output_write_args(state& s) {
       .frontend = shared_res.rs.mt_frontend,
       .pm = shared_res.rs.cp_partition_manager,
       .inputs = s.routes,
+      .denylist = shared_res.in_progress_deletes,
       .locks = shared_res.log_mtx};
 }
 

--- a/src/v/coproc/tests/pacemaker_tests.cc
+++ b/src/v/coproc/tests/pacemaker_tests.cc
@@ -10,6 +10,7 @@
 
 #include "coproc/api.h"
 #include "coproc/pacemaker.h"
+#include "coproc/partition_manager.h"
 #include "coproc/tests/fixtures/coproc_test_fixture.h"
 #include "coproc/tests/utils/batch_utils.h"
 #include "coproc/tests/utils/coprocessor.h"
@@ -162,4 +163,86 @@ FIXTURE_TEST(test_copro_auto_deregister_function, coproc_test_fixture) {
         return root_fixture()->app.coprocessing->get_pacemaker().map_reduce0(
           std::move(map), true, std::logical_and<>());
     }).get();
+}
+
+/// Ensures that a deletion of a materialized topic doesn't conflict
+/// with an active coprocessor producing onto it. Furthermore asserts the topic
+/// exists at tests end and contains all expected records.
+FIXTURE_TEST(test_copro_delete_topic, coproc_test_fixture) {
+    model::topic_namespace tbd(model::kafka_namespace, model::topic("tbd"));
+    setup({{tbd.tp, 4}}).get();
+    auto id = coproc::script_id(59);
+    // Use the earliest policy so that when the topic is re-created processing
+    // begins at 0, so that the full amount of records can be asserted at tests
+    // end
+    enable_coprocessors(
+      {{.id = id(),
+        .data{
+          .tid = copro_typeid::identity_coprocessor,
+          .topics = {{tbd.tp, coproc::topic_ingestion_policy::earliest}}}}})
+      .get();
+
+    /// Find shard of one of the partitions
+    model::partition_id target_pid(0);
+    auto shard = root_fixture()->app.shard_table.local().shard_for(
+      model::ntp(tbd.ns, tbd.tp, target_pid));
+    BOOST_CHECK(shard.has_value());
+    info("On shard: {}", *shard);
+
+    /// Setup listeners to inject the deletion
+    model::ntp target(
+      tbd.ns,
+      to_materialized_topic(tbd.tp, identity_coprocessor::identity_topic),
+      target_pid);
+    auto f = root_fixture()
+               ->app.cp_partition_manager
+               .invoke_on(
+                 *shard,
+                 [this, target](coproc::partition_manager& pm) {
+                     ss::promise<> p;
+                     auto f = p.get_future();
+                     auto id = pm.register_manage_notification(
+                       target.ns,
+                       target.tp.topic,
+                       [this, p = std::move(p)](
+                         ss::lw_shared_ptr<coproc::partition>) mutable {
+                           p.set_value();
+                       });
+                     return f.then(
+                       [id, &pm] { pm.unregister_manage_notification(id); });
+                 })
+               .then([this, target] {
+                   model::topic_namespace tp{target.ns, target.tp.topic};
+                   info("Deleting topic: {} ", tp);
+                   return root_fixture()->delete_topic(tp).then(
+                     [this, tp] { info("Topic {} deleted", tp); });
+               });
+
+    // Push some data across input topic....
+    const std::size_t total_records = 10000;
+    std::vector<ss::future<>> fs;
+    fs.reserve(4);
+    for (auto i = 0; i < 4; ++i) {
+        info("Producing onto: {}-{}", tbd, i);
+        fs.emplace_back(produce(
+          model::ntp(tbd.ns, tbd.tp, model::partition_id(i)),
+          make_random_batch(total_records)));
+    }
+    ss::when_all_succeed(fs.begin(), fs.end()).get();
+    info("All produced onto: {}", tbd);
+    f.get();
+
+    /// Wait until all data is recieved on output topic, which should have been
+    /// recreated and fully processed from the earliest offset
+    for (auto i = 0; i < 4; ++i) {
+        auto results = consume(
+                         model::ntp(
+                           tbd.ns,
+                           to_materialized_topic(
+                             tbd.tp, identity_coprocessor::identity_topic),
+                           model::partition_id(i)),
+                         total_records)
+                         .get();
+        BOOST_CHECK_EQUAL(num_records(results), total_records);
+    }
 }

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -181,8 +181,8 @@ static ss::future<read_result> read_from_partition(
  * build error responses if anything goes wrong.
  */
 static ss::future<read_result> do_read_from_ntp(
-  cluster::partition_manager& mgr,
-  cluster::metadata_cache& md_cache,
+  cluster::partition_manager& cluster_pm,
+  coproc::partition_manager& coproc_pm,
   ntp_fetch_config ntp_config,
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
@@ -190,7 +190,7 @@ static ss::future<read_result> do_read_from_ntp(
      * lookup the ntp's partition
      */
     auto kafka_partition = make_partition_proxy(
-      ntp_config.ntp(), md_cache, mgr);
+      ntp_config.ntp(), cluster_pm, coproc_pm);
     if (unlikely(!kafka_partition)) {
         return ss::make_ready_future<read_result>(
           error_code::unknown_topic_or_partition);
@@ -234,14 +234,18 @@ make_ntp_fetch_config(const model::ntp& ntp, const fetch_config& fetch_cfg) {
 }
 
 ss::future<read_result> read_from_ntp(
-  cluster::partition_manager& pm,
-  cluster::metadata_cache& md_cache,
+  cluster::partition_manager& cluster_pm,
+  coproc::partition_manager& coproc_pm,
   const model::ntp& ntp,
   fetch_config config,
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
     return do_read_from_ntp(
-      pm, md_cache, make_ntp_fetch_config(ntp, config), foreign_read, deadline);
+      cluster_pm,
+      coproc_pm,
+      make_ntp_fetch_config(ntp, config),
+      foreign_read,
+      deadline);
 }
 
 static void fill_fetch_responses(
@@ -322,18 +326,18 @@ static void fill_fetch_responses(
 }
 
 static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
-  cluster::partition_manager& mgr,
-  cluster::metadata_cache& md_cache,
+  cluster::partition_manager& cluster_pm,
+  coproc::partition_manager& coproc_pm,
   std::vector<ntp_fetch_config> ntp_fetch_configs,
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
     return ssx::parallel_transform(
       std::move(ntp_fetch_configs),
-      [&mgr, &md_cache, deadline, foreign_read](
+      [&cluster_pm, &coproc_pm, deadline, foreign_read](
         const ntp_fetch_config& ntp_cfg) {
           auto p_id = ntp_cfg.ntp().tp.partition;
           return do_read_from_ntp(
-                   mgr, md_cache, ntp_cfg, foreign_read, deadline)
+                   cluster_pm, coproc_pm, ntp_cfg, foreign_read, deadline)
             .then([p_id](read_result res) {
                 res.partition = p_id;
                 return res;
@@ -373,7 +377,7 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
           cluster::partition_manager& mgr) mutable {
             return fetch_ntps_in_parallel(
               mgr,
-              octx.rctx.metadata_cache(),
+              octx.rctx.coproc_partition_manager().local(),
               std::move(configs),
               foreign_read,
               deadline);

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -309,7 +309,7 @@ struct fetch_plan {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
-  cluster::metadata_cache&,
+  coproc::partition_manager&,
   const model::ntp&,
   fetch_config,
   bool,

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -66,7 +66,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
   model::isolation_level isolation_lvl,
   cluster::partition_manager& mgr) {
     auto kafka_partition = make_partition_proxy(
-      ntp, octx.rctx.metadata_cache(), mgr);
+      ntp, mgr, octx.rctx.coproc_partition_manager().local());
     if (!kafka_partition) {
         co_return list_offsets_response::make_partition(
           ntp.tp.partition, error_code::unknown_topic_or_partition);

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -12,6 +12,7 @@
 
 #include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
+#include "coproc/fwd.h"
 #include "model/fundamental.h"
 #include "storage/translating_reader.h"
 #include "storage/types.h"
@@ -101,6 +102,6 @@ partition_proxy make_partition_proxy(Args&&... args) {
 }
 
 std::optional<partition_proxy> make_partition_proxy(
-  const model::ntp&, cluster::metadata_cache&, cluster::partition_manager&);
+  const model::ntp&, cluster::partition_manager&, coproc::partition_manager&);
 
 } // namespace kafka

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -50,6 +50,7 @@ protocol::protocol(
   ss::sharded<cluster::security_frontend>& sec_fe,
   ss::sharded<cluster::controller_api>& controller_api,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
+  ss::sharded<coproc::partition_manager>& coproc_partition_manager,
   ss::sharded<v8_engine::data_policy_table>& data_policy_table,
   std::optional<qdc_monitor::config> qdc_config) noexcept
   : _smp_group(smp)
@@ -71,6 +72,7 @@ protocol::protocol(
   , _security_frontend(sec_fe)
   , _controller_api(controller_api)
   , _tx_gateway_frontend(tx_gateway_frontend)
+  , _coproc_partition_manager(coproc_partition_manager)
   , _data_policy_table(data_policy_table) {
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -13,6 +13,7 @@
 
 #include "cluster/fwd.h"
 #include "config/configuration.h"
+#include "coproc/fwd.h"
 #include "kafka/latency_probe.h"
 #include "kafka/server/fetch_metadata_cache.hh"
 #include "kafka/server/fwd.h"
@@ -47,6 +48,7 @@ public:
       ss::sharded<cluster::security_frontend>&,
       ss::sharded<cluster::controller_api>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
+      ss::sharded<coproc::partition_manager>&,
       ss::sharded<v8_engine::data_policy_table>&,
       std::optional<qdc_monitor::config>) noexcept;
 
@@ -76,6 +78,9 @@ public:
     }
     kafka::group_router& group_router() { return _group_router.local(); }
     cluster::shard_table& shard_table() { return _shard_table.local(); }
+    ss::sharded<coproc::partition_manager>& coproc_partition_manager() {
+        return _coproc_partition_manager;
+    }
     ss::sharded<cluster::partition_manager>& partition_manager() {
         return _partition_manager;
     }
@@ -143,6 +148,7 @@ private:
     ss::sharded<cluster::security_frontend>& _security_frontend;
     ss::sharded<cluster::controller_api>& _controller_api;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
+    ss::sharded<coproc::partition_manager>& _coproc_partition_manager;
     ss::sharded<v8_engine::data_policy_table>& _data_policy_table;
     std::optional<qdc_monitor> _qdc_mon;
     kafka::fetch_metadata_cache _fetch_metadata_cache;

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -122,6 +122,10 @@ public:
 
     cluster::shard_table& shards() { return _conn->server().shard_table(); }
 
+    ss::sharded<coproc::partition_manager>& coproc_partition_manager() {
+        return _conn->server().coproc_partition_manager();
+    }
+
     ss::sharded<cluster::partition_manager>& partition_manager() {
         return _conn->server().partition_manager();
     }

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -172,7 +172,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
             [&octx, ntp, config](cluster::partition_manager& pm) {
                 return kafka::read_from_ntp(
                   pm,
-                  octx.rctx.metadata_cache(),
+                  octx.rctx.coproc_partition_manager().local(),
                   ntp,
                   config,
                   true,

--- a/src/v/kafka/server/tests/find_coordinator_test.cc
+++ b/src/v/kafka/server/tests/find_coordinator_test.cc
@@ -49,28 +49,3 @@ FIXTURE_TEST(find_coordinator, redpanda_thread_fixture) {
     BOOST_TEST(resp.data.host == "127.0.0.1");
     BOOST_TEST(resp.data.port == 9092);
 }
-
-FIXTURE_TEST(
-  find_coordinator_for_non_replicatable_topic, redpanda_thread_fixture) {
-    wait_for_controller_leadership().get();
-    model::topic_namespace src{model::kafka_namespace, model::topic("src")};
-    model::topic_namespace dst{model::kafka_namespace, model::topic("dst")};
-    add_topic(src).get();
-    add_non_replicable_topic(std::move(src), std::move(dst)).get();
-
-    auto client = make_kafka_client().get0();
-    client.connect().get();
-    kafka::find_coordinator_request req("src");
-    kafka::find_coordinator_request req2("dst");
-    std::vector<kafka::find_coordinator_response> resps;
-    resps.push_back(client.dispatch(req, kafka::api_version(1)).get0());
-    resps.push_back(client.dispatch(req2, kafka::api_version(1)).get0());
-    client.stop().then([&client] { client.shutdown(); }).get();
-
-    for (const auto& r : resps) {
-        BOOST_TEST(r.data.error_code == kafka::error_code::none);
-        BOOST_TEST(r.data.node_id == model::node_id(1));
-        BOOST_TEST(r.data.host == "127.0.0.1");
-        BOOST_TEST(r.data.port == 9092);
-    }
-}

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -785,6 +785,8 @@ void application::wire_up_redpanda_services() {
           coprocessing,
           config::node().coproc_supervisor_server(),
           std::ref(storage),
+          std::ref(controller->get_topics_state()),
+          std::ref(shard_table),
           std::ref(controller->get_topics_frontend()),
           std::ref(metadata_cache),
           std::ref(partition_manager));

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1167,6 +1167,7 @@ void application::start_redpanda() {
             controller->get_security_frontend(),
             controller->get_api(),
             tx_gateway_frontend,
+            cp_partition_manager,
             data_policies,
             qdc_config);
           s.set_protocol(std::move(proto));

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -74,6 +74,7 @@ public:
     ss::sharded<cluster::shard_table> shard_table;
     ss::sharded<storage::api> storage;
     std::unique_ptr<coproc::api> coprocessing;
+    ss::sharded<coproc::partition_manager> cp_partition_manager;
     ss::sharded<cluster::partition_manager> partition_manager;
     ss::sharded<raft::recovery_throttle> recovery_throttle;
     ss::sharded<raft::group_manager> raft_group_manager;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -20,9 +20,11 @@
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
 #include "config/node_config.h"
+#include "coproc/api.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
+#include "kafka/server/protocol.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/timeout_clock.h"
@@ -99,6 +101,7 @@ public:
           app.controller->get_security_frontend(),
           app.controller->get_api(),
           app.tx_gateway_frontend,
+          app.cp_partition_manager,
           app.data_policies,
           std::nullopt);
     }


### PR DESCRIPTION
Currently cluster::partitions are ss::lw_shared_ptr instances where it is not known which shared_ptr copy will be the last holder before destruction. Therefore when a partition is deleted, stop() is called without waiting for all consumers of the interface to stop whatever they are doing. Upon next invocation of some method ss::gate_closed_exception will be called, and the shutdown can safely occur.

Materialized logs have no abstraction, they are literally writes to a storage::log instance. Due to the introduction of the ability to delete materialized logs, there now needs to be a way to safely shut them down. If close() is called twice on a storage::log assertions will be called. Also there are assertions that fire during writes if close() is being concurrently performed.

This PR attempts to solve these problems by creating an abstraction called cluster::non_replicable_partition. The solution works in the same way cluster::partitions are shut down. This class looks and feels like a normal cluster::partition, however its much simpler. It simply contains a gate that allows for safe shutdown of the storage::log. Reads & writes are wrapped with code that knows when the gate is closed, so a record_batch_reader::impl or consumer impl can stop iteration when the gate has been closed. Just like cluster::partition if usage is performed to the class while the gate is closed the class throws ss::gate_closed_exception.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/592a700d59f28392a09d5944fc3ee2a32b7f6d68..cd68e33572b70d6cf831e66b23f61ebbc75b15cc)
- Have coproc consume from these new changes, i.e. writes query the new partition_manager cache instead of querying storage directly

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/8742aba1bca15cb71e466452ce779351f642985e..284ef0992cf51dca6dc08ac19bf9c07ffbcf30e1)
- Implementing vadims feedback about consistent use of entering/leaving gates

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/97db5ca8e25e8f1d12d59aa36533cf1fde3debf3..db5654e47c905d9820e911d6ad70884dcc290221)
- Resolved conflict by rebasing latest dev
- Only conflict was in `kafka/server/handlers/list_offsets.cc`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/db5654e47c905d9820e911d6ad70884dcc290221..8b94772300eb00daba92f6f445f6536a81fe508f)
- Rebased dev to grab changes from PR #2970

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/8b94772300eb00daba92f6f445f6536a81fe508f..7f908e2e8fb4ac195a8e4f5c1c69b4089d7d269b)
- Cleaned up solution to not have `controller_backend` log events that it didn't handle
- Fixed bug that would have `reconciliation_backend` not reconcile events for which didn't have an associated partition for. This bug was making a node failure test fail.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/7f908e2e8fb4ac195a8e4f5c1c69b4089d7d269b..351ef8a8c5a6224c596fad50368a15b78d27462e)
- Addressed all comments and nits by Ben. Included renames, unused vars, missing gate issues, better error messages, better assert messages, removal of magic numbers etc.
- Removed the `gated_shutdown_reader` in the `coproc::partition`.
- Replaced a sleep call within `reconciliation_backend` with use of a `ss::timer` 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/351ef8a8c5a6224c596fad50368a15b78d27462e..9248a4c4bb6e6a998feeb2dacc79576006df1705)
- Rebased against dev to resolve conflicts

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/9248a4c4bb6e6a998feeb2dacc79576006df1705..ddc1ef87a7b9b863e5ea31848e4847b8db942711)
- Added descriptive comments, nits, and modified commit messages
- Modified how the enable coproc flag is used
- Dropped the `safe_appender` solution for setting up a proper barrier when removing materialized topics.
- Within this barrier called the right methods to release resources allocated to materialized topics, something which previously wasn't done before

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/ddc1ef87a7b9b863e5ea31848e4847b8db942711..ad8707e7503e3dbd52170a949f790e080ed17fa4)
- Fixed erroneous push

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/ad8707e7503e3dbd52170a949f790e080ed17fa4..4c1cf86de6fdde74eaf743492a5a7a59f4cf2809)
- Added a notification mechanism to `coproc::partition_manager` so a test could be written
- Added a new test (that used the above feature) that removes a materialized topic while a fiber is actively writing to one
- Modified how the enable_coproc flag worked
- Fixed a bug with materialized topic deletion. `deallocate_topic()` in `topic_updates_dispatcher` cannot be called on materialized topics
- Clang formatted incorrectly formatted file

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/3bc86cce5c9d0a06d6c6882f8536e336110061c1..c786a4c190aa1b37b23340f6417dc44047ddca7b)
- Rebase against dev to resolve a conflict in `kafka/server/materialized_partition.h`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/c786a4c190aa1b37b23340f6417dc44047ddca7b..b87d902aca866cd2f834ca0928414d5747bbe6fa)
- Removed -1 raft group id logic
- Partition allocation information now takes into account non_replicable topics.
- enable_coproc flag reverted to working how it used to, if its off `coproc::api` isn't instantiated. Any `non_replicable` tests that exist in `v/kafka` were moved into `v/coproc` or removed if there were already similar tests existing in coproc.
- Addressed random C++ items from Michal & Noahs most recent review comments

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/b87d902aca866cd2f834ca0928414d5747bbe6fa..1e2c00be228b7960018c785e3f2126e205e9790f)
- Rebased dev to resolve a conflict

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/1e2c00be228b7960018c785e3f2126e205e9790f..09a0862c07fd8f780bf95845f455638dfaf4431c)
- Rebased dev to resolve a conflict in `kafka/server/materialized_partition.h`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/09a0862c07fd8f780bf95845f455638dfaf4431c..107a8aea367b3a8d7c7192932634b39fd4c15d69)
- Rebased dev to resolve another conflict in `kafka/server/materialzied_partition.h`