### PR TITLE
backport/v21.10.x: #3159, #3161

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -11,6 +11,7 @@
 
 #include "cluster/logger.h"
 #include "config/configuration.h"
+#include "model/fundamental.h"
 #include "model/namespace.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "raft/types.h"
@@ -335,9 +336,9 @@ ss::future<> partition::stop() {
     return f;
 }
 
-ss::future<std::optional<storage::timequery_result>>
-partition::timequery(model::timestamp t, ss::io_priority_class p) {
-    storage::timequery_config cfg(t, _raft->committed_offset(), p);
+ss::future<std::optional<storage::timequery_result>> partition::timequery(
+  model::timestamp t, model::offset offset_limit, ss::io_priority_class p) {
+    storage::timequery_config cfg(t, offset_limit, p);
     return _raft->timequery(cfg);
 }
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -129,7 +129,7 @@ public:
     const model::ntp& ntp() const { return _raft->ntp(); }
 
     ss::future<std::optional<storage::timequery_result>>
-      timequery(model::timestamp, ss::io_priority_class);
+      timequery(model::timestamp, model::offset, ss::io_priority_class);
 
     bool is_leader() const { return _raft->is_leader(); }
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -134,7 +134,9 @@ static ss::future<read_result> read_from_partition(
     auto lso = part.last_stable_offset();
     auto start_o = part.start_offset();
     // if we have no data read, return fast
-    if (hw < config.start_offset || config.skip_read) {
+    if (
+      hw < config.start_offset || config.skip_read
+      || config.start_offset > config.max_offset) {
         co_return read_result(start_o, hw, lso);
     }
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -544,6 +544,7 @@ template<>
 ss::future<response_ptr>
 fetch_handler::handle(request_context rctx, ss::smp_service_group ssg) {
     return ss::do_with(op_context(std::move(rctx), ssg), [](op_context& octx) {
+        vlog(klog.trace, "handling fetch request: {}", octx.request);
         // top-level error is used for session-level errors
         if (octx.session_ctx.has_error()) {
             octx.response.data.error_code = octx.session_ctx.error();

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -100,9 +100,13 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
         co_return list_offsets_response::make_partition(
           ntp.tp.partition, model::timestamp(-1), offset);
     }
+    const auto offset_limit = isolation_lvl
+                                  == model::isolation_level::read_committed
+                                ? kafka_partition->last_stable_offset()
+                                : kafka_partition->high_watermark();
 
     auto res = co_await kafka_partition->timequery(
-      timestamp, kafka_read_priority());
+      timestamp, offset_limit, kafka_read_priority());
     auto id = ntp.tp.partition;
     if (res) {
         co_return list_offsets_response::make_partition(

--- a/src/v/kafka/server/materialized_partition.h
+++ b/src/v/kafka/server/materialized_partition.h
@@ -57,9 +57,11 @@ public:
         return _log.make_reader(cfg);
     }
 
-    ss::future<std::optional<storage::timequery_result>>
-    timequery(model::timestamp ts, ss::io_priority_class io_pc) final {
-        storage::timequery_config cfg(ts, _log.offsets().dirty_offset, io_pc);
+    ss::future<std::optional<storage::timequery_result>> timequery(
+      model::timestamp ts,
+      model::offset offset_limit,
+      ss::io_priority_class io_pc) final {
+        storage::timequery_config cfg(ts, offset_limit, io_pc);
         return _log.timequery(cfg);
     };
 

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -38,7 +38,7 @@ public:
           std::optional<model::timeout_clock::time_point>)
           = 0;
         virtual ss::future<std::optional<storage::timequery_result>>
-          timequery(model::timestamp, ss::io_priority_class) = 0;
+          timequery(model::timestamp, model::offset, ss::io_priority_class) = 0;
         virtual ss::future<std::vector<cluster::rm_stm::tx_range>>
           aborted_transactions(model::offset, model::offset) = 0;
         virtual cluster::partition_probe& probe() = 0;
@@ -75,9 +75,11 @@ public:
         return _impl->make_reader(cfg, deadline);
     }
 
-    ss::future<std::optional<storage::timequery_result>>
-    timequery(model::timestamp ts, ss::io_priority_class io_pc) {
-        return _impl->timequery(ts, io_pc);
+    ss::future<std::optional<storage::timequery_result>> timequery(
+      model::timestamp ts,
+      model::offset offset_limit,
+      ss::io_priority_class io_pc) {
+        return _impl->timequery(ts, offset_limit, io_pc);
     }
 
     cluster::partition_probe& probe() { return _impl->probe(); }

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -88,9 +88,11 @@ ss::future<model::record_batch_reader> replicated_partition::make_reader(
 
 ss::future<std::optional<storage::timequery_result>>
 replicated_partition::timequery(
-  model::timestamp ts, ss::io_priority_class io_pc) {
-    return _partition->timequery(ts, io_pc).then(
-      [this](std::optional<storage::timequery_result> r) {
+  model::timestamp ts,
+  model::offset offset_limit,
+  ss::io_priority_class io_pc) {
+    return _partition->timequery(ts, offset_limit, io_pc)
+      .then([this](std::optional<storage::timequery_result> r) {
           if (r) {
               r->offset = _translator->from_log_offset(r->offset);
           }

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -54,8 +54,10 @@ public:
         co_return r.error();
     }
 
-    ss::future<std::optional<storage::timequery_result>>
-    timequery(model::timestamp ts, ss::io_priority_class io_pc) final;
+    ss::future<std::optional<storage::timequery_result>> timequery(
+      model::timestamp ts,
+      model::offset offset_limit,
+      ss::io_priority_class io_pc) final;
 
     ss::future<result<model::offset>>
       replicate(model::record_batch_reader, raft::replicate_options);

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2948,4 +2948,16 @@ std::vector<follower_metrics> consensus::get_follower_metrics() const {
     return ret;
 }
 
+ss::future<std::optional<storage::timequery_result>>
+consensus::timequery(storage::timequery_config cfg) {
+    return _log.timequery(cfg).then(
+      [this](std::optional<storage::timequery_result> res) {
+          if (res) {
+              // do not return offset that is earlier raft start offset
+              res->offset = std::max(res->offset, start_offset());
+          }
+          return res;
+      });
+}
+
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -255,9 +255,7 @@ public:
     }
 
     ss::future<std::optional<storage::timequery_result>>
-    timequery(storage::timequery_config cfg) {
-        return _log.timequery(cfg);
-    }
+    timequery(storage::timequery_config cfg);
 
     model::offset start_offset() const {
         return details::next_offset(_last_snapshot_index);

--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -84,3 +84,8 @@ class KafkaCat:
             return None, replicas
         else:
             return leader_id, replicas
+
+    def query_offset(self, topic, partition, ts):
+        res = self._cmd(["-Q", "-t", f"{topic}:{partition}:{ts}"])
+
+        return res[topic][f"{partition}"]["offset"]

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -114,7 +114,7 @@ class RpkTool:
 
         def partition_line(line):
             m = re.match(
-                r" *(?P<id>\d+) +(?P<leader>\d+) +\[(?P<replicas>.+?)\] +(?P<logstart>.*?) +(?P<hw>\d+) *",
+                r" *(?P<id>\d+) +(?P<leader>\d+) +\[(?P<replicas>.+?)\] +(?P<logstart>\d+?) +(?P<hw>\d+) *",
                 line)
             if m == None:
                 return None

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -131,6 +131,26 @@ class RpkTool:
         cmd = ['alter-config', topic, "--set", f"{set_key}={set_value}"]
         self._run_topic(cmd)
 
+    def consume(self,
+                topic,
+                n=None,
+                group=None,
+                regex=False,
+                offset=None,
+                fetch_max_bytes=None):
+        cmd = ["consume", topic]
+        if group is not None:
+            cmd += ["-g", group]
+        if n is not None:
+            cmd.append(f"-n{n}")
+        if regex:
+            cmd.append("-r")
+        if fetch_max_bytes is not None:
+            cmd += ["--fetch-max-bytes", str(fetch_max_bytes)]
+        if offset is not None:
+            cmd += ["-o", f"{n}"]
+        return self._run_topic(cmd)
+
     def wasm_deploy(self, script, name, description):
         cmd = [
             self._rpk_binary(), 'wasm', 'deploy', script, '--brokers',

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -23,15 +23,17 @@ class RpkException(Exception):
 
 
 class RpkPartition:
-    def __init__(self, id, leader, replicas, hw):
+    def __init__(self, id, leader, replicas, hw, start_offset):
         self.id = id
         self.leader = leader
         self.replicas = replicas
         self.high_watermark = hw
+        self.start_offset = start_offset
 
     def __str__(self):
-        return "id: {}, leader: {}, replicas: {}, hw: {}".format(
-            self.id, self.leader, self.replicas, self.high_watermark)
+        return "id: {}, leader: {}, replicas: {}, hw: {}, start_offset: {}".format(
+            self.id, self.leader, self.replicas, self.high_watermark,
+            self.start_offset)
 
 
 class RpkClusterInfoNode:
@@ -120,7 +122,8 @@ class RpkTool:
             return RpkPartition(id=int(m.group('id')),
                                 leader=int(m.group('leader')),
                                 replicas=replicas,
-                                hw=int(m.group('hw')))
+                                hw=int(m.group('hw')),
+                                start_offset=int(m.group("logstart")))
 
         return filter(lambda p: p != None, map(partition_line, lines))
 

--- a/tests/rptest/tests/fetch_after_deletion_test.py
+++ b/tests/rptest/tests/fetch_after_deletion_test.py
@@ -1,0 +1,103 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.mark import parametrize
+from ducktape.tests.test import Test
+import json
+
+from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import RedpandaService
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
+from rptest.clients.kcl import KCL
+from rptest.util import (
+    Scale,
+    produce_until_segments,
+    wait_for_segments_removal,
+)
+
+
+class FetchAfterDeleteTest(Test):
+    def __init__(self, test_context):
+        super(FetchAfterDeleteTest, self).__init__(test_context)
+        self.scale = Scale(test_context)
+
+    @cluster(num_nodes=3)
+    @parametrize(transactions_enabled=True)
+    @parametrize(transactions_enabled=False)
+    def test_fetch_after_committed_offset_was_removed(self,
+                                                      transactions_enabled):
+        """
+        Test fetching when consumer offset was deleted by retention
+        """
+        segment_size = 1048576
+        self.redpanda = RedpandaService(self.test_context,
+                                        3,
+                                        KafkaCliTools,
+                                        extra_rp_conf={
+                                            "enable_transactions":
+                                            transactions_enabled,
+                                            "enable_idempotence":
+                                            transactions_enabled,
+                                            "log_compaction_interval_ms": 5000,
+                                            "log_segment_size": segment_size,
+                                            "enable_leader_balancer": False,
+                                        })
+        self.redpanda.start()
+        topic = TopicSpec(partition_count=1,
+                          replication_factor=3,
+                          cleanup_policy=TopicSpec.CLEANUP_DELETE)
+        self.redpanda.create_topic(topic)
+        self.topic = topic.name
+
+        kafka_tools = KafkaCliTools(self.redpanda)
+
+        # produce until segments have been compacted
+        produce_until_segments(
+            self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+        )
+        consumer_group = 'test'
+        rpk = RpkTool(self.redpanda)
+
+        def consume(n=1):
+
+            out = rpk.consume(self.topic, group=consumer_group, n=n)
+            split = out.split('}')
+            split = filter(lambda s: "{" in s, split)
+
+            return map(lambda s: json.loads(s + "}"), split)
+
+        #consume from the beggining
+        msgs = consume(10)
+        last = list(msgs).pop()
+        offset = last['offset']
+
+        # change retention time
+        kafka_tools.alter_topic_config(
+            self.topic, {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 2 * segment_size,
+            })
+
+        wait_for_segments_removal(self.redpanda,
+                                  self.topic,
+                                  partition_idx=0,
+                                  count=5)
+
+        partitions = list(rpk.describe_topic(self.topic))
+        p = partitions[0]
+        assert p.start_offset > offset
+        # consume from the offset that doesn't exists,
+        # the one that was committed previously was already removed
+        out = list(consume(1))
+        assert out[0]['offset'] == p.start_offset

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -10,10 +10,12 @@
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix, ignore
+from rptest.clients.kafka_cat import KafkaCat
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.util import (produce_until_segments, segments_count)
 
 
 class RetentionPolicyTest(RedpandaTest):
@@ -180,3 +182,54 @@ class RetentionPolicyTest(RedpandaTest):
                    timeout_sec=120,
                    backoff_sec=5,
                    err_msg="Segments were not removed")
+
+    @cluster(num_nodes=3)
+    def test_timequery_after_segments_eviction(self):
+        """
+        Test checking if the offset returned by time based index is
+        valid during applying log cleanup policy
+        """
+        segment_size = 1048576
+
+        # produce until segments have been compacted
+        produce_until_segments(
+            self.redpanda,
+            topic=self.topic,
+            partition_idx=0,
+            count=10,
+            acks=-1,
+        )
+
+        # restart all nodes to force replicating raft configuration
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        kafka_tools = KafkaCliTools(self.redpanda)
+        # Wait for controller, alter configs doesn't have a retry loop
+        kafka_tools.describe_topic(self.topic)
+
+        # change retention bytes to preserve 15 segments
+        kafka_tools.alter_topic_config(
+            self.topic, {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 2 * segment_size,
+            })
+
+        def validate_time_query_until_deleted():
+            def done():
+                kcat = KafkaCat(self.redpanda)
+                ts = 1638748800  # 12.6.2021 - old timestamp, query first offset
+                offset = kcat.query_offset(self.topic, 0, ts)
+                # assert that offset is valid
+                assert offset >= 0
+
+                topic_partitions = segments_count(self.redpanda, self.topic, 0)
+                partitions = []
+                for p in topic_partitions:
+                    partitions.append(p <= 5)
+                return all([p <= 5 for p in topic_partitions])
+
+            wait_until(done,
+                       timeout_sec=30,
+                       backoff_sec=5,
+                       err_msg="Segments were not removed")
+
+        validate_time_query_until_deleted()

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from ducktape.utils.util import wait_until
+from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 class Scale:
     KEY = "scale"
@@ -38,3 +40,48 @@ class Scale:
     @property
     def release(self):
         return self._scale == Scale.RELEASE
+
+def segments_count(redpanda, topic, partition_idx):
+    storage = redpanda.storage()
+    topic_partitions = storage.partitions("kafka", topic)
+
+    return map(
+        lambda p: len(p.segments),
+        filter(lambda p: p.num == partition_idx, topic_partitions),
+    )
+
+
+def produce_until_segments(redpanda, topic, partition_idx, count, acks=-1):
+    """
+    Produce into the topic until given number of segments will appear
+    """
+    kafka_tools = KafkaCliTools(redpanda)
+
+    def done():
+        kafka_tools.produce(topic, 10000, 1024, acks=acks)
+        topic_partitions = segments_count(redpanda, topic, partition_idx)
+        partitions = []
+        for p in topic_partitions:
+            partitions.append(p >= count)
+        return all(partitions)
+
+    wait_until(done,
+               timeout_sec=120,
+               backoff_sec=2,
+               err_msg="Segments were not created")
+
+def wait_for_segments_removal(redpanda, topic, partition_idx, count):
+    """
+    Wait until only given number of segments will left in a partitions
+    """
+    def done():
+        topic_partitions = segments_count(redpanda, topic, partition_idx)
+        partitions = []
+        for p in topic_partitions:
+            partitions.append(p <= count)
+        return all(partitions)
+
+    wait_until(done,
+               timeout_sec=120,
+               backoff_sec=5,
+               err_msg="Segments were not removed")


### PR DESCRIPTION
Backports for v21.10.x:

Fixed querying offset based on timestamp #3161
Fixed assertion triggered when fetching from empty topics with transactions enabled #3159

Note: this had several merge conflicts that seemed pretty simple to resolve