### PR TITLE
Fix waiting for replicate result

### DIFF
--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -319,10 +319,13 @@ result<replicate_result> replicate_entries_stm::process_result(
     // better crash than allow for inconsistency
     vassert(
       appended_offset <= _ptr->_commit_index,
-      "Successfull replication means that committed offset passed last "
-      "appended offset. Current committed offset: {}, last appended offset: {}",
+      "{} - Successfull replication means that committed offset passed last "
+      "appended offset. Current committed offset: {}, last appended offset: "
+      "{}, initial_commited_offset: {}",
+      _ptr->ntp(),
       _ptr->committed_offset(),
-      appended_offset);
+      appended_offset,
+      _initial_committed_offset);
 
     vlog(
       _ctxlog.trace,


### PR DESCRIPTION
## Cover letter

Term change may happen while leader still have replicate requests pending. To determine outcome of pending replicate requests former leader have to wait until request has been either truncated or committed. When request was committed replication is successful otherwise former leader should return an error.

To determine the outcome of replication we have to wait for either of the conditions described before. Added truncation verification to replicate stop condition.

Previously assertion protecting correctness may have been triggered when heartbeat updated committed index but didn't triggered truncation. This is specific to redpanda since in redpanda heartbeats doesn't truncate the log.


Release note: 
Fixes potential crashes caused by assertion. 
