### PR TITLE
config: add metadata to mark secrets and redact them when logging

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -736,7 +736,7 @@ configuration::configuration()
       *this,
       "cloud_storage_secret_key",
       "AWS secret key",
-      {.visibility = visibility::user},
+      {.visibility = visibility::user, .secret = is_secret::yes},
       std::nullopt)
   , cloud_storage_region(
       *this,

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -103,7 +103,15 @@ public:
 
     operator T() const { return value(); } // NOLINT
 
-    void print(std::ostream& o) const override { o << name() << ":" << _value; }
+    void print(std::ostream& o) const override {
+        o << name() << ":";
+
+        if (is_secret() && !is_default()) {
+            o << secret_placeholder;
+        } else {
+            o << _value;
+        }
+    }
 
     // serialize the value. the key is taken from the property name at the
     // serialization point in config_store::to_json to avoid users from being

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -113,7 +113,7 @@ configuration::configuration()
       *this,
       "scram_password",
       "Password to use for SCRAM authentication mechanisms",
-      config::required::no,
+      {.secret = config::is_secret::yes},
       "") {}
 
 } // namespace kafka::client

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -129,6 +129,10 @@
           "type": "string",
           "description": "One of user|tunable|deprecated"
         },
+        "is_secret": {
+          "type": "boolean",
+          "description": "Whether this property is a secret (i.e. should not be logged)"
+        },
         "units": {
           "type": "string",
           "description": "If applicable, the units of the property (e.g. ms, bytes)",

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -614,6 +614,7 @@ void admin_server::register_cluster_config_routes() {
                 pm.visibility = ss::sstring(
                   config::to_string_view(p.get_visibility()));
                 pm.nullable = p.is_nullable();
+                pm.is_secret = p.is_secret();
 
                 if (p.is_array()) {
                     pm.type = "array";

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -548,3 +548,40 @@ class ClusterConfigTest(RedpandaTest):
 
             node = self.redpanda.nodes[i]
             assert int(node_id) == self.redpanda.idx(node)
+
+    @cluster(num_nodes=3)
+    def test_secret_redaction(self):
+        def search_log(pattern):
+            for node in self.redpanda.nodes:
+                for line in node.account.ssh_capture(
+                        f"grep \"{pattern}\" {self.redpanda.STDOUT_STDERR_CAPTURE} || true"
+                ):
+                    # We got a match
+                    self.logger.debug(
+                        f"Found {pattern} on node {node.name}: {line}")
+                    return True
+
+            # Fall through, no matches
+            return False
+
+        def set_and_search(key, value, expect_log):
+            patch_result = self.admin.patch_cluster_config(upsert={key: value})
+            self._wait_for_version_sync(patch_result['config_version'])
+
+            # Check value was/was not printed to log while applying
+            assert search_log(value) is expect_log
+
+            # Check we do/don't print on next startup
+            self.redpanda.restart_nodes(self.redpanda.nodes)
+            assert search_log(value) is expect_log
+
+        secret_key = "cloud_storage_secret_key"
+        secret_value = "ThePandaFliesTonight"
+        set_and_search(secret_key, secret_value, False)
+
+        # To avoid false negatives in the test of a secret, go through the same procedure
+        # but on a non-secret property, thereby validating that our log scanning procedure
+        # would have detected the secret if it had been printed
+        unsecret_key = "cloud_storage_api_endpoint"
+        unsecret_value = "http://nowhere"
+        set_and_search(unsecret_key, unsecret_value, True)


### PR DESCRIPTION
## Cover letter

While we don't have an encrypted secret store, we can still make an effort to handle secrets in our configuration carefully, such as by not writing them out to the log (all config properties are logged on redpanda startup).

With this change, secrets show up as `[secret]` in the log.  There is a regression test to make sure we do not accidentally start logging secret properties on startup or during config changes.

## Release notes

### Improvements

* Cloud storage key is now redacted when logging redpanda configuration
