### PR TITLE
schema_registry: Support protobuf compatibility checks

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -181,7 +181,8 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);
     rq.req.reset();
 
-    static const std::vector<std::string_view> schemas_types{"AVRO"};
+    static const std::vector<std::string_view> schemas_types{
+      "PROTOBUF", "AVRO"};
     auto json_rslt = ppj::rjson_serialize(schemas_types);
     rp.rep->write_body("json", json_rslt);
     return ss::make_ready_future<server::reply_t>(std::move(rp));

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -24,11 +24,7 @@
 
 namespace pandaproxy::schema_registry {
 
-namespace {
-
 namespace pb = google::protobuf;
-
-}
 
 class io_error_collector final : public pb::io::ErrorCollector {
     enum class level {
@@ -245,6 +241,134 @@ make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema) {
     auto validated = co_await validate_protobuf_schema(store, temp);
     co_return canonical_schema{
       std::move(temp).sub(), std::move(validated), std::move(temp).refs()};
+}
+
+namespace {
+
+enum class encoding {
+    struct_ = 0,
+    varint,
+    zigzag,
+    bytes,
+    int32,
+    int64,
+    float_,
+    double_,
+};
+
+encoding get_encoding(pb::FieldDescriptor::Type type) {
+    switch (type) {
+    case pb::FieldDescriptor::Type::TYPE_MESSAGE:
+    case pb::FieldDescriptor::Type::TYPE_GROUP:
+        return encoding::struct_;
+    case pb::FieldDescriptor::Type::TYPE_FLOAT:
+        return encoding::float_;
+    case pb::FieldDescriptor::Type::TYPE_DOUBLE:
+        return encoding::double_;
+    case pb::FieldDescriptor::Type::TYPE_INT64:
+    case pb::FieldDescriptor::Type::TYPE_UINT64:
+    case pb::FieldDescriptor::Type::TYPE_INT32:
+    case pb::FieldDescriptor::Type::TYPE_UINT32:
+    case pb::FieldDescriptor::Type::TYPE_BOOL:
+    case pb::FieldDescriptor::Type::TYPE_ENUM:
+        return encoding::varint;
+    case pb::FieldDescriptor::Type::TYPE_SINT32:
+    case pb::FieldDescriptor::Type::TYPE_SINT64:
+        return encoding::zigzag;
+    case pb::FieldDescriptor::Type::TYPE_STRING:
+    case pb::FieldDescriptor::Type::TYPE_BYTES:
+        return encoding::bytes;
+    case pb::FieldDescriptor::Type::TYPE_FIXED32:
+    case pb::FieldDescriptor::Type::TYPE_SFIXED32:
+        return encoding::int32;
+    case pb::FieldDescriptor::Type::TYPE_FIXED64:
+    case pb::FieldDescriptor::Type::TYPE_SFIXED64:
+        return encoding::int64;
+    }
+    __builtin_unreachable();
+}
+
+struct compatibility_checker {
+    bool check_compatible() { return check_compatible(_writer.fd); }
+
+    bool check_compatible(const pb::FileDescriptor* writer) {
+        // There must be a compatible reader message for every writer message
+        for (int i = 0; i < writer->message_type_count(); ++i) {
+            auto w = writer->message_type(i);
+            auto r = _reader._dp.FindMessageTypeByName(w->full_name());
+            if (!r || !check_compatible(r, w)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool check_compatible(
+      const pb::Descriptor* reader, const pb::Descriptor* writer) {
+        for (int i = 0; i < writer->field_count(); ++i) {
+            if (reader->IsReservedNumber(i) || writer->IsReservedNumber(i)) {
+                continue;
+            }
+            int number = writer->field(i)->number();
+            auto r = reader->FindFieldByNumber(number);
+            // A reader may ignore a writer field
+            if (r && !check_compatible(r, writer->field(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool check_compatible(
+      const pb::FieldDescriptor* reader, const pb::FieldDescriptor* writer) {
+        switch (writer->type()) {
+        case pb::FieldDescriptor::Type::TYPE_MESSAGE:
+        case pb::FieldDescriptor::Type::TYPE_GROUP: {
+            bool type_is_compat = reader->type()
+                                    == pb::FieldDescriptor::Type::TYPE_MESSAGE
+                                  || reader->type()
+                                       == pb::FieldDescriptor::Type::TYPE_GROUP;
+            return type_is_compat
+                   && check_compatible(
+                     reader->message_type(), writer->message_type());
+        }
+        case pb::FieldDescriptor::Type::TYPE_FLOAT:
+        case pb::FieldDescriptor::Type::TYPE_DOUBLE:
+        case pb::FieldDescriptor::Type::TYPE_INT64:
+        case pb::FieldDescriptor::Type::TYPE_UINT64:
+        case pb::FieldDescriptor::Type::TYPE_INT32:
+        case pb::FieldDescriptor::Type::TYPE_UINT32:
+        case pb::FieldDescriptor::Type::TYPE_BOOL:
+        case pb::FieldDescriptor::Type::TYPE_ENUM:
+        case pb::FieldDescriptor::Type::TYPE_SINT32:
+        case pb::FieldDescriptor::Type::TYPE_SINT64:
+        case pb::FieldDescriptor::Type::TYPE_STRING:
+        case pb::FieldDescriptor::Type::TYPE_BYTES:
+        case pb::FieldDescriptor::Type::TYPE_FIXED32:
+        case pb::FieldDescriptor::Type::TYPE_SFIXED32:
+        case pb::FieldDescriptor::Type::TYPE_FIXED64:
+        case pb::FieldDescriptor::Type::TYPE_SFIXED64:
+            return check_compatible(
+              get_encoding(reader->type()), get_encoding(writer->type()));
+        }
+        __builtin_unreachable();
+    }
+
+    bool check_compatible(encoding reader, encoding writer) {
+        return reader == writer && reader != encoding::struct_;
+    }
+
+    const protobuf_schema_definition::impl& _reader;
+    const protobuf_schema_definition::impl& _writer;
+};
+
+} // namespace
+
+bool check_compatible(
+  const protobuf_schema_definition& reader,
+  const protobuf_schema_definition& writer) {
+    compatibility_checker checker{reader(), writer()};
+    return checker.check_compatible();
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -25,4 +25,8 @@ validate_protobuf_schema(sharded_store& store, const canonical_schema& schema);
 ss::future<canonical_schema>
 make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema);
 
+bool check_compatible(
+  const protobuf_schema_definition& reader,
+  const protobuf_schema_definition& writer);
+
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -154,9 +154,9 @@ sharded_store::project_ids(const canonical_schema& schema) {
     auto v_id = co_await _store.invoke_on(
       shard_for(schema.sub()),
       _smp_opts,
-      &store::project_version,
-      schema.sub(),
-      s_id.value());
+      [sub{schema.sub()}, id{s_id.value()}](store& s) {
+          return s.project_version(sub, id);
+      });
 
     co_return insert_result{
       v_id.value_or(invalid_schema_version), s_id.value(), v_id.has_value()};
@@ -214,9 +214,10 @@ sharded_store::has_schema(const canonical_schema& schema) {
 
 ss::future<canonical_schema_definition>
 sharded_store::get_schema_definition(const schema_id& id) {
-    auto schema = co_await _store.invoke_on(
-      shard_for(id), _smp_opts, &store::get_schema_definition, id);
-    co_return std::move(schema).value();
+    co_return co_await _store.invoke_on(
+      shard_for(id), _smp_opts, [id](store& s) {
+          return s.get_schema_definition(id).value();
+      });
 }
 
 ss::future<std::vector<subject_version>>
@@ -235,21 +236,15 @@ ss::future<subject_schema> sharded_store::get_subject_schema(
   const subject& sub,
   std::optional<schema_version> version,
   include_deleted inc_del) {
-    auto v_id = (co_await _store.invoke_on(
-                   shard_for(sub),
-                   _smp_opts,
-                   &store::get_subject_version_id,
-                   sub,
-                   version,
-                   inc_del))
-                  .value();
+    auto v_id = co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [sub, version, inc_del](store& s) {
+          return s.get_subject_version_id(sub, version, inc_del).value();
+      });
 
-    auto def = (co_await _store.invoke_on(
-                  shard_for(v_id.id),
-                  _smp_opts,
-                  &store::get_schema_definition,
-                  v_id.id))
-                 .value();
+    auto def = co_await _store.invoke_on(
+      shard_for(v_id.id), _smp_opts, [id{v_id.id}](store& s) {
+          return s.get_schema_definition(id).value();
+      });
 
     co_return subject_schema{
       .schema = {sub, std::move(def), std::move(v_id.refs)},
@@ -273,9 +268,10 @@ sharded_store::get_subjects(include_deleted inc_del) {
 
 ss::future<std::vector<schema_version>>
 sharded_store::get_versions(const subject& sub, include_deleted inc_del) {
-    auto versions = co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, &store::get_versions, sub, inc_del);
-    co_return std::move(versions).value();
+    co_return co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [sub, inc_del](store& s) {
+          return s.get_versions(sub, inc_del).value();
+      });
 }
 
 ss::future<bool>
@@ -286,61 +282,50 @@ sharded_store::is_referenced(const subject& sub, schema_version ver) {
 
 ss::future<std::vector<schema_version>> sharded_store::delete_subject(
   seq_marker marker, const subject& sub, permanent_delete permanent) {
-    auto versions = co_await _store.invoke_on(
-      shard_for(sub),
-      _smp_opts,
-      &store::delete_subject,
-      marker,
-      sub,
-      permanent);
-    co_return std::move(versions).value();
+    co_return co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [marker, sub, permanent](store& s) {
+          return s.delete_subject(marker, sub, permanent).value();
+      });
 }
 
 ss::future<is_deleted> sharded_store::is_subject_deleted(const subject& sub) {
-    auto deleted = co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, &store::is_subject_deleted, sub);
-
-    co_return std::move(deleted).value();
+    co_return co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [sub](store& s) {
+          return s.is_subject_deleted(sub).value();
+      });
 }
 
 ss::future<is_deleted> sharded_store::is_subject_version_deleted(
-  const subject& sub, const schema_version version) {
-    auto deleted = co_await _store.invoke_on(
-      shard_for(sub),
-      _smp_opts,
-      &store::is_subject_version_deleted,
-      sub,
-      version);
-
-    co_return std::move(deleted).value();
+  const subject& sub, const schema_version ver) {
+    co_return co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [sub, ver](store& s) {
+          return s.is_subject_version_deleted(sub, ver).value();
+      });
 }
 
 ss::future<std::vector<seq_marker>>
 sharded_store::get_subject_written_at(const subject& sub) {
-    auto history = co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, &store::get_subject_written_at, sub);
-
-    co_return std::move(history).value();
+    co_return co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [sub](store& s) {
+          return s.store::get_subject_written_at(sub).value();
+      });
 }
 
 ss::future<std::vector<seq_marker>>
 sharded_store::get_subject_version_written_at(
-  const subject& sub, schema_version version) {
-    auto history = co_await _store.invoke_on(
-      shard_for(sub),
-      _smp_opts,
-      &store::get_subject_version_written_at,
-      sub,
-      version);
-
-    co_return std::move(history).value();
+  const subject& sub, schema_version ver) {
+    co_return co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [sub, ver](store& s) {
+          return s.get_subject_version_written_at(sub, ver).value();
+      });
 }
 
-ss::future<bool> sharded_store::delete_subject_version(
-  const subject& sub, schema_version version) {
-    auto deleted = co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, &store::delete_subject_version, sub, version);
-    co_return deleted.value();
+ss::future<bool>
+sharded_store::delete_subject_version(const subject& sub, schema_version ver) {
+    co_return co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [sub, ver](store& s) {
+          return s.delete_subject_version(sub, ver).value();
+      });
 }
 
 ss::future<compatibility_level> sharded_store::get_compatibility() {
@@ -349,11 +334,10 @@ ss::future<compatibility_level> sharded_store::get_compatibility() {
 
 ss::future<compatibility_level> sharded_store::get_compatibility(
   const subject& sub, default_to_global fallback) {
-    auto get = [sub, fallback](store& s) {
-        return s.get_compatibility(sub, fallback);
-    };
-    auto level = co_await _store.invoke_on(shard_for(sub), get);
-    co_return level.value();
+    co_return co_await _store.invoke_on(
+      shard_for(sub), [sub, fallback](store& s) {
+          return s.get_compatibility(sub, fallback).value();
+      });
 }
 
 ss::future<bool>
@@ -367,29 +351,26 @@ sharded_store::set_compatibility(compatibility_level compatibility) {
 
 ss::future<bool> sharded_store::set_compatibility(
   seq_marker marker, const subject& sub, compatibility_level compatibility) {
-    using overload_t = result<bool> (store::*)(
-      seq_marker, const subject&, compatibility_level);
-    auto set = co_await _store.invoke_on(
-      shard_for(sub),
-      _smp_opts,
-      static_cast<overload_t>(&store::set_compatibility),
-      marker,
-      sub,
-      compatibility);
-    co_return set.value();
+    co_return co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [marker, sub, compatibility](store& s) {
+          return s.set_compatibility(marker, sub, compatibility).value();
+      });
 }
 
 ss::future<bool> sharded_store::clear_compatibility(const subject& sub) {
-    auto cleared = co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, &store::clear_compatibility, sub);
-    co_return cleared.value();
+    co_return co_await _store.invoke_on(
+      shard_for(sub), _smp_opts, [sub](store& s) {
+          return s.clear_compatibility(sub).value();
+      });
 }
 
 ss::future<bool>
 sharded_store::upsert_schema(schema_id id, canonical_schema_definition def) {
     co_await maybe_update_max_schema_id(id);
     co_return co_await _store.invoke_on(
-      shard_for(id), _smp_opts, &store::upsert_schema, id, std::move(def));
+      shard_for(id), _smp_opts, [id, def{std::move(def)}](store& s) mutable {
+          return s.upsert_schema(id, std::move(def));
+      });
 }
 
 ss::future<sharded_store::insert_subject_result> sharded_store::insert_subject(
@@ -397,10 +378,9 @@ ss::future<sharded_store::insert_subject_result> sharded_store::insert_subject(
     auto [version, inserted] = co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
-      &store::insert_subject,
-      sub,
-      std::move(refs),
-      id);
+      [sub, refs{std::move(refs)}, id](store& s) mutable {
+          return s.insert_subject(sub, std::move(refs), id);
+      });
     co_return insert_subject_result{version, inserted};
 }
 
@@ -414,13 +394,15 @@ ss::future<bool> sharded_store::upsert_subject(
     co_return co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
-      &store::upsert_subject,
-      marker,
-      sub,
-      std::move(refs),
-      version,
-      id,
-      deleted);
+      [marker,
+       sub{std::move(sub)},
+       refs{std::move(refs)},
+       version,
+       id,
+       deleted](store& s) mutable {
+          return s.upsert_subject(
+            marker, std::move(sub), std::move(refs), version, id, deleted);
+      });
 }
 
 /// \brief Get the schema ID to be used for next insert

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -470,8 +470,10 @@ ss::future<bool> sharded_store::is_compatible(
         co_return true;
     }
 
-    // Currently only support AVRO
-    if (new_schema.type() != schema_type::avro) {
+    // Currently support PROTOBUF, AVRO
+    if (
+      new_schema.type() != schema_type::avro
+      && new_schema.type() != schema_type::protobuf) {
         throw as_exception(invalid_schema_type(new_schema.type()));
     }
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -498,13 +498,15 @@ ss::future<bool> sharded_store::is_compatible(
         if (
           compat == compatibility_level::backward
           || compat == compatibility_level::backward_transitive
-          || compat == compatibility_level::full) {
+          || compat == compatibility_level::full
+          || compat == compatibility_level::full_transitive) {
             is_compat = is_compat && check_compatible(new_valid, old_valid);
         }
         if (
           compat == compatibility_level::forward
           || compat == compatibility_level::forward_transitive
-          || compat == compatibility_level::full) {
+          || compat == compatibility_level::full
+          || compat == compatibility_level::full_transitive) {
             is_compat = is_compat && check_compatible(old_valid, new_valid);
         }
     }

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -76,24 +76,22 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_failure) {
       });
 }
 
