### PR TITLE
.github: fix labels on new enhancement tickets

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: 🚀 Feature request
 about: Suggest an enhancement to Redpanda
-labels: "kind/enhancement"
+labels: "kind/enhance"
 ---
 
 ### Who is this for and what problem do they have today?


### PR DESCRIPTION
## Cover letter

If the template's label doesn't match the existing
label (which was kind/enhance) then the issue is
created with no labels.

## Release notes

* none
