### PR TITLE
Fixed assertion triggered when fetching from empty topics with transactions enabled

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -546,6 +546,7 @@ template<>
 ss::future<response_ptr>
 fetch_handler::handle(request_context rctx, ss::smp_service_group ssg) {
     return ss::do_with(op_context(std::move(rctx), ssg), [](op_context& octx) {
+        vlog(klog.trace, "handling fetch request: {}", octx.request);
         // top-level error is used for session-level errors
         if (octx.session_ctx.has_error()) {
             octx.response.data.error_code = octx.session_ctx.error();

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -134,7 +134,9 @@ static ss::future<read_result> read_from_partition(
     auto lso = part.last_stable_offset();
     auto start_o = part.start_offset();
     // if we have no data read, return fast
-    if (hw < config.start_offset || config.skip_read) {
+    if (
+      hw < config.start_offset || config.skip_read
+      || config.start_offset > config.max_offset) {
         co_return read_result(start_o, hw, lso);
     }
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -142,6 +142,26 @@ class RpkTool:
         cmd = ['alter-config', topic, "--set", f"{set_key}={set_value}"]
         self._run_topic(cmd)
 
+    def consume(self,
+                topic,
+                n=None,
+                group=None,
+                regex=False,
+                offset=None,
+                fetch_max_bytes=None):
+        cmd = ["consume", topic]
+        if group is not None:
+            cmd += ["-g", group]
+        if n is not None:
+            cmd.append(f"-n{n}")
+        if regex:
+            cmd.append("-r")
+        if fetch_max_bytes is not None:
+            cmd += ["--fetch-max-bytes", str(fetch_max_bytes)]
+        if offset is not None:
+            cmd += ["-o", f"{n}"]
+        return self._run_topic(cmd)
+
     def wasm_deploy(self, script, name, description):
         cmd = [
             self._rpk_binary(), 'wasm', 'deploy', script, '--brokers',

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -25,15 +25,17 @@ class RpkException(Exception):
 
 
 class RpkPartition:
-    def __init__(self, id, leader, replicas, hw):
+    def __init__(self, id, leader, replicas, hw, start_offset):
         self.id = id
         self.leader = leader
         self.replicas = replicas
         self.high_watermark = hw
+        self.start_offset = start_offset
 
     def __str__(self):
-        return "id: {}, leader: {}, replicas: {}, hw: {}".format(
-            self.id, self.leader, self.replicas, self.high_watermark)
+        return "id: {}, leader: {}, replicas: {}, hw: {}, start_offset: {}".format(
+            self.id, self.leader, self.replicas, self.high_watermark,
+            self.start_offset)
 
 
 class RpkClusterInfoNode:
@@ -131,7 +133,8 @@ class RpkTool:
             return RpkPartition(id=int(m.group('id')),
                                 leader=int(m.group('leader')),
                                 replicas=replicas,
-                                hw=int(m.group('hw')))
+                                hw=int(m.group('hw')),
+                                start_offset=int(m.group("logstart")))
 
         return filter(lambda p: p != None, map(partition_line, lines))
 

--- a/tests/rptest/tests/fetch_after_deletion_test.py
+++ b/tests/rptest/tests/fetch_after_deletion_test.py
@@ -1,0 +1,103 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.mark import parametrize
+from ducktape.tests.test import Test
+import json
+
+from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import RedpandaService
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
+from rptest.clients.kcl import KCL
+from rptest.util import (
+    Scale,
+    produce_until_segments,
+    wait_for_segments_removal,
+)
+
+
+class FetchAfterDeleteTest(Test):
+    def __init__(self, test_context):
+        super(FetchAfterDeleteTest, self).__init__(test_context)
+        self.scale = Scale(test_context)
+
+    @cluster(num_nodes=3)
+    @parametrize(transactions_enabled=True)
+    @parametrize(transactions_enabled=False)
+    def test_fetch_after_committed_offset_was_removed(self,
+                                                      transactions_enabled):
+        """
+        Test fetching when consumer offset was deleted by retention
+        """
+        segment_size = 1048576
+        self.redpanda = RedpandaService(self.test_context,
+                                        3,
+                                        KafkaCliTools,
+                                        extra_rp_conf={
+                                            "enable_transactions":
+                                            transactions_enabled,
+                                            "enable_idempotence":
+                                            transactions_enabled,
+                                            "log_compaction_interval_ms": 5000,
+                                            "log_segment_size": segment_size,
+                                            "enable_leader_balancer": False,
+                                        })
+        self.redpanda.start()
+        topic = TopicSpec(partition_count=1,
+                          replication_factor=3,
+                          cleanup_policy=TopicSpec.CLEANUP_DELETE)
+        self.redpanda.create_topic(topic)
+        self.topic = topic.name
+
+        kafka_tools = KafkaCliTools(self.redpanda)
+
+        # produce until segments have been compacted
+        produce_until_segments(
+            self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+        )
+        consumer_group = 'test'
+        rpk = RpkTool(self.redpanda)
+
+        def consume(n=1):
+
+            out = rpk.consume(self.topic, group=consumer_group, n=n)
+            split = out.split('}')
+            split = filter(lambda s: "{" in s, split)
+
+            return map(lambda s: json.loads(s + "}"), split)
+
+        #consume from the beggining
+        msgs = consume(10)
+        last = list(msgs).pop()
+        offset = last['offset']
+
+        # change retention time
+        kafka_tools.alter_topic_config(
+            self.topic, {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 2 * segment_size,
+            })
+
+        wait_for_segments_removal(self.redpanda,
+                                  self.topic,
+                                  partition_idx=0,
+                                  count=5)
+
+        partitions = list(rpk.describe_topic(self.topic))
+        p = partitions[0]
+        assert p.start_offset > offset
+        # consume from the offset that doesn't exists,
+        # the one that was committed previously was already removed
+        out = list(consume(1))
+        assert out[0]['offset'] == p.start_offset


### PR DESCRIPTION
## Cover letter

It may happen that last stable offset is equal to log start offset.
In this case when consumer requests a read with a `read_committed`
isolation level it should receive no batches since the log is empty.
Otherwise when records are present in the log we need to read up to
`LSO-1`  since batch pointed by `LSO` is the first offset for which
transactions may not be resolved.

Added explicit check to partition read code path to return fast
when requested max offset is smaller than start offset indicating no
data should be returned.
