### PR TITLE
schema_registry: Prevent deleting referenced schema

### DIFF
--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -58,6 +58,8 @@ struct reply_error_category final : std::error_category {
             return "Invalid schema version";
         case reply_error_code::compatibility_level_invalid:
             return "Invalid compatibility level";
+        case reply_error_code::subject_version_has_references:
+            return "One or more references exist to the schema";
         case reply_error_code::write_collision:
             return "write_collision";
         case reply_error_code::zookeeper_error:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -43,6 +43,7 @@ enum class reply_error_code : uint16_t {
     schema_empty = 42201,
     schema_version_invalid = 42202,
     compatibility_level_invalid = 42203,
+    subject_version_has_references = 42206,
     write_collision = 50301,
     zookeeper_error = 50001,
     kafka_error = 50002,

--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -50,6 +50,8 @@ struct error_category final : std::error_category {
                    "permanently";
         case error_code::subject_version_not_deleted:
             return "Version not deleted before being permanently deleted";
+        case error_code::subject_version_has_references:
+            return "One or more references exist to the schema";
         case error_code::subject_schema_invalid:
             return "Error while looking up schema under subject";
         case error_code::write_collision:
@@ -92,6 +94,8 @@ struct error_category final : std::error_category {
             return reply_error_code::schema_empty; // 42201
         case error_code::schema_version_invalid:
             return reply_error_code::schema_version_invalid; // 42202
+        case error_code::subject_version_has_references:
+            return reply_error_code::subject_version_has_references; // 42206
         case error_code::schema_incompatible:
             return reply_error_code::conflict; // 409
         case error_code::topic_parse_error:

--- a/src/v/pandaproxy/schema_registry/error.h
+++ b/src/v/pandaproxy/schema_registry/error.h
@@ -28,6 +28,7 @@ enum class error_code {
     subject_not_deleted,
     subject_version_soft_deleted,
     subject_version_not_deleted,
+    subject_version_has_references,
     subject_schema_invalid,
     write_collision,
     topic_parse_error,

--- a/src/v/pandaproxy/schema_registry/errors.h
+++ b/src/v/pandaproxy/schema_registry/errors.h
@@ -140,4 +140,14 @@ inline error_info invalid_schema(const canonical_schema& schema) {
       error_code::schema_invalid, fmt::format("Invalid schema {}", schema)};
 }
 
+inline error_info has_references(const subject& sub, schema_version ver) {
+    return {
+      error_code::subject_version_has_references,
+      fmt::format(
+        "One or more references exist to the schema "
+        "{{magic=1,keytype=SCHEMA,subject={},version={}}}",
+        sub(),
+        ver())};
+}
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -73,6 +73,9 @@ public:
     ss::future<std::vector<schema_version>>
     get_versions(const subject& sub, include_deleted inc_del);
 
+    ///\brief Return whether there are any references to a subject version.
+    ss::future<bool> is_referenced(const subject& sub, schema_version ver);
+
     ///\brief Delete a subject.
     ss::future<std::vector<schema_version>> delete_subject(
       seq_marker marker, const subject& sub, permanent_delete permanent);

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -293,6 +293,23 @@ public:
         return sub_it->second.versions;
     }
 
+    bool is_referenced(const subject& sub, schema_version ver) {
+        return std::any_of(
+          _subjects.begin(), _subjects.end(), [&sub, ver](const auto& s) {
+              return std::any_of(
+                s.second.versions.begin(),
+                s.second.versions.end(),
+                [&sub, ver](const auto& v) {
+                    return std::any_of(
+                      v.refs.begin(),
+                      v.refs.end(),
+                      [&sub, ver](const auto& ref) {
+                          return ref.sub == sub && ref.version == ver;
+                      });
+                });
+          });
+    }
+
     ///\brief Delete a subject.
     result<std::vector<schema_version>> delete_subject(
       seq_marker marker, const subject& sub, permanent_delete permanent) {

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -33,6 +33,7 @@ rp_test(
   SOURCES
     get_schema_types.cc
     post_subjects_subject_version.cc
+    delete_subject_endpoints.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::application
   # TODO(Ben): Make schema_registry properly sharded

--- a/src/v/pandaproxy/schema_registry/test/avro_payloads.h
+++ b/src/v/pandaproxy/schema_registry/test/avro_payloads.h
@@ -1,0 +1,60 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "pandaproxy/schema_registry/avro.h"
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+const ss::sstring avro_string_payload{
+  R"(
+{
+  "schema": "\"string\"",
+  "schemaType": "AVRO",
+  "references": [
+    {
+       "name": "com.acme.Referenced",
+       "subject":  "childSubject",
+       "version": 1
+    }
+  ]
+})"};
+const ss::sstring expected_avro_string_def{R"({"string"})"};
+
+const ss::sstring avro_int_payload{
+  R"(
+{
+  "schema": "\"int\"",
+  "schemaType": "AVRO",
+  "references": [
+    {
+       "name": "com.acme.Referenced",
+       "subject":  "childSubject",
+       "version": 1
+    }
+  ]
+})"};
+const ss::sstring expected_avro_int_def{R"({"int"})"};
+
+const ss::sstring avro_long_payload{
+  R"(
+{
+  "schema": "\"long\"",
+  "schemaType": "AVRO",
+  "references": [
+    {
+       "name": "com.acme.Referenced",
+       "subject":  "childSubject",
+       "version": 1
+    }
+  ]
+})"};
+const ss::sstring expected_avro_long_def{R"({"long"})"};

--- a/src/v/pandaproxy/schema_registry/test/avro_payloads.h
+++ b/src/v/pandaproxy/schema_registry/test/avro_payloads.h
@@ -18,14 +18,7 @@ const ss::sstring avro_string_payload{
   R"(
 {
   "schema": "\"string\"",
-  "schemaType": "AVRO",
-  "references": [
-    {
-       "name": "com.acme.Referenced",
-       "subject":  "childSubject",
-       "version": 1
-    }
-  ]
+  "schemaType": "AVRO"
 })"};
 const ss::sstring expected_avro_string_def{R"({"string"})"};
 
@@ -33,14 +26,7 @@ const ss::sstring avro_int_payload{
   R"(
 {
   "schema": "\"int\"",
-  "schemaType": "AVRO",
-  "references": [
-    {
-       "name": "com.acme.Referenced",
-       "subject":  "childSubject",
-       "version": 1
-    }
-  ]
+  "schemaType": "AVRO"
 })"};
 const ss::sstring expected_avro_int_def{R"({"int"})"};
 
@@ -48,13 +34,6 @@ const ss::sstring avro_long_payload{
   R"(
 {
   "schema": "\"long\"",
-  "schemaType": "AVRO",
-  "references": [
-    {
-       "name": "com.acme.Referenced",
-       "subject":  "childSubject",
-       "version": 1
-    }
-  ]
+  "schemaType": "AVRO"
 })"};
 const ss::sstring expected_avro_long_def{R"({"long"})"};

--- a/src/v/pandaproxy/schema_registry/test/client_utils.h
+++ b/src/v/pandaproxy/schema_registry/test/client_utils.h
@@ -99,3 +99,20 @@ get_body_versions(const ss::sstring& body) {
 
     return found_versions;
 }
+
+inline int get_body_error_code(const ss::sstring& body) {
+    rapidjson::Document doc;
+    if (doc.Parse(body).HasParseError()) {
+        throw ppj::parse_error(doc.GetErrorOffset());
+    }
+    if (!doc.IsObject()) {
+        throw ppj::exception_base{
+          ppj::error_code::invalid_json, "Body is not an object"};
+    }
+    auto obj = doc.GetObject();
+    if (!obj["error_code"].IsInt()) {
+        throw ppj::exception_base{
+          ppj::error_code::invalid_json, "error_code not an int"};
+    }
+    return obj["error_code"].Get<int>();
+}

--- a/src/v/pandaproxy/schema_registry/test/client_utils.h
+++ b/src/v/pandaproxy/schema_registry/test/client_utils.h
@@ -1,0 +1,43 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "http/client.h"
+#include "pandaproxy/json/exceptions.h"
+#include "pandaproxy/json/types.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "pandaproxy/test/utils.h"
+
+#include <absl/algorithm/container.h>
+#include <boost/beast/http/status.hpp>
+#include <boost/beast/http/verb.hpp>
+
+#include <iterator>
+
+namespace pp = pandaproxy;
+namespace ppj = pp::json;
+namespace pps = pp::schema_registry;
+
+inline iobuf make_body(const ss::sstring& body) {
+    iobuf buf;
+    buf.append(body.data(), body.size());
+    return buf;
+}
+
+inline auto post_schema(
+  http::client& client, const pps::subject& sub, const ss::sstring& payload) {
+    return http_request(
+      client,
+      fmt::format("/subjects/{}/versions", sub()),
+      make_body(payload),
+      boost::beast::http::verb::post,
+      ppj::serialization_format::schema_registry_v1_json,
+      ppj::serialization_format::schema_registry_v1_json);
+}

--- a/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
+++ b/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
@@ -1,0 +1,120 @@
+// Copyright 2020 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/test/avro_payloads.h"
+#include "pandaproxy/schema_registry/test/client_utils.h"
+#include "pandaproxy/schema_registry/types.h"
+#include "pandaproxy/test/pandaproxy_fixture.h"
+#include "pandaproxy/test/utils.h"
+
+#include <boost/beast/http/field.hpp>
+#include <boost/beast/http/status.hpp>
+#include <boost/beast/http/verb.hpp>
+#include <boost/test/tools/old/interface.hpp>
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Connecting client");
+    auto client = make_schema_reg_client();
+
+    {
+        info("Post a schema as key");
+        auto res = post_schema(
+          client, pps::subject{"test-key"}, avro_int_payload);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+
+    {
+        info("Expect version 1");
+        auto res = get_subject_versions(client, pps::subject{"test-key"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{1}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    {
+        info("Delete version 1");
+        auto res = delete_subject_version(
+          client, pps::subject{"test-key"}, pps::schema_version{1});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+
+    {
+        info("Expect subject not_found");
+        auto res = get_subject_versions(client, pps::subject{"test-key"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::not_found);
+    }
+
+    {
+        info("Expect deleted version 1");
+        auto res = get_subject_versions(
+          client, pps::subject{"test-key"}, pps::include_deleted::yes);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{1}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    {
+        info("Hard delete version 1");
+        auto res = delete_subject_version(
+          client,
+          pps::subject{"test-key"},
+          pps::schema_version{1},
+          pps::permanent_delete::yes);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+
+    {
+        info("Expect sub not found");
+        auto res = get_subject_versions(
+          client, pps::subject{"test-key"}, pps::include_deleted::yes);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::not_found);
+    }
+
+    {
+        info("Repost a schema as key");
+        auto res = post_schema(
+          client, pps::subject{"test-key"}, avro_int_payload);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+
+    {
+        info("Expect version 1");
+        auto res = get_subject_versions(client, pps::subject{"test-key"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{1}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    {
+        info("Delete subject");
+        auto res = delete_subject(client, pps::subject{"test-key"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+}

--- a/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
+++ b/src/v/pandaproxy/schema_registry/test/delete_subject_endpoints.cc
@@ -118,3 +118,101 @@ FIXTURE_TEST(test_delete_subject, pandaproxy_test_fixture) {
           res.headers.result(), boost::beast::http::status::ok);
     }
 }
+
+FIXTURE_TEST(test_delete_referenced_subject, pandaproxy_test_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Connecting client");
+    auto client = make_schema_reg_client();
+
+    {
+        info("Post a schema as key");
+        auto res = post_schema(
+          client, pps::subject{"int-key"}, avro_int_payload);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+
+    {
+        info("Expect version 1");
+        auto res = get_subject_versions(client, pps::subject{"int-key"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+
+        std::vector<pps::schema_version> expected{pps::schema_version{1}};
+        auto versions = get_body_versions(res.body);
+        BOOST_REQUIRE_EQUAL(versions, expected);
+    }
+
+    {
+        info("Post a schema as key, which references the first");
+        auto res = post_schema(
+          client,
+          pps::subject{"reference-key"},
+          ss::sstring{
+            R"(
+{
+  "schema": "\"long\"",
+  "schemaType": "AVRO",
+  "references": [
+    {
+       "name": "com.acme.Referenced",
+       "subject":  "int-key",
+       "version": 1
+    }
+  ]
+})"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+
+    {
+        info("Delete version 1, expect failure 42206");
+        auto res = delete_subject_version(
+          client, pps::subject{"int-key"}, pps::schema_version{1});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(),
+          boost::beast::http::status::unprocessable_entity);
+        BOOST_REQUIRE_EQUAL(get_body_error_code(res.body), 42206);
+    }
+
+    {
+        info("Delete subject int-key, expect failure 42206");
+        auto res = delete_subject(client, pps::subject{"int-key"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(),
+          boost::beast::http::status::unprocessable_entity);
+        BOOST_REQUIRE_EQUAL(get_body_error_code(res.body), 42206);
+    }
+
+    {
+        info("Delete subject reference-key");
+        auto res = delete_subject(client, pps::subject{"reference-key"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+
+    {
+        info("Delete subject int-key");
+        auto res = delete_subject(client, pps::subject{"int-key"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(),
+          boost::beast::http::status::unprocessable_entity);
+        BOOST_REQUIRE_EQUAL(get_body_error_code(res.body), 42206);
+    }
+
+    {
+        info("Permanantly delete subject reference-key");
+        auto res = delete_subject(
+          client, pps::subject{"reference-key"}, pps::permanent_delete::yes);
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+
+    {
+        info("Delete subject int-key");
+        auto res = delete_subject(client, pps::subject{"int-key"});
+        BOOST_REQUIRE_EQUAL(
+          res.headers.result(), boost::beast::http::status::ok);
+    }
+}

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "http/client.h"
+#include "pandaproxy/schema_registry/test/avro_payloads.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/test/pandaproxy_fixture.h"
 #include "pandaproxy/test/utils.h"
@@ -20,51 +21,6 @@
 namespace pp = pandaproxy;
 namespace ppj = pp::json;
 namespace pps = pp::schema_registry;
-
-const ss::sstring avro_string_payload{
-  R"(
-{
-  "schema": "\"string\"",
-  "schemaType": "AVRO",
-  "references": [
-    {
-       "name": "com.acme.Referenced",
-       "subject":  "childSubject",
-       "version": 1
-    }
-  ]
-})"};
-const ss::sstring expected_avro_string_def{R"({"string"})"};
-
-const ss::sstring avro_int_payload{
-  R"(
-{
-  "schema": "\"int\"",
-  "schemaType": "AVRO",
-  "references": [
-    {
-       "name": "com.acme.Referenced",
-       "subject":  "childSubject",
-       "version": 1
-    }
-  ]
-})"};
-const ss::sstring expected_avro_int_def{R"({"int"})"};
-
-const ss::sstring avro_long_payload{
-  R"(
-{
-  "schema": "\"long\"",
-  "schemaType": "AVRO",
-  "references": [
-    {
-       "name": "com.acme.Referenced",
-       "subject":  "childSubject",
-       "version": 1
-    }
-  ]
-})"};
-const ss::sstring expected_avro_long_def{R"({"long"})"};
 
 iobuf make_body(const ss::sstring& body) {
     iobuf buf;

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -7,37 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "http/client.h"
 #include "pandaproxy/schema_registry/test/avro_payloads.h"
+#include "pandaproxy/schema_registry/test/client_utils.h"
 #include "pandaproxy/schema_registry/types.h"
 #include "pandaproxy/test/pandaproxy_fixture.h"
 #include "pandaproxy/test/utils.h"
 
-#include <boost/beast/http/field.hpp>
-#include <boost/beast/http/status.hpp>
-#include <boost/beast/http/verb.hpp>
-#include <boost/test/tools/old/interface.hpp>
-
 namespace pp = pandaproxy;
 namespace ppj = pp::json;
 namespace pps = pp::schema_registry;
-
-iobuf make_body(const ss::sstring& body) {
-    iobuf buf;
-    buf.append(body.data(), body.size());
-    return buf;
-}
-
-auto post_schema(
-  http::client& client, const pps::subject& sub, const ss::sstring& payload) {
-    return http_request(
-      client,
-      fmt::format("/subjects/{}/versions", sub()),
-      make_body(payload),
-      boost::beast::http::verb::post,
-      ppj::serialization_format::schema_registry_v1_json,
-      ppj::serialization_format::schema_registry_v1_json);
-}
 
 FIXTURE_TEST(
   schema_registry_post_subjects_subject_version, pandaproxy_test_fixture) {


### PR DESCRIPTION
## Cover letter

If a schema is referenced by another schema, it should be prevented from being deleted, returning `"error_code": 42206`.

## Release notes

schema_registry: Prevent deleting referenced schema
