### PR TITLE
Get aborted transaction ids for remote segments

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -11,9 +11,9 @@
 #include "archival/archival_policy.h"
 
 #include "archival/logger.h"
-#include "raft/offset_translator.h"
 #include "storage/disk_log_impl.h"
 #include "storage/fs_utils.h"
+#include "storage/offset_translator_state.h"
 #include "storage/parser.h"
 #include "storage/segment.h"
 #include "storage/segment_set.h"
@@ -81,7 +81,7 @@ archival_policy::lookup_result archival_policy::find_segment(
   model::offset start_offset,
   model::offset adjusted_lso,
   storage::log log,
-  const raft::offset_translator& offset_translator) {
+  const storage::offset_translator_state& ot_state) {
     vlog(
       archival_log.debug,
       "Upload policy for {} invoked, start offset: {}",
@@ -153,9 +153,8 @@ archival_policy::lookup_result archival_policy::find_segment(
     }
 
     if (!closed) {
-        auto kafka_start_offset = offset_translator.from_log_offset(
-          start_offset);
-        auto kafka_lso = offset_translator.from_log_offset(adjusted_lso);
+        auto kafka_start_offset = ot_state.from_log_offset(start_offset);
+        auto kafka_lso = ot_state.from_log_offset(adjusted_lso);
         if (kafka_start_offset >= kafka_lso) {
             // If timeboxed uploads are enabled and there is no producer
             // activity, we can get into a nasty loop where we upload a segment,
@@ -449,12 +448,12 @@ ss::future<upload_candidate> archival_policy::get_next_candidate(
   model::offset begin_inclusive,
   model::offset end_exclusive,
   storage::log log,
-  const raft::offset_translator& offset_translator) {
+  const storage::offset_translator_state& ot_state) {
     // NOTE: end_exclusive (which is initialized with LSO) points to the first
     // unstable recordbatch we need to look at the previous batch if needed.
     auto adjusted_lso = end_exclusive - model::offset(1);
     auto [segment, ntp_conf, forced] = find_segment(
-      begin_inclusive, adjusted_lso, std::move(log), offset_translator);
+      begin_inclusive, adjusted_lso, std::move(log), ot_state);
     if (segment.get() == nullptr || ntp_conf == nullptr) {
         co_return upload_candidate{};
     }

--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -13,7 +13,7 @@
 #include "archival/probe.h"
 #include "archival/types.h"
 #include "model/fundamental.h"
-#include "raft/fwd.h"
+#include "storage/fwd.h"
 #include "storage/log_manager.h"
 #include "storage/ntp_config.h"
 #include "storage/segment_set.h"
@@ -57,7 +57,7 @@ public:
       model::offset begin_inclusive,
       model::offset end_exclusive,
       storage::log,
-      const raft::offset_translator&);
+      const storage::offset_translator_state&);
 
 private:
     /// Check if the upload have to be forced due to timeout
@@ -77,7 +77,7 @@ private:
       model::offset last_offset,
       model::offset adjusted_lso,
       storage::log,
-      const raft::offset_translator&);
+      const storage::offset_translator_state&);
 
     model::ntp _ntp;
     service_probe& _svc_probe;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -15,7 +15,6 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/types.h"
 #include "model/metadata.h"
-#include "raft/configuration_manager.h"
 #include "s3/client.h"
 #include "s3/error.h"
 #include "storage/disk_log_impl.h"
@@ -146,7 +145,7 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
       start_upload_offset,
       last_stable_offset,
       *log,
