### PR TITLE
rpk: add `topic add-partitions` command

### DIFF
--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -3,7 +3,7 @@ module github.com/vectorizedio/redpanda/src/go/k8s
 go 1.16
 
 require (
-	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/banzaicloud/k8s-objectmatcher v1.5.1
 	github.com/go-logr/logr v0.3.0
 	github.com/hashicorp/go-multierror v1.1.0

--- a/src/go/rpk/pkg/cli/cmd/acl.go
+++ b/src/go/rpk/pkg/cli/cmd/acl.go
@@ -221,6 +221,8 @@ PRODUCING/CONSUMING
                  CREATE on CLUSTER for kafka-cluster (if automatically creating topics)
                  CREATE on TOPIC for topics (if automatically creating topics)
 
+    InitProducerID  IDEMPOTENT_WRITE on CLUSTER
+
     OffsetForLeaderEpoch  DESCRIBE on TOPIC for topics
 
 GROUP CONSUMING

--- a/src/go/rpk/pkg/cli/cmd/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic.go
@@ -36,13 +36,16 @@ func NewTopicCommand(fs afero.Fs, mgr config.Manager) *cobra.Command {
 
 	common.AddKafkaFlags(command, &configFile, &user, &password, &mechanism, &enableTLS, &certFile, &keyFile, &truststoreFile, &brokers)
 
-	command.AddCommand(topic.NewCreateCommand(fs))
-	command.AddCommand(topic.NewDeleteCommand(fs))
-	command.AddCommand(topic.NewAlterConfigCommand(fs))
-	command.AddCommand(topic.NewDescribeCommand(fs))
-	command.AddCommand(topic.NewListCommand(fs))
-	command.AddCommand(topic.NewConsumeCommand(fs))
-	command.AddCommand(topic.NewProduceCommand(fs))
+	command.AddCommand(
+		topic.NewAddPartitionsCommand(fs),
+		topic.NewAlterConfigCommand(fs),
+		topic.NewConsumeCommand(fs),
+		topic.NewCreateCommand(fs),
+		topic.NewDeleteCommand(fs),
+		topic.NewDescribeCommand(fs),
+		topic.NewListCommand(fs),
+		topic.NewProduceCommand(fs),
+	)
 
 	return command
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/add_partitions.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/add_partitions.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package topic
+
+import (
+	"context"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/config"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/out"
+)
+
+func NewAddPartitionsCommand(fs afero.Fs) *cobra.Command {
+	var num int
+	cmd := &cobra.Command{
+		Use:   "add-partitions [TOPICS...] --num [#]",
+		Short: "Add partitions to existing topics.",
+		Args:  cobra.MinimumNArgs(1),
+		Long:  `Add partitions to existing topics.`,
+		Run: func(cmd *cobra.Command, topics []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p, cfg)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			if num <= 0 {
+				out.Die("No additional partitions requested, exiting!")
+			}
+
+			resps, err := adm.CreatePartitions(context.Background(), num, topics...)
+			out.MaybeDie(err, "create partitions request failed: %v", err)
+
+			tw := out.NewTable("topic", "error")
+			defer tw.Flush()
+
+			for _, resp := range resps.Sorted() {
+				msg := "OK"
+				if e := resp.Err; e != nil {
+					msg = e.Error()
+				}
+				tw.Print(resp.Topic, msg)
+			}
+		},
+	}
+	cmd.Flags().IntVarP(&num, "num", "n", 0, "numer of partitions to add to each topic")
+	return cmd
+}


### PR DESCRIPTION
This command adds partitions to topics. The single current flag "add" is
not required, which allows us to add a different, more involved flag
"assign" down the line where we will allow specifying which replicas to
add new partitions to.

Also runs `task rpk:tidy` and fixes one line of doc in `rpk acl`.

# Release notes

* rpk now has `topic add-partitions` to add partitions to existing topics