### PR TITLE
enable archival unit tests

### DIFF
--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ rp_test(
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::application Boost::unit_test_framework v::archival v::storage_test_utils
   ARGS "-- -c 1"
-  LABELS archival disable_on_ci  # Disabled for https://github.com/vectorizedio/redpanda/issues/2438
+  LABELS archival
 )
 
 

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -424,18 +424,21 @@ void segment_matcher<Fixture>::verify_manifest_content(
 template class segment_matcher<archiver_fixture>;
 
 enable_cloud_storage_fixture::enable_cloud_storage_fixture() {
-    auto& cfg = config::shard_local_cfg();
-    cfg.cloud_storage_enabled.set_value(true);
-    cfg.cloud_storage_api_endpoint.set_value(
-      std::optional<ss::sstring>{httpd_host_name});
-    cfg.cloud_storage_api_endpoint_port.set_value(httpd_port_number);
-    cfg.cloud_storage_access_key.set_value(
-      std::optional<ss::sstring>{"access-key"});
-    cfg.cloud_storage_secret_key.set_value(
-      std::optional<ss::sstring>{"secret-key"});
-    cfg.cloud_storage_region.set_value(std::optional<ss::sstring>{"us-east1"});
-    cfg.cloud_storage_bucket.set_value(
-      std::optional<ss::sstring>{"test-bucket"});
+    ss::smp::invoke_on_all([]() {
+        auto& cfg = config::shard_local_cfg();
+        cfg.cloud_storage_enabled.set_value(true);
+        cfg.cloud_storage_api_endpoint.set_value(
+          std::optional<ss::sstring>{httpd_host_name});
+        cfg.cloud_storage_api_endpoint_port.set_value(httpd_port_number);
+        cfg.cloud_storage_access_key.set_value(
+          std::optional<ss::sstring>{"access-key"});
+        cfg.cloud_storage_secret_key.set_value(
+          std::optional<ss::sstring>{"secret-key"});
+        cfg.cloud_storage_region.set_value(
+          std::optional<ss::sstring>{"us-east1"});
+        cfg.cloud_storage_bucket.set_value(
+          std::optional<ss::sstring>{"test-bucket"});
+    }).get0();
 }
 
 enable_cloud_storage_fixture::~enable_cloud_storage_fixture() {


### PR DESCRIPTION
Draft just to trigger Buildkite and see what archival unit tests are currently failing