-      *_partition->get_offset_translator());
+      *_partition->get_offset_translator_state());
 
     if (upload.source.get() == nullptr) {
         vlog(
@@ -220,8 +219,8 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
     auto offset = upload.final_offset;
     auto base = upload.starting_offset;
     start_upload_offset = offset + model::offset(1);
-    auto delta = base
-                 - _partition->get_offset_translator()->from_log_offset(base);
+    auto delta
+      = base - _partition->get_offset_translator_state()->from_log_offset(base);
     co_return scheduled_upload{
       .result = upload_segment(upload, parent),
       .inclusive_last_offset = offset,

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -17,6 +17,7 @@
 #include "model/metadata.h"
 #include "s3/client.h"
 #include "storage/ntp_config.h"
+#include "storage/translating_reader.h"
 #include "storage/types.h"
 #include "utils/intrusive_list_helpers.h"
 #include "utils/retry_chain_node.h"
@@ -68,7 +69,7 @@ public:
     /// All offset translation is done internally. The returned record batch
     /// reader will produce batches with kafka offsets and the config will be
     /// updated using kafka offsets.
-    ss::future<model::record_batch_reader> make_reader(
+    ss::future<storage::translating_reader> make_reader(
       storage::log_reader_config config,
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -121,8 +121,8 @@ private:
 
         /// Borrow reader or make a new one.
         /// In either case return a reader.
-        std::unique_ptr<remote_segment_batch_reader>
-        borrow_reader(const log_reader_config& cfg, retry_chain_logger& ctxlog);
+        std::unique_ptr<remote_segment_batch_reader> borrow_reader(
+          const storage::log_reader_config& cfg, retry_chain_logger& ctxlog);
 
         ss::future<> stop();
 
@@ -154,7 +154,9 @@ private:
     /// \param offset_key is an key of the segment state in the _segments
     /// \param st is a segment state referenced by offset_key
     std::unique_ptr<remote_segment_batch_reader> borrow_reader(
-      log_reader_config config, model::offset offset_key, segment_state& st);
+      storage::log_reader_config config,
+      model::offset offset_key,
+      segment_state& st);
 
     /// Return reader back to segment_state
     void return_reader(

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -28,6 +28,7 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/timed_out_error.hh>
+#include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
 
 #include <exception>
@@ -271,13 +272,11 @@ public:
       storage::log_reader_config& conf,
       remote_segment_batch_reader& parent,
       model::term_id term,
-      model::offset initial_delta,
       const model::ntp& ntp,
       retry_chain_node& rtc)
       : _config(conf)
       , _parent(parent)
       , _term(term)
-      , _delta(initial_delta)
       , _rtc(&rtc)
       , _ctxlog(cst_log, _rtc, ntp.path()) {}
 
@@ -286,18 +285,18 @@ public:
     /// \note this can only be applied to current record batch
     model::offset rp_to_kafka(model::offset k) const noexcept {
         vassert(
-          k >= _delta,
+          k >= _parent._cur_delta,
           "Redpanda offset {} is smaller than the delta {}",
           k,
-          _delta);
-        return k - _delta;
+          _parent._cur_delta);
+        return k - _parent._cur_delta;
     }
 
     /// Translate kafka offset to redpanda offset
     ///
     /// \note this can only be applied to current record batch
     model::offset kafka_to_rp(model::offset k) const noexcept {
-        return k + _delta;
+        return k + _parent._cur_delta;
     }
 
     /// Point config.start_offset to the next record batch
@@ -322,7 +321,7 @@ public:
           _ctxlog.trace,
           "accept_batch_start {}, current delta: {}",
           header,
-          _delta);
+          _parent._cur_delta);
 
         if (rp_to_kafka(header.base_offset) > _config.max_offset) {
             vlog(
@@ -399,13 +398,30 @@ public:
       size_t /*physical_base_offset*/,
       size_t /*size_on_disk*/) override {
         // NOTE: that advance_config_start_offset should be called before
-        // changing the _delta. The _delta that is be used for current record
-        // batch can only account record batches in all previous batches.
+        // changing the _cur_delta. The _cur_delta that is be used for current
+        // record batch can only account record batches in all previous batches.
         vlog(
           _ctxlog.debug, "skip_batch_start called for {}", header.base_offset);
         advance_config_offsets(header);
-        if (header.type != model::record_batch_type::raft_data) {
-            _delta += header.last_offset_delta + model::offset{1};
+        if (
+          header.type == model::record_batch_type::raft_configuration
+          || header.type == model::record_batch_type::archival_metadata) {
+            vassert(
+              _parent._cur_ot_state,
+              "ntp {}: offset translator state for "
+              "remote_segment_batch_consumer not initialized",
+              _parent._seg->get_ntp());
+
+            _parent._cur_ot_state->get().add_gap(
+              header.base_offset, header.last_offset());
+            vlog(
+              _ctxlog.debug,
+              "added offset translation gap [{}-{}], current state: {}",
+              header.base_offset,
+              header.last_offset(),
+              _parent._cur_ot_state);
+
+            _parent._cur_delta += header.last_offset_delta + model::offset{1};
         }
     }
 
@@ -447,27 +463,42 @@ private:
     model::record_batch_header _header;
     iobuf _records;
     model::term_id _term;
-    model::offset _delta;
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
 };
 
 remote_segment_batch_reader::remote_segment_batch_reader(
-  ss::lw_shared_ptr<remote_segment> s, const storage::log_reader_config& config) noexcept
+  ss::lw_shared_ptr<remote_segment> s,
+  const storage::log_reader_config& config) noexcept
   : _seg(std::move(s))
   , _config(config)
   , _rtc(_seg->get_retry_chain_node())
   , _ctxlog(cst_log, _rtc, _seg->get_ntp().path())
   , _initial_delta(_seg->get_base_offset_delta())
-  , _cur_rp_offset(_seg->get_base_rp_offset()) {}
+  , _cur_rp_offset(_seg->get_base_rp_offset())
+  , _cur_delta(_initial_delta) {}
 
 ss::future<result<ss::circular_buffer<model::record_batch>>>
 remote_segment_batch_reader::read_some(
-  model::timeout_clock::time_point deadline) {
+  model::timeout_clock::time_point deadline,
+  storage::offset_translator_state& ot_state) {
     if (_ringbuf.empty()) {
         if (!_parser) {
             _parser = co_await init_parser();
         }
+
+        if (ot_state.add_absolute_delta(_cur_rp_offset, _cur_delta)) {
+            vlog(
+              _ctxlog.debug,
+              "offset translation: add_absolute_delta at offset {}, "
+              "delta {}, current state: {}",
+              _cur_rp_offset,
+              _cur_delta,
+              ot_state);
+        }
+
+        _cur_ot_state = ot_state;
+        auto deferred = ss::defer([this] { _cur_ot_state = std::nullopt; });
         auto bytes_consumed = co_await _parser->consume();
         if (!bytes_consumed) {
             co_return bytes_consumed.error();
@@ -487,7 +518,6 @@ remote_segment_batch_reader::init_parser() {
         _config,
         *this,
         _seg->get_term(),
-        _initial_delta,
         _seg->get_ntp(),
         *_seg->get_retry_chain_node()),
       std::move(stream));

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -119,46 +119,23 @@ private:
       _wait_list;
 };
 
-/// Log reader config for shadow-indexing
-///
-/// The difference between storage::log_reader_config and this
-/// object is that storage::log_reader_config stores redpanda
-/// offsets in start_offset and max_offset fields. The
-/// cloud_storage::log_reader_config stores kafka offsets in these
-/// fields. It also adds extra field 'start_offset_redpanda' which
-/// always contain the same offset as 'start_offset' but translated
-/// from kafka to redpanda.
-///
-/// The problem here is that shadow-indexing operates on sparse data.
-/// It can't translate every offset. Only the base offsets of uploaded
-/// segment. But it can also translate offsets as it scans the segment.
-/// But this is all done internally, so caller have to proviede kafka
-/// offsets. Mechanisms which require redpanda offset can use
-/// 'start_offset_redpanda' field. It's guaranteed to point to the same
-/// record batch but the offset is not translated back to kafka. This is
-/// useful since we can, for instance, compare it to committed_offset of
-/// the uploaded segment to know that we scanned the whole segment.
-struct log_reader_config : public storage::log_reader_config {
-    explicit log_reader_config(const storage::log_reader_config& cfg)
-      : storage::log_reader_config(cfg)
-      , next_offset_redpanda(model::offset::min()) {}
-
-    log_reader_config(
-      model::offset start_offset,
-      model::offset max_offset,
-      ss::io_priority_class prio)
-      : storage::log_reader_config(start_offset, max_offset, prio) {}
-
-    /// Next redpanda offset that we're going to look at
-    model::offset next_offset_redpanda;
-};
-
 class remote_segment_batch_consumer;
 
 /// The segment reader that can be used to fetch data from cloud storage
 ///
 /// The reader invokes 'data_stream' method of the 'remote_segment'
 /// which returns hydrated segment from disk.
+///
+/// The problem here is that shadow-indexing operates on sparse data.
+/// It can't translate every offset. Only the base offsets of uploaded
+/// segment. But it can also translate offsets as it scans the segment.
+/// But this is all done internally, so caller have to proviede kafka
+/// offsets. Mechanisms which require redpanda offset can use
+/// '_cur_rp_offset' field. It's guaranteed to point to the same
+/// record batch but the offset is not translated back to kafka. This is
+/// useful since we can, for instance, compare it to committed_offset of
+/// the uploaded segment to know that we scanned the whole segment.
+///
 /// The batches returned from the reader have offsets which are already
 /// translated.
 class remote_segment_batch_reader final {
@@ -167,7 +144,7 @@ class remote_segment_batch_reader final {
 public:
     remote_segment_batch_reader(
       ss::lw_shared_ptr<remote_segment>,
-      const log_reader_config& config) noexcept;
+      const storage::log_reader_config& config) noexcept;
 
     remote_segment_batch_reader(
       remote_segment_batch_reader&&) noexcept = delete;
@@ -183,14 +160,20 @@ public:
 
     ss::future<> stop();
 
-    const log_reader_config& config() const { return _config; }
-    log_reader_config& config() { return _config; }
+    const storage::log_reader_config& config() const { return _config; }
+    storage::log_reader_config& config() { return _config; }
 
     /// Get max offset (redpanda offset)
     model::offset max_rp_offset() const { return _seg->get_max_rp_offset(); }
 
     /// Get base offset (redpanda offset)
     model::offset base_rp_offset() const { return _seg->get_base_rp_offset(); }
+
+    bool is_eof() const { return _cur_rp_offset > _seg->get_max_rp_offset(); }
+
+    void set_eof() {
+        _cur_rp_offset = _seg->get_max_rp_offset() + model::offset{1};
+    }
 
 private:
     friend class single_record_consumer;
@@ -199,7 +182,7 @@ private:
     size_t produce(model::record_batch batch);
 
     ss::lw_shared_ptr<remote_segment> _seg;
-    log_reader_config _config;
+    storage::log_reader_config _config;
     std::unique_ptr<storage::continuous_batch_parser> _parser;
     ss::circular_buffer<model::record_batch> _ringbuf;
     size_t _total_size{0};
@@ -207,6 +190,7 @@ private:
     retry_chain_logger _ctxlog;
     model::term_id _term;
     model::offset _initial_delta;
+    model::offset _cur_rp_offset;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -316,7 +316,7 @@ static model::record_batch_header read_single_batch_from_remote_partition(
     auto partition = ss::make_lw_shared<remote_partition>(
       manifest, api, *fixture.cache, bucket);
 
-    auto reader = partition->make_reader(reader_config).get();
+    auto reader = partition->make_reader(reader_config).get().reader;
 
     auto headers_read
       = reader.consume(test_consumer(), model::no_timeout).get();
@@ -348,7 +348,7 @@ static std::vector<model::record_batch_header> scan_remote_partition(
     auto partition = ss::make_lw_shared<remote_partition>(
       manifest, api, *imposter.cache, bucket);
 
-    auto reader = partition->make_reader(reader_config).get();
+    auto reader = partition->make_reader(reader_config).get().reader;
 
     auto headers_read
       = reader.consume(test_consumer(), model::no_timeout).get();
@@ -568,7 +568,7 @@ FIXTURE_TEST(test_remote_partition_lifetime_issue, cloud_storage_fixture) {
 
     storage::log_reader_config reader_config(
       base, max, ss::default_priority_class());
-    auto reader = partition->make_reader(reader_config).get();
+    auto reader = partition->make_reader(reader_config).get().reader;
 
     partition->stop().get();
     partition = {};
@@ -876,7 +876,7 @@ scan_remote_partition_incrementally(
     int num_fetches = 0;
     while (next < max) {
         reader_config.start_offset = next;
-        auto reader = partition->make_reader(reader_config).get();
+        auto reader = partition->make_reader(reader_config).get().reader;
         auto headers_read
           = reader.consume(test_consumer(), model::no_timeout).get();
         if (headers_read.empty()) {

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -134,7 +134,7 @@ FIXTURE_TEST(
       = remote.upload_segment(bucket, name, clen, reset_stream, m, fib).get();
     BOOST_REQUIRE(upl_res == upload_result::success);
 
-    log_reader_config reader_config(
+    storage::log_reader_config reader_config(
       model::offset(1), model::offset(1), ss::default_priority_class());
     auto segment = ss::make_lw_shared<remote_segment>(
       remote, *cache, bucket, m, name, fib);
@@ -209,7 +209,8 @@ void test_remote_segment_batch_reader(
     model::offset begin = headers.at(ix_begin).base_offset;
     model::offset end = headers.at(ix_end).last_offset();
 
-    log_reader_config reader_config(begin, end, ss::default_priority_class());
+    storage::log_reader_config reader_config(
+      begin, end, ss::default_priority_class());
     reader_config.max_bytes = std::numeric_limits<size_t>::max();
 
     m.add(
@@ -329,7 +330,7 @@ FIXTURE_TEST(
 
     remote_segment_batch_reader reader(
       segment,
-      log_reader_config(
+      storage::log_reader_config(
         headers.at(0).base_offset,
         headers.at(0).last_offset(),
         ss::default_priority_class()));

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -178,9 +178,9 @@ public:
         return _raft->get_configuration_manager();
     }
 
-    const ss::lw_shared_ptr<raft::offset_translator>&
-    get_offset_translator() const {
-        return _raft->get_offset_translator();
+    ss::lw_shared_ptr<const storage::offset_translator_state>
+    get_offset_translator_state() const {
+        return _raft->get_offset_translator_state();
     }
 
     ss::shared_ptr<cluster::rm_stm> rm_stm();

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -27,6 +27,7 @@
 #include "raft/group_configuration.h"
 #include "raft/log_eviction_stm.h"
 #include "raft/types.h"
+#include "storage/translating_reader.h"
 #include "storage/types.h"
 
 #include <seastar/core/shared_ptr.hh>
@@ -226,7 +227,7 @@ public:
     }
 
     /// Create a reader that will fetch data from remote storage
-    ss::future<model::record_batch_reader> make_cloud_reader(
+    ss::future<storage::translating_reader> make_cloud_reader(
       storage::log_reader_config config,
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt) {
         vassert(

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -150,14 +150,16 @@ static ss::future<read_result> read_from_partition(
 
     reader_config.strict_max_bytes = config.strict_max_bytes;
     auto rdr = co_await part.make_reader(reader_config);
-    auto result = co_await std::move(rdr).consume(
-      kafka_batch_serializer(), deadline ? *deadline : model::no_timeout);
+    auto result = co_await std::move(rdr.reader)
+                    .consume(
+                      kafka_batch_serializer(),
+                      deadline ? *deadline : model::no_timeout);
     auto data = std::make_unique<iobuf>(std::move(result.data));
     std::vector<cluster::rm_stm::tx_range> aborted_transactions;
     part.probe().add_records_fetched(result.record_count);
     if (result.record_count > 0) {
         aborted_transactions = co_await part.aborted_transactions(
-          result.base_offset, result.last_offset);
+          result.base_offset, result.last_offset, std::move(rdr.ot_state));
     }
 
     if (foreign_read) {

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -13,6 +13,7 @@
 #include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
 #include "model/fundamental.h"
+#include "storage/translating_reader.h"
 #include "storage/types.h"
 
 #include <optional>
@@ -33,14 +34,18 @@ public:
         virtual model::offset last_stable_offset() const = 0;
         virtual bool is_leader() const = 0;
         virtual ss::future<std::error_code> linearizable_barrier() = 0;
-        virtual ss::future<model::record_batch_reader> make_reader(
+        virtual ss::future<storage::translating_reader> make_reader(
           storage::log_reader_config,
           std::optional<model::timeout_clock::time_point>)
           = 0;
         virtual ss::future<std::optional<storage::timequery_result>>
           timequery(model::timestamp, ss::io_priority_class) = 0;
         virtual ss::future<std::vector<cluster::rm_stm::tx_range>>
-          aborted_transactions(model::offset, model::offset) = 0;
+          aborted_transactions(
+            model::offset,
+            model::offset,
+            ss::lw_shared_ptr<const storage::offset_translator_state>)
+          = 0;
         virtual cluster::partition_probe& probe() = 0;
         virtual ~impl() noexcept = default;
     };
@@ -64,12 +69,14 @@ public:
 
     const model::ntp& ntp() const { return _impl->ntp(); }
 
-    ss::future<std::vector<cluster::rm_stm::tx_range>>
-    aborted_transactions(model::offset base, model::offset last) {
-        return _impl->aborted_transactions(base, last);
+    ss::future<std::vector<cluster::rm_stm::tx_range>> aborted_transactions(
+      model::offset base,
+      model::offset last,
+      ss::lw_shared_ptr<const storage::offset_translator_state> ot_state) {
+        return _impl->aborted_transactions(base, last, std::move(ot_state));
     }
 
-    ss::future<model::record_batch_reader> make_reader(
+    ss::future<storage::translating_reader> make_reader(
       storage::log_reader_config cfg,
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt) {
         return _impl->make_reader(cfg, deadline);

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -29,7 +29,7 @@ replicated_partition::replicated_partition(
 }
 
 // TODO: use previous translation speed up lookup
-ss::future<model::record_batch_reader> replicated_partition::make_reader(
+ss::future<storage::translating_reader> replicated_partition::make_reader(
   storage::log_reader_config cfg,
   std::optional<model::timeout_clock::time_point> deadline) {
     auto local_kafka_start_offset = _translator->from_log_offset(
@@ -92,32 +92,51 @@ ss::future<model::record_batch_reader> replicated_partition::make_reader(
         ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
     };
     auto rdr = co_await _partition->make_reader(cfg, deadline);
-    co_return model::make_record_batch_reader<reader>(
-      std::move(rdr).release(), _translator);
+    co_return storage::translating_reader(
+      model::make_record_batch_reader<reader>(
+        std::move(rdr).release(), _translator),
+      _translator);
 }
 
 ss::future<std::vector<cluster::rm_stm::tx_range>>
 replicated_partition::aborted_transactions(
-  model::offset base, model::offset last) {
-    model::offset local_kafka_start_offset = _translator->from_log_offset(
-      _partition->start_offset());
-    if (base < local_kafka_start_offset) {
-        // TODO: get offset translation information for the offsets range
-        // that we have read and use it to query
-        // _partition->aborted_transactions.
-        co_return std::vector<cluster::rm_stm::tx_range>{};
-    }
+  model::offset base,
+  model::offset last,
+  ss::lw_shared_ptr<const storage::offset_translator_state> ot_state) {
+    vassert(ot_state, "ntp {}: offset translator state must be present", ntp());
 
-    auto source = co_await _partition->aborted_transactions(
-      _translator->to_log_offset(base), _translator->to_log_offset(last));
+    // Note: here we expect that local _partition contains aborted transaction
+    // ids for both local and remote offset ranges. This is true as long as
+    // rm_stm state has not been reset (for example when there is a partition
+    // transfer or when a stale replica recovers its log from beyond the log
+    // eviction point). See https://github.com/vectorizedio/redpanda/issues/3001
+
+    auto base_rp = ot_state->to_log_offset(base);
+    auto last_rp = ot_state->to_log_offset(last);
+    auto source = co_await _partition->aborted_transactions(base_rp, last_rp);
+
+    // We trim beginning of aborted ranges to `trim_at` because we don't have
+    // offset translation info for earlier offsets.
+    model::offset trim_at;
+    if (base_rp >= _partition->start_offset()) {
+        // Local fetch. Trim to start of the log - it is safe because clients
+        // can't read earlier offsets.
+        trim_at = _partition->start_offset();
+    } else {
+        // Fetch from cloud data. Trim to start of the read range - this is
+        // incorrect because clients can still see earlier offsets but will work
+        // if they won't use aborted ranges from this request to filter batches
+        // belonging to earlier offsets.
+        trim_at = base_rp;
+    }
 
     std::vector<cluster::rm_stm::tx_range> target;
     target.reserve(source.size());
     for (const auto& range : source) {
         target.push_back(cluster::rm_stm::tx_range{
           .pid = range.pid,
-          .first = _translator->from_log_offset(range.first),
-          .last = _translator->from_log_offset(range.last)});
+          .first = ot_state->from_log_offset(std::max(trim_at, range.first)),
+          .last = ot_state->from_log_offset(range.last)});
     }
 
     co_return target;

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -106,7 +106,7 @@ public:
 
 private:
     ss::lw_shared_ptr<cluster::partition> _partition;
-    ss::lw_shared_ptr<raft::offset_translator> _translator;
+    ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -72,12 +72,14 @@ public:
       model::record_batch_reader&&,
       raft::replicate_options);
 
-    ss::future<model::record_batch_reader> make_reader(
+    ss::future<storage::translating_reader> make_reader(
       storage::log_reader_config cfg,
       std::optional<model::timeout_clock::time_point>) final;
 
-    ss::future<std::vector<cluster::rm_stm::tx_range>>
-    aborted_transactions(model::offset base, model::offset last) final;
+    ss::future<std::vector<cluster::rm_stm::tx_range>> aborted_transactions(
+      model::offset base,
+      model::offset last,
+      ss::lw_shared_ptr<const storage::offset_translator_state>) final;
 
     cluster::partition_probe& probe() final { return _partition->probe(); }
 

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -77,30 +77,7 @@ public:
       std::optional<model::timeout_clock::time_point>) final;
 
     ss::future<std::vector<cluster::rm_stm::tx_range>>
-    aborted_transactions(model::offset base, model::offset last) final {
-        model::offset local_kafka_start_offset = _translator->from_log_offset(
-          _partition->start_offset());
-        if (base < local_kafka_start_offset) {
-            // TODO: get offset translation information for the offsets range
-            // that we have read and use it to query
-            // _partition->aborted_transactions.
-            co_return std::vector<cluster::rm_stm::tx_range>{};
-        }
-
-        auto source = co_await _partition->aborted_transactions(
-          _translator->to_log_offset(base), _translator->to_log_offset(last));
-
-        std::vector<cluster::rm_stm::tx_range> target;
-        target.reserve(source.size());
-        for (const auto& range : source) {
-            target.push_back(cluster::rm_stm::tx_range{
-              .pid = range.pid,
-              .first = _translator->from_log_offset(range.first),
-              .last = _translator->from_log_offset(range.last)});
-        }
-
-        co_return target;
-    }
+    aborted_transactions(model::offset base, model::offset last) final;
 
     cluster::partition_probe& probe() final { return _partition->probe(); }
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -119,7 +119,9 @@ operator<<(std::ostream& o, const record_batch_attributes& attrs) {
     } else {
         o << "invalid compression";
     }
-    return o << ", type:" << attrs.timestamp_type() << "}";
+    return o << ", type:" << attrs.timestamp_type()
+             << ", transactional: " << attrs.is_transactional()
+             << ", control: " << attrs.is_control() << "}";
 }
 
 std::ostream& operator<<(std::ostream& o, const record_batch_header& h) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -68,11 +68,11 @@ consensus::consensus(
   , _group(group)
   , _jit(std::move(jit))
   , _log(l)
-  , _offset_translator(ss::make_lw_shared<offset_translator>(
+  , _offset_translator(
       offset_translator_batch_types(_log.config().ntp()),
       group,
       _log.config().ntp(),
-      storage))
+      storage)
   , _scheduling(scheduling_config)
   , _disk_timeout(disk_timeout)
   , _client_protocol(client)
@@ -1040,8 +1040,7 @@ ss::future<> consensus::do_start() {
                 = _configuration_manager.get_highest_known_offset(),
               };
 
-              return _offset_translator->start(
-                must_reset, std::move(bootstrap));
+              return _offset_translator.start(must_reset, std::move(bootstrap));
           })
           .then([this] { return hydrate_snapshot(); })
           .then([this] {
@@ -1103,7 +1102,7 @@ ss::future<> consensus::do_start() {
                   update_follower_stats(_configuration_manager.get_latest());
               });
           })
-          .then([this] { return _offset_translator->sync_with_log(_log, _as); })
+          .then([this] { return _offset_translator.sync_with_log(_log, _as); })
           .then([this] {
               /**
                * fix for incorrectly persisted configuration index. In previous
@@ -1638,7 +1637,7 @@ consensus::do_append_entries(append_entries_request&& r) {
         // eventually log and offset translator will become consistent. OTOH if
         // log truncation were first and saving offset translator state failed,
         // we wouldn't retry and log and offset translator could diverge.
-        return _offset_translator->truncate(truncate_at)
+        return _offset_translator.truncate(truncate_at)
           .then([this, truncate_at] {
               return _log.truncate(storage::truncate_config(
                 truncate_at, _scheduling.default_iopc));
@@ -1740,7 +1739,7 @@ ss::future<> consensus::truncate_to_latest_snapshot() {
     // metadata
     return _configuration_manager.prefix_truncate(_last_snapshot_index)
       .then([this] {
-          return _offset_translator->prefix_truncate(_last_snapshot_index);
+          return _offset_translator.prefix_truncate(_last_snapshot_index);
       })
       .then([this] {
           return _log.truncate_prefix(storage::truncate_prefix_config(
@@ -1776,7 +1775,7 @@ ss::future<> consensus::do_hydrate_snapshot(storage::snapshot_reader& reader) {
         return _configuration_manager
           .add(_last_snapshot_index, std::move(metadata.latest_configuration))
           .then([this, delta = metadata.log_start_delta] {
-              return _offset_translator->prefix_truncate_reset(
+              return _offset_translator.prefix_truncate_reset(
                 _last_snapshot_index, delta);
           })
           .then([this] {
@@ -1947,7 +1946,8 @@ consensus::do_write_snapshot(model::offset last_included_index, iobuf&& data) {
       .latest_configuration = *config,
       .cluster_time = clock_type::time_point::min(),
       .log_start_delta = offset_translator_delta(
-        _offset_translator->delta(details::next_offset(last_included_index))),
+        _offset_translator.state()->delta(
+          details::next_offset(last_included_index))),
     };
 
     return details::persist_snapshot(
@@ -1959,8 +1959,7 @@ consensus::do_write_snapshot(model::offset last_included_index, iobuf&& data) {
           // update configuration manager
           return _configuration_manager.prefix_truncate(_last_snapshot_index)
             .then([this] {
-                return _offset_translator->prefix_truncate(
-                  _last_snapshot_index);
+                return _offset_translator.prefix_truncate(_last_snapshot_index);
             });
       });
 }
@@ -2095,7 +2094,7 @@ ss::future<storage::append_result> consensus::disk_append(
     return details::for_each_ref_extract_configuration(
              _log.offsets().dirty_offset,
              std::move(reader),
-             consumer(*_offset_translator, _log.make_appender(cfg)),
+             consumer(_offset_translator, _log.make_appender(cfg)),
              cfg.timeout)
       .then([this, should_update_last_quorum_idx](
               std::tuple<ret_t, std::vector<offset_configuration>> t) {
@@ -2136,7 +2135,7 @@ ss::future<storage::append_result> consensus::disk_append(
               // the write path caused by KVStore flush debouncing.
 
               (void)ss::with_gate(
-                _bg, [this] { return _offset_translator->maybe_checkpoint(); });
+                _bg, [this] { return _offset_translator.maybe_checkpoint(); });
 
               (void)ss::with_gate(
                 _bg, [this, last_offset = ret.last_offset, sz = ret.byte_size] {
@@ -2791,7 +2790,7 @@ ss::future<> consensus::remove_persistent_state() {
     // configuration manager
     co_await _configuration_manager.remove_persistent_state();
     // offset translator
-    co_await _offset_translator->remove_persistent_state();
+    co_await _offset_translator.remove_persistent_state();
     // snapshot
     co_await _snapshot_mgr.remove_snapshot();
     co_await _snapshot_mgr.remove_partial_snapshots();

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -300,8 +300,9 @@ public:
 
     storage::log& log() { return _log; }
 
-    const ss::lw_shared_ptr<offset_translator>& get_offset_translator() {
-        return _offset_translator;
+    ss::lw_shared_ptr<const storage::offset_translator_state>
+    get_offset_translator_state() {
+        return _offset_translator.state();
     }
 
     /**
@@ -531,7 +532,7 @@ private:
     raft::group_id _group;
     timeout_jitter _jit;
     storage::log _log;
-    ss::lw_shared_ptr<offset_translator> _offset_translator;
+    offset_translator _offset_translator;
     scheduling_config _scheduling;
     model::timeout_clock::duration _disk_timeout;
     consensus_client_protocol _client_protocol;

--- a/src/v/raft/fwd.h
+++ b/src/v/raft/fwd.h
@@ -16,6 +16,5 @@ namespace raft {
 class consensus;
 class group_manager;
 class recovery_throttle;
-class offset_translator;
 
 } // namespace raft

--- a/src/v/raft/offset_translator.cc
+++ b/src/v/raft/offset_translator.cc
@@ -12,7 +12,6 @@
 #include "raft/offset_translator.h"
 
 #include "raft/consensus_utils.h"
-#include "serde/serde.h"
 #include "storage/api.h"
 #include "storage/kvstore.h"
 #include "vlog.h"
@@ -29,107 +28,15 @@ offset_translator::offset_translator(
   model::ntp ntp,
   storage::api& storage_api)
   : _filtered_types(std::move(filtered_types))
+  , _state(ss::make_lw_shared<storage::offset_translator_state>(std::move(ntp)))
   , _group(group)
-  , _ntp(std::move(ntp))
-  , _logger(logger, ssx::sformat("ntp: {}", _ntp))
+  , _logger(logger, ssx::sformat("ntp: {}", _state->ntp()))
   , _storage_api(storage_api) {}
-
-int64_t offset_translator::delta(model::offset o) const {
-    if (_filtered_types.empty()) {
-        return 0;
-    }
-
-    auto it = _last_offset2batch.lower_bound(o);
-    if (it == _last_offset2batch.begin()) {
-        throw std::runtime_error{_logger.format(
-          "log offset {} is outside the translation range (starting at {})",
-          o,
-          details::next_offset(_last_offset2batch.begin()->first))};
-    }
-
-    auto delta = std::prev(it)->second.next_delta;
-    if (it == _last_offset2batch.end() || o < it->second.base_offset) {
-        return delta;
-    } else {
-        // The offset is inside the non-data batch, so the data offset stops
-        // increasing at the base offset.
-        return delta + (o - it->second.base_offset);
-    }
-}
-
-model::offset offset_translator::from_log_offset(model::offset o) const {
-    const auto d = delta(o);
-    return model::offset(o - d);
-}
-
-model::offset offset_translator::to_log_offset(
-  model::offset data_offset, model::offset hint) const {
-    if (_filtered_types.empty()) {
-        return data_offset;
-    }
-
-    if (data_offset == model::offset::max()) {
-        return data_offset;
-    }
-
-    vassert(
-      !_last_offset2batch.empty(),
-      "ntp {}: offsets map shouldn't be empty",
-      _ntp);
-
-    model::offset min_log_offset = details::next_offset(
-      _last_offset2batch.begin()->first);
-
-    model::offset min_data_offset
-      = min_log_offset
-        - model::offset(_last_offset2batch.begin()->second.next_delta);
-    vassert(
-      data_offset >= min_data_offset,
-      "ntp {}: data offset {} must be inside translation range (starting at "
-      "{})",
-      _ntp,
-      data_offset,
-      min_data_offset);
-
-    model::offset search_start = std::max(
-      std::max(hint, data_offset), min_log_offset);
-
-    // We iterate over the intervals (beginning exclusive, end inclusive)
-    // with constant delta, starting at the interval containing
-    // log offset equal to `data_offset` (because log offset is at least as
-    // big as data offset) and stopping when we find the interval where
-    // given data offset is achievable.
-    auto interval_end_it = _last_offset2batch.lower_bound(search_start);
-    vassert(
-      interval_end_it != _last_offset2batch.begin(),
-      "ntp {}: log offset search start too small: {}",
-      search_start);
-    auto delta = std::prev(interval_end_it)->second.next_delta;
-
-    while (interval_end_it != _last_offset2batch.end()) {
-        model::offset max_do_this_interval
-          = details::prev_offset(interval_end_it->second.base_offset)
-            - model::offset{delta};
-        if (max_do_this_interval >= data_offset) {
-            break;
-        }
-
-        delta = interval_end_it->second.next_delta;
-        ++interval_end_it;
-    }
-
-    return data_offset + model::offset(delta);
-}
 
 void offset_translator::process(const model::record_batch& batch) {
     if (_filtered_types.empty()) {
         return;
     }
-
-    vassert(
-      !_last_offset2batch.empty(),
-      "ntp {}: offsets map shouldn't be empty",
-      _ntp);
 
     _bytes_processed += batch.size_bytes();
 
@@ -137,29 +44,15 @@ void offset_translator::process(const model::record_batch& batch) {
       std::find(
         _filtered_types.begin(), _filtered_types.end(), batch.header().type)
       != _filtered_types.end()) {
-        auto rbegin = _last_offset2batch.rbegin();
-        vassert(
-          batch.base_offset() > rbegin->first,
-          "ntp {}: trying to add batch to offset translator at offset {} that "
-          "is not higher than the previous last offset {}",
-          _ntp,
-          batch.base_offset(),
-          rbegin->first);
-
-        int32_t length = batch.header().last_offset_delta + 1;
-        int64_t next_delta = rbegin->second.next_delta + length;
+        _state->add_gap(batch.base_offset(), batch.last_offset());
 
         vlog(
           _logger.trace,
           "adding batch, offsets: [{},{}], delta: {}",
           batch.base_offset(),
           batch.last_offset(),
-          next_delta);
+          _state->last_delta());
 
-        _last_offset2batch.emplace(
-          batch.last_offset(),
-          offset_translator::batch_info{
-            .base_offset = batch.base_offset(), .next_delta = next_delta});
         ++_map_version;
     }
 
@@ -174,31 +67,6 @@ enum class kvstore_key_type : int8_t {
     highest_known_offset = 1,
 };
 
-struct persisted_batch {
-    model::offset base_offset;
-    int32_t length;
-
-    friend inline void read_nested(
-      iobuf_parser& in, persisted_batch& b, size_t const bytes_left_limit) {
-        serde::read_nested(in, b.base_offset, bytes_left_limit);
-        serde::read_nested(in, b.length, bytes_left_limit);
-    }
-
-    friend inline void write(iobuf& out, const persisted_batch& b) {
-        serde::write(out, b.base_offset);
-        serde::write(out, b.length);
-    }
-};
-
-struct persisted_batches_map
-  : serde::envelope<
-      persisted_batches_map,
-      serde::version<0>,
-      serde::compat_version<0>> {
-    int64_t start_delta = 0;
-    std::vector<persisted_batch> batches;
-};
-
 bytes serialize_kvstore_key(raft::group_id group, kvstore_key_type key_type) {
     iobuf buf;
     reflection::serialize(buf, key_type, group);
@@ -207,70 +75,12 @@ bytes serialize_kvstore_key(raft::group_id group, kvstore_key_type key_type) {
 
 } // namespace
 
-iobuf offset_translator::serialize_batches_map(
-  const batches_map_t& last_offset2batch) {
-    vassert(
-      !last_offset2batch.empty(),
-      "ntp {}: offsets map shouldn't be empty",
-      _ntp);
-
-    std::vector<persisted_batch> batches;
-    batches.reserve(last_offset2batch.size());
-    for (const auto& [o, b] : last_offset2batch) {
-        int32_t length = int32_t(o - b.base_offset) + 1;
-        batches.push_back(
-          persisted_batch{.base_offset = b.base_offset, .length = length});
-    }
-
-    persisted_batches_map persisted{
-      .start_delta = last_offset2batch.begin()->second.next_delta,
-      .batches = std::move(batches),
-    };
-
-    return serde::to_iobuf(std::move(persisted));
-}
-
-offset_translator::batches_map_t
-offset_translator::deserialize_batches_map(iobuf buf) {
-    auto persisted = serde::from_iobuf<persisted_batches_map>(std::move(buf));
-    if (persisted.batches.empty()) {
-        throw std::runtime_error{
-          _logger.format("persisted offset translator map shouldn't be empty")};
-    }
-
-    absl::btree_map<model::offset, batch_info> last_offset2batch;
-    int64_t cur_delta = persisted.start_delta;
-    model::offset prev_last_offset;
-    for (auto it = persisted.batches.begin(); it != persisted.batches.end();
-         ++it) {
-        const persisted_batch& b = *it;
-        if (it != persisted.batches.begin()) {
-            if (b.base_offset <= prev_last_offset) {
-                throw std::runtime_error{_logger.format(
-                  "inconsistency in serialized offset translator state: offset "
-                  "{} is after {}",
-                  b.base_offset,
-                  prev_last_offset)};
-            }
-            cur_delta += b.length;
-        }
-
-        model::offset last_offset = b.base_offset + model::offset{b.length - 1};
-        last_offset2batch.emplace(
-          last_offset,
-          batch_info{.base_offset = b.base_offset, .next_delta = cur_delta});
-        prev_last_offset = last_offset;
-    }
-
-    return last_offset2batch;
-}
-
 ss::future<>
 offset_translator::start(must_reset reset, bootstrap_state&& bootstrap) {
     vassert(
-      _last_offset2batch.empty(),
-      "ntp {}: offset_translator was modified before start()",
-      _ntp);
+      _state->empty(),
+      "ntp {}: offset translator state was modified before start()",
+      _state->ntp());
 
     if (_filtered_types.empty()) {
         co_return;
@@ -279,9 +89,8 @@ offset_translator::start(must_reset reset, bootstrap_state&& bootstrap) {
     if (reset) {
         vlog(_logger.info, "resetting offset translation state");
 
-        _last_offset2batch.emplace(
-          model::offset::min(),
-          batch_info{.base_offset = model::offset::min(), .next_delta = 0});
+        _state = storage::offset_translator_state(
+          _state->ntp(), model::offset::min(), 0);
         ++_map_version;
         _highest_known_offset = model::offset::min();
 
@@ -294,14 +103,15 @@ offset_translator::start(must_reset reset, bootstrap_state&& bootstrap) {
           highest_known_offset_key());
 
         if (map_buf && highest_known_offset_buf) {
-            _last_offset2batch = deserialize_batches_map(std::move(*map_buf));
+            _state = storage::offset_translator_state::from_serialized_map(
+              _state->ntp(), std::move(*map_buf));
             _highest_known_offset = reflection::from_iobuf<model::offset>(
               std::move(*highest_known_offset_buf));
 
             // highest known offset could be more stale than the map, in
             // this case we take it from the map
             _highest_known_offset = std::max(
-              _highest_known_offset, _last_offset2batch.rbegin()->first);
+              _highest_known_offset, _state->last_gap_offset());
         } else {
             // For backwards compatibility: load state from
             // configuration_manager state
@@ -310,10 +120,8 @@ offset_translator::start(must_reset reset, bootstrap_state&& bootstrap) {
               "offset translation kvstore state not found, loading from "
               "provided bootstrap state");
 
-            for (const auto& [o, d] : bootstrap.offset2delta) {
-                _last_offset2batch.emplace(
-                  o, batch_info{.base_offset = o, .next_delta = d});
-            }
+            _state = storage::offset_translator_state::from_bootstrap_state(
+              _state->ntp(), bootstrap.offset2delta);
             ++_map_version;
             _highest_known_offset = bootstrap.highest_known_offset;
 
@@ -322,18 +130,14 @@ offset_translator::start(must_reset reset, bootstrap_state&& bootstrap) {
     }
 
     vassert(
-      !_last_offset2batch.empty(),
-      "ntp {}: offsets map shouldn't be empty",
-      _ntp);
+      !_state->empty(),
+      "ntp {}: offset translation state shouldn't be empty",
+      _state->ntp());
 
     vlog(
       _logger.info,
-      "started, base offset/delta: {}/{}, map size: {}, last delta: {}, "
-      "highest_known_offset: {}",
-      _last_offset2batch.begin()->first,
-      _last_offset2batch.begin()->second.next_delta,
-      _last_offset2batch.size(),
-      _last_offset2batch.rbegin()->second.next_delta,
+      "started, state: {}, highest_known_offset: {}",
+      _state,
       _highest_known_offset);
 }
 
@@ -344,25 +148,15 @@ ss::future<> offset_translator::sync_with_log(
     }
 
     vassert(
-      !_last_offset2batch.empty(),
-      "ntp {}: offsets map shouldn't be empty",
-      _ntp);
+      !_state->empty(),
+      "ntp {}: offset translation state shouldn't be empty",
+      _state->ntp());
 
     auto log_offsets = log.offsets();
 
     // Trim the offset2delta map to log dirty_offset (discrepancy can
     // happen if the offsets map was persisted, but the log wasn't flushed).
-    auto end_it = _last_offset2batch.upper_bound(log_offsets.dirty_offset);
-    if (end_it == _last_offset2batch.begin()) {
-        throw std::runtime_error{_logger.format(
-          "can't sync offset_translator with log: dirty offset {} is < "
-          "base translation offset {}",
-          log_offsets.dirty_offset,
-          _last_offset2batch.begin()->first)};
-    }
-
-    if (end_it != _last_offset2batch.end()) {
-        _last_offset2batch.erase(end_it, _last_offset2batch.end());
+    if (_state->truncate(details::next_offset(log_offsets.dirty_offset))) {
         ++_map_version;
     }
 
@@ -396,12 +190,8 @@ ss::future<> offset_translator::sync_with_log(
 
     vlog(
       _logger.info,
-      "synced with log, base offset/delta: {}/{}, map size: {}, last delta: "
-      "{}, highest_known_offset: {}",
-      _last_offset2batch.begin()->first,
-      _last_offset2batch.begin()->second.next_delta,
-      _last_offset2batch.size(),
-      _last_offset2batch.rbegin()->second.next_delta,
+      "synced with log, state: {}, highest_known_offset: {}",
+      _state,
       _highest_known_offset);
 
     co_await maybe_checkpoint();
@@ -412,43 +202,14 @@ ss::future<> offset_translator::truncate(model::offset offset) {
         co_return;
     }
 
-    vassert(
-      !_last_offset2batch.empty(),
-      "ntp {}: offsets map shouldn't be empty",
-      _ntp);
-
-    auto it = _last_offset2batch.lower_bound(offset);
-    if (it == _last_offset2batch.begin()) {
-        throw std::runtime_error{_logger.format(
-          "trying to truncate offset_translator at offset {} which "
-          "is <= base translation offset {}",
-          offset,
-          _last_offset2batch.begin()->first)};
-    }
-
-    if (it != _last_offset2batch.end()) {
-        if (offset > it->second.base_offset) {
-            throw std::runtime_error{_logger.format(
-              "trying to truncate offset_translator at offset {} which "
-              "is in the middle of the batch [{},{}]",
-              offset,
-              it->second.base_offset,
-              it->first)};
-        }
-
-        _last_offset2batch.erase(it, _last_offset2batch.end());
+    if (_state->truncate(offset)) {
         ++_map_version;
     }
 
     model::offset prev = details::prev_offset(offset);
     _highest_known_offset = std::min(prev, _highest_known_offset);
 
-    vlog(
-      _logger.info,
-      "truncate at offset: {}, new map size: {}, new last delta: {}",
-      offset,
-      _last_offset2batch.size(),
-      _last_offset2batch.rbegin()->second.next_delta);
+    vlog(_logger.info, "truncate at offset: {}, new state: {}", offset, _state);
 
     co_await _checkpoint_lock.with([this] { return do_checkpoint(); });
 }
@@ -458,11 +219,6 @@ ss::future<> offset_translator::prefix_truncate(model::offset offset) {
         co_return;
     }
 
-    vassert(
-      !_last_offset2batch.empty(),
-      "ntp {}: offsets map shouldn't be empty",
-      _ntp);
-
     if (offset > _highest_known_offset) {
         throw std::runtime_error{_logger.format(
           "trying to prefix truncate offset translator at offset {} which "
@@ -471,38 +227,17 @@ ss::future<> offset_translator::prefix_truncate(model::offset offset) {
           _highest_known_offset)};
     }
 
-    auto it = _last_offset2batch.upper_bound(offset);
-    if (it != _last_offset2batch.end() && offset >= it->second.base_offset) {
-        throw std::runtime_error{_logger.format(
-          "trying to prefix truncate offset translator at offset {} which "
-          "is in the middle of the batch {}-{}",
-          offset,
-          it->second.base_offset,
-          it->first)};
-    }
-
-    if (it == _last_offset2batch.begin()) {
+    if (!_state->prefix_truncate(offset)) {
         co_return;
     }
 
-    auto prev_it = std::prev(it);
-    if (prev_it == _last_offset2batch.begin() && prev_it->first == offset) {
-        co_return;
-    }
-
-    auto base_batch = prev_it->second;
-    _last_offset2batch.erase(_last_offset2batch.begin(), it);
-    _last_offset2batch.emplace(offset, base_batch);
     ++_map_version;
 
     vlog(
       _logger.info,
-      "prefix_truncate at offset: {}, new base delta: {}, new map size: {}, "
-      "new last delta: {}",
+      "prefix_truncate at offset: {}, new state: {}",
       offset,
-      base_batch.next_delta,
-      _last_offset2batch.size(),
-      _last_offset2batch.rbegin()->second.next_delta);
+      _state);
 
     co_await _checkpoint_lock.with([this] { return do_checkpoint(); });
 }
@@ -521,17 +256,12 @@ offset_translator::prefix_truncate_reset(model::offset offset, int64_t delta) {
     vassert(
       delta >= 0,
       "not enough state to recover offset translator. Requested to reset "
-      "at offset {}. Translator highest_known offset {}, last delta: {}, base "
-      "offset: {}, base delta: {}",
+      "at offset {}. Translator highest_known_offset: {}, state: {}",
       offset,
       _highest_known_offset,
-      _last_offset2batch.begin()->second.base_offset,
-      _last_offset2batch.begin()->second.next_delta,
-      _last_offset2batch.rbegin()->second.next_delta);
+      _state);
 
-    _last_offset2batch.clear();
-    _last_offset2batch.emplace(
-      offset, batch_info{.base_offset = offset, .next_delta = delta});
+    _state = storage::offset_translator_state(_state->ntp(), offset, delta);
     ++_map_version;
 
     _highest_known_offset = offset;
@@ -582,12 +312,9 @@ ss::future<> offset_translator::maybe_checkpoint() {
 
         vlog(
           _logger.trace,
-          "threshold reached, performing checkpoint; base offset/delta: {}/{}, "
-          "map size: {}, last delta: {}, highest_known_offset: {}",
-          _last_offset2batch.begin()->first,
-          _last_offset2batch.begin()->second.next_delta,
-          _last_offset2batch.size(),
-          _last_offset2batch.rbegin()->second.next_delta,
+          "threshold reached, performing checkpoint; state: {}, "
+          "highest_known_offset: {}",
+          _state,
           _highest_known_offset);
 
         co_await do_checkpoint();
@@ -602,7 +329,7 @@ ss::future<> offset_translator::do_checkpoint() {
 
     std::optional<iobuf> map_buf;
     if (map_version > _map_version_at_checkpoint) {
-        map_buf.emplace(serialize_batches_map(_last_offset2batch));
+        map_buf.emplace(_state->serialize_map());
     }
 
     iobuf hko_buf = reflection::to_iobuf(_highest_known_offset);

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -814,7 +814,7 @@ static void validate_offset_translation(raft_group& gr) {
     for (auto o = start; o < end; o++) {
         reference[o] = gr.get_members()
                          .begin()
-                         ->second.consensus->get_offset_translator()
+                         ->second.consensus->get_offset_translator_state()
                          ->from_log_offset(o);
     }
 
@@ -829,7 +829,8 @@ static void validate_offset_translation(raft_group& gr) {
             if (!reference.contains(o)) {
                 continue;
             }
-            auto translated = it->second.consensus->get_offset_translator()
+            auto translated = it->second.consensus
+                                ->get_offset_translator_state()
                                 ->from_log_offset(o);
             tstlog.info(
               "translation for offset {}, validating {} == {}\n",

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
     parser.cc
     log_reader.cc
     log_replayer.cc
+    offset_translator_state.cc
     probe.cc
     record_batch_builder.cc
     logger.cc

--- a/src/v/storage/fwd.h
+++ b/src/v/storage/fwd.h
@@ -22,5 +22,6 @@ class simple_snapshot_manager;
 class snapshot_manager;
 class readers_cache;
 class compaction_controller;
+class offset_translator_state;
 
 } // namespace storage

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -263,6 +263,7 @@ bool offset_translator_state::prefix_truncate(model::offset offset) {
     }
 
     auto base_batch = prev_it->second;
+    base_batch.base_offset = offset;
     _last_offset2batch.erase(_last_offset2batch.begin(), it);
     _last_offset2batch.emplace(offset, base_batch);
     return true;

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "storage/offset_translator_state.h"
+
+#include "vassert.h"
+
+namespace storage {
+
+namespace {
+
+inline constexpr model::offset next_offset(model::offset o) {
+    if (o < model::offset{0}) {
+        return model::offset{0};
+    }
+    return o + model::offset{1};
+}
+
+inline constexpr model::offset prev_offset(model::offset o) {
+    if (o <= model::offset{0}) {
+        return model::offset{};
+    }
+    return o - model::offset{1};
+}
+
+} // namespace
+
+int64_t offset_translator_state::delta(model::offset o) const {
+    if (_last_offset2batch.empty()) {
+        return 0;
+    }
+
+    auto it = _last_offset2batch.lower_bound(o);
+    if (it == _last_offset2batch.begin()) {
+        throw std::runtime_error{fmt::format(
+          "ntp {}: log offset {} is outside the translation range (starting at "
+          "{})",
+          _ntp,
+          o,
+          next_offset(_last_offset2batch.begin()->first))};
+    }
+
+    auto delta = std::prev(it)->second.next_delta;
+    if (it == _last_offset2batch.end() || o < it->second.base_offset) {
+        return delta;
+    } else {
+        // The offset is inside the non-data batch, so the data offset stops
+        // increasing at the base offset.
+        return delta + (o - it->second.base_offset);
+    }
+}
+
+model::offset offset_translator_state::from_log_offset(model::offset o) const {
+    const auto d = delta(o);
+    return model::offset(o - d);
+}
+
+model::offset offset_translator_state::to_log_offset(
+  model::offset data_offset, model::offset hint) const {
+    if (_last_offset2batch.empty()) {
+        return data_offset;
+    }
+
+    if (data_offset == model::offset::max()) {
+        return data_offset;
+    }
+
+    model::offset min_log_offset = next_offset(
+      _last_offset2batch.begin()->first);
+
+    model::offset min_data_offset
+      = min_log_offset
+        - model::offset(_last_offset2batch.begin()->second.next_delta);
+    vassert(
+      data_offset >= min_data_offset,
+      "ntp {}: data offset {} must be inside translation range (starting at "
+      "{})",
+      _ntp,
+      data_offset,
+      min_data_offset);
+
+    model::offset search_start = std::max(
+      std::max(hint, data_offset), min_log_offset);
+
+    // We iterate over the intervals (beginning exclusive, end inclusive)
+    // with constant delta, starting at the interval containing
+    // log offset equal to `data_offset` (because log offset is at least as
+    // big as data offset) and stopping when we find the interval where
+    // given data offset is achievable.
+    auto interval_end_it = _last_offset2batch.lower_bound(search_start);
+    vassert(
+      interval_end_it != _last_offset2batch.begin(),
+      "ntp {}: log offset search start too small: {}",
+      search_start);
+    auto delta = std::prev(interval_end_it)->second.next_delta;
+
+    while (interval_end_it != _last_offset2batch.end()) {
+        model::offset max_do_this_interval
+          = prev_offset(interval_end_it->second.base_offset)
+            - model::offset{delta};
+        if (max_do_this_interval >= data_offset) {
+            break;
+        }
+
+        delta = interval_end_it->second.next_delta;
+        ++interval_end_it;
+    }
+
+    return data_offset + model::offset(delta);
+}
+
+int64_t offset_translator_state::last_delta() const {
+    vassert(
+      !_last_offset2batch.empty(),
+      "ntp {}: offsets map shouldn't be empty",
+      _ntp);
+
+    return _last_offset2batch.rbegin()->second.next_delta;
+}
+
+model::offset offset_translator_state::last_gap_offset() const {
+    vassert(
+      !_last_offset2batch.empty(),
+      "ntp {}: offsets map shouldn't be empty",
+      _ntp);
+
+    return _last_offset2batch.rbegin()->first;
+}
+
+void offset_translator_state::add_gap(
+  model::offset base_offset, model::offset last_offset) {
+    vassert(
+      !_last_offset2batch.empty(),
+      "ntp {}: offsets map shouldn't be empty",
+      _ntp);
+
+    auto rbegin = _last_offset2batch.rbegin();
+    vassert(
+      base_offset > rbegin->first,
+      "ntp {}: trying to add batch to offset translator at offset {} that "
+      "is not higher than the previous last offset {}",
+      _ntp,
+      base_offset,
+      rbegin->first);
+
+    int64_t length = last_offset() - base_offset() + 1;
+    int64_t next_delta = rbegin->second.next_delta + length;
+    _last_offset2batch.emplace(
+      last_offset,
+      batch_info{.base_offset = base_offset, .next_delta = next_delta});
+}
+
+bool offset_translator_state::truncate(model::offset offset) {
+    vassert(
+      !_last_offset2batch.empty(),
+      "ntp {}: offsets map shouldn't be empty",
+      _ntp);
+
+    auto it = _last_offset2batch.lower_bound(offset);
+    if (it == _last_offset2batch.begin()) {
+        throw std::runtime_error{fmt::format(
+          "ntp {}: trying to truncate offset_translator at offset {} which is "
+          "<= base translation offset {}",
+          _ntp,
+          offset,
+          _last_offset2batch.begin()->first)};
+    }
+
+    if (it != _last_offset2batch.end()) {
+        if (offset > it->second.base_offset) {
+            throw std::runtime_error{fmt::format(
+              "ntp {}: trying to truncate offset_translator at offset {} which "
+              "is in the middle of the batch [{},{}]",
+              _ntp,
+              offset,
+              it->second.base_offset,
+              it->first)};
+        }
+
+        _last_offset2batch.erase(it, _last_offset2batch.end());
+        return true;
+    }
+
+    return false;
+}
+
+bool offset_translator_state::prefix_truncate(model::offset offset) {
+    vassert(
+      !_last_offset2batch.empty(),
+      "ntp {}: offsets map shouldn't be empty",
+      _ntp);
+
+    auto it = _last_offset2batch.upper_bound(offset);
+    if (it != _last_offset2batch.end() && offset >= it->second.base_offset) {
+        throw std::runtime_error{fmt::format(
+          "ntp {}: trying to prefix truncate offset translator at offset {} "
+          "which is in the middle of the batch {}-{}",
+          _ntp,
+          offset,
+          it->second.base_offset,
+          it->first)};
+    }
+
+    if (it == _last_offset2batch.begin()) {
+        return false;
+    }
+
+    auto prev_it = std::prev(it);
+    if (prev_it == _last_offset2batch.begin() && prev_it->first == offset) {
+        return false;
+    }
+
+    auto base_batch = prev_it->second;
+    _last_offset2batch.erase(_last_offset2batch.begin(), it);
+    _last_offset2batch.emplace(offset, base_batch);
+    return true;
+}
+
+namespace {
+
+struct persisted_batch {
+    model::offset base_offset;
+    int32_t length;
+
+    friend inline void read_nested(
+      iobuf_parser& in, persisted_batch& b, size_t const bytes_left_limit) {
+        serde::read_nested(in, b.base_offset, bytes_left_limit);
+        serde::read_nested(in, b.length, bytes_left_limit);
+    }
+
+    friend inline void write(iobuf& out, const persisted_batch& b) {
+        serde::write(out, b.base_offset);
+        serde::write(out, b.length);
+    }
+};
+
+struct persisted_batches_map
+  : serde::envelope<
+      persisted_batches_map,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    int64_t start_delta = 0;
+    std::vector<persisted_batch> batches;
+};
+
+} // namespace
+
+iobuf offset_translator_state::serialize_map() const {
+    vassert(
+      !_last_offset2batch.empty(),
+      "ntp {}: offsets map shouldn't be empty",
+      _ntp);
+
+    std::vector<persisted_batch> batches;
+    batches.reserve(_last_offset2batch.size());
+    for (const auto& [o, b] : _last_offset2batch) {
+        int32_t length = int32_t(o - b.base_offset) + 1;
+        batches.push_back(
+          persisted_batch{.base_offset = b.base_offset, .length = length});
+    }
+
+    persisted_batches_map persisted{
+      .start_delta = _last_offset2batch.begin()->second.next_delta,
+      .batches = std::move(batches),
+    };
+
+    return serde::to_iobuf(std::move(persisted));
+}
+
+offset_translator_state
+offset_translator_state::from_serialized_map(model::ntp ntp, iobuf buf) {
+    auto persisted = serde::from_iobuf<persisted_batches_map>(std::move(buf));
+    if (persisted.batches.empty()) {
+        throw std::runtime_error{fmt::format(
+          "ntp {}: persisted offset translator map shouldn't be empty", ntp)};
+    }
+
+    absl::btree_map<model::offset, batch_info> last_offset2batch;
+    int64_t cur_delta = persisted.start_delta;
+    model::offset prev_last_offset;
+    for (auto it = persisted.batches.begin(); it != persisted.batches.end();
+         ++it) {
+        const persisted_batch& b = *it;
+        if (it != persisted.batches.begin()) {
+            if (b.base_offset <= prev_last_offset) {
+                throw std::runtime_error{fmt::format(
+                  "ntp {}: inconsistency in serialized offset translator "
+                  "state: offset {} is after {}",
+                  ntp,
+                  b.base_offset,
+                  prev_last_offset)};
+            }
+            cur_delta += b.length;
+        }
+
+        model::offset last_offset = b.base_offset + model::offset{b.length - 1};
+        last_offset2batch.emplace(
+          last_offset,
+          batch_info{.base_offset = b.base_offset, .next_delta = cur_delta});
+        prev_last_offset = last_offset;
+    }
+
+    offset_translator_state state(std::move(ntp));
+    state._last_offset2batch = std::move(last_offset2batch);
+    return state;
+}
+
+offset_translator_state offset_translator_state::from_bootstrap_state(
+  model::ntp ntp, const absl::btree_map<model::offset, int64_t>& offset2delta) {
+    offset_translator_state state(std::move(ntp));
+    for (const auto& [o, d] : offset2delta) {
+        state._last_offset2batch.emplace(
+          o, batch_info{.base_offset = o, .next_delta = d});
+    }
+    return state;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const offset_translator_state& state) {
+    const auto& map = state._last_offset2batch;
+
+    if (map.empty()) {
+        return os << "{empty}";
+    }
+
+    return os << "{base offset/delta: " << map.begin()->first << "/"
+              << map.begin()->second.next_delta << ", map size: " << map.size()
+              << ", last delta: " << map.rbegin()->second.next_delta << "}";
+}
+
+} // namespace storage

--- a/src/v/storage/offset_translator_state.h
+++ b/src/v/storage/offset_translator_state.h
@@ -71,6 +71,11 @@ public:
     /// Add a filtered batch to the end of the offset translation state.
     void add_gap(model::offset base_offset, model::offset last_offset);
 
+    /// Amend the offset translation state (by appending an artificial batch to
+    /// the map) so that delta at `offset` equals to `delta`. Returns true if
+    /// the map changed.
+    bool add_absolute_delta(model::offset offset, int64_t delta);
+
     /// Removes the offset translation state starting from the offset
     /// (inclusive). Returns true if the map changed.
     bool truncate(model::offset);

--- a/src/v/storage/offset_translator_state.h
+++ b/src/v/storage/offset_translator_state.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/fundamental.h"
+#include "serde/serde.h"
+
+#include <absl/container/btree_map.h>
+
+namespace storage {
+
+/// Provides offset translation between raw log offsets and offsets not counting
+/// filtered batches (basically our internal batch types that we write into the
+/// data partitions). This is needed because even though our internal batch
+/// types are filtered out when sent to clients, kafka clients are not prepared
+/// for these batches to occupy offset space (see
+/// https://github.com/vectorizedio/redpanda/issues/1184 for details).
+///
+/// It works by maintaining an in-memory map of all filtered batch offsets.
+/// This map allows us to quickly find a delta between the raw log offset and
+/// corresponding translated offset.
+class offset_translator_state {
+public:
+    /// Create an empty translator - the delta between log and kafka offsets is
+    /// always 0
+    offset_translator_state(model::ntp ntp)
+      : _ntp(std::move(ntp)) {}
+
+    /// Create a translator with delta `base_delta` for all offsets strictly
+    /// greater than `base_offset`.
+    offset_translator_state(
+      model::ntp ntp, model::offset base_offset, int64_t base_delta)
+      : _ntp(std::move(ntp)) {
+        _last_offset2batch.emplace(
+          base_offset,
+          batch_info{.base_offset = base_offset, .next_delta = base_delta});
+    }
+
+    offset_translator_state(const offset_translator_state&) = delete;
+    offset_translator_state& operator=(const offset_translator_state&) = delete;
+    offset_translator_state(offset_translator_state&&) = default;
+    offset_translator_state& operator=(offset_translator_state&&) = default;
+
+    const model::ntp& ntp() const { return _ntp; }
+
+    bool empty() const { return _last_offset2batch.empty(); }
+
+    /// Difference between the log offset and the kafka offset.
+    int64_t delta(model::offset) const;
+
+    /// Translate log offset into kafka offset.
+    model::offset from_log_offset(model::offset) const;
+
+    /// Translate kafka offset into log offset.
+    model::offset to_log_offset(
+      model::offset data_offset, model::offset hint = model::offset{}) const;
+
+    /// Precondition: !empty()
+    int64_t last_delta() const;
+    model::offset last_gap_offset() const;
+
+    /// Add a filtered batch to the end of the offset translation state.
+    void add_gap(model::offset base_offset, model::offset last_offset);
+
+    /// Removes the offset translation state starting from the offset
+    /// (inclusive). Returns true if the map changed.
+    bool truncate(model::offset);
+
+    /// Removes the offset translation state up to and including the offset. The
+    /// offset delta for the next offsets is preserved. Returns true if the map
+    /// changed.
+    bool prefix_truncate(model::offset);
+
+    iobuf serialize_map() const;
+    static offset_translator_state
+    from_serialized_map(model::ntp ntp, iobuf buf);
+
+    /// Bootstrap offset translator state from the raft configuration manager
+    /// state.
+    static offset_translator_state from_bootstrap_state(
+      model::ntp, const absl::btree_map<model::offset, int64_t>&);
+
+    friend std::ostream&
+    operator<<(std::ostream&, const offset_translator_state&);
+
+private:
+    struct batch_info {
+        model::offset base_offset;
+        int64_t next_delta;
+    };
+
+    // Map from the last offset of non-data batches to the corresponding batch
+    // info. next_delta in the batch info is active in the log offset interval
+    // (last offset; next last offset] (left end exclusive, right end
+    // inclusive). As prefix truncations happen, we maintain an invariant that
+    // there is always an element of the map with the key prev_offset(start of
+    // the log) - this way we can calculate delta for any offset in the log.
+    using batches_map_t = absl::btree_map<model::offset, batch_info>;
+
+private:
+    model::ntp _ntp;
+    batches_map_t _last_offset2batch;
+};
+
+} // namespace storage

--- a/src/v/storage/translating_reader.h
+++ b/src/v/storage/translating_reader.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/fundamental.h"
+#include "model/record_batch_reader.h"
+#include "storage/offset_translator_state.h"
+
+#include <seastar/core/shared_ptr.hh>
+
+namespace storage {
+
+/// A struct that holds together a reader that performs offset translation and
+/// the corresponding offset translation state (useful when offsets of returned
+/// batches need to be translated back to the original offset space)
+struct translating_reader {
+    model::record_batch_reader reader;
+    ss::lw_shared_ptr<const offset_translator_state> ot_state;
+
+    explicit translating_reader(
+      model::record_batch_reader&& reader,
+      ss::lw_shared_ptr<const offset_translator_state> ot_state = nullptr)
+      : reader(std::move(reader))
+      , ot_state(std::move(ot_state)) {}
+};
+
+} // namespace storage

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -1,0 +1,185 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from rptest.archival.s3_client import S3Client
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.util import (
+    segments_count,
+    wait_for_segments_removal,
+)
+
+import confluent_kafka as ck
+
+import uuid
+import random
+from itertools import zip_longest
+
+
+class ShadowIndexingTxTest(RedpandaTest):
+    segment_size = 1048576  # 1 Mb
+    s3_host_name = "minio-s3"
+    s3_access_key = "panda-user"
+    s3_secret_key = "panda-secret"
+    s3_region = "panda-region"
+    s3_topic_name = "panda-topic"
+    topics = (TopicSpec(name='panda-topic',
+                        partition_count=1,
+                        replication_factor=3), )
+
+    def __init__(self, test_context):
+        self.s3_bucket_name = f"panda-bucket-{uuid.uuid1()}"
+        extra_rp_conf = dict(
+            log_segment_size=self.segment_size,
+            cloud_storage_enabled=True,
+            cloud_storage_access_key=self.s3_access_key,
+            cloud_storage_secret_key=self.s3_secret_key,
+            cloud_storage_region=self.s3_region,
+            cloud_storage_bucket=self.s3_bucket_name,
+            cloud_storage_disable_tls=True,
+            cloud_storage_api_endpoint=self.s3_host_name,
+            cloud_storage_api_endpoint_port=9000,
+            cloud_storage_reconciliation_interval_ms=500,
+            cloud_storage_max_connections=5,
+            enable_idempotence=True,
+            enable_transactions=True,
+            enable_leader_balancer=False,
+            enable_auto_rebalance_on_node_add=False,
+        )
+
+        super(ShadowIndexingTxTest, self).__init__(test_context=test_context,
+                                                   extra_rp_conf=extra_rp_conf)
+
+        s3client = S3Client(
+            region=self.s3_region,
+            access_key=self.s3_access_key,
+            secret_key=self.s3_secret_key,
+            endpoint=f"http://{self.s3_host_name}:9000",
+            logger=self.logger,
+        )
+        s3client.create_bucket(self.s3_bucket_name)
+
+    @cluster(num_nodes=3)
+    def test_shadow_indexing_aborted_txs(self):
+        """Check that messages belonging to aborted transaction are not seen by clients
+        when fetching from remote segments."""
+        topic = self.topics[0]
+
+        class Producer:
+            def __init__(self, brokers, logger):
+                self.keys = []
+                self.cur_offset = 0
+                self.brokers = brokers
+                self.logger = logger
+                self.num_aborted = 0
+                self.reconnect()
+
+            def reconnect(self):
+                self.producer = ck.Producer({
+                    'bootstrap.servers':
+                    self.brokers,
+                    'transactional.id':
+                    'shadow-indexing-tx-test',
+                })
+                self.producer.init_transactions()
+
+            def produce(self, topic):
+                """produce some messages inside a transaction with increasing keys
+                and random values. Then randomly commit/abort the transaction."""
+
+                n_msgs = random.randint(50, 100)
+                keys = []
+
+                self.producer.begin_transaction()
+                for _ in range(n_msgs):
+                    val = ''.join(
+                        map(chr, (random.randint(0, 256)
+                                  for _ in range(random.randint(100, 1000)))))
+                    self.producer.produce(topic.name, val,
+                                          str(self.cur_offset))
+                    keys.append(str(self.cur_offset).encode('utf8'))
+                    self.cur_offset += 1
+
+                self.logger.info(
+                    f"writing {len(keys)} msgs: {keys[0]}-{keys[-1]}...")
+                self.producer.flush()
+                if random.random() < 0.1:
+                    self.producer.abort_transaction()
+                    self.num_aborted += 1
+                    self.logger.info("aborted txn")
+                else:
+                    self.producer.commit_transaction()
+                    self.keys.extend(keys)
+
+        producer = Producer(self.redpanda.brokers(), self.logger)
+
+        def done():
+            for _ in range(100):
+                try:
+                    producer.produce(topic)
+                except ck.KafkaException as err:
+                    self.logger.warn(f"producer error: {err}")
+                    producer.reconnect()
+            self.logger.info("producer iteration complete")
+            topic_partitions = segments_count(self.redpanda,
+                                              topic.name,
+                                              partition_idx=0)
+            partitions = []
+            for p in topic_partitions:
+                partitions.append(p >= 10)
+            return all(partitions)
+
+        wait_until(done,
+                   timeout_sec=120,
+                   backoff_sec=1,
+                   err_msg="producing failed")
+
+        assert producer.num_aborted > 0
+
+        kafka_tools = KafkaCliTools(self.redpanda)
+        kafka_tools.alter_topic_config(
+            self.topic,
+            {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 3 * self.segment_size,
+            },
+        )
+        wait_for_segments_removal(redpanda=self.redpanda,
+                                  topic=self.topic,
+                                  partition_idx=0,
+                                  count=6)
+
+        consumer = ck.Consumer(
+            {
+                'bootstrap.servers': self.redpanda.brokers(),
+                'group.id': 'shadow-indexing-tx-test',
+                'auto.offset.reset': 'earliest',
+            },
+            logger=self.logger)
+        consumer.subscribe([topic.name])
+
+        consumed = []
+        while True:
+            msgs = consumer.consume(timeout=5.0)
+            if len(msgs) == 0:
+                break
+            consumed.extend([(m.key(), m.offset()) for m in msgs])
+
+        first_mismatch = ''
+        for p_key, (c_key, c_offset) in zip_longest(producer.keys, consumed):
+            if p_key != c_key:
+                first_mismatch = f"produced: {p_key}, consumed: {c_key} (offset: {c_offset})"
+                break
+
+        assert (not first_mismatch), (
+            f"produced and consumed messages differ, "
+            f"produced length: {len(producer.keys)}, consumed length: {len(consumed)}, "
+            f"first mismatch: {first_mismatch}")

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'ducktape@git+https://github.com/vectorizedio/ducktape.git@master',
         'prometheus-client==0.9.0', 'pyyaml==5.3.1', 'kafka-python==2.0.2',
-        'crc32c==2.2', 'confluent-kafka==1.6.1', 'zstandard==0.15.2',
+        'crc32c==2.2', 'confluent-kafka==1.7.0', 'zstandard==0.15.2',
         'xxhash==2.0.2'
     ],
     scripts=[],

--- a/tools/metadata_viewer/kafka.py
+++ b/tools/metadata_viewer/kafka.py
@@ -1,0 +1,12 @@
+from storage import Segment
+
+
+class KafkaLog:
+    def __init__(self, ntp):
+        self.ntp = ntp
+
+    def batch_headers(self):
+        for path in self.ntp.segments:
+            s = Segment(path)
+            for batch in s:
+                yield batch.header._asdict()

--- a/tools/metadata_viewer/storage.py
+++ b/tools/metadata_viewer/storage.py
@@ -82,9 +82,15 @@ class RecordIter:
         timestamp_delta = self.rdr.read_varint()
         offset_delta = self.rdr.read_varint()
         key_length = self.rdr.read_varint()
-        key = self.rdr.read_bytes(key_length)
+        if key_length > 0:
+            key = self.rdr.read_bytes(key_length)
+        else:
+            key = None
         value_length = self.rdr.read_varint()
-        value = self.rdr.read_bytes(value_length)
+        if value_length > 0:
+            value = self.rdr.read_bytes(value_length)
+        else:
+            value = None
         hdr_size = self.rdr.read_varint()
         headers = []
         for i in range(0, hdr_size):

--- a/tools/metadata_viewer/storage.py
+++ b/tools/metadata_viewer/storage.py
@@ -186,6 +186,8 @@ class Store:
     def __search(self):
         dirs = os.walk(self.base_dir)
         for ntpd in (p[0] for p in dirs if not p[1]):
+            if 'cloud_storage_cache' in ntpd:
+                continue
             head, part_ntp_id = os.path.split(ntpd)
             [part, ntp_id] = part_ntp_id.split("_")
             head, topic = os.path.split(head)


### PR DESCRIPTION
## Cover letter

Most of the times (if rm_stm didn't reset its state) aborted transaction ids for offset ranges that correspond to remote data will still be in rm_stm. The difficulty lies in translating offsets - rm_stm will use redpanda/raw log offsets and in the kafka layer we get kafka offsets. Also we can't use raft offset_translator because it contains only information for translating local offsets. So offset translation data is used that we build incrementally when reading from remote segments.

To reuse the offset translation algorithm we extract it from the raft offset translator.

Fixes #3029 

## Release notes

Release note: Shadow indexing fetches now correctly take into account aborted transactions: batches from aborted transactions will be filtered by clients.