### PR TITLE
Fixed deriving initial revision of x-core moved NTP

### DIFF
--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -142,12 +142,16 @@ ss::future<> metadata_dissemination_service::start() {
 void metadata_dissemination_service::handle_leadership_notification(
   model::ntp ntp, model::term_id term, std::optional<model::node_id> lid) {
     (void)ss::with_gate(_bg, [this, ntp = std::move(ntp), lid, term]() mutable {
-        return container().invoke_on(
-          0,
-          [ntp = std::move(ntp), lid, term](
-            metadata_dissemination_service& s) mutable {
-              return s.apply_leadership_notification(std::move(ntp), term, lid);
-          });
+        // the lock sequences the updates from raft
+        return _lock.with([this, ntp = std::move(ntp), lid, term]() mutable {
+            return container().invoke_on(
+              0,
+              [ntp = std::move(ntp), lid, term](
+                metadata_dissemination_service& s) mutable {
+                  return s.apply_leadership_notification(
+                    std::move(ntp), term, lid);
+              });
+        });
     });
 }
 
@@ -156,21 +160,18 @@ ss::future<> metadata_dissemination_service::apply_leadership_notification(
     // the gate also needs to be taken on the destination core.
     return ss::with_gate(
       _bg, [this, ntp = std::move(ntp), lid, term]() mutable {
-          // the lock sequences the updates from raft
-          return _lock.with([this, ntp = std::move(ntp), lid, term]() mutable {
-              // update partition leaders
-              auto f = _leaders.invoke_on_all(
-                [ntp, lid, term](partition_leaders_table& leaders) {
-                    leaders.update_partition_leader(ntp, term, lid);
-                });
-              if (lid == _self.id()) {
-                  // only disseminate from current leader
-                  f = f.then([this, ntp = std::move(ntp), term, lid]() mutable {
-                      return disseminate_leadership(std::move(ntp), term, lid);
-                  });
-              }
-              return f;
-          });
+          // update partition leaders
+          auto f = _leaders.invoke_on_all(
+            [ntp, lid, term](partition_leaders_table& leaders) {
+                leaders.update_partition_leader(ntp, term, lid);
+            });
+          if (lid == _self.id()) {
+              // only disseminate from current leader
+              f = f.then([this, ntp = std::move(ntp), term, lid]() mutable {
+                  return disseminate_leadership(std::move(ntp), term, lid);
+              });
+          }
+          return f;
       });
 }
 


### PR DESCRIPTION
## Cover letter

Fixed deriving initial revision of cross core moved partition. When partition is moved cross core and `controller_backend` is bootstrapping we need to correctly identify the revision that the partition was created with for the first time on a given node. 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #2246

## Release notes

### Improvements
- Fixes a corner case that might happen when partition was re-balanced



