### PR TITLE
Fix broken coproc delete topic unit test 

### DIFF
--- a/src/v/coproc/pacemaker.cc
+++ b/src/v/coproc/pacemaker.cc
@@ -280,4 +280,10 @@ bool pacemaker::local_script_id_exists(script_id id) {
     return _scripts.find(id) != _scripts.end();
 }
 
+bool pacemaker::is_up_to_date() const {
+    return std::all_of(_scripts.cbegin(), _scripts.cend(), [](const auto& p) {
+        return p.second->is_up_to_date();
+    });
+}
+
 } // namespace coproc

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -154,6 +154,12 @@ public:
         _shared_res.in_progress_deletes.erase(materialized);
     }
 
+    /// True if all fibers on this shard have no more data to consume
+    ///
+    /// Only useful for testing in the case where all input has been produced to
+    /// all input topics up front
+    bool is_up_to_date() const;
+
 private:
     void do_add_source(
       script_id,

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -167,4 +167,16 @@ ss::future<> script_context::send_request(
       });
 }
 
+bool script_context::is_up_to_date() const {
+    for (const auto& [_, src] : _routes) {
+        const auto highest = src->rctx.input->last_stable_offset();
+        for (const auto& [_, o] : src->wctx.offsets) {
+            if (o < highest) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 } // namespace coproc

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -85,6 +85,12 @@ public:
     ss::future<>
     remove_output(const model::ntp& source, const model::ntp& materialized);
 
+    /// Returns true if fiber is up to date with all of its inputs
+    ///
+    /// This is when the stored offsets currently match the input logs dirty
+    /// offsets for respective tracked partitions
+    bool is_up_to_date() const;
+
 private:
     ss::future<> do_execute();
 


### PR DESCRIPTION
This test was failing in CI due to a race between deletion of materialized topic and completion of the coproc fiber.

Its decided to not add a tool to synchronize around this as in real production workloads a deletion could occur at any time. So this type of chaos is actually ideal for this type of test.

So the fix is to just apply a different assertion depending on what async action completed first. If the deletion occurred after the fiber finished processing, assert that the topic doesn't exist, otherwise assert that all data exists.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/444165285abd9bd3ad39a964dd747abe3e42eeb6..b2f73e61f0e78ce525c5cfd2ff4fcc183d8d1aa7)
- Verify all data exists up until `last_stable_offset` instead of `dirty_offset` because that is the maximum offset that coproc will read up until.
- Add additional verification in test that after deletion occurs no entry for materialized ntp exists in the shard table

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/b2f73e61f0e78ce525c5cfd2ff4fcc183d8d1aa7..c457f2623376c7975c95dbf619bb741656e35cff)
- Removed unused var

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/c457f2623376c7975c95dbf619bb741656e35cff..04f3ef59c1e5646e01f76b2ae733f516faa5ad4f)
- Replaced decltype(xx)& with const auto& param