### PR TITLE
tests/failure_injector: make kill idempotent

### DIFF
--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -75,7 +75,9 @@ class FailureInjector:
     def _kill(self, node):
         self.redpanda.logger.info(
             f"killing redpanda on { self.redpanda.idx(node)}")
-        self.redpanda.signal_redpanda(node, signal=signal.SIGKILL)
+        self.redpanda.signal_redpanda(node,
+                                      signal=signal.SIGKILL,
+                                      idempotent=True)
         timeout_sec = 10
         wait_until(lambda: self.redpanda.redpanda_pid(node) == None,
                    timeout_sec=timeout_sec,


### PR DESCRIPTION
## Cover letter

Previously this could cause an unhandled exception
in tests that ran the failure injector in a background
loop, leading the test to continue running but without
failures being injected.

(in the case where the failure injector tries to kill
redpanda on a node where it is not running & therefore
the PID is None)

There is still a more general issue where failure injector
can fail on background threads without causing a test failure,
but this was the one specific case I noticed when running
a test locally and watching the log scroll by.

## Release notes

None