### PR TITLE
tools: extend test backtrace catching for AddressSanitizer

### DIFF
--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -41,7 +41,7 @@ class BacktraceCapture(threading.Thread):
     """
 
     BACKTRACE_START = re.compile(
-        "(^Backtrace:|.+Sanitizer.*|.+Backtrace below:$|^Direct leak.+|^Indirect leak.+)"
+        "(^Backtrace:|.+Sanitizer.*|.+Backtrace below:$|^Direct leak.+|^Indirect leak.+|^READ of size.*|^0x.+ is located.+|^previously allocated by.+|^Thread.+created by.+)"
     )
     BACKTRACE_BODY = re.compile("^(  |==|0x)")
 


### PR DESCRIPTION
## Cover letter

AddressSanitizer errors can output a series of backtraces
prefixed with explanatory messages.

This regex is growing unwieldy, and we maybe need to switch
to a different way of scraping backtraces (e.g. scraping any
contiguous range of address-like lines) but for the moment
I want the tool to give us backtraces for the specific
type of failure seen in tests like:
https://buildkite.com/vectorized/redpanda/builds/4371#ee26681c-c0cd-4cc6-948a-4246bf707726

## Release notes

None