### PR TITLE
[v8_engine]: Add settings for max_old_gen_size

### DIFF
--- a/src/v/v8_engine/script.cc
+++ b/src/v/v8_engine/script.cc
@@ -34,6 +34,9 @@ script::script(size_t max_heap_size_in_bytes, size_t timeout_ms)
         v8::ArrayBuffer::Allocator::NewDefaultAllocator());
     isolate_params.constraints.ConfigureDefaultsFromHeapSize(
       0, max_heap_size_in_bytes);
+    // https://github.com/vectorizedio/redpanda/issues/3166
+    isolate_params.constraints.set_max_old_generation_size_in_bytes(
+      _max_old_gen_size);
     _isolate = std::unique_ptr<v8::Isolate, isolate_deleter>(
       v8::Isolate::New(isolate_params), isolate_deleter());
 }

--- a/src/v/v8_engine/script.h
+++ b/src/v/v8_engine/script.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "seastarx.h"
+#include "units.h"
 #include "v8_engine/environment.h"
 
 #include <seastar/core/future.hh>
@@ -44,6 +45,7 @@ private:
 class script {
     // Timeout for run script in first time for initialization
     static constexpr std::chrono::milliseconds _first_run_timeout_ms{500};
+    static constexpr uint64_t _max_old_gen_size{10_MiB};
 
 public:
     // Init new instance.


### PR DESCRIPTION
In old v8 versions it was self calculated params, but in new v8 versions we need to use `ConfigureDefaultsFromHeapSize` together with `set_max_old_generation_size_in_bytes`.

Need to understand limits before data-policy release
https://github.com/vectorizedio/redpanda/issues/3166

Without `set_max_old_generation_size_in_bytes` tests for v8_engine fail with new v8 version. 
Fix for llvm, seastar, v8 update https://github.com/vectorizedio/vtools/pull/316