### PR TITLE
[transactions] Add get transaction request to admin_api

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -26,6 +26,7 @@
 #include "utils/expiring_promise.h"
 #include "utils/mutex.h"
 
+#include <absl/container/btree_map.h>
 #include <absl/container/btree_set.h>
 #include <absl/container/flat_hash_map.h>
 
@@ -177,6 +178,60 @@ public:
 
     void testing_only_enable_transactions() { _is_tx_enabled = true; }
 
+    struct expiration_info {
+        duration_type timeout;
+        time_point_type last_update;
+
+        time_point_type deadline() const { return last_update + timeout; }
+    };
+
+    struct transaction_info {
+        enum class status_t { ongoing, preparing, prepared, initiating };
+        status_t status;
+
+        model::offset lso_bound;
+        std::optional<expiration_info> info;
+
+        std::string_view get_status() const {
+            switch (status) {
+            case status_t::ongoing:
+                return "ongoing";
+            case status_t::prepared:
+                return "prepared";
+            case status_t::preparing:
+                return "preparing";
+            case status_t::initiating:
+                return "initiating";
+            }
+        }
+
+        bool is_expired() const {
+            return !info.has_value()
+                   || info.value().deadline() <= clock_type::now();
+        }
+
+        std::optional<duration_type> get_staleness() const {
+            if (is_expired()) {
+                return std::nullopt;
+            }
+
+            auto now = ss::lowres_clock::now();
+            return now - info->last_update;
+        }
+
+        std::optional<duration_type> get_timeout() const {
+            if (is_expired()) {
+                return std::nullopt;
+            }
+
+            return info->timeout;
+        }
+    };
+
+    using transaction_set
+      = absl::btree_map<model::producer_identity, rm_stm::transaction_info>;
+    ss::future<result<transaction_set>> get_transactions();
+
 protected:
     ss::future<> handle_eviction() override;
 
@@ -278,13 +333,6 @@ private:
         absl::flat_hash_map<model::producer_identity, seq_entry> seq_table;
     };
 
-    struct expiration_info {
-        duration_type timeout;
-        time_point_type last_update;
-
-        time_point_type deadline() const { return last_update + timeout; }
-    };
-
     struct mem_state {
         // once raft's term has passed mem_state::term we wipe mem_state
         // and wait until log_state catches up with current committed index.
@@ -332,6 +380,11 @@ private:
         }
         return lock_it->second;
     }
+
+    transaction_info::status_t
+    get_tx_status(model::producer_identity pid) const;
+    std::optional<expiration_info>
+    get_expiration_info(model::producer_identity pid) const;
 
     ss::basic_rwlock<> _state_lock;
     absl::flat_hash_map<model::producer_id, ss::lw_shared_ptr<mutex>> _tx_locks;

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -135,6 +135,40 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/partitions/{namespace}/{topic}/{partition}/transactions",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get all transactions for partition",
+                    "type": "transactions",
+                    "nickname": "get_transactions",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -208,6 +242,66 @@
                         "type": "assignment"
                     },
                     "description": "Replica assignments"
+                }
+            }
+        },
+        "producer_identity": {
+            "id": "producer_identity",
+            "description": "Producer identity",
+            "properties": {
+                "id": {
+                    "type": "long",
+                    "description": "Producer id"
+                },
+                "epoch": {
+                    "type": "long",
+                    "description": "Producer epoch"
+                }
+            }
+        },
+        "transaction": {
+            "id": "transaction",
+            "description": "Transaction details",
+            "properties": {
+                "producer_id": {
+                    "type": "producer_identity",
+                    "description": "Producer id"
+                },
+                "lso_bound": {
+                    "type": "long",
+                    "description": "First offset"
+                },
+                "staleness_ms": {
+                    "type": "long",
+                    "description": "How long transaction does not make progress"
+                },
+                "timeout_ms": {
+                    "type": "long",
+                    "description": "Transaction timeout"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Transaction status"
+                }
+            }
+        },
+        "transactions": {
+            "id": "transactions",
+            "description": "Transactions for current partition",
+            "properties": {
+                "active_transactions": {
+                    "type": "array",
+                    "items": {
+                        "type": "transaction"
+                    },
+                    "description": "Active transactions"
+                },
+                "expired_transactions": {
+                    "type": "array",
+                    "items": {
+                        "type": "transaction"
+                    },
+                    "description": "Expired transactions"
                 }
             }
         }

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -187,6 +187,13 @@ class Admin:
             path = f"{path}/{namespace}/{topic}/{partition}"
         return self._request('get', path, node=node).json()
 
