### PR TITLE
V21.11.x backport pr3232: Abort transactions with same pid but older epoch when detected

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -247,9 +247,32 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(
 
     // checking / setting pid fencing
     auto fence_it = _log_state.fence_pid_epoch.find(pid.get_id());
-    if (
-      fence_it == _log_state.fence_pid_epoch.end()
-      || pid.get_epoch() > fence_it->second) {
+    auto is_new_pid = fence_it == _log_state.fence_pid_epoch.end();
+    if (is_new_pid || pid.get_epoch() > fence_it->second) {
+        if (!is_new_pid && pid.get_epoch() > fence_it->second) {
+            auto old_pid = model::producer_identity{
+              .id = pid.get_id(), .epoch = fence_it->second};
+            // there is a fence, it might be that tm_stm failed, forget about
+            // an ongoing transaction, assigned next pid for the same tx.id and
+            // started a new transaction without aborting the previous one.
+            //
+            // at the same time it's possible that it already aborted the old
+            // tx before starting this. do_abort_tx is idempotent so calling it
+            // just in case to proactivly abort the tx instead of waiting for
+            // the timeout
+            //
+            // moreover do_abort_tx is co-idempotent with do_commit_tx so if a
+            // tx was committed calling do_abort_tx will do nothing
+            auto ar = co_await do_abort_tx(
+              old_pid, std::nullopt, _sync_timeout);
+            if (ar == tx_errc::stale) {
+                co_return tx_errc::stale;
+            }
+            if (ar != tx_errc::none) {
+                co_return tx_errc::unknown_server_error;
+            }
+        }
+
         auto batch = make_fence_batch(
           rm_stm::fence_control_record_version, pid);
         auto reader = model::make_memory_record_batch_reader(std::move(batch));
@@ -588,10 +611,11 @@ ss::future<tx_errc> rm_stm::abort_tx(
 
 // abort_tx is invoked strictly after a tx is canceled on the tm_stm
 // the purpose of abort is to put tx_range into the list of aborted txes
-// and to fence off the old epoch
+// and to fence off the old epoch.
+// we need to check tx_seq to filter out stale requests
 ss::future<tx_errc> rm_stm::do_abort_tx(
   model::producer_identity pid,
-  model::tx_seq tx_seq,
+  std::optional<model::tx_seq> tx_seq,
   model::timeout_clock::duration timeout) {
     // doesn't make sense to fence off an abort because transaction
     // manager has already decided to abort and acked to a client
@@ -610,23 +634,26 @@ ss::future<tx_errc> rm_stm::do_abort_tx(
         co_return tx_errc::none;
     }
 
-    auto origin = get_abort_origin(pid, tx_seq);
-    if (origin == abort_origin::past) {
-        // rejecting a delayed abort command to prevent aborting
-        // a wrong transaction
-        co_return tx_errc::request_rejected;
-    }
-    if (origin == abort_origin::future) {
-        // impossible situation: before transactional coordinator may issue
-        // abort of the current transaction it should begin it and abort all
-        // previous transactions with the same pid
-        vlog(
-          clusterlog.error,
-          "Rejecting abort (pid:{}, tx_seq: {}) because it isn't consistent "
-          "with the current ongoing transaction",
-          pid,
-          tx_seq);
-        co_return tx_errc::request_rejected;
+    if (tx_seq) {
+        auto origin = get_abort_origin(pid, tx_seq.value());
+        if (origin == abort_origin::past) {
+            // rejecting a delayed abort command to prevent aborting
+            // a wrong transaction
+            co_return tx_errc::request_rejected;
+        }
+        if (origin == abort_origin::future) {
+            // impossible situation: before transactional coordinator may issue
+            // abort of the current transaction it should begin it and abort all
+            // previous transactions with the same pid
+            vlog(
+              clusterlog.error,
+              "Rejecting abort (pid:{}, tx_seq: {}) because it isn't "
+              "consistent "
+              "with the current ongoing transaction",
+              pid,
+              tx_seq.value());
+            co_return tx_errc::request_rejected;
+        }
     }
 
     // preventing prepare and replicte once we

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -306,6 +306,7 @@ private:
         absl::flat_hash_map<model::producer_identity, prepare_marker> preparing;
         absl::flat_hash_map<model::producer_identity, expiration_info>
           expiration;
+        model::offset last_end_tx{-1};
 
         void forget(model::producer_identity pid) {
             expected.erase(pid);

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -192,7 +192,9 @@ private:
     ss::future<tx_errc> do_commit_tx(
       model::producer_identity, model::tx_seq, model::timeout_clock::duration);
     ss::future<tx_errc> do_abort_tx(
-      model::producer_identity, model::tx_seq, model::timeout_clock::duration);
+      model::producer_identity,
+      std::optional<model::tx_seq>,
+      model::timeout_clock::duration);
     ss::future<> apply_snapshot(stm_snapshot_header, iobuf&&) override;
     ss::future<stm_snapshot> take_snapshot() override;
     ss::future<std::optional<abort_snapshot>> load_abort_snapshot(abort_index);


### PR DESCRIPTION
## Cover letter

Backport #3232

## Release notes

Fixes a consistency issue with transactions