### PR TITLE
serde: add serde_fields

### DIFF
--- a/src/v/serde/serde.h
+++ b/src/v/serde/serde.h
@@ -125,7 +125,7 @@ inline constexpr auto const is_serde_compatible_v
     || (std::is_scalar_v<T>  //
          && (!std::is_same_v<float, T> || std::numeric_limits<float>::is_iec559)
          && (!std::is_same_v<double, T> || std::numeric_limits<double>::is_iec559)
-         && (!serde_is_enum_v<T> || sizeof(T{}) <= sizeof(serde_enum_serialized_t)))
+         && (!serde_is_enum_v<T> || sizeof(std::decay_t<T>) <= sizeof(serde_enum_serialized_t)))
     || reflection::is_std_vector_v<T>
     || reflection::is_named_type_v<T>
     || reflection::is_ss_bool_v<T>

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -645,3 +645,22 @@ SEASTAR_THREAD_TEST_CASE(serde_checksum_update_1) {
       serde::from_iobuf<std::vector<new_no_cs>>(serde::to_iobuf(old_vec))
       == new_vec);
 }
+
+struct serde_fields_test_struct
+  : serde::
+      envelope<test_msg1_new, serde::version<10>, serde::compat_version<5>> {
+    serde_fields_test_struct() = default;
+    explicit serde_fields_test_struct(int a)
+      : _a{a} {}
+    auto serde_fields() { return std::tie(_a, _m, _b, _c); }
+    int _a;
+    test_msg0 _m;
+    int _b, _c;
+};
+
+SEASTAR_THREAD_TEST_CASE(serde_fields_test_struct_test) {
+    BOOST_CHECK(
+      serde::from_iobuf<serde_fields_test_struct>(
+        serde::to_iobuf(serde_fields_test_struct{123}))
+      == serde_fields_test_struct{123});
+}


### PR DESCRIPTION
Implementing serde_fields helps for types that have a ctor that prevents structured-bindings-based reflection

Example:
```cpp
struct serde_fields_test_struct
  : serde::
      envelope<test_msg1_new, serde::version<10>, serde::compat_version<5>> {
    serde_fields_test_struct() = default;
    explicit serde_fields_test_struct(int a)
      : _a{a} {}
    auto serde_fields() { return std::tie(_a, _m, _b, _c); }
    int _a;
    test_msg0 _m;
    int _b, _c;
};
```