### PR TITLE
[data-policy] Delete usless data-policy property from topic_frontend log message

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -203,10 +203,12 @@ ss::future<std::vector<topic_result>> topics_frontend::update_topic_properties(
 // data-policy
 ss::future<std::error_code> topics_frontend::do_update_data_policy(
   topic_properties_update& update, model::timeout_clock::time_point timeout) {
-    switch (update.properties.data_policy.op) {
+    switch (update.custom_properties.data_policy.op) {
     case incremental_update_operation::set:
         co_return co_await _dp_frontend.local().create_data_policy(
-          update.tp_ns, update.properties.data_policy.value.value(), timeout);
+          update.tp_ns,
+          update.custom_properties.data_policy.value.value(),
+          timeout);
     case incremental_update_operation::remove: {
         co_return co_await _dp_frontend.local().clear_data_policy(
           update.tp_ns, timeout);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -528,14 +528,40 @@ adl<cluster::configuration_invariants>::from(iobuf_parser& parser) {
 
 void adl<cluster::topic_properties_update>::to(
   iobuf& out, cluster::topic_properties_update&& r) {
-    reflection::serialize(out, r.tp_ns, r.properties);
+    reflection::serialize(
+      out, r.version, r.tp_ns, r.properties, r.custom_properties);
 }
 
 cluster::topic_properties_update
 adl<cluster::topic_properties_update>::from(iobuf_parser& parser) {
+    /**
+     * We use the same versioning trick as for `cluster::topic_configuration`.
+     *
+     * NOTE: The first field of the topic_properties_update is a
+     * model::topic_namespace. Serialized ss::string starts from either
+     * int32_t for string length. We use negative version to encode new format
+     * of incremental topic_properties_update
+     */
+
+    auto version = adl<int32_t>{}.from(parser.peek(4));
+    if (version < 0) {
+        // Consume version from stream
+        parser.skip(4);
+        vassert(
+          version == cluster::topic_properties_update::version,
+          "topic_properties_update version {} is not supported",
+          version);
+    } else {
+        version = 0;
+    }
+
     auto tp_ns = adl<model::topic_namespace>{}.from(parser);
     cluster::topic_properties_update ret(std::move(tp_ns));
     ret.properties = adl<cluster::incremental_topic_updates>{}.from(parser);
+    if (version < 0) {
+        ret.custom_properties
+          = adl<cluster::incremental_topic_custom_updates>{}.from(parser);
+    }
 
     return ret;
 }
@@ -1028,6 +1054,20 @@ adl<cluster::cluster_config_status_cmd_data>::from(iobuf_parser& in) {
     return cluster::cluster_config_status_cmd_data{
       .status = std::move(status),
     };
+}
+
+void adl<cluster::incremental_topic_custom_updates>::to(
+  iobuf& out, cluster::incremental_topic_custom_updates&& t) {
+    reflection::serialize(out, t.data_policy);
+}
+
+cluster::incremental_topic_custom_updates
+adl<cluster::incremental_topic_custom_updates>::from(iobuf_parser& in) {
+    cluster::incremental_topic_custom_updates updates;
+    updates.data_policy
+      = adl<cluster::property_update<std::optional<v8_engine::data_policy>>>{}
+          .from(in);
+    return updates;
 }
 
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -347,9 +347,11 @@ struct property_update<tristate<T>> {
 };
 
 struct incremental_topic_updates {
-    // negative version indicating new format (with included data_policy
-    // property)
-    static constexpr int8_t version = -1;
+    static constexpr int8_t version_with_data_policy = -1;
+    // negative version indicating different format:
+    // -1 - topic_updates with data_policy
+    // -2 - topic_updates without data_policy
+    static constexpr int8_t version = -2;
     property_update<std::optional<model::compression>> compression;
     property_update<std::optional<model::cleanup_policy_bitflags>>
       cleanup_policy_bitflags;
@@ -359,10 +361,6 @@ struct incremental_topic_updates {
     property_update<std::optional<size_t>> segment_size;
     property_update<tristate<size_t>> retention_bytes;
     property_update<tristate<std::chrono::milliseconds>> retention_duration;
-
-    // Data-policy property is replicated by data_policy_frontend and handled by
-    // data_policy_manager.
-    property_update<std::optional<v8_engine::data_policy>> data_policy;
 
     friend bool operator==(
       const incremental_topic_updates&, const incremental_topic_updates&)

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -381,6 +381,8 @@ struct incremental_topic_custom_updates {
  * Struct representing single topic properties update
  */
 struct topic_properties_update {
+    // We need version to indetify request with custom_properties
+    static constexpr int32_t version = -1;
     explicit topic_properties_update(model::topic_namespace tp_ns)
       : tp_ns(std::move(tp_ns)) {}
 
@@ -884,4 +886,9 @@ struct adl<cluster::cluster_config_status_cmd_data> {
     cluster::cluster_config_status_cmd_data from(iobuf_parser&);
 };
 
+template<>
+struct adl<cluster::incremental_topic_custom_updates> {
+    void to(iobuf& out, cluster::incremental_topic_custom_updates&&);
+    cluster::incremental_topic_custom_updates from(iobuf_parser&);
+};
 } // namespace reflection

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -369,6 +369,14 @@ struct incremental_topic_updates {
       = default;
 };
 
+// This class contains updates for topic properties which are replicates not by
+// topic_frontend
+struct incremental_topic_custom_updates {
+    // Data-policy property is replicated by data_policy_frontend and handled by
+    // data_policy_manager.
+    property_update<std::optional<v8_engine::data_policy>> data_policy;
+};
+
 /**
  * Struct representing single topic properties update
  */
@@ -377,7 +385,14 @@ struct topic_properties_update {
       : tp_ns(std::move(tp_ns)) {}
 
     model::topic_namespace tp_ns;
+
+    // Tihs properties is serialized to update_topic_properties_cmd by
+    // topic_frontend
     incremental_topic_updates properties;
+
+    // This properties is not serialized to update_topic_properties_cmd, because
+    // they have custom services for replication.
+    incremental_topic_custom_updates custom_properties;
 };
 
 // Structure holding topic configuration, optionals will be replaced by broker

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -95,7 +95,7 @@ create_topic_properties_update(alter_configs_resource& resource) {
       = cluster::incremental_update_operation::set;
     update.properties.retention_duration.op
       = cluster::incremental_update_operation::set;
-    update.properties.data_policy.op
+    update.custom_properties.data_policy.op
       = cluster::incremental_update_operation::none;
 
     for (auto& cfg : resource.configs) {

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -206,9 +206,9 @@ create_topic_properties_update(incremental_alter_configs_resource& resource) {
           fmt::format("invalid topic property: {}", cfg.name));
     }
     try {
-        update.properties.data_policy.value = data_policy_from_parser(
+        update.custom_properties.data_policy.value = data_policy_from_parser(
           dp_parser);
-        update.properties.data_policy.op = dp_parser.op;
+        update.custom_properties.data_policy.op = dp_parser.op;
     } catch (const v8_engine::data_policy_exeption& e) {
         return make_error_alter_config_resource_response<
           incremental_alter_configs_resource_response>(


### PR DESCRIPTION
## Cover letter

`Data-policy` is replicated by `data_policy_frontend`, so we can delete this useless property from `incremental_topic_updates`
Also we need to change `incremental_topic_updates` version, because "broken" (record about updates property with data_policy) log records are used in some poduction cluster. 

Fixes #2766 