### PR TITLE
storage: coroutinize segment_index

### DIFF
--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -187,12 +187,12 @@ ss::future<> segment_index::flush() {
     _needs_persistence = false;
     co_await _out.truncate(0);
     auto out = co_await ss::make_file_output_stream(ss::file(_out.dup()));
-          auto b = serde::to_iobuf(_state.copy());
-          for (const auto& f : b) {
-              co_await out.write(f.get(), f.size());
-          }
-          co_await out.flush();
-          co_await out.close();
+    auto b = serde::to_iobuf(_state.copy());
+    for (const auto& f : b) {
+        co_await out.write(f.get(), f.size());
+    }
+    co_await out.flush();
+    co_await out.close();
 }
 ss::future<> segment_index::close() {
     return flush().then([this] { return _out.close(); });

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -15,6 +15,7 @@
 #include "storage/logger.h"
 #include "vassert.h"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/iostream.hh>
 
@@ -121,7 +122,7 @@ segment_index::find_nearest(model::offset o) {
 
 ss::future<> segment_index::truncate(model::offset o) {
     if (o < _state.base_offset) {
-        return ss::now();
+        co_return;
     }
     const uint32_t i = o() - _state.base_offset();
     auto it = std::lower_bound(
@@ -151,7 +152,7 @@ ss::future<> segment_index::truncate(model::offset o) {
         }
     }
 
-    return flush();
+    co_return co_await flush();
 }
 
 ss::future<bool> segment_index::materialize_index() {

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -195,7 +195,8 @@ ss::future<> segment_index::flush() {
     co_await out.close();
 }
 ss::future<> segment_index::close() {
-    return flush().then([this] { return _out.close(); });
+    co_await flush();
+    co_await _out.close();
 }
 std::ostream& operator<<(std::ostream& o, const segment_index& i) {
     return o << "{file:" << i.filename() << ", offsets:" << i.base_offset()

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -156,27 +156,23 @@ ss::future<> segment_index::truncate(model::offset o) {
 }
 
 ss::future<bool> segment_index::materialize_index() {
-    return _out.size()
-      .then([this](uint64_t size) mutable {
-          return _out.dma_read_bulk<char>(0, size);
-      })
-      .then([this](ss::temporary_buffer<char> buf) {
+    auto size = co_await _out.size();
+    auto buf = co_await _out.dma_read_bulk<char>(0, size);
           if (buf.empty()) {
-              return false;
+              co_return false;
           }
           iobuf b;
           b.append(std::move(buf));
           try {
               _state = serde::from_iobuf<index_state>(std::move(b));
-              return true;
+              co_return true;
           } catch (const serde::serde_exception& ex) {
               vlog(
                 stlog.info,
                 "Rebuilding index_state after decoding failure: {}",
                 ex.what());
-              return false;
+              co_return false;
           }
-      });
 }
 
 ss::future<> segment_index::drop_all_data() {

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -158,21 +158,21 @@ ss::future<> segment_index::truncate(model::offset o) {
 ss::future<bool> segment_index::materialize_index() {
     auto size = co_await _out.size();
     auto buf = co_await _out.dma_read_bulk<char>(0, size);
-          if (buf.empty()) {
-              co_return false;
-          }
-          iobuf b;
-          b.append(std::move(buf));
-          try {
-              _state = serde::from_iobuf<index_state>(std::move(b));
-              co_return true;
-          } catch (const serde::serde_exception& ex) {
-              vlog(
-                stlog.info,
-                "Rebuilding index_state after decoding failure: {}",
-                ex.what());
-              co_return false;
-          }
+    if (buf.empty()) {
+        co_return false;
+    }
+    iobuf b;
+    b.append(std::move(buf));
+    try {
+        _state = serde::from_iobuf<index_state>(std::move(b));
+        co_return true;
+    } catch (const serde::serde_exception& ex) {
+        vlog(
+          stlog.info,
+          "Rebuilding index_state after decoding failure: {}",
+          ex.what());
+        co_return false;
+    }
 }
 
 ss::future<> segment_index::drop_all_data() {


### PR DESCRIPTION
## Cover letter

Convert segment_index to use coroutines. This PR is intended to be a 1-1 conversion that preserves the same semantics. This is in preparation for some changes to the way that the segment_index manages its file handle.

## Release notes

* None