### PR TITLE
Fetch session fairness 

### DIFF
--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -159,6 +159,11 @@ public:
                + partitions.size() * sizeof(fetch_session_partition);
     }
 
+    void move_to_end(iterator it) {
+        it->second->_hook.unlink();
+        insertion_order.push_back(*it->second);
+    }
+
     iterator begin() { return partitions.begin(); }
     iterator end() { return partitions.end(); }
 

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -167,7 +167,7 @@ log_segment_batch_reader::read_some(model::timeout_clock::time_point timeout) {
       _config.max_offset,
       _config.type_filter,
       _config.first_timestamp,
-      max_buffer_size,
+      std::min(max_buffer_size, _config.max_bytes),
       _config.skip_batch_cache);
 
     // handles cases where the type filter skipped batches. see

--- a/tests/rptest/clients/kcl.py
+++ b/tests/rptest/clients/kcl.py
@@ -21,12 +21,21 @@ class KCL:
     def produce(self, topic, msg):
         return self._cmd(["produce", topic], input=msg)
 
-    def consume(self, topic, n=None, group=None):
+    def consume(self,
+                topic,
+                n=None,
+                group=None,
+                regex=False,
+                fetch_max_bytes=None):
         cmd = ["consume"]
         if group is not None:
             cmd += ["-g", group]
         if n is not None:
             cmd.append(f"-n{n}")
+        if regex:
+            cmd.append("-r")
+        if fetch_max_bytes is not None:
+            cmd += ["--fetch-max-bytes", str(fetch_max_bytes)]
         cmd.append(topic)
         return self._cmd(cmd)
 

--- a/tests/rptest/tests/fetch_fairness_test.py
+++ b/tests/rptest/tests/fetch_fairness_test.py
@@ -1,0 +1,103 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import sys
+import time
+import re
+import random
+
+from ducktape.mark.resource import cluster
+from ducktape.mark import parametrize
+from ducktape.mark import ignore
+from ducktape.utils.util import wait_until
+
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.kcl import KCL
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.clients.types import TopicSpec
+from rptest.services.failure_injector import FailureInjector, FailureSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.rpk_producer import RpkProducer
+from rptest.services.kaf_producer import KafProducer
+from rptest.services.admin import Admin
+
+
+class FetchTest(RedpandaTest):
+    def __init__(self, test_ctx, *args, **kwargs):
+        self._ctx = test_ctx
+        super(FetchTest, self).__init__(test_ctx,
+                                        num_brokers=1,
+                                        *args,
+                                        extra_rp_conf={},
+                                        **kwargs)
+
+    """
+    Validates key availability properties of the system using a single
+    partition.
+    """
+
+    @cluster(num_nodes=1)
+    @parametrize(type='multiple-topics')
+    @parametrize(type='multiple-partitions')
+    def simple_fetch_handler_fairness_test(self, type):
+        """
+        Testing if when fetching from single node all partitions are 
+        returned in round robin fashion
+        """
+        def multiple_topics(count):
+            return list(
+                map(
+                    lambda i: TopicSpec(partition_count=1,
+                                        replication_factor=1), range(0,
+                                                                     count)))
+
+        def multiple_partitions(count):
+            return [TopicSpec(partition_count=count, replication_factor=1)]
+
+        number_of_partitions = 32
+        records_per_partition = 10
+        topics = []
+
+        if type == 'multiple-topics':
+            topics = multiple_topics(number_of_partitions)
+        else:
+            topics = multiple_partitions(number_of_partitions)
+
+        # create topics
+        self.redpanda.create_topic(specs=topics)
+        self.redpanda.logger.info(f"topics: {topics}")
+        rpk = RpkTool(self.redpanda)
+
+        # publish 10 messages to each topic/partition
+
+        for s in topics:
+            t = s.name
+            for p in range(0, s.partition_count):
+                for i in range(0, records_per_partition):
+                    self.redpanda.logger.info(f"producing to : {t}/{p}")
+                    rpk.produce(t,
+                                f"k.{t}.{p}.{i}",
+                                f"p.{t}.{p}.{i}",
+                                partition=p)
+
+        # configure kcl to fetch at most 1 byte in single fetch request,
+        # this way we should receive exactly one record per each partition
+
+        kcl = KCL(self.redpanda)
+        consumed = kcl.consume(topic="topic-.*",
+                               n=number_of_partitions,
+                               regex=True,
+                               fetch_max_bytes=1,
+                               group="test-gr-1")
+        consumed_partitions = set()
+        for c in consumed.split():
+            parts = c.split('.')
+            consumed_partitions.add((parts[1], parts[2]))
+
+        assert len(consumed_partitions) == number_of_partitions


### PR DESCRIPTION
## Cover letter
    
From [KIP-277](https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability#KIP227:IntroduceIncrementalFetchRequeststoIncreasePartitionScalability-Cacheddataabouteachpartition):

In order to solve the starvation problem, the server must rotate the order in which it returns partition information.  The server does this by maintaining a linked list of all partitions in the fetch session.  When data is returned for a partition, that partition is moved to the end of the list.  This ensures that we eventually return data about all partitions for which data is available.

