### PR TITLE
Add topic level configuration for archival/SI

### DIFF
--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -184,6 +184,9 @@ public:
           model::topic_namespace(ntp.ns, ntp.tp.topic)));
     }
 
+    ss::future<> add_topic_with_archival_enabled(
+      model::topic_namespace_view tp_ns, int partitions = 1);
+
 private:
     void
     initialize_shard(storage::api& api, const std::vector<segment_desc>& segm);

--- a/src/v/archival/tests/service_test.cc
+++ b/src/v/archival/tests/service_test.cc
@@ -165,7 +165,7 @@ FIXTURE_TEST(test_segment_upload, archiver_fixture) {
       builder->bytes_written(),
       ntp.path());
     builder.reset();
-    add_topic(model::topic_namespace_view(ntp)).get();
+    add_topic_with_archival_enabled(model::topic_namespace_view(ntp)).get();
 
     wait_for_partition_leadership(ntp);
 

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -272,6 +272,11 @@ ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
 }
 
 model::offset archival_metadata_stm::max_collectible_offset() {
+    if (!_raft->log_config().is_archival_enabled()) {
+        // The archival is disabled but the state machine still exists so we
+        // shouldn't stop eviction from happening.
+        return model::offset::max();
+    }
     return _last_offset;
 }
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -74,7 +74,6 @@ partition::partition(
             stm_manager->add_stm(_rm_stm);
         }
 
-        // TODO: check topic config if archival is enabled for this topic
         if (
           config::shard_local_cfg().cloud_storage_enabled()
           && cloud_storage_api.local_is_initialized()

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -209,6 +209,12 @@ public:
         return _archival_meta_stm;
     }
 
+    /// Return true if shadow indexing is enabled for the partition
+    bool is_remote_fetch_enabled() const {
+        const auto& cfg = _raft->log_config();
+        return cfg.is_remote_fetch_enabled();
+    }
+
     /// Check if cloud storage is connected to cluster partition
     ///
     /// The remaining 'cloud' methods can only be called if this

--- a/src/v/cluster/tests/topic_configuration_compat_test.cc
+++ b/src/v/cluster/tests/topic_configuration_compat_test.cc
@@ -12,13 +12,17 @@
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/timestamp.h"
 #include "reflection/adl.h"
 #include "test_utils/randoms.h"
 #include "test_utils/rpc.h"
 #include "units.h"
+#include "v8_engine/data_policy.h"
 
 #include <seastar/core/loop.hh>
 #include <seastar/testing/thread_test_case.hh>
+
+#include <chrono>
 
 using namespace std::chrono_literals; // NOLINT
 
@@ -69,6 +73,59 @@ struct topic_configuration_assignment {
 
     topic_configuration cfg;
     std::vector<cluster::partition_assignment> assignments;
+};
+
+struct incremental_topic_updates_1 {
+    static constexpr int8_t version = -1;
+    cluster::property_update<std::optional<model::compression>> compression;
+    cluster::property_update<std::optional<model::cleanup_policy_bitflags>>
+      cleanup_policy_bitflags;
+    cluster::property_update<std::optional<model::compaction_strategy>>
+      compaction_strategy;
+    cluster::property_update<std::optional<model::timestamp_type>>
+      timestamp_type;
+    cluster::property_update<std::optional<size_t>> segment_size;
+    cluster::property_update<tristate<size_t>> retention_bytes;
+    cluster::property_update<tristate<std::chrono::milliseconds>>
+      retention_duration;
+    cluster::property_update<std::optional<v8_engine::data_policy>> data_policy;
+};
+
+struct incremental_topic_updates_2 {
+    static constexpr int8_t version = -2;
+    cluster::property_update<std::optional<model::compression>> compression;
+    cluster::property_update<std::optional<model::cleanup_policy_bitflags>>
+      cleanup_policy_bitflags;
+    cluster::property_update<std::optional<model::compaction_strategy>>
+      compaction_strategy;
+    cluster::property_update<std::optional<model::timestamp_type>>
+      timestamp_type;
+    cluster::property_update<std::optional<size_t>> segment_size;
+    cluster::property_update<tristate<size_t>> retention_bytes;
+    cluster::property_update<tristate<std::chrono::milliseconds>>
+      retention_duration;
+};
+
+/**
+ * Struct representing single topic properties update
+ */
+struct topic_properties_update_v1 {
+    explicit topic_properties_update_v1(model::topic_namespace tp_ns)
+      : tp_ns(std::move(tp_ns)) {}
+
+    model::topic_namespace tp_ns;
+    incremental_topic_updates_1 properties;
+};
+struct topic_properties_update_v2 {
+    explicit topic_properties_update_v2(model::topic_namespace tp_ns)
+      : tp_ns(std::move(tp_ns)) {}
+
+    model::topic_namespace tp_ns;
+    incremental_topic_updates_2 properties;
+};
+
+struct update_topic_properties_request {
+    std::vector<topic_properties_update_v2> updates;
 };
 
 } // namespace old
