### PR TITLE
Metrics cleanup

### DIFF
--- a/docs/www/monitoring.md
+++ b/docs/www/monitoring.md
@@ -85,7 +85,7 @@ Most of the metrics are used for debugging, but these metrics can be useful to m
 | Metric | Definition | Diagnostics |
 | --- | --- | --- |
 | vectorized_application_uptime | Redpanda uptime in milliseconds |  |
-| vectorized_cluster_partition_last_stable_offset | Last stable offset | If this is the last record received by the cluster, then the cluster is up-to-date and ready for maintenance |
+| vectorized_partition_last_stable_offset | Last stable offset | If this is the last record received by the cluster, then the cluster is up-to-date and ready for maintenance |
 | vectorized_io_queue_delay | Total delay time in the queue | Can indicate latency caused by disk operations in seconds |
 | vectorized_io_queue_queue_length | Number of requests in the queue | Can indicate latency caused by disk operations |
 | vectorized_kafka_rpc_active_connections | kafka_rpc: Currently active connections | Shows the number of clients actively connected |

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -40,7 +40,7 @@ void replicated_partition_probe::setup_metrics(const model::ntp& ntp) {
     };
 
     _metrics.add_group(
-      prometheus_sanitize::metrics_name("cluster:partition"),
+      prometheus_sanitize::metrics_name("partition"),
       {
         sm::make_gauge(
           "leader",

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -84,6 +84,16 @@ void replicated_partition_probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _records_fetched; },
           sm::description("Total number of records fetched"),
           labels),
+        sm::make_total_bytes(
+          "bytes_produced_total",
+          [this] { return _bytes_fetched; },
+          sm::description("Total number of bytes produced"),
+          labels),
+        sm::make_total_bytes(
+          "bytes_fetched_total",
+          [this] { return _records_fetched; },
+          sm::description("Total number of bytes fetched"),
+          labels),
       });
 }
 partition_probe make_materialized_partition_probe() {
@@ -92,6 +102,8 @@ partition_probe make_materialized_partition_probe() {
         void setup_metrics(const model::ntp&) final {}
         void add_records_fetched(uint64_t) final {}
         void add_records_produced(uint64_t) final {}
+        void add_bytes_fetched(uint64_t) final {}
+        void add_bytes_produced(uint64_t) final {}
     };
     return partition_probe(std::make_unique<impl>());
 }

--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -53,32 +53,14 @@ void replicated_partition_probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _partition.last_stable_offset(); },
           sm::description("Last stable offset"),
           labels),
-        sm::make_gauge(
-          "committed_offset",
-          [this] { return _partition.committed_offset(); },
-          sm::description("Partition commited offset. i.e. safely persisted on "
-                          "majority of replicas"),
-          labels),
-        sm::make_gauge(
-          "end_offset",
-          [this] { return _partition.dirty_offset(); },
-          sm::description(
-            "Last offset stored by current partition on this node"),
-          labels),
+
         sm::make_gauge(
           "high_watermark",
           [this] { return _partition.high_watermark(); },
           sm::description(
             "Partion high watermark i.e. highest consumable offset"),
           labels),
