### PR TITLE
serde: add precondition checks to envelope_to_tuple

### DIFF
--- a/src/v/serde/envelope_for_each_field.h
+++ b/src/v/serde/envelope_for_each_field.h
@@ -40,8 +40,14 @@ constexpr inline auto envelope_to_tuple(T&& t) {
     return t.serde_fields();
 }
 
-template<typename T>
+template<
+  typename T,
+  std::enable_if_t<!detail::has_serde_fields_v<T>, void*> = nullptr>
 constexpr inline auto envelope_to_tuple(T& t) {
+    static_assert(std::is_aggregate_v<T>);
+    static_assert(std::is_standard_layout_v<T>);
+    static_assert(!std::is_polymorphic_v<T>);
+
     constexpr auto const a = reflection::arity<T>() - 1;
     if constexpr (a == 0) {
         return std::tie();


### PR DESCRIPTION
For reflection magic to work the following needs to be true:

```cpp
  static_assert(std::is_aggregate_v<T>);
  static_assert(std::is_standard_layout_v<T>);
  static_assert(!std::is_polymorphic_v<T>);
```