### PR TITLE
Kafka: improve logging for authorization errors

### DIFF
--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -74,27 +74,28 @@ public:
           security::principal_type::user, std::move(user));
 
         bool authorized = _proto.authorizer().authorized(
-          name,
-          operation,
-          std::move(principal),
-          security::acl_host(_client_addr));
+          name, operation, principal, security::acl_host(_client_addr));
 
         if (!authorized) {
             if (quiet) {
                 vlog(
                   _authlog.debug,
-                  "proto: {}, sasl state: {}, acl op: {}, resource: {}",
+                  "proto: {}, sasl state: {}, acl op: {}, principal: {}, "
+                  "resource: {}",
                   _proto.name(),
                   security::sasl_state_to_str(_sasl.state()),
                   operation,
+                  principal,
                   name);
             } else {
                 vlog(
                   _authlog.info,
-                  "proto: {}, sasl state: {}, acl op: {}, resource: {}",
+                  "proto: {}, sasl state: {}, acl op: {}, principal: {}, "
+                  "resource: {}",
                   _proto.name(),
                   security::sasl_state_to_str(_sasl.state()),
                   operation,
+                  principal,
                   name);
             }
         }

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -201,8 +201,14 @@ get_topic_metadata(request_context& ctx, metadata_request& request) {
           topics.begin(),
           topics.end(),
           [&ctx](const model::topic_metadata& t_md) {
+              /*
+               * quiet authz failures. this isn't checking for a specifically
+               * requested topic, but rather checking visibility of all topics.
+               */
               return ctx.authorized(
-                security::acl_operation::describe, t_md.tp_ns.tp);
+                security::acl_operation::describe,
+                t_md.tp_ns.tp,
+                authz_quiet{true});
           });
         std::transform(
           topics.begin(),

--- a/src/v/kafka/server/handlers/offset_fetch.cc
+++ b/src/v/kafka/server/handlers/offset_fetch.cc
@@ -64,8 +64,14 @@ offset_fetch_handler::handle(request_context ctx, ss::smp_service_group) {
           resp.data.topics.begin(),
           resp.data.topics.end(),
           [&ctx](const offset_fetch_response_topic& topic) {
+              /*
+               * quiet authz failures. this is checking for visibility across
+               * all topics not specifically requested topics.
+               */
               return ctx.authorized(
-                security::acl_operation::describe, topic.name);
+                security::acl_operation::describe,
+                topic.name,
+                authz_quiet{true});
           });
         resp.data.topics.erase(unauthorized, resp.data.topics.end());
 

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -170,8 +170,11 @@ public:
     }
 
     template<typename T>
-    bool authorized(security::acl_operation operation, const T& name) {
-        return _conn->authorized(operation, name);
+    bool authorized(
+      security::acl_operation operation,
+      const T& name,
+      authz_quiet quiet = authz_quiet{false}) {
+        return _conn->authorized(operation, name, quiet);
     }
 
     cluster::security_frontend& security_frontend() const {


### PR DESCRIPTION
## Cover letter

Improve authorization logging:

1. Logs at debug level for authorization failures that are expected (e.g. when performing authorization to establish client visibility rather than authorizing for a specific resource requested by a client).
2. Logs the authenticated principal when authorization fails

Fixes: #3235

## Release notes

### Improvements

1. Logs at debug level for authorization failures that are expected (e.g. when performing authorization to establish client visibility rather than authorizing for a specific resource requested by a client).
2. Logs the authenticated principal when authorization fails
