### PR TITLE
Creating a new multi node text fixture for coproc

### DIFF
--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -68,7 +68,7 @@ public:
         set_configuration("disable_metrics", true);
     }
 
-    ~cluster_test_fixture() {
+    virtual ~cluster_test_fixture() {
         std::filesystem::remove_all(std::filesystem::path(_base_dir));
     }
 

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set(fixture_srcs
     utils/supervisor.cc
     utils/wasm_event_generator.cc
     utils/batch_utils.cc
+    fixtures/coproc_cluster_fixture.cc
     fixtures/coproc_test_fixture.cc
     fixtures/coproc_bench_fixture.cc
     fixtures/fiber_mock_fixture.cc

--- a/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc_cluster_fixture.h"
+
+#include "coproc/tests/utils/event_publisher_utils.h"
+
+coproc_cluster_fixture::coproc_cluster_fixture() noexcept
+  : cluster_test_fixture()
+  , coproc_api_fixture() {
+    set_configuration("enable_coproc", true);
+}
+
+ss::future<>
+coproc_cluster_fixture::enable_coprocessors(std::vector<deploy> copros) {
+    std::vector<coproc::script_id> ids;
+    std::vector<ss::future<>> wait;
+    std::transform(
+      copros.cbegin(),
+      copros.cend(),
+      std::back_inserter(ids),
+      [](const deploy& d) { return coproc::script_id(d.id); });
+    co_await coproc_api_fixture::enable_coprocessors(std::move(copros));
+    auto node_ids = get_node_ids();
+    co_await ss::parallel_for_each(
+      node_ids, [this, ids](const model::node_id& node_id) {
+          application* app = get_node_application(node_id);
+          return ss::parallel_for_each(ids, [this, app](coproc::script_id id) {
+              return coproc::wasm::wait_for_copro(
+                app->coprocessing->get_pacemaker(), id);
+          });
+      });
+}
+
+application* coproc_cluster_fixture::create_node_application(
+  model::node_id node_id,
+  int kafka_port,
+  int rpc_port,
+  int proxy_port,
+  int schema_reg_port,
+  int coproc_supervisor_port) {
+    application* app = cluster_test_fixture::create_node_application(
+      node_id,
+      kafka_port,
+      rpc_port,
+      proxy_port,
+      schema_reg_port,
+      coproc_supervisor_port);
+    _instances.emplace(
+      node_id,
+      std::make_unique<supervisor_test_fixture>(
+        coproc_supervisor_port + node_id()));
+    return app;
+}
+
+std::vector<model::node_id> coproc_cluster_fixture::get_node_ids() {
+    std::vector<model::node_id> ids;
+    std::transform(
+      _instances.cbegin(),
+      _instances.cend(),
+      std::back_inserter(ids),
+      [](const auto& p) { return p.first; });
+    return ids;
+}

--- a/src/v/coproc/tests/fixtures/coproc_cluster_fixture.h
+++ b/src/v/coproc/tests/fixtures/coproc_cluster_fixture.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/tests/cluster_test_fixture.h"
+#include "coproc/tests/fixtures/coproc_test_fixture.h"
+#include "coproc/tests/fixtures/supervisor_test_fixture.h"
+
+#include <absl/container/flat_hash_map.h>
+
+/// A cluster_test_fixture with a kafka::client and convienence methods from
+/// coproc_api_fixture useful for multi-node coproc unit tests
+class coproc_cluster_fixture
+  : public cluster_test_fixture
+  , public coproc_api_fixture {
+public:
+    using wasm_ptr = std::unique_ptr<supervisor_test_fixture>;
+
+    /// Class constructor
+    ///
+    /// Calls superclass constructors and ensures 'enable_coproc' is true
+    coproc_cluster_fixture() noexcept;
+
+    /// Calls coproc_api_fixture superclass method with same name
+    ///
+    /// Additionally this method waits until the coprocessors are deployed
+    /// within the coproc::pacemaker on all instances of rp that belong to the
+    /// cluster_test_fixture
+    ss::future<> enable_coprocessors(std::vector<deploy>);
+
+    /// Calls cluster_test_fixture superclass method with same name
+    ///
+    /// Additionally instantiates an instance of the wasm engine used for
+    /// testing and places it in the \ref instances map
+    application* create_node_application(
+      model::node_id node_id,
+      int kafka_port = 9092,
+      int rpc_port = 11000,
+      int proxy_port = 8082,
+      int schema_reg_port = 8081,
+      int coproc_supervisor_port = 43189);
+
+private:
+    std::vector<model::node_id> get_node_ids();
+
+private:
+    absl::flat_hash_map<model::node_id, wasm_ptr> _instances;
+};

--- a/src/v/coproc/tests/fixtures/supervisor_test_fixture.h
+++ b/src/v/coproc/tests/fixtures/supervisor_test_fixture.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "coproc/tests/utils/supervisor.h"
 #include "rpc/test/rpc_integration_fixture.h"
+#include "vassert.h"
 
 /// Use this test fixture when you want to start a coproc::supervisor up.
 /// Optionally query the internal state of the c++ 'wasm' engine with the
@@ -28,9 +29,16 @@ public:
           })
           .get();
         _coprocessors.start().get();
