### PR TITLE
k8s: Set 30min default cloud storage upload interval

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -282,6 +282,7 @@ func (r *ConfigMapResource) createConfiguration(
 	cr.Other["auto_create_topics_enabled"] = r.pandaCluster.Spec.Configuration.AutoCreateTopics
 	cr.Other["enable_idempotence"] = true
 	cr.Other["enable_transactions"] = true
+	cr.Other["cloud_storage_segment_max_upload_interval_sec"] = 1800 // 60s * 30 = 30 minutes
 
 	segmentSize := logSegmentSize
 	cr.LogSegmentSize = &segmentSize

--- a/src/go/k8s/tests/e2e/additional-configuration/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/additional-configuration/00-assert.yaml
@@ -14,3 +14,4 @@ collectors:
 - type: pod
   selector: app.kubernetes.io/name=redpanda
   tail: -1
+  namespace: default

--- a/src/go/k8s/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/additional-configuration/00-redpanda-cluster.yaml
@@ -4,8 +4,8 @@ metadata:
   name: additional-configuration
   namespace: default
 spec:
-  image: "localhost/redpanda"
-  version: "dev"
+  image: "vectorized/redpanda"
+  version: "v21.11.2"
   replicas: 1
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
+++ b/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
@@ -71,4 +71,5 @@ schema_registry:
     port: 8081
 EOF
 )
+echo "$actual"
 diff <(echo "$actual") <(echo "$expected")

--- a/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
+++ b/src/go/k8s/tests/e2e/additional-configuration/verify-config.sh
@@ -30,6 +30,7 @@ redpanda:
     address: additional-configuration-0.additional-configuration.default.svc.cluster.local.
     port: 33145
   auto_create_topics_enabled: false
+  cloud_storage_segment_max_upload_interval_sec: 1800
   data_directory: /var/lib/redpanda/data
   default_topic_partitions: 3
   developer_mode: true

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/00-assert.yaml
@@ -4,11 +4,3 @@ metadata:
   name: cluster-tls-node-certificate
   namespace: given-cert
 
----
-
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-collectors:
-- type: pod
-  selector: app.kubernetes.io/name=redpanda
-  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-assert.yaml
@@ -14,3 +14,4 @@ collectors:
 - type: pod
   selector: app.kubernetes.io/name=redpanda
   tail: -1
+  namespace: given-cert

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/00-assert.yaml
@@ -3,12 +3,3 @@ kind: Secret
 metadata:
   name: cluster-tls-secret-node-certificate
   namespace: cert-manager
-
----
-
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-collectors:
-- type: pod
-  selector: app.kubernetes.io/name=redpanda
-  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-assert.yaml
@@ -14,3 +14,4 @@ collectors:
 - type: pod
   selector: app.kubernetes.io/name=redpanda
   tail: -1
+  namespace: given-cert-secret

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/00-assert.yaml
@@ -32,12 +32,3 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
-
----
-
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-collectors:
-- type: pod
-  selector: app.kubernetes.io/name=redpanda
-  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/00-assert.yaml
@@ -32,12 +32,3 @@ status:
     - reason: Ready
       status: "True"
       type: Ready
-
----
-
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-collectors:
-- type: pod
-  selector: app.kubernetes.io/name=redpanda
-  tail: -1

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/00-current-image.yaml
@@ -23,7 +23,7 @@ metadata:
   name: update-image-cluster-and-node-port
 spec:
   image: "vectorized/redpanda"
-  version: "v21.6.6"
+  version: "v21.11.1"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-assert.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
+    image: "vectorized/redpanda:v21.11.2"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir
@@ -36,7 +36,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
+    image: "vectorized/redpanda:v21.11.2"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/01-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/01-new-image-and-pv.yaml
@@ -12,7 +12,7 @@ kind: Cluster
 metadata:
   name: update-image-cluster-and-node-port
 spec:
-  version: "v21.10.1-si-beta14"
+  version: "v21.11.2"
   cloudStorage:
     enabled: true
     accessKey: XXX

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.6.6"
+  version: "v21.11.1"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-assert.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
+    image: "vectorized/redpanda:v21.11.2"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir
@@ -40,7 +40,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
+    image: "vectorized/redpanda:v21.11.2"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth/01-new-image-and-pv.yaml
@@ -12,7 +12,7 @@ kind: Cluster
 metadata:
   name: up-img
 spec:
-  version: "v21.10.1-si-beta14"
+  version: "v21.11.2"
   cloudStorage:
     enabled: true
     accessKey: XXX

--- a/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/00-current-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: up-img
 spec:
   image: "vectorized/redpanda"
-  version: "v21.6.6"
+  version: "v21.11.1"
   replicas: 2
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-assert.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
+    image: "vectorized/redpanda:v21.11.2"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir
@@ -38,7 +38,7 @@ metadata:
 spec:
   containers:
   - name: redpanda
-    image: "vectorized/redpanda:v21.10.1-si-beta14"
+    image: "vectorized/redpanda:v21.11.2"
     volumeMounts:
     - mountPath: /etc/redpanda
       name: config-dir

--- a/src/go/k8s/tests/e2e/update-image-tls/01-new-image-and-pv.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls/01-new-image-and-pv.yaml
@@ -12,7 +12,7 @@ kind: Cluster
 metadata:
   name: up-img
 spec:
-  version: "v21.10.1-si-beta14"
+  version: "v21.11.2"
   cloudStorage:
     enabled: true
     accessKey: XXX


### PR DESCRIPTION
## Cover letter

Sets a 30-minute default cloud storage maximum upload interval (`cloud_storage_segment_max_upload_interval_sec`) for Redpanda nodes created through the Kubernetes operator.

## Release notes


* Kubernetes operator: All Redpanda nodes created through the Kubernetes operator will have a default cloud storage maximum upload interval (`cloud_storage_segment_max_upload_interval_sec`) of 30 minutes.