### PR TITLE
tests/rpk: fixed parsing rpk describe offset line

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -125,7 +125,7 @@ class RpkTool:
 
         def partition_line(line):
             m = re.match(
-                r" *(?P<id>\d+) +(?P<leader>\d+) +\[(?P<replicas>.+?)\] +(?P<logstart>.*?) +(?P<hw>\d+) *",
+                r" *(?P<id>\d+) +(?P<leader>\d+) +\[(?P<replicas>.+?)\] +(?P<logstart>\d+?) +(?P<hw>\d+) *",
                 line)
             if m == None:
                 return None


### PR DESCRIPTION
Fixed parsing line of `rpk topic describe` output. Previously the line
matched even if there were no information for offsets available
