### PR TITLE
Add ingress management permissions to default ClusterRole config

### DIFF
--- a/src/go/k8s/helm-chart/charts/redpanda-operator/templates/clusterrole.yaml
+++ b/src/go/k8s/helm-chart/charts/redpanda-operator/templates/clusterrole.yaml
@@ -137,4 +137,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{- end -}}


### PR DESCRIPTION
## Cover letter

Using the default operator ClusterRole configuration, when trying to create a cluster with external connectivity on Kubernetes, the following errors are found in the logs and no ingress is created: 

```
ERROR   controller-runtime.manager.controller.cluster   Reconciler error        {"reconciler group": "redpanda.vectorized.io", "reconciler kind": "Cluster", "name": "redpanda-production", "namespace": "default", "error": "unable to create Ingress resource: ingresses.networking.k8s.io is forbidden: User \"system:serviceaccount:redpanda-system:redpanda-operator\" cannot create resource \"ingresses\" in API group \"networking.k8s.io\" in the namespace \"default\""}
```

## Release notes

Redpanda Operator can now create ingresses for Kubernetes clusters by default.
