### PR TITLE
config: add `property_binding` for live-settable properties

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -222,9 +222,6 @@ ss::future<> controller::start() {
           }
       })
       .then([this] {
-          if (!config::shard_local_cfg().enable_leader_balancer()) {
-              return ss::now();
-          }
           _leader_balancer = std::make_unique<leader_balancer>(
             _tp_state.local(),
             _partition_leaders.local(),
@@ -233,9 +230,10 @@ ss::future<> controller::start() {
             std::ref(_partition_manager),
             std::ref(_raft_manager),
             std::ref(_as),
-            config::shard_local_cfg().leader_balancer_idle_timeout(),
-            config::shard_local_cfg().leader_balancer_mute_timeout(),
-            config::shard_local_cfg().leader_balancer_node_mute_timeout(),
+            config::shard_local_cfg().enable_leader_balancer.bind(),
+            config::shard_local_cfg().leader_balancer_idle_timeout.bind(),
+            config::shard_local_cfg().leader_balancer_mute_timeout.bind(),
+            config::shard_local_cfg().leader_balancer_node_mute_timeout.bind(),
             _raft0);
           return _leader_balancer->start();
       })

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -43,13 +43,15 @@ leader_balancer::leader_balancer(
   ss::sharded<partition_manager>& partition_manager,
   ss::sharded<raft::group_manager>& group_manager,
   ss::sharded<ss::abort_source>& as,
-  std::chrono::milliseconds idle_timeout,
-  std::chrono::milliseconds mute_timeout,
-  std::chrono::milliseconds node_mute_timeout,
+  config::binding<bool>&& enabled,
+  config::binding<std::chrono::milliseconds>&& idle_timeout,
+  config::binding<std::chrono::milliseconds>&& mute_timeout,
+  config::binding<std::chrono::milliseconds>&& node_mute_timeout,
   consensus_ptr raft0)
-  : _idle_timeout(idle_timeout)
-  , _mute_timeout(mute_timeout)
-  , _node_mute_timeout(node_mute_timeout)
+  : _enabled(std::move(enabled))
+  , _idle_timeout(std::move(idle_timeout))
+  , _mute_timeout(std::move(mute_timeout))
+  , _node_mute_timeout(std::move(node_mute_timeout))
   , _topics(topics)
   , _leaders(leaders)
   , _client(std::move(client))
@@ -77,22 +79,27 @@ ss::future<> leader_balancer::start() {
                 return;
             }
             if (_raft0->is_leader()) {
-                vlog(
-                  clusterlog.info,
-                  "Leader balancer: controller leadership detected. Starting "
-                  "rebalancer in {} seconds",
-                  std::chrono::duration_cast<std::chrono::seconds>(
-                    leader_activation_delay)
-                    .count());
+                if (_enabled()) {
+                    vlog(
+                      clusterlog.info,
+                      "Leader balancer: controller leadership detected. "
+                      "Starting "
+                      "rebalancer in {} seconds",
+                      std::chrono::duration_cast<std::chrono::seconds>(
+                        leader_activation_delay)
+                        .count());
+                }
                 _timer.cancel();
                 _timer.arm(leader_activation_delay);
             } else {
-                vlog(
-                  clusterlog.info,
-                  "Leader balancer: controller leadership lost");
+                if (_enabled()) {
+                    vlog(
+                      clusterlog.info,
+                      "Leader balancer: controller leadership lost");
+                }
                 _need_controller_refresh = true;
                 _timer.cancel();
-                _timer.arm(_idle_timeout);
+                _timer.arm(_idle_timeout());
             }
         });
 
@@ -101,8 +108,10 @@ ss::future<> leader_balancer::start() {
      * during registration, so make sure the timer is unarmed before arming.
      */
     if (!_timer.armed()) {
-        _timer.arm(_idle_timeout);
+        _timer.arm(_idle_timeout());
     }
+
+    _enabled.watch([this]() { on_enable_changed(); });
 
     co_return;
 }
