### PR TITLE
redpanda: Reduce header dependencies

### DIFF
--- a/src/v/cloud_storage/fwd.h
+++ b/src/v/cloud_storage/fwd.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace cloud_storage {
+
+class cache;
+class partition_recovery_manager;
+class remote;
+
+} // namespace cloud_storage

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -12,6 +12,7 @@
 #include "coproc/api.h"
 
 #include "cluster/non_replicable_topics_frontend.h"
+#include "coproc/event_handler.h"
 #include "coproc/event_listener.h"
 #include "coproc/pacemaker.h"
 

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "cluster/fwd.h"
-#include "coproc/event_handler.h"
 #include "coproc/fwd.h"
 #include "coproc/sys_refs.h"
 #include "utils/unresolved_address.h"

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -20,6 +20,7 @@ class script_context;
 namespace wasm {
 
 class script_dispatcher;
+class async_event_handler;
 class event_listener;
 
 } // namespace wasm

--- a/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
@@ -13,6 +13,7 @@
 
 #include "config/configuration.h"
 #include "coproc/api.h"
+#include "coproc/event_handler.h"
 #include "coproc/logger.h"
 #include "coproc/tests/utils/event_publisher_utils.h"
 #include "coproc/tests/utils/kafka_publish_consumer.h"

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -12,8 +12,7 @@
 #pragma once
 
 #include "archival/fwd.h"
-#include "cloud_storage/cache_service.h"
-#include "cloud_storage/partition_recovery_manager.h"
+#include "cloud_storage/fwd.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
 #include "coproc/fwd.h"


### PR DESCRIPTION
## Cover letter

Reduce transitive includes from `application.h` to reduce rebuild times.

## Release notes

None