### PR TITLE
r/consensus: fixed handling replicate result when term changed

### DIFF
--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -119,6 +119,7 @@ private:
     ss::gate _req_bg;
     ctx_log _ctxlog;
     model::offset _dirty_offset;
+    model::offset _initial_committed_offset;
     ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> _units;
 };
 


### PR DESCRIPTION
Fixed problem that may lead to situation in which replication might be
claimed successful but replicated entries were truncated. This might
lead to consistency violation.

Consider an example:
```
F1 - fiber processing replicate in replicate entries stm
F2 - fiber processing append entries request

F1 - append to leader log
F1 - dispatch requests to followers and flush on leader
F1 - wait for dispatches and flush
F2 - processing new append entries with term greater than current
F2 - grab oplock
F2 - new term detected, step down, update term
F1 - check stop condition, detected term update
F1 - check term of self appended entry matches stored term -> TRUE
F1 - claim successful replication
F2 - truncate log, new leader log doesn't match <- violation
```
The problem was caused by the fact that `raft::replicate_entries_stm` did not wait for committed index update before evaluation replication results. This way a result might have been calculated based on the incorrect assumptions. Waiting for actual update of committed index before proceeding to result calculation give us a guarantee that all the state was update to decide if replication was successful. 

Signed-off-by: Michal Maslanka <michal@vectorized.io>