-SEASTAR_THREAD_TEST_CASE(test_protobuf_imported) {
+SEASTAR_THREAD_TEST_CASE(test_protobuf_imported_not_referenced) {
     simple_sharded_store store;
 
     auto schema1 = pps::canonical_schema{pps::subject{"simple"}, simple};
     auto schema2 = pps::canonical_schema{pps::subject{"imported"}, imported};
-    auto schema3 = pps::canonical_schema{
-      pps::subject{"imported-again"}, imported_again};
 
     auto sch1 = store.insert(schema1, pps::schema_version{1});
-    auto sch2 = store.insert(schema2, pps::schema_version{1});
-    auto sch3 = store.insert(schema3, pps::schema_version{1});
 
     auto valid_simple
       = pps::make_protobuf_schema_definition(store.store, schema1).get();
-    auto valid_imported
-      = pps::make_protobuf_schema_definition(store.store, schema2).get();
-    auto valid_imported_again
-      = pps::make_protobuf_schema_definition(store.store, schema3).get();
+    BOOST_REQUIRE_EXCEPTION(
+      pps::make_protobuf_schema_definition(store.store, schema2).get(),
+      pps::exception,
+      [](const pps::exception& ex) {
+          return ex.code() == pps::error_code::schema_invalid;
+      });
 }
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -13,6 +13,7 @@
 #include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/protobuf.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
@@ -52,6 +53,28 @@ struct simple_sharded_store {
     pps::schema_id next_id{1};
     pps::sharded_store store;
 };
+
+bool check_compatible(
+  pps::compatibility_level lvl,
+  std::string_view reader,
+  std::string_view writer) {
+    simple_sharded_store store;
+    store.store.set_compatibility(lvl).get();
+    auto sch1 = store.insert(
+      pandaproxy::schema_registry::canonical_schema{
+        pps::subject{"sub"},
+        pps::canonical_schema_definition{writer, pps::schema_type::protobuf},
+        {}},
+      pps::schema_version{1});
+    return store.store
+      .is_compatible(
+        pps::schema_version{1},
+        pps::canonical_schema{
+          pps::subject{"sub"},
+          pps::canonical_schema_definition{reader, pps::schema_type::protobuf},
+          {}})
+      .get();
+}
 
 SEASTAR_THREAD_TEST_CASE(test_protobuf_simple) {
     simple_sharded_store store;
@@ -117,4 +140,140 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
       = pps::make_protobuf_schema_definition(store.store, schema2).get();
     auto valid_imported_again
       = pps::make_protobuf_schema_definition(store.store, schema3).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_empty) {
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full,
+      R"(syntax = "proto3";)",
+      R"(syntax = "proto3";)"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_encoding) {
+    BOOST_REQUIRE(check_compatible(
+      // varint
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Test { int32 id = 1; })",
+      R"(syntax = "proto3"; message Test { int32 id = 1; })"));
+
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Test { int32 id = 1; })",
+      R"(syntax = "proto3"; message Test { uint32 id = 1; })"));
+
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Test { int32 id = 1; })",
+      R"(syntax = "proto3"; message Test { uint64 id = 1; })"));
+
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Test { int32 id = 1; })",
+      R"(syntax = "proto3"; message Test { bool id = 1; })"));
+
+    // zigzag
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Test { sint32 id = 1; })",
+      R"(syntax = "proto3"; message Test { sint64 id = 1; })"));
+
+    // bytes
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Test { string id = 1; })",
+      R"(syntax = "proto3"; message Test { bytes id = 1; })"));
+
+    // int32
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Test { fixed32 id = 1; })",
+      R"(syntax = "proto3"; message Test { sfixed32 id = 1; })"));
+
+    // int64
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Test { fixed64 id = 1; })",
+      R"(syntax = "proto3"; message Test { sfixed64 id = 1; })"));
+
+    // A subset of incompatible types
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::forward,
+      R"(syntax = "proto3"; message Test { int32 id = 1; })",
+      R"(syntax = "proto3"; message Test { string id = 1; })"));
+
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward,
+      R"(syntax = "proto3"; message Test { int32 id = 1; })",
+      R"(syntax = "proto3"; message Test { string id = 1; })"));
+
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::backward_transitive,
+      R"(syntax = "proto3"; message Test { int32 id = 1; })",
+      R"(syntax = "proto3"; message Test { fixed32 id = 1; })"));
+
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::forward_transitive,
+      R"(syntax = "proto3"; message Test { fixed32 id = 1; })",
+      R"(syntax = "proto3"; message Test { fixed64 id = 1; })"));
+
+    BOOST_REQUIRE(!check_compatible(
+      pps::compatibility_level::full,
+      R"(syntax = "proto3"; message Test { float id = 1; })",
+      R"(syntax = "proto3"; message Test { double id = 1; })"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_rename_field) {
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full,
+      R"(syntax = "proto3"; message Simple { string id = 1; })",
+      R"(syntax = "proto3"; message Simple { string identifier = 1; })"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_add_field) {
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full,
+      R"(
+syntax = "proto3"; message Simple { string id = 1; })",
+      R"(
+syntax = "proto3"; message Simple { string id = 1; string name = 2; })"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_add_message_after) {
+    auto reader = R"(syntax = "proto3";
+message Simple { string id = 1; }
+message Simple2 { int64 id = 1; })";
+    auto writer = R"(syntax = "proto3";
+message Simple { string id = 1; })";
+    BOOST_REQUIRE(
+      check_compatible(pps::compatibility_level::backward, reader, writer));
+    BOOST_REQUIRE(
+      !check_compatible(pps::compatibility_level::forward, reader, writer));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_add_message_before) {
+    auto reader = R"(
+syntax = "proto3";
+message Simple2 { int64 id = 1; }
+message Simple { string id = 1; })";
+    auto writer = R"(
+syntax = "proto3";
+message Simple { string id = 1; })";
+    BOOST_REQUIRE(
+      check_compatible(pps::compatibility_level::backward, reader, writer));
+    BOOST_REQUIRE(
+      !check_compatible(pps::compatibility_level::forward, reader, writer));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_reserved_field) {
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Simple { reserved 1; int32 id = 2; })",
+      R"(syntax = "proto3"; message Simple { int64 res = 1; int32 id = 2; })"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_missing_field) {
+    BOOST_REQUIRE(check_compatible(
+      pps::compatibility_level::full_transitive,
+      R"(syntax = "proto3"; message Simple { int32 id = 2; })",
+      R"(syntax = "proto3"; message Simple { string res = 1; int32 id = 2; })"));
 }

