### PR TITLE
Disable fstrim tuner by default in prod mode

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/mode_test.go
@@ -36,7 +36,7 @@ func fillRpkConfig(path, mode string) *config.Config {
 		TuneDiskWriteCache: val,
 		TuneNomerges:       val,
 		TuneDiskIrq:        val,
-		TuneFstrim:         val,
+		TuneFstrim:         false,
 		TuneCpu:            val,
 		TuneAioEvents:      val,
 		TuneClocksource:    val,

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -183,7 +183,7 @@ func setProduction(conf *Config) *Config {
 	conf.Rpk.TuneDiskScheduler = true
 	conf.Rpk.TuneNomerges = true
 	conf.Rpk.TuneDiskIrq = true
-	conf.Rpk.TuneFstrim = true
+	conf.Rpk.TuneFstrim = false
 	conf.Rpk.TuneCpu = true
 	conf.Rpk.TuneAioEvents = true
 	conf.Rpk.TuneClocksource = true

--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -1914,7 +1914,7 @@ func TestSetMode(t *testing.T) {
 				TuneNomerges:       val,
 				TuneDiskWriteCache: val,
 				TuneDiskIrq:        val,
-				TuneFstrim:         val,
+				TuneFstrim:         false,
 				TuneCpu:            val,
 				TuneAioEvents:      val,
 				TuneClocksource:    val,


### PR DESCRIPTION
fstrim is not reliable on all hardware, so for now we disable it by
default in mode production.

Fixes #3068.

## Cover letter

fstrim tuner, which enables fstrim.timer service, can occasionally cause instability when run on in-use filesystems, depending on hardware, software and OS configuration.

Since we don't have a specific test we can do to detect this problem, and no exhaustive "good" and "bad" lists of configuration, we are disabling the tuner by default for now in mode production. Of course, users may still have the fstrim task enabled themselves (it is a service shipped with many distros, and is being enabled, for example, [in Fedora 32](https://fedoraproject.org/wiki/Changes/EnableFSTrimTimer)), and this won't change that.

## Release notes

Release note: The fstrim tuner, which enables or installs the `fstrim.service` an d `fstrim.timer` is no longer enabled by default when running `rpk redpanda mode production`.