@@ -171,6 +228,145 @@ struct adl<old::topic_configuration_assignment> {
           = adl<std::vector<cluster::partition_assignment>>{}.from(in);
         return old::topic_configuration_assignment(
           std::move(cfg), std::move(assignments));
+    }
+};
+
+template<>
+struct adl<old::incremental_topic_updates_1> {
+    void to(iobuf& out, old::incremental_topic_updates_1&& t) {
+        reflection::serialize(
+          out,
+          old::incremental_topic_updates_1::version,
+          t.compression,
+          t.cleanup_policy_bitflags,
+          t.compaction_strategy,
+          t.timestamp_type,
+          t.segment_size,
+          t.retention_bytes,
+          t.retention_duration,
+          t.data_policy);
+    }
+
+    old::incremental_topic_updates_1 from(iobuf_parser& in) {
+        auto version = adl<int8_t>{}.from(in.peek(1));
+        if (version < 0) {
+            // Consume version from stream
+            in.skip(1);
+            vassert(
+              version >= old::incremental_topic_updates_1::version,
+              "topic_configuration version {} is not supported",
+              version);
+        } else {
+            version = 0;
+        }
+
+        old::incremental_topic_updates_1 updates;
+        updates.compression
+          = adl<cluster::property_update<std::optional<model::compression>>>{}
+              .from(in);
+        updates.cleanup_policy_bitflags = adl<cluster::property_update<
+          std::optional<model::cleanup_policy_bitflags>>>{}
+                                            .from(in);
+        updates.compaction_strategy = adl<cluster::property_update<
+          std::optional<model::compaction_strategy>>>{}
+                                        .from(in);
+        updates.timestamp_type
+          = adl<
+              cluster::property_update<std::optional<model::timestamp_type>>>{}
+              .from(in);
+        updates.segment_size
+          = adl<cluster::property_update<std::optional<size_t>>>{}.from(in);
+        updates.retention_bytes
+          = adl<cluster::property_update<tristate<size_t>>>{}.from(in);
+        updates.retention_duration
+          = adl<cluster::property_update<tristate<std::chrono::milliseconds>>>{}
+              .from(in);
+        if (version < 0) {
+            updates.data_policy = adl<cluster::property_update<
+              std::optional<v8_engine::data_policy>>>{}
+                                    .from(in);
+        }
+        return updates;
+    }
+};
+
+template<>
+struct adl<old::incremental_topic_updates_2> {
+    void to(iobuf& out, old::incremental_topic_updates_2&& t) {
+        reflection::serialize(
+          out,
+          old::incremental_topic_updates_2::version,
+          t.compression,
+          t.cleanup_policy_bitflags,
+          t.compaction_strategy,
+          t.timestamp_type,
+          t.segment_size,
+          t.retention_bytes,
+          t.retention_duration);
+    }
+    old::incremental_topic_updates_2 from(iobuf_parser& in) {
+        auto version = adl<int8_t>{}.from(in.peek(1));
+        if (version < 0) {
+            // Consume version from stream
+            in.skip(1);
+            vassert(
+              version >= old::incremental_topic_updates_2::version,
+              "topic_configuration version {} is not supported",
+              version);
+        } else {
+            version = 0;
+        }
+
+        old::incremental_topic_updates_2 updates;
+        updates.compression
+          = adl<cluster::property_update<std::optional<model::compression>>>{}
+              .from(in);
+        updates.cleanup_policy_bitflags = adl<cluster::property_update<
+          std::optional<model::cleanup_policy_bitflags>>>{}
+                                            .from(in);
+        updates.compaction_strategy = adl<cluster::property_update<
+          std::optional<model::compaction_strategy>>>{}
+                                        .from(in);
+        updates.timestamp_type
+          = adl<
+              cluster::property_update<std::optional<model::timestamp_type>>>{}
+              .from(in);
+        updates.segment_size
+          = adl<cluster::property_update<std::optional<size_t>>>{}.from(in);
+        updates.retention_bytes
+          = adl<cluster::property_update<tristate<size_t>>>{}.from(in);
+        updates.retention_duration
+          = adl<cluster::property_update<tristate<std::chrono::milliseconds>>>{}
+              .from(in);
+        return updates;
+    }
+};
+
+template<>
+struct adl<old::topic_properties_update_v1> {
+    void to(iobuf& out, old::topic_properties_update_v1&& r) {
+        reflection::serialize(out, r.tp_ns, r.properties);
+    }
+
+    old::topic_properties_update_v1 from(iobuf_parser& parser) {
+        auto tp_ns = adl<model::topic_namespace>{}.from(parser);
+        old::topic_properties_update_v1 ret(std::move(tp_ns));
+        ret.properties = adl<old::incremental_topic_updates_1>{}.from(parser);
+        return ret;
+    }
+};
+
+template<>
+struct adl<old::topic_properties_update_v2> {
+    void to(iobuf& out, old::topic_properties_update_v2&& r) {
+        reflection::serialize(out, r.tp_ns, r.properties);
+    }
+
+    old::topic_properties_update_v2 from(iobuf_parser& parser) {
+        auto tp_ns = adl<model::topic_namespace>{}.from(parser);
+        old::topic_properties_update_v2 ret(std::move(tp_ns));
+        ret.properties = adl<old::incremental_topic_updates_2>{}.from(parser);
+        return ret;
     }
 };
 
