### PR TITLE
kafka: enable queue depth control by default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -82,7 +82,7 @@ configuration::configuration()
       "TCP receive buffer size in bytes.",
       required::no,
       std::nullopt,
-      32_KiB)
+      64_KiB)
   , rpc_server_tcp_send_buf(
       *this,
       "rpc_server_tcp_send_buf",
@@ -826,7 +826,7 @@ configuration::configuration()
       "kafka_qdc_enable",
       "Enable kafka queue depth control.",
       required::no,
-      false)
+      true)
   , kafka_qdc_depth_alpha(
       *this,
       "kafka_qdc_depth_alpha",
@@ -838,13 +838,13 @@ configuration::configuration()
       "kafka_qdc_max_latency_ms",
       "Max latency threshold for kafka queue depth control depth tracking.",
       required::no,
-      80ms)
+      4ms)
   , kafka_qdc_idle_depth(
       *this,
       "kafka_qdc_idle_depth",
       "Queue depth when idleness is detected in kafka queue depth control.",
       required::no,
-      10)
+      8)
   , kafka_qdc_min_depth(
       *this,
       "kafka_qdc_min_depth",
@@ -856,7 +856,7 @@ configuration::configuration()
       "kafka_qdc_max_depth",
       "Maximum queue depth used in kafka queue depth control.",
       required::no,
-      100)
+      32)
   , kafka_qdc_depth_update_ms(
       *this,
       "kafka_qdc_depth_update_ms",


### PR DESCRIPTION
This PR enables the Kafka queue depth controls by default. It was observed in AWS and Azure that these settings significantly help reduce producer ack latency when disks reach write saturation.

```
sudo rpk config set redpanda.kafka_qdc_enable true
sudo rpk config set redpanda.kafka_qdc_idle_depth 8
sudo rpk config set redpanda.kafka_qdc_max_depth 32
sudo rpk config set redpanda.kafka_qdc_max_latency_ms 4
sudo rpk config set redpanda.rpc_server_tcp_recv_buf 65536
```