### PR TITLE
Parse longer device controller paths

### DIFF
--- a/src/go/rpk/pkg/tuners/disk/block_devices.go
+++ b/src/go/rpk/pkg/tuners/disk/block_devices.go
@@ -216,11 +216,10 @@ func (b *blockDevices) getDeviceControllerPath(
 	splitSystemPath := strings.Split(devSystemPath, "/")
 	controllerPathParts := append([]string{"/"}, splitSystemPath[0:4]...)
 	pattern, _ := regexp.Compile(
-		"^[0-9ABCDEFabcdef]{4}:[0-9ABCDEFabcdef]{2}:[0-9ABCDEFabcdef]{2}\\.[0-9ABCDEFabcdef]$")
+		`^[0-9ABCDEFabcdef]{4}:[0-9ABCDEFabcdef]{2}:[0-9ABCDEFabcdef]{2}\.[0-9ABCDEFabcdef]$`)
 	for _, systemPathPart := range splitSystemPath[4:] {
+		controllerPathParts = append(controllerPathParts, systemPathPart)
 		if pattern.MatchString(systemPathPart) {
-			controllerPathParts = append(controllerPathParts, systemPathPart)
-		} else {
 			break
 		}
 	}

--- a/src/go/rpk/pkg/tuners/disk/block_devices_test.go
+++ b/src/go/rpk/pkg/tuners/disk/block_devices_test.go
@@ -10,6 +10,7 @@
 package disk
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -53,6 +54,19 @@ func Test_blockDevices_getDeviceControllerPath(t *testing.T) {
 	// then
 	require.Nil(t, err)
 	require.Equal(t, "/sys/devices/pci0000:00/0000:00:1f.2", controllerPath)
+
+	// given
+	var sb strings.Builder
+	sb.WriteString("/sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A03:00/device:07/VMBUS:01")
+	sb.WriteString("/129e938b-5639-4ac2-819d-5c2c778b0c49/pci5639:00/5639:00:00.0")
+	expected := sb.String()
+	sb.WriteString("/nvme/nvme0/nvme0n1")
+	devSystemPath = sb.String()
+	// when
+	controllerPath, err = blockDevices.getDeviceControllerPath(devSystemPath)
+	// then
+	require.Nil(t, err)
+	require.Equal(t, expected, controllerPath)
 }
 
 func Test_blockDevices_isIRQNvmeFastPathIRQ(t *testing.T) {


### PR DESCRIPTION
Azure VMs have longer device controller paths than its peers, for example:

- AWS: `/sys/devices/pci0000:00/0000:00:1e.0/nvme/nvme1/nvme1n1`
- Azure: `/sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A03:00/device:07/VMBUS:01/feb5be9c-953e-4dea-b7c7-947fe89ed363/pci953e:00/953e:00:00.0/nvme/nvme1/nvme1n1`

These longer paths are not being parsed correctly by the `disk_irq` tuner, causing it to output an error message:

```
TUNER     APPLIED  ENABLED  SUPPORTED  ERROR
  disk_irq  false    true     true       err=signal: segmentation
                                         fault (core dumped),
                                         stderr=
```

This PR fixes #2990.