### PR TITLE
config: add schema API endpoint & extended property metadata

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -161,23 +161,10 @@ redpanda:
     - host:
       address: 192.168.0.1
       port: 33145
-  # Number of partitions for the internal raft metadata topic.
-  # Default: 7
-  seed_server_meta_topic_partitions: 7
 
   # The raft leader heartbeat interval in milliseconds.
   # Default: 150
   raft_heartbeat_interval_ms: 150
-  
-  # Minimum redpanda version
-  min_version: 0
-  
-  # Maximum redpanda version
-  max_version: 1
-  
-  # Manage CPU scheduling.
-  # Default: false
-  use_scheduling_groups: false 
   
   # Default number of quota tracking windows.
   # Default: 10
@@ -751,7 +738,7 @@ Here is a more comprehensive view of the configration so that you can see all of
 | `max_version` | max redpanda compat version | 1 |
 | `metadata_dissemination_interval_ms` | Interaval for metadata dissemination batching | 3000ms |
 | `metadata_dissemination_retries` | Number of attempts of looking up a topic's meta data like shard before failing a request | 10 |
-| `metadata_dissemination_retry_delay_ms` | Delay before retry a topic lookup in a shard or other meta tables | 100ms |
+| `metadata_dissemination_retry_delay_ms` | Delay before retry a topic lookup in a shard or other meta tables | 500ms |
 | `min_version` | minimum redpanda compat version | 0 |
 | `pandaproxy_api` | Rest API listen address and port | 0.0.0.0:8082 |
 | `pandaproxy_api_tls` | TLS configuration for Pandaproxy api | validate_many |

--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -735,11 +735,9 @@ Here is a more comprehensive view of the configration so that you can see all of
 | `log_segment_size` | How large in bytes should each log segment be (default 1G) | 1GB |
 | `max_compacted_log_segment_size` | Max compacted segment size after consolidation | 5GB |
 | `max_kafka_throttle_delay_ms` | Fail-safe maximum throttle delay on kafka requests | 60000ms |
-| `max_version` | max redpanda compat version | 1 |
 | `metadata_dissemination_interval_ms` | Interaval for metadata dissemination batching | 3000ms |
 | `metadata_dissemination_retries` | Number of attempts of looking up a topic's meta data like shard before failing a request | 10 |
 | `metadata_dissemination_retry_delay_ms` | Delay before retry a topic lookup in a shard or other meta tables | 500ms |
-| `min_version` | minimum redpanda compat version | 0 |
 | `pandaproxy_api` | Rest API listen address and port | 0.0.0.0:8082 |
 | `pandaproxy_api_tls` | TLS configuration for Pandaproxy api | validate_many |
 | `quota_manager_gc_sec` | Quota manager GC frequency in milliseconds | 30000ms |
@@ -764,7 +762,6 @@ Here is a more comprehensive view of the configration so that you can see all of
 | `rm_violation_recovery_policy` | Describes how to recover from an invariant violation happened on the partition level | crash |
 | `rpc_server` | IP address and port for RPC server | 127.0.0.1:33145 |
 | `rpc_server_tls` | TLS configuration for RPC server | validate |
-| `seed_server_meta_topic_partitions` | Number of partitions in internal raft metadata topic | 7 |
 | `seed_servers` | List of the seed servers used to join current cluster; If the seed_server list is empty the node will be a cluster root and it will form a new cluster | None |
 | `segment_appender_flush_timeout_ms` | Maximum delay until buffered data is written | 1sms |
 | `superusers` | List of superuser usernames | None |
@@ -772,5 +769,4 @@ Here is a more comprehensive view of the configration so that you can see all of
 | `tm_sync_timeout_ms` | Time to wait state catch up before rejecting a request | 2000ms |
 | `tm_violation_recovery_policy` | Describes how to recover from an invariant violation happened on the transaction coordinator level | crash |
 | `transactional_id_expiration_ms` | Producer ids are expired once this time has elapsed after the last write with the given producer ID | 10080min |
-| `use_scheduling_groups` | Manage CPU scheduling | false |
 | `wait_for_leader_timeout_ms` | Timeout (ms) to wait for leadership in metadata cache | 5000ms |

--- a/src/v/config/base_property.cc
+++ b/src/v/config/base_property.cc
@@ -30,4 +30,17 @@ std::ostream& operator<<(std::ostream& o, const base_property& p) {
     return o;
 }
 
+std::string_view to_string_view(visibility v) {
+    switch (v) {
+    case config::visibility::tunable:
+        return "tunable";
+    case config::visibility::user:
+        return "user";
+    case config::visibility::deprecated:
+        return "deprecated";
+    }
+
+    return "{invalid}";
+}
+
 }; // namespace config

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -33,6 +33,7 @@ public:
     struct metadata {
         required required{required::no};
         needs_restart needs_restart{needs_restart::yes};
+        std::optional<ss::sstring> example{std::nullopt};
     };
 
     base_property(
@@ -45,7 +46,7 @@ public:
     const std::string_view& desc() const { return _desc; }
 
     const required is_required() const { return _meta.required; }
-    bool needs_restart() { return bool(_meta.needs_restart); }
+    bool needs_restart() const { return bool(_meta.needs_restart); }
 
     // this serializes the property value. a full configuration serialization is
     // performed in config_store::to_json where the json object key is taken
@@ -58,6 +59,13 @@ public:
     virtual void set_value(std::any) = 0;
     virtual void reset() = 0;
     virtual bool is_default() const = 0;
+
+    virtual std::string_view type_name() const = 0;
+    virtual std::optional<std::string_view> units_name() const = 0;
+    virtual bool is_nullable() const = 0;
+    virtual bool is_array() const = 0;
+    std::optional<std::string_view> example() const { return _meta.example; }
+
     virtual std::optional<validation_error> validate() const = 0;
     virtual base_property& operator=(const base_property&) = 0;
     virtual ~base_property() noexcept = default;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -55,14 +55,14 @@ configuration::configuration()
       *this,
       "log_segment_size",
       "How large in bytes should each log segment be (default 1G)",
-      required::no,
+      {.example = "2147483648"},
       1_GiB)
   , compacted_log_segment_size(
       *this,
       "compacted_log_segment_size",
       "How large in bytes should each compacted log segment be (default "
       "256MiB)",
-      required::no,
+      {.example = "268435456"},
       256_MiB)
   , readers_cache_eviction_timeout_ms(
       *this,
@@ -80,14 +80,14 @@ configuration::configuration()
       *this,
       "rpc_server_tcp_recv_buf",
       "TCP receive buffer size in bytes.",
-      required::no,
+      {.example = "65536"},
       std::nullopt,
       32_KiB)
   , rpc_server_tcp_send_buf(
       *this,
       "rpc_server_tcp_send_buf",
       "TCP transmit buffer size in bytes.",
-      required::no,
+      {.example = "65536"},
       std::nullopt,
       32_KiB)
   , enable_coproc(
@@ -175,7 +175,7 @@ configuration::configuration()
       *this,
       "target_quota_byte_rate",
       "Target quota byte rate (bytes per second) - 2GB default",
-      required::no,
+      {.example = "1073741824"},
       2_GiB)
   , cluster_id(
       *this, "cluster_id", "Cluster identifier", required::no, std::nullopt)
@@ -219,7 +219,7 @@ configuration::configuration()
       *this,
       "metadata_dissemination_interval_ms",
       "Interaval for metadata dissemination batching",
