### PR TITLE
kafka: support setting broker properties via kafka APIs

### DIFF
--- a/src/v/cluster/config_frontend.cc
+++ b/src/v/cluster/config_frontend.cc
@@ -34,7 +34,8 @@ ss::future<> config_frontend::stop() { return ss::now(); }
  * version numbers.
  */
 ss::future<std::error_code> config_frontend::patch(
-  config_update& update, model::timeout_clock::time_point timeout) {
+  config_update_request const& update,
+  model::timeout_clock::time_point timeout) {
     vassert(
       ss::this_shard_id() == version_shard, "Must be called on version_shard");
 

--- a/src/v/cluster/config_frontend.cc
+++ b/src/v/cluster/config_frontend.cc
@@ -34,7 +34,7 @@ ss::future<> config_frontend::stop() { return ss::now(); }
  * if we aren't it.
  */
 ss::future<std::error_code> config_frontend::patch(
-  config_update_request&& update, model::timeout_clock::time_point timeout) {
+  config_update_request update, model::timeout_clock::time_point timeout) {
     auto leader = _leaders.local().get_leader(model::controller_ntp);
     if (!leader) {
         co_return errc::no_leader_controller;

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -25,10 +25,16 @@ public:
     static constexpr ss::shard_id version_shard = cluster::controller_stm_shard;
 
     config_frontend(
-      ss::sharded<controller_stm>&, ss::sharded<ss::abort_source>&);
+      ss::sharded<controller_stm>&,
+      ss::sharded<rpc::connection_cache>&,
+      ss::sharded<partition_leaders_table>&,
+      ss::sharded<ss::abort_source>&);
 
     ss::future<std::error_code>
-    patch(config_update_request const&, model::timeout_clock::time_point);
+    patch(config_update_request&&, model::timeout_clock::time_point);
+
+    ss::future<std::error_code>
+    do_patch(config_update_request&&, model::timeout_clock::time_point);
 
     ss::future<std::error_code>
     set_status(config_status&, model::timeout_clock::time_point);
@@ -40,6 +46,8 @@ public:
 
 private:
     ss::sharded<controller_stm>& _stm;
+    ss::sharded<rpc::connection_cache>& _connections;
+    ss::sharded<partition_leaders_table>& _leaders;
     ss::sharded<ss::abort_source>& _as;
 
     // Initially unset, frontend is not writeable until backend finishes

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -15,11 +15,6 @@
 
 namespace cluster {
 
-struct config_update final {
-    std::vector<std::pair<ss::sstring, ss::sstring>> upsert;
-    std::vector<ss::sstring> remove;
-};
-
 class config_frontend final {
 public:
     // Shard ID that will track the next available version and serialize
@@ -33,7 +28,7 @@ public:
       ss::sharded<controller_stm>&, ss::sharded<ss::abort_source>&);
 
     ss::future<std::error_code>
-    patch(config_update&, model::timeout_clock::time_point);
+    patch(config_update_request const&, model::timeout_clock::time_point);
 
     ss::future<std::error_code>
     set_status(config_status&, model::timeout_clock::time_point);

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -24,16 +24,21 @@ public:
     // on the same shard that should keep its version state up to date.
     static constexpr ss::shard_id version_shard = cluster::controller_stm_shard;
 
+    struct patch_result {
+        std::error_code errc;
+        config_version version;
+    };
+
     config_frontend(
       ss::sharded<controller_stm>&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_leaders_table>&,
       ss::sharded<ss::abort_source>&);
 
-    ss::future<std::error_code>
+    ss::future<patch_result>
       patch(config_update_request, model::timeout_clock::time_point);
 
-    ss::future<std::error_code>
+    ss::future<patch_result>
     do_patch(config_update_request&&, model::timeout_clock::time_point);
 
     ss::future<std::error_code>

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -31,7 +31,7 @@ public:
       ss::sharded<ss::abort_source>&);
 
     ss::future<std::error_code>
-    patch(config_update_request&&, model::timeout_clock::time_point);
+      patch(config_update_request, model::timeout_clock::time_point);
 
     ss::future<std::error_code>
     do_patch(config_update_request&&, model::timeout_clock::time_point);

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -135,7 +135,7 @@ void config_manager::start_bootstrap() {
  * since upgrading to a redpanda version with central config)
  */
 ss::future<> config_manager::do_bootstrap() {
-    config_update update;
+    config_update_request update;
 
     config::shard_local_cfg().for_each([&update](
                                          const config::base_property& p) {

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -155,7 +155,8 @@ ss::future<> config_manager::do_bootstrap() {
 
     try {
         co_await _frontend.local().patch(
-          update, model::timeout_clock::now() + bootstrap_write_timeout);
+          std::move(update),
+          model::timeout_clock::now() + bootstrap_write_timeout);
     } catch (...) {
         // On errors, just drop out: start_bootstrap will go around
         // its loop again.

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -99,7 +99,11 @@ ss::future<> controller::start() {
           return _members_manager.local().validate_configuration_invariants();
       })
       .then([this] {
-          return _config_frontend.start(std::ref(_stm), std::ref(_as));
+          return _config_frontend.start(
+            std::ref(_stm),
+            std::ref(_connections),
+            std::ref(_partition_leaders),
+            std::ref(_as));
       })
       .then([this] {
           return _config_manager.start(

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -72,6 +72,11 @@
             "output_type": "config_status_reply"
         },
         {
+            "name": "config_update",
+            "input_type": "config_update_request",
+            "output_type": "config_update_reply"
+        },
+        {
             "name": "collect_node_health_report",
             "input_type": "get_node_health_request",
             "output_type": "get_node_health_reply"

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -283,9 +283,9 @@ ss::future<config_update_reply>
 service::config_update(config_update_request&& req, rpc::streaming_context&) {
     auto ec = co_await _config_frontend.invoke_on(
       config_frontend::version_shard,
-      [req = std::move(req)](config_frontend& fe) {
+      [req = std::move(req)](config_frontend& fe) mutable {
           return fe.patch(
-            req,
+            std::move(req),
             config::shard_local_cfg().replicate_append_timeout_ms()
               + model::timeout_clock::now());
       });

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -279,6 +279,24 @@ service::config_status(config_status_request&& req, rpc::streaming_context&) {
     }
 }
 
+ss::future<config_update_reply>
+service::config_update(config_update_request&& req, rpc::streaming_context&) {
+    auto ec = co_await _config_frontend.invoke_on(
+      config_frontend::version_shard,
+      [req = std::move(req)](config_frontend& fe) {
+          return fe.patch(
+            req,
+            config::shard_local_cfg().replicate_append_timeout_ms()
+              + model::timeout_clock::now());
+      });
+
+    if (ec.category() == error_category()) {
+        co_return config_update_reply{.error = errc(ec.value())};
+    } else {
+        co_return config_update_reply{.error = errc::replication_error};
+    }
+}
+
 ss::future<finish_reallocation_reply>
 service::do_finish_reallocation(finish_reallocation_request req) {
     auto ec = co_await _members_frontend.local().finish_node_reallocations(

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -72,6 +72,9 @@ public:
     ss::future<config_status_reply>
     config_status(config_status_request&&, rpc::streaming_context&) final;
 
+    ss::future<config_update_reply>
+    config_update(config_update_request&&, rpc::streaming_context&) final;
+
     ss::future<get_node_health_reply> collect_node_health_report(
       get_node_health_request&&, rpc::streaming_context&) final;
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -778,6 +778,15 @@ struct create_non_replicable_topics_reply {
     std::vector<topic_result> results;
 };
 
+struct config_update_request final {
+    std::vector<std::pair<ss::sstring, ss::sstring>> upsert;
+    std::vector<ss::sstring> remove;
+};
+
+struct config_update_reply {
+    errc error;
+};
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -785,6 +785,7 @@ struct config_update_request final {
 
 struct config_update_reply {
     errc error;
+    cluster::config_version latest_version{config_version_unset};
 };
 
 } // namespace cluster

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -222,7 +222,7 @@ alter_topic_configuration(
 
 static ss::future<std::vector<alter_configs_resource_response>>
 alter_broker_configuartion(std::vector<alter_configs_resource> resources) {
-    return do_alter_broker_configuartion<
+    return unsupported_broker_configuration<
       alter_configs_resource,
       alter_configs_resource_response>(std::move(resources));
 }

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -224,7 +224,11 @@ static ss::future<std::vector<alter_configs_resource_response>>
 alter_broker_configuartion(std::vector<alter_configs_resource> resources) {
     return unsupported_broker_configuration<
       alter_configs_resource,
-      alter_configs_resource_response>(std::move(resources));
+      alter_configs_resource_response>(
+      std::move(resources),
+      "changing broker properties isn't supported via this "
+      "API. Try using kafka incremental config API or "
+      "redpanda admin API.");
 }
 
 template<>

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -184,7 +184,7 @@ ss::future<std::vector<R>> do_alter_topics_configuration(
 
 template<typename T, typename R>
 ss::future<std::vector<R>>
-do_alter_broker_configuartion(std::vector<T> resources) {
+unsupported_broker_configuration(std::vector<T> resources) {
     // for now we do not support altering any of brokers config, generate
     // errors
     std::vector<R> responses;

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -183,23 +183,17 @@ ss::future<std::vector<R>> do_alter_topics_configuration(
 }
 
 template<typename T, typename R>
-ss::future<std::vector<R>>
-unsupported_broker_configuration(std::vector<T> resources) {
-    // for now we do not support altering any of brokers config, generate
-    // errors
+ss::future<std::vector<R>> unsupported_broker_configuration(
+  std::vector<T> resources, std::string_view const msg) {
     std::vector<R> responses;
     responses.reserve(resources.size());
     std::transform(
       resources.begin(),
       resources.end(),
       std::back_inserter(responses),
-      [](T& resource) {
+      [msg](T& resource) {
           return make_error_alter_config_resource_response<R>(
-            resource,
-            error_code::invalid_config,
-            fmt::format(
-              "changing '{}' broker property isn't currently supported",
-              resource.resource_name));
+            resource, error_code::invalid_config, ss::sstring(msg));
       });
 
     return ss::make_ready_future<std::vector<R>>(std::move(responses));

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -280,7 +280,7 @@ static ss::future<std::vector<resp_resource_t>> alter_topic_configuration(
 
 static ss::future<std::vector<resp_resource_t>>
 alter_broker_configuartion(std::vector<req_resource_t> resources) {
-    return do_alter_broker_configuartion<req_resource_t, resp_resource_t>(
+    return unsupported_broker_configuration<req_resource_t, resp_resource_t>(
       std::move(resources));
 }
 

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -319,18 +319,11 @@ static ss::future<std::vector<resp_resource_t>> alter_broker_configuartion(
 
     // If central config is disabled, we cannot set broker properties
     if (!config::node().enable_central_config()) {
-        std::transform(
-          resources.begin(),
-          resources.end(),
-          std::back_inserter(responses),
-          [](req_resource_t& resource) {
-              return make_error_alter_config_resource_response<resp_resource_t>(
-                resource,
-                error_code::invalid_config,
-                fmt::format(
-                  "changing '{}' broker property isn't currently supported",
-                  resource.resource_name));
-          });
+        co_return co_await unsupported_broker_configuration<
+          req_resource_t,
+          resp_resource_t>(
+          std::move(resources),
+          "changing broker properties via this API is not enabled");
 
         co_return responses;
     }

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -429,7 +429,8 @@ static ss::future<std::vector<resp_resource_t>> alter_broker_configuartion(
                         + config::shard_local_cfg()
                             .alter_topic_cfg_timeout_ms());
                 })
-              .then([resource](std::error_code ec) {
+              .then([resource](cluster::config_frontend::patch_result pr) {
+                  std::error_code& ec = pr.errc;
                   error_code kec = error_code::none;
 
                   std::string err_str;

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -38,6 +38,7 @@ protocol::protocol(
   ss::smp_service_group smp,
   ss::sharded<cluster::metadata_cache>& meta,
   ss::sharded<cluster::topics_frontend>& tf,
+  ss::sharded<cluster::config_frontend>& cf,
   ss::sharded<quota_manager>& quota,
   ss::sharded<kafka::group_router>& router,
   ss::sharded<cluster::shard_table>& tbl,
@@ -55,6 +56,7 @@ protocol::protocol(
   std::optional<qdc_monitor::config> qdc_config) noexcept
   : _smp_group(smp)
   , _topics_frontend(tf)
+  , _config_frontend(cf)
   , _metadata_cache(meta)
   , _quota_mgr(quota)
   , _group_router(router)

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -68,8 +68,8 @@ public:
     cluster::topics_frontend& topics_frontend() {
         return _topics_frontend.local();
     }
-    cluster::config_frontend& config_frontend() {
-        return _config_frontend.local();
+    ss::sharded<cluster::config_frontend>& config_frontend() {
+        return _config_frontend;
     }
     cluster::metadata_cache& metadata_cache() {
         return _metadata_cache.local();

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -36,6 +36,7 @@ public:
       ss::smp_service_group,
       ss::sharded<cluster::metadata_cache>&,
       ss::sharded<cluster::topics_frontend>&,
+      ss::sharded<cluster::config_frontend>&,
       ss::sharded<quota_manager>&,
       ss::sharded<kafka::group_router>&,
       ss::sharded<cluster::shard_table>&,
@@ -66,6 +67,9 @@ public:
     ss::smp_service_group smp_group() const { return _smp_group; }
     cluster::topics_frontend& topics_frontend() {
         return _topics_frontend.local();
+    }
+    cluster::config_frontend& config_frontend() {
+        return _config_frontend.local();
     }
     cluster::metadata_cache& metadata_cache() {
         return _metadata_cache.local();
@@ -133,6 +137,7 @@ public:
 private:
     ss::smp_service_group _smp_group;
     ss::sharded<cluster::topics_frontend>& _topics_frontend;
+    ss::sharded<cluster::config_frontend>& _config_frontend;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
     ss::sharded<quota_manager>& _quota_mgr;
     ss::sharded<kafka::group_router>& _group_router;

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -86,6 +86,10 @@ public:
         return _conn->server().topics_frontend();
     }
 
+    ss::sharded<cluster::config_frontend>& config_frontend() const {
+        return _conn->server().config_frontend();
+    }
+
     cluster::id_allocator_frontend& id_allocator_frontend() const {
         return _conn->server().id_allocator_frontend();
     }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -396,6 +396,7 @@ ss::future<> admin_server::throw_on_error(
               id));
         case cluster::errc::update_in_progress:
         case cluster::errc::waiting_for_recovery:
+        case cluster::errc::no_leader_controller:
             throw ss::httpd::base_exception(
               fmt::format("Not ready ({})", ec.message()),
               ss::httpd::reply::status_type::service_unavailable);

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -745,9 +745,10 @@ void admin_server::register_cluster_config_routes() {
 
           auto err = co_await _controller->get_config_frontend().invoke_on(
             cluster::config_frontend::version_shard,
-            [update](cluster::config_frontend& fe) mutable
+            [update = std::move(update)](cluster::config_frontend& fe) mutable
             -> ss::future<std::error_code> {
-                return fe.patch(update, model::timeout_clock::now() + 5s);
+                return fe.patch(
+                  std::move(update), model::timeout_clock::now() + 5s);
             });
 
           co_await throw_on_error(*req, err, model::controller_ntp);

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -672,7 +672,7 @@ void admin_server::register_cluster_config_routes() {
           auto doc = parse_json_body(*req);
           apply_validator(cluster_config_validator, doc);
 
-          cluster::config_update update;
+          cluster::config_update_request update;
 
           // Deserialize removes
           const auto& json_remove = doc["remove"];

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -743,21 +743,20 @@ void admin_server::register_cluster_config_routes() {
             update.upsert.size(),
             update.remove.size());
 
-          auto err = co_await _controller->get_config_frontend().invoke_on(
-            cluster::config_frontend::version_shard,
-            [update = std::move(update)](cluster::config_frontend& fe) mutable
-            -> ss::future<std::error_code> {
-                return fe.patch(
-                  std::move(update), model::timeout_clock::now() + 5s);
-            });
+          auto patch_result
+            = co_await _controller->get_config_frontend().invoke_on(
+              cluster::config_frontend::version_shard,
+              [update = std::move(update)](cluster::config_frontend& fe) mutable
+              -> ss::future<cluster::config_frontend::patch_result> {
+                  return fe.patch(
+                    std::move(update), model::timeout_clock::now() + 5s);
+              });
 
-          co_await throw_on_error(*req, err, model::controller_ntp);
+          co_await throw_on_error(
+            *req, patch_result.errc, model::controller_ntp);
 
           ss::httpd::cluster_config_json::cluster_config_write_result result;
-          result.config_version
-            = co_await _controller->get_config_manager().invoke_on(
-              cluster::controller_stm_shard,
-              [](cluster::config_manager& mgr) { return mgr.get_version(); });
+          result.config_version = patch_result.version;
           co_return ss::json::json_return_type(std::move(result));
       });
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1162,6 +1162,7 @@ void application::start_redpanda() {
             smp_service_groups.kafka_smp_sg(),
             metadata_cache,
             controller->get_topics_frontend(),
+            controller->get_config_frontend(),
             quota_mgr,
             group_router,
             shard_table,

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -89,6 +89,7 @@ public:
           app.smp_service_groups.kafka_smp_sg(),
           app.metadata_cache,
           app.controller->get_topics_frontend(),
+          app.controller->get_config_frontend(),
           app.quota_mgr,
           app.group_router,
           app.shard_table,


### PR DESCRIPTION
## Cover letter

The Kafka API support brokers as resources in [Incremental]AlterConfigs APIs.  We can plumb this into redpanda's configuration store for the case of cluster-wide requests, and map some traditional kafka config values (e.g. topic defaults) to redpanda config values to enable interoperability with applications that use the kafka API to set these properties.

Fixes https://github.com/vectorizedio/redpanda/issues/2645

## Release notes

* none

(not announcing central config changes until we enable them by default)
