### PR TITLE
docs/quick-start-k8s: Improve helm install command

### DIFF
--- a/docs/www/quick-start-kubernetes-CN.md
+++ b/docs/www/quick-start-kubernetes-CN.md
@@ -117,10 +117,11 @@ helm install \
 
     ```
     helm install \
+    redpanda-operator \
+    redpanda/redpanda-operator \
     --namespace redpanda-system \
-    --create-namespace redpanda-operator \
-    --version $VERSION \
-    redpanda/redpanda-operator
+    --create-namespace \
+    --version $VERSION
     ```
 
 ## 连接到Redpanda cluster

--- a/docs/www/quick-start-kubernetes.md
+++ b/docs/www/quick-start-kubernetes.md
@@ -209,10 +209,11 @@ noglob kubectl apply \
 
     ```
     helm install \
+    redpanda-operator \
+    redpanda/redpanda-operator \
     --namespace redpanda-system \
-    --create-namespace redpanda-system \
-    --version $VERSION \
-    redpanda/redpanda-operator
+    --create-namespace \
+    --version $VERSION
     ```
 
 ## Install and connect to a Redpanda cluster


### PR DESCRIPTION
## Cover letter

The usage guide suggests name and chart first:
```
Usage:
  helm install [NAME] [CHART] [flags]
```

Additionally, if `$VERSION` is empty, the error is:
```
Error: INSTALLATION FAILED: must either provide a name or specify --generate-name
```

With the flags and `$VERSION` last, it becomes:
```
Error: flag needs an argument: --version
```

**NOTE**: The EN and CN versions are now consistent with the installation name of `redpanda-operator`, I believe the order and layout of the flags was confusing the intention.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

none