-      required::no,
+      {.example = "5000"},
       3'000ms)
   , metadata_dissemination_retry_delay_ms(
       *this,
@@ -245,7 +245,7 @@ configuration::configuration()
       "tm_violation_recovery_policy",
       "Describes how to recover from an invariant violation happened on the "
       "transaction coordinator level",
-      required::no,
+      {.example = "best_effort"},
       model::violation_recovery_policy::crash)
   , rm_sync_timeout_ms(
       *this,
@@ -264,7 +264,7 @@ configuration::configuration()
       "rm_violation_recovery_policy",
       "Describes how to recover from an invariant violation happened on the "
       "partition level",
-      required::no,
+      {.example = "best_effort"},
       model::violation_recovery_policy::crash)
   , fetch_reads_debounce_timeout(
       *this,
@@ -284,19 +284,19 @@ configuration::configuration()
       *this,
       "log_cleanup_policy",
       "Default topic cleanup policy",
-      {required::no, needs_restart::no},
+      {required::no, needs_restart::no, "compact,delete"},
       model::cleanup_policy_bitflags::deletion)
   , log_message_timestamp_type(
       *this,
       "log_message_timestamp_type",
       "Default topic messages timestamp type",
-      {required::no, needs_restart::no},
+      {required::no, needs_restart::no, "LogAppendTime"},
       model::timestamp_type::create_time)
   , log_compression_type(
       *this,
       "log_compression_type",
       "Default topic compression type",
-      {required::no, needs_restart::no},
+      {required::no, needs_restart::no, "snappy"},
       model::compression::producer)
   , fetch_max_bytes(
       *this,
@@ -378,7 +378,7 @@ configuration::configuration()
       *this,
       "transaction_coordinator_cleanup_policy",
       "Cleanup policy for a transaction coordinator topic",
-      required::no,
+      {.required = required::no, .example = "compact,delete"},
       model::cleanup_policy_bitflags::deletion)
   , transaction_coordinator_delete_retention_ms(
       *this,
@@ -572,14 +572,14 @@ configuration::configuration()
       *this,
       "append_chunk_size",
       "Size of direct write operations to disk",
-      required::no,
+      {.example = "32768"},
       16_KiB,
       storage::internal::chunk_cache::validate_chunk_size)
   , max_compacted_log_segment_size(
       *this,
       "max_compacted_log_segment_size",
       "Max compacted segment size after consolidation",
-      required::no,
+      {.example = "10737418240"},
       5_GiB)
   , id_allocator_log_capacity(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -49,32 +49,32 @@ configuration::configuration()
     "developer_mode",
     "Skips most of the checks performed at startup, not recomended for "
     "production use",
-    required::no,
+    {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
     false)
   , log_segment_size(
       *this,
       "log_segment_size",
       "How large in bytes should each log segment be (default 1G)",
-      {.example = "2147483648"},
+      {.example = "2147483648", .visibility = visibility::tunable},
       1_GiB)
   , compacted_log_segment_size(
       *this,
       "compacted_log_segment_size",
       "How large in bytes should each compacted log segment be (default "
       "256MiB)",
-      {.example = "268435456"},
+      {.example = "268435456", .visibility = visibility::tunable},
       256_MiB)
   , readers_cache_eviction_timeout_ms(
       *this,
       "readers_cache_eviction_timeout_ms",
       "Duration after which inactive readers will be evicted from cache",
-      required::no,
+      {.visibility = visibility::tunable},
       30s)
   , rpc_server_listen_backlog(
       *this,
       "rpc_server_listen_backlog",
       "TCP connection queue length for Kafka server and internal RPC server",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , rpc_server_tcp_recv_buf(
       *this,
@@ -91,99 +91,102 @@ configuration::configuration()
       std::nullopt,
       32_KiB)
   , enable_coproc(
-      *this, "enable_coproc", "Enable coprocessing mode", required::no, false)
+      *this,
+      "enable_coproc",
+      "Enable coprocessing mode",
+      {.visibility = visibility::user},
+      false)
   , coproc_max_inflight_bytes(
       *this,
       "coproc_max_inflight_bytes",
       "Maximum amountt of inflight bytes when sending data to wasm engine",
-      required::no,
+      {.visibility = visibility::tunable},
       10_MiB)
   , coproc_max_ingest_bytes(
       *this,
       "coproc_max_ingest_bytes",
       "Maximum amount of data to hold from input logs in memory",
-      required::no,
+      {.visibility = visibility::tunable},
       640_KiB)
   , coproc_max_batch_size(
       *this,
       "coproc_max_batch_size",
       "Maximum amount of bytes to read from one topic read",
-      required::no,
+      {.visibility = visibility::tunable},
       32_KiB)
   , coproc_offset_flush_interval_ms(
       *this,
       "coproc_offset_flush_interval_ms",
       "Interval for which all coprocessor offsets are flushed to disk",
-      required::no,
+      {.visibility = visibility::tunable},
       300000ms) // five minutes
   , seed_server_meta_topic_partitions(
-      *this,
-      "seed_server_meta_topic_partitions",
-      "Number of partitions in internal raft metadata topic",
-      required::no,
-      7)
+      *this, "seed_server_meta_topic_partitions")
   , raft_heartbeat_interval_ms(
       *this,
       "raft_heartbeat_interval_ms",
       "Milliseconds for raft leader heartbeats",
-      required::no,
+      {.visibility = visibility::tunable},
       std::chrono::milliseconds(150))
   , raft_heartbeat_timeout_ms(
       *this,
       "raft_heartbeat_timeout_ms",
       "raft heartbeat RPC timeout",
-      required::no,
+      {.visibility = visibility::tunable},
       3s)
   , raft_heartbeat_disconnect_failures(
       *this,
       "raft_heartbeat_disconnect_failures",
       "After how many failed heartbeats to forcibly close an unresponsive TCP "
       "connection.  Set to 0 to disable force disconnection.",
-      required::no,
+      {.visibility = visibility::tunable},
       3)
