### PR TITLE
cmake: Use official download repositories.

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -118,7 +118,7 @@ else ()
 endif()
 ExternalProject_Add(boost
   # Boost outcome is only installed on boost 1.70.0+
-  URL https://storage.googleapis.com/vectorizedio-public/dependencies/boost_1_75_0.tar.gz
+  URL https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz
   URL_MD5 38813f6feb40387dfe90160debd71251
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   PATCH_COMMAND
@@ -150,8 +150,11 @@ ExternalProject_Add(boost
     dll-path=@REDPANDA_DEPS_INSTALL_DIR@/lib)
 
 ExternalProject_Add(cryptopp
-  URL https://storage.googleapis.com/vectorizedio-public/dependencies/CRYPTOPP_8_5_0.tar.gz
-  URL_MD5 6d0d360b0c90e53789e626e192a49d34
+  URL https://github.com/weidai11/cryptopp/archive/refs/tags/CRYPTOPP_8_5_0.tar.gz
+  URL_MD5 5968e6014dc6ae5199e3987fb39cf8d3
+  PATCH_COMMAND
+    COMMAND curl -s -o CMakeLists.txt https://raw.githubusercontent.com/noloader/cryptopp-cmake/CRYPTOPP_8_5_0/CMakeLists.txt
+    COMMAND curl -s -o cryptopp-config.cmake https://raw.githubusercontent.com/noloader/cryptopp-cmake/CRYPTOPP_8_5_0/cryptopp-config.cmake
   INSTALL_DIR @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   DEPENDS ${default_depends}
@@ -184,7 +187,7 @@ ExternalProject_Add(seastar
   DEPENDS ${default_depends} boost cryptopp)
 
 ExternalProject_Add(HdrHistogram
-  URL https://storage.googleapis.com/vectorizedio-public/dependencies/HdrHistogram_c-0.11.2.tar.gz
+  URL https://github.com/HdrHistogram/HdrHistogram_c/archive/refs/tags/0.11.2.tar.gz
   URL_MD5 95970dea64f1a7a8d199aeb9f7c15e60
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -27,7 +27,7 @@ docker run \
 If you need rebuild the toolchain image locally:
 
 ```bash
-docker build \
+DOCKER_BUILDKIT=1 docker build \
   -t vectorized/redpanda-toolchain \
   -f tools/docker/Dockerfile \
   .


### PR DESCRIPTION
## Cover letter

* Switch `Boost`, `CryptoPP`, and `HdrHistogram` to official upstream repositories.
* Improve command line to ensure `tools/docker/Dockerfile.ignore` is used.

## Release notes

* none
