### PR TITLE
Fix for wasm engine not recording exact recordCount in RecordBatches

### DIFF
--- a/src/js/modules/public/Utils.ts
+++ b/src/js/modules/public/Utils.ts
@@ -103,6 +103,39 @@ export const createRecordBatchFunctor = (
   return { ...recordBatch, map };
 };
 
+export const copyRecordBatch = (
+  recordBatch: RecordBatch
+): RecordBatchFunctor => {
+  const deepCopiedRecords = recordBatch.records.map((record) => {
+    const deepCopiedRecordHeaders = record.headers.map((header) => {
+      const newKey = Buffer.alloc(header.headerKey.length);
+      const newVal = Buffer.alloc(header.value.length);
+      header.headerKey.copy(newKey);
+      header.value.copy(newVal);
+      return {
+        ...header,
+        headerKey: newKey,
+        value: newVal,
+      };
+    });
+    const newKey = Buffer.alloc(record.key.length);
+    const newVal = Buffer.alloc(record.value.length);
+    record.key.copy(newKey);
+    record.value.copy(newVal);
+    return {
+      ...record,
+      key: newKey,
+      value: newVal,
+      headers: deepCopiedRecordHeaders,
+    };
+  });
+  const newBatch = {
+    header: recordBatch.header,
+    records: deepCopiedRecords,
+  };
+  return createRecordBatchFunctor(newBatch);
+};
+
 // receive int64 and return Uint64
 const encodeZigzag = (field: bigint): bigint => {
   // Create Bigint with 64 bytes length and sign 63

--- a/src/js/modules/public/Utils.ts
+++ b/src/js/modules/public/Utils.ts
@@ -72,35 +72,35 @@ interface PartialRecordBatch {
 }
 
 interface RecordBatchFunctor extends RecordBatch {
-  map(fn: (record) => RecordBatch): RecordBatch;
+  map(fn: (recordBatch) => RecordBatch): RecordBatch;
 }
 
 export const createRecordBatch = (
   record?: PartialRecordBatch
 ): RecordBatchFunctor => {
   const map =
-    (record: RecordBatch) =>
-    (fn: (record) => RecordBatch): RecordBatch => {
-      return fn(record);
+    (recordBatch: RecordBatch) =>
+    (fn: (recordBatch) => RecordBatch): RecordBatch => {
+      return fn(recordBatch);
     };
   const records = record?.records || [];
-  const resultRecord = {
+  const resultBatch = {
     header: createHeader(record?.header || {}),
     records: records.map(createRecord),
   };
   return {
-    ...resultRecord,
-    map: map(resultRecord),
+    ...resultBatch,
+    map: map(resultBatch),
   };
 };
 
 export const createRecordBatchFunctor = (
-  record: RecordBatch
+  recordBatch: RecordBatch
 ): RecordBatchFunctor => {
-  const map = (fn: (record) => RecordBatch): RecordBatch => {
-    return fn(record);
+  const map = (fn: (recordBatch) => RecordBatch): RecordBatch => {
+    return fn(recordBatch);
   };
-  return { ...record, map };
+  return { ...recordBatch, map };
 };
 
 // receive int64 and return Uint64

--- a/src/js/modules/public/index.ts
+++ b/src/js/modules/public/index.ts
@@ -11,6 +11,7 @@
 import { SimpleTransform } from "./SimpleTransform";
 import { PolicyError, PolicyInjection } from "./Coprocessor";
 import {
+  copyRecordBatch,
   createRecordBatch,
   calculateRecordLength,
   calculateRecordBatchSize,
@@ -20,6 +21,7 @@ export {
   SimpleTransform,
   PolicyError,
   PolicyInjection,
+  copyRecordBatch,
   createRecordBatch,
   calculateRecordLength,
   calculateRecordBatchSize,

--- a/src/js/modules/supervisors/Repository.ts
+++ b/src/js/modules/supervisors/Repository.ts
@@ -18,7 +18,7 @@ import { ProcessBatchServer } from "../rpc/server";
 import {
   calculateRecordBatchSize,
   calculateRecordLength,
-  createRecordBatch,
+  copyRecordBatch,
 } from "../public";
 import LogService from "../utilities/Logging";
 
@@ -192,7 +192,7 @@ class Repository {
           }
           try {
             return handle.coprocessor
-              .apply(createRecordBatch(recordBatch), this.wasmLogger)
+              .apply(copyRecordBatch(recordBatch), this.wasmLogger)
               .then((resultMap) =>
                 this.validateResultApply(
                   requestItem,

--- a/src/js/modules/supervisors/Repository.ts
+++ b/src/js/modules/supervisors/Repository.ts
@@ -149,6 +149,7 @@ class Repository {
         });
         value.header.sizeBytes = calculateRecordBatchSize(value.records);
         value.header.term = recordBatch.header.term;
+        value.header.recordCount = value.records.length;
         results.push({
           coprocessorId: BigInt(handle.coprocessor.globalId),
           source: requestItem.ntp,

--- a/src/js/test/rpc/server.test.ts
+++ b/src/js/test/rpc/server.test.ts
@@ -396,13 +396,10 @@ describe("Server", function () {
           globalId: BigInt(id),
           apply: (recordBatch) => {
             const result = new Map();
-            const transformedRecord =
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              recordBatch.map(({ header, records }) => ({
-                header,
-                records: records.map(uppercase),
-              }));
+            const transformedRecord = {
+              header: recordBatch.header,
+              records: recordBatch.records.map(uppercase),
+            };
             result.set("result", transformedRecord);
             return Promise.resolve(result);
           },
@@ -416,7 +413,7 @@ describe("Server", function () {
             header: {
               recordCount: 1,
             },
-            records: [{ value: Buffer.from("b") }],
+            records: [{ value: Buffer.from("b"), valueLen: 1 }],
           }),
         ],
         coprocessorIds: [BigInt(1)],
@@ -446,13 +443,10 @@ describe("Server", function () {
           globalId: BigInt(id),
           apply: (recordBatch) => {
             const result = new Map();
-            const transformedRecord =
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              recordBatch.map(({ header, records }) => ({
-                header,
-                records: records.map(uppercase),
-              }));
+            const transformedRecord = {
+              header: recordBatch.header,
+              records: recordBatch.records.map(uppercase),
+            };
             result.set("result", transformedRecord);
             return Promise.resolve(result);
           },
@@ -466,7 +460,7 @@ describe("Server", function () {
               header: {
                 recordCount: 1,
               },
-              records: [{ value: Buffer.from("b") }],
+              records: [{ value: Buffer.from("b"), valueLen: 1 }],
             }),
           ],
           coprocessorIds: [BigInt(1)],
@@ -479,7 +473,7 @@ describe("Server", function () {
               header: {
                 recordCount: 1,
               },
-              records: [{ value: Buffer.from("b") }],
+              records: [{ value: Buffer.from("b"), valueLen: 1 }],
             }),
           ],
         }));

--- a/src/v/coproc/exception.h
+++ b/src/v/coproc/exception.h
@@ -45,6 +45,11 @@ private:
     script_id _id;
 };
 
+/// brief Thrown when the wasm engine returns a malformed response
+class engine_protocol_failure : public script_exception {
+    using script_exception::script_exception;
+};
+
 /// \brief Thrown when a coprocessor running within nodejs fails for whatever
 /// reason
 class script_failed_exception final : public script_exception {

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -22,15 +22,15 @@
 #include <seastar/core/coroutine.hh>
 
 namespace coproc {
-class crc_failed_exception final : public exception {
-    using exception::exception;
-};
-
 class follower_create_topic_exception final : public exception {
     using exception::exception;
 };
 
 class log_not_yet_created_exception final : public exception {
+    using exception::exception;
+};
+
+class malformed_batch_exception final : public exception {
     using exception::exception;
 };
 
@@ -52,21 +52,43 @@ private:
     model::record_batch_reader::data_t _batches;
 };
 
+/// Necessary because the javascript project has potential areas where
+/// inconsistent record batches may be built and sent back to rp
+class verify_record_batch_consistency {
+public:
+    ss::future<ss::stop_iteration> operator()(const model::record_batch& b) {
+        _is_consistent &= (b.header().record_count == b.record_count());
+        co_return _is_consistent ? ss::stop_iteration::no
+                                 : ss::stop_iteration::yes;
+    }
+
+    bool end_of_stream() const { return _is_consistent; }
+
+private:
+    bool _is_consistent{true};
+};
+
 static ss::future<> do_write_materialized_partition(
   storage::log log, model::record_batch_reader reader) {
     /// Re-write all batch term_ids to 1, otherwise they will carry the
     /// term ids of records coming from parent batches
-    auto [success, batch_w_correct_terms]
+    auto [crc_success, all_headers_valid, batch_w_correct_terms]
       = co_await std::move(reader).for_each_ref(
         reference_window_consumer(
-          model::record_batch_crc_checker(), set_term_id_to_zero()),
+          model::record_batch_crc_checker(),
+          verify_record_batch_consistency(),
+          set_term_id_to_zero()),
         model::no_timeout);
-    if (!success) {
-        /// In the case crc checks failed, do NOT write records to storage
-        throw crc_failed_exception(fmt::format(
-          "Batch failed crc checks, check wasm engine impl: {}",
-          log.config().ntp()));
+
+    if (!crc_success) {
+        throw malformed_batch_exception(
+          "Wasm engine failed to compile correct crc check");
     }
+    if (!all_headers_valid) {
+        throw malformed_batch_exception(
+          "Wasm engine returned malformatted batch/header");
+    }
+
     /// Compress the data before writing...
     auto compressed = co_await std::move(batch_w_correct_terms)
                         .for_each_ref(
@@ -211,12 +233,6 @@ process_one_reply(process_batch_reply::data e, output_write_args args) {
     try {
         co_await write_materialized_partition(
           e.ntp, std::move(*e.reader), ntp_ctx, args);
-    } catch (const crc_failed_exception& ex) {
-        vlog(
-          coproclog.error,
-          "Reprocessing record, failure encountered, {}",
-          ex.what());
-        co_return;
     } catch (const cluster::non_replicable_topic_creation_exception& ex) {
         vlog(
           coproclog.error,
@@ -232,6 +248,8 @@ process_one_reply(process_batch_reply::data e, output_write_args args) {
     } catch (const log_not_yet_created_exception& ex) {
         vlog(coproclog.trace, "Waiting for underlying log: {}", ex.what());
         co_return;
+    } catch (const malformed_batch_exception& ex) {
+        throw engine_protocol_failure(args.id, ex.what());
     }
     auto ofound = ntp_ctx->offsets.find(args.id);
     vassert(

--- a/tests/rptest/tests/wasm_filter_test.py
+++ b/tests/rptest/tests/wasm_filter_test.py
@@ -1,0 +1,82 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from kafka import TopicPartition
+from ducktape.mark.resource import cluster
+from ducktape.mark import ignore
+from rptest.clients.types import TopicSpec
+from rptest.wasm.wasm_build_tool import WasmTemplateRepository
+from rptest.wasm.wasm_test import WasmTest, WasmScript, random_string
+from rptest.clients.rpk import RpkTool
+from rptest.wasm.topic import construct_materialized_topic
+from rptest.wasm.native_kafka_consumer import NativeKafkaConsumer
+from ducktape.utils.util import wait_until
+
+
+class WasmFilterTest(WasmTest):
+    topics = (TopicSpec(partition_count=3, ), )
+
+    def __init__(self, test_context, extra_rp_conf=None):
+        super(WasmFilterTest, self).__init__(test_context,
+                                             extra_rp_conf=extra_rp_conf or {})
+        self._num_records = 32
+        self._expected_record_cnt = self._num_records / 2
+        self._output_topic = "default_output"
+        self._script = WasmScript(
+            inputs=[x.name for x in self.topics],
+            outputs=[(self._output_topic, self._expected_record_cnt)],
+            script=WasmTemplateRepository.FILTER_TRANSFORM,
+        )
+
+    def push_test_data_to_inputs(self):
+        for topic in self.topics:
+            for i in range(topic.partition_count):
+                for j in range(self._num_records):
+                    self._rpk_tool.produce(topic.name,
+                                           str(j),
+                                           str(j), [],
+                                           partition=i)
+
+    @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
+    @cluster(num_nodes=3)
+    def verify_filter_test(self):
+        # 1. Fill source topics with test data
+        self.push_test_data_to_inputs()
+
+        # 2. Start coprocessor
+        self._build_script(self._script)
+
+        # 3. Drain from output topics within timeout
+        materialized_topic = construct_materialized_topic(
+            self.topic, self._output_topic)
+        output_tps = [
+            TopicPartition(materialized_topic, i)
+            for i in range(self.topics[0].partition_count)
+        ]
+        consumer = NativeKafkaConsumer(self.redpanda.brokers(), output_tps,
+                                       self._expected_record_cnt)
+
+        # Wait until materialized topic is up
+        def topic_created():
+            topics = self._rpk_tool.list_topics()
+            return materialized_topic in list(topics)
+
+        wait_until(topic_created, timeout_sec=10, backoff_sec=1)
+
+        # Consume from materialized topic
+        def finished():
+            self.logger.info("Recs read: %s" % consumer.results.num_records())
+            return consumer.is_finished()
+
+        consumer.start()
+        wait_until(finished, timeout_sec=10, backoff_sec=1)
+        consumer.join()
+
+        # Assert success
+        assert consumer.results.num_records() == self._expected_record_cnt

--- a/tests/rptest/wasm/templates/filter_transform.j2
+++ b/tests/rptest/wasm/templates/filter_transform.j2
@@ -1,0 +1,28 @@
+const {
+  SimpleTransform,
+  PolicyError,
+  PolicyInjection
+} = require("/root/js-public/wasm-api");
+const transform = new SimpleTransform();
+transform.subscribe([{{input_topics}}]);
+transform.errorHandler(PolicyError.SkipOnFailure);
+const filterOdds = (record) => {
+  // TODO: Error handling
+  const asString = record.value.toString('utf8');
+  const asNumber = parseInt(asString, 10);
+  return (asNumber % 2) == 0;
+}
+transform.processRecord((recordBatch) => {
+  const result = new Map();
+  const transformedBatch = recordBatch.map( ({ header, records }) => {
+    return {
+      header: recordBatch.header,
+      records: records.filter(filterOdds)
+    };
+  });
+  {% for output_topic in output_topics %}
+  result.set("{{output_topic}}", transformedBatch);
+  {% endfor %}
+  return Promise.resolve(result);
+});
+exports["default"] = transform;

--- a/tests/rptest/wasm/topic.py
+++ b/tests/rptest/wasm/topic.py
@@ -10,7 +10,7 @@
 import re
 
 # Regex for materialized topics
-mt_rgx = re.compile("(.*)\\.\\$(.*)\\$")
+mt_rgx = re.compile("(.*)\\.\_(.*)\_")
 
 # Regex for normal kafka topics
 topic_rgx = re.compile("^([a-zA-Z0-9\\.\\_\\-])*$")

--- a/tests/rptest/wasm/wasm_build_tool.py
+++ b/tests/rptest/wasm/wasm_build_tool.py
@@ -16,6 +16,7 @@ import jinja2
 
 class WasmTemplateRepository:
     IDENTITY_TRANSFORM = "identity_transform.j2"
+    FILTER_TRANSFORM = "filter_transform.j2"
 
     def __init__(self, template_dir):
         self.template_dir = template_dir


### PR DESCRIPTION
The wasm engine isn't correctly fufilling the `recordCount` property. This isn't an issue if one doesn't mutate records within the batches themselves. The fix is a one liner to record the correct number of records and an assertion in redpanda to include some additional sanity checks.

One other change in this PR is a change to expose correct record properties to the client. Without this fix when querying for recordbatch or header attributes they will be observed as 0 or filled with default values.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/350f2d42af83db03e5ad9f18b1f26c96dd2091e7..7db1c49e3ce33b408c674061f658416dbaf82856)
- Various python fixes added to ducktape test.
- Ducktape test marked with @ignore since wasm ducktape is currently disabled in CI
- Modified redpanda to not crash when detecting malformed batch responses, but rather deregister the coprocessor

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/7db1c49e3ce33b408c674061f658416dbaf82856..ef249acab922e7e409c02c8d61eb1e3d7f13e666)
- Linted edited python source files