@@ -526,4 +722,115 @@ SEASTAR_THREAD_TEST_CASE(topics_configuration_assignment_uniform_rt_test) {
     topic_configuration_assignment_roundtrip<
       cluster::topic_configuration_assignment,
       cluster::topic_configuration_assignment>();
+}
+
+template<class T>
+T make_incremental_topic_properties() {
+    T upd;
+    upd.cleanup_policy_bitflags.op = cluster::incremental_update_operation::set;
+    upd.cleanup_policy_bitflags.value
+      = model::cleanup_policy_bitflags::deletion;
+    upd.compaction_strategy.op = cluster::incremental_update_operation::set;
+    upd.compaction_strategy.value = model::compaction_strategy::offset;
+    upd.compression.op = cluster::incremental_update_operation::set;
+    upd.compression.value = model::compression::zstd;
+    upd.retention_bytes.op = cluster::incremental_update_operation::set;
+    upd.retention_bytes.value = tristate<unsigned long>(12345);
+    upd.segment_size.op = cluster::incremental_update_operation::set;
+    upd.segment_size.value = 54321;
+    upd.retention_duration.op = cluster::incremental_update_operation::set;
+    upd.retention_duration.value = tristate<std::chrono::milliseconds>(10s);
+    upd.timestamp_type.op = cluster::incremental_update_operation::set;
+    upd.timestamp_type.value = model::timestamp_type::create_time;
+    if constexpr (std::is_same<T, cluster::incremental_topic_updates>::value) {
+        upd.shadow_indexing.op = cluster::incremental_update_operation::set;
+        upd.shadow_indexing.value = model::shadow_indexing_mode::archival;
+    }
+    if constexpr (std::is_same<T, old::incremental_topic_updates_1>::value) {
+        upd.data_policy.op = cluster::incremental_update_operation::set;
+        upd.data_policy.value = v8_engine::data_policy("fn", "sn");
+    }
+    return upd;
+}
+
+template<class UpdIn, class UpdOut>
+void compare_incremental_topic_updates(const UpdIn& upd, const UpdOut& res) {
+    BOOST_REQUIRE(
+      upd.cleanup_policy_bitflags.op == res.cleanup_policy_bitflags.op);
+    BOOST_REQUIRE(
+      upd.cleanup_policy_bitflags.value == res.cleanup_policy_bitflags.value);
+    BOOST_REQUIRE(upd.compaction_strategy.op == res.compaction_strategy.op);
+    BOOST_REQUIRE(
+      upd.compaction_strategy.value == res.compaction_strategy.value);
+    BOOST_REQUIRE(upd.compression.op == res.compression.op);
+    BOOST_REQUIRE(upd.compression.value == res.compression.value);
+    BOOST_REQUIRE(upd.retention_bytes.op == res.retention_bytes.op);
+    BOOST_REQUIRE(upd.retention_bytes.value == res.retention_bytes.value);
+    BOOST_REQUIRE(upd.segment_size.op == res.segment_size.op);
+    BOOST_REQUIRE(upd.segment_size.value == res.segment_size.value);
+    BOOST_REQUIRE(upd.retention_duration.op == res.retention_duration.op);
+    BOOST_REQUIRE(upd.retention_duration.value == res.retention_duration.value);
+    BOOST_REQUIRE(upd.timestamp_type.op == res.timestamp_type.op);
+    BOOST_REQUIRE(upd.timestamp_type.value == res.timestamp_type.value);
+    if constexpr (std::is_same<UpdIn, cluster::incremental_topic_updates>::
+                    value) {
+        BOOST_REQUIRE(upd.shadow_indexing.op == res.shadow_indexing.op);
+        BOOST_REQUIRE(upd.shadow_indexing.value == res.shadow_indexing.value);
+    }
+}
+
+template<class UpdIn, class UpdOut>
+void incremental_topic_updates_roundtrip() {
+    auto upd = make_incremental_topic_properties<UpdIn>();
+    auto tmp = upd;
+    auto res = serialize_upgrade_rpc<UpdIn, UpdOut>(std::move(tmp));
+    compare_incremental_topic_updates(upd, res);
+}
+
+SEASTAR_THREAD_TEST_CASE(incremental_topic_updates_upgrade_rt_test_v1) {
+    incremental_topic_updates_roundtrip<
+      old::incremental_topic_updates_1,
+      cluster::incremental_topic_updates>();
+}
+
+SEASTAR_THREAD_TEST_CASE(incremental_topic_updates_upgrade_rt_test_v2) {
+    incremental_topic_updates_roundtrip<
+      old::incremental_topic_updates_2,
+      cluster::incremental_topic_updates>();
+}
+
+SEASTAR_THREAD_TEST_CASE(incremental_topic_updates_uniform_rt_test) {
+    incremental_topic_updates_roundtrip<
+      cluster::incremental_topic_updates,
+      cluster::incremental_topic_updates>();
+}
+
+template<class UpdIn, class UpdOut>
+void topic_properties_updates_roundtrip() {
+    UpdIn upd(model::topic_namespace(model::ns("ns"), model::topic("topic")));
+    upd.properties
+      = make_incremental_topic_properties<decltype(upd.properties)>();
+
+    auto tmp = upd;
+    auto res = serialize_upgrade_rpc<UpdIn, UpdOut>(std::move(tmp));
+
+    compare_incremental_topic_updates(upd.properties, res.properties);
+}
+
+SEASTAR_THREAD_TEST_CASE(topic_properties_updates_upgrade_rt_test_v1) {
+    topic_properties_updates_roundtrip<
+      old::topic_properties_update_v1,
+      cluster::topic_properties_update>();
+}
+
+SEASTAR_THREAD_TEST_CASE(topic_properties_updates_upgrade_rt_test_v2) {
+    topic_properties_updates_roundtrip<
+      old::topic_properties_update_v2,
+      cluster::topic_properties_update>();
+}
+
+SEASTAR_THREAD_TEST_CASE(topic_properties_updates_uniform_rt_test) {
+    topic_properties_updates_roundtrip<
+      cluster::topic_properties_update,
+      cluster::topic_properties_update>();
 }

