### PR TITLE
r/consensus: using cfg manager when there is no delta in snapshot metadata

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1774,7 +1774,17 @@ ss::future<> consensus::do_hydrate_snapshot(storage::snapshot_reader& reader) {
         update_follower_stats(metadata.latest_configuration);
         return _configuration_manager
           .add(_last_snapshot_index, std::move(metadata.latest_configuration))
-          .then([this, delta = metadata.log_start_delta] {
+          .then([this, delta = metadata.log_start_delta]() mutable {
+              if (delta < offset_translator_delta(0)) {
+                  delta = offset_translator_delta(
+                    _configuration_manager.offset_delta(_last_snapshot_index));
+                  vlog(
+                    _ctxlog.warn,
+                    "received snapshot without delta field in metadata, "
+                    "falling back to delta obtained from configuration "
+                    "manager: {}",
+                    delta);
+              }
               return _offset_translator.prefix_truncate_reset(
                 _last_snapshot_index, delta);
           })


### PR DESCRIPTION
Recently we added a delta field to raft snapshot metadata. The delta
field is used to recover `offset_translator` state when there is not
enough information in log. When updating from previous redpanda versions
we must support a situation in which delta field may not be present. In
this case we must fallback to previous behavior and use configuration
manager as a source of offset delta.
