### PR TITLE
utils: Capture state in retry_chain_logger

### DIFF
--- a/src/v/utils/retry_chain_node.cc
+++ b/src/v/utils/retry_chain_node.cc
@@ -301,3 +301,9 @@ ss::abort_source* retry_chain_node::find_abort_source() {
     }
     return root->get_abort_source();
 }
+
+void retry_chain_logger::do_log(
+  ss::log_level lvl,
+  ss::noncopyable_function<void(ss::logger&, ss::log_level)> fn) const {
+    fn(_log, lvl);
+}


### PR DESCRIPTION
## Cover letter

Caputure state in lambda function inside retry_chain_logger::log method.
This is needed to prevent clang compiler bug from manifesting. The log
method works the same way as seastar::logger::log which is immune to the
same compiler bug.




## Release notes

N/A