### PR TITLE
[coproc] Fix rptest.tests.wasm_filter_test.WasmFilterTest.verify_filter_test

### DIFF
--- a/tests/rptest/tests/wasm_filter_test.py
+++ b/tests/rptest/tests/wasm_filter_test.py
@@ -30,7 +30,7 @@ class WasmFilterTest(WasmTest):
         self._output_topic = "default_output"
         self._script = WasmScript(
             inputs=[x.name for x in self.topics],
-            outputs=[(self._output_topic, self._expected_record_cnt)],
+            outputs=[self._output_topic],
             script=WasmTemplateRepository.FILTER_TRANSFORM,
         )
 


### PR DESCRIPTION
## Cover letter

Now `rptest.tests.wasm_filter_test.WasmFilterTest.verify_filter_test` fails with timeout.
On leader I got
```
INFO  2021-12-09 11:48:20,478 [shard 0] cluster - topics_frontend.cc:585 - Invalid topic name validation pattern [a-zA-Z0-9_\.\-] failed for topic-wazynoyvpo._('default_output', 16.0)_
```

This pr fix output topic name for filter test