### PR TITLE
Add PopOS to install-dependencies.sh

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -62,7 +62,7 @@ fedora_deps=(
 )
 
 case "$ID" in
-  ubuntu | debian)
+  ubuntu | debian | pop)
     apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get install -y "${deb_deps[@]}"
     ;;


### PR DESCRIPTION
## Cover letter

Allows the install-dependencies.sh script to be used by PopOS users out of the box.

Supporting change to seastar: https://github.com/scylladb/seastar/pull/971