### PR TITLE
ducktape: Disable test_consumer_group_json_v2

### DIFF
--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -747,6 +747,7 @@ class PandaProxyTest(RedpandaTest):
         rc_res = c0.remove()
         assert rc_res.status_code == requests.codes.no_content
 
+    @ignore  # https://github.com/vectorizedio/redpanda/issues/2501
     @cluster(num_nodes=3)
     def test_consumer_group_json_v2(self):
         """


### PR DESCRIPTION
## Cover letter

This is issue #2501, apparently it's not fixed by #2926

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

None