### PR TITLE
admin: do up-front validation of configuration changes

### DIFF
--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -16,7 +16,25 @@
           "nickname": "patch_cluster_config",
           "produces": ["application/json"],
           "parameters": [
-          ]
+            {
+              "in": "query",
+              "name": "force",
+              "schema": {"type": "integer"},
+              "required": false,
+              "description": "If nonzero, skip validation of properties, and permit setting unknown properties"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "OK"
+            },
+            "400": {
+              "description": "Invalid properties.  Response is a map of property name to error string",
+              "schema":{
+                "type": "object"
+              }
+            }
+          }
         }
       ]
     },

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -125,14 +125,18 @@ class Admin:
     def get_cluster_config_schema(self, node=None):
         return self._request("GET", "cluster_config/schema", node=node).json()
 
-    def patch_cluster_config(self, upsert=None, remove=None):
+    def patch_cluster_config(self, upsert=None, remove=None, force=False):
         if upsert is None:
             upsert = {}
         if remove is None:
             remove = []
 
+        path = "cluster_config"
+        if force:
+            path = path + "?force=true"
+
         return self._request("PUT",
-                             "cluster_config",
+                             path,
                              json={
                                  'upsert': upsert,
                                  'remove': remove


### PR DESCRIPTION
## Cover letter

Previously invalid values would be accepted by the API but later reported in config status as invalid.  This moves validation earlier.  A `force` flag is added for callers that know they want to inject configuration which is _currently_ invalid but will become valid after an upgrade (e.g. setting a new property before all the nodes are running a version of redpanda that supports it).

There is a FIXME in here to provide a proper structured response on invalid input: this will be fixed in a followup PR (https://github.com/vectorizedio/redpanda/pull/3209), it depends on a seastar change to enable passing back response bodies in http exceptions.

## Release notes

* none