### PR TITLE
Mitigate idempotency violation

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -726,7 +726,7 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
     }
 
     if (!check_seq(bid)) {
-        co_return errc::sequence_out_of_order;
+        co_return errc::generic_tx_error;
     }
 
     if (!_mem_state.tx_start.contains(bid.pid)) {
@@ -772,7 +772,7 @@ ss::future<result<raft::replicate_result>> rm_stm::replicate_seq(
         co_return errc::not_leader;
     }
     if (!check_seq(bid)) {
-        co_return errc::sequence_out_of_order;
+        co_return errc::generic_tx_error;
     }
     co_return co_await _c->replicate(_insync_term, std::move(br), opts);
 }

--- a/src/v/cluster/tests/idempotency_tests.cc
+++ b/src/v/cluster/tests/idempotency_tests.cc
@@ -184,7 +184,7 @@ FIXTURE_TEST(test_rm_stm_prevents_duplicates, mux_state_machine_fixture) {
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get0();
     BOOST_REQUIRE(
-      r2 == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
+      r2 == failure_type<cluster::errc>(cluster::errc::generic_tx_error));
 }
 
 FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
@@ -236,7 +236,7 @@ FIXTURE_TEST(test_rm_stm_prevents_gaps, mux_state_machine_fixture) {
                   raft::replicate_options(raft::consistency_level::quorum_ack))
                 .get0();
     BOOST_REQUIRE(
-      r2 == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
+      r2 == failure_type<cluster::errc>(cluster::errc::generic_tx_error));
 }
 
 FIXTURE_TEST(
@@ -273,5 +273,5 @@ FIXTURE_TEST(
                  raft::replicate_options(raft::consistency_level::quorum_ack))
                .get0();
     BOOST_REQUIRE(
-      r == failure_type<cluster::errc>(cluster::errc::sequence_out_of_order));
+      r == failure_type<cluster::errc>(cluster::errc::generic_tx_error));
 }


### PR DESCRIPTION
Currently Redpanda doesn't do de duplication and returns `OutOfOrderSequenceException` error when it suspects an out of order record. Modern clients consider it as a non fatal error, bumps an epoch, resets seq number and retries the request. As a result in case of a network isolation (client <-> leader) or an leader termination (kill -9) a record may be produced twice.

Mitigating the problem by returning a generic fatal error.

Fixes: #3039