### PR TITLE
redpanda: clean up spurious errors in log, and add test infrastructure for detecting unexpected errors.

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2294,10 +2294,12 @@ ss::future<> consensus::maybe_commit_configuration(ss::semaphore_units<> u) {
         return replicate_configuration(std::move(u), std::move(latest_cfg))
           .then([this, contains_current](std::error_code ec) {
               if (ec) {
-                  vlog(
-                    _ctxlog.error,
-                    "unable to replicate updated configuration - {}",
-                    ec);
+                  if (ec != errc::shutting_down) {
+                      vlog(
+                        _ctxlog.error,
+                        "unable to replicate updated configuration: {}",
+                        ec.message());
+                  }
                   return;
               }
               // leader was removed, step down.

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -89,7 +89,7 @@ struct errc_category final : public std::error_category {
         case errc::replicate_batcher_cache_error:
             return "unable to append batch to replicate batcher cache";
         case errc::group_not_exists:
-            return "raft group does not exists on target broker";
+            return "raft group does not exist on target broker";
         case errc::replicate_first_stage_exception:
             return "unable to finish replicate since exception was thrown in "
                    "first phase";

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import functools
+
+from ducktape.mark.resource import ClusterUseMetadata
+from ducktape.mark._mark import Mark
+
+
+def cluster(**kwargs):
+    """
+    Drop-in replacement for Ducktape `cluster` that imposes additional
+    redpanda-specific checks and defaults.
+
+    These go into a decorator rather than setUp/tearDown methods
+    because they may raise errors that we would like to expose
+    as test failures.
+    """
+    def cluster_use_metadata_adder(f):
+        Mark.mark(f, ClusterUseMetadata(**kwargs))
+
+        @functools.wraps(f)
+        def wrapped(self, *args, **kwargs):
+            f(self, *args, **kwargs)
+
+        wrapped.marks = f.marks
+        wrapped.mark_names = f.mark_names
+
+        return wrapped
+
+    return cluster_use_metadata_adder

--- a/tests/rptest/tests/acls_test.py
+++ b/tests/rptest/tests/acls_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 from rptest.tests.redpanda_test import RedpandaTest
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
 from rptest.clients.kafka_cli_tools import KafkaCliTools, ClusterAuthorizationError
 

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -10,7 +10,7 @@
 import random
 import string
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.mark import parametrize
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -7,7 +7,7 @@
 # https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
 
 from rptest.clients.kafka_cat import KafkaCat
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.archival.s3_client import S3Client
 from rptest.services.redpanda import RedpandaService

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -32,6 +32,15 @@ import re
 
 NTP = namedtuple("NTP", ['ns', 'topic', 'partition', 'revision'])
 
+# Log errors expected when connectivity between redpanda and the S3
+# backend is disrupted
+CONNECTION_ERROR_LOGS = [
+    "archival - .*Failed to create archivers",
+
+    # e.g. archival - [fiber1] - service.cc:484 - Failed to upload 3 segments out of 4
+    r"archival - .*Failed to upload \d+ segments"
+]
+
 
 class ValidationError(Exception):
     pass
@@ -216,7 +225,7 @@ class ArchivalTest(RedpandaTest):
         self.kafka_tools.produce(self.topic, 10000, 1024)
         validate(self._quick_verify, self.logger, 90)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
     def test_isolate(self):
         """Verify that our isolate/rejoin facilities actually work"""
         with firewall_blocked(self.redpanda.nodes, self._get_s3_endpoint_ip()):
@@ -236,7 +245,7 @@ class ArchivalTest(RedpandaTest):
                 assert topic_manifest_id == keys[0], \
                     f"Bucket should be empty or contain only {topic_manifest_id}, but contains {keys[0]}"
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
     def test_reconnect(self):
         """Disconnect redpanda from S3, write data, connect redpanda to S3
         and check that the data is uploaded"""
@@ -248,7 +257,7 @@ class ArchivalTest(RedpandaTest):
             # will even try to upload new segments
         validate(self._quick_verify, self.logger, 90)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
     def test_one_node_reconnect(self):
         """Disconnect one redpanda node from S3, write data, connect redpanda to S3
         and check that the data is uploaded"""
@@ -262,7 +271,7 @@ class ArchivalTest(RedpandaTest):
             # will even try to upload new segments
         validate(self._quick_verify, self.logger, 90)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
     def test_connection_drop(self):
         """Disconnect redpanda from S3 during the active upload, restore connection
         and check that everything is uploaded"""
@@ -274,7 +283,7 @@ class ArchivalTest(RedpandaTest):
             # will even try to upload new segments
         validate(self._quick_verify, self.logger, 90)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
     def test_connection_flicker(self):
         """Disconnect redpanda from S3 during the active upload for short period of time
         during upload and check that everything is uploaded"""
@@ -400,7 +409,7 @@ class ArchivalTest(RedpandaTest):
 
         validate(check_upload, self.logger, 90)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
     def test_retention_archival_coordination(self):
         """
         Test that only archived segments can be evicted and that eviction

--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -13,7 +13,7 @@ from rptest.clients.default import DefaultClient
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.services.failure_injector import FailureSpec
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
 from rptest.tests.e2e_finjector import EndToEndFinjectorTest
 
 
@@ -33,7 +33,7 @@ class AvailabilityTests(EndToEndFinjectorTest):
                             producer_timeout_sec=producer_timeout_sec,
                             consumer_timeout_sec=consumer_timeout_sec)
 
-    @cluster(num_nodes=5)
+    @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_availability_when_one_node_failed(self):
         self.redpanda = RedpandaService(
             self.test_context,
@@ -60,7 +60,7 @@ class AvailabilityTests(EndToEndFinjectorTest):
 
         self.validate_records()
 
-    @cluster(num_nodes=5)
+    @cluster(num_nodes=5, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_recovery_after_catastrophic_failure(self):
 
         self.redpanda = RedpandaService(

--- a/tests/rptest/tests/availability_test.py
+++ b/tests/rptest/tests/availability_test.py
@@ -9,8 +9,8 @@
 
 import random
 
-from ducktape.mark.resource import cluster
 from rptest.clients.default import DefaultClient
+from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.services.failure_injector import FailureSpec
 from rptest.services.redpanda import RedpandaService

--- a/tests/rptest/tests/bytes_sent_test.py
+++ b/tests/rptest/tests/bytes_sent_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.clients.kafka_cli_tools import KafkaCliTools

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -17,7 +17,7 @@ import tempfile
 from rptest.services.admin import Admin
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 BOOTSTRAP_CONFIG = {

--- a/tests/rptest/tests/compacted_term_rolled_recovery_test.py
+++ b/tests/rptest/tests/compacted_term_rolled_recovery_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/compacted_topic_verifier_test.py
+++ b/tests/rptest/tests/compacted_topic_verifier_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from ducktape.errors import DucktapeError
 

--- a/tests/rptest/tests/compaction_recovery_test.py
+++ b/tests/rptest/tests/compaction_recovery_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/compatibility/franzgo_test.py
+++ b/tests/rptest/tests/compatibility/franzgo_test.py
@@ -7,8 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
-
+from rptest.services.cluster import cluster
 from rptest.services.compatibility.example_runner import ExampleRunner
 import rptest.services.compatibility.franzgo_examples as FranzGoExamples
 from rptest.tests.redpanda_test import RedpandaTest

--- a/tests/rptest/tests/compatibility/kafka_streams_test.py
+++ b/tests/rptest/tests/compatibility/kafka_streams_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.services.compatibility.example_runner import ExampleRunner

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 
 import random
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.services.rpk_producer import RpkProducer

--- a/tests/rptest/tests/configuration_update_test.py
+++ b/tests/rptest/tests/configuration_update_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.services.redpanda import RedpandaService

--- a/tests/rptest/tests/controller_recovery_test.py
+++ b/tests/rptest/tests/controller_recovery_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.tests.redpanda_test import RedpandaTest

--- a/tests/rptest/tests/create_partitions_test.py
+++ b/tests/rptest/tests/create_partitions_test.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 import random
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
 

--- a/tests/rptest/tests/custom_topic_assignment_test.py
+++ b/tests/rptest/tests/custom_topic_assignment_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.clients.rpk import RpkTool

--- a/tests/rptest/tests/data_policy_test.py
+++ b/tests/rptest/tests/data_policy_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.types import TopicSpec
 

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -9,7 +9,7 @@
 import random
 
 from ducktape.utils.util import wait_until
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda import RedpandaService

--- a/tests/rptest/tests/fetch_after_deletion_test.py
+++ b/tests/rptest/tests/fetch_after_deletion_test.py
@@ -7,13 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from rptest.services.cluster import cluster
-from ducktape.mark import parametrize
-from ducktape.tests.test import Test
 import json
 
+from ducktape.mark import parametrize
+
+from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
-from rptest.services.redpanda import RedpandaService
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.default import DefaultClient
 from rptest.clients.rpk import RpkTool
@@ -24,10 +24,20 @@ from rptest.util import (
 )
 
 
-class FetchAfterDeleteTest(Test):
+class FetchAfterDeleteTest(RedpandaTest):
     def __init__(self, test_context):
-        super(FetchAfterDeleteTest, self).__init__(test_context)
-        self.scale = Scale(test_context)
+        self.segment_size = 1048576
+        super(FetchAfterDeleteTest,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf={
+                                 "log_compaction_interval_ms": 5000,
+                                 "log_segment_size": self.segment_size,
+                                 "enable_leader_balancer": False,
+                             })
+
+    def setUp(self):
+        # Override parent's setUp so that we can start redpanda later
+        pass
 
     @cluster(num_nodes=3)
     @parametrize(transactions_enabled=True)
@@ -37,31 +47,24 @@ class FetchAfterDeleteTest(Test):
         """
         Test fetching when consumer offset was deleted by retention
         """
-        segment_size = 1048576
-        self.redpanda = RedpandaService(self.test_context,
-                                        3,
-                                        extra_rp_conf={
-                                            "enable_transactions":
-                                            transactions_enabled,
-                                            "enable_idempotence":
-                                            transactions_enabled,
-                                            "log_compaction_interval_ms": 5000,
-                                            "log_segment_size": segment_size,
-                                            "enable_leader_balancer": False,
-                                        })
+
+        self.redpanda._extra_rp_conf[
+            "enable_transactions"] = transactions_enabled
+        self.redpanda._extra_rp_conf[
+            "enable_idempotence"] = transactions_enabled
         self.redpanda.start()
+
         topic = TopicSpec(partition_count=1,
                           replication_factor=3,
                           cleanup_policy=TopicSpec.CLEANUP_DELETE)
         DefaultClient(self.redpanda).create_topic(topic)
-        self.topic = topic.name
 
         kafka_tools = KafkaCliTools(self.redpanda)
 
         # produce until segments have been compacted
         produce_until_segments(
             self.redpanda,
-            topic=self.topic,
+            topic=topic.name,
             partition_idx=0,
             count=10,
         )
@@ -70,7 +73,7 @@ class FetchAfterDeleteTest(Test):
 
         def consume(n=1):
 
-            out = rpk.consume(self.topic, group=consumer_group, n=n)
+            out = rpk.consume(topic.name, group=consumer_group, n=n)
             split = out.split('}')
             split = filter(lambda s: "{" in s, split)
 
@@ -83,16 +86,16 @@ class FetchAfterDeleteTest(Test):
 
         # change retention time
         kafka_tools.alter_topic_config(
-            self.topic, {
-                TopicSpec.PROPERTY_RETENTION_BYTES: 2 * segment_size,
+            topic.name, {
+                TopicSpec.PROPERTY_RETENTION_BYTES: 2 * self.segment_size,
             })
 
         wait_for_segments_removal(self.redpanda,
-                                  self.topic,
+                                  topic.name,
                                   partition_idx=0,
                                   count=5)
 
-        partitions = list(rpk.describe_topic(self.topic))
+        partitions = list(rpk.describe_topic(topic.name))
         p = partitions[0]
         assert p.start_offset > offset
         # consume from the offset that doesn't exists,

--- a/tests/rptest/tests/fetch_after_deletion_test.py
+++ b/tests/rptest/tests/fetch_after_deletion_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.mark import parametrize
 from ducktape.tests.test import Test
 import json

--- a/tests/rptest/tests/fetch_fairness_test.py
+++ b/tests/rptest/tests/fetch_fairness_test.py
@@ -9,7 +9,7 @@
 
 from collections import defaultdict
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.mark import parametrize
 
 from rptest.clients.kcl import KCL

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -11,7 +11,7 @@ import time
 import requests
 import random
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/kafka_cli_client_compat_test.py
+++ b/tests/rptest/tests/kafka_cli_client_compat_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -11,7 +11,7 @@ import collections
 import random
 import time
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
 

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -12,6 +12,7 @@ import random
 import time
 
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
 
@@ -133,7 +134,7 @@ class AutomaticLeadershipBalancingTest(RedpandaTest):
         leaders = (p["leader"] for p in topic["partitions"])
         return collections.Counter(leaders)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_automatic_rebalance(self):
         def all_partitions_present(num_nodes, per_node=None):
             leaders = self._get_leaders_by_node()

--- a/tests/rptest/tests/librdkafka_test.py
+++ b/tests/rptest/tests/librdkafka_test.py
@@ -10,7 +10,7 @@
 import subprocess
 import os
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.mark import matrix, ignore
 
 from ducktape.tests.test import Test

--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -6,9 +6,10 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-import ducktape.errors
-from ducktape.mark.resource import cluster
 
+import ducktape.errors
+
+from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin
 

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -11,19 +11,29 @@ import json
 import random
 
 from rptest.services.cluster import cluster
-from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
 from rptest.clients.default import DefaultClient
 from rptest.clients.types import TopicSpec
 
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.http_server import HttpServer
 from rptest.services.redpanda import RedpandaService
 
 
-class MetricsReporterTest(Test):
+class MetricsReporterTest(RedpandaTest):
     def __init__(self, test_ctx):
         self._ctx = test_ctx
-        super(MetricsReporterTest, self).__init__(test_context=test_ctx)
+        self.http = HttpServer(self._ctx)
+        super(MetricsReporterTest, self).__init__(
+            test_context=test_ctx,
+            extra_rp_conf={
+                "health_monitor_tick_interval": 1000,
+                # report every two seconds
+                "metrics_reporter_tick_interval": 2000,
+                "metrics_reporter_report_interval": 1000,
+                "enable_metrics_reporter": True,
+                "metrics_reporter_url": f"{self.http.url}/metrics",
+            })
 
     """
     Validates key availability properties of the system using a single
@@ -37,20 +47,7 @@ class MetricsReporterTest(Test):
         returned in round robin fashion
         """
         # setup http server
-        http = HttpServer(self._ctx)
-        http.start()
-        # report every two seconds
-        extra_conf = {
-            "health_monitor_tick_interval": 1000,
-            "metrics_reporter_tick_interval": 2000,
-            "metrics_reporter_report_interval": 1000,
-            "enable_metrics_reporter": True,
-            "metrics_reporter_url": f"{http.url}/metrics",
-        }
-        self.redpanda = RedpandaService(self.test_context,
-                                        3,
-                                        extra_rp_conf=extra_conf)
-
+        self.http.start()
         self.redpanda.start()
 
         total_topics = 5
@@ -67,14 +64,14 @@ class MetricsReporterTest(Test):
         )
 
         def _state_up_to_date():
-            if http.requests:
-                r = json.loads(http.requests[-1]['body'])
+            if self.http.requests:
+                r = json.loads(self.http.requests[-1]['body'])
                 return r['topic_count'] == total_topics
             return False
 
         wait_until(_state_up_to_date, 20, backoff_sec=1)
-        http.stop()
-        metadata = [json.loads(r['body']) for r in http.requests]
+        self.http.stop()
+        metadata = [json.loads(r['body']) for r in self.http.requests]
         for m in metadata:
             self.redpanda.logger.info(m)
 

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -10,7 +10,7 @@
 import json
 import random
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
 from rptest.clients.default import DefaultClient

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -13,7 +13,7 @@ import time
 import requests
 
 from ducktape.mark import parametrize
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kcl import KCL

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -21,7 +21,7 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.default import DefaultClient
 from rptest.services.admin import Admin
 from rptest.services.failure_injector import FailureInjector, FailureSpec
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService, CHAOS_LOG_ALLOW_LIST
 from rptest.tests.end_to_end import EndToEndTest
 
 DECOMMISSION = "decommission"
@@ -112,7 +112,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
     nodes
     """
 
-    @cluster(num_nodes=7)
+    @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @parametrize(enable_failures=True)
     @parametrize(enable_failures=False)
     def test_node_opeartions(self, enable_failures):

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -15,6 +15,7 @@ from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST
 
 
 class NodesDecommissioningTest(EndToEndTest):
@@ -59,7 +60,7 @@ class NodesDecommissioningTest(EndToEndTest):
 
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
 
-    @cluster(num_nodes=6)
+    @cluster(num_nodes=6, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def test_decommissioning_crashed_node(self):
 
         self.start_redpanda(num_nodes=4)

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -9,7 +9,7 @@
 
 import random
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -11,7 +11,7 @@ import http.client
 import json
 import uuid
 import requests
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.mark import ignore
 from ducktape.utils.util import wait_until
 

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -11,7 +11,7 @@ import random
 import time
 import requests
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
 import requests

--- a/tests/rptest/tests/prefix_truncate_recovery_test.py
+++ b/tests/rptest/tests/prefix_truncate_recovery_test.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.mark import matrix
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/prefix_truncate_recovery_test.py
+++ b/tests/rptest/tests/prefix_truncate_recovery_test.py
@@ -16,6 +16,12 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.admin import Admin
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+
+LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [
+    # raft - [follower: {id: {1}, revision: {9}}] [group_id:1, {kafka/topic-xyeyqcbyxi/0}] - recovery_stm.cc:422 - recovery append entries error: rpc::errc::exponential_backoff
+    "raft - .*recovery append entries error"
+]
 
 
 class PrefixTruncateRecoveryTest(RedpandaTest):
@@ -83,7 +89,7 @@ class PrefixTruncateRecoveryTest(RedpandaTest):
         self.kafka_tools.produce(self.topic, 1024, 1024, acks=acks)
         return False
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=LOG_ALLOW_LIST)
     @matrix(acks=[-1, 1], start_empty=[True, False])
     def test_prefix_truncate_recovery(self, acks, start_empty):
         # cover boundary conditions of partition being empty/non-empty

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -12,7 +12,6 @@ import time
 import re
 import random
 
-from ducktape.mark.resource import cluster
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 
@@ -24,6 +23,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.kaf_producer import KafProducer
 from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
 
 ELECTION_TIMEOUT = 10
 

--- a/tests/rptest/tests/raft_availability_test.py
+++ b/tests/rptest/tests/raft_availability_test.py
@@ -24,8 +24,15 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.services.kaf_producer import KafProducer
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 
 ELECTION_TIMEOUT = 10
+
+# Logs that may appear when a node is network-isolated
+ISOLATION_LOG_ALLOW_LIST = [
+    # rpc - server.cc:91 - vectorized internal rpc protocol - Error[shutting down] remote address: 10.89.0.16:60960 - std::__1::system_error (error system:32, sendmsg: Broken pipe)
+    "rpc - .*Broken pipe",
+]
 
 
 class MetricCheckFailed(Exception):
@@ -475,7 +482,7 @@ class RaftAvailabilityTest(RedpandaTest):
         producer.wait()
         producer.free()
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_follower_isolation(self):
         """
         Simplest HA test.  Stop the leader for our partition.  Validate that

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -12,7 +12,7 @@ import re
 import zipfile
 import json
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.tests.redpanda_test import RedpandaTest

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -7,8 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
-
+from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk_remote import RpkRemoteTool
 from rptest.services.redpanda import RedpandaService

--- a/tests/rptest/tests/rpk_topic_test.py
+++ b/tests/rptest/tests/rpk_topic_test.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 
 from ducktape.utils.util import wait_until
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 import ducktape.errors
 
 from rptest.tests.redpanda_test import RedpandaTest

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -15,7 +15,7 @@ import time
 import random
 import os
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.services.background_thread import BackgroundThreadService
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/scram_pythonlib_test.py
+++ b/tests/rptest/tests/scram_pythonlib_test.py
@@ -6,7 +6,8 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-from ducktape.mark.resource import cluster
+
+from rptest.services.cluster import cluster
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -10,7 +10,7 @@ import random
 import string
 import requests
 import time
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.archival.s3_client import S3Client
 from rptest.clients.rpk import RpkTool

--- a/tests/rptest/tests/simple_e2e_test.py
+++ b/tests/rptest/tests/simple_e2e_test.py
@@ -6,7 +6,8 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-from ducktape.mark.resource import cluster
+
+from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.tests.end_to_end import EndToEndTest
 

--- a/tests/rptest/tests/topic_autocreate_test.py
+++ b/tests/rptest/tests/topic_autocreate_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -6,7 +6,7 @@
 #
 # https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.mark import ignore
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.archival.s3_client import S3Client

--- a/tests/rptest/tests/tx_feature_flag_test.py
+++ b/tests/rptest/tests/tx_feature_flag_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.clients.kafka_cat import KafkaCat
 
 from rptest.clients.types import TopicSpec
@@ -15,7 +16,7 @@ from rptest.tests.end_to_end import EndToEndTest
 
 
 class TxFeatureFlagTest(EndToEndTest):
-    @cluster(num_nodes=6)
+    @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_disabling_transactions_after_they_being_used(self):
         '''
         Validate that transactions can be safely disabled after 

--- a/tests/rptest/tests/tx_feature_flag_test.py
+++ b/tests/rptest/tests/tx_feature_flag_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from rptest.clients.kafka_cat import KafkaCat
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/tx_reads_writes_test.py
+++ b/tests/rptest/tests/tx_reads_writes_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.errors import DucktapeError
 
 from rptest.tests.redpanda_test import RedpandaTest

--- a/tests/rptest/tests/tx_verifier_test.py
+++ b/tests/rptest/tests/tx_verifier_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.errors import DucktapeError
 
 from rptest.tests.redpanda_test import RedpandaTest

--- a/tests/rptest/tests/tx_verifier_test.py
+++ b/tests/rptest/tests/tx_verifier_test.py
@@ -15,6 +15,13 @@ from rptest.clients.rpk import RpkTool
 
 import subprocess
 
+# Expected log errors in tests that test misbehaving
+# transactional clients.
+TX_ERROR_LOGS = [
+    # e.g. cluster - rm_stm.cc:370 - Can't prepare pid:{producer_identity: id=1, epoch=27} - unknown session
+    "cluster - rm_stm.*unknown session"
+]
+
 
 class TxVerifierTest(RedpandaTest):
     """
@@ -69,7 +76,7 @@ class TxVerifierTest(RedpandaTest):
         if len(errors) > 0:
             raise DucktapeError(errors)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=TX_ERROR_LOGS)
     def test_all_tx_tests(self):
         self.verify([
             "init", "tx", "txes", "abort", "commuting-txes", "conflicting-tx",

--- a/tests/rptest/tests/wait_for_local_consumer_test.py
+++ b/tests/rptest/tests/wait_for_local_consumer_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec

--- a/tests/rptest/tests/wasm_filter_test.py
+++ b/tests/rptest/tests/wasm_filter_test.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0
 
 from kafka import TopicPartition
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.mark import ignore
 from rptest.clients.types import TopicSpec
 from rptest.wasm.wasm_build_tool import WasmTemplateRepository

--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -14,6 +14,7 @@ from rptest.wasm.topic import construct_materialized_topic, get_source_topic
 from rptest.wasm.topics_result_set import materialized_result_set_compare
 from rptest.wasm.wasm_build_tool import WasmTemplateRepository
 from rptest.wasm.wasm_test import WasmScript, WasmTest
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST
 
 
 class WasmIdentityTest(WasmTest):
@@ -66,7 +67,7 @@ class WasmIdentityTest(WasmTest):
         return materialized_result_set_compare
 
     @ignore  # https://github.com/vectorizedio/redpanda/issues/2514
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     def verify_materialized_topics_test(self):
         """
         Entry point for all tests, asynchronously we perform the following:

--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from ducktape.mark import ignore
 from rptest.clients.types import TopicSpec
 from rptest.wasm.topic import construct_materialized_topic, get_source_topic

--- a/tests/rptest/tests/wasm_topics_test.py
+++ b/tests/rptest/tests/wasm_topics_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from ducktape.mark.resource import cluster
+from rptest.services.cluster import cluster
 from rptest.tests.wasm_identity_test import WasmIdentityTest
 
 


### PR DESCRIPTION
## Cover letter

It's important for our customers and our own SREs that Redpanda avoids logging "ERROR" level messages that are not really errors.

This PR:
- Improves redpanda logging in cases of easily identifiable log spam, such as logging errors on gate_closed during shutdown
- Introduces a new redpanda-specific `@cluster` test decorator that enables us to do uniform end-of-test checks
- Cut over to using our own `@cluster` in all existing ducktape tests
- Create a `raise_on_bad_logs` method on RedpandaService, and call it from `@cluster` at end of tests.
- Add allow-lists to existing tests that trigger errors.

It's not perfect: we still log more errors than we should on innocuous things like the connections that drop when something restarts.  But it's good to get this kind of testing in as early as possible, because it'll make sure all functionality we add doesn't include spurious log errors.

Related: https://github.com/vectorizedio/redpanda/issues/2691

## Release notes

### Improvements

* Remove some misleading error-level log messages that occurred during node shutdown