-        register_service<coproc::supervisor>(
-          std::ref(_coprocessors), std::ref(_delay_heartbeat));
-        start_server();
+        try {
+            register_service<coproc::supervisor>(
+              std::ref(_coprocessors), std::ref(_delay_heartbeat));
+            start_server();
+        } catch (const std::exception& ex) {
+            vassert(
+              false,
+              "Exception in supervisor_test_fixture constructor: {}",
+              ex);
+        }
     }
 
     ~supervisor_test_fixture() override {

--- a/src/v/coproc/tests/fixtures/supervisor_test_fixture.h
+++ b/src/v/coproc/tests/fixtures/supervisor_test_fixture.h
@@ -19,8 +19,8 @@
 /// provided methods
 class supervisor_test_fixture : public rpc_sharded_integration_fixture {
 public:
-    supervisor_test_fixture()
-      : rpc_sharded_integration_fixture(43189) {
+    explicit supervisor_test_fixture(uint32_t port = 43189)
+      : rpc_sharded_integration_fixture(port) {
         configure_server();
         _delay_heartbeat.start().get();
         _delay_heartbeat

--- a/src/v/coproc/tests/utils/event_publisher_utils.h
+++ b/src/v/coproc/tests/utils/event_publisher_utils.h
@@ -9,6 +9,7 @@
  */
 
 #pragma once
+#include "coproc/types.h"
 #include "kafka/client/client.h"
 #include "model/record_batch_reader.h"
 
@@ -28,5 +29,8 @@ publish_events(kafka::client::client&, model::record_batch_reader);
 /// Performs additional validation ensuring that the topic is created with the
 /// expected parameters, if validation fails, this will assert
 ss::future<> create_coproc_internal_topic(kafka::client::client&);
+
+/// Resolves when \ref id is fully registered within the fixtures pacemaker
+ss::future<> wait_for_copro(ss::sharded<coproc::pacemaker>&, coproc::script_id);
 
 } // namespace coproc::wasm

--- a/src/v/rpc/test/rpc_integration_fixture.h
+++ b/src/v/rpc/test/rpc_integration_fixture.h
@@ -96,13 +96,11 @@ class rpc_base_integration_fixture {
 public:
     explicit rpc_base_integration_fixture(uint16_t port)
       : _listen_address("127.0.0.1", port)
-      , _ssg(ss::create_smp_service_group({5000}).get0()) {
-        _sg = ss::create_scheduling_group("rpc scheduling group", 200).get0();
-    }
+      , _ssg(ss::create_smp_service_group({5000}).get0())
+      , _sg(ss::default_scheduling_group()) {}
 
     virtual ~rpc_base_integration_fixture() {
         destroy_smp_service_group(_ssg).get0();
-        destroy_scheduling_group(_sg).get0();
     }
 
     virtual void start_server() = 0;
@@ -156,6 +154,7 @@ public:
       std::optional<ss::tls::credentials_builder> credentials = std::nullopt,
       ss::tls::reload_callback&& cb = {}) override {
         rpc::server_configuration scfg("unit_test_rpc");
+        scfg.disable_metrics = rpc::metrics_disabled::yes;
         auto resolved = rpc::resolve_dns(_listen_address).get();
         scfg.addrs.emplace_back(
           resolved,
@@ -203,6 +202,7 @@ public:
       std::optional<ss::tls::credentials_builder> credentials = std::nullopt,
       ss::tls::reload_callback&& cb = {}) override {
         rpc::server_configuration scfg("unit_test_rpc_sharded");
+        scfg.disable_metrics = rpc::metrics_disabled::yes;
         auto resolved = rpc::resolve_dns(_listen_address).get();
         scfg.addrs.emplace_back(
           resolved,


### PR DESCRIPTION
These changes are opened in a separate pull request then from the work that depends on them for more then one reason. Firstly it breaks out the complexity of this into a separate PR, and more importantly this work will be dependent on two concurrent coproc pull requests, the first being the materialized partition movement PR #3212 and the other being the work on autocreation of materialized topics #3119

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/a9ad9f083aecdbaf4b26b0dd4d8e685c97309676..5f3cf89f064ad1c6078d8262901f51e2f63cfff0)
- Use the default_scheduling_group in rpc_integration_test_fixture instead of genning a uniquely named new scheduler
- Pass `rpc::disable_metrics::yes` to all of the server configurations in the same fixture, ensuring no `enable_metrics()` methods of any generated services are called. 