### PR TITLE
docs: Fix kafka file tree in data-migration

### DIFF
--- a/docs/www/data-migration.md
+++ b/docs/www/data-migration.md
@@ -51,8 +51,9 @@ You can find the MirrorMaker script and configuration files in the expanded Kafk
 ```
 .
 └── kafka_2.13-3.0.0
-    └── config
+    └── bin
         └── connect-mirror-maker.sh
+    └── config
         └── connect-mirror-maker.properties
 ```
 


### PR DESCRIPTION
## Cover letter

Fixes the docs to show that the MirrorMaker script is in the bin directory.

Fixes: #NNN, #NNN, ...

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