@@ -112,6 +121,25 @@ ss::future<> leader_balancer::stop() {
       _leader_notify_handle);
     _timer.cancel();
     return _gate.close();
+}
+
+/**
+ * Hook for changes to enable_leader_balancer config property
+ */
+void leader_balancer::on_enable_changed() {
+    if (_gate.is_closed()) {
+        return;
+    }
+
+    if (_enabled()) {
+        vlog(clusterlog.info, "Leader balancer enabled");
+        if (!_timer.armed()) {
+            _timer.arm(_idle_timeout());
+        }
+    } else {
+        vlog(clusterlog.info, "Leader balancer disabled");
+        _timer.cancel();
+    }
 }
 
 void leader_balancer::trigger_balance() {
@@ -127,7 +155,11 @@ void leader_balancer::trigger_balance() {
     if (_gate.get_count()) {
         vlog(
           clusterlog.info, "Cannot start rebalance until previous fiber exits");
-        _timer.arm(_idle_timeout);
+        _timer.arm(_idle_timeout());
+    }
+
+    if (!_enabled()) {
+        return;
     }
 
     (void)ss::try_with_gate(_gate, [this] {
@@ -145,10 +177,11 @@ void leader_balancer::trigger_balance() {
                 "Leadership rebalance experienced an unhandled error: {}. "
                 "Retrying in {} seconds",
                 e,
-                std::chrono::duration_cast<std::chrono::seconds>(_idle_timeout)
+                std::chrono::duration_cast<std::chrono::seconds>(
+                  _idle_timeout())
                   .count());
               _timer.cancel();
-              _timer.arm(_idle_timeout);
+              _timer.arm(_idle_timeout());
           });
     }).handle_exception_type([](const ss::gate_closed_exception&) {});
 }
@@ -167,7 +200,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
     if (!_raft0->is_leader()) {
         vlog(clusterlog.debug, "Leadership balancer tick: not leader");
         if (!_timer.armed()) {
-            _timer.arm(_idle_timeout);
+            _timer.arm(_idle_timeout());
         }
         _need_controller_refresh = true;
         co_return ss::stop_iteration::yes;
@@ -236,7 +269,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
           error,
           _muted.size());
         if (!_timer.armed()) {
-            _timer.arm(_idle_timeout);
+            _timer.arm(_idle_timeout());
         }
         _probe.leader_transfer_no_improvement();
         co_return ss::stop_iteration::yes;
@@ -260,7 +293,8 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
          */
         _probe.leader_transfer_error();
         co_await ss::sleep_abortable(5s, _as.local());
-        _muted.try_emplace(transfer->group, clock_type::now() + _mute_timeout);
+        _muted.try_emplace(
+          transfer->group, clock_type::now() + _mute_timeout());
         co_return ss::stop_iteration::no;
     }
 
@@ -299,7 +333,8 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
           "Leadership balancer muting group {} not found in topics table",
           transfer->group);
         co_await ss::sleep_abortable(5s, _as.local());
-        _muted.try_emplace(transfer->group, clock_type::now() + _mute_timeout);
+        _muted.try_emplace(
+          transfer->group, clock_type::now() + _mute_timeout());
         co_return ss::stop_iteration::no;
     }
 
@@ -352,7 +387,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
      * thrashing (we'll still mute the group), but also because we may have
      * simply been racing with organic leadership movement.
      */
-    _muted.try_emplace(transfer->group, clock_type::now() + _mute_timeout);
+    _muted.try_emplace(transfer->group, clock_type::now() + _mute_timeout());
     co_return ss::stop_iteration::no;
 }
 
