### PR TITLE
storage: 16k fallocate in developer_mode

### DIFF
--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -36,6 +36,7 @@ public:
     using chunk = segment_appender_chunk;
 
     static constexpr const size_t write_behind_memory = 1_MiB;
+    static constexpr const size_t developer_mode_fallocation_step = 16_KiB;
     static constexpr const size_t fallocation_step = 32_MiB;
 
     struct options {

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -169,7 +169,9 @@ ss::future<segment_appender_ptr> make_segment_appender(
               // 1MB of memory aligned buffers
               return ss::make_ready_future<segment_appender_ptr>(
                 std::make_unique<segment_appender>(
-                  writer, segment_appender::options(iopc, number_of_chunks)));
+                  writer,
+                  segment_appender::options(
+                    iopc, number_of_chunks, fallocation_step_from_config())));
           } catch (...) {
               auto e = std::current_exception();
               vlog(stlog.error, "could not allocate appender: {}", e);
@@ -178,6 +180,13 @@ ss::future<segment_appender_ptr> make_segment_appender(
               });
           }
       });
+}
+
+size_t fallocation_step_from_config() {
+    if (config::shard_local_cfg().developer_mode()) {
+        return segment_appender::developer_mode_fallocation_step;
+    }
+    return segment_appender::fallocation_step;
 }
 
 size_t number_of_chunks_from_config(const ntp_config& ntpc) {

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -106,6 +106,7 @@ ss::future<segment_appender_ptr> make_segment_appender(
   size_t number_of_chunks,
   ss::io_priority_class iopc);
 
+size_t fallocation_step_from_config();
 size_t number_of_chunks_from_config(const storage::ntp_config&);
 
 /*


### PR DESCRIPTION
## Cover letter

"For developer mode, we do not need to so aggressively optimize disk usage. 32M fallocations can be especially problematic if I create a topic with 1000 partitions: 32G of my disk will suddenly be eaten.
We can use much, much smaller fallocations in developer mode." #2877 

## Release notes

Use 16K rather than 32M for fallocate segment in developer_mode
