### PR TITLE
tests: fixes to stabilize topic_recovery_test

### DIFF
--- a/src/v/cloud_storage/offset_translation_layer.cc
+++ b/src/v/cloud_storage/offset_translation_layer.cc
@@ -37,9 +37,11 @@ ss::future<uint64_t> offset_translator::copy_stream(
       removed != model::offset::min(),
       "Can't copy segment which isn't in the manifest");
     auto pred = [&removed, &ctxlog](model::record_batch_header& hdr) {
-        if (hdr.type == model::record_batch_type::raft_configuration) {
+        if (
+          hdr.type == model::record_batch_type::raft_configuration
+          || hdr.type == model::record_batch_type::archival_metadata) {
             vlog(ctxlog.debug, "skipping batch {}", hdr);
-            removed++;
+            removed += hdr.last_offset_delta + 1;
             return storage::batch_consumer::consume_result::skip_batch;
         }
         auto old_offset = hdr.base_offset;

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -328,6 +328,8 @@ class RedpandaService(Service):
                    timeout_sec=timeout_sec,
                    err_msg="Redpanda node failed to stop in %d seconds" %
                    timeout_sec)
+        if node in self._started:
+            self._started.remove(node)
 
     def clean_node(self, node):
         node.account.kill_process("redpanda", clean_shutdown=False)

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1477,7 +1477,7 @@ class TopicRecoveryTest(RedpandaTest):
                     # We can use it to wait until the recovery is completed.
                     for partition in topic_state:
                         self.logger.info(f"partition: {partition}")
-                        if partition.leader:
+                        if partition.leader in partition.replicas:
                             num_leaders += 1
             except:
                 pass


### PR DESCRIPTION
The issue in https://github.com/vectorizedio/redpanda/issues/2569 is not reproducible anymore, but there's a new issue https://github.com/vectorizedio/redpanda/issues/2976 that makes some tests flaky.

This PR doesn't change test cases that may be affected by https://github.com/vectorizedio/redpanda/issues/2976 and re-enables the rest.