### PR TITLE
kafka: Improve stability of parttition leadership in metadata for newly created topics

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -53,7 +53,7 @@ controller::controller(
   , _partition_manager(pm)
   , _shard_table(st)
   , _storage(storage)
-  , _tp_updates_dispatcher(_partition_allocator, _tp_state)
+  , _tp_updates_dispatcher(_partition_allocator, _tp_state, _partition_leaders)
   , _security_manager(_credentials, _authorizer)
   , _data_policy_manager(data_policy_table)
   , _raft_manager(raft_manager) {}

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -126,5 +126,6 @@ struct topic_table_fixture {
 
     ss::sharded<cluster::partition_allocator> allocator;
     ss::sharded<cluster::topic_table> table;
+    ss::sharded<cluster::partition_leaders_table> leaders;
     ss::abort_source as;
 };

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -21,7 +21,7 @@ using namespace std::chrono_literals;
 
 struct topic_table_updates_dispatcher_fixture : topic_table_fixture {
     topic_table_updates_dispatcher_fixture()
-      : dispatcher(allocator, table) {}
+      : dispatcher(allocator, table, leaders) {}
 
     void create_topics() {
         auto cmd_1 = make_create_topic_cmd("test_tp_1", 1, 3);

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -49,7 +49,9 @@ namespace cluster {
 class topic_updates_dispatcher {
 public:
     topic_updates_dispatcher(
-      ss::sharded<partition_allocator>&, ss::sharded<topic_table>&);
+      ss::sharded<partition_allocator>&,
+      ss::sharded<topic_table>&,
+      ss::sharded<partition_leaders_table>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -71,6 +73,9 @@ private:
     template<typename Cmd>
     ss::future<std::error_code> dispatch_updates_to_cores(Cmd, model::offset);
 
+    using ntp_leader = std::pair<model::ntp, model::node_id>;
+
+    ss::future<> update_leaders_with_estimates(std::vector<ntp_leader> leaders);
     void update_allocations(const create_topic_cmd&);
     void update_allocations(const create_partition_cmd&);
     void deallocate_topic(const model::topic_metadata&);
@@ -80,6 +85,7 @@ private:
 
     ss::sharded<partition_allocator>& _partition_allocator;
     ss::sharded<topic_table>& _topic_table;
+    ss::sharded<partition_leaders_table>& _partition_leaders_table;
 };
 
 } // namespace cluster

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -349,59 +349,32 @@ ss::future<topic_result> topics_frontend::replicate_create_topic(
       tp_ns,
       topic_configuration_assignment(std::move(cfg), units.get_assignments()));
 
-    std::vector<ntp_leader> leaders;
-    leaders.reserve(cmd.value.assignments.size());
     for (auto& p_as : cmd.value.assignments) {
         std::shuffle(
           p_as.replicas.begin(),
           p_as.replicas.end(),
           random_generators::internal::gen);
-        // guesstimate leaders
-        leaders.emplace_back(
-          model::ntp(tp_ns.ns, tp_ns.tp, p_as.id),
-          p_as.replicas.begin()->node_id);
     }
 
     return replicate_and_wait(_stm, _as, std::move(cmd), timeout)
-      .then_wrapped(
-        [this,
-         tp_ns = std::move(tp_ns),
-         units = std::move(units),
-         leaders = std::move(leaders)](ss::future<std::error_code> f) mutable {
-            try {
-                auto error_code = f.get0();
-                auto ret_f = ss::now();
-                if (!error_code) {
-                    ret_f = update_leaders_with_estimates(std::move(leaders));
-                }
-
-                return ret_f.then([tp_ns = std::move(tp_ns),
-                                   error_code]() mutable {
+      .then_wrapped([tp_ns = std::move(tp_ns), units = std::move(units)](
+                      ss::future<std::error_code> f) mutable {
+          try {
+              auto error_code = f.get0();
+              auto ret_f = ss::now();
+              return ret_f.then(
+                [tp_ns = std::move(tp_ns), error_code]() mutable {
                     return topic_result(std::move(tp_ns), map_errc(error_code));
                 });
 
-            } catch (...) {
-                vlog(
-                  clusterlog.warn,
-                  "Unable to create topic - {}",
-                  std::current_exception());
-                return ss::make_ready_future<topic_result>(
-                  topic_result(std::move(tp_ns), errc::replication_error));
-            }
-        });
-}
-
-ss::future<> topics_frontend::update_leaders_with_estimates(
-  std::vector<ntp_leader> leaders) {
-    return ss::do_with(
-      std::move(leaders), [this](std::vector<ntp_leader>& leaders) {
-          return ss::parallel_for_each(leaders, [this](ntp_leader& leader) {
-              return _leaders.invoke_on_all(
-                [leader](partition_leaders_table& l) {
-                    return l.update_partition_leader(
-                      leader.first, model::term_id(1), leader.second);
-                });
-          });
+          } catch (...) {
+              vlog(
+                clusterlog.warn,
+                "Unable to create topic - {}",
+                std::current_exception());
+              return ss::make_ready_future<topic_result>(
+                topic_result(std::move(tp_ns), errc::replication_error));
+          }
       });
 }
 

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -96,7 +96,6 @@ private:
       topic_properties_update&, model::timeout_clock::time_point);
     ss::future<topic_result> do_update_topic_properties(
       topic_properties_update, model::timeout_clock::time_point);
-    ss::future<> update_leaders_with_estimates(std::vector<ntp_leader>);
 
     ss::future<result<model::offset>>
       stm_linearizable_barrier(model::timeout_clock::time_point);


### PR DESCRIPTION
## Cover letter

This way all the nodes have
the same initial leader guess for newly created topics, rather
than the node that serviced the create having a leader while
other nodes do not.

This avoids leadership appearing to flap directly after creation,
if a client sends metadata requests to a different node than they
sent the creation to.

Fixes: #2546

## Release notes

Initial leadership information for newly created topics is set more uniformly across the cluster, avoiding some client delays when accessing a newly created topic that has not gone through a leadership election yet.