-        sm::make_gauge(
-          "leader_id",
-          [this] {
-              return _partition._raft->get_leader_id().value_or(
-                model::node_id(-1));
-          },
-          sm::description("Id of current partition leader"),
-          labels),
+
         sm::make_gauge(
           "under_replicated_replicas",
           [this] {

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -26,6 +26,8 @@ public:
     struct impl {
         virtual void add_records_produced(uint64_t) = 0;
         virtual void add_records_fetched(uint64_t) = 0;
+        virtual void add_bytes_produced(uint64_t) = 0;
+        virtual void add_bytes_fetched(uint64_t) = 0;
         virtual void setup_metrics(const model::ntp&) = 0;
         virtual ~impl() noexcept = default;
     };
@@ -44,6 +46,13 @@ public:
     void add_records_fetched(uint64_t num_records) {
         return _impl->add_records_fetched(num_records);
     }
+    void add_bytes_produced(uint64_t bytes) {
+        return _impl->add_bytes_produced(bytes);
+    }
+
+    void add_bytes_fetched(uint64_t bytes) {
+        return _impl->add_bytes_fetched(bytes);
+    }
 
 private:
     std::unique_ptr<impl> _impl;
@@ -56,11 +65,15 @@ public:
 
     void add_records_fetched(uint64_t cnt) final { _records_fetched += cnt; }
     void add_records_produced(uint64_t cnt) final { _records_produced += cnt; }
+    void add_bytes_fetched(uint64_t cnt) final { _bytes_fetched += cnt; }
+    void add_bytes_produced(uint64_t cnt) final { _bytes_produced += cnt; }
 
 private:
     const partition& _partition;
     uint64_t _records_produced{0};
     uint64_t _records_fetched{0};
+    uint64_t _bytes_produced{0};
+    uint64_t _bytes_fetched{0};
     ss::metrics::metric_groups _metrics;
 };
 

--- a/src/v/dashboard/src/prometheus-test-snapshot.js
+++ b/src/v/dashboard/src/prometheus-test-snapshot.js
@@ -14,21 +14,21 @@ vectorized_alien_total_sent_messages{shard="1"} 0
 # HELP vectorized_application_uptime Redpanda uptime in milliseconds
 # TYPE vectorized_application_uptime gauge
 vectorized_application_uptime{shard="0"} 12964954.000000
-# HELP vectorized_cluster_partition_committed_offset Committed offset
-# TYPE vectorized_cluster_partition_committed_offset gauge
-vectorized_cluster_partition_committed_offset{namespace="redpanda",partition="0",shard="0",topic="controller"} 4.000000
-# HELP vectorized_cluster_partition_last_stable_offset Last stable offset
-# TYPE vectorized_cluster_partition_last_stable_offset gauge
-vectorized_cluster_partition_last_stable_offset{namespace="redpanda",partition="0",shard="0",topic="controller"} 5.000000
-# HELP vectorized_cluster_partition_leader Flag indicating if this partition instance is a leader
-# TYPE vectorized_cluster_partition_leader gauge
-vectorized_cluster_partition_leader{namespace="redpanda",partition="0",shard="0",topic="controller"} 1.000000
-# HELP vectorized_cluster_partition_records_fetched Total number of records fetched
-# TYPE vectorized_cluster_partition_records_fetched counter
-vectorized_cluster_partition_records_fetched{namespace="redpanda",partition="0",shard="0",topic="controller"} 0
-# HELP vectorized_cluster_partition_records_produced Total number of records produced
-# TYPE vectorized_cluster_partition_records_produced counter
-vectorized_cluster_partition_records_produced{namespace="redpanda",partition="0",shard="0",topic="controller"} 0
+# HELP vectorized_partition_committed_offset Committed offset
+# TYPE vectorized_partition_committed_offset gauge
+vectorized_partition_committed_offset{namespace="redpanda",partition="0",shard="0",topic="controller"} 4.000000
+# HELP vectorized_partition_last_stable_offset Last stable offset
+# TYPE vectorized_partition_last_stable_offset gauge
+vectorized_partition_last_stable_offset{namespace="redpanda",partition="0",shard="0",topic="controller"} 5.000000
+# HELP vectorized_partition_leader Flag indicating if this partition instance is a leader
+# TYPE vectorized_partition_leader gauge
+vectorized_partition_leader{namespace="redpanda",partition="0",shard="0",topic="controller"} 1.000000
+# HELP vectorized_partition_records_fetched Total number of records fetched
+# TYPE vectorized_partition_records_fetched counter
+vectorized_partition_records_fetched{namespace="redpanda",partition="0",shard="0",topic="controller"} 0
+# HELP vectorized_partition_records_produced Total number of records produced
+# TYPE vectorized_partition_records_produced counter
+vectorized_partition_records_produced{namespace="redpanda",partition="0",shard="0",topic="controller"} 0
 # HELP vectorized_httpd_connections_current The current number of open  connections
 # TYPE vectorized_httpd_connections_current gauge
 vectorized_httpd_connections_current{service="admin",shard="0"} 2.000000

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -96,6 +96,7 @@ static ss::future<read_result> read_from_partition(
     auto data = std::make_unique<iobuf>(std::move(result.data));
     std::vector<cluster::rm_stm::tx_range> aborted_transactions;
     part.probe().add_records_fetched(result.record_count);
+    part.probe().add_bytes_fetched(result.data.size_bytes());
     if (result.record_count > 0) {
         aborted_transactions = co_await part.aborted_transactions(
           result.base_offset, result.last_offset, std::move(rdr.ot_state));

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -15,6 +15,8 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/net/inet_address.hh>
 
+#include <fmt/core.h>
+
 #include <ostream>
 
 namespace net {
@@ -22,7 +24,7 @@ void server_probe::setup_metrics(
   ss::metrics::metric_groups& mgs, const char* proto) {
     namespace sm = ss::metrics;
     mgs.add_group(
-      prometheus_sanitize::metrics_name(proto),
+      prometheus_sanitize::metrics_name(fmt::format("{}:server", proto)),
       {
         sm::make_gauge(
           "active_connections",

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -210,7 +210,7 @@ void server::setup_metrics() {
         return;
     }
     _metrics.add_group(
-      prometheus_sanitize::metrics_name(cfg.name),
+      prometheus_sanitize::metrics_name(fmt::format("{}:server", cfg.name)),
       {sm::make_total_bytes(
          "max_service_mem_bytes",
          [this] { return cfg.max_service_memory_per_core; },

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -75,7 +75,7 @@ void probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _log_segments_removed; },
           sm::description("Number of removed log segments"),
           labels),
-        sm::make_derive(
+        sm::make_gauge(
           "log_segments_active",
           [this] { return _log_segments_active; },
           sm::description("Number of active log segments"),

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -644,8 +644,8 @@ class RedpandaService(Service):
            will return an array containing MetricSample instances for each node and
            core/shard in the cluster. Each entry will correspond to a value from:
 
-              family = vectorized_cluster_partition_under_replicated_replicas
-              sample = vectorized_cluster_partition_under_replicated_replicas
+              family = vectorized_partition_under_replicated_replicas
+              sample = vectorized_partition_under_replicated_replicas
         """
         nodes = nodes or self.nodes
         found_sample = None
@@ -705,7 +705,7 @@ class RedpandaService(Service):
             idx = self.idx(node)
             for family in metrics:
                 for sample in family.samples:
-                    if sample.name == "vectorized_cluster_partition_under_replicated_replicas":
+                    if sample.name == "vectorized_partition_under_replicated_replicas":
                         if counts[idx] is None:
                             counts[idx] = 0
                         counts[idx] += int(sample.value)

--- a/tests/rptest/tests/bytes_sent_test.py
+++ b/tests/rptest/tests/bytes_sent_test.py
@@ -42,8 +42,8 @@ class BytesSentTest(RedpandaTest):
 
             # Find the metric family that tracks bytes sent from kafka subsystem
             family_filter = filter(
-                lambda fam: fam.name == "vectorized_kafka_rpc_sent_bytes",
-                metrics)
+                lambda fam: fam.name ==
+                "vectorized_kafka_rpc_server_sent_bytes", metrics)
             family = next(family_filter)
 
             # Sum bytes sent

--- a/tests/rptest/tests/compacted_term_rolled_recovery_test.py
+++ b/tests/rptest/tests/compacted_term_rolled_recovery_test.py
@@ -113,7 +113,7 @@ class CompactionTermRollRecoveryTest(RedpandaTest):
                 metrics = self.redpanda.metrics(node)
                 for family in metrics:
                     for sample in family.samples:
-                        if sample.name == "vectorized_cluster_partition_last_stable_offset" and \
+                        if sample.name == "vectorized_partition_last_stable_offset" and \
                                 sample.labels["namespace"] == "kafka" and \
                                 sample.labels["topic"] == topic and \
                                 int(sample.labels["partition"]) == partition:

--- a/tools/rpcgen.py
+++ b/tools/rpcgen.py
@@ -83,7 +83,7 @@ public:
               service_label("{{service_name}}"),
               method_label("{{method.name}}")};
             _metrics.add_group(
-              prometheus_sanitize::metrics_name("internal_rpc"),
+              prometheus_sanitize::metrics_name("internal_rpc_server"),
               {sm::make_histogram(
                 "latency",
                 [this] { return _methods[{{loop.index-1}}].probes.latency_hist().seastar_histogram_logform(); },


### PR DESCRIPTION
## Cover letter

Reduced number of metrics exposed per partition, changed metric names to be more descriptive.

## Release notes
- May brake existing metrics scraping since names have changed. 