### PR TITLE
update PR template with instructions on adding release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,29 @@
 
 Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.
 
-Fixes: #NNN, #NNN, ...
+<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
+Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...
 
 ## Release notes
+<!--
 
-If the PR changes the user experience, write a short summary of the changes. See the [CONTRIBUTING](https://github.com/vectorizedio/redpanda/blob/dev/CONTRIBUTING.md) guidelines for details.
+If this PR does not need to be included in the release notes, then
+simply have a bullet point for `none` directly under the `Release notes`
+section, e.g.
 
-Release note: [1-2 sentences of what this PR changes]
+* none
+
+Otherwise, add one or more of the following sections. A section must have
+at least 1 bullet point. You can add multiple sections with multiple
+bullet points if this PR represents multiple release note items. See
+the CONTRIBUTING.md guidelines for more details.
+
+### Features
+
+* Short description of the feature. Explain how to configure the new feature if applicable.
+
+### Improvements
+
+* Short description of how this PR improves redpanda.
+
+-->


### PR DESCRIPTION
## Cover letter

Carrying PR #2956 under my name so @ivotron can review.

I've adjusted the PR template to give instructions on what format it expects for the release notes section. The instructions are in HTML comments to keep the markdown render clean by default. Similar to https://github.com/cli/cli/blob/trunk/.github/PULL_REQUEST_TEMPLATE.md

The sections in the instructions were chosen to mimic the structure of [v21.8.1 release notes](https://github.com/vectorizedio/redpanda/releases/tag/v21.8.1).

## Release notes

* none