### PR TITLE
schema_registry: Prefer to pass coroutine params by value

### DIFF
--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -16,11 +16,11 @@
 
 namespace pandaproxy::schema_registry {
 
-ss::future<protobuf_schema_definition> make_protobuf_schema_definition(
-  sharded_store& store, const canonical_schema& schema);
+ss::future<protobuf_schema_definition>
+make_protobuf_schema_definition(sharded_store& store, canonical_schema schema);
 
 ss::future<canonical_schema_definition>
-validate_protobuf_schema(sharded_store& store, const canonical_schema& schema);
+validate_protobuf_schema(sharded_store& store, canonical_schema schema);
 
 ss::future<canonical_schema>
 make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema);

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -30,10 +30,10 @@ public:
     ss::future<canonical_schema> make_canonical_schema(unparsed_schema schema);
 
     ///\brief Check the schema parses with the native format
-    ss::future<void> validate_schema(const canonical_schema& schema);
+    ss::future<void> validate_schema(canonical_schema schema);
 
     ///\brief Construct a schema in the native format
-    ss::future<valid_schema> make_valid_schema(const canonical_schema& schema);
+    ss::future<valid_schema> make_valid_schema(canonical_schema schema);
 
     struct insert_result {
         schema_version version;
@@ -41,7 +41,7 @@ public:
         bool inserted;
     };
 
-    ss::future<insert_result> project_ids(const canonical_schema& schema);
+    ss::future<insert_result> project_ids(canonical_schema schema);
 
     ss::future<bool> upsert(
       seq_marker marker,


### PR DESCRIPTION
## Cover letter

Prefer to pass coroutine parameters by value:

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#cp53-parameters-to-coroutines-should-not-be-passed-by-reference

Fixes #3211 

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

### Improvements

* Schema Registry: Fix a crash during compatibility checks.
