### PR TITLE
Add gobal shadow indexing flags

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -340,7 +340,10 @@ scheduler_service_impl::create_archivers(std::vector<model::ntp> to_create) {
                       auto part = _partition_manager.local().get(ntp);
                       if (
                         !log.has_value() || !part
-                        || !part->get_ntp_config().is_archival_enabled()) {
+                        || !(
+                          part->get_ntp_config().is_archival_enabled()
+                          || config::shard_local_cfg()
+                               .cloud_storage_enable_remote_read())) {
                           return ss::now();
                       }
                       auto svc = ss::make_lw_shared<ntp_archiver>(

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/archival_metadata_stm.h"
 
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
@@ -272,7 +273,9 @@ ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
 }
 
 model::offset archival_metadata_stm::max_collectible_offset() {
-    if (!_raft->log_config().is_archival_enabled()) {
+    if (
+      !_raft->log_config().is_archival_enabled()
+      && !config::shard_local_cfg().cloud_storage_enable_remote_write.value()) {
         // The archival is disabled but the state machine still exists so we
         // shouldn't stop eviction from happening.
         return model::offset::max();

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -200,4 +200,17 @@ std::optional<std::chrono::milliseconds>
 metadata_cache::get_default_retention_duration() const {
     return config::shard_local_cfg().delete_retention_ms();
 }
+
+model::shadow_indexing_mode
+metadata_cache::get_default_shadow_indexing_mode() const {
+    model::shadow_indexing_mode m = model::shadow_indexing_mode::disabled;
+    if (config::shard_local_cfg().cloud_storage_enable_remote_write()) {
+        m = model::shadow_indexing_mode::archival;
+    }
+    if (config::shard_local_cfg().cloud_storage_enable_remote_read()) {
+        m = model::add_shadow_indexing_flag(
+          m, model::shadow_indexing_mode::fetch);
+    }
+    return m;
+}
 } // namespace cluster

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/types.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/timestamp.h"
 #include "seastarx.h"
@@ -137,6 +138,7 @@ public:
     std::optional<size_t> get_default_retention_bytes() const;
     std::optional<std::chrono::milliseconds>
     get_default_retention_duration() const;
+    model::shadow_indexing_mode get_default_shadow_indexing_mode() const;
 
 private:
     ss::sharded<topic_table>& _topics_state;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -19,6 +19,7 @@
 #include "cluster/rm_stm.h"
 #include "cluster/tm_stm.h"
 #include "cluster/types.h"
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record_batch_reader.h"
@@ -212,7 +213,9 @@ public:
     /// Return true if shadow indexing is enabled for the partition
     bool is_remote_fetch_enabled() const {
         const auto& cfg = _raft->log_config();
-        return cfg.is_remote_fetch_enabled();
+        return cfg.is_remote_fetch_enabled()
+               || config::shard_local_cfg()
+                    .cloud_storage_enable_remote_read.value();
     }
 
     /// Check if cloud storage is connected to cluster partition

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -276,28 +276,24 @@ void incremental_update(
   property_update<std::optional<model::shadow_indexing_mode>> override) {
     switch (override.op) {
     case incremental_update_operation::remove:
-        // remove override, fallback to default
-        if (property) {
-            property = override.value ? model::drop_shadow_indexing_flag(
-                         *property, *override.value)
-                                      : model::shadow_indexing_mode::disabled;
-            if (property.value() == model::shadow_indexing_mode::disabled) {
-                property = std::nullopt;
-            }
-        } else {
+        if (!override.value || !property) {
+            break;
+        }
+        // It's guaranteed that the remove operation will only be
+        // used with one of the 'drop_' flags.
+        property = model::add_shadow_indexing_flag(*property, *override.value);
+        if (*property == model::shadow_indexing_mode::disabled) {
             property = std::nullopt;
         }
         return;
     case incremental_update_operation::set:
         // set new value
-        if (property) {
-            property = override.value ? model::add_shadow_indexing_flag(
-                         *property, *override.value)
-                                      : model::shadow_indexing_mode::disabled;
-        } else {
-            property = override.value ? *override.value
-                                      : model::shadow_indexing_mode::disabled;
+        if (!override.value) {
+            break;
         }
+        property = model::add_shadow_indexing_flag(
+          property ? *property : model::shadow_indexing_mode::disabled,
+          *override.value);
         return;
     case incremental_update_operation::none:
         // do nothing

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -689,6 +689,18 @@ configuration::configuration()
       "Enable archival storage",
       {.visibility = visibility::user},
       false)
+  , cloud_storage_enable_remote_read(
+      *this,
+      "cloud_storage_enable_remote_read",
+      "Enable remote read for all topics",
+      {.visibility = visibility::tunable},
+      false)
+  , cloud_storage_enable_remote_write(
+      *this,
+      "cloud_storage_enable_remote_write",
+      "Enable remote write for all topics",
+      {.visibility = visibility::tunable},
+      false)
   , cloud_storage_access_key(
       *this,
       "cloud_storage_access_key",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -161,6 +161,8 @@ struct configuration final : public config_store {
 
     // Archival storage
     property<bool> cloud_storage_enabled;
+    property<bool> cloud_storage_enable_remote_read;
+    property<bool> cloud_storage_enable_remote_write;
     property<std::optional<ss::sstring>> cloud_storage_access_key;
     property<std::optional<ss::sstring>> cloud_storage_secret_key;
     property<std::optional<ss::sstring>> cloud_storage_region;

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -527,13 +527,13 @@ ss::future<response_ptr> describe_configs_handler::handle(
               resource,
               result,
               topic_property_remote_read,
-              false,
+              model::is_fetch_enabled(
+                ctx.metadata_cache().get_default_shadow_indexing_mode()),
               topic_property_remote_read,
-              (topic_config->properties.shadow_indexing
-               == model::shadow_indexing_mode::full)
-                  || (topic_config->properties.shadow_indexing == model::shadow_indexing_mode::fetch)
-                ? std::make_optional(true)
-                : std::make_optional(false),
+              topic_config->properties.shadow_indexing.has_value()
+                ? std::make_optional(model::is_fetch_enabled(
+                  *topic_config->properties.shadow_indexing))
+                : std::nullopt,
               request.data.include_synonyms,
               &describe_as_string<bool>);
 
@@ -541,13 +541,13 @@ ss::future<response_ptr> describe_configs_handler::handle(
               resource,
               result,
               topic_property_remote_write,
-              false,
+              model::is_archival_enabled(
+                ctx.metadata_cache().get_default_shadow_indexing_mode()),
               topic_property_remote_write,
-              (topic_config->properties.shadow_indexing
-               == model::shadow_indexing_mode::full)
-                  || (topic_config->properties.shadow_indexing == model::shadow_indexing_mode::archival)
-                ? std::make_optional(true)
-                : std::make_optional(false),
+              topic_config->properties.shadow_indexing.has_value()
+                ? std::make_optional(model::is_archival_enabled(
+                  *topic_config->properties.shadow_indexing))
+                : std::nullopt,
               request.data.include_synonyms,
               &describe_as_string<bool>);
 

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -89,18 +89,18 @@ static void parse_and_set_shadow_indexing_mode(
   model::shadow_indexing_mode enabled_value) {
     switch (op) {
     case config_resource_operation::remove:
-        simode.value = std::nullopt;
         simode.op = cluster::incremental_update_operation::remove;
+        simode.value = model::negate_shadow_indexing_flag(enabled_value);
         break;
     case config_resource_operation::set:
+        simode.op = cluster::incremental_update_operation::set;
         simode.value
-          = string_switch<std::optional<model::shadow_indexing_mode>>(*value)
-              .match("no", std::nullopt)
-              .match("false", std::nullopt)
+          = string_switch<model::shadow_indexing_mode>(*value)
+              .match("no", model::negate_shadow_indexing_flag(enabled_value))
+              .match("false", model::negate_shadow_indexing_flag(enabled_value))
               .match("yes", enabled_value)
               .match("true", enabled_value)
-              .default_match(std::nullopt);
-        simode.op = cluster::incremental_update_operation::set;
+              .default_match(model::shadow_indexing_mode::disabled);
         break;
     case config_resource_operation::append:
     case config_resource_operation::subtract:

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -64,9 +64,9 @@ get_bool_value(const config_map_t& config, std::string_view key) {
     return std::nullopt;
 }
 
-static model::shadow_indexing_mode
+static std::optional<model::shadow_indexing_mode>
 get_shadow_indexing_mode(const config_map_t& config) {
-    model::shadow_indexing_mode mode = model::shadow_indexing_mode::disabled;
+    std::optional<model::shadow_indexing_mode> mode;
     auto arch_enabled = get_bool_value(config, topic_property_remote_write);
     if (arch_enabled && *arch_enabled) {
         mode = model::shadow_indexing_mode::archival;

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -381,6 +381,15 @@ std::ostream& operator<<(std::ostream& o, const shadow_indexing_mode& si) {
     case shadow_indexing_mode::full:
         o << "full";
         break;
+    case shadow_indexing_mode::drop_archival:
+        o << "drop_archival";
+        break;
+    case shadow_indexing_mode::drop_fetch:
+        o << "drop_fetch";
+        break;
+    case shadow_indexing_mode::drop_full:
+        o << "drop_full";
+        break;
     }
     return o;
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -159,6 +159,10 @@ class RpkTool:
         cmd = ['alter-config', topic, "--set", f"{set_key}={set_value}"]
         self._run_topic(cmd)
 
+    def delete_topic_config(self, topic, key):
+        cmd = ['alter-config', topic, "--delete", key]
+        self._run_topic(cmd)
+
     def consume(self,
                 topic,
                 n=None,

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -138,6 +138,23 @@ class RpkTool:
 
         return filter(lambda p: p != None, map(partition_line, lines))
 
+    def describe_topic_configs(self, topic):
+        cmd = ['describe', topic, '-c']
+        output = self._run_topic(cmd)
+        if "not found" in output:
+            return None
+        lines = output.splitlines()
+        res = {}
+        for line in lines:
+            try:
+                key, value, source = line.split()
+                if key == "KEY":
+                    continue
+                res[key] = value, source
+            except:
+                pass
+        return res
+
     def alter_topic_config(self, topic, set_key, set_value):
         cmd = ['alter-config', topic, "--set", f"{set_key}={set_value}"]
         self._run_topic(cmd)

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -44,6 +44,8 @@ class EndToEndShadowIndexingTest(EndToEndTest):
         self.topic = EndToEndShadowIndexingTest.s3_topic_name
         self._extra_rp_conf = dict(
             cloud_storage_enabled=True,
+            cloud_storage_enable_remote_read=True,
+            cloud_storage_enable_remote_write=True,
             cloud_storage_access_key=EndToEndShadowIndexingTest.s3_access_key,
             cloud_storage_secret_key=EndToEndShadowIndexingTest.s3_secret_key,
             cloud_storage_region=EndToEndShadowIndexingTest.s3_region,
@@ -79,9 +81,6 @@ class EndToEndShadowIndexingTest(EndToEndTest):
         self.s3_client.empty_bucket(self.s3_bucket_name)
         self.s3_client.create_bucket(self.s3_bucket_name)
         self.redpanda.start()
-        for topic in self.topics:
-            rpk.alter_topic_config(topic.name, 'redpanda.remote.write', 'true')
-            rpk.alter_topic_config(topic.name, 'redpanda.remote.read', 'true')
 
     def tearDown(self):
         self.s3_client.empty_bucket(self.s3_bucket_name)


### PR DESCRIPTION
## Cover letter

This PR adds global flags that enable shadow indexing for all topics:
- `cloud_storage_enable_remote_read` is similar to `redpanda.remote.read` and enables fetching from cloud storage
- `cloud_storage_enable_remote_write` is similar to `redpanda.remote.write` and enables uploading to cloud storage

If shadow indexing is disabled in the config topic level configurations can be used to enable it for a topic.
If shadow indexing is enabled in the config topic level configuration can be used to disable it for a topic.

## Release notes


* Add cluster level configuration parameters `cloud_storage_enable_remote_read` and `cloud_storage_enable_remote_write` that can be used to enable shadow indexing for all topics

### Features

* Cluster level configuration parameter `cloud_storage_enable_remote_read` can be used to enable shadow indexing fetch for all topics (disabled by default).
* Cluster level configuration parameter `cloud_storage_enable_remote_write` can be used to enable archival uploads for all topics (disabled by default).

### Improvements

* Adds cluster level configuration for shadow indexing
