### PR TITLE
Fix mapping shutdown error

### DIFF
--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -23,6 +23,7 @@
 #include "model/namespace.h"
 #include "model/record_batch_reader.h"
 #include "model/timestamp.h"
+#include "raft/errc.h"
 #include "raft/types.h"
 #include "storage/shard_assignment.h"
 #include "utils/remote.h"
@@ -127,6 +128,10 @@ static error_code map_produce_error_code(std::error_code ec) {
         case raft::errc::not_leader:
         case raft::errc::replicated_entry_truncated:
             return error_code::not_leader_for_partition;
+        // map shutting down error code to timeout since replication result may
+        // be not determined, it may succeed or be aborted earlier and abandoned
+        case raft::errc::shutting_down:
+            return error_code::request_timed_out;
         default:
             return error_code::unknown_server_error;
         }


### PR DESCRIPTION
## Cover letter

Fixed mapping of raft error code to Kafka error codes in offset commit handling code path. When offset commit request fails we need to preserve the error semantic from Kafka broker. All the error indicating that current node is not a leader should be translated to `NOT_COORDINATOR` error. Other errors should be translated to generic server error as the client should rebuild its state instead of assuming particular broker behavior.

### Problem description

The incorrect handling was causing several tests to fail intermittently. Ducktape tests that are using `VerifiableConsumer` reported that they can not consume up to certain offset. `VerifiableConsumer` waits for `offset_committed` event to verify if all records were consumed. If the offset commit request return `NOT_CORIDNATOR` error offset commit will not be retried. If the offset commit request was successfully replicated and there are no more batches in the partition consumer will not receive any more batches and will not issue another offset commit request. This will result in lack of `offset_committed` event and consumer reporting it wasn't able to consume produced offset.

Example logs:

Consumer reported that is is unable to consume up to offset `1444` of partition `topic-6/5`

Entry was actually consumed
```
{
    "timestamp": 1638995749450,
    "name": "record_data",
    "key": null,
    "value": "1.13869",
    "topic": "topic-6",
    "partition": 5,
    "offset": 1444
}
```
But offset commit failed 
```
{
    "timestamp": 1638995753101,
    "name": "offsets_committed",
    "offsets": [
        {
            "topic": "topic-6",
            "partition": 5,
            "offset": 1445
        },
        {
            "topic": "topic-6",
            "partition": 3,
            "offset": 1466
        }
    ],
    "error": "Commit cannot be completed since the group has already rebalanced and assigned the partitions to another member. This means that the time between subsequent calls to poll() was longer than the configured max.poll.interval.ms, which typically implies that the poll loop is spending too much time message processing. You can address this either by increasing max.poll.interval.ms or by reducing the maximum size of batches returned in poll() with max.poll.records.",
    "success": false
}
```
Redpanda in subsequent offset fetch request returned information that offset was committed

```
TRACE 2021-12-08 20:35:53,105 [shard 1] kafka - request_context.h:156 - [172.18.0.17:36020] sending 9:offset fetch response {throttle_time_ms=0 topics={{name={topic-6} partitions={
{partition_index=1 committed_offset=1287 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }},
{partition_index=0 committed_offset=1085 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }}, 
{partition_index=9 committed_offset=1218 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }}, 
{partition_index=8 committed_offset=1423 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }}, 
{partition_index=7 committed_offset=2222 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }},
{partition_index=6 committed_offset=1315 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }}, 
{partition_index=5 committed_offset=1445 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }}, 
{partition_index=4 committed_offset=1286 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }}, 
{partition_index=3 committed_offset=1466 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }}, 
{partition_index=2 committed_offset=963 committed_leader_epoch=-1 metadata={} error_code={ error_code: none [0] }}}}} error_code={ error_code: none [0] }}
```


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes: #2142, #2568

## Release notes

### Improvements
- Better handling of consumer group related errors
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