--- a/src/v/pandaproxy/schema_registry/test/get_schema_types.cc
+++ b/src/v/pandaproxy/schema_registry/test/get_schema_types.cc
@@ -30,7 +30,7 @@ FIXTURE_TEST(schema_registry_get_schema_types, pandaproxy_test_fixture) {
         auto res = http_request(client, "/schemas/types");
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
-        BOOST_REQUIRE_EQUAL(res.body, R"(["AVRO"])");
+        BOOST_REQUIRE_EQUAL(res.body, R"(["PROTOBUF","AVRO"])");
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
           to_header_value(ppj::serialization_format::schema_registry_v1_json));
@@ -46,7 +46,7 @@ FIXTURE_TEST(schema_registry_get_schema_types, pandaproxy_test_fixture) {
           ppj::serialization_format::schema_registry_json);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
-        BOOST_REQUIRE_EQUAL(res.body, R"(["AVRO"])");
+        BOOST_REQUIRE_EQUAL(res.body, R"(["PROTOBUF","AVRO"])");
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
           to_header_value(ppj::serialization_format::schema_registry_json));

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -276,7 +276,7 @@ class SchemaRegistryTest(RedpandaTest):
         result_raw = self._get_schemas_types()
         assert result_raw.status_code == requests.codes.ok
         result = result_raw.json()
