### PR TITLE
Make list_offset linearizable

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -133,6 +133,10 @@ public:
 
     bool is_leader() const { return _raft->is_leader(); }
 
+    ss::future<result<model::offset>> linearizable_barrier() {
+        return _raft->linearizable_barrier();
+    }
+
     ss::future<std::error_code>
     transfer_leadership(std::optional<model::node_id> target) {
         return _raft->do_transfer_leadership(target);

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -62,6 +62,55 @@ struct list_offsets_ctx {
 static ss::future<list_offset_partition_response> list_offsets_partition(
   list_offsets_ctx& octx,
   model::timestamp timestamp,
+  model::ntp ntp,
+  model::isolation_level isolation_lvl,
+  cluster::partition_manager& mgr) {
+    auto kafka_partition = make_partition_proxy(
+      ntp, octx.rctx.metadata_cache(), mgr);
+    if (!kafka_partition) {
+        co_return list_offsets_response::make_partition(
+          ntp.tp.partition, error_code::unknown_topic_or_partition);
+    }
+
+    if (!kafka_partition->is_leader()) {
+        co_return list_offsets_response::make_partition(
+          ntp.tp.partition, error_code::not_leader_for_partition);
+    }
+
+    /*
+     * the responses for earliest/latest timestamp queries do not require
+     * that the actual timestamp be returned. only the offset is required.
+     */
+    if (timestamp == list_offsets_request::earliest_timestamp) {
+        co_return list_offsets_response::make_partition(
+          ntp.tp.partition,
+          model::timestamp(-1),
+          kafka_partition->start_offset());
+
+    } else if (timestamp == list_offsets_request::latest_timestamp) {
+        const auto offset = isolation_lvl
+                                == model::isolation_level::read_committed
+                              ? kafka_partition->last_stable_offset()
+                              : kafka_partition->high_watermark();
+
+        co_return list_offsets_response::make_partition(
+          ntp.tp.partition, model::timestamp(-1), offset);
+    }
+
+    auto res = co_await kafka_partition->timequery(
+      timestamp, kafka_read_priority());
+    auto id = ntp.tp.partition;
+    if (res) {
+        co_return list_offsets_response::make_partition(
+          id, res->time, res->offset);
+    }
+    co_return list_offsets_response::make_partition(
+      id, model::timestamp(-1), kafka_partition->last_stable_offset());
+}
+
+static ss::future<list_offset_partition_response> list_offsets_partition(
+  list_offsets_ctx& octx,
+  model::timestamp timestamp,
   list_offset_topic& topic,
   list_offset_partition& part) {
     model::ntp ntp(model::kafka_namespace, topic.name, part.partition_index);
@@ -80,57 +129,10 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
        &octx,
        ntp = std::move(ntp),
        isolation_lvl = model::isolation_level(
-         octx.request.data.isolation_level)](cluster::partition_manager& mgr) {
-          auto kafka_partition = make_partition_proxy(
-            ntp, octx.rctx.metadata_cache(), mgr);
-          if (!kafka_partition) {
-              return ss::make_ready_future<list_offset_partition_response>(
-                list_offsets_response::make_partition(
-                  ntp.tp.partition, error_code::unknown_topic_or_partition));
-          }
-
-          if (!kafka_partition->is_leader()) {
-              return ss::make_ready_future<list_offset_partition_response>(
-                list_offsets_response::make_partition(
-                  ntp.tp.partition, error_code::not_leader_for_partition));
-          }
-
-          /*
-           * the responses for earliest/latest timestamp queries do not require
-           * that the actual timestamp be returned. only the offset is required.
-           */
-          if (timestamp == list_offsets_request::earliest_timestamp) {
-              return ss::make_ready_future<list_offset_partition_response>(
-                list_offsets_response::make_partition(
-                  ntp.tp.partition,
-                  model::timestamp(-1),
-                  kafka_partition->start_offset()));
-
-          } else if (timestamp == list_offsets_request::latest_timestamp) {
-              const auto offset = isolation_lvl
-                                      == model::isolation_level::read_committed
-                                    ? kafka_partition->last_stable_offset()
-                                    : kafka_partition->high_watermark();
-
-              return ss::make_ready_future<list_offset_partition_response>(
-                list_offsets_response::make_partition(
-                  ntp.tp.partition, model::timestamp(-1), offset));
-          }
-
-          return kafka_partition->timequery(timestamp, kafka_read_priority())
-            .then([partition = std::move(kafka_partition),
-                   id = ntp.tp.partition](
-                    std::optional<storage::timequery_result> res) {
-                if (res) {
-                    return ss::make_ready_future<
-                      list_offset_partition_response>(
-                      list_offsets_response::make_partition(
-                        id, res->time, res->offset));
-                }
-                return ss::make_ready_future<list_offset_partition_response>(
-                  list_offsets_response::make_partition(
-                    id, model::timestamp(-1), partition->last_stable_offset()));
-            });
+         octx.request.data.isolation_level)](
+        cluster::partition_manager& mgr) mutable {
+          return list_offsets_partition(
+            octx, timestamp, std::move(ntp), isolation_lvl, mgr);
       });
 }
 

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -38,6 +38,16 @@ public:
 
     bool is_leader() const final { return _partition->is_leader(); }
 
+    ss::future<result<model::offset>> linearizable_barrier() {
+        return _partition->linearizable_barrier().then(
+          [this](result<model::offset> r) {
+              if (r) {
+                  return result<model::offset>(last_stable_offset());
+              }
+              return r;
+          });
+    }
+
     ss::future<model::record_batch_reader> make_reader(
       storage::log_reader_config cfg,
       std::optional<model::timeout_clock::time_point>) final {

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -31,6 +31,7 @@ public:
         virtual model::offset high_watermark() const = 0;
         virtual model::offset last_stable_offset() const = 0;
         virtual bool is_leader() const = 0;
+        virtual ss::future<result<model::offset>> linearizable_barrier() = 0;
         virtual ss::future<model::record_batch_reader> make_reader(
           storage::log_reader_config,
           std::optional<model::timeout_clock::time_point>)
@@ -52,6 +53,10 @@ public:
 
     model::offset last_stable_offset() const {
         return _impl->last_stable_offset();
+    }
+
+    ss::future<result<model::offset>> linearizable_barrier() {
+        return _impl->linearizable_barrier();
     }
 
     bool is_leader() const { return _impl->is_leader(); }

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -44,6 +44,15 @@ public:
 
     bool is_leader() const final { return _partition->is_leader(); }
 
+    ss::future<result<model::offset>> linearizable_barrier() {
+        auto r = co_await _partition->linearizable_barrier();
+        if (r) {
+            co_return result<model::offset>(
+              _translator->from_log_offset(r.value()));
+        }
+        co_return r;
+    }
+
     ss::future<std::optional<storage::timequery_result>>
     timequery(model::timestamp ts, ss::io_priority_class io_pc) final;
 


### PR DESCRIPTION
When we call `consensus::is_leader` the call uses cached state so there is a possibility of returning stale data: the node still thinks it's a leader while in fact it was isolated and the rest of the cluster elected a new leader.

Switching `is_leader` with `linearizable_barrier` to make sure that the current node is/was a leader when it started executing the `list_offset` request.