### PR TITLE
coproc: Move materialized partitions

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -585,7 +585,7 @@ bool topic_table::contains(
 std::optional<cluster::partition_assignment>
 topic_table::get_partition_assignment(const model::ntp& ntp) const {
     auto it = _topics.find(model::topic_namespace_view(ntp));
-    if (it == _topics.end() || !it->second.is_topic_replicable()) {
+    if (it == _topics.end()) {
         return {};
     }
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -161,16 +161,24 @@ topic_table::apply(create_partition_cmd cmd, model::offset offset) {
 ss::future<std::error_code>
 topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
     auto tp = _topics.find(model::topic_namespace_view(cmd.key));
-    if (tp == _topics.end() || !tp->second.is_topic_replicable()) {
+    if (tp == _topics.end()) {
         return ss::make_ready_future<std::error_code>(errc::topic_not_exists);
     }
+    if (!tp->second.is_topic_replicable()) {
+        return ss::make_ready_future<std::error_code>(
+          errc::topic_operation_error);
+    }
+    auto find_partition = [](
+                            std::vector<partition_assignment>& assignments,
+                            model::partition_id p_id) {
+        return std::find_if(
+          assignments.begin(),
+          assignments.end(),
+          [p_id](const partition_assignment& p_as) { return p_id == p_as.id; });
+    };
 
-    auto current_assignment_it = std::find_if(
-      tp->second.configuration.assignments.begin(),
-      tp->second.configuration.assignments.end(),
-      [p_id = cmd.key.tp.partition](partition_assignment& p_as) {
-          return p_id == p_as.id;
-      });
+    auto current_assignment_it = find_partition(
+      tp->second.configuration.assignments, cmd.key.tp.partition);
 
     if (current_assignment_it == tp->second.configuration.assignments.end()) {
         return ss::make_ready_future<std::error_code>(
@@ -193,6 +201,39 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
     // replace partition replica set
     current_assignment_it->replicas = cmd.value;
 
+    /// Update all non_replicable topics to have the same 'in-progress' state
+    auto found = _topics_hierarchy.find(model::topic_namespace_view(cmd.key));
+    if (found != _topics_hierarchy.end()) {
+        for (const auto& cs : found->second) {
+            /// Insert non-replicable topic into the 'update_in_progress' set
+            auto [_, success] = _update_in_progress.insert(
+              model::ntp(cs.ns, cs.tp, current_assignment_it->id));
+            vassert(
+              success,
+              "non_replicable topic {}-{} already in _update_in_progress set",
+              cs.tp,
+              current_assignment_it->id);
+            /// For each child topic of the to-be-moved source, update its new
+            /// replica assignment to reflect the change
+            auto sfound = _topics.find(cs);
+            vassert(
+              sfound != _topics.end(),
+              "Non replicable topic must exist: {}",
+              cs);
+            auto assignment_it = find_partition(
+              sfound->second.configuration.assignments,
+              current_assignment_it->id);
+            vassert(
+              assignment_it != sfound->second.configuration.assignments.end(),
+              "Non replicable partition doesn't exist: {}-{}",
+              cs,
+              current_assignment_it->id);
+            /// The new assignments of the non_replicable topic/partition must
+            /// match the source topic
+            assignment_it->replicas = cmd.value;
+        }
+    }
+
     // calculate deleta for backend
     model::ntp ntp(tp->first.ns, tp->first.tp, current_assignment_it->id);
     _pending_deltas.emplace_back(
@@ -210,8 +251,12 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
 ss::future<std::error_code>
 topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
     auto tp = _topics.find(model::topic_namespace_view(cmd.key));
-    if (tp == _topics.end() || !tp->second.is_topic_replicable()) {
+    if (tp == _topics.end()) {
         return ss::make_ready_future<std::error_code>(errc::topic_not_exists);
+    }
+    if (!tp->second.is_topic_replicable()) {
+        return ss::make_ready_future<std::error_code>(
+          errc::topic_operation_error);
     }
 
     // calculate deleta for backend
@@ -239,6 +284,22 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
       .id = current_assignment_it->id,
       .replicas = std::move(cmd.value),
     };
+
+    /// Remove child non_replicable topics out of the 'update_in_progress' set
+    auto found = _topics_hierarchy.find(model::topic_namespace_view(cmd.key));
+    if (found != _topics_hierarchy.end()) {
+        for (const auto& cs : found->second) {
+            bool erased = _update_in_progress.erase(
+                            model::ntp(cs.ns, cs.tp, cmd.key.tp.partition))
+                          > 0;
+            if (!erased) {
+                vlog(
+                  clusterlog.error,
+                  "non_replicable_topic expected to exist in "
+                  "update_in_progress set");
+            }
+        }
+    }
 
     // notify backend about finished update
     _pending_deltas.emplace_back(

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -160,6 +160,8 @@ public:
 
     const underlying_t& topics_map() const { return _topics; }
 
+    const hierarchy_t& hierarchy_map() const { return _topics_hierarchy; }
+
     bool is_update_in_progress(const model::ntp&) const;
 
     bool has_updates_in_progress() const {

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -17,6 +17,7 @@
 #include "coproc/pacemaker.h"
 #include "coproc/partition_manager.h"
 #include "coproc/reconciliation_backend.h"
+#include "coproc/script_database.h"
 #include "coproc/script_dispatcher.h"
 
 #include <seastar/core/coroutine.hh>
@@ -56,6 +57,7 @@ ss::future<> api::start() {
     co_await _reconciliation_backend.invoke_on_all(
       &coproc::reconciliation_backend::start);
 
+    co_await _sdb.start_single();
     co_await _mt_frontend.start_single(std::ref(_rs.topics_frontend));
     co_await _pacemaker.start(_engine_addr, std::ref(_rs));
     co_await _pacemaker.invoke_on_all(&coproc::pacemaker::start);
@@ -64,7 +66,8 @@ ss::future<> api::start() {
     vassert(!_dispatcher, "nullptr expected");
     vassert(!_wasm_async_handler, "nullptr expected");
     _listener = std::make_unique<wasm::event_listener>(_as);
-    _dispatcher = std::make_unique<wasm::script_dispatcher>(_pacemaker, _as);
+    _dispatcher = std::make_unique<wasm::script_dispatcher>(
+      _pacemaker, _sdb, _as);
     _wasm_async_handler = std::make_unique<coproc::wasm::async_event_handler>(
       std::ref(*_dispatcher));
     _listener->register_handler(
@@ -77,6 +80,7 @@ ss::future<> api::stop() {
     co_await _listener->stop();
     co_await _pacemaker.stop();
     co_await _mt_frontend.stop();
+    co_await _sdb.stop();
 }
 
 } // namespace coproc

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -52,7 +52,8 @@ ss::future<> api::start() {
       std::ref(_rs.shard_table),
       std::ref(_rs.partition_manager),
       std::ref(_rs.cp_partition_manager),
-      std::ref(_pacemaker));
+      std::ref(_pacemaker),
+      std::ref(_sdb));
 
     co_await _reconciliation_backend.invoke_on_all(
       &coproc::reconciliation_backend::start);

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -42,7 +42,8 @@ public:
 private:
     net::unresolved_address _engine_addr;
 
-    ss::sharded<pacemaker> _pacemaker; /// one per core
+    ss::sharded<wasm::script_database> _sdb; // one instance
+    ss::sharded<pacemaker> _pacemaker;       /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
     ss::sharded<reconciliation_backend>

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -15,8 +15,10 @@
 #include "coproc/fwd.h"
 #include "coproc/sys_refs.h"
 #include "net/unresolved_address.h"
-namespace coproc {
 
+#include <seastar/core/abort_source.hh>
+
+namespace coproc {
 class api {
 public:
     api(
@@ -40,16 +42,17 @@ public:
 private:
     net::unresolved_address _engine_addr;
 
-    std::unique_ptr<wasm::event_listener> _listener; /// one instance
-    ss::sharded<pacemaker> _pacemaker;               /// one per core
+    ss::sharded<pacemaker> _pacemaker; /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
     ss::sharded<reconciliation_backend>
       _reconciliation_backend; /// one per core
 
     sys_refs _rs;
+    ss::abort_source _as;
 
-    // Event handlers
+    std::unique_ptr<wasm::script_dispatcher> _dispatcher;
+    std::unique_ptr<wasm::event_listener> _listener;
     std::unique_ptr<wasm::async_event_handler> _wasm_async_handler;
 };
 

--- a/src/v/coproc/errc.h
+++ b/src/v/coproc/errc.h
@@ -86,9 +86,9 @@ struct errc_category final : public std::error_category {
         case errc::script_id_does_not_exist:
             return "Could not find coprocessor with matching script_id";
         case errc::partition_not_exists:
-            return "Partition missing from coproc::partition_manager";
+            return "Partition not found";
         case errc::partition_already_exists:
-            return "Partition alreday exists in coproc::partition_manager";
+            return "Partition already exists";
         default:
             return "Undefined coprocessor error encountered";
         }

--- a/src/v/coproc/event_handler.cc
+++ b/src/v/coproc/event_handler.cc
@@ -10,15 +10,14 @@
 
 #include "coproc/event_handler.h"
 
+#include "coproc/script_dispatcher.h"
 #include "utils/gate_guard.h"
 #include "vlog.h"
 
 namespace coproc::wasm {
 
-async_event_handler::async_event_handler(
-  ss::abort_source& abort_source, ss::sharded<pacemaker>& pacemaker)
-  : _abort_source(abort_source)
-  , _dispatcher(pacemaker, _abort_source) {}
+async_event_handler::async_event_handler(script_dispatcher& dispatcher)
+  : _dispatcher(dispatcher) {}
 
 ss::future<> async_event_handler::start() { co_return; }
 

--- a/src/v/coproc/event_handler.h
+++ b/src/v/coproc/event_handler.h
@@ -77,9 +77,6 @@ public:
     process(absl::btree_map<script_id, parsed_event> wsas) override;
 
 private:
-    /// Set of known script ids to be active
-    absl::btree_set<script_id> _active_ids;
-
     ss::gate _gate;
 
     /// Used to make requests to the wasm engine

--- a/src/v/coproc/event_handler.h
+++ b/src/v/coproc/event_handler.h
@@ -10,13 +10,14 @@
 
 #pragma once
 
+#include "coproc/fwd.h"
 #include "coproc/logger.h"
-#include "coproc/script_dispatcher.h"
 #include "coproc/wasm_event.h"
 #include "seastarx.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
 
 #include <absl/container/btree_map.h>
 #include <absl/container/btree_set.h>
@@ -64,8 +65,7 @@ public:
 
 class async_event_handler final : public event_handler {
 public:
-    explicit async_event_handler(
-      ss::abort_source& abort_source, ss::sharded<pacemaker>& pacemaker);
+    explicit async_event_handler(script_dispatcher&);
 
     ss::future<> start() override;
     ss::future<> stop() override;
@@ -80,13 +80,10 @@ private:
     /// Set of known script ids to be active
     absl::btree_set<script_id> _active_ids;
 
-    /// Pass it tot script_dispatcher
-    ss::abort_source& _abort_source;
-
     ss::gate _gate;
 
     /// Used to make requests to the wasm engine
-    script_dispatcher _dispatcher;
+    script_dispatcher& _dispatcher;
 };
 
 class data_policy_event_handler final : public event_handler {

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -59,8 +59,9 @@ ss::future<> event_listener::stop() {
       });
 }
 
-event_listener::event_listener()
-  : _client(make_client()) {}
+event_listener::event_listener(ss::abort_source& as)
+  : _client(make_client())
+  , _abort_source(as) {}
 
 ss::future<> event_listener::start() {
     co_await ss::parallel_for_each(
@@ -97,8 +98,6 @@ void event_listener::register_handler(event_type type, event_handler* handler) {
       "Register new handler for wasm_event_type: {}",
       coproc_type_as_string_view(type));
 }
-
-ss::abort_source& event_listener::get_abort_source() { return _abort_source; }
 
 static ss::future<std::vector<model::record_batch>>
 decompress_wasm_events(model::record_batch_reader::data_t events) {

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -35,7 +35,7 @@ namespace coproc::wasm {
 class event_listener {
 public:
     /// class constructor
-    event_listener();
+    explicit event_listener(ss::abort_source&);
 
     /// To be invoked once on redpanda::application startup
     ///
@@ -68,7 +68,7 @@ private:
 
     /// Primitives used to manage the poll loop
     ss::gate _gate;
-    ss::abort_source _abort_source;
+    ss::abort_source& _abort_source;
 
     /// Current offset into the 'coprocessor_internal_topic'
     model::offset _offset{0};

--- a/src/v/coproc/exception.h
+++ b/src/v/coproc/exception.h
@@ -31,6 +31,21 @@ private:
     ss::sstring _msg;
 };
 
+/// Not necessarily a fatal error, explicity handle these events as theres no
+/// way to ensure handles to partitions aren't in use before
+/// partition::shutdown() is called
+class partition_shutdown_exception final : public exception {
+public:
+    partition_shutdown_exception(model::ntp ntp, ss::sstring msg) noexcept
+      : exception(std::move(msg))
+      , _ntp(std::move(ntp)) {}
+
+    const model::ntp& ntp() const { return _ntp; }
+
+private:
+    model::ntp _ntp;
+};
+
 /// Root exception type for classes of exceptions that are only thrown by
 /// actions interpreted by coprocessors themselves
 class script_exception : public exception {

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -21,6 +21,7 @@ class reconciliation_backend;
 
 namespace wasm {
 
+class script_database;
 class script_dispatcher;
 class async_event_handler;
 class event_listener;

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -132,7 +132,7 @@ public:
     ss::future<>
     with_hold(const model::ntp& source, const model::ntp& materialized, Fn fn) {
         _shared_res.in_progress_deletes.emplace(materialized);
-        std::vector<ss::future<>> fs;
+        std::vector<ss::future<errc>> fs;
         for (auto& [_, script] : _scripts) {
             fs.emplace_back(
               script->remove_output(source, materialized)
@@ -141,6 +141,7 @@ public:
                       coproclog.info,
                       "Script shutdown during barriers emplacement: {}",
                       ex);
+                    return errc::success;
                 }));
         }
         /// When this future completes, it can safely be assumed that all fibers

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -112,6 +112,21 @@ public:
     ss::future<errc> wait_for_script(script_id);
 
     /**
+     * Restarts a partition. Useful after source partition is moved.
+     */
+    using script_inputs_t
+      = absl::flat_hash_map<script_id, std::vector<topic_namespace_policy>>;
+    ss::future<absl::flat_hash_map<script_id, errc>>
+      restart_partition(model::ntp, script_inputs_t);
+
+    /**
+     * Removes partition from any active scripts that may be processing it
+     *
+     * @returns Ids of scripts that were reading from this partition
+     */
+    ss::future<std::vector<script_id>> shutdown_partition(model::ntp);
+
+    /**
      * @returns true if a matching script id exists on 'this' shard
      */
     bool local_script_id_exists(script_id);

--- a/src/v/coproc/partition_manager.cc
+++ b/src/v/coproc/partition_manager.cc
@@ -77,6 +77,7 @@ ss::future<> partition_manager::remove(const model::ntp& ntp) {
           ntp));
     }
 
+    vlog(coproclog.info, "Removing materialized log: {}", ntp);
     auto partition = found->second;
     _ntp_table.erase(found);
     _unmanage_watchers.notify(ntp, ntp.tp.partition);

--- a/src/v/coproc/partition_manager.h
+++ b/src/v/coproc/partition_manager.h
@@ -57,6 +57,15 @@ public:
         _unmanage_watchers.unregister_notify(id);
     }
 
+    /*
+     * read-only interface to partitions.
+     *
+     * note that users of this interface must take care not to hold iterators
+     * across scheduling events as the underlying table may be modified and
+     * invalidate iterators.
+     */
+    const ntp_table_container& partitions() const { return _ntp_table; }
+
 private:
     ss::future<> do_shutdown(ss::lw_shared_ptr<partition>);
 

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -14,7 +14,6 @@
 #include "cluster/topic_table.h"
 #include "coproc/fwd.h"
 #include "storage/fwd.h"
-#include "utils/mutex.h"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
@@ -44,11 +43,12 @@ public:
 
 private:
     using update_t = cluster::topic_table::delta;
-    ss::future<std::error_code> process_update(update_t);
-    ss::future<std::vector<update_t>>
-      process_events_for_ntp(model::ntp, std::vector<update_t>);
+    using events_cache_t
+      = absl::node_hash_map<model::ntp, std::vector<update_t>>;
 
-    ss::future<> fetch_and_reconcile();
+    ss::future<> fetch_and_reconcile(events_cache_t);
+    ss::future<> process_updates(model::ntp, std::vector<update_t>);
+    ss::future<std::error_code> process_update(model::ntp, update_t);
 
     ss::future<>
     delete_non_replicable_partition(model::ntp ntp, model::revision_id rev);
@@ -57,22 +57,17 @@ private:
     ss::future<> add_to_shard_table(
       model::ntp ntp, ss::shard_id shard, model::revision_id revision);
 
-    template<typename Fn>
-    ss::future<> within_context(Fn&&);
+    void enqueue_events(std::vector<update_t>);
+    ss::future<> process_loop();
 
 private:
-    static constexpr auto retry_timeout_interval = std::chrono::milliseconds(
-      100);
-
     cluster::notification_id_type _id_cb;
     model::node_id _self;
     ss::sstring _data_directory;
-    absl::node_hash_map<model::ntp, std::vector<update_t>> _topic_deltas;
+    events_cache_t _topic_deltas;
 
-    mutex _mutex;
     ss::gate _gate;
     ss::abort_source _as;
-    ss::timer<model::timeout_clock> _retry_timer;
 
     ss::sharded<cluster::topic_table>& _topics;
     ss::sharded<cluster::shard_table>& _shard_table;

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -77,6 +77,13 @@ public:
      */
     ss::future<> shutdown();
 
+    /// Query for particular route
+    inline ss::lw_shared_ptr<coproc::source>
+    get_route(const model::ntp& ntp) const {
+        auto f = _routes.find(ntp);
+        return f != _routes.end() ? f->second : nullptr;
+    }
+
     /// Returns copy of active routes
     routes_t get_routes() const { return _routes; }
 

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "coproc/errc.h"
 #include "coproc/exception.h"
 #include "coproc/script_context_router.h"
 #include "coproc/shared_script_resources.h"
@@ -25,7 +26,7 @@
 
 namespace coproc {
 
-/// Raised when futures enqueued by \ref remove_output were failed to be
+/// Raised when futures enqueued by an async update were failed to be
 /// fufilled due to shutdown before the event occurring
 class wait_future_stranded final : public exception {
     using exception::exception;
@@ -82,7 +83,7 @@ public:
     /// Clean-up associated resources with removed output
     ///
     /// This is to be invoked after a materialized topic is deleted
-    ss::future<>
+    ss::future<errc>
     remove_output(const model::ntp& source, const model::ntp& materialized);
 
     /// Returns true if fiber is up to date with all of its inputs
@@ -91,18 +92,50 @@ public:
     /// offsets for respective tracked partitions
     bool is_up_to_date() const;
 
+    /// Start ingestion on the interested ntp.
+    ///
+    /// Useful for the cases where an input partition was moved or updated.
+    ss::future<errc> start_processing_ntp(const model::ntp&, read_context&&);
+
+    /// Stop ingestion on the interested ntp.
+    ///
+    /// Useful for the cases where an input partition is to be moved or updated.
+    ss::future<errc> stop_processing_ntp(const model::ntp&);
+
 private:
     ss::future<> do_execute();
 
     ss::future<> process_reply(process_batch_reply);
     void notify_waiters();
 
+    ss::future<ss::stop_iteration> process_send_write(rpc::transport*);
+
+private:
+    /// State to track in-progress ntp modifications
     struct update {
-        model::ntp source;
-        std::vector<ss::promise<>> ps;
+        std::vector<ss::promise<errc>> ps;
+        virtual ~update() = default;
+        virtual errc handle(const model::ntp&, routes_t&) = 0;
     };
 
-    ss::future<ss::stop_iteration> process_send_write(rpc::transport*);
+    struct insert_update final : public update {
+        /// New input topic is inserted after initial start
+        read_context rctx;
+        explicit insert_update(read_context) noexcept;
+        errc handle(const model::ntp&, routes_t&) final;
+    };
+
+    struct remove_update final : public update {
+        /// Existing input topic is removed after initial start
+        errc handle(const model::ntp&, routes_t&) final;
+    };
+
+    struct output_remove_update final : public update {
+        /// Materialized topic (output topic) removed
+        model::ntp source;
+        explicit output_remove_update(model::ntp) noexcept;
+        errc handle(const model::ntp&, routes_t&) final;
+    };
 
 private:
     /// Killswitch for in-process reads
@@ -112,7 +145,7 @@ private:
     ss::gate _gate;
 
     /// Allows the ability to asynchronously remove items from the router map
-    absl::node_hash_map<model::ntp, update> _updates;
+    absl::node_hash_map<model::ntp, std::unique_ptr<update>> _updates;
 
     // Reference to resources shared across all script_contexts on 'this'
     // shard

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -94,9 +94,6 @@ public:
 private:
     ss::future<> do_execute();
 
-    ss::future<>
-      send_request(supervisor_client_protocol, process_batch_request);
-
     ss::future<> process_reply(process_batch_reply);
     void notify_waiters();
 
@@ -104,6 +101,8 @@ private:
         model::ntp source;
         std::vector<ss::promise<>> ps;
     };
+
+    ss::future<ss::stop_iteration> process_send_write(rpc::transport*);
 
 private:
     /// Killswitch for in-process reads

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -124,7 +124,7 @@ static ss::future<> do_write_materialized_partition(
 }
 
 static ss::future<ss::lw_shared_ptr<partition>>
-get_partition(partition_manager& pm, const model::ntp& ntp) {
+get_partition(partition_manager& pm, model::ntp ntp) {
     auto found = pm.get(ntp);
     if (found) {
         /// Log exists, do nothing and return it
@@ -133,8 +133,9 @@ get_partition(partition_manager& pm, const model::ntp& ntp) {
     /// In the case the storage::log has not been created, but the topic has.
     /// Retry again.
     co_await ss::sleep(100ms);
-    throw log_not_yet_created_exception(fmt::format(
-      "Materialized topic created but underlying log doesn't yet exist", ntp));
+    throw log_not_yet_created_exception(ssx::sformat(
+      "Materialized topic created but underlying log doesn't yet exist: {}",
+      ntp));
 }
 
 static ss::future<> maybe_make_materialized_log(

--- a/src/v/coproc/script_context_frontend.cc
+++ b/src/v/coproc/script_context_frontend.cc
@@ -12,6 +12,7 @@
 #include "coproc/script_context_frontend.h"
 
 #include "cluster/partition.h"
+#include "coproc/exception.h"
 #include "coproc/logger.h"
 #include "coproc/reference_window_consumer.hpp"
 #include "model/fundamental.h"
@@ -85,20 +86,30 @@ ss::future<std::optional<process_batch_request::data>>
 read_ntp(input_read_args args, ss::lw_shared_ptr<source> ctx) {
     storage::log_reader_config cfg = get_reader(
       args.abort_src, ctx->rctx, ctx->wctx);
-    auto rbr = co_await ctx->rctx.input->make_reader(cfg);
-    auto read_result = co_await std::move(rbr).for_each_ref(
-      coproc::reference_window_consumer(
-        high_offset_tracker(), storage::internal::decompress_batch_consumer()),
-      model::no_timeout);
-    auto& [info, nrbr] = read_result;
-    if (info.size == 0) {
-        co_return std::nullopt;
+    try {
+        auto rbr = co_await ctx->rctx.input->make_reader(cfg);
+        auto read_result = co_await std::move(rbr).for_each_ref(
+          coproc::reference_window_consumer(
+            high_offset_tracker(),
+            storage::internal::decompress_batch_consumer()),
+          model::no_timeout);
+        auto& [info, nrbr] = read_result;
+        if (info.size > 0) {
+            ctx->rctx.last_read = info.last + model::offset{1};
+            co_return process_batch_request::data{
+              .ids = std::vector<script_id>{args.id},
+              .ntp = ctx->rctx.input->ntp(),
+              .reader = std::move(nrbr)};
+        }
+    } catch (const ss::gate_closed_exception&) {
+        throw partition_shutdown_exception(
+          ctx->rctx.input->ntp(),
+          fmt::format(
+            "Partition {} shutdown while script {} was attempting to read",
+            ctx->rctx.input->ntp(),
+            args.id));
     }
-    ctx->rctx.last_read = info.last + model::offset{1};
-    co_return process_batch_request::data{
-      .ids = std::vector<script_id>{args.id},
-      .ntp = ctx->rctx.input->ntp(),
-      .reader = std::move(nrbr)};
+    co_return std::nullopt;
 }
 
 ss::future<std::vector<process_batch_request::data>>

--- a/src/v/coproc/script_database.h
+++ b/src/v/coproc/script_database.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "coproc/types.h"
+
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
+
+#include <vector>
+
+namespace coproc::wasm {
+/// In memory cache of all coprocessors of all coprocessors
+///
+/// Useful when its necessary to redeploy or reference a shutdown or partitally
+/// shutdown coprocessor for its metadata
+class script_database {
+public:
+    struct script_metadata {
+        iobuf source;
+        std::vector<topic_namespace_policy> inputs;
+    };
+
+    using underlying_t = absl::node_hash_map<script_id, script_metadata>;
+    using inverted_lookup_t = absl::node_hash_map<
+      model::topic_namespace,
+      absl::node_hash_set<script_id>,
+      model::topic_namespace_hash,
+      model::topic_namespace_eq>;
+    using const_iterator = underlying_t::const_iterator;
+    using const_inv_iterator = inverted_lookup_t::const_iterator;
+
+    /// Querying
+    /// ... by scripts
+    bool exists(script_id id) { return _db.contains(id); }
+    const_iterator find(script_id id) const { return _db.find(id); }
+    const_iterator cbegin() const { return _db.cbegin(); }
+    const_iterator cend() const { return _db.cend(); }
+
+    /// ... by topic/namespace
+    bool exists(model::topic_namespace_view tnv) const {
+        return _by_input.contains(tnv);
+    }
+    const_inv_iterator find(model::topic_namespace_view tnv) const {
+        return _by_input.find(tnv);
+    }
+    const_inv_iterator inv_cbegin() const { return _by_input.cbegin(); }
+    const_inv_iterator inv_cend() const { return _by_input.cend(); }
+
+    underlying_t::size_type size() const { return _db.size(); }
+    inverted_lookup_t::size_type unique_inputs() const {
+        return _by_input.size();
+    }
+
+    /// Removal
+    bool remove_script(script_id id) {
+        auto found = _db.find(id);
+        if (found == _db.end()) {
+            return false;
+        }
+        for (const auto& e : found->second.inputs) {
+            _by_input.erase(e.tn);
+        }
+        _db.erase(found);
+        return true;
+    }
+    void clear() {
+        _db.clear();
+        _by_input.clear();
+    }
+
+    /// Addition
+    bool add_script(
+      script_id id, iobuf source, std::vector<topic_namespace_policy> inputs) {
+        script_metadata meta{.source = std::move(source), .inputs = inputs};
+        auto [_, success] = _db.emplace(id, std::move(meta));
+        if (!success) {
+            return false;
+        }
+        for (auto& input : inputs) {
+            auto found = _by_input.find(input.tn);
+            if (found == _by_input.end()) {
+                absl::node_hash_set<script_id> ns;
+                ns.emplace(id);
+                _by_input.emplace(std::move(input.tn), std::move(ns));
+            } else {
+                found->second.emplace(id);
+            }
+        }
+        return true;
+    }
+
+private:
+    underlying_t _db;
+    inverted_lookup_t _by_input;
+};
+
+/// \brief script_database is a sharded service that only exists on shard 0.
+/// Use this as its 'home_shard' when calling 'invoke_on'
+static constexpr ss::shard_id script_database_main_shard = 0;
+
+} // namespace coproc::wasm

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ rp_test(
   SOURCES
     ${fixture_srcs}
     retry_logic_tests.cc
+    partition_movement_tests.cc
     topic_ingestion_policy_tests.cc
     failure_recovery_tests.cc
     pacemaker_tests.cc

--- a/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
@@ -15,6 +15,7 @@
 #include "coproc/api.h"
 #include "coproc/event_handler.h"
 #include "coproc/logger.h"
+#include "coproc/pacemaker.h"
 #include "coproc/tests/utils/event_publisher_utils.h"
 #include "coproc/tests/utils/kafka_publish_consumer.h"
 #include "kafka/client/client.h"

--- a/src/v/coproc/tests/partition_movement_tests.cc
+++ b/src/v/coproc/tests/partition_movement_tests.cc
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/partition_manager.h"
+#include "coproc/tests/fixtures/coproc_bench_fixture.h"
+#include "coproc/tests/fixtures/coproc_cluster_fixture.h"
+#include "coproc/tests/utils/batch_utils.h"
+#include "coproc/tests/utils/coprocessor.h"
+#include "kafka/client/client.h"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test_log.hpp>
+
+using copro_typeid = coproc::registry::type_identifier;
+
+/// Test moves across shards on same node works
+FIXTURE_TEST(test_move_source_topic, coproc_test_fixture) {
+    model::topic mvp("mvp");
+    setup({{mvp, 4}}).get();
+
+    auto id = coproc::script_id(443920);
+    enable_coprocessors(
+      {{.id = id(),
+        .data{
+          .tid = copro_typeid::identity_coprocessor,
+          .topics = {{mvp, coproc::topic_ingestion_policy::latest}}}}})
+      .get();
+
+    /// Push sample data onto all partitions
+    std::vector<ss::future<>> fs;
+    for (auto i = 0; i < 4; ++i) {
+        model::ntp input_ntp(
+          model::kafka_namespace, mvp, model::partition_id(i));
+        auto f = produce(input_ntp, make_random_batch(40));
+        fs.emplace_back(std::move(f));
+    }
+    ss::when_all_succeed(fs.begin(), fs.end()).get();
+
+    /// Wait until the materialized topic has come into existance
+    model::ntp origin_ntp(model::kafka_namespace, mvp, model::partition_id(0));
+    model::ntp target_ntp = origin_ntp;
+    target_ntp.tp.topic = to_materialized_topic(
+      mvp, identity_coprocessor::identity_topic);
+    auto r = consume(target_ntp, 40).get();
+    BOOST_REQUIRE(num_records(r) == 40);
+    auto shard = root_fixture()->app.shard_table.local().shard_for(target_ntp);
+    BOOST_REQUIRE(shard);
+
+    /// Choose target and calculate where to move it to
+    const ss::shard_id next_shard = (*shard + 1) % ss::smp::count;
+    info("Current target shard {} and next shard {}", *shard, next_shard);
+    model::broker_shard bs{
+      .node_id = model::node_id(config::node().node_id), .shard = next_shard};
+
+    /// Move the input onto the new desired target
+    auto& topics_fe = root_fixture()->app.controller->get_topics_frontend();
+    auto ec = topics_fe.local()
+                .move_partition_replicas(origin_ntp, {bs}, model::no_timeout)
+                .get();
+    info("Error code: {}", ec);
+    BOOST_REQUIRE(!ec);
+
+    /// Wait until the shard table is updated with the new shard
+    tests::cooperative_spin_wait_with_timeout(
+      10s,
+      [this, target_ntp, next_shard] {
+          auto s = root_fixture()->app.shard_table.local().shard_for(
+            target_ntp);
+          return s && *s == next_shard;
+      })
+      .get();
+
+    /// Issue a read from the target shard, and expect the topic content
+    info("Draining from shard....{}", bs.shard);
+    r = consume(target_ntp, 40).get();
+    BOOST_CHECK_EQUAL(num_records(r), 40);
+
+    /// Finally, ensure there is no materialized partition on original shard
+    auto logf = root_fixture()->app.storage.invoke_on(
+      *shard, [origin_ntp](storage::api& api) {
+          return api.log_mgr().get(origin_ntp).has_value();
+      });
+    auto cpmf = root_fixture()->app.cp_partition_manager.invoke_on(
+      *shard, [origin_ntp](coproc::partition_manager& pm) {
+          return (bool)pm.get(origin_ntp);
+      });
+    BOOST_CHECK(!logf.get0());
+    BOOST_CHECK(!cpmf.get0());
+}
+
+bool partition_exists_on_node(
+  cluster_test_fixture* ctf, model::broker_shard bs, const model::ntp& ntp) {
+    auto n1 = ctf->get_node_application(model::node_id(0))
+                ->controller->get_partition_leaders()
+                .local()
+                .get_leader(ntp);
+    if (!n1 || (*n1 != bs.node_id)) {
+        return false;
+    }
+    auto s1 = ctf->get_node_application(bs.node_id);
+    auto shard = s1->shard_table.local().shard_for(ntp);
+    return bs.shard == *shard;
+}
+
+FIXTURE_TEST(test_move_topic_across_nodes, coproc_cluster_fixture) {
+    const auto n = 3;
+    for (auto i = 0; i < n; ++i) {
+        create_node_application(model::node_id(i));
+    }
+    wait_for_all_members(5s).get();
+    for (auto i = 0; i < n; ++i) {
+        wait_for_controller_leadership(model::node_id(i)).get();
+    }
+    start().get();
+
+    /// Find leader node
+    auto leader_node_id = get_node_application(model::node_id(0))
+                            ->controller->get_partition_leaders()
+                            .local()
+                            .get_leader(model::controller_ntp);
+    BOOST_REQUIRE(leader_node_id.has_value());
+    auto leader = get_node_application(*leader_node_id);
+
+    /// Create topic
+    auto n_partitions = 3;
+    model::topic_namespace tp(model::kafka_namespace, model::topic("source"));
+    cluster::topic_configuration tcfg(tp.ns, tp.tp, n_partitions, 1);
+    auto oec = leader->controller->get_topics_frontend()
+                 .local()
+                 .autocreate_topics({tcfg}, 5s)
+                 .get();
+    BOOST_REQUIRE_EQUAL(oec.size(), 1);
+    BOOST_REQUIRE_EQUAL(oec[0].ec, cluster::errc::success);
+    BOOST_REQUIRE_EQUAL(oec[0].tp_ns, tp);
+
+    /// Deploy coprocessor
+    auto id = coproc::script_id(440);
+    enable_coprocessors(
+      {{.id = id(),
+        .data{
+          .tid = copro_typeid::identity_coprocessor,
+          .topics = {{tp.tp, coproc::topic_ingestion_policy::earliest}}}}})
+      .get();
+
+    /// Push some sample data
+    std::vector<ss::future<>> fs;
+    for (auto i = 0; i < n_partitions; ++i) {
+        model::ntp input_ntp(
+          model::kafka_namespace, tp.tp, model::partition_id(i));
+        auto f = produce(input_ntp, make_random_batch(40));
+        fs.emplace_back(std::move(f));
+    }
+    ss::when_all_succeed(fs.begin(), fs.end()).get();
+
+    /// Push consume all materialized log data from target partition
+    model::ntp source_ntp(tp.ns, tp.tp, model::partition_id(0));
+    model::ntp materialized_ntp(
+      tp.ns,
+      to_materialized_topic(tp.tp, identity_coprocessor::identity_topic),
+      model::partition_id(0));
+    auto r = consume(materialized_ntp, 40).get();
+    BOOST_REQUIRE(num_records(r) == 40);
+
+    /// Finally move the source topic after all processing by coproc has been
+    /// completed. To do this, first find out what model::broker_shard the
+    /// source_ntp exists on, then attempt to move it to the node with the next
+    /// node/shard id (mod n)
+    auto topic_leader_id
+      = leader->controller->get_partition_leaders().local().get_leader(
+        source_ntp);
+    BOOST_REQUIRE(topic_leader_id);
+    auto topic_leader = get_node_application(*topic_leader_id);
+    auto origin_shard = topic_leader->shard_table.local().shard_for(source_ntp);
+    BOOST_REQUIRE(origin_shard.has_value());
+    model::broker_shard old_bs{
+      .node_id = *topic_leader_id, .shard = *origin_shard};
+    model::broker_shard new_bs{
+      .node_id = model::node_id((*topic_leader_id + 1) % n),
+      .shard = ss::shard_id((*origin_shard + 1) % n)};
+
+    info("Old broker_shard {} moving to new broker_shard {}", old_bs, new_bs);
+    auto& topics_fe = leader->controller->get_topics_frontend();
+    auto ec = topics_fe.local()
+                .move_partition_replicas(
+                  source_ntp, {new_bs}, model::timeout_clock::now() + 5s)
+                .get();
+    info("Error code: {}", ec);
+    BOOST_REQUIRE(!ec);
+
+    /// Wait until the move occurs
+    info("Waiting for move of {} to {}", source_ntp, new_bs);
+    tests::cooperative_spin_wait_with_timeout(
+      10s,
+      [this, source_ntp, new_bs]() {
+          return ss::make_ready_future<bool>(
+            partition_exists_on_node(this, new_bs, source_ntp));
+      })
+      .get();
+
+    /// Wait until the materialized moves also occurred
+    info("Waiting for move of {} to {}", materialized_ntp, new_bs);
+    tests::cooperative_spin_wait_with_timeout(
+      10s,
+      [this, materialized_ntp, new_bs]() {
+          return ss::make_ready_future<bool>(
+            partition_exists_on_node(this, new_bs, materialized_ntp));
+      })
+      .get();
+
+    /// Try to consume from the materialized partition
+    get_client().update_metadata().get();
+    r = consume(materialized_ntp, 40).get();
+    BOOST_REQUIRE(num_records(r) == 40);
+
+    /// Verify no reminents exist on old broker/shard
+    auto logf = get_node_application(old_bs.node_id)
+                  ->storage.invoke_on(
+                    old_bs.shard, [source_ntp](storage::api& api) {
+                        return api.log_mgr().get(source_ntp).has_value();
+                    });
+    BOOST_CHECK(!logf.get());
+}

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -191,6 +191,10 @@
                 "core": {
                     "type": "long",
                     "description": "core"
+                },
+                "materialized": {
+                    "type": "boolean",
+                    "description": "materialized"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -72,6 +72,7 @@ static ss::logger logger{"admin_api_server"};
 admin_server::admin_server(
   admin_server_cfg cfg,
   ss::sharded<cluster::partition_manager>& pm,
+  ss::sharded<coproc::partition_manager>& cpm,
   cluster::controller* controller,
   ss::sharded<cluster::shard_table>& st,
   ss::sharded<cluster::metadata_cache>& metadata_cache)
@@ -79,6 +80,7 @@ admin_server::admin_server(
   , _server("admin")
   , _cfg(std::move(cfg))
   , _partition_manager(pm)
+  , _cp_partition_manager(cpm)
   , _controller(controller)
   , _shard_table(st)
   , _metadata_cache(metadata_cache) {}
@@ -1074,27 +1076,36 @@ void admin_server::register_partition_routes() {
     ss::httpd::partition_json::get_partitions.set(
       _server._routes, [this](std::unique_ptr<ss::httpd::request>) {
           using summary = ss::httpd::partition_json::partition_summary;
-          return _partition_manager
-            .map_reduce0(
-              [](cluster::partition_manager& pm) {
-                  std::vector<summary> partitions;
-                  partitions.reserve(pm.partitions().size());
-                  for (const auto& it : pm.partitions()) {
-                      summary p;
-                      p.ns = it.first.ns;
-                      p.topic = it.first.tp.topic;
-                      p.partition_id = it.first.tp.partition;
-                      p.core = ss::this_shard_id();
-                      partitions.push_back(std::move(p));
-                  }
-                  return partitions;
-              },
-              std::vector<summary>{},
-              [](std::vector<summary> acc, std::vector<summary> update) {
-                  acc.insert(acc.end(), update.begin(), update.end());
-                  return acc;
-              })
-            .then([](std::vector<summary> partitions) {
+          auto get_summaries = [](auto& partition_manager, bool materialized) {
+              return partition_manager.map_reduce0(
+                [materialized](auto& pm) {
+                    std::vector<summary> partitions;
+                    partitions.reserve(pm.partitions().size());
+                    for (const auto& it : pm.partitions()) {
+                        summary p;
+                        p.ns = it.first.ns;
+                        p.topic = it.first.tp.topic;
+                        p.partition_id = it.first.tp.partition;
+                        p.core = ss::this_shard_id();
+                        p.materialized = materialized;
+                        partitions.push_back(std::move(p));
+                    }
+                    return partitions;
+                },
+                std::vector<summary>{},
+                [](std::vector<summary> acc, std::vector<summary> update) {
+                    acc.insert(acc.end(), update.begin(), update.end());
+                    return acc;
+                });
+          };
+          auto f1 = get_summaries(_partition_manager, false);
+          auto f2 = get_summaries(_cp_partition_manager, true);
+          return ss::when_all_succeed(std::move(f1), std::move(f2))
+            .then([](auto summaries) {
+                auto& [partitions, s2] = summaries;
+                for (auto& s : s2) {
+                    partitions.push_back(std::move(s));
+                }
                 return ss::make_ready_future<ss::json::json_return_type>(
                   std::move(partitions));
             });

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "cluster/fwd.h"
 #include "config/endpoint_tls_config.h"
+#include "coproc/partition_manager.h"
 #include "model/metadata.h"
 #include "seastarx.h"
 
@@ -38,6 +39,7 @@ public:
     explicit admin_server(
       admin_server_cfg,
       ss::sharded<cluster::partition_manager>&,
+      ss::sharded<coproc::partition_manager>&,
       cluster::controller*,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::metadata_cache>&);
@@ -110,6 +112,7 @@ private:
     ss::http_server _server;
     admin_server_cfg _cfg;
     ss::sharded<cluster::partition_manager>& _partition_manager;
+    ss::sharded<coproc::partition_manager>& _cp_partition_manager;
     cluster::controller* _controller;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -414,6 +414,7 @@ void application::configure_admin_server() {
       _admin,
       admin_server_cfg_from_global_cfg(_scheduling_groups),
       std::ref(partition_manager),
+      std::ref(cp_partition_manager),
       controller.get(),
       std::ref(shard_table),
       std::ref(metadata_cache))

--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -1,0 +1,127 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from rptest.services.admin import Admin
+from ducktape.utils.util import wait_until
+
+
+class PartitionMovementMixin():
+    @staticmethod
+    def _random_partition(metadata):
+        topic = random.choice(metadata)
+        partition = random.choice(topic["partitions"])
+        return topic["topic"], partition["partition"]
+
+    @staticmethod
+    def _choose_replacement(admin, assignments):
+        """
+        Does not produce assignments that contain duplicate nodes. This is a
+        limitation in redpanda raft implementation.
+        """
+        replication_factor = len(assignments)
+        node_ids = lambda x: set([a["node_id"] for a in x])
+
+        assert replication_factor >= 1
+        assert len(node_ids(assignments)) == replication_factor
+
+        # remove random assignment(s). we allow no changes to be made to
+        # exercise the code paths responsible for dealing with no-ops.
+        num_replacements = random.randint(0, replication_factor)
+        selected = random.sample(assignments, num_replacements)
+        for assignment in selected:
+            assignments.remove(assignment)
+
+        # choose a valid random replacement
+        replacements = []
+        brokers = admin.get_brokers()
+        while len(assignments) != replication_factor:
+            broker = random.choice(brokers)
+            node_id = broker["node_id"]
+            if node_id in node_ids(assignments):
+                continue
+            core = random.randint(0, broker["num_cores"] - 1)
+            replacement = dict(node_id=node_id, core=core)
+            assignments.append(replacement)
+            replacements.append(replacement)
+
+        return selected, replacements
+
+    @staticmethod
+    def _get_assignments(admin, topic, partition):
+        res = admin.get_partitions(topic, partition)
+
+        def normalize(a):
+            return dict(node_id=a["node_id"], core=a["core"])
+
+        return [normalize(a) for a in res["replicas"]]
+
+    @staticmethod
+    def _equal_assignments(r0, r1):
+        def to_tuple(a):
+            return a["node_id"], a["core"]
+
+        r0 = [to_tuple(a) for a in r0]
+        r1 = [to_tuple(a) for a in r1]
+        return set(r0) == set(r1)
+
+    def _get_current_partitions(self, admin, topic, partition_id):
+        def keep(p):
+            return p["ns"] == "kafka" and p["topic"] == topic and p[
+                "partition_id"] == partition_id
+
+        result = []
+        for node in self.redpanda.nodes:
+            node_id = self.redpanda.idx(node)
+            partitions = admin.get_partitions(node=node)
+            partitions = filter(keep, partitions)
+            for partition in partitions:
+                result.append(dict(node_id=node_id, core=partition["core"]))
+        return result
+
+    def _move_and_verify(self):
+        admin = Admin(self.redpanda)
+
+        # choose a random topic-partition
+        metadata = self.client().describe_topics()
+        topic, partition = self._random_partition(metadata)
+        self.logger.info(f"selected topic-partition: {topic}-{partition}")
+
+        # get the partition's replica set, including core assignments. the kafka
+        # api doesn't expose core information, so we use the redpanda admin api.
+        assignments = self._get_assignments(admin, topic, partition)
+        self.logger.info(f"assignments for {topic}-{partition}: {assignments}")
+
+        # build new replica set by replacing a random assignment
+        selected, replacements = self._choose_replacement(admin, assignments)
+        self.logger.info(
+            f"replacement for {topic}-{partition}:{len(selected)}: {selected} -> {replacements}"
+        )
+        self.logger.info(
+            f"new assignments for {topic}-{partition}: {assignments}")
+
+        r = admin.set_partition_replicas(topic, partition, assignments)
+
+        def status_done():
+            info = admin.get_partitions(topic, partition)
+            self.logger.info(
+                f"current assignments for {topic}-{partition}: {info}")
+            converged = self._equal_assignments(info["replicas"], assignments)
+            return converged and info["status"] == "done"
+
+        # wait until redpanda reports complete
+        wait_until(status_done, timeout_sec=90, backoff_sec=2)
+
+        def derived_done():
+            info = self._get_current_partitions(admin, topic, partition)
+            self.logger.info(
+                f"derived assignments for {topic}-{partition}: {info}")
+            return self._equal_assignments(info, assignments)
+
+        wait_until(derived_done, timeout_sec=90, backoff_sec=2)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -19,6 +19,7 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
+from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.services.honey_badger import HoneyBadger
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.kaf_producer import KafProducer
@@ -31,7 +32,7 @@ PARTITION_MOVEMENT_LOG_ERRORS = [
 ]
 
 
-class PartitionMovementTest(EndToEndTest):
+class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     """
     Basic partition movement tests. Each test builds a number of topics and then
     performs a series of random replica set changes. After each change a
@@ -53,119 +54,6 @@ class PartitionMovementTest(EndToEndTest):
             },
             **kwargs)
         self._ctx = ctx
-
-    @staticmethod
-    def _random_partition(metadata):
-        topic = random.choice(metadata)
-        partition = random.choice(topic["partitions"])
-        return topic["topic"], partition["partition"]
-
-    @staticmethod
-    def _choose_replacement(admin, assignments):
-        """
-        Does not produce assignments that contain duplicate nodes. This is a
-        limitation in redpanda raft implementation.
-        """
-        replication_factor = len(assignments)
-        node_ids = lambda x: set([a["node_id"] for a in x])
-
-        assert replication_factor >= 1
-        assert len(node_ids(assignments)) == replication_factor
-
-        # remove random assignment(s). we allow no changes to be made to
-        # exercise the code paths responsible for dealing with no-ops.
-        num_replacements = random.randint(0, replication_factor)
-        selected = random.sample(assignments, num_replacements)
-        for assignment in selected:
-            assignments.remove(assignment)
-
-        # choose a valid random replacement
-        replacements = []
-        brokers = admin.get_brokers()
-        while len(assignments) != replication_factor:
-            broker = random.choice(brokers)
-            node_id = broker["node_id"]
-            if node_id in node_ids(assignments):
-                continue
-            core = random.randint(0, broker["num_cores"] - 1)
-            replacement = dict(node_id=node_id, core=core)
-            assignments.append(replacement)
-            replacements.append(replacement)
-
-        return selected, replacements
-
-    @staticmethod
-    def _get_assignments(admin, topic, partition):
-        res = admin.get_partitions(topic, partition)
-
-        def normalize(a):
-            return dict(node_id=a["node_id"], core=a["core"])
-
-        return [normalize(a) for a in res["replicas"]]
-
-    @staticmethod
-    def _equal_assignments(r0, r1):
-        def to_tuple(a):
-            return a["node_id"], a["core"]
-
-        r0 = [to_tuple(a) for a in r0]
-        r1 = [to_tuple(a) for a in r1]
-        return set(r0) == set(r1)
-
-    def _get_current_partitions(self, admin, topic, partition_id):
-        def keep(p):
-            return p["ns"] == "kafka" and p["topic"] == topic and p[
-                "partition_id"] == partition_id
-
-        result = []
-        for node in self.redpanda.nodes:
-            node_id = self.redpanda.idx(node)
-            partitions = admin.get_partitions(node=node)
-            partitions = filter(keep, partitions)
-            for partition in partitions:
-                result.append(dict(node_id=node_id, core=partition["core"]))
-        return result
-
-    def _move_and_verify(self):
-        admin = Admin(self.redpanda)
-
-        # choose a random topic-partition
-        metadata = self.client().describe_topics()
-        topic, partition = self._random_partition(metadata)
-        self.logger.info(f"selected topic-partition: {topic}-{partition}")
-
-        # get the partition's replica set, including core assignments. the kafka
-        # api doesn't expose core information, so we use the redpanda admin api.
-        assignments = self._get_assignments(admin, topic, partition)
-        self.logger.info(f"assignments for {topic}-{partition}: {assignments}")
-
-        # build new replica set by replacing a random assignment
-        selected, replacements = self._choose_replacement(admin, assignments)
-        self.logger.info(
-            f"replacement for {topic}-{partition}:{len(selected)}: {selected} -> {replacements}"
-        )
-        self.logger.info(
-            f"new assignments for {topic}-{partition}: {assignments}")
-
-        r = admin.set_partition_replicas(topic, partition, assignments)
-
-        def status_done():
-            info = admin.get_partitions(topic, partition)
-            self.logger.info(
-                f"current assignments for {topic}-{partition}: {info}")
-            converged = self._equal_assignments(info["replicas"], assignments)
-            return converged and info["status"] == "done"
-
-        # wait until redpanda reports complete
-        wait_until(status_done, timeout_sec=90, backoff_sec=2)
-
-        def derived_done():
-            info = self._get_current_partitions(admin, topic, partition)
-            self.logger.info(
-                f"derived assignments for {topic}-{partition}: {info}")
-            return self._equal_assignments(info, assignments)
-
-        wait_until(derived_done, timeout_sec=90, backoff_sec=2)
 
     @cluster(num_nodes=3)
     def test_moving_not_fully_initialized_partition(self):

--- a/tests/rptest/tests/wasm_filter_test.py
+++ b/tests/rptest/tests/wasm_filter_test.py
@@ -12,7 +12,9 @@ from rptest.services.cluster import cluster
 from ducktape.mark import ignore
 from rptest.clients.types import TopicSpec
 from rptest.wasm.wasm_build_tool import WasmTemplateRepository
-from rptest.wasm.wasm_test import WasmTest, WasmScript
+from rptest.wasm.wasm_test import WasmTest
+from rptest.wasm.wasm_script import WasmScript, random_string
+from rptest.clients.rpk import RpkTool
 from rptest.wasm.topic import construct_materialized_topic
 from rptest.wasm.native_kafka_consumer import NativeKafkaConsumer
 from ducktape.utils.util import wait_until

--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -13,7 +13,8 @@ from rptest.clients.types import TopicSpec
 from rptest.wasm.topic import construct_materialized_topic, get_source_topic
 from rptest.wasm.topics_result_set import materialized_result_set_compare
 from rptest.wasm.wasm_build_tool import WasmTemplateRepository
-from rptest.wasm.wasm_test import WasmScript, WasmTest
+from rptest.wasm.wasm_test import WasmTest
+from rptest.wasm.wasm_script import WasmScript
 from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST
 
 

--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -1,0 +1,198 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import random
+from functools import partial
+
+from rptest.services.admin import Admin
+from rptest.services.verifiable_consumer import VerifiableConsumer
+
+from ducktape.mark.resource import cluster
+from ducktape.mark import ignore
+from ducktape.utils.util import wait_until
+
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.clients.rpk import RpkTool
+
+from rptest.wasm.wasm_build_tool import WasmTemplateRepository, WasmBuildTool
+from rptest.wasm.topic import construct_materialized_topic
+from rptest.wasm.wasm_script import WasmScript
+
+from rptest.tests.partition_movement import PartitionMovementMixin
+from rptest.clients.types import TopicSpec
+
+
+class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
+    """
+    Tests to ensure that the materialized partition movement feature
+    is working as expected. This feature has materialized topics move to
+    where their respective sources are moved to.
+    """
+    def __init__(self, ctx, *args, **kvargs):
+        super(WasmPartitionMovementTest, self).__init__(
+            ctx,
+            *args,
+            extra_rp_conf={
+                # Disable leader balancer, as this test is doing its own
+                # partition movement and the balancer would interfere
+                'enable_leader_balancer': False,
+                'enable_coproc': True,
+                'developer_mode': True,
+                'auto_create_topics_enabled': False
+            },
+            **kvargs)
+        self._ctx = ctx
+        self._rpk_tool = None
+        self._build_tool = None
+        self.result_data = []
+        self.mconsumer = None
+
+    def start_redpanda_nodes(self, nodes):
+        self.start_redpanda(num_nodes=nodes)
+        self._rpk_tool = RpkTool(self.redpanda)
+        self._build_tool = WasmBuildTool(self._rpk_tool)
+
+    def restart_random_redpanda_node(self):
+        node = random.sample(self.redpanda.nodes, 1)[0]
+        self.logger.info(f"Randomly killing redpanda node: {node.name}")
+        self.redpanda.restart_nodes(node)
+
+    def _deploy_identity_copro(self, inputs, outputs):
+        script = WasmScript(inputs=inputs,
+                            outputs=outputs,
+                            script=WasmTemplateRepository.IDENTITY_TRANSFORM)
+
+        self._build_tool.build_test_artifacts(script)
+
+        self._rpk_tool.wasm_deploy(
+            script.get_artifact(self._build_tool.work_dir), script.name,
+            "ducktape")
+
+    def _verify_materialized_assignments(self, topic, partition, assignments):
+        admin = Admin(self.redpanda)
+        massignments = self._get_assignments(admin, topic, partition)
+        self.logger.info(
+            f"materialized assignments for {topic}-{partition}: {massignments}"
+        )
+
+        self._wait_post_move(topic, partition, assignments)
+
+    def _grab_input(self, topic):
+        metadata = self.client().describe_topics()
+        selected = [x for x in metadata if x['topic'] == topic]
+        assert len(selected) == 1
+        partition = random.choice(selected[0]["partitions"])
+        return selected[0]["topic"], partition["partition"]
+
+    def _on_data_consumed(self, record, node):
+        self.result_data.append(record["value"])
+
+    def _start_mconsumer(self, materialized_topic):
+        self.mconsumer = VerifiableConsumer(
+            self.test_context,
+            num_nodes=1,
+            redpanda=self.redpanda,
+            topic=materialized_topic,
+            group_id="test_group",
+            on_record_consumed=self._on_data_consumed)
+        self.mconsumer.start()
+
+    def _await_consumer(self, limit, timeout):
+        wait_until(
+            lambda: self.mconsumer.total_consumed() >= limit,
+            timeout_sec=timeout,
+            err_msg=
+            "Timeout of after %ds while awaiting delivery of %d materialized records, recieved: %d"
+            % (timeout, limit, self.mconsumer.total_consumed()))
+        self.mconsumer.stop()
+
+    def _prime_env(self):
+        output_topic = "identity_output2"
+        self.start_redpanda_nodes(3)
+        spec = TopicSpec(name="topic2",
+                         partition_count=3,
+                         replication_factor=3)
+        self.client().create_topic(spec)
+        self._deploy_identity_copro([spec.name], [output_topic])
+        self.topic = spec.name
+        self.start_producer(num_nodes=1, throughput=10000)
+        self.start_consumer(1)
+        self.await_startup(min_records=500)
+        materialized_topic = construct_materialized_topic(
+            spec.name, output_topic)
+
+        def topic_created():
+            metadata = self.client().describe_topics()
+            self.logger.info(f"metadata: {metadata}")
+            return any([x['topic'] == materialized_topic for x in metadata])
+
+        wait_until(topic_created, timeout_sec=30, backoff_sec=2)
+
+        self._start_mconsumer(materialized_topic)
+        t, p = self._grab_input(spec.name)
+        return {
+            'topic': t,
+            'partition': p,
+            'materialized_topic': materialized_topic
+        }
+
+    @cluster(num_nodes=6)
+    def test_dynamic(self):
+        """
+        Move partitions with active consumer / producer
+        """
+        s = self._prime_env()
+        for _ in range(5):
+            _, partition, assignments = self._do_move_and_verify(
+                s['topic'], s['partition'])
+            self._verify_materialized_assignments(s['materialized_topic'],
+                                                  partition, assignments)
+
+        # Vaidate input
+        self.run_validation(min_records=500,
+                            enable_idempotence=False,
+                            consumer_timeout_sec=90)
+
+        # Wait for all output
+        self._await_consumer(self.consumer.total_consumed(), 90)
+
+        # Validate number of records & their content
+        self.logger.info(
+            f'A: {self.mconsumer.total_consumed()} B: {self.consumer.total_consumed()}'
+        )
+        assert self.mconsumer.total_consumed() == self.consumer.total_consumed(
+        )
+        # Since the identity copro was deployed, contents of logs should be identical
+        assert set(self.records_consumed) == set(self.result_data)
+
+    @cluster(num_nodes=6)
+    def test_dynamic_with_failure(self):
+        s = self._prime_env()
+        _, partition, assignments = self._do_move_and_verify(
+            s['topic'], s['partition'])
+
+        # Crash a node before verifying, it has a fixed amount of seconds to restart
+        n = random.sample(self.redpanda.nodes, 1)[0]
+        self.redpanda.restart_nodes(n)
+
+        self._verify_materialized_assignments(s['materialized_topic'],
+                                              partition, assignments)
+
+        self.run_validation(min_records=500,
+                            enable_idempotence=False,
+                            consumer_timeout_sec=90)
+
+        # Wait for all output
+        self._await_consumer(self.consumer.total_consumed(), 90)
+
+        # GTE due to the fact that upon error, copro may re-processed already processed
+        # data depending on when offsets were checkpointed
+        assert self.mconsumer.total_consumed() >= self.consumer.total_consumed(
+        )

--- a/tests/rptest/wasm/wasm_script.py
+++ b/tests/rptest/wasm/wasm_script.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import string
+import uuid
+import os
+
+
+def random_string(N):
+    return ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for _ in range(N))
+
+
+class WasmScript:
+    def __init__(self, inputs=[], outputs=[], script=None):
+        self.name = random_string(10)
+        self.inputs = inputs
+        self.outputs = outputs
+        self.script = script
+        self.dir_name = str(uuid.uuid4())
+
+    def get_artifact(self, build_dir):
+        artifact = os.path.join(build_dir, self.dir_name, "dist",
+                                f"{self.dir_name}.js")
+        if not os.path.exists(artifact):
+            raise Exception(f"Artifact {artifact} was not built")
+        return artifact

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -7,16 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import os
-import uuid
-import random
-import string
-
 from kafka import TopicPartition
 
 from rptest.wasm.topic import get_source_topic
 from rptest.wasm.native_kafka_consumer import NativeKafkaConsumer
 from rptest.wasm.cli_kafka_producer import CliKafkaProducer
+from rptest.wasm.wasm_script import WasmScript
 
 from rptest.wasm.topic import construct_materialized_topic
 from rptest.wasm.wasm_build_tool import WasmBuildTool
@@ -33,28 +29,6 @@ from functools import reduce
 
 def flat_map(fn, ll):
     return reduce(lambda acc, x: acc + fn(x), ll, [])
-
-
-def random_string(N):
-    return ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for _ in range(N))
-
-
-class WasmScript:
-    def __init__(self, inputs=[], outputs=[], script=None):
-        self.name = random_string(10)
-        self.inputs = inputs
-        self.outputs = outputs
-        self.script = script
-        self.dir_name = str(uuid.uuid4())
-
-    def get_artifact(self, build_dir):
-        artifact = os.path.join(build_dir, self.dir_name, "dist",
-                                f"{self.dir_name}.js")
-        if not os.path.exists(artifact):
-            raise Exception(f"Artifact {artifact} was not built")
-        return artifact
 
 
 class WasmTest(RedpandaTest):


### PR DESCRIPTION
This pull request adds the ability for redpanda to move materialized partitions. This will not be able to be manually controlled, however will occur whenever a materialized parent topic is moved. The materialized partition will move to the exact same node/shard as its parent topic.

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/013820374467ba8e2fef5addf9a0c917fecf2fcd..a6f19951810c01be8cd0a5bc4bdd092ad77b8538)
- Remove stale code
- Removed test harness that has already been checked into dev
- Fixed bug with partitions that are restarting across nodes, restart was not occurring

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/a6f19951810c01be8cd0a5bc4bdd092ad77b8538..663025a9d9fa8e2046e0a66d3fae4908f1d2980a)
- Rebased against dev to obtain the recently checked in `coproc_cluster_fixture`

Chagnes in [force-push](https://github.com/vectorizedio/redpanda/compare/663025a9d9fa8e2046e0a66d3fae4908f1d2980a..7b6338929cb5cc11eff2817b1c376e7aedb73052)
- Fixed bug in new wasm partition movement unit test

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/7b6338929cb5cc11eff2817b1c376e7aedb73052..423385fc5c21e683fc1d5d994a4ee56733a42b91)
- Removed x-shard materialized partition move optimization
- Fixed bug where processing post move didn't start at offset 0
- Fixed bug where topic config updates during move didn't propagate to materialized topics, resulting in stale metadata.
- Fixed bug where admin-api wasn't reporting materialized topics.
- New ducktape test

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/423385fc5c21e683fc1d5d994a4ee56733a42b91..423385fc5c21e683fc1d5d994a4ee56733a42b91)
- Reverting erraneous force-push

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/423385fc5c21e683fc1d5d994a4ee56733a42b91..ebf9f17a972dac0fc2e065b65a9f5cc80907170c)
- Implemented Ben's C++ suggestions

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/ebf9f17a972dac0fc2e065b65a9f5cc80907170c..8c72568505565b2fff8d0966595bf76170b6eaf1)
- Rebased dev to resolve one line conflict in `coproc/api.h`

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/8c72568505565b2fff8d0966595bf76170b6eaf1..c8722ce73a7ebfe78bde919edaa3ef95f4eb1101)
- Fixed all of the bugs mentioned in my personal review comments below

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/c8722ce73a7ebfe78bde919edaa3ef95f4eb1101..aa2e6b28df0126829fa93fc31ade899fbb2e5600)
- Replaced use of `ss::circular_buffer<>` within reconciliation backend

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/aa2e6b28df0126829fa93fc31ade899fbb2e5600..b2754dae38ed993a367887b181e3e57b7db9d2ae)
- Rebased against dev to resolve conflicts with modifications to ducktape tests 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/b2754dae38ed993a367887b181e3e57b7db9d2ae..4b0529758d1d2f35c12dd2d8615f0960bf119dff)
- Modified git commit messages
- Replaced assert with log
- Fixed issue where code was edited in commit that had stated only a move was performed
- Added a new field in 'partition_summary' that denotes if a partition is materialized or not
- Added a new test that crashes a node in the middle of a materialized partition move

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/4b0529758d1d2f35c12dd2d8615f0960bf119dff..82eb39fbcaa5be4a9b366e28d4ba241a34bf316b)
- Removed @ignore directive on test that crashed a node during move now that #3558 has been merged