### PR TITLE
Fixed querying offset based on timestamp

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/logger.h"
 #include "config/configuration.h"
+#include "model/fundamental.h"
 #include "model/namespace.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "raft/types.h"
@@ -360,9 +361,9 @@ ss::future<> partition::stop() {
     return f;
 }
 
-ss::future<std::optional<storage::timequery_result>>
-partition::timequery(model::timestamp t, ss::io_priority_class p) {
-    storage::timequery_config cfg(t, _raft->committed_offset(), p);
+ss::future<std::optional<storage::timequery_result>> partition::timequery(
+  model::timestamp t, model::offset offset_limit, ss::io_priority_class p) {
+    storage::timequery_config cfg(t, offset_limit, p);
     return _raft->timequery(cfg);
 }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -134,7 +134,7 @@ public:
     const model::ntp& ntp() const { return _raft->ntp(); }
 
     ss::future<std::optional<storage::timequery_result>>
-      timequery(model::timestamp, ss::io_priority_class);
+      timequery(model::timestamp, model::offset, ss::io_priority_class);
 
     bool is_leader() const { return _raft->is_leader(); }
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -134,7 +134,9 @@ static ss::future<read_result> read_from_partition(
     auto lso = part.last_stable_offset();
     auto start_o = part.start_offset();
     // if we have no data read, return fast
-    if (hw < config.start_offset || config.skip_read) {
+    if (
+      hw < config.start_offset || config.skip_read
+      || config.start_offset > config.max_offset) {
         co_return read_result(start_o, hw, lso);
     }
 

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -100,9 +100,13 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
         co_return list_offsets_response::make_partition(
           ntp.tp.partition, model::timestamp(-1), offset);
     }
+    const auto offset_limit = isolation_lvl
+                                  == model::isolation_level::read_committed
+                                ? kafka_partition->last_stable_offset()
+                                : kafka_partition->high_watermark();
 
     auto res = co_await kafka_partition->timequery(
-      timestamp, kafka_read_priority());
+      timestamp, offset_limit, kafka_read_priority());
     auto id = ntp.tp.partition;
     if (res) {
         co_return list_offsets_response::make_partition(

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -57,9 +57,11 @@ public:
         co_return storage::translating_reader(co_await _log.make_reader(cfg));
     }
 
-    ss::future<std::optional<storage::timequery_result>>
-    timequery(model::timestamp ts, ss::io_priority_class io_pc) final {
-        storage::timequery_config cfg(ts, _log.offsets().dirty_offset, io_pc);
+    ss::future<std::optional<storage::timequery_result>> timequery(
+      model::timestamp ts,
+      model::offset offset_limit,
+      ss::io_priority_class io_pc) final {
+        storage::timequery_config cfg(ts, offset_limit, io_pc);
         return _log.timequery(cfg);
     };
 

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -39,7 +39,7 @@ public:
           std::optional<model::timeout_clock::time_point>)
           = 0;
         virtual ss::future<std::optional<storage::timequery_result>>
-          timequery(model::timestamp, ss::io_priority_class) = 0;
+          timequery(model::timestamp, model::offset, ss::io_priority_class) = 0;
         virtual ss::future<std::vector<cluster::rm_stm::tx_range>>
           aborted_transactions(
             model::offset,
@@ -82,9 +82,11 @@ public:
         return _impl->make_reader(cfg, deadline);
     }
 
-    ss::future<std::optional<storage::timequery_result>>
-    timequery(model::timestamp ts, ss::io_priority_class io_pc) {
-        return _impl->timequery(ts, io_pc);
+    ss::future<std::optional<storage::timequery_result>> timequery(
+      model::timestamp ts,
+      model::offset offset_limit,
+      ss::io_priority_class io_pc) {
+        return _impl->timequery(ts, offset_limit, io_pc);
     }
 
     cluster::partition_probe& probe() { return _impl->probe(); }

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -144,9 +144,11 @@ replicated_partition::aborted_transactions(
 
 ss::future<std::optional<storage::timequery_result>>
 replicated_partition::timequery(
-  model::timestamp ts, ss::io_priority_class io_pc) {
-    return _partition->timequery(ts, io_pc).then(
-      [this](std::optional<storage::timequery_result> r) {
+  model::timestamp ts,
+  model::offset offset_limit,
+  ss::io_priority_class io_pc) {
+    return _partition->timequery(ts, offset_limit, io_pc)
+      .then([this](std::optional<storage::timequery_result> r) {
           if (r) {
               r->offset = _translator->from_log_offset(r->offset);
           }

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -61,8 +61,10 @@ public:
         co_return r.error();
     }
 
-    ss::future<std::optional<storage::timequery_result>>
-    timequery(model::timestamp ts, ss::io_priority_class io_pc) final;
+    ss::future<std::optional<storage::timequery_result>> timequery(
+      model::timestamp ts,
+      model::offset offset_limit,
+      ss::io_priority_class io_pc) final;
 
     ss::future<result<model::offset>>
       replicate(model::record_batch_reader, raft::replicate_options);

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2985,4 +2985,16 @@ consensus::get_follower_metrics(model::node_id id) const {
       id, _log.offsets(), _jit.base_duration(), it->second);
 }
 
+ss::future<std::optional<storage::timequery_result>>
+consensus::timequery(storage::timequery_config cfg) {
+    return _log.timequery(cfg).then(
+      [this](std::optional<storage::timequery_result> res) {
+          if (res) {
+              // do not return offset that is earlier raft start offset
+              res->offset = std::max(res->offset, start_offset());
+          }
+          return res;
+      });
+}
+
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -255,9 +255,7 @@ public:
     }
 
     ss::future<std::optional<storage::timequery_result>>
-    timequery(storage::timequery_config cfg) {
-        return _log.timequery(cfg);
-    }
+    timequery(storage::timequery_config cfg);
 
     model::offset start_offset() const {
         return details::next_offset(_last_snapshot_index);

--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -114,3 +114,8 @@ class KafkaCat:
         newest = offset(self._cmd(cmd(-1)))
 
         return (oldest, newest)
+
+    def query_offset(self, topic, partition, ts):
+        res = self._cmd(["-Q", "-t", f"{topic}:{partition}:{ts}"])
+
+        return res[topic][f"{partition}"]["offset"]


### PR DESCRIPTION
## Cover letter

Fixed `ListOffsets` request handler when log offsets are being queried with timestamp. Implemented correct limits of returned offset based on requested `isolation_level`. Previously the `isolation_level` was ignored which may lead to situation in which client requesting offset with `read_committed` isolation would receive offset that is greater than `last stable offset` i.e. may contain not resolved transactions. 

Fixes: #NNN, #NNN, ...

## Release notes
Release note: 
- fixed time based offset queries in `ListOffsetsRequest`  handler