@@ -361,7 +396,7 @@ absl::flat_hash_set<model::node_id> leader_balancer::muted_nodes() const {
     const auto now = raft::clock_type::now();
     for (const auto& follower : _raft0->get_follower_metrics()) {
         auto last_hbeat_age = now - follower.last_heartbeat;
-        if (last_hbeat_age > _node_mute_timeout) {
+        if (last_hbeat_age > _node_mute_timeout()) {
             nodes.insert(follower.id);
             vlog(
               clusterlog.info,
@@ -481,7 +516,7 @@ leader_balancer::index_type leader_balancer::build_index() {
                     _last_leader.insert_or_assign(
                       partition.group,
                       last_known_leader{
-                        *leader_core, clock_type::now() + _mute_timeout});
+                        *leader_core, clock_type::now() + _mute_timeout()});
                 } else {
                     vlog(
                       clusterlog.info,

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -171,7 +171,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
         }
         _need_controller_refresh = true;
         co_return ss::stop_iteration::yes;
-    } else if (_raft0->config().brokers().size() == 0) {
+    } else if (_raft0->config().brokers().size() == 1) {
         vlog(clusterlog.trace, "Leadership balancer tick: single node cluster");
         co_return ss::stop_iteration::yes;
     }

--- a/src/v/config/base_property.cc
+++ b/src/v/config/base_property.cc
@@ -10,6 +10,7 @@
 #include "config/base_property.h"
 
 #include "config/config_store.h"
+#include "vassert.h"
 
 #include <ostream>
 
@@ -41,6 +42,17 @@ std::string_view to_string_view(visibility v) {
     }
 
     return "{invalid}";
+}
+
+/**
+ * Helper for property methods that should only be used
+ * on live-settable properties.
+ */
+void base_property::assert_live_settable() const {
+    vassert(
+      _meta.needs_restart == needs_restart::no,
+      "Property must be be marked as "
+      "needs_restart::no");
 }
 
 }; // namespace config

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -92,5 +92,8 @@ private:
     std::string_view _name;
     std::string_view _desc;
     metadata _meta;
+
+protected:
+    void assert_live_settable() const;
 };
 }; // namespace config

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -911,25 +911,25 @@ configuration::configuration()
       *this,
       "enable_leader_balancer",
       "Enable automatic leadership rebalancing",
