### PR TITLE
kafka: probe to send group offset to prometheus

### DIFF
--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace kafka {
+class group_offset_probe {
+public:
+    explicit group_offset_probe(model::offset& offset) noexcept
+      : _offset(offset) {}
+
+    void setup_metrics(
+      const kafka::group_id& group_id, const model::topic_partition& tp) {
+        namespace sm = ss::metrics;
+
+        if (config::shard_local_cfg().disable_metrics()) {
+            return;
+        }
+
+        auto group_label = sm::label("group");
+        auto topic_label = sm::label("topic");
+        auto partition_label = sm::label("partition");
+        std::vector<sm::label_instance> labels{
+          group_label(group_id()),
+          topic_label(tp.topic()),
+          partition_label(tp.partition())};
+        _metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka:group"),
+          {sm::make_gauge(
+            "offset",
+            [this] { return _offset; },
+            sm::description("Group topic partition offset"),
+            labels)});
+    }
+
+private:
+    model::offset& _offset;
+    ss::metrics::metric_groups _metrics;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1313,10 +1313,7 @@ void group::complete_offset_commit(
     if (p_it != _pending_offset_commits.end()) {
         // save the tp commit if it hasn't yet been seen, or we are completing
         // for an instance that is newer based on log offset
-        auto o_it = _offsets.find(tp);
-        if (o_it == _offsets.end() || o_it->second.log_offset < md.log_offset) {
-            _offsets[tp] = md;
-        }
+        try_upsert_offset(tp, md);
 
         // clear pending for this tp
         if (p_it->second.offset == md.offset) {
@@ -1422,10 +1419,7 @@ group::commit_tx(cluster::commit_group_tx_request r) {
     }
 
     for (const auto& [tp, md] : prepare_it->second.offsets) {
-        auto o_it = _offsets.find(tp);
-        if (o_it == _offsets.end() || o_it->second.log_offset < md.log_offset) {
-            _offsets[tp] = md;
-        }
+        try_upsert_offset(tp, md);
     }
 
     _prepared_txs.erase(prepare_it);
@@ -1974,8 +1968,8 @@ group::handle_offset_fetch(offset_fetch_request&& r) {
         for (const auto& e : _offsets) {
             offset_fetch_response_partition p = {
               .partition_index = e.first.partition,
-              .committed_offset = e.second.offset,
-              .metadata = e.second.metadata,
+              .committed_offset = e.second->metadata.offset,
+              .metadata = e.second->metadata.metadata,
               .error_code = error_code::none,
             };
             // BUG: support leader_epoch (KIP-320)
@@ -2132,7 +2126,7 @@ group::remove_topic_partitions(const std::vector<model::topic_partition>& tps) {
         _pending_offset_commits.erase(tp);
         if (auto offset = _offsets.extract(tp); offset) {
             removed.emplace_back(
-              std::move(offset.key()), std::move(offset.mapped()));
+              std::move(offset.key()), std::move(offset.mapped()->metadata));
         }
     }
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -162,6 +162,14 @@ class RpkTool:
             cmd += ["-o", f"{n}"]
         return self._run_topic(cmd)
 
+    def group_seek_to(self, group, to):
+        cmd = ["seek", group, "--to", to]
+        self._run_group(cmd)
+
+    def group_seek_to_group(self, group, to_group):
+        cmd = ["seek", group, "--to-group", to_group]
+        self._run_group(cmd)
+
     def wasm_deploy(self, script, name, description):
         cmd = [
             self._rpk_binary(), 'wasm', 'deploy', script, '--brokers',
@@ -181,6 +189,13 @@ class RpkTool:
     def _run_topic(self, cmd, stdin=None, timeout=None):
         cmd = [
             self._rpk_binary(), "topic", "--brokers",
+            self._redpanda.brokers()
+        ] + cmd
+        return self._execute(cmd, stdin=stdin, timeout=timeout)
+
+    def _run_group(self, cmd, stdin=None, timeout=None):
+        cmd = [
+            self._rpk_binary(), "group", "--brokers",
             self._redpanda.brokers()
         ] + cmd
         return self._execute(cmd, stdin=stdin, timeout=timeout)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -594,7 +594,8 @@ class RedpandaService(Service):
         that exactly one (family, sample) match the query. All values for the
         sample across the requested set of nodes are returned in a flat array.
 
-        An exception will be raised unless exactly one (family, sample) matches.
+        None will be returned if less than one (family, sample) matches.
+        An exception will be raised if more than one (family, sample) matches.
 
         Example:
 
@@ -627,8 +628,7 @@ class RedpandaService(Service):
                         MetricSample(family.name, sample.name, node,
                                      sample.value, sample.labels))
         if not sample_values:
-            raise Exception(
-                f"No metric sample matching '{sample_pattern}' found")
+            return None
         return MetricSamples(sample_values)
 
     def read_configuration(self, node):


### PR DESCRIPTION
## Cover letter

To monitor group status we need to push offset for each topic partition to prometheus
According to topic partition offset we can calculate group lag

Fixes: https://github.com/vectorizedio/redpanda/issues/1275

## Release notes

kafka server send group topic partition offset metric to prometheus

