### PR TITLE
pandaproxy: Improve logging

### DIFF
--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -13,6 +13,7 @@
 
 #include "kafka/client/configuration.h"
 #include "kafka/client/exceptions.h"
+#include "kafka/client/logger.h"
 #include "kafka/client/transport.h"
 #include "model/metadata.h"
 #include "utils/mutex.h"
@@ -57,9 +58,14 @@ public:
     template<typename T, typename Ret = typename T::api_type::response_type>
     CONCEPT(requires(KafkaApi<typename T::api_type>))
     ss::future<Ret> dispatch(T r) {
+        using api_t = typename T::api_type;
         return _gated_mutex
           .with([this, r{std::move(r)}]() mutable {
-              return _client.dispatch(std::move(r));
+              vlog(kclog.debug, "Dispatch: {} req: {}", api_t::name, r);
+              return _client.dispatch(std::move(r)).then([](Ret res) {
+                  vlog(kclog.debug, "Dispatch: {} res: ", api_t::name, res);
+                  return std::move(res);
+              });
           })
           .handle_exception_type([this](const std::bad_optional_access&) {
               // Short read

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -308,7 +308,6 @@ ss::future<fetch_response> client::fetch_partition(
       std::move(build_request),
       std::move(tp),
       [this](auto& build_request, model::topic_partition& tp) {
-          vlog(kclog.debug, "fetching: {}", tp);
           return gated_retry_with_mitigation([this, &tp, &build_request]() {
                      return _topic_cache.leader(tp)
                        .then([this](model::node_id leader) {
@@ -450,6 +449,7 @@ ss::future<kafka::fetch_response> client::consumer_fetch(
     const auto end = model::timeout_clock::now()
                      + std::min(config_timout, timeout.value_or(config_timout));
     return gated_retry_with_mitigation([this, g_id, name, end, max_bytes]() {
+        vlog(kclog.debug, "consumer_fetch: group_id: {}, name: {}", g_id, name);
         return get_consumer(g_id, name)
           .then([end, max_bytes](shared_consumer_t c) {
               auto timeout = std::max(

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -85,15 +85,19 @@ reduce_fetch_response(fetch_response result, fetch_response val) {
 } // namespace detail
 
 void consumer::start() {
-    kclog.info("Consumer: {}: start", *this);
+    vlog(kclog.info, "Consumer: {}: start", *this);
     _timer.set_callback([me{shared_from_this()}]() {
-        kclog.trace("Consumer: {}: timer cb", *me);
+        vlog(kclog.trace, "Consumer: {}: timer cb", *me);
         (void)me->heartbeat()
           .handle_exception_type([me](const consumer_error& e) {
-              kclog.error("Consumer: {}: heartbeat failed: {}", *me, e.error);
+              vlog(
+                kclog.error,
+                "Consumer: {}: heartbeat failed: {}",
+                *me,
+                e.error);
           })
           .handle_exception_type([me](const ss::gate_closed_exception& e) {
-              kclog.trace("Consumer: {}: heartbeat failed: {}", *me, e);
+              vlog(kclog.trace, "Consumer: {}: heartbeat failed: {}", *me, e);
           });
     });
     _timer.rearm_periodic(std::chrono::duration_cast<ss::timer<>::duration>(
@@ -192,7 +196,8 @@ void consumer::on_leader_join(const join_group_response& res) {
       std::unique(_subscribed_topics.begin(), _subscribed_topics.end()),
       _subscribed_topics.end());
 
-    kclog.info(
+    vlog(
+      kclog.info,
       "Consumer: {}: join: members: {}, topics: {}",
       *this,
       _members,
@@ -359,9 +364,9 @@ consumer::offset_commit(std::vector<offset_commit_request_topic> topics) {
 ss::future<fetch_response>
 consumer::dispatch_fetch(broker_reqs_t::value_type br) {
     auto& [broker, req] = br;
-    kclog.trace("Consumer: {}, fetch_req: {}", *this, req);
+    vlog(kclog.trace, "Consumer: {}, fetch_req: {}", *this, req);
     auto res = co_await broker->dispatch(std::move(req));
-    kclog.trace("Consumer: {}, fetch_res: {}", *this, res);
+    vlog(kclog.trace, "Consumer: {}, fetch_res: {}", *this, res);
 
     if (res.data.error_code != error_code::none) {
         throw broker_error(broker->id(), res.data.error_code);


### PR DESCRIPTION
## Cover letter

Improve logging:
 * Always use `vlog`
 * Add logging to handlers
 * Add request/response logging to `broker::dispatch`

This should also help diagnose: #2501

Unrelated failure:
```
Module: rptest.tests.availability_test
Class:  AvailabilityTests
Method: test_availability_when_one_node_failed
```

## Release notes
* none