+    def get_transactions(self, topic, partition, namespace, node=None):
+        """
+        Get transaction for current partition
+        """
+        path = f"partitions/{namespace}/{topic}/{partition}/transactions"
+        return self._request('get', path, node=node).json()
+
     def set_partition_replicas(self,
                                topic,
                                partition,

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -226,6 +226,13 @@ class Admin:
         path = f"partitions/{namespace}/{topic}/{partition}/transfer_leadership?target={target_id}"
         self._request("POST", path)
 
+    def get_partition_leader(self, *, namespace, topic, partition):
+        partition_info = self.get_partitions(topic=topic,
+                                             partition=partition,
+                                             namespace=namespace)
+
+        return partition_info['leader_id']
+
     def transfer_leadership_to(self, *, namespace, topic, partition, target):
         """
         Looks up current ntp leader and transfer leadership to target node, 

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -1,0 +1,163 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from rptest.clients.types import TopicSpec
+from rptest.clients.kafka_cat import KafkaCat
+from ducktape.utils.util import wait_until
+from rptest.services.admin import Admin
+
+import confluent_kafka as ck
+
+import random
+import time
+
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class TxAdminTest(RedpandaTest):
+    topics = (TopicSpec(name="tx_test",
+                        partition_count=3,
+                        replication_factor=3), )
+
+    def __init__(self, test_context):
+        super(TxAdminTest,
+              self).__init__(test_context=test_context,
+                             num_brokers=3,
+                             extra_rp_conf={
+                                 "enable_idempotence": True,
+                                 "enable_transactions": True,
+                                 "tx_timeout_delay_ms": 10000000,
+                                 "abort_timed_out_transactions_interval_ms":
+                                 10000000,
+                                 'enable_leader_balancer': False
+                             })
+
+        self.admin = Admin(self.redpanda)
+
+    def extract_pid(self, tx):
+        return (tx["producer_id"]["id"], tx["producer_id"]["epoch"])
+
+    @cluster(num_nodes=3)
+    def test_simple_get_transaction(self):
+        producer1 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+        })
+        producer2 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '1',
+        })
+        producer1.init_transactions()
+        producer2.init_transactions()
+        producer1.begin_transaction()
+        producer2.begin_transaction()
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                producer1.produce(topic.name, '0', '0', partition)
+                producer2.produce(topic.name, '0', '1', partition)
+
+        producer1.flush()
+        producer2.flush()
+
+        expected_pids = None
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                txs_info = self.admin.get_transactions(topic.name, partition,
+                                                       "kafka")
+                assert ('expired_transactions' not in txs_info)
+                if expected_pids == None:
+                    expected_pids = set(
+                        map(self.extract_pid, txs_info['active_transactions']))
+                    assert (len(expected_pids) == 2)
+
+                assert (len(expected_pids) == len(
+                    txs_info['active_transactions']))
+                for tx in txs_info['active_transactions']:
+                    assert (self.extract_pid(tx) in expected_pids)
+                    assert (tx['status'] == 'ongoing')
+                    assert (tx['timeout_ms'] == 60000)
+
+    @cluster(num_nodes=3)
+    def test_expired_transaction(self):
+        '''
+        Problem: rm_stm contains timer to run try_abort_old_txs.
+        This timer rearm on begin_tx to smallest transaction deadline,
+        and after try_abort_old_txs to one of settings 
+        abort_timed_out_transactions_interval_ms or tx_timeout_delay_ms.
+        If we do sleep to transaction timeout and try to get expired 
+        transaction, timer can be signal before our request and after clean
+        expire transactions.
+
+        How to solve:
+        0) Run transaction
+        1) Change leader for parititons 
+        (New leader did not get requests for begin_txs,
+        so his timer is armed on one of settings)
+        2) Get expired transactions
+        '''
+        assert (len(self.redpanda.nodes) >= 2)
+
+        producer1 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+            'transaction.timeout.ms': '30000'
+        })
+        producer1.init_transactions()
+        producer1.begin_transaction()
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                producer1.produce(topic.name, '0', '0', partition)
+
+        producer1.flush()
+
+        # We need to change leader for all partition to another node
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                old_leader = self.admin.get_partition_leader(
+                    namespace="kafka", topic=self.topic, partition=partition)
+
+                self.admin.transfer_leadership_to(namespace="kafka",
+                                                  topic=self.topic,
+                                                  partition=partition,
+                                                  target=None)
+
+                def leader_is_changed():
+                    return self.admin.get_partition_leader(
+                        namespace="kafka",
+                        topic=self.topic,
+                        partition=partition) != old_leader
+
+                wait_until(leader_is_changed,
+                           timeout_sec=30,
+                           backoff_sec=2,
+                           err_msg="Failed to establish current leader")
+
+        expected_pids = None
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                txs_info = self.admin.get_transactions(topic.name, partition,
+                                                       "kafka")
+                assert ('active_transactions' not in txs_info)
+                if expected_pids == None:
+                    expected_pids = set(
+                        map(self.extract_pid,
+                            txs_info['expired_transactions']))
+                    assert (len(expected_pids) == 1)
+
+                assert (len(expected_pids) == len(
+                    txs_info['expired_transactions']))
+                for tx in txs_info['expired_transactions']:
+                    assert (self.extract_pid(tx) in expected_pids)
+                    assert (tx['status'] == 'ongoing')
+                    assert (tx['timeout_ms'] == -1)


### PR DESCRIPTION
## Cover letter

Implement `get_transaction` request for admin api. It returns information about all transactions for current partition.
Transaction can be :

1. `active` if transaction `deadline` < `now`
2. `expired` if transaction `deadline` >= `now`

Each transaction_info contains:
-  `producer_id` (`id` and `epoch`)
- `lso_bound` similar to first_offset.
- `staleness_ms` how long transaction did not do progress. For expired tx is -1
- `timeout_ms` timeout for transaction. For expired tx is -1
- `status` can be {'initiating', 'preparing, 'preparing', ''ongoing}

If replica get http request it will resend it to leader for partition.

---
This pr is part of fixed for #2987.