-      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
   , leader_balancer_idle_timeout(
       *this,
       "leader_balancer_idle_timeout",
       "Leadership rebalancing idle timeout",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       2min)
   , leader_balancer_mute_timeout(
       *this,
       "leader_balancer_mute_timeout",
       "Leadership rebalancing mute timeout",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       5min)
   , leader_balancer_node_mute_timeout(
       *this,
       "leader_balancer_mute_timeout",
       "Leadership rebalancing node mute timeout",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       20s)
   , internal_topic_replication_factor(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -618,7 +618,7 @@ configuration::configuration()
       *this,
       "enable_sasl",
       "Enable SASL authentication for Kafka connections.",
-      {.visibility = visibility::user},
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
   , controller_backend_housekeeping_interval_ms(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -527,7 +527,7 @@ configuration::configuration()
       *this,
       "kvstore_flush_interval",
       "Key-value store flush interval (ms)",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::chrono::milliseconds(10))
   , kvstore_max_segment_size(
       *this,

--- a/src/v/raft/kvelldb/kvserver.cc
+++ b/src/v/raft/kvelldb/kvserver.cc
@@ -95,8 +95,13 @@ public:
       , _consensus_client_protocol(
           raft::make_rpc_client_protocol(self, clients))
       , _storage(
-          storage::kvstore_config(
-            1_MiB, 10ms, directory, storage::debug_sanitize_files::yes),
+          [directory]() {
+              return storage::kvstore_config(
+                1_MiB,
+                config::mock_binding(10ms),
+                directory,
+                storage::debug_sanitize_files::yes);
+          },
           storage::log_config(
             storage::log_config::storage_type::disk,
             std::move(directory),

--- a/src/v/raft/tests/bootstrap_configuration_test.cc
+++ b/src/v/raft/tests/bootstrap_configuration_test.cc
@@ -34,8 +34,13 @@ struct bootstrap_fixture : raft::simple_record_fixture {
     using raft::simple_record_fixture::active_nodes;
     bootstrap_fixture()
       : _storage(
-        storage::kvstore_config(
-          1_MiB, 10ms, "test.dir", storage::debug_sanitize_files::yes),
+        []() {
+            return storage::kvstore_config(
+              1_MiB,
+              config::mock_binding(10ms),
+              "test.dir",
+              storage::debug_sanitize_files::yes);
+        },
         storage::log_config(
           storage::log_config::storage_type::disk,
           "test.dir",

--- a/src/v/raft/tests/configuration_manager_test.cc
+++ b/src/v/raft/tests/configuration_manager_test.cc
@@ -36,11 +36,13 @@ using namespace std::chrono_literals; // NOLINT
 struct config_manager_fixture {
     config_manager_fixture()
       : _storage(storage::api(
-        std::move(storage::kvstore_config(
-          100_MiB,
-          std::chrono::milliseconds(10),
-          base_dir,
-          storage::debug_sanitize_files::yes)),
+        std::move([this]() {
+            return storage::kvstore_config(
+              100_MiB,
+              config::mock_binding(std::chrono::milliseconds(10)),
+              base_dir,
+              storage::debug_sanitize_files::yes);
+        }),
         std::move(storage::log_config(
           storage::log_config::storage_type::disk,
           base_dir,

--- a/src/v/raft/tests/foreign_entry_test.cc
+++ b/src/v/raft/tests/foreign_entry_test.cc
@@ -46,8 +46,13 @@ struct foreign_entry_fixture {
 
     foreign_entry_fixture()
       : _storage(
-        storage::kvstore_config(
-          1_MiB, 10ms, test_dir, storage::debug_sanitize_files::yes),
+        [this]() {
+            return storage::kvstore_config(
+              1_MiB,
+              config::mock_binding(10ms),
+              test_dir,
+              storage::debug_sanitize_files::yes);
+        },
         storage::log_config(
           storage::log_config::storage_type::disk,
           test_dir,

--- a/src/v/raft/tests/mux_state_machine_fixture.h
+++ b/src/v/raft/tests/mux_state_machine_fixture.h
@@ -41,11 +41,12 @@ struct mux_state_machine_fixture {
         // configure and start kvstore
         storage::kvstore_config kv_conf(
           8192,
-          std::chrono::milliseconds(10),
+          config::mock_binding(std::chrono::milliseconds(10)),
           _data_dir,
           storage::debug_sanitize_files::yes);
 
-        _storage.start(kv_conf, default_log_cfg()).get0();
+        _storage.start([kv_conf]() { return kv_conf; }, default_log_cfg())
+          .get0();
         _storage.invoke_on_all(&storage::api::start).get0();
         _connections.start().get0();
         _recovery_throttle.start(100_MiB).get();

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -34,13 +34,16 @@ struct base_fixture {
     base_fixture()
       : _test_dir(
         fmt::format("test_{}", random_generators::gen_alphanum_string(6)))
-      , _api(make_kv_cfg(), make_log_cfg()) {
+      , _api([this]() { return make_kv_cfg(); }, make_log_cfg()) {
         _api.start().get();
     }
 
     storage::kvstore_config make_kv_cfg() const {
         return storage::kvstore_config(
-          1_MiB, 10ms, _test_dir, storage::debug_sanitize_files::yes);
+          1_MiB,
+          config::mock_binding(10ms),
+          _test_dir,
+          storage::debug_sanitize_files::yes);
     }
 
     storage::log_config make_log_cfg() const {

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -101,8 +101,13 @@ struct raft_node {
 
         storage
           .start(
-            storage::kvstore_config(
-              1_MiB, 10ms, storage_dir, storage::debug_sanitize_files::yes),
+            [storage_dir]() {
+                return storage::kvstore_config(
+                  1_MiB,
+                  config::mock_binding(10ms),
+                  storage_dir,
+                  storage::debug_sanitize_files::yes);
+            },
             storage::log_config(
               storage_type,
               storage_dir,

--- a/src/v/raft/tron/server.cc
+++ b/src/v/raft/tron/server.cc
@@ -87,8 +87,13 @@ public:
       , _consensus_client_protocol(
           raft::make_rpc_client_protocol(self, clients))
       , _storage(
-          storage::kvstore_config(
-            1_MiB, 10ms, directory, storage::debug_sanitize_files::yes),
+          [directory]() {
+              return storage::kvstore_config(
+                1_MiB,
+                config::mock_binding(10ms),
+                directory,
+                storage::debug_sanitize_files::yes);
+          },
           storage::log_config(
             storage::log_config::storage_type::disk,
             std::move(directory),

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -429,7 +429,7 @@ static storage::kvstore_config kvstore_config_from_global_config() {
      */
     return storage::kvstore_config(
       config::shard_local_cfg().kvstore_max_segment_size(),
-      config::shard_local_cfg().kvstore_flush_interval(),
+      config::shard_local_cfg().kvstore_flush_interval.bind(),
       config::node().data_directory().as_sstring(),
       storage::debug_sanitize_files::no);
 }
@@ -583,7 +583,8 @@ void application::wire_up_redpanda_services() {
     log_cfg.reclaim_opts.background_reclaimer_sg
       = _scheduling_groups.cache_background_reclaim_sg();
 
-    construct_service(storage, kvstore_config_from_global_config(), log_cfg)
+    construct_service(
+      storage, []() { return kvstore_config_from_global_config(); }, log_cfg)
       .get();
 
     syschecks::systemd_message("Intializing raft recovery throttle").get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -56,7 +56,6 @@
 #include "storage/compaction_controller.h"
 #include "storage/directories.h"
 #include "syschecks/syschecks.h"
-#include "test_utils/logs.h"
 #include "utils/file_io.h"
 #include "utils/human.h"
 #include "v8_engine/data_policy_table.h"

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -31,7 +31,7 @@ static ss::logger lg("kvstore");
 namespace storage {
 
 kvstore::kvstore(kvstore_config kv_conf)
-  : _conf(std::move(kv_conf))
+  : _conf(kv_conf)
   , _ntpc(model::kvstore_ntp(ss::this_shard_id()), _conf.base_dir)
   , _snap(
       std::filesystem::path(_ntpc.work_directory()),
@@ -174,7 +174,7 @@ ss::future<> kvstore::put(key_space ks, bytes key, std::optional<iobuf> value) {
       _gate, [this, key = std::move(key), value = std::move(value)]() mutable {
           auto& w = _ops.emplace_back(std::move(key), std::move(value));
           if (!_timer.armed()) {
-              _timer.arm(_conf.commit_interval);
+              _timer.arm(_conf.commit_interval());
           }
           return w.done.get_future();
       });

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -73,13 +73,13 @@ namespace storage {
  */
 struct kvstore_config {
     size_t max_segment_size;
-    std::chrono::milliseconds commit_interval;
+    config::binding<std::chrono::milliseconds> commit_interval;
     ss::sstring base_dir;
     debug_sanitize_files sanitize_fileops;
 
     kvstore_config(
       size_t max_segment_size,
-      std::chrono::milliseconds commit_interval,
+      config::binding<std::chrono::milliseconds> commit_interval,
       ss::sstring base_dir,
       debug_sanitize_files sanitize_fileops)
       : max_segment_size(max_segment_size)

--- a/src/v/storage/tests/kvstore_test.cc
+++ b/src/v/storage/tests/kvstore_test.cc
@@ -43,7 +43,7 @@ static ss::future<storage::kvstore_config> prepare_store(ss::sstring dir) {
 
     co_return storage::kvstore_config(
       8192,
-      std::chrono::milliseconds(10),
+      config::mock_binding(std::chrono::milliseconds(10)),
       dir,
       storage::debug_sanitize_files::yes);
 }

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -58,8 +58,13 @@ ntp_config config_from_ntp(const model::ntp& ntp) {
 SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
     auto conf = make_config();
     storage::api store(
-      storage::kvstore_config(
-        1_MiB, 10ms, conf.base_dir, storage::debug_sanitize_files::yes),
+      [conf]() {
+          return storage::kvstore_config(
+            1_MiB,
+            config::mock_binding(10ms),
+            conf.base_dir,
+            storage::debug_sanitize_files::yes);
+      },
       conf);
     store.start().get();
     auto stop_kvstore = ss::defer([&store] { store.stop().get(); });

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -50,7 +50,10 @@ public:
     storage_test_fixture()
       : test_dir("test.data." + random_generators::gen_alphanum_string(10))
       , kvstore(storage::kvstore_config(
-          1_MiB, 10ms, test_dir, storage::debug_sanitize_files::yes)) {
+          1_MiB,
+          config::mock_binding(10ms),
+          test_dir,
+          storage::debug_sanitize_files::yes)) {
         configure_unit_test_logging();
         // avoid double metric registrations
         ss::smp::invoke_on_all([] {

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -24,8 +24,13 @@ namespace storage {
 disk_log_builder::disk_log_builder(storage::log_config config)
   : _log_config(std::move(config))
   , _storage(
-      kvstore_config(
-        1_MiB, 10ms, _log_config.base_dir, debug_sanitize_files::yes),
+      [this]() {
+          return kvstore_config(
+            1_MiB,
+            config::mock_binding(10ms),
+            _log_config.base_dir,
+            debug_sanitize_files::yes);
+      },
       _log_config) {}
 
 // Batch generation

--- a/src/v/test_utils/logs.h
+++ b/src/v/test_utils/logs.h
@@ -31,8 +31,13 @@ static inline ss::future<> persist_log_file(
                       file_ntp = std::move(file_ntp),
                       batches = std::move(batches)]() mutable {
         storage::api storage(
-          storage::kvstore_config(
-            1_MiB, 10ms, base_dir, storage::debug_sanitize_files::yes),
+          [base_dir]() {
+              return storage::kvstore_config(
+                1_MiB,
+                config::mock_binding(10ms),
+                base_dir,
+                storage::debug_sanitize_files::yes);
+          },
           storage::log_config(
             storage::log_config::storage_type::disk,
             base_dir,
@@ -85,8 +90,13 @@ read_log_file(ss::sstring base_dir, model::ntp file_ntp) {
     return ss::async([base_dir = std::move(base_dir),
                       file_ntp = std::move(file_ntp)]() mutable {
         storage::api storage(
-          storage::kvstore_config(
-            1_MiB, 10ms, base_dir, storage::debug_sanitize_files::yes),
+          [base_dir]() {
+              return storage::kvstore_config(
+                1_MiB,
+                config::mock_binding(10ms),
+                base_dir,
+                storage::debug_sanitize_files::yes);
+          },
           storage::log_config(
             storage::log_config::storage_type::disk,
             base_dir,


### PR DESCRIPTION
## Cover letter

Now that we have an API for changing config properties at runtime, and a `needs_restart` metadata attribute to indicate which properties can be safely mutated at runtime, we can start to make more of our config changeable at runtime.

This PR adds a `property_binding` helper for classes that would like to keep their own copy of a value, but have it updated in-place when the configuration changes.  This can also be constructed with a standalone static value, for use in unit tests where classes are instantiated without a global configuration object.

Then prove it out by making several existing settings live settable.

## Release notes

None

(This will form part of a larger release note addition about centralized config when we enable it by default)
