### PR TITLE
Custom partition assignment

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -185,6 +185,21 @@ std::vector<topic_result> create_topic_results(
     return results;
 }
 
+std::vector<topic_result> create_topic_results(
+  const std::vector<custom_assignable_topic_configuration>& requests,
+  errc error_code) {
+    std::vector<topic_result> results;
+    results.reserve(requests.size());
+    std::transform(
+      requests.cbegin(),
+      requests.cend(),
+      std::back_inserter(results),
+      [error_code](const custom_assignable_topic_configuration& r) {
+          return topic_result(r.cfg.tp_ns, error_code);
+      });
+    return results;
+}
+
 model::broker make_self_broker(const config::node_config& node_cfg) {
     auto kafka_addr = node_cfg.advertised_kafka_api();
     auto rpc_addr = node_cfg.advertised_rpc_api();
@@ -248,6 +263,20 @@ bool are_replica_sets_equal(
     std::sort(r_sorted.begin(), r_sorted.end(), cmp);
 
     return l_sorted == r_sorted;
+}
+
+std::vector<custom_assignable_topic_configuration>
+without_custom_assignments(std::vector<topic_configuration> topics) {
+    std::vector<custom_assignable_topic_configuration> assignable_topics;
+    assignable_topics.reserve(topics.size());
+    std::transform(
+      topics.begin(),
+      topics.end(),
+      std::back_inserter(assignable_topics),
+      [](topic_configuration cfg) {
+          return custom_assignable_topic_configuration(std::move(cfg));
+      });
+    return assignable_topics;
 }
 
 } // namespace cluster

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -58,6 +58,10 @@ std::vector<topic_result> create_topic_results(
 }
 
 std::vector<topic_result> create_topic_results(
+  const std::vector<custom_assignable_topic_configuration>& requests,
+  errc error_code);
+
+std::vector<topic_result> create_topic_results(
   const std::vector<model::topic_namespace>& topics, errc error_code);
 
 ss::future<> update_broker_client(
@@ -192,5 +196,8 @@ ss::future<std::error_code> replicate_and_wait(
             });
       });
 }
+
+std::vector<custom_assignable_topic_configuration>
+  without_custom_assignments(std::vector<topic_configuration>);
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -20,6 +20,8 @@ hard_constraint_evaluator is_active();
 
 hard_constraint_evaluator on_node(model::node_id);
 
