### PR TITLE
Implement upload throttling in archival

### DIFF
--- a/src/v/archival/CMakeLists.txt
+++ b/src/v/archival/CMakeLists.txt
@@ -7,6 +7,7 @@ v_cc_library(
     ntp_archiver_service.cc
     probe.cc
     types.cc
+    upload_controller.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/archival/CMakeLists.txt
+++ b/src/v/archival/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     service.cc
     ntp_archiver_service.cc
     probe.cc
+    types.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/archival/fwd.h
+++ b/src/v/archival/fwd.h
@@ -14,5 +14,6 @@
 namespace archival {
 
 class scheduler_service;
+class upload_controller;
 
 } // namespace archival

--- a/src/v/archival/logger.h
+++ b/src/v/archival/logger.h
@@ -16,4 +16,5 @@
 
 namespace archival {
 inline ss::logger archival_log("archival");
+inline ss::logger upload_ctrl_log("archival-ctrl");
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -24,6 +24,7 @@
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/io_priority_class.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -34,29 +35,6 @@
 namespace archival {
 
 using namespace std::chrono_literals;
-
-/// Archiver service configuration
-struct configuration {
-    /// Bucket used to store all archived data
-    s3::bucket_name bucket_name;
-    /// Time interval to run uploads & deletes
-    ss::lowres_clock::duration interval;
-    /// Initial backoff for uploads
-    ss::lowres_clock::duration initial_backoff;
-    /// Long upload timeout
-    ss::lowres_clock::duration segment_upload_timeout;
-    /// Shor upload timeout
-    ss::lowres_clock::duration manifest_upload_timeout;
-    /// Flag that indicates that service level metrics are disabled
-    service_metrics_disabled svc_metrics_disabled;
-    /// Flag that indicates that ntp-archiver level metrics are disabled
-    per_ntp_metrics_disabled ntp_metrics_disabled;
-    /// Upload time limit (if segment is not uploaded this amount of time the
-    /// upload is triggered)
-    std::optional<segment_time_limit> time_limit;
-};
-
-std::ostream& operator<<(std::ostream& o, const configuration& cfg);
 
 /// This class performs per-ntp arhcival workload. Every ntp can be
 /// processed independently, without the knowledge about others. All
@@ -199,6 +177,7 @@ private:
     ss::lowres_clock::duration _initial_backoff;
     ss::lowres_clock::duration _segment_upload_timeout;
     ss::lowres_clock::duration _manifest_upload_timeout;
+    ss::io_priority_class _io_priority;
 };
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -16,6 +16,7 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/types.h"
 #include "cluster/partition.h"
+#include "cluster/partition_manager.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "s3/client.h"
@@ -108,6 +109,8 @@ public:
       storage::log_manager& lm,
       retry_chain_node& parent,
       std::optional<model::offset> last_stable_offset_override = std::nullopt);
+
+    uint64_t estimate_backlog_size(cluster::partition_manager& pm);
 
 private:
     /// Information about started upload

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -33,13 +33,16 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/io_priority_class.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/when_all.hh>
+#include <seastar/core/with_scheduling_group.hh>
 
 #include <boost/iterator/counting_iterator.hpp>
 
@@ -111,7 +114,8 @@ static ss::sstring get_value_or_throw(
 
 /// Use shard-local configuration to generate configuration
 ss::future<archival::configuration>
-scheduler_service_impl::get_archival_service_config() {
+scheduler_service_impl::get_archival_service_config(
+  ss::scheduling_group sg, ss::io_priority_class p) {
     vlog(archival_log.debug, "Generating archival configuration");
     auto disable_metrics = rpc::metrics_disabled(
       config::shard_local_cfg().disable_metrics());
@@ -147,7 +151,9 @@ scheduler_service_impl::get_archival_service_config() {
         static_cast<bool>(disable_metrics)),
       .ntp_metrics_disabled = per_ntp_metrics_disabled(
         static_cast<bool>(disable_metrics)),
-      .time_limit = time_limit_opt};
+      .time_limit = time_limit_opt,
+      .upload_scheduling_group = sg,
+      .upload_io_priority = p};
     vlog(archival_log.debug, "Archival configuration generated: {}", cfg);
     co_return cfg;
 }
@@ -169,7 +175,8 @@ scheduler_service_impl::scheduler_service_impl(
   , _probe(conf.svc_metrics_disabled)
   , _remote(remote)
   , _topic_manifest_upload_timeout(conf.manifest_upload_timeout)
-  , _initial_backoff(conf.initial_backoff) {}
+  , _initial_backoff(conf.initial_backoff)
+  , _upload_sg(conf.upload_scheduling_group) {}
 
 scheduler_service_impl::scheduler_service_impl(
   ss::sharded<cloud_storage::remote>& remote,
@@ -181,22 +188,25 @@ scheduler_service_impl::scheduler_service_impl(
 
 void scheduler_service_impl::rearm_timer() {
     (void)ss::with_gate(_gate, [this] {
-        return reconcile_archivers()
-          .finally([this] {
-              if (_gate.is_closed()) {
-                  return;
-              }
-              _timer.rearm(_jitter());
-          })
-          .handle_exception([this](std::exception_ptr e) {
-              vlog(_rtclog.info, "Error in timer callback: {}", e);
-          });
+        return ss::with_scheduling_group(_upload_sg, [this] {
+            return reconcile_archivers()
+              .finally([this] {
+                  if (_gate.is_closed()) {
+                      return;
+                  }
+                  _timer.rearm(_jitter());
+              })
+              .handle_exception([this](std::exception_ptr e) {
+                  vlog(_rtclog.info, "Error in timer callback: {}", e);
+              });
+        });
     });
 }
 ss::future<> scheduler_service_impl::start() {
     _timer.set_callback([this] { rearm_timer(); });
     _timer.rearm(_jitter());
-    (void)run_uploads();
+    (void)ss::with_scheduling_group(
+      _upload_sg, [this] { return run_uploads(); });
     return ss::now();
 }
 

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -50,6 +50,7 @@
 #include <exception>
 #include <optional>
 #include <stdexcept>
+#include <tuple>
 
 using namespace std::chrono_literals;
 
@@ -423,6 +424,16 @@ cloud_storage::remote& scheduler_service_impl::get_remote() {
 
 s3::bucket_name scheduler_service_impl::get_bucket() const {
     return _conf.bucket_name;
+}
+
+uint64_t scheduler_service_impl::estimate_backlog_size() {
+    uint64_t size = 0;
+    for (const auto& [ntp, item] : _queue) {
+        std::ignore = ntp;
+        size += item.archiver->estimate_backlog_size(
+          _partition_manager.local());
+    }
+    return size;
 }
 
 ss::future<> scheduler_service_impl::run_uploads() {

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -23,7 +23,9 @@
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/io_priority_class.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/weak_ptr.hh>
 
 #include <absl/container/node_hash_map.h>
@@ -123,7 +125,11 @@ public:
     /// \brief create scheduler service config
     /// This mehtod will use shard-local redpanda configuration
     /// to generate the configuration.
-    static ss::future<archival::configuration> get_archival_service_config();
+    /// \param sg is a scheduling group used to run all uploads
+    /// \param p is an io priority class used to throttle upload file reads
+    static ss::future<archival::configuration> get_archival_service_config(
+      ss::scheduling_group sg = ss::default_scheduling_group(),
+      ss::io_priority_class p = ss::default_priority_class());
 
     /// Start archiver
     ss::future<> start();
@@ -183,6 +189,7 @@ private:
     ss::sharded<cloud_storage::remote>& _remote;
     ss::lowres_clock::duration _topic_manifest_upload_timeout;
     ss::lowres_clock::duration _initial_backoff;
+    ss::scheduling_group _upload_sg;
 };
 
 } // namespace internal

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -162,6 +162,9 @@ public:
     /// Get configured bucket
     s3::bucket_name get_bucket() const;
 
+    /// Total size of data that have to be uploaded
+    uint64_t estimate_backlog_size();
+
 private:
     /// Remove archivers from the workingset
     ss::future<> remove_archivers(std::vector<model::ntp> to_remove);
@@ -225,6 +228,9 @@ public:
 
     /// Get configured bucket
     using internal::scheduler_service_impl::get_bucket;
+
+    /// Estimate total size of the upload backlog
+    using internal::scheduler_service_impl::estimate_backlog_size;
 };
 
 } // namespace archival

--- a/src/v/archival/types.cc
+++ b/src/v/archival/types.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/types.h"
+
+#include <fmt/format.h>
+
+namespace archival {
+
+std::ostream&
+operator<<(std::ostream& o, const std::optional<segment_time_limit>& tl) {
+    if (tl) {
+        fmt::print(o, "{}", tl.value()().count());
+    } else {
+        fmt::print(o, "N/A");
+    }
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
+    fmt::print(
+      o,
+      "{{bucket_name: {}, interval: {}, initial_backoff: {}, "
+      "segment_upload_timeout: {}, "
+      "manifest_upload_timeout: {}, time_limit: {}}}",
+      cfg.bucket_name,
+      cfg.interval.count(),
+      cfg.initial_backoff.count(),
+      cfg.segment_upload_timeout.count(),
+      cfg.manifest_upload_timeout.count(),
+      cfg.time_limit);
+    return o;
+}
+
+} // namespace archival

--- a/src/v/archival/upload_controller.cc
+++ b/src/v/archival/upload_controller.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/upload_controller.h"
+
+#include "archival/logger.h"
+
+#include <fmt/format.h>
+
+namespace archival {
+
+struct upload_backlog_sampler : public storage::backlog_controller::sampler {
+    explicit upload_backlog_sampler(ss::sharded<scheduler_service>& api)
+      : _service(api) {}
+
+    ss::future<int64_t> sample_backlog() final {
+        co_return _service.local().estimate_backlog_size();
+    }
+
+private:
+    ss::sharded<scheduler_service>& _service;
+};
+
+upload_controller::upload_controller(
+  ss::sharded<scheduler_service>& api, storage::backlog_controller_config cfg)
+  : _ctrl(std::make_unique<upload_backlog_sampler>(api), upload_ctrl_log, cfg) {
+    _ctrl.setup_metrics("archival:upload");
+}
+
+} // namespace archival

--- a/src/v/archival/upload_controller.h
+++ b/src/v/archival/upload_controller.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "archival/service.h"
+#include "seastarx.h"
+#include "storage/backlog_controller.h"
+#include "utils/named_type.h"
+#include "utils/prefix_logger.h"
+
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/sharded.hh>
+
+#include <filesystem>
+
+namespace archival {
+
+/// PID controller to controll compaction scheduling and IO shares
+/// Modeled after compaction_controller.
+class upload_controller {
+public:
+    upload_controller(
+      ss::sharded<scheduler_service>&, storage::backlog_controller_config);
+
+    ss::future<> start() { return _ctrl.start(); }
+    ss::future<> stop() { return _ctrl.stop(); }
+
+private:
+    storage::backlog_controller _ctrl;
+};
+
+} // namespace archival

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -752,6 +752,36 @@ configuration::configuration()
       "remote storage (sec)",
       required::no,
       std::nullopt)
+  , cloud_storage_upload_ctrl_update_interval_ms(
+      *this,
+      "cloud_storage_upload_ctrl_update_interval_ms",
+      "",
+      required::no,
+      60s)
+  , cloud_storage_upload_ctrl_p_coeff(
+      *this,
+      "cloud_storage_upload_ctrl_p_coeff",
+      "proportional coefficient for upload PID controller",
+      required::no,
+      -2.0)
+  , cloud_storage_upload_ctrl_d_coeff(
+      *this,
+      "cloud_storage_upload_ctrl_d_coeff",
+      "derivative coefficient for upload PID controller.",
+      required::no,
+      0.0)
+  , cloud_storage_upload_ctrl_min_shares(
+      *this,
+      "compaction_ctrl_min_shares",
+      "minimum number of IO and CPU shares that archival upload can use",
+      required::no,
+      100)
+  , cloud_storage_upload_ctrl_max_shares(
+      *this,
+      "cloud_storage_upload_ctrl_max_shares",
+      "maximum number of IO and CPU shares that archival upload can use",
+      required::no,
+      1000)
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -179,6 +179,14 @@ struct configuration final : public config_store {
     property<std::optional<std::chrono::seconds>>
       cloud_storage_segment_max_upload_interval_sec;
 
+    // Archival upload controller
+    property<std::chrono::milliseconds>
+      cloud_storage_upload_ctrl_update_interval_ms;
+    property<double> cloud_storage_upload_ctrl_p_coeff;
+    property<double> cloud_storage_upload_ctrl_d_coeff;
+    property<int16_t> cloud_storage_upload_ctrl_min_shares;
+    property<int16_t> cloud_storage_upload_ctrl_max_shares;
+
     // Archival cache
     property<size_t> cloud_storage_cache_size;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -665,8 +665,10 @@ void application::wire_up_redpanda_services() {
         ss::sharded<archival::configuration> arch_configs;
         arch_configs.start().get();
         arch_configs
-          .invoke_on_all([](archival::configuration& c) {
-              return archival::scheduler_service::get_archival_service_config()
+          .invoke_on_all([this](archival::configuration& c) {
+              return archival::scheduler_service::get_archival_service_config(
+                       _scheduling_groups.archival_upload(),
+                       archival_priority())
                 .then(
                   [&c](archival::configuration cfg) { c = std::move(cfg); });
           })

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -11,6 +11,7 @@
 
 #include "archival/ntp_archiver_service.h"
 #include "archival/service.h"
+#include "archival/upload_controller.h"
 #include "cluster/cluster_utils.h"
 #include "cluster/controller.h"
 #include "cluster/fwd.h"
@@ -50,6 +51,7 @@
 #include "resource_mgmt/io_priority.h"
 #include "rpc/server.h"
 #include "rpc/simple_protocol.h"
+#include "storage/backlog_controller.h"
 #include "storage/chunk_cache.h"
 #include "storage/compaction_controller.h"
 #include "storage/directories.h"
@@ -63,6 +65,7 @@
 
 #include <seastar/core/metrics.hh>
 #include <seastar/core/prometheus.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/json/json_elements.hh>
@@ -493,6 +496,39 @@ static storage::backlog_controller_config compaction_controller_config(
       config::shard_local_cfg().compaction_ctrl_max_shares());
 }
 
+static storage::backlog_controller_config
+make_upload_controller_config(ss::scheduling_group sg) {
+    // This settings are similar to compaction_controller_config.
+    // The desired setpoint for archival is set to 0 since the goal is to upload
+    // all data that we have.
+    // If the size of the backlog (the data which should be uploaded to S3) is
+    // larger than this value we need to bump the scheduling priority.
+    // Otherwise, we're good with the minimal.
+    // Since the setpoint is 0 we can't really use integral component of the
+    // controller. This is because upload backlog size never gets negative so
+    // once integral part will rump up high enough it won't be able to go down
+    // even if everything is uploaded.
+
+    auto available
+      = ss::fs_avail(config::node().data_directory().path.string()).get();
+    int64_t setpoint = 0;
+    int64_t normalization = static_cast<int64_t>(available)
+                            / (1000 * ss::smp::count);
+    return {
+      config::shard_local_cfg().cloud_storage_upload_ctrl_p_coeff(),
+      0,
+      config::shard_local_cfg().cloud_storage_upload_ctrl_d_coeff(),
+      normalization,
+      setpoint,
+      static_cast<int>(
+        priority_manager::local().archival_priority().get_shares()),
+      config::shard_local_cfg().cloud_storage_upload_ctrl_update_interval_ms(),
+      sg,
+      priority_manager::local().archival_priority(),
+      config::shard_local_cfg().cloud_storage_upload_ctrl_min_shares(),
+      config::shard_local_cfg().cloud_storage_upload_ctrl_max_shares()};
+}
+
 // add additional services in here
 void application::wire_up_services() {
     if (_redpanda_enabled) {
@@ -682,6 +718,12 @@ void application::wire_up_redpanda_services() {
           std::ref(arch_configs))
           .get();
         arch_configs.stop().get();
+
+        construct_service(
+          _archival_upload_controller,
+          std::ref(archival_scheduler),
+          make_upload_controller_config(_scheduling_groups.archival_upload()))
+          .get();
     }
     // group membership
     syschecks::systemd_message("Creating partition manager").get();
@@ -1095,5 +1137,8 @@ void application::start_redpanda() {
     }
 
     _compaction_controller.invoke_on_all(&storage::compaction_controller::start)
+      .get();
+    _archival_upload_controller
+      .invoke_on_all(&archival::upload_controller::start)
       .get();
 }

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -142,6 +142,7 @@ private:
     ss::sharded<pandaproxy::rest::proxy> _proxy;
     std::unique_ptr<pandaproxy::schema_registry::api> _schema_registry;
     ss::sharded<storage::compaction_controller> _compaction_controller;
+    ss::sharded<archival::upload_controller> _archival_upload_controller;
 
     ss::metrics::metric_groups _metrics;
     std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -34,6 +34,8 @@ public:
           "log_compaction", 100);
         _raft_learner_recovery = co_await ss::create_scheduling_group(
           "raft_learner_recovery", 50);
+        _archival_upload = co_await ss::create_scheduling_group(
+          "archival_upload", 100);
     }
 
     ss::future<> destroy_groups() {
@@ -45,6 +47,7 @@ public:
         co_await destroy_scheduling_group(_cache_background_reclaim);
         co_await destroy_scheduling_group(_compaction);
         co_await destroy_scheduling_group(_raft_learner_recovery);
+        co_await destroy_scheduling_group(_archival_upload);
         co_return;
     }
 
@@ -60,6 +63,7 @@ public:
     ss::scheduling_group raft_learner_recovery_sg() {
         return _raft_learner_recovery;
     }
+    ss::scheduling_group archival_upload() { return _archival_upload; }
 
 private:
     ss::scheduling_group _admin;
@@ -70,4 +74,5 @@ private:
     ss::scheduling_group _cache_background_reclaim;
     ss::scheduling_group _compaction;
     ss::scheduling_group _raft_learner_recovery;
+    ss::scheduling_group _archival_upload;
 };

--- a/src/v/resource_mgmt/io_priority.h
+++ b/src/v/resource_mgmt/io_priority.h
@@ -30,6 +30,7 @@ public:
     ss::io_priority_class shadow_indexing_priority() {
         return _shadow_indexing_priority;
     }
+    ss::io_priority_class archival_priority() { return _archival_priority; }
 
     static priority_manager& local() {
         static thread_local priority_manager pm = priority_manager();
@@ -48,7 +49,9 @@ private:
       , _raft_learner_recovery_priority(
           ss::io_priority_class::register_one("raft-learner-recovery", 100))
       , _shadow_indexing_priority(
-          ss::io_priority_class::register_one("shadow-indexing", 1000)) {}
+          ss::io_priority_class::register_one("shadow-indexing", 1000))
+      , _archival_priority(
+          ss::io_priority_class::register_one("archival", 200)) {}
 
     ss::io_priority_class _raft_priority;
     ss::io_priority_class _controller_priority;
@@ -56,6 +59,7 @@ private:
     ss::io_priority_class _compaction_priority;
     ss::io_priority_class _raft_learner_recovery_priority;
     ss::io_priority_class _shadow_indexing_priority;
+    ss::io_priority_class _archival_priority;
 };
 
 inline ss::io_priority_class raft_priority() {
@@ -76,4 +80,12 @@ inline ss::io_priority_class compaction_priority() {
 
 inline ss::io_priority_class raft_learner_recovery_priority() {
     return priority_manager::local().raft_learner_recovery_priority();
+}
+
+inline ss::io_priority_class shadow_indexing_priority() {
+    return priority_manager::local().shadow_indexing_priority();
+}
+
+inline ss::io_priority_class archival_priority() {
+    return priority_manager::local().archival_priority();
 }


### PR DESCRIPTION
## Cover letter

This PR is supposed to solve the resource utilisation problem in a situation when
the archival subsystem is enable when Redpanda already has a lot of data. In this
situation the size of the upload backlog is large and Redpanda will constantly upload
everything using default priority. This can result in performance degradation.

To solve this problem we introduce throttling into the archival subsystem. Normally,
the archival uploads will run with lower priority than everything else. But when we have
large upload backlog the priority have to be increased. Otherwise we may run out of
disk space. This can happen because when archival is enabled the eviction can be
performed only on data that is already uploaded.

In order to implement all this a dedicated `io_priority_class` and `scheduling_group`
are added.
The initial value for both is 200 units (same as compaction). The group is used in
both `archival::ntp_archiver` and `archival::scheduler_service` to run uploads and
downloads of manifests.

Add `upload_controller` that uses `backlog_controller` from the `storage`. Add
method `estimate_backlog_size` to both 'ntp_archiver` and `scheduler_service`.
The sampler for the `upload_controller` uses this method to calculate current value.

The `upload_controller` is initialised in application using new config parameters:

- `cloud_storage_upload_ctrl_d_coeff`
- `cloud_storage_upload_ctrl_p_coeff`
- ` cloud_storage_upload_ctrl_update_interval_ms`
- `cloud_storage_upload_ctrl_min_shares`
- `cloud_storage_upload_ctrl_max_shares`

all with reasonable defaults. The set point for the controller is set to zero, since the
goal is to simply upload everything asap (but without causing problems for other
subsystems).

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/32a864b3fff101d67222db3cbab10ed0d5d0de8b..9272a6979b33eb02f89a631cac6c1b5d3504320f)
- Code review fixes

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/9272a6979b33eb02f89a631cac6c1b5d3504320f..3bbfab2f62538da559a222ebd482ff027b48b2a8)
- Code review fixes
- Remove `cloud_storage_upload_ctrl_i_coeff` parameter and make integral component equal 0 all the time because it doesn't make sense to use it in this case


## Release notes

N/A