### PR TITLE
cluster: autocreate non_replicable topics

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -171,35 +171,6 @@ ss::future<> update_broker_client(
       });
 }
 
-std::vector<topic_result> create_topic_results(
-  const std::vector<model::topic_namespace>& topics, errc error_code) {
-    std::vector<topic_result> results;
-    results.reserve(topics.size());
-    std::transform(
-      std::cbegin(topics),
-      std::cend(topics),
-      std::back_inserter(results),
-      [error_code](const model::topic_namespace& t) {
-          return topic_result(t, error_code);
-      });
-    return results;
-}
-
-std::vector<topic_result> create_topic_results(
-  const std::vector<custom_assignable_topic_configuration>& requests,
-  errc error_code) {
-    std::vector<topic_result> results;
-    results.reserve(requests.size());
-    std::transform(
-      requests.cbegin(),
-      requests.cend(),
-      std::back_inserter(results),
-      [error_code](const custom_assignable_topic_configuration& r) {
-          return topic_result(r.cfg.tp_ns, error_code);
-      });
-    return results;
-}
-
 model::broker make_self_broker(const config::node_config& node_cfg) {
     auto kafka_addr = node_cfg.advertised_kafka_api();
     auto rpc_addr = node_cfg.advertised_rpc_api();

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -25,6 +25,23 @@
 
 #include <utility>
 
+namespace detail {
+
+template<typename T, typename Fn>
+std::vector<cluster::topic_result>
+create_topic_results(const std::vector<T>& topics, Fn fn) {
+    std::vector<cluster::topic_result> results;
+    results.reserve(topics.size());
+    std::transform(
+      topics.cbegin(),
+      topics.cend(),
+      std::back_inserter(results),
+      [&fn](const T& t) { return fn(t); });
+    return results;
+}
+
+} // namespace detail
+
 namespace config {
 struct configuration;
 }
@@ -47,22 +64,35 @@ CONCEPT(requires requires(const T& req) {
 // clang-format on
 std::vector<topic_result> create_topic_results(
   const std::vector<T>& requests, errc error_code) {
-    std::vector<topic_result> results;
-    results.reserve(requests.size());
-    std::transform(
-      std::cbegin(requests),
-      std::cend(requests),
-      std::back_inserter(results),
-      [error_code](const T& r) { return topic_result(r.tp_ns, error_code); });
-    return results;
+    return detail::create_topic_results(requests, [error_code](const T& r) {
+        return topic_result(r.tp_ns, error_code);
+    });
 }
 
-std::vector<topic_result> create_topic_results(
-  const std::vector<custom_assignable_topic_configuration>& requests,
-  errc error_code);
+inline std::vector<topic_result> create_topic_results(
+  const std::vector<model::topic_namespace>& topics, errc error_code) {
+    return detail::create_topic_results(
+      topics, [error_code](const model::topic_namespace& t) {
+          return topic_result(t, error_code);
+      });
+}
 
-std::vector<topic_result> create_topic_results(
-  const std::vector<model::topic_namespace>& topics, errc error_code);
+inline std::vector<topic_result> create_topic_results(
+  const std::vector<custom_assignable_topic_configuration>& requests,
+  errc error_code) {
+    return detail::create_topic_results(
+      requests, [error_code](const custom_assignable_topic_configuration& r) {
+          return topic_result(r.cfg.tp_ns, error_code);
+      });
+}
+
+inline std::vector<topic_result> create_topic_results(
+  const std::vector<non_replicable_topic>& requests, errc error_code) {
+    return detail::create_topic_results(
+      requests, [error_code](const non_replicable_topic& nrt) {
+          return topic_result(nrt.name, error_code);
+      });
+}
 
 ss::future<> update_broker_client(
   model::node_id,

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -22,6 +22,11 @@
             "output_type": "create_topics_reply"
         },
         {
+            "name": "create_non_replicable_topics",
+            "input_type": "create_non_replicable_topics_request",
+            "output_type": "create_non_replicable_topics_reply"
+        },
+        {
             "name": "finish_partition_update",
             "input_type": "finish_partition_update_request",
             "output_type": "finish_partition_update_reply"

--- a/src/v/cluster/non_replicable_topics_frontend.cc
+++ b/src/v/cluster/non_replicable_topics_frontend.cc
@@ -92,7 +92,7 @@ void non_replicable_topics_frontend::topic_creation_exception(
 
 ss::future<> non_replicable_topics_frontend::create_non_replicable_topics(
   std::vector<cluster::non_replicable_topic> topics,
-  model::timeout_clock::time_point timeout) {
+  model::timeout_clock::duration timeout) {
     std::vector<ss::future<>> all;
     std::vector<cluster::non_replicable_topic> todos;
     for (auto& topic : topics) {
@@ -107,7 +107,7 @@ ss::future<> non_replicable_topics_frontend::create_non_replicable_topics(
     }
     if (!todos.empty()) {
         auto f = _topics_frontend.local()
-                   .create_non_replicable_topics(todos, timeout)
+                   .autocreate_non_replicable_topics(todos, timeout)
                    .then(
                      [this](const std::vector<cluster::topic_result>& result) {
                          topic_creation_resolved(result);

--- a/src/v/cluster/non_replicable_topics_frontend.h
+++ b/src/v/cluster/non_replicable_topics_frontend.h
@@ -60,7 +60,7 @@ public:
     /// command completes.
     ss::future<> create_non_replicable_topics(
       std::vector<cluster::non_replicable_topic>,
-      model::timeout_clock::time_point timeout);
+      model::timeout_clock::duration timeout);
 
 private:
     void topic_creation_resolved(const std::vector<cluster::topic_result>&);

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -87,6 +87,20 @@ service::create_topics(create_topics_request&& r, rpc::streaming_context&) {
       });
 }
 
+ss::future<create_non_replicable_topics_reply>
+service::create_non_replicable_topics(
+  create_non_replicable_topics_request&& r, rpc::streaming_context&) {
+    return ss::with_scheduling_group(
+             get_scheduling_group(),
+             [this, r = std::move(r)]() mutable {
+                 return _topics_frontend.local().create_non_replicable_topics(
+                   std::move(r.topics), model::time_from_now(r.timeout));
+             })
+      .then([](std::vector<topic_result> res) {
+          return create_non_replicable_topics_reply{std::move(res)};
+      });
+}
+
 std::pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
 service::fetch_metadata_and_cfg(const std::vector<topic_result>& res) {
     std::vector<model::topic_metadata> md;

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -40,6 +40,9 @@ public:
     virtual ss::future<create_topics_reply>
     create_topics(create_topics_request&&, rpc::streaming_context&) override;
 
+    ss::future<create_non_replicable_topics_reply> create_non_replicable_topics(
+      create_non_replicable_topics_request&&, rpc::streaming_context&) final;
+
     ss::future<configuration_update_reply> update_node_configuration(
       configuration_update_request&&, rpc::streaming_context&) final;
 

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -71,7 +71,11 @@ public:
       model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_result>> create_non_replicable_topics(
-      std::vector<non_replicable_topic>, model::timeout_clock::time_point);
+      std::vector<non_replicable_topic> topics,
+      model::timeout_clock::time_point timeout);
+
+    ss::future<std::vector<topic_result>> autocreate_non_replicable_topics(
+      std::vector<non_replicable_topic>, model::timeout_clock::duration);
 
     ss::future<bool> validate_shard(model::node_id node, uint32_t shard) const;
 
@@ -94,6 +98,13 @@ private:
       model::node_id,
       std::vector<topic_configuration>,
       model::timeout_clock::duration);
+
+    ss::future<std::vector<topic_result>>
+    dispatch_create_non_replicable_to_leader(
+      model::node_id leader,
+      std::vector<non_replicable_topic> topics,
+      model::timeout_clock::duration timeout);
+
     ss::future<std::error_code> do_update_data_policy(
       topic_properties_update&, model::timeout_clock::time_point);
     ss::future<topic_result> do_update_topic_properties(

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -478,6 +478,50 @@ adl<cluster::create_topics_request>::from(iobuf_parser& in) {
     return cluster::create_topics_request{std::move(configs), timeout};
 }
 
+void adl<cluster::create_non_replicable_topics_request>::to(
+  iobuf& out, cluster::create_non_replicable_topics_request&& r) {
+    reflection::serialize(
+      out,
+      cluster::create_non_replicable_topics_request::current_version,
+      std::move(r.topics),
+      r.timeout);
+}
+
+cluster::create_non_replicable_topics_request
+adl<cluster::create_non_replicable_topics_request>::from(iobuf_parser& in) {
+    auto version = adl<int8_t>{}.from(in);
+    vassert(
+      version == cluster::create_non_replicable_topics_request::current_version,
+      "Unexpected version: {} (expected: {})",
+      version,
+      cluster::create_non_replicable_topics_request::current_version);
+    auto topics = adl<std::vector<cluster::non_replicable_topic>>().from(in);
+    auto timeout = adl<model::timeout_clock::duration>().from(in);
+    return cluster::create_non_replicable_topics_request{
+      std::move(topics), timeout};
+}
+
+void adl<cluster::create_non_replicable_topics_reply>::to(
+  iobuf& out, cluster::create_non_replicable_topics_reply&& r) {
+    reflection::serialize(
+      out,
+      cluster::create_non_replicable_topics_reply::current_version,
+      std::move(r.results));
+}
+
+cluster::create_non_replicable_topics_reply
+adl<cluster::create_non_replicable_topics_reply>::from(iobuf_parser& in) {
+    auto version = adl<int8_t>{}.from(in);
+    vassert(
+      version == cluster::create_non_replicable_topics_reply::current_version,
+      "Unexpected version: {} (expected: {})",
+      version,
+      cluster::create_non_replicable_topics_reply::current_version);
+    auto results = adl<std::vector<cluster::topic_result>>().from(in);
+    return cluster::create_non_replicable_topics_reply{
+      .results = std::move(results)};
+}
+
 void adl<cluster::create_topics_reply>::to(
   iobuf& out, cluster::create_topics_reply&& r) {
     reflection::serialize(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -767,6 +767,17 @@ struct config_status_reply {
     errc error;
 };
 
+struct create_non_replicable_topics_request {
+    static constexpr int8_t current_version = 1;
+    std::vector<non_replicable_topic> topics;
+    model::timeout_clock::duration timeout;
+};
+
+struct create_non_replicable_topics_reply {
+    static constexpr int8_t current_version = 1;
+    std::vector<topic_result> results;
+};
+
 } // namespace cluster
 namespace std {
 template<>
@@ -814,6 +825,18 @@ struct adl<cluster::create_topics_request> {
     void to(iobuf&, cluster::create_topics_request&&);
     cluster::create_topics_request from(iobuf);
     cluster::create_topics_request from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::create_non_replicable_topics_request> {
+    void to(iobuf&, cluster::create_non_replicable_topics_request&&);
+    cluster::create_non_replicable_topics_request from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::create_non_replicable_topics_reply> {
+    void to(iobuf&, cluster::create_non_replicable_topics_reply&&);
+    cluster::create_non_replicable_topics_reply from(iobuf_parser&);
 };
 
 template<>

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -178,7 +178,7 @@ static ss::future<> maybe_make_materialized_log(
       [topics = std::move(topics)](
         cluster::non_replicable_topics_frontend& mtfe) mutable {
           return mtfe.create_non_replicable_topics(
-            std::move(topics), model::no_timeout);
+            std::move(topics), model::max_duration);
       });
 }
 

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ rp_test(
     topic_ingestion_policy_tests.cc
     failure_recovery_tests.cc
     pacemaker_tests.cc
+    autocreate_topic_tests.cc
     coproc_bench_tests.cc
     offset_storage_utils_tests.cc
     wasm_event_tests.cc

--- a/src/v/coproc/tests/autocreate_topic_tests.cc
+++ b/src/v/coproc/tests/autocreate_topic_tests.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/partition_manager.h"
+#include "coproc/tests/fixtures/coproc_cluster_fixture.h"
+#include "test_utils/async.h"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test_log.hpp>
+
+ss::future<bool> partition_exists(application* app, const model::ntp& ntp) {
+    /// A non_replicable partition is considered to exist if it exists in the
+    /// shard table, partition manager and storage
+    auto shard = app->shard_table.local().shard_for(ntp);
+    if (!shard) {
+        co_return false;
+    }
+    auto p_exists = co_await app->cp_partition_manager.invoke_on(
+      *shard,
+      [ntp](coproc::partition_manager& pm) { return (bool)pm.get(ntp); });
+    if (!p_exists) {
+        co_return false;
+    }
+    auto log_exists = co_await app->storage.invoke_on(
+      *shard,
+      [ntp](storage::api& api) { return (bool)api.log_mgr().get(ntp); });
+    if (!log_exists) {
+        co_return false;
+    }
+    co_return true;
+}
+
+FIXTURE_TEST(autocreate_non_replicable_topic_test, coproc_cluster_fixture) {
+    /// Start the test with a new cluster with 3 nodes
+    auto n = 3;
+    for (auto i = 0; i < n; ++i) {
+        create_node_application(model::node_id(i));
+    }
+    wait_for_all_members(5s).get();
+    for (auto i = 0; i < n; ++i) {
+        wait_for_controller_leadership(model::node_id(i)).get();
+    }
+
+    /// Find a node thats NOT the leader and make the request there
+    auto leader_id = get_node_application(model::node_id(0))
+                       ->controller->get_partition_leaders()
+                       .local()
+                       .get_leader(model::controller_ntp);
+    BOOST_REQUIRE(leader_id.has_value());
+    auto non_leader_id = model::node_id((*leader_id + 1) % n);
+    auto leader = get_node_application(*leader_id);
+    auto non_leader = get_node_application(non_leader_id);
+
+    /// Create test topic
+    cluster::non_replicable_topic nrt{
+      .source = model::topic_namespace(
+        model::kafka_namespace, model::topic("test")),
+      .name = model::topic_namespace(
+        model::kafka_namespace, model::topic("test-materialized"))};
+    auto n_partitions = 3;
+    cluster::topic_configuration cfg(nrt.source.ns, nrt.source.tp, 3, 1);
+    auto secf
+      = non_leader->controller->get_topics_frontend().local().autocreate_topics(
+        {cfg}, 10s);
+    auto ec = secf.get();
+    BOOST_REQUIRE_EQUAL(ec.size(), 1);
+    BOOST_REQUIRE_EQUAL(ec[0].tp_ns, nrt.source);
+    BOOST_REQUIRE_EQUAL(ec[0].ec, cluster::errc::success);
+
+    /// Create non_replicable topic on a node thats NOT the leader
+    auto ecf = non_leader->controller->get_topics_frontend()
+                 .local()
+                 .autocreate_non_replicable_topics({nrt}, 25s);
+    ec = ecf.get();
+    BOOST_REQUIRE_EQUAL(ec.size(), 1);
+    BOOST_REQUIRE_EQUAL(ec[0].tp_ns, nrt.name);
+    BOOST_REQUIRE_EQUAL(ec[0].ec, cluster::errc::success);
+
+    /// Where to look for the partitions
+    std::vector<std::pair<model::node_id, model::ntp>> partition_mapping;
+    auto& leaders_table = leader->controller->get_partition_leaders().local();
+    for (auto i = 0; i < n_partitions; ++i) {
+        model::ntp src_ntp(
+          nrt.source.ns, nrt.source.tp, model::partition_id(i));
+        model::ntp nrt_ntp(nrt.name.ns, nrt.name.tp, model::partition_id(i));
+        /// Quick verify that non_replicable topics match their sources
+        auto src_leader = leaders_table.get_leader(src_ntp);
+        auto nrt_leader = leaders_table.get_leader(src_ntp);
+        BOOST_REQUIRE(src_leader.has_value());
+        BOOST_REQUIRE(nrt_leader.has_value());
+        BOOST_REQUIRE_EQUAL(*src_leader, *nrt_leader);
+        partition_mapping.emplace_back(*nrt_leader, nrt_ntp);
+    }
+    tests::cooperative_spin_wait_with_timeout(15s, [this, partition_mapping]() {
+        return ss::map_reduce(
+          partition_mapping.begin(),
+          partition_mapping.end(),
+          [this](const auto& p) {
+              return partition_exists(get_node_application(p.first), p.second);
+          },
+          true,
+          std::logical_and<>());
+    }).get();
+}

--- a/src/v/coproc/tests/fixtures/coproc_test_fixture.h
+++ b/src/v/coproc/tests/fixtures/coproc_test_fixture.h
@@ -33,6 +33,9 @@ public:
     coproc_api_fixture();
     ~coproc_api_fixture();
 
+    /// Starts the client and creates the internal copro topic
+    ss::future<> start();
+
     /// Higher level abstraction of 'publish_events'
     ///
     /// Maps tuple to proper encoded wasm record and calls 'publish_events'

--- a/src/v/model/timeout_clock.h
+++ b/src/v/model/timeout_clock.h
@@ -27,4 +27,12 @@ static constexpr timeout_clock::time_point no_timeout
 static constexpr timeout_clock::duration max_duration
   = timeout_clock::duration::max();
 
+inline model::timeout_clock::time_point
+time_from_now(model::timeout_clock::duration d) {
+    /// Saturate now() + duration at no_timeout, avoid overflow
+    const auto now = model::timeout_clock::now();
+    const auto remaining = model::no_timeout - now;
+    return d < remaining ? now + d : model::no_timeout;
+}
+
 } // namespace model

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -284,7 +284,8 @@ public:
           .source = std::move(tp_ns_src), .name = std::move(tp_ns)};
         return app.controller->get_topics_frontend()
           .local()
-          .create_non_replicable_topics({std::move(nrt)}, model::no_timeout)
+          .autocreate_non_replicable_topics(
+            {std::move(nrt)}, model::max_duration)
           .then([this](std::vector<cluster::topic_result> results) {
               return wait_for_topics(std::move(results));
           });


### PR DESCRIPTION
This PR adds the ability for a node which is not the controller leader to `autocreate` non replicable topics by forwarding the request to create the non replicable topic to the controller leader. 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/741f510eab555fa9190563110f7c2a838bfe1038..515264d27b42a9c9f76605d5fe3da1bcf5b88ae4)
- Implemented Noah's feedback (version new struct, replace std::cbegin/end with .cbegin()/end(), and remove un-needed forwarding reference)

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/515264d27b42a9c9f76605d5fe3da1bcf5b88ae4..3afdabefc921d115c67db395aa7080cd6c64a880)
- Rebased against dev mainly to receive new coproc test harness changes

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/5a4c0382720f73f2c699335150055372bf244361..2fc7b33654927ce6fda7fd6a50419db9f27911d0)
- Added an additional version check to the `create_non_replicable_topics_reply` type 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/2fc7b33654927ce6fda7fd6a50419db9f27911d0..61171766e8af25e05980e71121d5a987a40c5d1d)
- Addressed Bens feedback about sending a `ss::lowres_clock::time_point` between nodes