### PR TITLE
r/consensus: do not move flushed offset backward

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2044,7 +2044,8 @@ ss::future<> consensus::flush_log() {
     _probe.log_flushed();
     auto flushed_up_to = _log.offsets().dirty_offset;
     return _log.flush().then([this, flushed_up_to] {
-        _flushed_offset = flushed_up_to;
+        _flushed_offset = std::max(flushed_up_to, _flushed_offset);
+        vlog(_ctxlog.trace, "flushed offset updated: {}", _flushed_offset);
         // TODO: remove this assertion when we will remove committed_offset
         // from storage.
         auto lstats = _log.offsets();


### PR DESCRIPTION
Prevent `_flushed_offset` from being moved backward. In raft
`replicate_stm` we allow multiple pending flushes to be executed in
background. Even if flush operations are interleaved we should not
move the `_flushed` offset backward.

Fixes: #3100
