### PR TITLE
kafka/client: Send leader_epoch with requests.

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -166,7 +166,9 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
         switch (ex.error) {
         case error_code::unknown_topic_or_partition:
         case error_code::not_leader_for_partition:
-        case error_code::leader_not_available: {
+        case error_code::leader_not_available:
+        case error_code::fenced_leader_epoch:
+        case error_code::unknown_leader_epoch: {
             vlog(kclog.debug, "partition_error: {}", ex);
             return _wait_or_start_update_metadata();
         }
@@ -280,16 +282,18 @@ client::create_topic(kafka::creatable_topic req) {
 ss::future<list_offsets_response>
 client::list_offsets(model::topic_partition tp) {
     return gated_retry_with_mitigation([this, tp]() {
-        return _topic_cache.leader(tp)
-          .then(
-            [this](model::node_id node_id) { return _brokers.find(node_id); })
-          .then([tp](auto broker) mutable {
-              return broker->dispatch(kafka::list_offsets_request{
-                .data = {.topics{
-                  {{.name{std::move(tp.topic)},
-                    .partitions{
-                      {{.partition_index{tp.partition},
-                        .max_num_offsets = 1}}}}}}}});
+        return _topic_cache.leader(tp).then(
+          [this, tp](topic_cache::partition_data part) {
+              return _brokers.find(part.leader)
+                .then([tp, part](auto broker) mutable {
+                    return broker->dispatch(list_offsets_request{
+                      .data = {.topics{
+                        {{.name{std::move(tp.topic)},
+                          .partitions{
+                            {{.partition_index{tp.partition},
+                              .current_leader_epoch = part.leader_epoch,
+                              .max_num_offsets = 1}}}}}}}});
+                });
           });
     });
 }
@@ -299,22 +303,26 @@ ss::future<fetch_response> client::fetch_partition(
   model::offset offset,
   int32_t max_bytes,
   std::chrono::milliseconds timeout) {
-    auto build_request =
-      [offset, max_bytes, timeout](model::topic_partition& tp) {
-          return make_fetch_request(tp, offset, max_bytes, timeout);
-      };
+    auto build_request = [offset, max_bytes, timeout](
+                           model::topic_partition& tp,
+                           kafka::leader_epoch epoch) {
+        return make_fetch_request(tp, epoch, offset, max_bytes, timeout);
+    };
 
     return ss::do_with(
       std::move(build_request),
       std::move(tp),
       [this](auto& build_request, model::topic_partition& tp) {
           return gated_retry_with_mitigation([this, &tp, &build_request]() {
-                     return _topic_cache.leader(tp)
-                       .then([this](model::node_id leader) {
-                           return _brokers.find(leader);
-                       })
-                       .then([&tp, &build_request](shared_broker_t&& b) {
-                           return b->dispatch(build_request(tp));
+                     return _topic_cache.leader(tp).then(
+                       [this, &tp, &build_request](
+                         topic_cache::partition_data part) {
+                           return _brokers.find(part.leader)
+                             .then([&tp, &part, &build_request](
+                                     shared_broker_t&& b) {
+                                 return b->dispatch(
+                                   build_request(tp, part.leader_epoch));
+                             });
                        });
                  })
             .handle_exception([&tp](std::exception_ptr ex) {

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -383,8 +383,8 @@ ss::future<fetch_response> consumer::fetch(
     for (auto const& [t, ps] : _assignment) {
         for (const auto& p : ps) {
             auto tp = model::topic_partition{t, p};
-            auto leader = co_await _topic_cache.leader(tp);
-            auto broker = co_await _brokers.find(leader);
+            auto part = co_await _topic_cache.leader(tp);
+            auto broker = co_await _brokers.find(part.leader);
             auto& session = _fetch_sessions[broker];
 
             auto& req = broker_reqs
@@ -411,6 +411,7 @@ ss::future<fetch_response> consumer::fetch(
             req.data.topics.back().fetch_partitions.push_back(
               fetch_request::partition{
                 .partition_index = p,
+                .current_leader_epoch = part.leader_epoch,
                 .fetch_offset = session.offset(tp),
                 .max_bytes = max_bytes.value_or(
                   _config.consumer_request_max_bytes)});

--- a/src/v/kafka/client/fetcher.cc
+++ b/src/v/kafka/client/fetcher.cc
@@ -22,13 +22,14 @@ namespace kafka::client {
 
 fetch_request make_fetch_request(
   const model::topic_partition& tp,
+  kafka::leader_epoch epoch,
   model::offset offset,
   int32_t max_bytes,
   std::chrono::milliseconds timeout) {
     std::vector<fetch_request::partition> partitions;
     partitions.push_back(fetch_request::partition{
       .partition_index{tp.partition},
-      .current_leader_epoch = kafka::invalid_leader_epoch,
+      .current_leader_epoch{epoch},
       .fetch_offset{offset},
       .log_start_offset{model::offset{-1}},
       .max_bytes = max_bytes});

--- a/src/v/kafka/client/fetcher.h
+++ b/src/v/kafka/client/fetcher.h
@@ -17,6 +17,7 @@ namespace kafka::client {
 
 fetch_request make_fetch_request(
   const model::topic_partition& tp,
+  kafka::leader_epoch epoch,
   model::offset offset,
   int32_t max_bytes,
   std::chrono::milliseconds timeout);

--- a/src/v/kafka/client/producer.cc
+++ b/src/v/kafka/client/producer.cc
@@ -71,7 +71,9 @@ producer::produce(model::topic_partition tp, model::record_batch&& batch) {
 ss::future<produce_response::partition>
 producer::do_send(model::topic_partition tp, model::record_batch&& batch) {
     return _topic_cache.leader(tp)
-      .then([this](model::node_id leader) { return _brokers.find(leader); })
+      .then([this](topic_cache::partition_data part) {
+          return _brokers.find(part.leader);
+      })
       .then([tp{std::move(tp)},
              batch{std::move(batch)}](shared_broker_t broker) mutable {
           return broker->dispatch(


### PR DESCRIPTION
## Cover letter

* Store the leader_epoch with the leader for each partition.
* Pass the leader epoch when fetching and listing offsets
* Handle `fenced_leader_epoch` and `unknown_leader_epoch`
  as retryable errors by updating metadata.

See [KIP-320](https://cwiki.apache.org/confluence/display/KAFKA/KIP-320:+Allow+fetchers+to+detect+and+handle+log+truncation)

Fixes #2046

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

### Improvements

* kafka/client: Improve handling of `fetch` and `list_offsets` under leadership transfer