### PR TITLE
storage: convert open_segment to be a coroutine

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -563,11 +563,10 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
     // sealed segments are supposed to be very rare events. The hotpath of
     // truncating the appender, is optimized.
     auto f = co_await internal::make_reader_handle(path, sanitize_fileops);
+    auto st = co_await f.stat();
 
-    co_return co_await f.stat().then([f](struct stat s) {
-              return ss::make_ready_future<std::tuple<uint64_t, ss::file>>(
-                std::make_tuple(s.st_size, f));
-      })
+              co_return co_await ss::make_ready_future<std::tuple<uint64_t, ss::file>>(
+                std::make_tuple(st.st_size, f))
       .then([buf_size, path](std::tuple<uint64_t, ss::file> t) {
           auto& [size, fd] = t;
           return std::make_unique<segment_reader>(

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -588,19 +588,20 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
             return ss::make_exception_future<ss::lw_shared_ptr<segment>>(e);
         });
     }
+
     auto idx = segment_index(
       index_name,
-      fd,
+      std::move(fd),
       meta->base_offset,
       segment_index::default_data_buffer_step);
-    co_return co_await ss::make_ready_future<ss::lw_shared_ptr<segment>>(
-      ss::make_lw_shared<segment>(
-        segment::offset_tracker(meta->term, meta->base_offset),
-        std::move(*rdr),
-        std::move(idx),
-        nullptr,
-        std::nullopt,
-        std::move(batch_cache)));
+
+    co_return ss::make_lw_shared<segment>(
+      segment::offset_tracker(meta->term, meta->base_offset),
+      std::move(*rdr),
+      std::move(idx),
+      nullptr,
+      std::nullopt,
+      std::move(batch_cache));
 }
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -571,6 +571,12 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
                         .replace_extension("base_index")
                         .string();
 
+    /*
+     * NOTE for the next round of clean-up here: it is safe to let a file handle
+     * be destroyed without closing as long as there isn't any queued work on
+     * the file. thus in this case we don't need to close the reader before
+     * returning if we happen to also hit an error opening the index.
+     */
     std::exception_ptr e;
     try {
         f = co_await internal::make_handle(

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -572,9 +572,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
                         .string();
 
     std::exception_ptr e;
-    ss::file fd;
     try {
-        fd = co_await internal::make_handle(
+        f = co_await internal::make_handle(
           index_name,
           ss::open_flags::create | ss::open_flags::rw,
           {},
@@ -590,7 +589,7 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
 
     auto idx = segment_index(
       index_name,
-      std::move(fd),
+      std::move(f),
       meta->base_offset,
       segment_index::default_data_buffer_step);
 

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -562,12 +562,11 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
     // preventing x-file synchronization This is fine, because truncation to
     // sealed segments are supposed to be very rare events. The hotpath of
     // truncating the appender, is optimized.
-    co_return co_await internal::make_reader_handle(path, sanitize_fileops)
-      .then([](ss::file f) {
-          return f.stat().then([f](struct stat s) {
+    auto f = co_await internal::make_reader_handle(path, sanitize_fileops);
+
+    co_return co_await f.stat().then([f](struct stat s) {
               return ss::make_ready_future<std::tuple<uint64_t, ss::file>>(
                 std::make_tuple(s.st_size, f));
-          });
       })
       .then([buf_size, path](std::tuple<uint64_t, ss::file> t) {
           auto& [size, fd] = t;

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -209,7 +209,7 @@ private:
  * exist
  */
 ss::future<ss::lw_shared_ptr<segment>> open_segment(
-  const std::filesystem::path& path,
+  std::filesystem::path path,
   debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache,
   size_t buf_size = default_segment_readahead_size);


### PR DESCRIPTION
## Cover letter

Simplifies storage::open_segment to use coroutines.

## Release notes

None