### PR TITLE
raft: simplify node removal tests

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -404,6 +404,18 @@ void consensus::process_append_entries_reply(
   result<append_entries_reply> r,
   follower_req_seq seq_id,
   model::offset dirty_offset) {
+    auto config = _configuration_manager.get_latest();
+    if (!config.contains_broker(physical_node)) {
+        // We might have sent an append_entries just before removing
+        // a node from configuration: ignore its reply, to avoid
+        // doing things like initiating recovery to this removed node.
+        vlog(
+          _ctxlog.debug,
+          "Ignoring reply from node {}, it is not in members list",
+          physical_node);
+        return;
+    }
+
     auto is_success = update_follower_index(
       physical_node, r, seq_id, dirty_offset);
     if (is_success) {


### PR DESCRIPTION
## Cover letter

These tests were polling on the underlying
log behind the consensus instance for the node
that was removed.

This diverges from how the code is used in
real life (the consenseus object for a removed
node is torn down by the controller, not left alive)
and could cause weird hangs in the test when
the orphaned consensus instance was left in
a just-truncated state.

Simplify the tests to just check the visible offset
at the raft layer to validate that the removed
node hasn't advanced, rather than reading its underlying
storage.

Fixes: #2799

## Release notes

None