### PR TITLE
kafka/client: Only update seeds when metadata::brokers is not empty

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -116,13 +116,16 @@ ss::future<> client::update_metadata(wait_or_start::tag) {
           .then([this](shared_broker_t broker) {
               return broker->dispatch(metadata_request{.list_all_topics = true})
                 .then([this](metadata_response res) {
-                    // Create new seeds from the returned set of brokers
-                    std::vector<unresolved_address> seeds;
-                    seeds.reserve(res.data.brokers.size());
-                    for (const auto& b : res.data.brokers) {
-                        seeds.emplace_back(b.host, b.port);
+                    // Create new seeds from the returned set of brokers if
+                    // they're not empty
+                    if (!res.data.brokers.empty()) {
+                        std::vector<unresolved_address> seeds;
+                        seeds.reserve(res.data.brokers.size());
+                        for (const auto& b : res.data.brokers) {
+                            seeds.emplace_back(b.host, b.port);
+                        }
+                        std::swap(_seeds, seeds);
                     }
-                    std::swap(_seeds, seeds);
 
                     return apply(std::move(res));
                 })


### PR DESCRIPTION
## Cover letter

A bug was found during testing where if the controller isn't ready,
empty brokers can be returned.

Replacing seeds with empty brokers prevents the client from ever
connecting to the cluster.

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes
* none
