### PR TITLE
Improved suppressing heartbeats

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -27,7 +27,6 @@
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/with_timeout.hh>
 
-#include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <bits/stdint-uintn.h>
 #include <boost/range/iterator_range.hpp>
@@ -48,7 +47,7 @@ struct heartbeat_requests {
 
 static heartbeat_requests requests_for_range(
   const consensus_set& c, clock_type::duration heartbeat_interval) {
-    absl::flat_hash_map<
+    absl::btree_map<
       model::node_id,
       std::vector<std::pair<heartbeat_metadata, follower_req_seq>>>
       pending_beats;
@@ -120,12 +119,10 @@ static heartbeat_requests requests_for_range(
     reqs.reserve(pending_beats.size());
     for (auto& p : pending_beats) {
         std::vector<heartbeat_metadata> requests;
-        absl::flat_hash_map<
-          raft::group_id,
-          heartbeat_manager::follower_request_meta>
-          meta_map;
+        absl::
+          btree_map<raft::group_id, heartbeat_manager::follower_request_meta>
+            meta_map;
         requests.reserve(p.second.size());
-        meta_map.reserve(p.second.size());
         for (auto& [hb, seq] : p.second) {
             meta_map.emplace(
               hb.meta.group,
@@ -233,7 +230,7 @@ ss::future<> heartbeat_manager::do_heartbeat(node_heartbeat&& r) {
 
 void heartbeat_manager::process_reply(
   model::node_id n,
-  absl::flat_hash_map<raft::group_id, follower_request_meta> groups,
+  absl::btree_map<raft::group_id, follower_request_meta> groups,
   result<heartbeat_reply> r) {
     if (!r) {
         vlog(

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -45,11 +45,37 @@ struct heartbeat_requests {
     absl::flat_hash_set<model::node_id> reconnect_nodes;
 };
 
+heartbeat_manager::follower_request_meta::follower_request_meta(
+  consensus_ptr ptr,
+  follower_req_seq seq,
+  model::offset dirty_offset,
+  vnode target)
+  : c(std::move(ptr))
+  , seq(seq)
+  , dirty_offset(dirty_offset)
+  , follower_vnode(target) {
+    if (c->self() != follower_vnode) {
+        c->update_suppress_heartbeats(
+          follower_vnode, seq, heartbeats_suppressed::yes);
+    }
+}
+
+heartbeat_manager::follower_request_meta::~follower_request_meta() noexcept {
+    if (c) {
+        if (c->self() != follower_vnode) {
+            c->update_suppress_heartbeats(
+              follower_vnode, seq, heartbeats_suppressed::no);
+        }
+    }
+}
+
 static heartbeat_requests requests_for_range(
   const consensus_set& c, clock_type::duration heartbeat_interval) {
     absl::btree_map<
       model::node_id,
-      std::vector<std::pair<heartbeat_metadata, follower_req_seq>>>
+      std::vector<std::pair<
+        heartbeat_metadata,
+        heartbeat_manager::follower_request_meta>>>
       pending_beats;
     if (c.empty()) {
         return {};
@@ -74,8 +100,11 @@ static heartbeat_requests requests_for_range(
             // self beat is used to make sure that the protocol will make
             // progress when there is only on node
             if (rni == ptr->self()) {
+                auto hb_metadata = ptr->meta();
                 pending_beats[rni.id()].emplace_back(
-                  heartbeat_metadata{ptr->meta(), rni}, 0);
+                  heartbeat_metadata{hb_metadata, rni},
+                  heartbeat_manager::follower_request_meta(
+                    ptr, follower_req_seq(0), hb_metadata.prev_log_index, rni));
                 return;
             }
 
@@ -100,10 +129,11 @@ static heartbeat_requests requests_for_range(
             }
 
             auto seq_id = ptr->next_follower_sequence(rni);
-            ptr->update_suppress_heartbeats(
-              rni, seq_id, heartbeats_suppressed::yes);
+            auto hb_meta = ptr->meta();
             pending_beats[rni.id()].emplace_back(
-              heartbeat_metadata{ptr->meta(), ptr->self(), rni}, seq_id);
+              heartbeat_metadata{hb_meta, ptr->self(), rni},
+              heartbeat_manager::follower_request_meta(
+                ptr, seq_id, hb_meta.prev_log_index, rni));
 
             if (ptr->should_reconnect_follower(rni)) {
                 reconnect_nodes.insert(rni.id());
@@ -123,11 +153,8 @@ static heartbeat_requests requests_for_range(
           btree_map<raft::group_id, heartbeat_manager::follower_request_meta>
             meta_map;
         requests.reserve(p.second.size());
-        for (auto& [hb, seq] : p.second) {
-            meta_map.emplace(
-              hb.meta.group,
-              heartbeat_manager::follower_request_meta{
-                seq, hb.meta.prev_log_index, hb.target_node_id});
+        for (auto& [hb, follower_meta] : p.second) {
+            meta_map.emplace(hb.meta.group, std::move(follower_meta));
             requests.push_back(std::move(hb));
         }
         reqs.emplace_back(
@@ -135,7 +162,7 @@ static heartbeat_requests requests_for_range(
     }
 
     return heartbeat_requests{
-      .requests{reqs}, .reconnect_nodes{reconnect_nodes}};
+      .requests{std::move(reqs)}, .reconnect_nodes{reconnect_nodes}};
 }
 
 heartbeat_manager::heartbeat_manager(
@@ -248,8 +275,6 @@ void heartbeat_manager::process_reply(
 
             (*it)->update_heartbeat_status(req_meta.follower_vnode, false);
 
-            (*it)->update_suppress_heartbeats(
-              req_meta.follower_vnode, req_meta.seq, heartbeats_suppressed::no);
             // propagate error
             (*it)->process_append_entries_reply(
               n,
@@ -267,10 +292,9 @@ void heartbeat_manager::process_reply(
               hbeatlog.error, "Could not find consensus for group:{}", m.group);
             continue;
         }
-        auto meta = groups.find(m.group)->second;
+        auto meta = std::move(groups.find(m.group)->second);
         (*it)->update_heartbeat_status(meta.follower_vnode, true);
-        (*it)->update_suppress_heartbeats(
-          meta.follower_vnode, meta.seq, heartbeats_suppressed::no);
+
         (*it)->process_append_entries_reply(
           n,
           result<append_entries_reply>(std::move(m)),

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -24,7 +24,7 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/util/log.hh>
 
-#include <absl/container/flat_hash_map.h>
+#include <absl/container/btree_map.h>
 #include <boost/container/flat_set.hpp>
 
 namespace raft::details {
@@ -99,7 +99,7 @@ public:
         node_heartbeat(
           model::node_id t,
           heartbeat_request req,
-          absl::flat_hash_map<raft::group_id, follower_request_meta> seqs)
+          absl::btree_map<raft::group_id, follower_request_meta> seqs)
           : target(t)
           , request(std::move(req))
           , meta_map(std::move(seqs)) {}
@@ -108,7 +108,7 @@ public:
         heartbeat_request request;
         // each raft group has its own follower metadata hence we need map to
         // track a sequence per group
-        absl::flat_hash_map<raft::group_id, follower_request_meta> meta_map;
+        absl::btree_map<raft::group_id, follower_request_meta> meta_map;
     };
 
     heartbeat_manager(
@@ -144,7 +144,7 @@ private:
     /// \param result if the node return successful heartbeats
     void process_reply(
       model::node_id n,
-      absl::flat_hash_map<raft::group_id, follower_request_meta> groups,
+      absl::btree_map<raft::group_id, follower_request_meta> groups,
       result<heartbeat_reply> result);
 
     // private members

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -90,6 +90,17 @@ public:
       flat_set<consensus_ptr, details::consensus_ptr_by_group_id>;
 
     struct follower_request_meta {
+        follower_request_meta(
+          consensus_ptr, follower_req_seq, model::offset, vnode);
+        ~follower_request_meta() noexcept;
+
+        follower_request_meta(const follower_request_meta&) = delete;
+        follower_request_meta(follower_request_meta&&) noexcept = default;
+        follower_request_meta& operator=(const follower_request_meta&) = delete;
+        follower_request_meta&
+        operator=(follower_request_meta&&) noexcept = default;
+
+        consensus_ptr c;
         follower_req_seq seq;
         model::offset dirty_offset;
         vnode follower_vnode;


### PR DESCRIPTION
## Cover letter

Using RAII helper to control suppression of heartbeats when they are being sent from heartbeat manager. Object controlling heartbeat suppression is destroyed when RPC request finishes so heartbeats are enabled back after control is returned back from rpc to heartbeat manager.

Previously an exception thrown from clients `heartbeat` method would result in heartbeats not being unsuppressed. This situation is not really common since errors from RPC layer are propagated in form of `result` however in unexpected situation like `bad_alloc` exception heartbeats would never be enabled back.

### Note on testing

I created an issue #3260 to create additional honey badger 🦡 failure injection points, preferably all the points where Raft interact with other subsystems i.e. RPC, storage, etc. should be intercepted with failure injection point.

## Release notes

### Improvements

* Fixed bug that may lead to situation in which partition will not be able to elect a leader since follower heartbeats are suppressed 

