### PR TITLE
Archival_meta_stm: handle absent manifest in handle_eviction

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -192,7 +192,12 @@ ss::future<> archival_metadata_stm::handle_eviction() {
       manifest,
       rc_node);
 
-    if (res != cloud_storage::download_result::success) {
+    if (res == cloud_storage::download_result::notfound) {
+        _insync_offset = raft::details::prev_offset(_raft->start_offset());
+        set_next(_raft->start_offset());
+        vlog(_logger.info, "handled log eviction, the manifest is absent");
+        co_return;
+    } else if (res != cloud_storage::download_result::success) {
         // sleep to the end of timeout to avoid calling handle_eviction in a
         // busy loop.
         co_await ss::sleep_abortable(rc_node.get_timeout(), _download_as);


### PR DESCRIPTION
After https://github.com/vectorizedio/redpanda/issues/2851 gets merged
it will be possible that archival_metadata_stm is enabled for a
partition but archival for it is turned off (and thus no manifest is
generated). This PR adds graceful handling for this situation in
the handle_eviction method.