### PR TITLE
Raft reconfiguration availability fix (demoting voter before removing it)

### DIFF
--- a/src/v/raft/configuration_manager.cc
+++ b/src/v/raft/configuration_manager.cc
@@ -413,15 +413,16 @@ ss::future<offset_configuration> configuration_manager::wait_for_change(
 
 ss::future<> configuration_manager::remove_persistent_state() {
     return _storage.kvs()
-      .remove(storage::kvstore::key_space::consensus, configurations_map_key())
-      .then([this] {
-          return _storage.kvs().remove(
-            storage::kvstore::key_space::consensus, highest_known_offset_key());
-      })
+      .remove(
+        storage::kvstore::key_space::consensus, highest_known_offset_key())
       .then([this] {
           return _storage.kvs().remove(
             storage::kvstore::key_space::consensus,
             next_configuration_idx_key());
+      })
+      .then([this] {
+          return _storage.kvs().remove(
+            storage::kvstore::key_space::consensus, configurations_map_key());
       });
 }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -810,8 +810,10 @@ void consensus::dispatch_vote(bool leadership_transfer) {
     // lower our required priority for next time.
     _target_priority = next_target_priority();
 
-    // skip sending vote request if current node is not a voter
-    if (!_configuration_manager.get_latest().is_voter(_self)) {
+    // skip sending vote request if current node is not a voter in current
+    // configuration
+    if (!_configuration_manager.get_latest().is_allowed_to_request_votes(
+          _self)) {
         arm_vote_timeout();
         return;
     }
@@ -2231,22 +2233,45 @@ ss::future<> consensus::maybe_commit_configuration(ss::semaphore_units<> u) {
     }
 
     auto latest_cfg = _configuration_manager.get_latest();
-    // as a leader replicate new simple configuration
-    if (
-      latest_cfg.type() == configuration_type::joint
-      && latest_cfg.current_config().learners.empty()) {
-        latest_cfg.discard_old_config();
-        vlog(
-          _ctxlog.trace,
-          "leaving joint consensus, new simple configuration {}",
-          latest_cfg);
+    /**
+     * simple configuration, there is nothing to do
+     */
+    if (latest_cfg.type() == configuration_type::simple) {
+        return ss::now();
+    }
+    /**
+     * at this point joint configuration is committed, and all added learners
+     * were promoted to voter
+     */
+    if (latest_cfg.current_config().learners.empty()) {
+        /*
+         * In the first step we demote all removed voters to learners
+         */
+
+        if (latest_cfg.maybe_demote_removed_voters()) {
+            vlog(
+              _ctxlog.info,
+              "demoting removed voters, new configuration {}",
+              latest_cfg);
+        } else {
+            /**
+             * When all old voters were demoted, as a leader, we replicate new
+             * configuration
+             */
+            latest_cfg.discard_old_config();
+            vlog(
+              _ctxlog.info,
+              "leaving joint consensus, new simple configuration {}",
+              latest_cfg);
+        }
+
         auto contains_current = latest_cfg.contains(_self);
         return replicate_configuration(std::move(u), std::move(latest_cfg))
           .then([this, contains_current](std::error_code ec) {
               if (ec) {
                   vlog(
                     _ctxlog.error,
-                    "unable to replicate simple configuration  - {}",
+                    "unable to replicate updated configuration - {}",
                     ec);
                   return;
               }
@@ -2259,7 +2284,6 @@ ss::future<> consensus::maybe_commit_configuration(ss::semaphore_units<> u) {
               }
           });
     }
-
     return ss::now();
 }
 

--- a/src/v/raft/prevote_stm.cc
+++ b/src/v/raft/prevote_stm.cc
@@ -131,6 +131,11 @@ ss::future<bool> prevote_stm::prevote(bool leadership_transfer) {
           }
 
           _config = _ptr->config();
+
+          // special case, it may happen that node requesting votes is not a
+          // voter, it may happen if it is a learner in previous configuration
+          _replies.emplace(_ptr->_self, vmeta{});
+
           _config->for_each_voter(
             [this](vnode id) { _replies.emplace(id, vmeta{}); });
 

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -110,6 +110,10 @@ ss::future<> vote_stm::vote(bool leadership_transfer) {
           _ptr->_term += model::term_id(1);
           _ptr->_voted_for = {};
 
+          // special case, it may happen that node requesting votes is not a
+          // voter, it may happen if it is a learner in previous configuration
+          _replies.emplace(_ptr->_self, vmeta{});
+
           // vote is the only method under _op_sem
           _config->for_each_voter(
             [this](vnode id) { _replies.emplace(id, vmeta{}); });


### PR DESCRIPTION
Fixed issue leading to unavailability that may occur during reconfiguration in face of failures.

Assumptions:

- raft group with single node
- configuration is described as

```
{current: {voters: [...], learners: [...]}, old: {voters: [...],
learners: [...]}}
```

where each array `[...]` is an array of node ids

Example.

At some point single replica partition was requested to move from one node to another, its configuration is going to change.

In Raft in order for this to happen configuration will need to evolve in a following steps (assuming we move replica from node 1 to 2)

1. `{current: {voters: [1], learners: []}, old: null}`
2. configuration change requested  from `1` -> `2`
3. `{current: {voters: [], learners: [2]}, old: {voters: [1], learners:[]}}`
4. after node 2 log is complete it is promoted to be a voter
5. `{current: {voters: [2], learners: []}, old: {voters: [1], learners:[]}}`
6. after configuration from previous step is committed, leader initiates leaving joint consensus mode
7. `{current: {voters: [2], learners: []}, old: null}`
8. after configuration from previous step is committed, old leader steps down

In this scenario raft group is vulnerable to availability loss when current leader crashes after appending configuration from step 7 or RPC request is not delivered to node `2` and leadership is lost.

In this scenario last configuration on node `2` is:
```
{current: {voters: [2], learners: []}, old: {voters: [1], learners: []}}
```

while on the node `1`:

```
{current: {voters: [2], learners: []}, old: null}
```

since node `1` appended configuration to its log already, its log is longer than on node `2`. This makes all vote requests from `2` to fail. Node `1` can not be elected as a leader since in its state it is not longer a part of a raft group.

In order to solve that unavailability issue we are going to introduce additional step between 5 & 7. In the additional step we demote all the voters from old configuration to learners.

1. `{current: {voters: [1], learners: []}, old: null}`
2. configuration change requested  from `1` -> `2`
3. `{current: {voters: [], learners: [2]}, old: {voters: [1], learners: []}}`
4. after node 2 log is complete it is promoted to be a voter
5. `{current: {voters: [2], learners: []}, old: {voters: [1], learners: []}}`
6. after configuration from previous step is committed we demote old voters to learners
7. `{current: {voters: [2], learners: []}, old: {voters: [], learners:[1]}}`
8. after configuration from previous step is committed, leader initiates leaving joint consensus mode
9. `{current: {voters: [2], learners: []}, old: null}`
10. after configuration is committed, old leader steps down

In case of a failure described previously, between steps 5 & 7, raft group will be able to make progress.

configuration on node `1`:

```
{current: {voters: [2], learners: []}, old: {voters: [], learners: [1]}}
```

configuration on node `2`:

```
{current: {voters: [2], learners: []}, old: {voters: [1], learners: []}}
```

in this scenario we must allow learners from old configuration to vote, this is safe since they must be up to date as they were a voters previously, additionally all the checks while casting votes will apply. In this scenario node `1` will become a leader and continue to drive the configuration change forward.

If a failure would occur between steps 7&9 nodes configuration would be following:

configuration on node `1`:

```
{current: {voters: [2], learners: []}, old: null}
```

configuration on node `2`:

```
{current: {voters: [2], learners: []}, old: {voters: [], learners: [1]}}
```

In this scenario node `2` will immediately win election since learner
is not a part of quorum.

Signed-off-by: Michal Maslanka <michal@vectorized.io>

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