+hard_constraint_evaluator on_nodes(const std::vector<model::node_id>&);
+
 hard_constraint_evaluator
 distinct_from(const std::vector<model::broker_shard>&);
 

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -69,7 +69,7 @@ service::create_topics(create_topics_request&& r, rpc::streaming_context&) {
              get_scheduling_group(),
              [this, r = std::move(r)]() mutable {
                  return _topics_frontend.local().create_topics(
-                   std::move(r.topics),
+                   without_custom_assignments(std::move(r.topics)),
                    model::timeout_clock::now() + r.timeout);
              })
       .then([this](std::vector<topic_result> res) {

--- a/src/v/cluster/tests/controller_api_tests.cc
+++ b/src/v/cluster/tests/controller_api_tests.cc
@@ -51,7 +51,9 @@ FIXTURE_TEST(test_querying_ntp_status, cluster_test_fixture) {
 
     leader->controller->get_topics_frontend()
       .local()
-      .create_topics(topics, 1s + model::timeout_clock::now())
+      .create_topics(
+        cluster::without_custom_assignments(topics),
+        1s + model::timeout_clock::now())
       .get();
 
     // wait for reconciliation to be finished

--- a/src/v/cluster/tests/controller_state_test.cc
+++ b/src/v/cluster/tests/controller_state_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "cluster/cluster_utils.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/shard_table.h"
 #include "cluster/simple_batch_builder.h"
@@ -52,11 +53,13 @@ FIXTURE_TEST(test_creating_same_topic_twice, cluster_test_fixture) {
 
     futures.push_back(
       node_0->controller->get_topics_frontend().local().create_topics(
-        {create_topic_cfg("test-1", 1, 3)}, model::timeout_clock::now() + 10s));
+        cluster::without_custom_assignments({create_topic_cfg("test-1", 1, 3)}),
+        model::timeout_clock::now() + 10s));
 
     futures.push_back(
       node_0->controller->get_topics_frontend().local().create_topics(
-        {create_topic_cfg("test-1", 2, 3)}, model::timeout_clock::now() + 10s));
+        cluster::without_custom_assignments({create_topic_cfg("test-1", 2, 3)}),
+        model::timeout_clock::now() + 10s));
 
     ss::when_all_succeed(futures.begin(), futures.end())
       .then([](std::vector<std::vector<cluster::topic_result>> results) {

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -86,7 +86,9 @@ FIXTURE_TEST(
     topics.emplace_back(model::ns("default"), model::topic("test_1"), 3, 1);
     cntrl_0->controller->get_topics_frontend()
       .local()
-      .create_topics(std::move(topics), model::no_timeout)
+      .create_topics(
+        cluster::without_custom_assignments(std::move(topics)),
+        model::no_timeout)
       .get0();
 
     auto leaders_0 = wait_for_leaders_updates(0, cache_0);
@@ -119,7 +121,9 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
     topics.emplace_back(model::ns("default"), model::topic("test_1"), 3, 1);
     cntrl_0->controller->get_topics_frontend()
       .local()
-      .create_topics(std::move(topics), model::no_timeout)
+      .create_topics(
+        cluster::without_custom_assignments(std::move(topics)),
+        model::no_timeout)
       .get0();
 
     // Add new now to the cluster

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -15,6 +15,7 @@
 #include "cluster/errc.h"
 #include "cluster/logger.h"
 #include "cluster/partition_leaders_table.h"
+#include "cluster/scheduling/constraints.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/types.h"
 #include "model/errc.h"
@@ -65,9 +66,9 @@ needs_linearizable_barrier(const std::vector<topic_result>& results) {
 }
 
 ss::future<std::vector<topic_result>> topics_frontend::create_topics(
-  std::vector<topic_configuration> topics,
+  std::vector<custom_assignable_topic_configuration> topics,
   model::timeout_clock::time_point timeout) {
-    vlog(clusterlog.trace, "Create topics {}", topics);
+    vlog(clusterlog.info, "Create topics {}", topics);
     // make sure that STM is up to date (i.e. we have the most recent state
     // available) before allocating topics
     return _stm
@@ -89,7 +90,7 @@ ss::future<std::vector<topic_result>> topics_frontend::create_topics(
             std::begin(topics),
             std::end(topics),
             std::back_inserter(futures),
-            [this, timeout](topic_configuration& t_cfg) {
+            [this, timeout](custom_assignable_topic_configuration& t_cfg) {
                 return do_create_topic(std::move(t_cfg), timeout);
             });
 
@@ -305,29 +306,75 @@ make_error_result(const model::topic_namespace& tp_ns, std::error_code ec) {
     return topic_result(tp_ns, errc::topic_operation_error);
 }
 
-allocation_request make_allocation_request(const topic_configuration& cfg) {
+allocation_request
+make_allocation_request(const custom_assignable_topic_configuration& ca_cfg) {
+    // no custom assignments, lets allocator decide based on partition count
     allocation_request req;
-    req.partitions.reserve(cfg.partition_count);
-    for (auto p = 0; p < cfg.partition_count; ++p) {
-        req.partitions.emplace_back(
-          model::partition_id(p), cfg.replication_factor);
+    if (!ca_cfg.has_custom_assignment()) {
+        req.partitions.reserve(ca_cfg.cfg.partition_count);
+        for (auto p = 0; p < ca_cfg.cfg.partition_count; ++p) {
+            req.partitions.emplace_back(
+              model::partition_id(p), ca_cfg.cfg.replication_factor);
+        }
+    } else {
+        req.partitions.reserve(ca_cfg.custom_assignments.size());
+        for (auto& cas : ca_cfg.custom_assignments) {
+            allocation_constraints constraints;
+            constraints.hard_constraints.push_back(
+              ss::make_lw_shared<hard_constraint_evaluator>(
+                on_nodes(cas.replicas)));
+
+            req.partitions.emplace_back(
+              cas.id, cas.replicas.size(), std::move(constraints));
+        }
     }
     return req;
 }
 
-ss::future<topic_result> topics_frontend::do_create_topic(
-  topic_configuration t_cfg, model::timeout_clock::time_point timeout) {
-    if (!validate_topic_name(t_cfg.tp_ns)) {
-        return ss::make_ready_future<topic_result>(
-          topic_result(t_cfg.tp_ns, errc::invalid_topic_name));
+errc topics_frontend::validate_topic_configuration(
+  const custom_assignable_topic_configuration& assignable_config) {
+    if (!validate_topic_name(assignable_config.cfg.tp_ns)) {
+        return errc::invalid_topic_name;
     }
+
+    if (assignable_config.cfg.partition_count < 1) {
+        return errc::topic_invalid_partitions;
+    }
+
+    if (assignable_config.cfg.replication_factor < 1) {
+        return errc::topic_invalid_replication_factor;
+    }
+
+    if (assignable_config.has_custom_assignment()) {
+        for (auto& custom : assignable_config.custom_assignments) {
+            if (
+              static_cast<int16_t>(custom.replicas.size())
+              != assignable_config.cfg.replication_factor) {
+                return errc::topic_invalid_replication_factor;
+            }
+        }
+    }
+
+    return errc::success;
+}
+
+ss::future<topic_result> topics_frontend::do_create_topic(
+  custom_assignable_topic_configuration assignable_config,
+  model::timeout_clock::time_point timeout) {
+    auto validation_err = validate_topic_configuration(assignable_config);
+
+    if (validation_err != errc::success) {
+        return ss::make_ready_future<topic_result>(
+          topic_result(assignable_config.cfg.tp_ns, validation_err));
+    }
+
     return _allocator
       .invoke_on(
         partition_allocator::shard,
-        [t_cfg](partition_allocator& al) {
-            return al.allocate(make_allocation_request(t_cfg));
+        [assignable_config](partition_allocator& al) {
+            return al.allocate(make_allocation_request(assignable_config));
         })
-      .then([this, t_cfg = std::move(t_cfg), timeout](
+      .then([this, t_cfg = std::move(assignable_config.cfg), timeout](
               result<allocation_units> units) mutable {
           // no assignments, error
           if (!units) {
@@ -470,7 +517,8 @@ ss::future<std::vector<topic_result>> topics_frontend::autocreate_topics(
     // current node is a leader controller
     if (leader == _self) {
         return create_topics(
-          std::move(topics), model::timeout_clock::now() + timeout);
+          without_custom_assignments(std::move(topics)),
+          model::timeout_clock::now() + timeout);
     }
     // dispatch to leader
     return dispatch_create_to_leader(

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -13,6 +13,7 @@
 
 #include "cluster/controller_stm.h"
 #include "cluster/data_policy_frontend.h"
+#include "cluster/errc.h"
 #include "cluster/fwd.h"
 #include "cluster/scheduling/types.h"
 #include "cluster/topic_table.h"
@@ -43,7 +44,8 @@ public:
       ss::sharded<ss::abort_source>&);
 
     ss::future<std::vector<topic_result>> create_topics(
-      std::vector<topic_configuration>, model::timeout_clock::time_point);
+      std::vector<custom_assignable_topic_configuration>,
+      model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_result>> delete_topics(
       std::vector<model::topic_namespace>, model::timeout_clock::time_point);
@@ -76,8 +78,8 @@ public:
 private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
-    ss::future<topic_result>
-      do_create_topic(topic_configuration, model::timeout_clock::time_point);
+    ss::future<topic_result> do_create_topic(
+      custom_assignable_topic_configuration, model::timeout_clock::time_point);
 
     ss::future<topic_result> replicate_create_topic(
       topic_configuration, allocation_units, model::timeout_clock::time_point);
@@ -103,6 +105,9 @@ private:
 
     // returns true if the topic name is valid
     static bool validate_topic_name(const model::topic_namespace&);
+
+    errc
+    validate_topic_configuration(const custom_assignable_topic_configuration&);
 
     ss::future<topic_result> do_create_partition(
       create_partititions_configuration, model::timeout_clock::time_point);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -302,6 +302,22 @@ std::ostream& operator<<(
     return o;
 }
 
+std::ostream&
+operator<<(std::ostream& o, const custom_assignable_topic_configuration& catc) {
+    fmt::print(
+      o,
+      "{{configuration: {}, custom_assignments: {}}}",
+      catc.cfg,
+      catc.custom_assignments);
+    return o;
+}
+
+std::ostream&
+operator<<(std::ostream& o, const custom_partition_assignment& cas) {
+    fmt::print(o, "{{partition_id: {}, replicas: {}}}", cas.id, cas.replicas);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -407,6 +407,30 @@ struct topic_configuration {
     friend std::ostream& operator<<(std::ostream&, const topic_configuration&);
 };
 
+struct custom_partition_assignment {
+    model::partition_id id;
+    std::vector<model::node_id> replicas;
+    friend std::ostream&
+    operator<<(std::ostream&, const custom_partition_assignment&);
+};
+/**
+ * custom_assignable_topic_configuration type represents topic configuration
+ * together with possible custom partition assignments. When assignments vector
+ * is empty all the partitions will be assigned automatically.
+ */
+struct custom_assignable_topic_configuration {
+    explicit custom_assignable_topic_configuration(topic_configuration cfg)
+      : cfg(std::move(cfg)){};
+
+    topic_configuration cfg;
+    std::vector<custom_partition_assignment> custom_assignments;
+
+    bool has_custom_assignment() const { return !custom_assignments.empty(); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const custom_assignable_topic_configuration&);
+};
+
 struct create_partititions_configuration {
     using custom_assignment = std::vector<model::node_id>;
     create_partititions_configuration(model::topic_namespace, int32_t);

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -38,6 +38,8 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
         return error_code::request_timed_out;
     case cluster::errc::invalid_topic_name:
         return error_code::invalid_topic_exception;
+    case cluster::errc::no_eligible_allocation_nodes:
+        return error_code::broker_not_available;
     case cluster::errc::replication_error:
     case cluster::errc::shutting_down:
     case cluster::errc::join_request_dispatch_error:
@@ -58,7 +60,6 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::invalid_node_operation:
     case cluster::errc::invalid_configuration_update:
     case cluster::errc::topic_operation_error:
-    case cluster::errc::no_eligible_allocation_nodes:
     case cluster::errc::allocation_error:
     case cluster::errc::partition_configuration_revision_not_updated:
     case cluster::errc::partition_configuration_in_joint_mode:

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -9,6 +9,7 @@
 
 #include "kafka/server/handlers/create_topics.h"
 
+#include "cluster/cluster_utils.h"
 #include "cluster/metadata_cache.h"
 #include "cluster/topics_frontend.h"
 #include "config/configuration.h"
@@ -161,7 +162,8 @@ ss::future<response_ptr> create_topics_handler::handle(
           // Create the topics with controller on core 0
           return ctx.topics_frontend()
             .create_topics(
-              std::move(to_create), to_timeout(request.data.timeout_ms))
+              cluster::without_custom_assignments(std::move(to_create)),
+              to_timeout(request.data.timeout_ms))
             .then([&ctx, tout = to_timeout(request.data.timeout_ms)](
                     std::vector<cluster::topic_result> c_res) mutable {
                 return wait_for_topics(c_res, ctx.controller_api(), tout)

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -52,10 +52,11 @@ bool is_supported(std::string_view name) {
 
 using validators = make_validator_types<
   creatable_topic,
-  no_custom_partition_assignment,
+  custom_partition_assignment_negative_partition_count,
   partition_count_must_be_positive,
   replication_factor_must_be_positive,
-  replication_factor_must_be_odd>;
+  replication_factor_must_be_odd,
+  replicas_diversity>;
 
 template<>
 ss::future<response_ptr> create_topics_handler::handle(
@@ -99,6 +100,10 @@ ss::future<response_ptr> create_topics_handler::handle(
 
           // fill in defaults if necessary
           for (auto& r : boost::make_iterator_range(begin, valid_range_end)) {
+              // skip custom assigned topics
+              if (!r.assignments.empty()) {
+                  continue;
+              }
               if (r.num_partitions == -1) {
                   r.num_partitions
                     = config::shard_local_cfg().default_topic_partitions();
@@ -153,8 +158,8 @@ ss::future<response_ptr> create_topics_handler::handle(
            * creating a topic. The the same policy is applied in Kafka.
            */
           for (auto& tp : to_create) {
-              if (!tp.properties.cleanup_policy_bitflags.has_value()) {
-                  tp.properties.cleanup_policy_bitflags
+              if (!tp.cfg.properties.cleanup_policy_bitflags.has_value()) {
+                  tp.cfg.properties.cleanup_policy_bitflags
                     = ctx.metadata_cache()
                         .get_default_cleanup_policy_bitflags();
               }
@@ -162,8 +167,7 @@ ss::future<response_ptr> create_topics_handler::handle(
           // Create the topics with controller on core 0
           return ctx.topics_frontend()
             .create_topics(
-              cluster::without_custom_assignments(std::move(to_create)),
-              to_timeout(request.data.timeout_ms))
+              std::move(to_create), to_timeout(request.data.timeout_ms))
             .then([&ctx, tout = to_timeout(request.data.timeout_ms)](
                     std::vector<cluster::topic_result> c_res) mutable {
                 return wait_for_topics(c_res, ctx.controller_api(), tout)

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -70,6 +70,7 @@ from_cluster_topic_result(const cluster::topic_result& err) {
 
 config_map_t config_map(const std::vector<createable_topic_config>& config);
 
-cluster::topic_configuration to_cluster_type(const creatable_topic& t);
+cluster::custom_assignable_topic_configuration
+to_cluster_type(const creatable_topic& t);
 
 } // namespace kafka

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "cluster/cluster_utils.h"
 #include "cluster/controller.h"
 #include "cluster/members_table.h"
 #include "cluster/metadata_cache.h"
@@ -266,7 +267,9 @@ public:
           cluster::topic_configuration(tp_ns.ns, tp_ns.tp, partitions, 1)};
         return app.controller->get_topics_frontend()
           .local()
-          .create_topics(std::move(cfgs), model::no_timeout)
+          .create_topics(
+            cluster::without_custom_assignments(std::move(cfgs)),
+            model::no_timeout)
           .then([this](std::vector<cluster::topic_result> results) {
               return wait_for_topics(std::move(results));
           });

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -92,6 +92,20 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
             args += ["--config", it]
         return self._run("kafka-topics.sh", args)
 
+    def create_topic_with_assignment(self, name, assignments):
+        self._redpanda.logger.debug(
+            f"Creating topic: {name}, custom assignment: {assignments}")
+
+        partitions = []
+        for assignment in assignments:
+            partitions.append(":".join(str(r) for r in assignment))
+
+        args = ["--create"]
+        args += ["--topic", name]
+        args += ["--replica-assignment", ",".join(partitions)]
+
+        return self._run("kafka-topics.sh", args)
+
     def delete_topic(self, topic):
         self._redpanda.logger.debug("Deleting topic: %s", topic)
         args = ["--delete"]

--- a/tests/rptest/clients/python_librdkafka.py
+++ b/tests/rptest/clients/python_librdkafka.py
@@ -50,6 +50,9 @@ class PythonLibrdkafka:
                     f"topic {topic} creation failed: {e}")
                 raise
 
+    def get_client(self):
+        return AdminClient(self._get_config())
+
     def _get_config(self):
         conf = {
             'bootstrap.servers': self._redpanda.brokers(),

--- a/tests/rptest/tests/custom_topic_assignment_test.py
+++ b/tests/rptest/tests/custom_topic_assignment_test.py
@@ -1,0 +1,100 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import random
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from rptest.clients.python_librdkafka import PythonLibrdkafka
+from rptest.clients.rpk import RpkTool
+from rptest.tests.redpanda_test import RedpandaTest
+from confluent_kafka.admin import NewTopic
+from confluent_kafka.error import KafkaException, KafkaError
+
+from rptest.clients.types import TopicSpec
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+
+
+class CustomTopicAssignmentTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(CustomTopicAssignmentTest,
+              self).__init__(test_context=test_context, num_brokers=5)
+
+    def create_and_validate(self, name, custom_assignment):
+        self.redpanda.logger.info(
+            f"creating topic {name} with {custom_assignment}")
+        cli = KafkaCliTools(self.redpanda)
+        rpk = RpkTool(self.redpanda)
+
+        cli.create_topic_with_assignment(name, custom_assignment)
+
+        def replica_matches():
+            replicas_per_partition = {}
+            for p in rpk.describe_topic(name):
+                replicas_per_partition[p.id] = list(p.replicas)
+            self.redpanda.logger.debug(
+                f"requested replicas: {custom_assignment}, current replicas: {replicas_per_partition}"
+            )
+
+            for p_id, replicas in enumerate(custom_assignment):
+                if p_id not in replicas_per_partition:
+                    return False
+
+                if set(replicas) != set(replicas_per_partition[p_id]):
+                    return False
+
+            return True
+
+        # each assignment defines a partition
+        wait_until(replica_matches, 10, backoff_sec=1)
+
+    @cluster(num_nodes=5)
+    def test_create_topic_with_custom_partition_assignment(self):
+        cli = KafkaCliTools(self.redpanda)
+        rpk = RpkTool(self.redpanda)
+        # 3 partitions with single replica
+        self.create_and_validate("topic-1", [[1], [3], [5]])
+        # 3 partitions with replication factor of 2
+        self.create_and_validate("topic-2", [[1, 2], [3, 4], [5, 1]])
+        # 1 partition with replication factor of 3
+        self.create_and_validate("topic-3", [[2, 4, 1]])
+
+    @cluster(num_nodes=5)
+    def test_custom_assignment_validation(self):
+        client = PythonLibrdkafka(self.redpanda).get_client()
+
+        def expect_failed_create_topic(name, custom_assignment,
+                                       expected_error):
+            topics = [
+                NewTopic(name,
+                         num_partitions=len(custom_assignment),
+                         replica_assignment=custom_assignment)
+            ]
+            res = client.create_topics(topics, request_timeout=10)
+            assert len(res) == 1
+            fut = res[name]
+            try:
+                fut.result()
+                assert False
+            except KafkaException as e:
+                kafka_error = e.args[0]
+                self.redpanda.logger.debug(
+                    f"topic {name} creation failed: {kafka_error}, expected error: {expected_error}"
+                )
+                assert kafka_error.code() == expected_error
+
+        # not unique replicas
+        expect_failed_create_topic("invalid-1", [[1, 1, 2]],
+                                   KafkaError.INVALID_REQUEST)
+        # not existing broker
+        expect_failed_create_topic("invalid-1", [[1, 10, 2]],
+                                   KafkaError.BROKER_NOT_AVAILABLE)
+
+        # different replication factors
+        expect_failed_create_topic("invalid-1", [[1, 2, 3], [4]],
+                                   KafkaError.INVALID_REPLICATION_FACTOR)


### PR DESCRIPTION
## Cover letter

Added support for manual partition assignment in `CreateTopics` API. The manual partition assignment allow user to specify which nodes should be members of a partition replica set. When custom partition assignment is specified number of partitions and replication factor are derived from assignments itself. 

### Implementation details

Custom partition assignment is passed by the client when creating topics. We do not differentiate manually assigned partitions from the one that are assigned automatically. The custom assignment portion of the `CreateTopics` request is used only during the assignment process itself. This approach have some advantages since the whole mechanics related with automatic partition rebalancing, nodes decommissioning and partition movement in general doesn't have to special case those manually assigned partitions. 

Release note: 

- Added support for manual partition assignment in `CreateTopics` API
  - Currently custom partition assignment is only used during initial partition allocation
  - Nodes decommissioning and automatic partition re-balancing may change the partition assignment