### PR TITLE
Enable fetches from cloud data

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "cloud_storage/manifest.h"
+#include "cloud_storage/remote_partition.h"
 #include "cluster/archival_metadata_stm.h"
 #include "cluster/id_allocator_stm.h"
 #include "cluster/partition_probe.h"
@@ -39,7 +41,8 @@ public:
     partition(
       consensus_ptr r,
       ss::sharded<cluster::tx_gateway_frontend>&,
-      ss::sharded<cloud_storage::remote>&);
+      ss::sharded<cloud_storage::remote>&,
+      ss::sharded<cloud_storage::cache>&);
 
     raft::group_id group() const { return _raft->group(); }
     ss::future<> start();
@@ -63,6 +66,7 @@ public:
       model::batch_identity,
       model::record_batch_reader&&,
       raft::replicate_options);
+
     /**
      * The reader is modified such that the max offset is configured to be
      * the minimum of the max offset requested and the committed index of the
@@ -200,6 +204,33 @@ public:
         return _archival_meta_stm;
     }
 
+    /// Check if cloud storage is connected to cluster partition
+    ///
+    /// The remaining 'cloud' methods can only be called if this
+    /// method returned 'true'.
+    bool cloud_data_available() const {
+        return static_cast<bool>(_cloud_storage_partition)
+               && _cloud_storage_partition->is_data_available();
+    }
+
+    /// Starting offset in the object store
+    model::offset start_cloud_offset() const {
+        vassert(
+          cloud_data_available(),
+          "Method can only be called if cloud data is available");
+        return _cloud_storage_partition->first_uploaded_offset();
+    }
+
+    /// Create a reader that will fetch data from remote storage
+    ss::future<model::record_batch_reader> make_cloud_reader(
+      storage::log_reader_config config,
+      std::optional<model::timeout_clock::time_point> deadline = std::nullopt) {
+        vassert(
+          cloud_data_available(),
+          "Method can only be called if cloud data is available");
+        return _cloud_storage_partition->make_reader(config, deadline);
+    }
+
 private:
     friend partition_manager;
     friend replicated_partition_probe;
@@ -218,6 +249,7 @@ private:
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
     bool _is_tx_enabled{false};
     bool _is_idempotence_enabled{false};
+    ss::lw_shared_ptr<cloud_storage::remote_partition> _cloud_storage_partition;
 
     friend std::ostream& operator<<(std::ostream& o, const partition& x);
 };

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -35,12 +35,14 @@ partition_manager::partition_manager(
   ss::sharded<raft::group_manager>& raft,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
   ss::sharded<cloud_storage::partition_recovery_manager>& recovery_mgr,
-  ss::sharded<cloud_storage::remote>& cloud_storage_api)
+  ss::sharded<cloud_storage::remote>& cloud_storage_api,
+  ss::sharded<cloud_storage::cache>& cloud_storage_cache)
   : _storage(storage.local())
   , _raft_manager(raft)
   , _tx_gateway_frontend(tx_gateway_frontend)
   , _partition_recovery_mgr(recovery_mgr)
-  , _cloud_storage_api(cloud_storage_api) {}
+  , _cloud_storage_api(cloud_storage_api)
+  , _cloud_storage_cache(cloud_storage_cache) {}
 
 partition_manager::ntp_table_container
 partition_manager::get_topic_partition_table(
@@ -82,7 +84,7 @@ ss::future<consensus_ptr> partition_manager::manage(
         group, std::move(initial_nodes), log);
 
     auto p = ss::make_lw_shared<partition>(
-      c, _tx_gateway_frontend, _cloud_storage_api);
+      c, _tx_gateway_frontend, _cloud_storage_api, _cloud_storage_cache);
 
     _ntp_table.emplace(log.config().ntp(), p);
     _raft_table.emplace(group, p);

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cloud_storage/cache_service.h"
 #include "cloud_storage/partition_recovery_manager.h"
 #include "cloud_storage/remote.h"
 #include "cluster/ntp_callbacks.h"
@@ -35,7 +36,8 @@ public:
       ss::sharded<raft::group_manager>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
       ss::sharded<cloud_storage::partition_recovery_manager>&,
-      ss::sharded<cloud_storage::remote>&);
+      ss::sharded<cloud_storage::remote>&,
+      ss::sharded<cloud_storage::cache>&);
 
     using manage_cb_t
       = ss::noncopyable_function<void(ss::lw_shared_ptr<partition>)>;
@@ -164,6 +166,7 @@ private:
     ss::sharded<cloud_storage::partition_recovery_manager>&
       _partition_recovery_mgr;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
+    ss::sharded<cloud_storage::cache>& _cloud_storage_cache;
     ss::gate _gate;
 
     friend std::ostream& operator<<(std::ostream&, const partition_manager&);

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -96,7 +96,7 @@ node_config::node_config() noexcept
       "Directory for archival cache. Should be present when "
       "`cloud_storage_enabled` is present",
       required::no,
-      (data_directory.value().path / "archival_cache").native())
+      std::nullopt)
   , enable_central_config(
       *this,
       "enable_central_config",

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -32,6 +32,16 @@ replicated_partition::replicated_partition(
 ss::future<model::record_batch_reader> replicated_partition::make_reader(
   storage::log_reader_config cfg,
   std::optional<model::timeout_clock::time_point> deadline) {
+    auto local_kafka_start_offset = _translator->from_log_offset(
+      _partition->start_offset());
+    if (
+      _partition->cloud_data_available()
+      && cfg.start_offset < local_kafka_start_offset
+      && cfg.start_offset >= _partition->start_cloud_offset()) {
+        cfg.type_filter = {model::record_batch_type::raft_data};
+        co_return co_await _partition->make_cloud_reader(cfg, deadline);
+    }
+
     cfg.start_offset = _translator->to_log_offset(cfg.start_offset);
     cfg.max_offset = _translator->to_log_offset(cfg.max_offset);
     cfg.type_filter = {model::record_batch_type::raft_data};

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -644,7 +644,8 @@ void application::wire_up_redpanda_services() {
       std::ref(raft_group_manager),
       std::ref(tx_gateway_frontend),
       std::ref(partition_recovery_manager),
-      std::ref(cloud_storage_api))
+      std::ref(cloud_storage_api),
+      std::ref(shadow_index_cache))
       .get();
     vlog(_log.info, "Partition manager started");
 

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "archival/fwd.h"
+#include "cloud_storage/cache_service.h"
 #include "cloud_storage/partition_recovery_manager.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
@@ -93,6 +94,7 @@ public:
     ss::sharded<cluster::rm_partition_frontend> rm_partition_frontend;
     ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
     ss::sharded<v8_engine::data_policy_table> data_policies;
+    ss::sharded<cloud_storage::cache> shadow_index_cache;
 
 private:
     using deferred_actions

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -270,7 +270,7 @@ class ArchivalTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def test_single_partition_leadership_transfer(self):
-        """Start uploading data, restart leader node of the partition 0 to trigger the 
+        """Start uploading data, restart leader node of the partition 0 to trigger the
         leadership transfer, continue upload, verify S3 bucket content"""
         self.kafka_tools.produce(self.topic, 5000, 1024)
         time.sleep(5)
@@ -285,7 +285,7 @@ class ArchivalTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def test_all_partitions_leadership_transfer(self):
-        """Start uploading data, restart leader nodes of all partitions to trigger the 
+        """Start uploading data, restart leader nodes of all partitions to trigger the
         leadership transfer, continue upload, verify S3 bucket content"""
         self.kafka_tools.produce(self.topic, 5000, 1024)
         time.sleep(5)
@@ -453,9 +453,9 @@ class ArchivalTest(RedpandaTest):
     def _cross_node_verify(self):
         """Verify data on all nodes taking into account possible alignment issues
         caused by leadership transitions.
-        The verification algorithm is following: 
+        The verification algorithm is following:
         - Download and verify partition manifest;
-        - Partition manifest has all segments and metadata like committed offset 
+        - Partition manifest has all segments and metadata like committed offset
           and base offset. We can also retrieve MD5 hash of every segment;
         - Load segment metadata for every redpanda node.
         - Scan every node's metadata and match segments with manifest, on success
@@ -467,7 +467,7 @@ class ArchivalTest(RedpandaTest):
         - The base offset and md5 hashes are the same;
         - The committed offset of both segments are the same, md5 hashes are different,
           and base offset of the segment from manifest is larger than base offset of the
-          segment from redpanda node. In this case we should also compare the data 
+          segment from redpanda node. In this case we should also compare the data
           directly by scanning both segments.
         """
         nodes = {}

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1,0 +1,110 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import RedpandaService
+from rptest.util import Scale
+from rptest.archival.s3_client import S3Client
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.util import (
+    produce_until_segments,
+    wait_for_segments_removal,
+)
+
+import uuid
+
+
+class EndToEndShadowIndexingTest(EndToEndTest):
+    segment_size = 1048576  # 1 Mb
+    s3_host_name = "minio-s3"
+    s3_access_key = "panda-user"
+    s3_secret_key = "panda-secret"
+    s3_region = "panda-region"
+    s3_topic_name = "panda-topic"
+    topics = (
+        TopicSpec(
+            name=s3_topic_name,
+            partition_count=1,
+            replication_factor=3,
+        ),
+    )
+
+    def __init__(self, test_context):
+        super(EndToEndShadowIndexingTest, self).__init__(test_context=test_context)
+
+        self.s3_bucket_name = f"panda-bucket-{uuid.uuid1()}"
+        self.topic = EndToEndShadowIndexingTest.s3_topic_name
+        self._extra_rp_conf = dict(
+            cloud_storage_enabled=True,
+            cloud_storage_access_key=EndToEndShadowIndexingTest.s3_access_key,
+            cloud_storage_secret_key=EndToEndShadowIndexingTest.s3_secret_key,
+            cloud_storage_region=EndToEndShadowIndexingTest.s3_region,
+            cloud_storage_bucket=self.s3_bucket_name,
+            cloud_storage_disable_tls=True,
+            cloud_storage_api_endpoint=EndToEndShadowIndexingTest.s3_host_name,
+            cloud_storage_api_endpoint_port=9000,
+            cloud_storage_reconciliation_interval_ms=500,
+            cloud_storage_max_connections=5,
+            log_segment_size=EndToEndShadowIndexingTest.segment_size,  # 1MB
+        )
+
+        self.scale = Scale(test_context)
+        self.redpanda = RedpandaService(
+            context=test_context,
+            num_brokers=3,
+            client_type=KafkaCliTools,
+            extra_rp_conf=self._extra_rp_conf,
+            topics=EndToEndShadowIndexingTest.topics,
+        )
+
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.s3_client = S3Client(
+            region=EndToEndShadowIndexingTest.s3_region,
+            access_key=EndToEndShadowIndexingTest.s3_access_key,
+            secret_key=EndToEndShadowIndexingTest.s3_secret_key,
+            endpoint=f"http://{EndToEndShadowIndexingTest.s3_host_name}:9000",
+            logger=self.logger,
+        )
+
+    def setUp(self):
+        self.s3_client.empty_bucket(self.s3_bucket_name)
+        self.s3_client.create_bucket(self.s3_bucket_name)
+        self.redpanda.start()
+
+    def tearDown(self):
+        self.s3_client.empty_bucket(self.s3_bucket_name)
+
+    @cluster(num_nodes=5)
+    def test_write(self):
+        """Write at least 10 segments, set retention policy to leave only 5
+        segments, wait for segments removal, consume data and run validation,
+        that everything that is acked is consumed."""
+        self.start_producer()
+        produce_until_segments(
+            redpanda=self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+        )
+
+        self.kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 5
+                * EndToEndShadowIndexingTest.segment_size,
+            },
+        )
+        wait_for_segments_removal(
+            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=6
+        )
+
+        self.start_consumer()
+        self.run_validation()

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -29,16 +29,15 @@ class EndToEndShadowIndexingTest(EndToEndTest):
     s3_secret_key = "panda-secret"
     s3_region = "panda-region"
     s3_topic_name = "panda-topic"
-    topics = (
-        TopicSpec(
-            name=s3_topic_name,
-            partition_count=1,
-            replication_factor=3,
-        ),
-    )
+    topics = (TopicSpec(
+        name=s3_topic_name,
+        partition_count=1,
+        replication_factor=3,
+    ), )
 
     def __init__(self, test_context):
-        super(EndToEndShadowIndexingTest, self).__init__(test_context=test_context)
+        super(EndToEndShadowIndexingTest,
+              self).__init__(test_context=test_context)
 
         self.s3_bucket_name = f"panda-bucket-{uuid.uuid1()}"
         self.topic = EndToEndShadowIndexingTest.s3_topic_name
@@ -98,13 +97,14 @@ class EndToEndShadowIndexingTest(EndToEndTest):
         self.kafka_tools.alter_topic_config(
             self.topic,
             {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 5
-                * EndToEndShadowIndexingTest.segment_size,
+                TopicSpec.PROPERTY_RETENTION_BYTES:
+                5 * EndToEndShadowIndexingTest.segment_size,
             },
         )
-        wait_for_segments_removal(
-            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=6
-        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=6)
 
         self.start_consumer()
         self.run_validation()

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -18,6 +18,7 @@ from rptest.util import (
     wait_for_segments_removal,
 )
 
+
 class RetentionPolicyTest(RedpandaTest):
     topics = (TopicSpec(partition_count=1,
                         replication_factor=3,
@@ -40,9 +41,9 @@ class RetentionPolicyTest(RedpandaTest):
             acks=[1, -1])
     def test_changing_topic_retention(self, property, acks):
         """
-        Test changing topic retention duration for topics with data produced 
-        with ACKS=1 and ACKS=-1. This test produces data until 10 segments 
-        appear, then it changes retention topic property and waits for 
+        Test changing topic retention duration for topics with data produced
+        with ACKS=1 and ACKS=-1. This test produces data until 10 segments
+        appear, then it changes retention topic property and waits for
         segments to be removed
         """
         kafka_tools = KafkaCliTools(self.redpanda)
@@ -67,9 +68,9 @@ class RetentionPolicyTest(RedpandaTest):
     @cluster(num_nodes=3)
     def test_changing_topic_retention_with_restart(self):
         """
-        Test changing topic retention duration for topics with data produced 
-        with ACKS=1 and ACKS=-1. This test produces data until 10 segments 
-        appear, then it changes retention topic property and waits for some 
+        Test changing topic retention duration for topics with data produced
+        with ACKS=1 and ACKS=-1. This test produces data until 10 segments
+        appear, then it changes retention topic property and waits for some
         segmetnts to be removed
         """
         segment_size = 1048576
@@ -95,24 +96,27 @@ class RetentionPolicyTest(RedpandaTest):
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 15 * segment_size,
             })
-        wait_for_segments_removal(
-            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=16
-        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=16)
 
         # change retention bytes again to preserve 10 segments
         kafka_tools.alter_topic_config(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 10 * segment_size,
             })
-        wait_for_segments_removal(
-            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=11
-        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=11)
 
         # change retention bytes again to preserve 5 segments
         kafka_tools.alter_topic_config(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 4 * segment_size,
             })
-        wait_for_segments_removal(
-            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=5
-        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=5)

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -8,13 +8,15 @@
 # by the Apache License, Version 2.0
 
 from ducktape.mark.resource import cluster
-from ducktape.utils.util import wait_until
-from ducktape.mark import matrix, ignore
+from ducktape.mark import matrix
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-
+from rptest.util import (
+    produce_until_segments,
+    wait_for_segments_removal,
+)
 
 class RetentionPolicyTest(RedpandaTest):
     topics = (TopicSpec(partition_count=1,
@@ -43,59 +45,24 @@ class RetentionPolicyTest(RedpandaTest):
         appear, then it changes retention topic property and waits for 
         segments to be removed
         """
-        # operate on a partition. doesn't matter which one
-        partition = self.redpanda.partitions(self.topic)[0]
+        kafka_tools = KafkaCliTools(self.redpanda)
 
         # produce until segments have been compacted
-        self._produce_until_segments(self.topic, 0, 10, acks)
-        kafka_tools = KafkaCliTools(self.redpanda)
+        produce_until_segments(
+            self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+            acks=acks,
+        )
         # change retention time
         kafka_tools.alter_topic_config(self.topic, {
             property: 10000,
         })
-        self._wait_for_segments_removal(self.topic, 0, 5)
-
-    def _segments_count(self, topic, partition_idx):
-        storage = self.redpanda.storage()
-        topic_partitions = storage.partitions("kafka", topic)
-
-        return map(lambda p: len(p.segments),
-                   filter(lambda p: p.num == partition_idx, topic_partitions))
-
-    def _produce_until_segments(self, topic, partition_idx, count, acks):
-        """
-        Produce into the topic until given number of segments will appear 
-        """
-        kafka_tools = KafkaCliTools(self.redpanda)
-
-        def done():
-            kafka_tools.produce(topic, 10000, 1024, acks=acks)
-            topic_partitions = self._segments_count(topic, partition_idx)
-            partitions = []
-            for p in topic_partitions:
-                partitions.append(p >= count)
-            return all(partitions)
-
-        wait_until(done,
-                   timeout_sec=60,
-                   backoff_sec=2,
-                   err_msg="Segments were not created")
-
-    def _wait_for_segments_removal(self, topic, partition_idx, count):
-        """
-        Wait until only given number of segments will left in a partitions
-        """
-        def done():
-            topic_partitions = self._segments_count(topic, partition_idx)
-            partitions = []
-            for p in topic_partitions:
-                partitions.append(p <= count)
-            return all(partitions)
-
-        wait_until(done,
-                   timeout_sec=120,
-                   backoff_sec=5,
-                   err_msg="Segments were not removed")
+        wait_for_segments_removal(self.redpanda,
+                                  self.topic,
+                                  partition_idx=0,
+                                  count=5)
 
     @cluster(num_nodes=3)
     def test_changing_topic_retention_with_restart(self):
@@ -108,13 +75,18 @@ class RetentionPolicyTest(RedpandaTest):
         segment_size = 1048576
 
         # produce until segments have been compacted
-        self._produce_until_segments(self.topic, 0, 20, -1)
+        produce_until_segments(
+            self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=20,
+            acks=-1,
+        )
 
         # restart all nodes to force replicating raft configuration
         self.redpanda.restart_nodes(self.redpanda.nodes)
 
         kafka_tools = KafkaCliTools(self.redpanda)
-
         # Wait for controller, alter configs doesn't have a retry loop
         kafka_tools.describe_topic(self.topic)
 
@@ -123,60 +95,24 @@ class RetentionPolicyTest(RedpandaTest):
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 15 * segment_size,
             })
-        self._wait_for_segments_removal(self.topic, 0, 16)
+        wait_for_segments_removal(
+            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=16
+        )
 
         # change retention bytes again to preserve 10 segments
         kafka_tools.alter_topic_config(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 10 * segment_size,
             })
-        self._wait_for_segments_removal(self.topic, 0, 11)
+        wait_for_segments_removal(
+            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=11
+        )
 
         # change retention bytes again to preserve 5 segments
         kafka_tools.alter_topic_config(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 4 * segment_size,
             })
-        self._wait_for_segments_removal(self.topic, 0, 5)
-
-    def _segments_count(self, topic, partition_idx):
-        storage = self.redpanda.storage()
-        topic_partitions = storage.partitions("kafka", topic)
-
-        return map(lambda p: len(p.segments),
-                   filter(lambda p: p.num == partition_idx, topic_partitions))
-
-    def _produce_until_segments(self, topic, partition_idx, count, acks):
-        """
-        Produce into the topic until given number of segments will appear 
-        """
-        kafka_tools = KafkaCliTools(self.redpanda)
-
-        def done():
-            kafka_tools.produce(topic, 10000, 1024, acks=acks)
-            topic_partitions = self._segments_count(topic, partition_idx)
-            partitions = []
-            for p in topic_partitions:
-                partitions.append(p >= count)
-            return all(partitions)
-
-        wait_until(done,
-                   timeout_sec=120,
-                   backoff_sec=2,
-                   err_msg="Segments were not created")
-
-    def _wait_for_segments_removal(self, topic, partition_idx, count):
-        """
-        Wait until only given number of segments will left in a partitions
-        """
-        def done():
-            topic_partitions = self._segments_count(topic, partition_idx)
-            partitions = []
-            for p in topic_partitions:
-                partitions.append(p <= count)
-            return all(partitions)
-
-        wait_until(done,
-                   timeout_sec=120,
-                   backoff_sec=5,
-                   err_msg="Segments were not removed")
+        wait_for_segments_removal(
+            redpanda=self.redpanda, topic=self.topic, partition_idx=0, count=5
+        )

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 
@@ -68,16 +67,16 @@ def produce_until_segments(redpanda, topic, partition_idx, count, acks=-1):
             partitions.append(p >= count)
         return all(partitions)
 
-    wait_until(
-        done, timeout_sec=120, backoff_sec=2, err_msg="Segments were not created"
-    )
+    wait_until(done,
+               timeout_sec=120,
+               backoff_sec=2,
+               err_msg="Segments were not created")
 
 
 def wait_for_segments_removal(redpanda, topic, partition_idx, count):
     """
     Wait until only given number of segments will left in a partitions
     """
-
     def done():
         topic_partitions = _segments_count(redpanda, topic, partition_idx)
         partitions = []
@@ -85,6 +84,7 @@ def wait_for_segments_removal(redpanda, topic, partition_idx, count):
             partitions.append(p <= count)
         return all(partitions)
 
-    wait_until(
-        done, timeout_sec=120, backoff_sec=5, err_msg="Segments were not removed"
-    )
+    wait_until(done,
+               timeout_sec=120,
+               backoff_sec=5,
+               err_msg="Segments were not removed")

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -8,6 +8,10 @@
 # by the Apache License, Version 2.0
 
 
+from ducktape.utils.util import wait_until
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+
+
 class Scale:
     KEY = "scale"
     LOCAL = "local"
@@ -38,3 +42,49 @@ class Scale:
     @property
     def release(self):
         return self._scale == Scale.RELEASE
+
+
+def _segments_count(redpanda, topic, partition_idx):
+    storage = redpanda.storage()
+    topic_partitions = storage.partitions("kafka", topic)
+
+    return map(
+        lambda p: len(p.segments),
+        filter(lambda p: p.num == partition_idx, topic_partitions),
+    )
+
+
+def produce_until_segments(redpanda, topic, partition_idx, count, acks=-1):
+    """
+    Produce into the topic until given number of segments will appear
+    """
+    kafka_tools = KafkaCliTools(redpanda)
+
+    def done():
+        kafka_tools.produce(topic, 10000, 1024, acks=acks)
+        topic_partitions = _segments_count(redpanda, topic, partition_idx)
+        partitions = []
+        for p in topic_partitions:
+            partitions.append(p >= count)
+        return all(partitions)
+
+    wait_until(
+        done, timeout_sec=120, backoff_sec=2, err_msg="Segments were not created"
+    )
+
+
+def wait_for_segments_removal(redpanda, topic, partition_idx, count):
+    """
+    Wait until only given number of segments will left in a partitions
+    """
+
+    def done():
+        topic_partitions = _segments_count(redpanda, topic, partition_idx)
+        partitions = []
+        for p in topic_partitions:
+            partitions.append(p <= count)
+        return all(partitions)
+
+    wait_until(
+        done, timeout_sec=120, backoff_sec=5, err_msg="Segments were not removed"
+    )

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -43,7 +43,7 @@ class Scale:
         return self._scale == Scale.RELEASE
 
 
-def _segments_count(redpanda, topic, partition_idx):
+def segments_count(redpanda, topic, partition_idx):
     storage = redpanda.storage()
     topic_partitions = storage.partitions("kafka", topic)
 
@@ -61,7 +61,7 @@ def produce_until_segments(redpanda, topic, partition_idx, count, acks=-1):
 
     def done():
         kafka_tools.produce(topic, 10000, 1024, acks=acks)
-        topic_partitions = _segments_count(redpanda, topic, partition_idx)
+        topic_partitions = segments_count(redpanda, topic, partition_idx)
         partitions = []
         for p in topic_partitions:
             partitions.append(p >= count)
@@ -78,7 +78,7 @@ def wait_for_segments_removal(redpanda, topic, partition_idx, count):
     Wait until only given number of segments will left in a partitions
     """
     def done():
-        topic_partitions = _segments_count(redpanda, topic, partition_idx)
+        topic_partitions = segments_count(redpanda, topic, partition_idx)
         partitions = []
         for p in topic_partitions:
             partitions.append(p <= count)


### PR DESCRIPTION
## Cover letter

This PR integrates `remote_partition` into `partition` and makes `remote_partition` available to the kafka layer - if there is cloud data available, fetches for offsets less than local start offset will use `remote_partition`.

Also port #2864 and #2839 to dev.

Fixes: #2853
Fixes: #2854

## Release notes

This PR enables shadow indexing (fetch from cloud data) - if cloud storage is enabled, start offset for the partition will take cloud data into account and fetches for data that was already deleted locally will go to cloud storage.