-        assert result == ["AVRO"]
+        assert set(result) == {"PROTOBUF", "AVRO"}
 
     @cluster(num_nodes=3)
     def test_get_schema_id_versions(self):

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -979,8 +979,15 @@ class SchemaRegistryTest(RedpandaTest):
         result_raw = self._post_subjects_subject_versions(
             subject="imported",
             data=json.dumps({
-                "schema": imported_proto_def,
-                "schemaType": "PROTOBUF"
+                "schema":
+                imported_proto_def,
+                "schemaType":
+                "PROTOBUF",
+                "references": [{
+                    "name": "simple",
+                    "subject": "simple",
+                    "version": 1
+                }]
             }))
         self.logger.info(result_raw)
         self.logger.info(result_raw.content)


### PR DESCRIPTION
## Cover letter

Support protobuf compatibility checks and enable protobuf support.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/0579249143867ad7f92fcd5c0d16741ff0005d09..09ca2c2f6c071a4d0a55237f086c530f434f3f02)
* Fix the crash in release mode. (added the first commit, works around https://github.com/ned14/outcome/issues/244)
* Fixup Ducktape test to compare sets

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/09ca2c2f6c071a4d0a55237f086c530f434f3f02..e551694222ff370658f68a6fa89e27fb06b79b03)
* Revert changes to `BOOST_OUTCOME_TRYX`
* Pass capturing lambdas to `invoke_on` (first commit)

## Release notes

Schema Registry: Support protobuf schema.