### PR TITLE
Health monitor abortable refresh

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -261,6 +261,7 @@ ss::future<> controller::start() {
             std::ref(_members_table),
             std::ref(_connections),
             std::ref(_partition_manager),
+            std::ref(_raft_manager),
             std::ref(_as));
       })
       .then([this] { return _hm_frontend.start(std::ref(_hm_backend)); });

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -57,6 +57,7 @@ enum class errc : int16_t {
     source_topic_still_in_use,
     wating_for_partition_shutdown,
     error_collecting_health_report,
+    leadership_changed,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -160,6 +161,9 @@ struct errc_category final : public std::error_category {
                    "originating core";
         case errc::error_collecting_health_report:
             return "Error requesting health monitor update";
+        case errc::leadership_changed:
+            return "Raft group leadership has changed while waiting for action "
+                   "to finish";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -45,6 +45,7 @@ public:
       ss::sharded<members_table>&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_manager>&,
+      ss::sharded<raft::group_manager>&,
       ss::sharded<ss::abort_source>&);
 
     ss::future<> stop();
@@ -119,14 +120,19 @@ private:
     std::chrono::milliseconds max_metadata_age();
     void abort_current_refresh();
 
+    void on_leadership_changed(
+      raft::group_id, model::term_id, std::optional<model::node_id>);
+
     ss::lw_shared_ptr<raft::consensus> _raft0;
     ss::sharded<members_table>& _members;
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_manager>& _partition_manager;
+    ss::sharded<raft::group_manager>& _raft_manager;
     ss::sharded<ss::abort_source>& _as;
 
     ss::lowres_clock::time_point _last_refresh;
     ss::lw_shared_ptr<abortable_refresh_request> _refresh_request;
+    cluster::notification_id_type _leadership_notification_handle;
 
     status_cache_t _status;
     report_cache_t _reports;

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -134,7 +134,7 @@ std::ostream& operator<<(std::ostream& o, const partitions_filter& filter) {
         }
         fmt::print(o, "]}},");
     }
-    fmt::print(o, "]}}");
+    fmt::print(o, "}}");
 
     return o;
 }

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -69,6 +69,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::data_policy_not_exists:
     case cluster::errc::wating_for_partition_shutdown:
     case cluster::errc::error_collecting_health_report:
+    case cluster::errc::leadership_changed:
         break;
     }
     return error_code::unknown_server_error;

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -28,8 +28,6 @@ from rptest.services.admin import Admin
 
 ELECTION_TIMEOUT = 10
 
-DEFAULT_PING_PONG_TIMEOUT = 5
-
 
 class MetricCheckFailed(Exception):
     def __init__(self, metric, old_value, new_value):
@@ -174,20 +172,13 @@ class RaftAvailabilityTest(RedpandaTest):
         assert result[0] is not None
         return result[0]
 
-    def _ping_pong(self, timeout=None):
-        """
-        :param timeout: for tests that expect things to take a little longer (e.g.
-                        right after a node failure) extend the default timeout.
-        """
-        if timeout is None:
-            timeout = DEFAULT_PING_PONG_TIMEOUT
-
+    def _ping_pong(self):
         kc = KafkaCat(self.redpanda)
         rpk = RpkTool(self.redpanda)
 
         payload = str(random.randint(0, 1000))
         start = time.time()
-        offset = rpk.produce(self.topic, "tkey", payload, timeout=timeout)
+        offset = rpk.produce(self.topic, "tkey", payload, timeout=5)
         consumed = kc.consume_one(self.topic, 0, offset)
         latency = time.time() - start
         self.logger.info(
@@ -511,11 +502,7 @@ class RaftAvailabilityTest(RedpandaTest):
 
             # expect messages to be produced and consumed without a timeout
             for i in range(0, 128):
-                # Use a generous timeout to avoid the test being flaky when the health monitor
-                # takes a long time to catch up with changes to controller leadership.
-                # Revert timeout to default when this issue is fixed:
-                # https://github.com/vectorizedio/redpanda/issues/3098
-                self._ping_pong(timeout=15)
+                self._ping_pong()
 
     @cluster(num_nodes=3)
     def test_initial_leader_stability(self):


### PR DESCRIPTION
## Cover letter

When a node is not raft0 leader it dispatches a request to raft0 leader
to query for current cluster health status. Refresh request is
dispatched when health monitor is asked about current cluster health. In
order to prevent multiple requests asking about the same in
`cluster::health_monitor_backend` we use mutex and skip pending
refresh request if current cluster health was refreshed not earlier than
certain threshold.

When controller leader is timing out health refresh request, it may take
a long time before cluster health refresh will eventually succeed since
all the requests to previous leader pending in `mutex` waiting list must
be processed. In order to make refresh more efficient and do not have to
wait for all previous request to succeed introduced
`abortable_refresh_request`. An abortable refresh request allows
aborting wait for previous refresh. This way previous request will
eventually time out in the background not blocking refresh with new
raft0 leader

Fixes: #3098 

## Release notes

