### PR TITLE
tests: fix compacted verifier

### DIFF
--- a/tests/rptest/clients/compacted_verifier.py
+++ b/tests/rptest/clients/compacted_verifier.py
@@ -69,3 +69,4 @@ class CompactedTopicVerifier:
         except subprocess.CalledProcessError as e:
             self._redpanda.logger.error("Error (%d) executing verifier:\n %s",
                                         e.returncode, e.output)
+            raise

--- a/tests/rptest/clients/compacted_verifier.py
+++ b/tests/rptest/clients/compacted_verifier.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0
 
 import subprocess
+import os
+import pathlib
 
 
 class CompactedTopicVerifier:
@@ -51,6 +53,10 @@ class CompactedTopicVerifier:
         return self._cmd('consume')
 
     def _cmd(self, cmd_str):
+        # Ensure output directory exists
+        out_dir = os.path.dirname(self.state_path)
+        pathlib.Path(out_dir).mkdir(parents=True, exist_ok=True)
+
         self._redpanda.logger.debug("starting compacted topic verifier")
         try:
             cmd = ("{java} -jar {verifier_jar} --broker {brokers} "


### PR DESCRIPTION
## Cover letter

This class was erroring out due to a missing dir, but not failing the test when that happened.

Make errors fatal, and fix the missing directory.

Noticed this while manually inspecting some test logs for warnings & saw the warning from the Java subprocess.

## Release notes

None