--- a/src/v/cluster/tests/topic_configuration_compat_test.cc
+++ b/src/v/cluster/tests/topic_configuration_compat_test.cc
@@ -199,8 +199,7 @@ void topic_config_roundtrip() {
     if constexpr (std::is_same<CfgIn, cluster::topic_configuration>::value) {
         // Init new fields
         cfg.properties.recovery = true;
-        cfg.properties.shadow_indexing
-          = model::shadow_indexing_mode::archival_storage;
+        cfg.properties.shadow_indexing = model::shadow_indexing_mode::archival;
     }
 
     auto d = serialize_upgrade_rpc<CfgIn, CfgOut>(std::move(cfg));
@@ -225,7 +224,7 @@ void topic_config_roundtrip() {
         BOOST_REQUIRE(d.properties.recovery == true);
         BOOST_REQUIRE(
           d.properties.shadow_indexing
-          == model::shadow_indexing_mode::archival_storage);
+          == model::shadow_indexing_mode::archival);
     } else {
         BOOST_REQUIRE_EQUAL(false, d.properties.recovery.has_value());
         BOOST_REQUIRE_EQUAL(false, d.properties.shadow_indexing.has_value());
@@ -289,13 +288,13 @@ SEASTAR_THREAD_TEST_CASE(topic_config_with_recovery_field_null_null_rt_test) {
 SEASTAR_THREAD_TEST_CASE(
   topic_config_with_recovery_field_true_archival_rt_test) {
     topic_config_with_recovery_field_roundtrip(
-      true, model::shadow_indexing_mode::archival_storage);
+      true, model::shadow_indexing_mode::archival);
 }
 
 SEASTAR_THREAD_TEST_CASE(
   topic_config_with_recovery_field_true_shadow_indexing_rt_test) {
     topic_config_with_recovery_field_roundtrip(
-      true, model::shadow_indexing_mode::shadow_indexing);
+      true, model::shadow_indexing_mode::fetch);
 }
 
 SEASTAR_THREAD_TEST_CASE(
@@ -312,11 +311,9 @@ void create_topics_request_roundtrip() {
     auto t2 = cfg_t(model::ns("default"), model::topic("tp-2"), 6, 5);
     if constexpr (std::is_same<cfg_t, cluster::topic_configuration>::value) {
         t1.properties.recovery = false;
-        t1.properties.shadow_indexing
-          = model::shadow_indexing_mode::archival_storage;
+        t1.properties.shadow_indexing = model::shadow_indexing_mode::archival;
         t2.properties.recovery = true;
-        t2.properties.shadow_indexing
-          = model::shadow_indexing_mode::shadow_indexing;
+        t2.properties.shadow_indexing = model::shadow_indexing_mode::fetch;
     }
     req.topics = {t1, t2};
     req.timeout = std::chrono::seconds(10101);
@@ -331,7 +328,7 @@ void create_topics_request_roundtrip() {
         BOOST_REQUIRE_EQUAL(res.topics[0].properties.recovery.value(), false);
         BOOST_REQUIRE_EQUAL(
           res.topics[0].properties.shadow_indexing.value(),
-          model::shadow_indexing_mode::archival_storage);
+          model::shadow_indexing_mode::archival);
     } else {
         BOOST_REQUIRE_EQUAL(
           res.topics[0].properties.recovery.has_value(), false);
@@ -347,7 +344,7 @@ void create_topics_request_roundtrip() {
         BOOST_REQUIRE_EQUAL(res.topics[1].properties.recovery.value(), true);
         BOOST_REQUIRE_EQUAL(
           res.topics[1].properties.shadow_indexing.value(),
-          model::shadow_indexing_mode::shadow_indexing);
+          model::shadow_indexing_mode::fetch);
     } else {
         BOOST_REQUIRE_EQUAL(
           res.topics[1].properties.recovery.has_value(), false);
@@ -376,11 +373,9 @@ void create_topics_reply_roundtrip() {
     auto t2 = cfg_t(model::ns("default"), model::topic("tp-2"), 6, 5);
     if constexpr (std::is_same<cfg_t, cluster::topic_configuration>::value) {
         t1.properties.recovery = false;
-        t1.properties.shadow_indexing
-          = model::shadow_indexing_mode::archival_storage;
+        t1.properties.shadow_indexing = model::shadow_indexing_mode::archival;
         t2.properties.recovery = true;
-        t2.properties.shadow_indexing
-          = model::shadow_indexing_mode::shadow_indexing;
+        t2.properties.shadow_indexing = model::shadow_indexing_mode::fetch;
     }
 
     auto md1 = model::topic_metadata(
@@ -438,7 +433,7 @@ void create_topics_reply_roundtrip() {
         BOOST_REQUIRE_EQUAL(res.configs[0].properties.recovery.value(), false);
         BOOST_REQUIRE_EQUAL(
           res.configs[0].properties.shadow_indexing.value(),
-          model::shadow_indexing_mode::archival_storage);
+          model::shadow_indexing_mode::archival);
     } else {
         BOOST_REQUIRE_EQUAL(
           res.configs[0].properties.recovery.has_value(), false);
@@ -454,7 +449,7 @@ void create_topics_reply_roundtrip() {
         BOOST_REQUIRE_EQUAL(res.configs[1].properties.recovery.value(), true);
         BOOST_REQUIRE_EQUAL(
           res.configs[1].properties.shadow_indexing.value(),
-          model::shadow_indexing_mode::shadow_indexing);
+          model::shadow_indexing_mode::fetch);
     } else {
         BOOST_REQUIRE_EQUAL(
           res.configs[1].properties.recovery.has_value(), false);
@@ -481,8 +476,7 @@ void topic_configuration_assignment_roundtrip() {
     auto tc = cfg_t(model::ns("default"), model::topic("tp-1"), 12, 3);
     if constexpr (std::is_same<cfg_t, cluster::topic_configuration>::value) {
         tc.properties.recovery = true;
-        tc.properties.shadow_indexing
-          = model::shadow_indexing_mode::archival_storage;
+        tc.properties.shadow_indexing = model::shadow_indexing_mode::archival;
     }
     auto p1 = cluster::partition_assignment{
       .group = raft::group_id{42},
@@ -514,7 +508,7 @@ void topic_configuration_assignment_roundtrip() {
         BOOST_REQUIRE_EQUAL(res.cfg.properties.recovery.value(), true);
         BOOST_REQUIRE_EQUAL(
           res.cfg.properties.shadow_indexing.value(),
-          model::shadow_indexing_mode::archival_storage);
+          model::shadow_indexing_mode::archival);
     } else {
         BOOST_REQUIRE_EQUAL(res.cfg.properties.recovery.has_value(), false);
         BOOST_REQUIRE_EQUAL(

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -53,6 +53,9 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.retention_bytes = retention_bytes;
     ret.retention_time = retention_duration;
     ret.segment_size = segment_size;
+    ret.shadow_indexing_mode = shadow_indexing
+                                 ? *shadow_indexing
+                                 : model::shadow_indexing_mode::disabled;
     return ret;
 }
 
@@ -81,7 +84,10 @@ storage::ntp_config topic_configuration::make_ntp_config(
             // during bootstrap.
             .cache_enabled = storage::with_cache(!is_internal()),
             .recovery_enabled = storage::topic_recovery_enabled(
-              properties.recovery ? *properties.recovery : false)});
+              properties.recovery ? *properties.recovery : false),
+            .shadow_indexing_mode = properties.shadow_indexing
+                                      ? *properties.shadow_indexing
+                                      : model::shadow_indexing_mode::disabled});
     }
     return storage::ntp_config(
       model::ntp(tp_ns.ns, tp_ns.tp, p_id),

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -956,7 +956,8 @@ void adl<cluster::incremental_topic_updates>::to(
       t.timestamp_type,
       t.segment_size,
       t.retention_bytes,
-      t.retention_duration);
+      t.retention_duration,
+      t.shadow_indexing);
 }
 
 cluster::incremental_topic_updates
@@ -1011,6 +1012,13 @@ adl<cluster::incremental_topic_updates>::from(iobuf_parser& in) {
         // create_data_policy_cmd_data, data_policy_manager handles it
         adl<cluster::property_update<std::optional<v8_engine::data_policy>>>{}
           .from(in);
+    }
+    if (
+      version
+      <= cluster::incremental_topic_updates::version_with_shadow_indexing) {
+        updates.shadow_indexing = adl<cluster::property_update<
+          std::optional<model::shadow_indexing_mode>>>{}
+                                    .from(in);
     }
     return updates;
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -348,10 +348,12 @@ struct property_update<tristate<T>> {
 
 struct incremental_topic_updates {
     static constexpr int8_t version_with_data_policy = -1;
+    static constexpr int8_t version_with_shadow_indexing = -3;
     // negative version indicating different format:
     // -1 - topic_updates with data_policy
     // -2 - topic_updates without data_policy
-    static constexpr int8_t version = -2;
+    // -3 - topic_updates with shadow_indexing
+    static constexpr int8_t version = -3;
     property_update<std::optional<model::compression>> compression;
     property_update<std::optional<model::cleanup_policy_bitflags>>
       cleanup_policy_bitflags;
@@ -361,6 +363,7 @@ struct incremental_topic_updates {
     property_update<std::optional<size_t>> segment_size;
     property_update<tristate<size_t>> retention_bytes;
     property_update<tristate<std::chrono::milliseconds>> retention_duration;
+    property_update<std::optional<model::shadow_indexing_mode>> shadow_indexing;
 
     friend bool operator==(
       const incremental_topic_updates&, const incremental_topic_updates&)

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -33,7 +33,7 @@
 
 namespace kafka {
 
-static constexpr std::array<std::string_view, 8> supported_configs{
+static constexpr std::array<std::string_view, 9> supported_configs{
   {"compression.type",
    "cleanup.policy",
    "message.timestamp.type",
@@ -41,7 +41,8 @@ static constexpr std::array<std::string_view, 8> supported_configs{
    "compaction.strategy",
    "retention.bytes",
    "retention.ms",
-   "x-redpanda-recovery"}};
+   "x-redpanda-recovery",
+   "redpanda.remote.write"}};
 
 bool is_supported(std::string_view name) {
     return std::any_of(

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -33,7 +33,7 @@
 
 namespace kafka {
 
-static constexpr std::array<std::string_view, 9> supported_configs{
+static constexpr std::array<std::string_view, 10> supported_configs{
   {"compression.type",
    "cleanup.policy",
    "message.timestamp.type",
@@ -42,7 +42,8 @@ static constexpr std::array<std::string_view, 9> supported_configs{
    "retention.bytes",
    "retention.ms",
    "x-redpanda-recovery",
-   "redpanda.remote.write"}};
+   "redpanda.remote.write",
+   "redpanda.remote.read"}};
 
 bool is_supported(std::string_view name) {
     return std::any_of(

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -41,7 +41,7 @@ static constexpr std::array<std::string_view, 10> supported_configs{
    "compaction.strategy",
    "retention.bytes",
    "retention.ms",
-   "x-redpanda-recovery",
+   "redpanda.remote.recovery",
    "redpanda.remote.write",
    "redpanda.remote.read"}};
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -71,6 +71,12 @@ get_shadow_indexing_mode(const config_map_t& config) {
     if (arch_enabled && *arch_enabled) {
         mode = model::shadow_indexing_mode::archival;
     }
+    auto si_enabled = get_bool_value(config, topic_property_remote_read);
+    if (si_enabled && *si_enabled) {
+        mode = mode == model::shadow_indexing_mode::archival
+                 ? model::shadow_indexing_mode::full
+                 : mode = model::shadow_indexing_mode::fetch;
+    }
     return mode;
 }
 

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -64,6 +64,16 @@ get_bool_value(const config_map_t& config, std::string_view key) {
     return std::nullopt;
 }
 
+static model::shadow_indexing_mode
+get_shadow_indexing_mode(const config_map_t& config) {
+    model::shadow_indexing_mode mode = model::shadow_indexing_mode::disabled;
+    auto arch_enabled = get_bool_value(config, topic_property_remote_write);
+    if (arch_enabled && *arch_enabled) {
+        mode = model::shadow_indexing_mode::archival;
+    }
+    return mode;
+}
+
 // Special case for options where Kafka allows -1
 // In redpanda the mapping is following
 //
@@ -112,6 +122,7 @@ to_cluster_type(const creatable_topic& t) {
         config_entries, topic_property_retention_duration);
     cfg.properties.recovery = get_bool_value(
       config_entries, topic_property_recovery);
+    cfg.properties.shadow_indexing = get_shadow_indexing_mode(config_entries);
 
     auto ret = cluster::custom_assignable_topic_configuration(cfg);
     /**

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -47,6 +47,8 @@ static constexpr std::string_view topic_property_retention_duration
   = "retention.ms";
 static constexpr std::string_view topic_property_recovery
   = "x-redpanda-recovery";
+static constexpr std::string_view topic_property_remote_write
+  = "redpanda.remote.write";
 
 // Data-policy property
 static constexpr std::string_view topic_property_data_policy_function_name

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -46,7 +46,7 @@ static constexpr std::string_view topic_property_retention_bytes
 static constexpr std::string_view topic_property_retention_duration
   = "retention.ms";
 static constexpr std::string_view topic_property_recovery
-  = "x-redpanda-recovery";
+  = "redpanda.remote.recovery";
 static constexpr std::string_view topic_property_remote_write
   = "redpanda.remote.write";
 static constexpr std::string_view topic_property_remote_read

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -49,6 +49,8 @@ static constexpr std::string_view topic_property_recovery
   = "x-redpanda-recovery";
 static constexpr std::string_view topic_property_remote_write
   = "redpanda.remote.write";
+static constexpr std::string_view topic_property_remote_read
+  = "redpanda.remote.read";
 
 // Data-policy property
 static constexpr std::string_view topic_property_data_policy_function_name

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -35,7 +35,8 @@ ss::future<storage::translating_reader> replicated_partition::make_reader(
     auto local_kafka_start_offset = _translator->from_log_offset(
       _partition->start_offset());
     if (
-      _partition->cloud_data_available()
+      _partition->is_remote_fetch_enabled()
+      && _partition->cloud_data_available()
       && cfg.start_offset < local_kafka_start_offset
       && cfg.start_offset >= _partition->start_cloud_offset()) {
         cfg.type_filter = {model::record_batch_type::raft_data};

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -36,7 +36,8 @@ public:
         auto local_kafka_start_offset = _translator->from_log_offset(
           _partition->start_offset());
         if (
-          _partition->cloud_data_available()
+          _partition->is_remote_fetch_enabled()
+          && _partition->cloud_data_available()
           && (_partition->start_cloud_offset() < local_kafka_start_offset)) {
             return _partition->start_cloud_offset();
         }

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -210,7 +210,12 @@ enum class shadow_indexing_mode : int8_t {
 };
 
 inline bool is_archival_enabled(shadow_indexing_mode m) {
-    return m == shadow_indexing_mode::archival;
+    return m == shadow_indexing_mode::archival
+           || m == shadow_indexing_mode::full;
+}
+
+inline bool is_fetch_enabled(shadow_indexing_mode m) {
+    return m == shadow_indexing_mode::fetch || m == shadow_indexing_mode::full;
 }
 
 std::ostream& operator<<(std::ostream&, const shadow_indexing_mode&);

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -218,6 +218,22 @@ inline bool is_fetch_enabled(shadow_indexing_mode m) {
     return m == shadow_indexing_mode::fetch || m == shadow_indexing_mode::full;
 }
 
+/// Set 'rhs' flag in 'lhs'
+inline shadow_indexing_mode
+add_shadow_indexing_flag(shadow_indexing_mode lhs, shadow_indexing_mode rhs) {
+    auto combined = static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs);
+    return static_cast<shadow_indexing_mode>(combined);
+}
+
+/// Drop 'rhs' flag in 'lhs'
+inline shadow_indexing_mode
+drop_shadow_indexing_flag(shadow_indexing_mode lhs, shadow_indexing_mode rhs) {
+    auto mask = static_cast<uint8_t>(rhs);
+    mask = ~mask;
+    auto combined = mask & static_cast<uint8_t>(lhs);
+    return static_cast<shadow_indexing_mode>(combined);
+}
+
 std::ostream& operator<<(std::ostream&, const shadow_indexing_mode&);
 
 } // namespace model

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -202,10 +202,16 @@ enum class shadow_indexing_mode : int8_t {
     // Upload is disabled
     disabled = 0,
     // Only upload data to the object storage
-    archival_storage = 1,
-    // Upload data and enable shadow indexing
-    shadow_indexing = 2,
+    archival = 1,
+    // Enable download from object storage
+    fetch = 2,
+    // Enable both upload and download
+    full = 3,
 };
+
+inline bool is_archival_enabled(shadow_indexing_mode m) {
+    return m == shadow_indexing_mode::archival;
+}
 
 std::ostream& operator<<(std::ostream&, const shadow_indexing_mode&);
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -372,11 +372,14 @@ std::ostream& operator<<(std::ostream& o, const shadow_indexing_mode& si) {
     case shadow_indexing_mode::disabled:
         o << "disabled";
         break;
-    case shadow_indexing_mode::archival_storage:
-        o << "archival_storage";
+    case shadow_indexing_mode::archival:
+        o << "archival";
         break;
-    case shadow_indexing_mode::shadow_indexing:
-        o << "shadow_indexing";
+    case shadow_indexing_mode::fetch:
+        o << "fetch";
+        break;
+    case shadow_indexing_mode::full:
+        o << "full";
         break;
     }
     return o;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -42,6 +42,10 @@ public:
         with_cache cache_enabled = with_cache::yes;
         // if set the value will be used during parititon recovery
         topic_recovery_enabled recovery_enabled = topic_recovery_enabled::yes;
+        // if set the value will control how data is uploaded and retrieved
+        // to/from S3
+        model::shadow_indexing_mode shadow_indexing_mode
+          = model::shadow_indexing_mode::disabled;
 
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
@@ -118,6 +122,11 @@ public:
 
     void set_overrides(default_overrides o) {
         _overrides = std::make_unique<default_overrides>(o);
+    }
+
+    bool is_archival_enabled() const {
+        return _overrides != nullptr
+               && model::is_archival_enabled(_overrides->shadow_indexing_mode);
     }
 
 private:

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -129,6 +129,11 @@ public:
                && model::is_archival_enabled(_overrides->shadow_indexing_mode);
     }
 
+    bool is_remote_fetch_enabled() const {
+        return _overrides != nullptr
+               && model::is_fetch_enabled(_overrides->shadow_indexing_mode);
+    }
+
 private:
     model::ntp _ntp;
     /// \brief currently this is the basedir. In the future

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -16,6 +16,7 @@ from rptest.archival.s3_client import S3Client
 from rptest.services.redpanda import RedpandaService
 
 from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.util import (
     segments_count,
@@ -186,6 +187,7 @@ class ArchivalTest(RedpandaTest):
                                            extra_rp_conf=self._extra_rp_conf)
 
         self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
         self.s3_client = S3Client(
             region='panda-region',
             access_key=u"panda-user",
@@ -200,6 +202,10 @@ class ArchivalTest(RedpandaTest):
         # see previously removed objects for a while.
         validate(self._check_bucket_is_emtpy, self.logger, 300)
         super().setUp()  # topic is created here
+        # enable archival for topic
+        for topic in self.topics:
+            self.rpk.alter_topic_config(topic.name, 'redpanda.remote.write',
+                                        'true')
 
     def tearDown(self):
         self.s3_client.empty_bucket(self.s3_bucket_name)

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -9,6 +9,7 @@
 
 from ducktape.mark.resource import cluster
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import RedpandaService
 from rptest.util import Scale
@@ -74,9 +75,13 @@ class EndToEndShadowIndexingTest(EndToEndTest):
         )
 
     def setUp(self):
+        rpk = RpkTool(self.redpanda)
         self.s3_client.empty_bucket(self.s3_bucket_name)
         self.s3_client.create_bucket(self.s3_bucket_name)
         self.redpanda.start()
+        for topic in self.topics:
+            rpk.alter_topic_config(topic.name, 'redpanda.remote.write', 'true')
+            rpk.alter_topic_config(topic.name, 'redpanda.remote.read', 'true')
 
     def tearDown(self):
         self.s3_client.empty_bucket(self.s3_bucket_name)

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -10,6 +10,7 @@
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 from rptest.archival.s3_client import S3Client
+from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -67,6 +68,13 @@ class ShadowIndexingTxTest(RedpandaTest):
             logger=self.logger,
         )
         s3client.create_bucket(self.s3_bucket_name)
+
+    def setUp(self):
+        rpk = RpkTool(self.redpanda)
+        super(ShadowIndexingTxTest, self).setUp()
+        for topic in self.topics:
+            rpk.alter_topic_config(topic.name, 'redpanda.remote.write', 'true')
+            rpk.alter_topic_config(topic.name, 'redpanda.remote.read', 'true')
 
     @cluster(num_nodes=3)
     def test_shadow_indexing_aborted_txs(self):

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -465,7 +465,7 @@ class BaseCase:
             val = manifest.get(mname)
             if val:
                 conf[cname] = val
-        conf['x-redpanda-recovery'] = 'true'
+        conf['redpanda.remote.recovery'] = 'true'
         conf.update(overrides)
         self.logger.info(f"Confg: {conf}")
         self._rpk.create_topic(topic, npart, nrepl, conf)


### PR DESCRIPTION
## Cover letter

This PR adds two topic level configuration options:
- `x-redpanda-archival` which enables archival subsystem for the topic
- `x-redpanda-shadowindex` which enables shadow indexing for the topic

The topic_configuration message was modified previously but the flags are not yet handled
in Kafka layer.

This PR adds this two properties to both create topic and alter-topic-config.
It also adds tests that check backward compatibility (since controller message is updated).
Also, it modifies related duck tape tests since the tests will be broken after the change (because
the default for both archival and shadow indexing is 'disabled').

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/5124ed3dceb95188a4f082c225f02a0c96f01cbc..1aeb14fecf40426dc5554558d960e507033c609e)
* change parameter names to `x-redpanda-remote-read` and `x-redpanda-remote-write`
* address code review issues

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/1aeb14fecf40426dc5554558d960e507033c609e..5422c87930536a6308c714c6089a71cc6efa6f5f)
* change `shadow_indexing_mode` enumeration members for better readability
* remove outdated TODO entry

Change in [force push](https://github.com/vectorizedio/redpanda/compare/5422c87930536a6308c714c6089a71cc6efa6f5f..fcfe34b0ac82420db4ffadbe7cc5b9918103d8bb)
* small refactoring
* fix CI failure

Change in [force push](https://github.com/vectorizedio/redpanda/compare/fcfe34b0ac82420db4ffadbe7cc5b9918103d8bb..ff23562312352e9d4f82bc2692826f9f1317789e)
- rebase dev

Change in [force push](https://github.com/vectorizedio/redpanda/compare/923806d20e4e5f5f2ac60ef78a24b4cdc9cd4215..82da1975a017cc275cb6da4019d29929d9682f80)
- change names from 'x-redpanda-***' to 'redpanda.remote.***'
- fix ducktape tests

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/82da1975a017cc275cb6da4019d29929d9682f80..16bfb4cb44a72ef72052b707d8843f9aad7a2e31)
- code review fixes

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/16bfb4cb44a72ef72052b707d8843f9aad7a2e31..40c43cd264a79998498c7b1a4f49b3169b18a875)
- rebase with dev
- add new commit that fixes newly added duck tape test

## Release notes

N/A