### PR TITLE
k8s/e2e: append redpanda logs on assertion failures

### DIFF
--- a/src/go/k8s/tests/e2e/additional-configuration/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/additional-configuration/00-assert.yaml
@@ -5,3 +5,12 @@ metadata:
   namespace: default
 status:
   replicas: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/admin-api-tls-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls-client-auth/00-assert.yaml
@@ -63,3 +63,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/admin-api-tls-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls-client-auth/01-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/admin-api-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls/00-assert.yaml
@@ -51,3 +51,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/admin-api-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls/01-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/admin-api/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api/00-assert.yaml
@@ -4,3 +4,10 @@ metadata:
   name: cluster
 status:
   readyReplicas: 1
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/admin-api/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/admin-api/01-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/00-assert.yaml
@@ -4,3 +4,12 @@ metadata:
   name: schema-registry-test
 status:
   readyReplicas: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/01-assert.yaml
@@ -4,3 +4,12 @@ metadata:
   name: cp-schema-registry
 status:
   readyReplicas: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/02-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/03-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/00-assert.yaml
@@ -3,3 +3,12 @@ kind: Secret
 metadata:
   name: cluster-tls-node-certificate
   namespace: given-cert
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-assert.yaml
@@ -5,3 +5,12 @@ metadata:
   namespace: given-cert
 status:
   readyReplicas: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/03-assert.yaml
@@ -8,3 +8,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+ 
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/00-assert.yaml
@@ -3,3 +3,12 @@ kind: Secret
 metadata:
   name: cluster-tls-secret-node-certificate
   namespace: cert-manager
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-assert.yaml
@@ -5,3 +5,12 @@ metadata:
   namespace: given-cert-secret
 status:
   readyReplicas: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/03-assert.yaml
@@ -8,3 +8,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/00-assert.yaml
@@ -32,3 +32,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/01-assert.yaml
@@ -74,3 +74,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/03-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/04-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/00-assert.yaml
@@ -32,3 +32,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/01-assert.yaml
@@ -16,3 +16,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/03-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-with-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-with-client-auth/00-assert.yaml
@@ -84,3 +84,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-with-client-auth/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-with-client-auth/02-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
@@ -81,3 +81,10 @@ status:
   - reason: Ready
     status: "True"
     type: Ready
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/node-select-tolerations/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/node-select-tolerations/02-assert.yaml
@@ -17,3 +17,12 @@ spec:
     redpanda-node: "true"
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/00-assert.yaml
@@ -27,3 +27,12 @@ spec:
       protocol: TCP
       targetPort: 8082
   type: ClusterIP
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/01-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/02-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/03-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/00-assert.yaml
@@ -74,3 +74,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/01-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/02-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/03-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/00-assert.yaml
@@ -27,3 +27,12 @@ spec:
       protocol: TCP
       targetPort: 8082
   type: ClusterIP
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/01-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/02-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/03-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/produce-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/00-assert.yaml
@@ -51,3 +51,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/produce-tls/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/02-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/produce-tls/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/03-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/00-assert.yaml
@@ -4,3 +4,12 @@ metadata:
   name: schema-registry
 status:
   readyReplicas: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/01-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/02-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/03-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/04-assert.yaml
@@ -42,3 +42,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/05-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/05-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/06-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/06-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/07-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/07-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/08-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/08-assert.yaml
@@ -7,3 +7,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/09-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/09-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/10-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/10-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/11-assert.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/11-assert.yaml
@@ -7,3 +7,12 @@ status:
     - status: "True"
       type: Complete
   succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/01-assert.yaml
@@ -11,3 +11,12 @@ spec:
         - image: "localhost/redpanda:dev"
 status:
   readyReplicas: 2
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-conf-image/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/02-assert.yaml
@@ -3,3 +3,12 @@ kind: TestAssert
 commands:
   - command: kubectl rollout status deployment redpanda-controller-manager -n redpanda-system
   - command: hack/wait-for-webhook-ready.sh
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-conf-image/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-conf-image/03-assert.yaml
@@ -31,3 +31,12 @@ metadata:
   name: update-image-cluster-1
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/00-assert.yaml
@@ -41,3 +41,12 @@ spec:
       protocol: TCP
       targetPort: 9645
   type: NodePort
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
@@ -69,3 +69,12 @@ spec:
       protocol: TCP
       targetPort: 9645
   type: NodePort
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/02-assert.yaml
@@ -30,3 +30,12 @@ spec:
     image: "localhost/redpanda:dev"
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/03-assert.yaml
@@ -44,3 +44,12 @@ spec:
       readOnly: true
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-assert.yaml
@@ -63,3 +63,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
@@ -56,3 +56,12 @@ spec:
       readOnly: true
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/02-assert.yaml
@@ -30,3 +30,12 @@ spec:
     image: "localhost/redpanda:dev"
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/03-assert.yaml
@@ -52,3 +52,12 @@ spec:
       readOnly: true
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-assert.yaml
@@ -51,3 +51,12 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
@@ -52,3 +52,12 @@ spec:
       readOnly: true
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-tls/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/02-assert.yaml
@@ -30,3 +30,12 @@ spec:
     image: "localhost/redpanda:dev"
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-tls/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/03-assert.yaml
@@ -48,3 +48,12 @@ spec:
       readOnly: true
 status:
   phase: "Running"
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/00-assert.yaml
@@ -23,3 +23,12 @@ spec:
       app.kubernetes.io/name: "redpanda"
       app.kubernetes.io/instance: "update-cluster"
       app.kubernetes.io/component: redpanda
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod 
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/01-assert.yaml
@@ -4,3 +4,12 @@ metadata:
   name: update-cluster
 status:
   readyReplicas: 2
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/02-assert.yaml
@@ -9,3 +9,12 @@ spec:
         - resources:
             requests:
               memory: 99M
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update/03-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/03-assert.yaml
@@ -19,3 +19,12 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/update/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/04-assert.yaml
@@ -14,3 +14,12 @@ spec:
       protocol: TCP
       targetPort: 9093
   type: ClusterIP
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1


### PR DESCRIPTION
## Cover letter

E2E tests running on kuttl do not have their redpanda logs recorded upon failure. This makes it hard to debug test failures.

This change ensures that redpanda (and configurator) logs are collected from any set of tests that fail. We achieve this by using the "collector" feature of the existing testing framework, kuttl:
- The downside is that all asserts need to be modified.
- The advantage is we rely on kuttl and don't introduce a custom command or other logging components in the testing. If kuttl adds a "global" setting for collecting pod-specific logs, we could adjust accordingly.

I tried this approach locally by failing a subset of the tests (in one run) and verifying the corresponding redpanda pod logs were present in the output.