### PR TITLE
Kafka: return shadow indexing configs in a topic describe handler

### DIFF
--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -522,6 +522,35 @@ ss::future<response_ptr> describe_configs_handler::handle(
               request.data.include_synonyms,
               &describe_as_string<model::timestamp_type>);
 
+            // Shadow indexing properties
+            add_topic_config_if_requested(
+              resource,
+              result,
+              topic_property_remote_read,
+              false,
+              topic_property_remote_read,
+              (topic_config->properties.shadow_indexing
+               == model::shadow_indexing_mode::full)
+                  || (topic_config->properties.shadow_indexing == model::shadow_indexing_mode::fetch)
+                ? std::make_optional(true)
+                : std::make_optional(false),
+              request.data.include_synonyms,
+              &describe_as_string<bool>);
+
+            add_topic_config_if_requested(
+              resource,
+              result,
+              topic_property_remote_write,
+              false,
+              topic_property_remote_write,
+              (topic_config->properties.shadow_indexing
+               == model::shadow_indexing_mode::full)
+                  || (topic_config->properties.shadow_indexing == model::shadow_indexing_mode::archival)
+                ? std::make_optional(true)
+                : std::make_optional(false),
+              request.data.include_synonyms,
+              &describe_as_string<bool>);
+
             // Data-policy property
             ss::sstring property_name = "redpanda.datapolicy";
             add_topic_config_if_requested(

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -53,7 +53,9 @@ class TopicSpec:
                  segment_bytes=1 * (2 ^ 30),
                  retention_bytes=None,
                  retention_ms=None,
-                 redpanda_datapolicy=None):
+                 redpanda_datapolicy=None,
+                 redpanda_remote_read=None,
+                 redpanda_remote_write=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -64,6 +66,8 @@ class TopicSpec:
         self.retention_bytes = retention_bytes
         self.retention_ms = retention_ms
         self.redpanda_datapolicy = redpanda_datapolicy
+        self.redpanda_remote_read = redpanda_remote_read
+        self.redpanda_remote_write = redpanda_remote_write
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Two new topic configs were added for shadow indexing:
redpanda.remote.read and redpanda.remote.write. This PR adds changes
to return this configs in topic describe response.
redpanda.remote.recovery is a cluster level configuration and will be
handled separately.