### PR TITLE
k/partition_proxy: do not return offset from linearizable barrier

### DIFF
--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -75,8 +75,8 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
     // using linearizable_barrier instead of is_leader to check that
     // current node is/was a leader at the moment it received the request
     // since the former uses cache and may return stale data
-    auto r = co_await kafka_partition->linearizable_barrier();
-    if (!r) {
+    auto err = co_await kafka_partition->linearizable_barrier();
+    if (err) {
         co_return list_offsets_response::make_partition(
           ntp.tp.partition, error_code::not_leader_for_partition);
     }

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -16,6 +16,7 @@
 #include "storage/types.h"
 
 #include <optional>
+#include <system_error>
 
 namespace kafka {
 
@@ -31,7 +32,7 @@ public:
         virtual model::offset high_watermark() const = 0;
         virtual model::offset last_stable_offset() const = 0;
         virtual bool is_leader() const = 0;
-        virtual ss::future<result<model::offset>> linearizable_barrier() = 0;
+        virtual ss::future<std::error_code> linearizable_barrier() = 0;
         virtual ss::future<model::record_batch_reader> make_reader(
           storage::log_reader_config,
           std::optional<model::timeout_clock::time_point>)
@@ -55,7 +56,7 @@ public:
         return _impl->last_stable_offset();
     }
 
-    ss::future<result<model::offset>> linearizable_barrier() {
+    ss::future<std::error_code> linearizable_barrier() {
         return _impl->linearizable_barrier();
     }
 


### PR DESCRIPTION
When linearizable barrier is used in Kafka layer returned offset is
ignored. Changed `partition_proxy` interface not to return offset. This
way we do not have to translate the offset returned from linearizable
barrier.

Linearizable barrier in `kafka::partition_proxy` lead to errors being thrown from the Kafka API handler since offset returner from the linearizable barrier was outside of the translation range. 