### PR TITLE
fix oss build (seastar requires new cryptopp)

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -149,6 +149,16 @@ ExternalProject_Add(boost
     hardcode-dll-paths=true
     dll-path=@REDPANDA_DEPS_INSTALL_DIR@/lib)
 
+ExternalProject_Add(cryptopp
+  URL https://storage.googleapis.com/vectorizedio-public/dependencies/CRYPTOPP_8_5_0.tar.gz
+  URL_MD5 6d0d360b0c90e53789e626e192a49d34
+  INSTALL_DIR @REDPANDA_DEPS_INSTALL_DIR@
+  CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
+  DEPENDS ${default_depends}
+  CMAKE_ARGS
+     ${common_cmake_args}
+    -DBUILD_TESTING=OFF)
+
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/vectorizedio/seastar.git
   GIT_TAG 710d960b19529e2b60a2b3df2d51003f9ea91f2b
@@ -171,7 +181,7 @@ ExternalProject_Add(seastar
     -DSeastar_CXX_DIALECT=c++20
     -DSeastar_UNUSED_RESULT_ERROR=ON
   INSTALL_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --target install
-  DEPENDS ${default_depends} boost)
+  DEPENDS ${default_depends} boost cryptopp)
 
 ExternalProject_Add(HdrHistogram
   URL https://storage.googleapis.com/vectorizedio-public/dependencies/HdrHistogram_c-0.11.2.tar.gz


### PR DESCRIPTION
The updated Seastar versions requires a new CryptoPP. This is not available from the apt package manager on Ubuntu 20.04. This PR adds the version of CryptoPP from vtools to the oss build and makes it compile on Ubuntu 20.04.
