### PR TITLE
coproc: Fix for missing data on output topics post retry

### DIFF
--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -282,12 +282,7 @@ static ss::future<> process_reply_group(
     }
     auto src_ptr = found->second;
     for (auto& e : reply_group) {
-        try {
-            co_await process_one_reply(std::move(e), src_ptr, args);
-        } catch (const bad_reply_exception& ex) {
-            /// A bad reply shouldn't affect the outcome, just ignore
-            vlog(coproclog.error, "Erraneous response detected: {}", ex);
-        }
+        co_await process_one_reply(std::move(e), src_ptr, args);
     }
     /// If we've reached here without error, all materialized
     /// partitions (working under the input) can be promoted, rational is to

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -200,17 +200,13 @@ static ss::future<> process_one_reply(
   process_batch_reply::data e,
   ss::lw_shared_ptr<source> src,
   output_write_args args) {
-    /// Ensure this 'script_context' instance is handling the correct reply
     if (e.id != args.id()) {
-        /// TODO: Maybe in the future errors of these type should mean redpanda
-        /// kill -9's the wasm engine.
-        vlog(
-          coproclog.error,
+        /// Engine got response mixed up with another request, protocol error
+        throw bad_reply_exception(ssx::sformat(
           "erranous reply from wasm engine, mismatched id observed, expected: "
           "{} and observed {}",
           args.id,
-          e.id);
-        co_return;
+          e.id));
     }
     if (!e.reader) {
         /// The wasm engine set the reader to std::nullopt meaning a fatal error

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -297,9 +297,11 @@ static ss::future<> process_reply_group(
     /// loop.
     for (auto& [_, o] : src_ptr->wctx.offsets) {
         if (o <= src_ptr->rctx.last_read) {
-            /// Omit increasing offets that are ahead of current read, only
-            /// possibility of this case would be a load of a stored offset that
-            /// is far ahead
+            /// Omit increasing offets that are ahead of current read, this
+            /// could occur upon load of a stored offset thats further ahead.
+            /// Also during retry avoids promoting offsets of materialized
+            /// topics that are ahead of the materialized topic that is the
+            /// intended target for the current read
             o = src_ptr->rctx.last_read;
         }
     }

--- a/src/v/coproc/script_context_router.h
+++ b/src/v/coproc/script_context_router.h
@@ -44,13 +44,14 @@ struct write_context {
 
     offsets_t offsets;
 
-    /// Returns the min offset in the collection, O(n) runtime
-    model::offset min_offset() const {
-        model::offset min = model::model_limits<model::offset>::max();
-        for (auto& [_, o] : offsets) {
-            min = std::min(min, o);
-        }
-        return min;
+    absl::btree_set<model::offset> unique_offsets() const {
+        absl::btree_set<model::offset> ofs;
+        std::transform(
+          offsets.cbegin(),
+          offsets.cend(),
+          std::inserter(ofs, ofs.begin()),
+          [](const offsets_t::value_type& p) { return p.second; });
+        return ofs;
     }
 };
 


### PR DESCRIPTION
Upon investigation it has been determined that the reason for this is a small error in the retry logic. The max offset passed to a `log_config_reader` read is always LSO of the input topic. This may change as the user pushes data to the input topic. The bug is that upon retry, a different endpoint may be selected for max offset during a read. This will mean that topics being 'retried' can exceed the coproc high watermark. For example:

`Output 1`:
[A] -> [B] -> [C] -> END

`Output 2`:
[A] -> [B] -> [C] -> [D] -> [E] -> END

If a reply is performed and the input has records published after [E], then `Output 1` could look like after retry:
[A] -> [B] -> [C] -> [D] -> [E] -> [F] -> [G] -> END

This would be fine, if `Output 2` begins processing at `E` as a retry, however there is logic that attempts to resolve filter use cases, that bumps the offsets of all logs lower then the last read. This is performed after processing all responses from the wasm engine. Since the last read is `[G]`, this means that `Output 1` will have its offset incorrectly promoted to `G`s offset and upon next iteration the diff between `[E]` and `[G]` for `Output 1` will be skipped.

The solution is to have replays be idempotent, or having the max offset of a reply never exceed the offset of the next output topic with the smallest offset. So with this fix applied, upon replay `Output 1` will only read up until `[E]`. Then reading can continue as normal.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/2d4423ce6b3614cf94b9cb0b1a3e185a7ff008fd..7e7762c882b26a2badadb8f136b485bc8a7a5150)
- Erraneously used a flat_hash_set instead of a btree type one which didn't have the expected ordering guarantees

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/7e7762c882b26a2badadb8f136b485bc8a7a5150..65156483d59cf85aeb781002f1fef3d47e3f20e7)
- Fixed conditional in vassert() call