-  , min_version(
-      *this, "min_version", "minimum redpanda compat version", required::no, 0)
-  , max_version(
-      *this, "max_version", "max redpanda compat version", required::no, 1)
-  , use_scheduling_groups(
-      *this,
-      "use_scheduling_groups",
-      "Manage CPU scheduling",
-      required::no,
-      false)
+
+  , min_version(*this, "min_version")
+  , max_version(*this, "max_version")
+
+  , use_scheduling_groups(*this, "use_scheduling_groups")
   , enable_admin_api(
-      *this, "enable_admin_api", "Enable the admin API", required::no, true)
+      *this,
+      "enable_admin_api",
+      "Enable the admin API",
+      base_property::metadata{},
+      true)
   , default_num_windows(
       *this,
       "default_num_windows",
       "Default number of quota tracking windows",
-      required::no,
+      {.visibility = visibility::tunable},
       10)
   , default_window_sec(
       *this,
       "default_window_sec",
       "Default quota tracking window size in milliseconds",
-      required::no,
+      {.visibility = visibility::tunable},
       std::chrono::milliseconds(1000))
   , quota_manager_gc_sec(
       *this,
       "quota_manager_gc_sec",
       "Quota manager GC frequency in milliseconds",
-      required::no,
+      {.visibility = visibility::tunable},
       std::chrono::milliseconds(30000))
   , target_quota_byte_rate(
       *this,
       "target_quota_byte_rate",
       "Target quota byte rate (bytes per second) - 2GB default",
-      {.example = "1073741824"},
+      {.example = "1073741824", .visibility = visibility::tunable},
       2_GiB)
   , cluster_id(
-      *this, "cluster_id", "Cluster identifier", required::no, std::nullopt)
+      *this,
+      "cluster_id",
+      "Cluster identifier",
+      {.needs_restart = needs_restart::no},
+      std::nullopt)
   , disable_metrics(
       *this,
       "disable_metrics",
       "Disable registering metrics",
-      required::no,
+      base_property::metadata{},
       false)
   , group_min_session_timeout_ms(
       *this,
@@ -192,117 +195,122 @@ configuration::configuration()
       "timeouts result in quicker failure detection at the cost of more "
       "frequent "
       "consumer heartbeating, which can overwhelm broker resources.",
-      required::no,
+      {.needs_restart = needs_restart::no},
       6000ms)
   , group_max_session_timeout_ms(
       *this,
       "group_max_session_timeout_ms",
       "The maximum allowed session timeout for registered consumers. Longer "
       "timeouts give consumers more time to process messages in between "
-      "heartbeats at the cost of a longer time to detect failures. "
-      "Default quota tracking window size in milliseconds",
-      required::no,
+      "heartbeats at the cost of a longer time to detect failures. ",
+      {.needs_restart = needs_restart::no},
       300s)
   , group_initial_rebalance_delay(
       *this,
       "group_initial_rebalance_delay",
       "Extra delay (ms) added to rebalance phase to wait for new members",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       300ms)
   , group_new_member_join_timeout(
       *this,
       "group_new_member_join_timeout",
       "Timeout for new member joins",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       30'000ms)
   , metadata_dissemination_interval_ms(
       *this,
       "metadata_dissemination_interval_ms",
       "Interaval for metadata dissemination batching",
-      {.example = "5000"},
+      {.example = "5000", .visibility = visibility::tunable},
       3'000ms)
   , metadata_dissemination_retry_delay_ms(
       *this,
       "metadata_dissemination_retry_delay_ms",
       "Delay before retry a topic lookup in a shard or other meta tables",
-      required::no,
+      {.visibility = visibility::tunable},
       0'500ms)
   , metadata_dissemination_retries(
       *this,
       "metadata_dissemination_retries",
       "Number of attempts of looking up a topic's meta data like shard before "
       "failing a request",
-      required::no,
+      {.visibility = visibility::tunable},
       30)
   , tm_sync_timeout_ms(
       *this,
       "tm_sync_timeout_ms",
       "Time to wait state catch up before rejecting a request",
-      required::no,
+      {.visibility = visibility::user},
       10s)
   , tm_violation_recovery_policy(
       *this,
       "tm_violation_recovery_policy",
       "Describes how to recover from an invariant violation happened on the "
       "transaction coordinator level",
-      {.example = "best_effort"},
+      {.example = "best_effort", .visibility = visibility::user},
       model::violation_recovery_policy::crash)
   , rm_sync_timeout_ms(
       *this,
       "rm_sync_timeout_ms",
       "Time to wait state catch up before rejecting a request",
-      required::no,
+      {.visibility = visibility::user},
       10s)
   , tx_timeout_delay_ms(
       *this,
       "tx_timeout_delay_ms",
       "Delay before scheduling next check for timed out transactions",
-      required::no,
+      {.visibility = visibility::user},
       1000ms)
   , rm_violation_recovery_policy(
       *this,
       "rm_violation_recovery_policy",
       "Describes how to recover from an invariant violation happened on the "
       "partition level",
-      {.example = "best_effort"},
+      {.example = "best_effort", .visibility = visibility::user},
       model::violation_recovery_policy::crash)
   , fetch_reads_debounce_timeout(
       *this,
       "fetch_reads_debounce_timeout",
       "Time to wait for next read in fetch request when requested min bytes "
       "wasn't reached",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1ms)
   , alter_topic_cfg_timeout_ms(
       *this,
       "alter_topic_cfg_timeout_ms",
       "Time to wait for entries replication in controller log when executing "
       "alter configuration requst",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5s)
   , log_cleanup_policy(
       *this,
       "log_cleanup_policy",
       "Default topic cleanup policy",
-      {required::no, needs_restart::no, "compact,delete"},
+      {.needs_restart = needs_restart::no,
+       .example = "compact,delete",
+       .visibility = visibility::user},
       model::cleanup_policy_bitflags::deletion)
   , log_message_timestamp_type(
       *this,
       "log_message_timestamp_type",
       "Default topic messages timestamp type",
-      {required::no, needs_restart::no, "LogAppendTime"},
+      {.needs_restart = needs_restart::no,
+       .example = "LogAppendTime",
+       .visibility = visibility::user},
       model::timestamp_type::create_time)
   , log_compression_type(
       *this,
       "log_compression_type",
       "Default topic compression type",
-      {required::no, needs_restart::no, "snappy"},
+      {.needs_restart = needs_restart::no,
+       .example = "snappy",
+       .visibility = visibility::user},
       model::compression::producer)
   , fetch_max_bytes(
       *this,
       "fetch_max_bytes",
       "Maximum number of bytes returned in fetch request",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       55_MiB)
   , metadata_status_wait_timeout_ms(
       *this,
@@ -316,248 +324,258 @@ configuration::configuration()
       "transactional_id_expiration_ms",
       "Producer ids are expired once this time has elapsed after the last "
       "write with the given producer id.",
-      required::no,
+      {.visibility = visibility::user},
       10080min)
   , enable_idempotence(
       *this,
       "enable_idempotence",
       "Enable idempotent producer",
-      required::no,
+      {.visibility = visibility::user},
       false)
   , enable_transactions(
-      *this, "enable_transactions", "Enable transactions", required::no, false)
+      *this,
+      "enable_transactions",
+      "Enable transactions",
+      {.visibility = visibility::user},
+      false)
   , abort_index_segment_size(
       *this,
       "abort_index_segment_size",
       "Capacity (in number of txns) of an abort index segment",
-      required::no,
+      {.visibility = visibility::tunable},
       50000)
   , delete_retention_ms(
       *this,
       "delete_retention_ms",
       "delete segments older than this - default 1 week",
-      required::no,
+      {.visibility = visibility::user},
       10080min)
   , log_compaction_interval_ms(
       *this,
       "log_compaction_interval_ms",
       "How often do we trigger background compaction",
-      required::no,
+      {.visibility = visibility::user},
       10s)
   , retention_bytes(
       *this,
       "retention_bytes",
-      "max bytes per partition on disk before triggering a compaction",
-      required::no,
+      "Default max bytes per partition on disk before triggering a compaction",
+      {.visibility = visibility::user},
       std::nullopt)
   , group_topic_partitions(
       *this,
       "group_topic_partitions",
       "Number of partitions in the internal group membership topic",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1)
   , default_topic_replication(
       *this,
       "default_topic_replications",
       "Default replication factor for new topics",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       1)
   , transaction_coordinator_replication(
       *this,
       "transaction_coordinator_replication",
       "Replication factor for a transaction coordinator topic",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       1)
   , id_allocator_replication(
       *this,
       "id_allocator_replication",
       "Replication factor for an id allocator topic",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       1)
   , transaction_coordinator_cleanup_policy(
       *this,
       "transaction_coordinator_cleanup_policy",
       "Cleanup policy for a transaction coordinator topic",
-      {.required = required::no, .example = "compact,delete"},
+      {.needs_restart = needs_restart::no,
+       .example = "compact,delete",
+       .visibility = visibility::user},
       model::cleanup_policy_bitflags::deletion)
   , transaction_coordinator_delete_retention_ms(
       *this,
       "transaction_coordinator_delete_retention_ms",
       "delete segments older than this - default 1 week",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       10080min)
   , transaction_coordinator_log_segment_size(
       *this,
       "transaction_coordinator_log_segment_size",
       "How large in bytes should each log segment be (default 1G)",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_GiB)
   , abort_timed_out_transactions_interval_ms(
       *this,
       "abort_timed_out_transactions_interval_ms",
       "How often look for the inactive transactions and abort them",
-      required::no,
+      {.visibility = visibility::tunable},
       1min)
   , create_topic_timeout_ms(
       *this,
       "create_topic_timeout_ms",
       "Timeout (ms) to wait for new topic creation",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       2'000ms)
   , wait_for_leader_timeout_ms(
       *this,
       "wait_for_leader_timeout_ms",
       "Timeout (ms) to wait for leadership in metadata cache",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5'000ms)
   , default_topic_partitions(
       *this,
       "default_topic_partitions",
       "Default number of partitions per topic",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       1)
   , disable_batch_cache(
       *this,
       "disable_batch_cache",
       "Disable batch cache in log manager",
-      required::no,
+      {.visibility = visibility::tunable},
       false)
   , raft_election_timeout_ms(
       *this,
       "election_timeout_ms",
       "Election timeout expressed in milliseconds",
-      required::no,
+      {.visibility = visibility::tunable},
       1'500ms)
   , kafka_group_recovery_timeout_ms(
       *this,
       "kafka_group_recovery_timeout_ms",
       "Kafka group recovery timeout expressed in milliseconds",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       30'000ms)
   , replicate_append_timeout_ms(
       *this,
       "replicate_append_timeout_ms",
       "Timeout for append entries requests issued while replicating entries",
-      required::no,
+      {.visibility = visibility::tunable},
       3s)
   , recovery_append_timeout_ms(
       *this,
       "recovery_append_timeout_ms",
       "Timeout for append entries requests issued while updating stale "
       "follower",
-      required::no,
+      {.visibility = visibility::tunable},
       5s)
   , raft_replicate_batch_window_size(
       *this,
       "raft_replicate_batch_window_size",
       "Max size of requests cached for replication",
-      required::no,
+      {.visibility = visibility::tunable},
       1_MiB)
   , raft_learner_recovery_rate(
       *this,
       "raft_learner_recovery_rate",
       "Raft learner recovery rate limit in bytes per sec",
-      required::no,
+      {.visibility = visibility::user},
       100_MiB)
   , raft_smp_max_non_local_requests(
       *this,
       "raft_smp_max_non_local_requests",
       "Maximum number of x-core requests pending in Raft seastar::smp group. "
       "(for more details look at `seastar::smp_service_group` documentation)",
-      required::no,
+      {.visibility = visibility::tunable},
       default_raft_non_local_requests())
   , raft_max_concurrent_append_requests_per_follower(
       *this,
       "raft_max_concurrent_append_requests_per_follower",
       "Maximum number of concurrent append entries requests sent by leader to "
       "one follower",
-      required::no,
+      {.visibility = visibility::tunable},
       16)
   , reclaim_min_size(
       *this,
       "reclaim_min_size",
       "Minimum batch cache reclaim size",
-      required::no,
+      {.visibility = visibility::tunable},
       128_KiB)
   , reclaim_max_size(
       *this,
       "reclaim_max_size",
       "Maximum batch cache reclaim size",
-      required::no,
+      {.visibility = visibility::tunable},
       4_MiB)
   , reclaim_growth_window(
       *this,
       "reclaim_growth_window",
       "Length of time in which reclaim sizes grow",
-      required::no,
+      {.visibility = visibility::tunable},
       3'000ms)
   , reclaim_stable_window(
       *this,
       "reclaim_stable_window",
       "Length of time above which growth is reset",
-      required::no,
+      {.visibility = visibility::tunable},
       10'000ms)
   , auto_create_topics_enabled(
       *this,
       "auto_create_topics_enabled",
       "Allow topic auto creation",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
   , enable_pid_file(
       *this,
       "enable_pid_file",
       "Enable pid file. You probably don't want to change this.",
-      required::no,
+      {.visibility = visibility::tunable},
       true)
   , kvstore_flush_interval(
       *this,
       "kvstore_flush_interval",
       "Key-value store flush interval (ms)",
-      required::no,
+      {.visibility = visibility::tunable},
       std::chrono::milliseconds(10))
   , kvstore_max_segment_size(
       *this,
       "kvstore_max_segment_size",
       "Key-value maximum segment size (bytes)",
-      required::no,
+      {.visibility = visibility::tunable},
       16_MiB)
   , max_kafka_throttle_delay_ms(
       *this,
       "max_kafka_throttle_delay_ms",
       "Fail-safe maximum throttle delay on kafka requests",
-      required::no,
+      {.visibility = visibility::tunable},
       60'000ms)
   , raft_io_timeout_ms(
-      *this, "raft_io_timeout_ms", "Raft I/O timeout", required::no, 10'000ms)
+      *this,
+      "raft_io_timeout_ms",
+      "Raft I/O timeout",
+      {.visibility = visibility::tunable},
+      10'000ms)
   , join_retry_timeout_ms(
       *this,
       "join_retry_timeout_ms",
       "Time between cluster join retries in milliseconds",
-      required::no,
+      {.visibility = visibility::tunable},
       5s)
   , raft_timeout_now_timeout_ms(
       *this,
       "raft_timeout_now_timeout_ms",
       "Timeout for a timeout now request",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1s)
   , raft_transfer_leader_recovery_timeout_ms(
       *this,
       "raft_transfer_leader_recovery_timeout_ms",
       "Timeout waiting for follower recovery when transferring leadership",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
   , release_cache_on_segment_roll(
       *this,
       "release_cache_on_segment_roll",
       "Free cache when segments roll",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
   , segment_appender_flush_timeout_ms(
       *this,
       "segment_appender_flush_timeout_ms",
       "Maximum delay until buffered data is written",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::chrono::milliseconds(1s))
   , fetch_session_eviction_timeout_ms(
       *this,
@@ -566,27 +584,27 @@ configuration::configuration()
       "sessions. Maximum time after which inactive session will be deleted is "
       "two time given configuration value"
       "cache",
-      required::no,
+      {.visibility = visibility::tunable},
       60s)
   , append_chunk_size(
       *this,
       "append_chunk_size",
       "Size of direct write operations to disk",
-      {.example = "32768"},
+      {.example = "32768", .visibility = visibility::tunable},
       16_KiB,
       storage::internal::chunk_cache::validate_chunk_size)
   , max_compacted_log_segment_size(
       *this,
       "max_compacted_log_segment_size",
       "Max compacted segment size after consolidation",
-      {.example = "10737418240"},
+      {.example = "10737418240", .visibility = visibility::tunable},
       5_GiB)
   , id_allocator_log_capacity(
       *this,
       "id_allocator_log_capacity",
       "Capacity of the id_allocator log in number of messages. "
       "Once it reached id_allocator_stm should compact the log.",
-      required::no,
+      {.visibility = visibility::tunable},
       100)
   , id_allocator_batch_size(
       *this,
@@ -594,170 +612,174 @@ configuration::configuration()
       "Id allocator allocates messages in batches (each batch is a "
       "one log record) and then serves requests from memory without "
       "touching the log until the batch is exhausted.",
-      required::no,
+      {.visibility = visibility::tunable},
       1000)
   , enable_sasl(
       *this,
       "enable_sasl",
       "Enable SASL authentication for Kafka connections.",
-      required::no,
+      {.visibility = visibility::user},
       false)
   , controller_backend_housekeeping_interval_ms(
       *this,
       "controller_backend_housekeeping_interval_ms",
       "Interval between iterations of controller backend housekeeping loop",
-      required::no,
+      {.visibility = visibility::tunable},
       1s)
   , node_management_operation_timeout_ms(
       *this,
       "node_management_operation_timeout_ms",
       "Timeout for executing node management operations",
-      required::no,
+      {.visibility = visibility::tunable},
       5s)
   , compaction_ctrl_update_interval_ms(
-      *this, "compaction_ctrl_update_interval_ms", "", required::no, 30s)
+      *this,
+      "compaction_ctrl_update_interval_ms",
+      "",
+      {.visibility = visibility::tunable},
+      30s)
   , compaction_ctrl_p_coeff(
       *this,
       "compaction_ctrl_p_coeff",
       "proportional coefficient for compaction PID controller. This has to be "
       "negative since compaction backlog should decrease when number of "
       "compaction shares increases",
-      required::no,
+      {.visibility = visibility::tunable},
       -12.5)
   , compaction_ctrl_i_coeff(
       *this,
       "compaction_ctrl_i_coeff",
       "integral coefficient for compaction PID controller.",
-      required::no,
+      {.visibility = visibility::tunable},
       0.0)
   , compaction_ctrl_d_coeff(
       *this,
       "compaction_ctrl_d_coeff",
       "derivative coefficient for compaction PID controller.",
-      required::no,
+      {.visibility = visibility::tunable},
       0.2)
   , compaction_ctrl_min_shares(
       *this,
       "compaction_ctrl_min_shares",
       "minimum number of IO and CPU shares that compaction process can use",
-      required::no,
+      {.visibility = visibility::tunable},
       10)
   , compaction_ctrl_max_shares(
       *this,
       "compaction_ctrl_max_shares",
       "maximum number of IO and CPU shares that compaction process can use",
-      required::no,
+      {.visibility = visibility::tunable},
       1000)
   , compaction_ctrl_backlog_size(
       *this,
       "compaction_ctrl_backlog_size",
       "target backlog size for compaction controller. if not set compaction "
       "target compaction backlog would be equal to ",
-      required::no,
+      {.visibility = visibility::tunable},
       std::nullopt)
   , members_backend_retry_ms(
       *this,
       "members_backend_retry_ms",
       "Time between members backend reconciliation loop retries ",
-      required::no,
+      {.visibility = visibility::tunable},
       5s)
   , cloud_storage_enabled(
       *this,
       "cloud_storage_enabled",
       "Enable archival storage",
-      required::no,
+      {.visibility = visibility::user},
       false)
   , cloud_storage_access_key(
       *this,
       "cloud_storage_access_key",
       "AWS access key",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , cloud_storage_secret_key(
       *this,
       "cloud_storage_secret_key",
       "AWS secret key",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , cloud_storage_region(
       *this,
       "cloud_storage_region",
       "AWS region that houses the bucket used for storage",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , cloud_storage_bucket(
       *this,
       "cloud_storage_bucket",
       "AWS bucket that should be used to store data",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , cloud_storage_api_endpoint(
       *this,
       "cloud_storage_api_endpoint",
       "Optional API endpoint",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , cloud_storage_reconciliation_ms(
       *this,
       "cloud_storage_reconciliation_interval_ms",
       "Interval at which the archival service runs reconciliation (ms)",
-      required::no,
+      {.visibility = visibility::tunable},
       10s)
   , cloud_storage_max_connections(
       *this,
       "cloud_storage_max_connections",
       "Max number of simultaneous uploads to S3",
-      required::no,
+      {.visibility = visibility::user},
       20)
   , cloud_storage_disable_tls(
       *this,
       "cloud_storage_disable_tls",
       "Disable TLS for all S3 connections",
-      required::no,
+      {.visibility = visibility::user},
       false)
   , cloud_storage_api_endpoint_port(
       *this,
       "cloud_storage_api_endpoint_port",
       "TLS port override",
-      required::no,
+      {.visibility = visibility::user},
       443)
   , cloud_storage_trust_file(
       *this,
       "cloud_storage_trust_file",
       "Path to certificate that should be used to validate server certificate "
       "during TLS handshake",
-      required::no,
+      {.visibility = visibility::user},
       std::nullopt)
   , cloud_storage_initial_backoff_ms(
       *this,
       "cloud_storage_initial_backoff_ms",
       "Initial backoff time for exponetial backoff algorithm (ms)",
-      required::no,
+      {.visibility = visibility::tunable},
       100ms)
   , cloud_storage_segment_upload_timeout_ms(
       *this,
       "cloud_storage_segment_upload_timeout_ms",
       "Log segment upload timeout (ms)",
-      required::no,
+      {.visibility = visibility::tunable},
       30s)
   , cloud_storage_manifest_upload_timeout_ms(
       *this,
       "cloud_storage_manifest_upload_timeout_ms",
       "Manifest upload timeout (ms)",
-      required::no,
+      {.visibility = visibility::tunable},
       10s)
   , cloud_storage_max_connection_idle_time_ms(
       *this,
       "cloud_storage_max_connection_idle_time_ms",
       "Max https connection idle time (ms)",
-      required::no,
+      {.visibility = visibility::tunable},
       5s)
   , cloud_storage_segment_max_upload_interval_sec(
       *this,
       "cloud_storage_segment_max_upload_interval_sec",
       "Time that segment can be kept locally without uploading it to the "
       "remote storage (sec)",
-      required::no,
+      {.visibility = visibility::tunable},
       std::nullopt)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
@@ -793,141 +815,145 @@ configuration::configuration()
       *this,
       "cloud_storage_cache_size",
       "Max size of archival cache",
-      required::no,
+      {.visibility = visibility::user},
       20_GiB)
   , cloud_storage_cache_check_interval_ms(
       *this,
       "cloud_storage_cache_check_interval",
       "Timeout to check if cache eviction should be triggered",
-      required::no,
+      {.visibility = visibility::tunable},
       30s)
   , superusers(
-      *this, "superusers", "List of superuser usernames", required::no, {})
+      *this,
+      "superusers",
+      "List of superuser usernames",
+      {.visibility = visibility::user},
+      {})
   , kafka_qdc_latency_alpha(
       *this,
       "kafka_qdc_latency_alpha",
       "Smoothing parameter for kafka queue depth control latency tracking.",
-      required::no,
+      {.visibility = visibility::tunable},
       0.002)
   , kafka_qdc_window_size_ms(
       *this,
       "kafka_qdc_window_size_ms",
       "Window size for kafka queue depth control latency tracking.",
-      required::no,
+      {.visibility = visibility::tunable},
       1500ms)
   , kafka_qdc_window_count(
       *this,
       "kafka_qdc_window_count",
       "Number of windows used in kafka queue depth control latency tracking.",
-      required::no,
+      {.visibility = visibility::tunable},
       12)
   , kafka_qdc_enable(
       *this,
       "kafka_qdc_enable",
       "Enable kafka queue depth control.",
-      required::no,
+      {.visibility = visibility::user},
       false)
   , kafka_qdc_depth_alpha(
       *this,
       "kafka_qdc_depth_alpha",
       "Smoothing factor for kafka queue depth control depth tracking.",
-      required::no,
+      {.visibility = visibility::tunable},
       0.8)
   , kafka_qdc_max_latency_ms(
       *this,
       "kafka_qdc_max_latency_ms",
       "Max latency threshold for kafka queue depth control depth tracking.",
-      required::no,
+      {.visibility = visibility::user},
       80ms)
   , kafka_qdc_idle_depth(
       *this,
       "kafka_qdc_idle_depth",
       "Queue depth when idleness is detected in kafka queue depth control.",
-      required::no,
+      {.visibility = visibility::tunable},
       10)
   , kafka_qdc_min_depth(
       *this,
       "kafka_qdc_min_depth",
       "Minimum queue depth used in kafka queue depth control.",
-      required::no,
+      {.visibility = visibility::tunable},
       1)
   , kafka_qdc_max_depth(
       *this,
       "kafka_qdc_max_depth",
       "Maximum queue depth used in kafka queue depth control.",
-      required::no,
+      {.visibility = visibility::tunable},
       100)
   , kafka_qdc_depth_update_ms(
       *this,
       "kafka_qdc_depth_update_ms",
       "Update frequency for kafka queue depth control.",
-      required::no,
+      {.visibility = visibility::tunable},
       7s)
   , zstd_decompress_workspace_bytes(
       *this,
       "zstd_decompress_workspace_bytes",
       "Size of the zstd decompression workspace",
-      required::no,
+      {.visibility = visibility::tunable},
       8_MiB)
   , full_raft_configuration_recovery_pattern(
       *this,
       "full_raft_configuration_recovery_pattern",
-      "Recovery raft configuration on start for NTPs matching pattern",
-      required::no,
+      "Recover raft configuration on start for NTPs matching pattern",
+      {.visibility = visibility::tunable},
       {})
   , enable_auto_rebalance_on_node_add(
       *this,
       "enable_auto_rebalance_on_node_add",
       "Enable automatic partition rebalancing when new nodes are added",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
   , enable_leader_balancer(
       *this,
       "enable_leader_balancer",
       "Enable automatic leadership rebalancing",
-      required::no,
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       true)
   , leader_balancer_idle_timeout(
       *this,
       "leader_balancer_idle_timeout",
       "Leadership rebalancing idle timeout",
-      required::no,
+      {.visibility = visibility::tunable},
       2min)
   , leader_balancer_mute_timeout(
       *this,
       "leader_balancer_mute_timeout",
       "Leadership rebalancing mute timeout",
-      required::no,
+      {.visibility = visibility::tunable},
       5min)
   , leader_balancer_node_mute_timeout(
       *this,
       "leader_balancer_mute_timeout",
       "Leadership rebalancing node mute timeout",
-      required::no,
+      {.visibility = visibility::tunable},
       20s)
   , internal_topic_replication_factor(
       *this,
       "internal_topic_replication_factor",
       "Target replication factor for internal topics",
-      required::no,
+      {.visibility = visibility::user},
       3)
   , health_manager_tick_interval(
       *this,
       "health_manager_tick_interval",
       "How often the health manager runs",
-      required::no,
+      {.visibility = visibility::tunable},
       3min)
   , health_monitor_tick_interval(
       *this,
       "health_monitor_tick_interval",
       "How often health monitor refresh cluster state",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
   , health_monitor_max_metadata_age(
       *this,
       "health_monitor_max_metadata_age",
       "Max age of metadata cached in the health monitor of non controller node",
-      required::no,
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s) {}
 
 void configuration::load(const YAML::Node& root_node) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -56,14 +56,14 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> coproc_offset_flush_interval_ms;
 
     // Raft
-    property<int32_t> seed_server_meta_topic_partitions;
+    deprecated_property seed_server_meta_topic_partitions;
     property<std::chrono::milliseconds> raft_heartbeat_interval_ms;
     property<std::chrono::milliseconds> raft_heartbeat_timeout_ms;
     property<size_t> raft_heartbeat_disconnect_failures;
-    property<int16_t> min_version;
-    property<int16_t> max_version;
+    deprecated_property min_version;
+    deprecated_property max_version;
     // Kafka
-    property<bool> use_scheduling_groups;
+    deprecated_property use_scheduling_groups;
     property<bool> enable_admin_api;
     property<int16_t> default_num_windows;
     property<std::chrono::milliseconds> default_window_sec;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -316,4 +316,16 @@ private:
     std::optional<T> _min;
     std::optional<T> _max;
 };
+
+/**
+ * A deprecated property only exposes metadata and does not expose a usable
+ * value.
+ */
+class deprecated_property : public property<ss::sstring> {
+public:
+    deprecated_property(config_store& conf, std::string_view name)
+      : property(conf, name, "", {.visibility = visibility::deprecated}) {}
+
+    void set_value(std::any) override { return; }
+};
 }; // namespace config

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -289,11 +289,11 @@ public:
       config_store& conf,
       std::string_view name,
       std::string_view desc,
-      required req = required::yes,
+      base_property::metadata meta,
       T def = T{},
       std::optional<T> min = std::nullopt,
       std::optional<T> max = std::nullopt)
-      : property<T>(conf, name, desc, req, def)
+      : property<T>(conf, name, desc, meta, def)
       , _min(min)
       , _max(max) {}
 

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "config/base_property.h"
 #include "config/rjson_serialization.h"
+#include "reflection/type_traits.h"
 #include "utils/to_string.h"
 
 #include <seastar/util/noncopyable_function.hh>
@@ -56,6 +57,14 @@ public:
     const T& value() const { return _value; }
 
     const T& default_value() const { return _default; }
+
+    std::string_view type_name() const override;
+
+    std::optional<std::string_view> units_name() const override;
+
+    bool is_nullable() const override;
+
+    bool is_array() const override;
 
     bool is_overriden() const { return is_required() || _value != _default; }
 
@@ -123,6 +132,128 @@ private:
     };
 };
 
+namespace detail {
+
+template<typename T>
+concept has_type_name = requires(T x) {
+    x.type_name();
+};
+
+template<typename T>
+concept is_collection = requires(T x) {
+    typename T::value_type;
+    !std::is_same_v<typename T::value_type, char>;
+    {x.size()};
+};
+
+template<typename T>
+struct dependent_false : std::false_type {};
+
+template<typename T>
+consteval std::string_view property_type_name() {
+    using type = std::decay_t<T>;
+    if constexpr (std::is_same_v<type, ss::sstring>) {
+        // String check must come before is_collection check
+        return "string";
+    } else if constexpr (std::is_same_v<type, bool>) {
+        // boolean check must come before is_integral check
+        return "boolean";
+    } else if constexpr (reflection::is_std_optional_v<type>) {
+        return property_type_name<typename type::value_type>();
+    } else if constexpr (is_collection<type>) {
+        return property_type_name<typename type::value_type>();
+    } else if constexpr (has_type_name<type>) {
+        return type::type_name();
+    } else if constexpr (std::is_same_v<type, model::compression>) {
+        return "string";
+    } else if constexpr (std::is_same_v<type, model::timestamp_type>) {
+        return "string";
+    } else if constexpr (std::is_same_v<type, model::cleanup_policy_bitflags>) {
+        return "string";
+    } else if constexpr (std::
+                           is_same_v<type, model::violation_recovery_policy>) {
+        return "string";
+    } else if constexpr (std::is_same_v<type, config::data_directory_path>) {
+        return "string";
+    } else if constexpr (std::is_same_v<type, model::node_id>) {
+        return "integer";
+    } else if constexpr (std::is_same_v<type, std::chrono::seconds>) {
+        return "integer";
+    } else if constexpr (std::is_same_v<type, std::chrono::milliseconds>) {
+        return "integer";
+    } else if constexpr (std::is_same_v<type, seed_server>) {
+        return "seed_server";
+    } else if constexpr (std::is_same_v<type, unresolved_address>) {
+        return "unresolved_address";
+    } else if constexpr (std::is_same_v<type, tls_config>) {
+        return "tls_config";
+    } else if constexpr (std::is_same_v<type, endpoint_tls_config>) {
+        return "endpoint_tls_config";
+    } else if constexpr (std::is_same_v<type, model::broker_endpoint>) {
+        return "broker_endpoint";
+    } else if constexpr (std::is_floating_point_v<type>) {
+        return "number";
+    } else if constexpr (std::is_integral_v<type>) {
+        return "integer";
+    } else {
+        static_assert(dependent_false<T>::value, "Type name not defined");
+    }
+}
+
+template<typename T>
+consteval std::string_view property_units_name() {
+    using type = std::decay_t<T>;
+    if constexpr (std::is_same_v<type, std::chrono::milliseconds>) {
+        return "ms";
+    } else if constexpr (std::is_same_v<type, std::chrono::seconds>) {
+        return "s";
+    } else if constexpr (reflection::is_std_optional_v<type>) {
+        return property_units_name<typename type::value_type>();
+    } else {
+        // This will be transformed to nullopt at runtime: returning
+        // std::optional from this function triggered a clang crash.
+        return "";
+    }
+}
+
+} // namespace detail
+
+template<typename T>
+std::string_view property<T>::type_name() const {
+    // Go via a non-member function so that specialized implementations
+    // can use concepts without all the same concepts having to apply
+    // to the type T in the class definition.
+    return detail::property_type_name<T>();
+}
+
+template<typename T>
+std::optional<std::string_view> property<T>::units_name() const {
+    auto u = detail::property_units_name<T>();
+    if (u == "") {
+        return std::nullopt;
+    } else {
+        return u;
+    }
+}
+
+template<typename T>
+bool property<T>::is_nullable() const {
+    if constexpr (reflection::is_std_optional_v<std::decay_t<T>>) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+template<typename T>
+bool property<T>::is_array() const {
+    if constexpr (detail::is_collection<std::decay_t<T>>) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 /*
  * Same as property<std::vector<T>> but will also decode a single T. This can be
  * useful for dealing with backwards compatibility or creating easier yaml
@@ -185,5 +316,4 @@ private:
     std::optional<T> _min;
     std::optional<T> _max;
 };
-
 }; // namespace config

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -155,4 +155,10 @@ void rjson_serialize(
     stringize(w, v);
 }
 
+void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const model::violation_recovery_policy& v) {
+    stringize(w, v);
+}
+
 } // namespace json

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -65,4 +65,8 @@ void rjson_serialize(
   rapidjson::Writer<rapidjson::StringBuffer>& w,
   const model::cleanup_policy_bitflags& v);
 
+void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const model::violation_recovery_policy& v);
+
 } // namespace json

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -39,13 +39,13 @@ struct test_config : public config::config_store {
         *this,
         "optional_int",
         "An optional int value",
-        config::required::no,
+        {.visibility = config::visibility::tunable},
         100)
       , required_string(
           *this,
           "required_string",
           "Required string value",
-          config::base_property::metadata{})
+          {.visibility = config::visibility::user})
       , an_int64_t(
           *this, "an_int64_t", "Some other int type", config::required::no, 200)
       , an_aggregate(
@@ -282,10 +282,16 @@ SEASTAR_THREAD_TEST_CASE(deserialize_explicit_null) {
 SEASTAR_THREAD_TEST_CASE(property_metadata) {
     auto cfg = test_config();
     BOOST_TEST(cfg.optional_int.type_name() == "integer");
+    BOOST_TEST(
+      config::to_string_view(cfg.optional_int.get_visibility()) == "tunable");
+
     BOOST_TEST(cfg.boolean.is_nullable() == false);
     BOOST_TEST(cfg.nullable_string.is_array() == false);
 
     BOOST_TEST(cfg.required_string.type_name() == "string");
+    BOOST_TEST(
+      config::to_string_view(cfg.required_string.get_visibility()) == "user");
+
     BOOST_TEST(cfg.boolean.is_nullable() == false);
     BOOST_TEST(cfg.nullable_string.is_array() == false);
 

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -33,6 +33,9 @@ struct test_config : public config::config_store {
     config::property<std::optional<int16_t>> nullable_int;
     config::property<std::optional<ss::sstring>> nullable_string;
     config::property<bool> boolean;
+    config::property<std::chrono::seconds> seconds;
+    config::property<std::optional<std::chrono::seconds>> optional_seconds;
+    config::property<std::chrono::milliseconds> milliseconds;
 
     test_config()
       : optional_int(
@@ -76,7 +79,20 @@ struct test_config : public config::config_store {
           "boolean",
           "Plain boolean property",
           config::required::no,
-          false) {}
+          false)
+      , seconds(*this, "seconds", "Plain seconds", config::required::no, {})
+      , optional_seconds(
+          *this,
+          "optional_seconds",
+          "Optional seconds",
+          config::required::no,
+          {})
+      , milliseconds(
+          *this,
+          "milliseconds",
+          "Plain milliseconds",
+          config::required::no,
+          {}) {}
 };
 
 YAML::Node minimal_valid_configuration() {
@@ -318,4 +334,19 @@ SEASTAR_THREAD_TEST_CASE(property_metadata) {
     BOOST_TEST(cfg.boolean.type_name() == "boolean");
     BOOST_TEST(cfg.boolean.is_nullable() == false);
     BOOST_TEST(cfg.boolean.is_array() == false);
+
+    BOOST_TEST(cfg.seconds.type_name() == "integer");
+    BOOST_TEST(cfg.seconds.units_name() == "s");
+    BOOST_TEST(cfg.seconds.is_nullable() == false);
+    BOOST_TEST(cfg.seconds.is_array() == false);
+
+    BOOST_TEST(cfg.optional_seconds.type_name() == "integer");
+    BOOST_TEST(cfg.optional_seconds.units_name() == "s");
+    BOOST_TEST(cfg.optional_seconds.is_nullable() == true);
+    BOOST_TEST(cfg.optional_seconds.is_array() == false);
+
+    BOOST_TEST(cfg.milliseconds.type_name() == "integer");
+    BOOST_TEST(cfg.milliseconds.units_name() == "ms");
+    BOOST_TEST(cfg.milliseconds.is_nullable() == false);
+    BOOST_TEST(cfg.milliseconds.is_array() == false);
 };

--- a/src/v/config/tests/custom_aggregate.h
+++ b/src/v/config/tests/custom_aggregate.h
@@ -22,4 +22,6 @@ struct custom_aggregate {
     bool operator==(const custom_aggregate& rhs) const {
         return string_value == rhs.string_value && int_value == rhs.int_value;
     }
+
+    static consteval std::string_view type_name() { return "custom_aggregate"; }
 };

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -94,6 +94,13 @@ void rjson_serialize(
 
 void rjson_serialize(
   rapidjson::Writer<rapidjson::StringBuffer>& w,
+  const std::chrono::seconds& v) {
+    uint64_t _tmp = v.count();
+    rjson_serialize(w, _tmp);
+}
+
+void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w,
   const model::broker_endpoint& ep) {
     w.StartObject();
     w.Key("name");

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -74,6 +74,9 @@ void rjson_serialize(
   const std::chrono::milliseconds& v);
 
 void rjson_serialize(
+  rapidjson::Writer<rapidjson::StringBuffer>& w, const std::chrono::seconds& v);
+
+void rjson_serialize(
   rapidjson::Writer<rapidjson::StringBuffer>&, const model::broker_endpoint&);
 
 template<typename T, typename = std::enable_if_t<std::is_enum_v<T>>>

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -306,8 +306,12 @@ struct topic_metadata {
 
 inline std::ostream&
 operator<<(std::ostream& o, const model::violation_recovery_policy& x) {
-    fmt::print(o, "violation_recovery_policy: {}", (int32_t)x);
-    return o;
+    switch (x) {
+    case model::violation_recovery_policy::best_effort:
+        return o << "best_effort";
+    case model::violation_recovery_policy::crash:
+        return o << "crash";
+    }
 }
 
 namespace internal {

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -35,6 +35,25 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/v1/cluster_config/schema",
+      "operations": [
+        {"method": "GET",
+          "summary": "Get schema describing all cluster configuration properties",
+          "type": "object",
+          "properties": {
+            "properties": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "nickname": "get_cluster_config_schema",
+          "produces": ["application/json"],
+          "parameters": [
+          ]
+        }
+      ]
     }
   ],
   "models": {
@@ -77,6 +96,57 @@
         "version": {
           "type": "long",
           "description": "Configuration version number, for cross referencing with node config status"
+        }
+      }
+    },
+    "cluster_config_property_metadata_items": {
+      "id": "cluster_config_property_metadata_items",
+      "description": "The type within 'items' for array properties",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "A scalar type name, like 'string'"
+        }
+      }
+    },
+    "cluster_config_property_metadata": {
+      "id": "cluster_config_property_metadata",
+      "description": "A single configuration property's metadata",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human readable description of property's purpose"
+        },
+        "nullable": {
+          "type": "boolean",
+          "description": "Whether this setting may be set to null"
+        },
+        "needs_restart": {
+          "type": "boolean",
+          "description": "Whether changes to this property will require a restart of redpanda nodes"
+        },
+        "visibility": {
+          "type": "string",
+          "description": "One of user|tunable|deprecated"
+        },
+        "units": {
+          "type": "string",
+          "description": "If applicable, the units of the property (e.g. ms, bytes)",
+          "nullable": true
+        },
+        "example": {
+          "type": "string",
+          "description": "Example of correct syntax for this property",
+          "nullable": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Expected syntax of the property value"
+        },
+        "items": {
+          "type": "cluster_config_property_metadata_items",
+          "description": "Type of items in an array",
+          "nullable": true
         }
       }
     }

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -69,7 +69,7 @@
           "type": "boolean",
           "description": "Restart required to apply pending configuration"
         },
-        "version": {
+        "config_version": {
           "type": "long",
           "description": "Configuration version number, for cross referencing with PUT results"
         },
@@ -93,7 +93,7 @@
       "id": "cluster_config_write_result",
       "description": "Result of writing changes to cluster configuration",
       "properties": {
-        "version": {
+        "config_version": {
           "type": "long",
           "description": "Configuration version number, for cross referencing with node config status"
         }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -565,7 +565,7 @@ void admin_server::register_cluster_config_routes() {
               auto& rs = res.emplace_back();
               rs.node_id = s.first;
               rs.restart = s.second.restart;
-              rs.version = s.second.version;
+              rs.config_version = s.second.version;
 
               // Workaround: seastar json_list hides empty lists by
               // default.  This complicates API clients, so always push
@@ -690,9 +690,10 @@ void admin_server::register_cluster_config_routes() {
           co_await throw_on_error(*req, err, model::controller_ntp);
 
           ss::httpd::cluster_config_json::cluster_config_write_result result;
-          result.version = co_await _controller->get_config_manager().invoke_on(
-            cluster::controller_stm_shard,
-            [](cluster::config_manager& mgr) { return mgr.get_version(); });
+          result.config_version
+            = co_await _controller->get_config_manager().invoke_on(
+              cluster::controller_stm_shard,
+              [](cluster::config_manager& mgr) { return mgr.get_version(); });
           co_return ss::json::json_return_type(std::move(result));
       });
 }

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -122,6 +122,9 @@ class Admin:
     def get_cluster_config(self, node=None):
         return self._request("GET", "config", node=node).json()
 
+    def get_cluster_config_schema(self, node=None):
+        return self._request("GET", "cluster_config/schema", node=node).json()
+
     def patch_cluster_config(self, upsert=None, remove=None):
         if upsert is None:
             upsert = {}

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -79,7 +79,8 @@ class ClusterConfigTest(RedpandaTest):
     def _wait_for_version_sync(self, version):
         wait_until(
             lambda: set([
-                n['version'] for n in self.admin.get_cluster_config_status()
+                n['config_version']
+                for n in self.admin.get_cluster_config_status()
             ]) == {version},
             timeout_sec=10,
             backoff_sec=0.5,
@@ -122,7 +123,7 @@ class ClusterConfigTest(RedpandaTest):
 
         patch_result = self.admin.patch_cluster_config(
             upsert=dict([new_setting]))
-        new_version = patch_result['version']
+        new_version = patch_result['config_version']
         self._wait_for_version_sync(new_version)
 
         assert self.admin.get_cluster_config()[
@@ -133,7 +134,7 @@ class ClusterConfigTest(RedpandaTest):
         # Test that a reset to default triggers the restart flag the same way as
         # an upsert does
         patch_result = self.admin.patch_cluster_config(remove=[new_setting[0]])
-        new_version = patch_result['version']
+        new_version = patch_result['config_version']
         self._wait_for_version_sync(new_version)
         assert self.admin.get_cluster_config()[
             new_setting[0]] != new_setting[1]
@@ -165,7 +166,7 @@ class ClusterConfigTest(RedpandaTest):
             norestart_new_setting[0]] == "CreateTime"  # Initially default
         patch_result = self.admin.patch_cluster_config(
             upsert=dict([norestart_new_setting]))
-        new_version = patch_result['version']
+        new_version = patch_result['config_version']
         self._wait_for_version_sync(new_version)
 
         assert self.admin.get_cluster_config()[
@@ -188,7 +189,7 @@ class ClusterConfigTest(RedpandaTest):
             invalid_setting[0]] == default_value
         patch_result = self.admin.patch_cluster_config(
             upsert=dict([invalid_setting]))
-        new_version = patch_result['version']
+        new_version = patch_result['config_version']
         self._wait_for_version_sync(new_version)
 
         assert self.admin.get_cluster_config()[
@@ -216,7 +217,7 @@ class ClusterConfigTest(RedpandaTest):
         # Reset the properties, check that it disappears from the list of invalid settings
         patch_result = self.admin.patch_cluster_config(
             remove=[invalid_setting[0]])
-        self._wait_for_version_sync(patch_result['version'])
+        self._wait_for_version_sync(patch_result['config_version'])
         assert self.admin.get_cluster_config()[
             invalid_setting[0]] == default_value
 
@@ -325,7 +326,7 @@ class ClusterConfigTest(RedpandaTest):
 
         patch_result = self.admin.patch_cluster_config(upsert=updates,
                                                        remove=[])
-        self._wait_for_version_sync(patch_result['version'])
+        self._wait_for_version_sync(patch_result['config_version'])
 
         def check_status(expect_restart):
             # Use one node's status, they should be symmetric


### PR DESCRIPTION
## Cover letter
<!--
testing comment
-->

To enable user interfaces (rpk, GUI) to introspect available configuration options, an admin API endpoint at /v1/cluster_config/schema is added, returning swagger-like descriptions of properties.

Internally, the base_property and property classes are extended with more metadata to populate this schema:
- type_name, units_name, is_nullable and is_array are all populated based on the property's wrapped type, with a mixture of concepts and explicit template specializations.
- `visibility` is an opinionated flag that indicates whether a property should be shown to the user at all by default, to separate first class configuration properties from tunables.
- `examples` lets properties give example values: these appear in the schema API output and are also used in automated tests to test modifying the property.

Unused properties are hidden from the schema and internally represented as instances of the new class `deprecated_property`, which enables the config system to accept these properties in existing configs, while making clear that they are not really used.

Existing properties are updated with metadata values for `visibility` based on a manual review of all properties, as well as updating `needs_restart` for properties where the value is not copied or cached at runtime, and therefore can be live-set without any extra work.

## Release notes

The `v1/cluster_config/schema` admin API endpoint is added for discovering available cluster configuration properties.
