### PR TITLE
Fix wrong acl user create parameter

### DIFF
--- a/docs/www/rpk-commands.md
+++ b/docs/www/rpk-commands.md
@@ -442,11 +442,10 @@ Create users
 
 ```cmd
 Usage:
-  rpk acl user create [flags]
+  rpk acl user create [username] [flags]
 
 Flags:
-      --new-password string   The new user's password
-      --new-username string   The user to be created
+      --password string   The new user's password
 ```
 
 #### acl user delete 


### PR DESCRIPTION
## Cover letter

```bash
# doesn't work
docker exec -it $(docker ps | grep redpanda | cut -d ' ' -f 1 )  rpk acl user create --new-username admin --new-password test123
Flag --new-username has been deprecated, the username now does not require a flag
Flag --new-password has been deprecated, renamed to --password

# works
docker exec -it $(docker ps | grep redpanda | cut -d ' ' -f 1 )  rpk acl user create admin --password test123
Created user "admin".
```

## Release notes

If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.

Release note: Fix wrong `acl user create` arguments
