### PR TITLE
k8s: Change the feature gate for shadow indexing directory cache

### DIFF
--- a/src/go/k8s/pkg/resources/featuregates/shadow_indexing.go
+++ b/src/go/k8s/pkg/resources/featuregates/shadow_indexing.go
@@ -15,12 +15,12 @@ import "github.com/Masterminds/semver/v3"
 
 const (
 	major = uint64(21)
-	minor = uint64(10)
+	minor = uint64(11)
 )
 
 // ShadowIndex feature gate should be removed in 3 version starting
-// from v21.10.x where cloud cache directory was introduced
-// TODO in version/month 22.01 remove this if statement GH-2631
+// from v21.11.x where cloud cache directory was introduced
+// TODO in version/month 22.02 remove this if statement GH-2631
 func ShadowIndex(version string) bool {
 	v, err := semver.NewVersion(version)
 	if err != nil {

--- a/src/go/k8s/pkg/resources/statefulset_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_test.go
@@ -253,7 +253,7 @@ func pandaCluster() *redpandav1alpha1.Cluster {
 		},
 		Spec: redpandav1alpha1.ClusterSpec{
 			Image:    "image",
-			Version:  "v21.10.1",
+			Version:  "v21.11.1",
 			Replicas: pointer.Int32Ptr(replicas),
 			CloudStorage: redpandav1alpha1.CloudStorageConfig{
 				Enabled: true,


### PR DESCRIPTION
## Cover letter

Redpanda in the 21.10.X version will not have shadow indexing directory cache included. Beside v21.10.1-si-betaX releases. This PR moves the feature gate to the eventual release version with the shadow indexing directory cache.
