### PR TITLE
raft/tests: increase election timeout to avoid leadership flaps

### DIFF
--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -366,7 +366,7 @@ struct raft_group {
           make_broker(node_id),
           _id,
           raft::group_configuration(_initial_brokers, model::revision_id(0)),
-          raft::timeout_jitter(heartbeat_interval * 2),
+          raft::timeout_jitter(heartbeat_interval * 10),
           ssx::sformat("{}/{}", _storage_dir, node_id()),
           _storage_type,
           [this, node_id](raft::leadership_status st) {
@@ -387,7 +387,7 @@ struct raft_group {
           broker,
           _id,
           raft::group_configuration({}, model::revision_id(0)),
-          raft::timeout_jitter(heartbeat_interval * 2),
+          raft::timeout_jitter(heartbeat_interval * 10),
           ssx::sformat("{}/{}", _storage_dir, node_id()),
           _storage_type,
           [this, node_id](raft::leadership_status st) {


### PR DESCRIPTION
## Cover letter

Some unit tests were changing leadership several times
shortly after startup, which could overlap with writes
and lead to truncations that interfered with tests.

This increases the runtime of the test from about 1:27 to about 1:35

Fixes: https://github.com/vectorizedio/redpanda/issues/2799

## Release notes

None