### PR TITLE
tests: wait for topics number  to be valid in metrics reporter test

### DIFF
--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -68,10 +68,13 @@ class MetricsReporterTest(Test):
             f"created {total_topics} topics with {total_partitions} partitions"
         )
 
-        def _has_request():
-            return len(http.requests) > 5
+        def _state_up_to_date():
+            if http.requests:
+                r = json.loads(http.requests[-1]['body'])
+                return r['topic_count'] == total_topics
+            return False
 
-        wait_until(_has_request, 20, backoff_sec=1)
+        wait_until(_state_up_to_date, 20, backoff_sec=1)
         http.stop()
         metadata = [json.loads(r['body']) for r in http.requests]
         for m in metadata:


### PR DESCRIPTION
## Cover letter

Made `metrics_reporter_test` more robust

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes N/A
## Release notes
* none
