### PR TITLE
add template for auto gen release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - changelog/ignore
+  categories:
+    - title: Features
+      labels:
+        - changelog/feature
+    - title: Improvements
+      labels:
+        - changelog/improvement
+    - title: Bug Fixes
+      labels:
+        - changelog/bugfix
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Cover letter

This template is used by github to help create release notes when a draft release is created. There is a magic button **Auto-generate release notes** that will create a changelog from the template. The changelog is generated from the title of the merged PRs.

The 3 sections of the template, **Features**, **Improvements**, **Bug Fixes**, were chosen because they are the sections used in the [v21.8.1 release notes](https://github.com/vectorizedio/redpanda/releases/tag/v21.8.1).

This template assumes 4 new [labels](https://github.com/vectorizedio/redpanda/labels) are available for PRs to optionally use to determine which section of the changelog the PR title will fall under:
* `changelog/ignore`
* `changelog/feature`
* `changelog/improvement`
* `changelog/bugfix`

See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes