### PR TITLE
config: Fix parameter name

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -779,7 +779,7 @@ configuration::configuration()
       0.0)
   , cloud_storage_upload_ctrl_min_shares(
       *this,
-      "compaction_ctrl_min_shares",
+      "cloud_storage_upload_ctrl_min_shares",
       "minimum number of IO and CPU shares that archival upload can use",
       required::no,
       100)


### PR DESCRIPTION

## Cover letter

Fix incorrect parameter name used to control min number of shares for
the upload controller in archival subsystem.




## Release notes

N/A