### PR TITLE
k8s: disable rpk-status sidecar by default

### DIFF
--- a/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
+++ b/src/go/k8s/apis/redpanda/v1alpha1/cluster_webhook.go
@@ -41,20 +41,6 @@ const (
 	defaultSchemaRegistryPort = 8081
 )
 
-var (
-	// DefaultRpkStatusResources is default resources setting for rpk debug
-	DefaultRpkStatusResources = &corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("10M"),
-			corev1.ResourceCPU:    resource.MustParse("0.2"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("30M"),
-			corev1.ResourceCPU:    resource.MustParse("0.2"),
-		},
-	}
-)
-
 type resourceField struct {
 	resources *corev1.ResourceRequirements
 	path      *field.Path
@@ -98,13 +84,6 @@ func (r *Cluster) Default() {
 	}
 
 	r.setDefaultAdditionalConfiguration()
-
-	if r.Spec.Sidecars.RpkStatus == nil {
-		r.Spec.Sidecars.RpkStatus = &Sidecar{
-			Enabled:   true,
-			Resources: DefaultRpkStatusResources,
-		}
-	}
 }
 
 var defaultAdditionalConfiguration = map[string]int{

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -516,14 +516,7 @@ func setCloudStorage(
 }
 
 func (r *StatefulSetResource) rpkStatusContainer() *corev1.Container {
-	if r.pandaCluster.Spec.Sidecars.RpkStatus == nil {
-		r.logger.Info("BUG! No resources found for rpk status - this should never happen with defaulting webhook enabled - please consider enabling the webhook")
-		r.pandaCluster.Spec.Sidecars.RpkStatus = &redpandav1alpha1.Sidecar{
-			Enabled:   true,
-			Resources: redpandav1alpha1.DefaultRpkStatusResources,
-		}
-	}
-	if !r.pandaCluster.Spec.Sidecars.RpkStatus.Enabled {
+	if r.pandaCluster.Spec.Sidecars.RpkStatus == nil || !r.pandaCluster.Spec.Sidecars.RpkStatus.Enabled {
 		return nil
 	}
 	return &corev1.Container{

--- a/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
@@ -9,6 +9,5 @@ spec:
         - image: "vectorized/configurator:v21.6.6"
       containers:
         - image: "localhost/redpanda:dev"
-        - image: "localhost/redpanda:dev"
 status:
   readyReplicas: 2

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
@@ -24,8 +24,6 @@ spec:
       name: shadow-index-cache
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
 status:
   phase: "Running"
 
@@ -48,8 +46,6 @@ spec:
       name: shadow-index-cache
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
 status:
   phase: "Running"
 

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
@@ -15,8 +15,6 @@ spec:
   containers:
   - name: redpanda
     image: "localhost/redpanda:dev"
-  - name: rpk-status
-    image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 
@@ -29,8 +27,6 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "localhost/redpanda:dev"
-  - name: rpk-status
     image: "localhost/redpanda:dev"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/03-assert.yaml
@@ -22,8 +22,6 @@ spec:
       name: datadir
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 
@@ -44,7 +42,5 @@ spec:
       name: datadir
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "localhost/redpanda:dev"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
@@ -28,8 +28,6 @@ spec:
       name: shadow-index-cache
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
 status:
   phase: "Running"
 
@@ -56,7 +54,5 @@ spec:
       name: shadow-index-cache
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-assert.yaml
@@ -15,8 +15,6 @@ spec:
   containers:
   - name: redpanda
     image: "localhost/redpanda:dev"
-  - name: rpk-status
-    image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 
@@ -29,8 +27,6 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "localhost/redpanda:dev"
-  - name: rpk-status
     image: "localhost/redpanda:dev"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/03-assert.yaml
@@ -26,8 +26,6 @@ spec:
       name: datadir
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 
@@ -52,7 +50,5 @@ spec:
       name: datadir
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "localhost/redpanda:dev"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
@@ -26,8 +26,6 @@ spec:
       name: shadow-index-cache
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
 status:
   phase: "Running"
 
@@ -52,7 +50,5 @@ spec:
       name: shadow-index-cache
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/02-assert.yaml
@@ -15,8 +15,6 @@ spec:
   containers:
   - name: redpanda
     image: "localhost/redpanda:dev"
-  - name: rpk-status
-    image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 
@@ -29,8 +27,6 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "localhost/redpanda:dev"
-  - name: rpk-status
     image: "localhost/redpanda:dev"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update-image-tls/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/03-assert.yaml
@@ -24,8 +24,6 @@ spec:
       name: datadir
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "localhost/redpanda:dev"
 status:
   phase: "Running"
 
@@ -48,7 +46,5 @@ spec:
       name: datadir
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
-  - name: rpk-status
-    image: "localhost/redpanda:dev"
 status:
   phase: "Running"

--- a/src/go/k8s/tests/e2e/update/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/02-assert.yaml
@@ -9,6 +9,3 @@ spec:
         - resources:
             requests:
               memory: 99M
-        - resources:
-            requests:
-              memory: 10M


### PR DESCRIPTION
## Cover letter

it stopped working with new versions of redpanda anyway and we'll be
building this functionality into redpanda itself.

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: [1-2 sentences of what this PR changes]
k8s: rpk-status sidecar is now disabled by default