### PR TITLE
gh: tweak pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,25 @@ Describe in plain language the motivation (bug, feature, etc.) behind the change
 Fixes: #NNN, #NNN, ...
 
 ## Release notes
+<!--
 
-If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.
+If this PR does not need to be included in the release notes, then
+simply have a bullet point for `none` directly under the `Release notes`
+section, e.g.
 
-Release note: [1-2 sentences of what this PR changes]
+* none
+
+Otherwise, add one or more of the following sections. A section must have
+at least 1 bullet point. You can add multiple sections with multiple
+bullet points if this PR represents multiple release note items. See
+the CONTRIBUTING.md guidelines for more details.
+
+### Features
+
+* Short description of the feature. Explain how to configure the new feature if applicable.
+
+### Improvements
+
+* Short description of how this PR improves redpanda.
+
+-->


### PR DESCRIPTION
@andrewhsu EDIT: I had a discussion with @ivotron about updating the PR template to allow for easier parsing of release notes. I'll be carrying this PR since he's going on vacation next week.

I've adjusted the PR template to give instructions on what format it expects for the release notes section. The instructions are in HTML comments to keep the markdown render clean by default. Similar to https://github.com/cli/cli/blob/trunk/.github/PULL_REQUEST_TEMPLATE.md

The 3 sections in the instructions were chosen to mimic the structure of [v21.8.1 release notes](https://github.com/vectorizedio/redpanda/releases/tag/v21.8.1).