### PR TITLE
r/consensus: use oplock when stepping down

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2754,27 +2754,28 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
                 .timeout_now(
                   target_rni.id(), std::move(req), rpc::client_opts(timeout))
 
-                .then([this](result<timeout_now_reply> reply) {
-                    if (!reply) {
-                        return seastar::make_ready_future<std::error_code>(
-                          reply.error());
-                    } else {
-                        // Step down before setting _transferring_leadership
-                        // to false, to ensure we do not accept any more writes
-                        // in the gap between new leader acking timeout now
-                        // and new leader sending a vote for its new term.
-                        // (If we accepted more writes, our log could get
-                        //  ahead of new leader, and it could lose election)
-                        do_step_down();
-                        if (_leader_id) {
-                            _leader_id = std::nullopt;
-                            trigger_leadership_notification();
-                        }
+                .then(
+                  [this](result<timeout_now_reply> reply)
+                    -> ss::future<std::error_code> {
+                      if (!reply) {
+                          co_return reply.error();
+                      } else {
+                          // Step down before setting _transferring_leadership
+                          // to false, to ensure we do not accept any more
+                          // writes in the gap between new leader acking timeout
+                          // now and new leader sending a vote for its new term.
+                          // (If we accepted more writes, our log could get
+                          //  ahead of new leader, and it could lose election)
+                          auto units = co_await _op_lock.get_units();
+                          do_step_down();
+                          if (_leader_id) {
+                              _leader_id = std::nullopt;
+                              trigger_leadership_notification();
+                          }
 
-                        return seastar::make_ready_future<std::error_code>(
-                          make_error_code(errc::success));
-                    }
-                });
+                          co_return make_error_code(errc::success);
+                      }
+                  });
           });
     });
 


### PR DESCRIPTION
When we step down after leadership transfer we need to grab an `_oplock` not to step down when raft is processing another request.
