### PR TITLE
docs: Update prometheus-url flag

### DIFF
--- a/docs/www/monitoring.md
+++ b/docs/www/monitoring.md
@@ -35,10 +35,10 @@ addresses.
 
 You can generate a comprehensive Grafana dashboard with
 ```
-rpk generate grafana-dashboard --datasource <name> --prometheus-url <url>
+rpk generate grafana-dashboard --datasource <name> --metrics-endpoint <url>
 ```
 
-`--prometheus-url` is the address to a redpanda node's metrics endpoint
+`--metrics-endpoint` is the address to a redpanda node's metrics endpoint
 (`<node ip>:9644/metrics`, by default).
 
 `<name>` is the name of the Prometheus datasource configured in your
@@ -52,7 +52,7 @@ Simply pipe the commmand's output to a file and import it in Grafana.
 ```
 rpk generate grafana-dashboard \
   --datasource prometheus \
-  --prometheus-url 172.32.89.236:9644/metrics > redpanda-dashboard.json
+  --metrics-endpoint 172.32.89.236:9644/metrics > redpanda-dashboard.json
 ```
 
 ## Stats Reporting

--- a/docs/www/rpk-commands.md
+++ b/docs/www/rpk-commands.md
@@ -516,7 +516,7 @@ Usage:
 Flags:
       --datasource string       The name of the Prometheus datasource as configured in your grafana instance.
       --job-name string         The prometheus job name by which to identify the redpanda nodes (default: "redpanda")
-      --prometheus-url string   The redpanda Prometheus URL from where to get the metrics metadata (default: "http://localhost:9644/metrics")
+      --metrics-endpoint string   The redpanda Prometheus URL from where to get the metrics metadata (default: "http://localhost:9644/metrics")
 ```
 
 ### generate prometheus-config 


### PR DESCRIPTION
## Cover letter

rpk suggested: "Flag --prometheus-url has been deprecated, Deprecated flag. Use --metrics-endpoint instead". This PR updates the flag in the docs.

Replaces https://github.com/vectorizedio/redpanda/pull/2971

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
