### PR TITLE
utils: fix retry_chain_node logger

### DIFF
--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -361,8 +361,9 @@ public:
                       "{} - {}",
                       _node("{}", _ctx.value()),
                       std::move(msg));
+                } else {
+                    logger.log(lvl, "{} - {}", _node(), std::move(msg));
                 }
-                logger.log(lvl, "{} - {}", _node(), std::move(msg));
             };
             do_log(lvl, std::move(lambda));
         }


### PR DESCRIPTION
`retry_chain_logger` used to write the same message two times, if the
context was present. This PR fixes that.
