### PR TITLE
k8s: fix bug reconciling clusters with fixed nodeport

### DIFF
--- a/src/go/k8s/controllers/redpanda/cluster_controller_test.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller_test.go
@@ -395,6 +395,78 @@ var _ = Describe("RedPandaCluster controller", func() {
 					len(cluster.Status.Nodes.Internal) > 0
 			}, timeout, interval).Should(BeTrue())
 		})
+		It("creates redpanda cluster with fixed nodeport", func() {
+			resources := corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			}
+
+			key := types.NamespacedName{
+				Name:      "external-fixed-redpanda",
+				Namespace: "default",
+			}
+			redpandaCluster := &v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: key.Namespace,
+				},
+				Spec: v1alpha1.ClusterSpec{
+					Image:    redpandaContainerImage,
+					Version:  redpandaContainerTag,
+					Replicas: pointer.Int32Ptr(replicas),
+					Configuration: v1alpha1.RedpandaConfig{
+						KafkaAPI: []v1alpha1.KafkaAPI{
+							{
+								Port: kafkaPort,
+							},
+							{
+								Port: 31111,
+								External: v1alpha1.ExternalConnectivityConfig{
+									Enabled:   true,
+									Subdomain: "vectorized.io",
+								},
+							},
+						},
+						AdminAPI: []v1alpha1.AdminAPI{{Port: adminPort}},
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits:   resources,
+						Requests: resources,
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), redpandaCluster)).Should(Succeed())
+
+			redpandaPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: key.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "redpanda",
+						"app.kubernetes.io/instance":  "internal-redpanda",
+						"app.kubernetes.io/name":      "redpanda",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+					Containers: []corev1.Container{{
+						Name:  "test",
+						Image: "test",
+					}},
+				},
+				Status: corev1.PodStatus{},
+			}
+			Expect(k8sClient.Create(context.Background(), redpandaPod)).Should(Succeed())
+
+			By("Creating StatefulSet")
+			var sts appsv1.StatefulSet
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), key, &sts)
+				return err == nil &&
+					*sts.Spec.Replicas == replicas
+			}, timeout, interval).Should(BeTrue())
+
+		})
 	})
 
 	Context("Calling reconcile", func() {

--- a/src/go/k8s/pkg/resources/certmanager/certificate.go
+++ b/src/go/k8s/pkg/resources/certmanager/certificate.go
@@ -152,6 +152,10 @@ func (r *CertificateResource) obj() (k8sclient.Object, error) {
 			Namespace: r.Key().Namespace,
 			Labels:    objLabels,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Certificate",
+			APIVersion: "cert-manager.io/v1",
+		},
 		Spec: cmapiv1.CertificateSpec{
 			SecretName:  r.Key().Name,
 			IssuerRef:   *r.issuerRef,

--- a/src/go/k8s/pkg/resources/certmanager/issuer.go
+++ b/src/go/k8s/pkg/resources/certmanager/issuer.go
@@ -92,7 +92,11 @@ func (r *IssuerResource) obj() (k8sclient.Object, error) {
 
 	issuer := &cmapiv1.Issuer{
 		ObjectMeta: objectMeta,
-		Spec:       spec,
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Issuer",
+			APIVersion: "cert-manager.io/v1",
+		},
+		Spec: spec,
 	}
 
 	err := controllerutil.SetControllerReference(r.pandaCluster, issuer, r.scheme)

--- a/src/go/k8s/pkg/resources/certmanager/keystore_password.go
+++ b/src/go/k8s/pkg/resources/certmanager/keystore_password.go
@@ -71,6 +71,10 @@ func (r *KeystoreSecretResource) obj() (k8sclient.Object, error) {
 			Namespace: r.Key().Namespace,
 			Labels:    objLabels,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
 		StringData: map[string]string{
 			passwordKey: r.pandaCluster.Name,
 		},

--- a/src/go/k8s/pkg/resources/certmanager/pki.go
+++ b/src/go/k8s/pkg/resources/certmanager/pki.go
@@ -238,6 +238,10 @@ func (r *PkiReconciler) copyNodeSecretToLocalNamespace(
 			Namespace: r.pandaCluster.Namespace,
 			Labels:    secret.Labels,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
 		Type: secret.Type,
 		Data: map[string][]byte{
 			cmmetav1.TLSCAKey:       caCrt,

--- a/src/go/k8s/pkg/resources/pdb.go
+++ b/src/go/k8s/pkg/resources/pdb.go
@@ -83,6 +83,10 @@ func (r *PDBResource) obj() (k8sclient.Object, error) {
 			Name:      r.Key().Name,
 			Namespace: r.Key().Namespace,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PodDisruptionBudget",
+			APIVersion: "policy/v1beta1",
+		},
 		Spec: policyv1beta1.PodDisruptionBudgetSpec{
 			MinAvailable:   r.pandaCluster.Spec.PodDisruptionBudget.MinAvailable,
 			MaxUnavailable: r.pandaCluster.Spec.PodDisruptionBudget.MaxUnavailable,

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -85,13 +86,28 @@ func CreateIfNotExists(
 	if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(obj); err != nil {
 		return false, fmt.Errorf("unable to add last applied annotation to %s: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
 	}
-	err := c.Create(ctx, obj)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return false, fmt.Errorf("unable to create %s resource: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
+	// this is needed because we cannot pass obj into get as the client methods
+	// modify the input received and we don't want to mutate the object passed
+	// in
+	actual := &unstructured.Unstructured{}
+	actual.SetGroupVersionKind(gvk)
+	err := c.Get(ctx, types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}, actual)
+	if err != nil && !errors.IsNotFound(err) {
+		return false, fmt.Errorf("error while fetching %s resource: %w", obj.GetName(), err)
 	}
-	if err == nil {
-		l.Info(fmt.Sprintf("%s %s did not exist, was created", gvk.Kind, obj.GetName()))
-		return true, nil
+	if errors.IsNotFound(err) {
+		// not exists, going to create it
+		err = c.Create(ctx, obj)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return false, fmt.Errorf("unable to create %s resource: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
+		}
+		if err == nil {
+			l.Info(fmt.Sprintf("%s %s did not exist, was created", gvk.Kind, obj.GetName()))
+			return true, nil
+		}
 	}
 	return false, nil
 }

--- a/src/go/k8s/pkg/resources/superusers.go
+++ b/src/go/k8s/pkg/resources/superusers.go
@@ -99,6 +99,10 @@ func (r *SuperUsersResource) obj() (k8sclient.Object, error) {
 			Name:      r.Key().Name,
 			Namespace: r.Key().Namespace,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
 		Type: corev1.SecretTypeBasicAuth,
 		Data: map[string][]byte{
 			corev1.BasicAuthUsernameKey: []byte(r.username),


### PR DESCRIPTION
## Cover letter

The nodeport service when `nodePort` field provided behaves a bit differently and repeated create on the same resource does not return createifnotexists error but rather an allocation error. so because of that, after the external service gets created after first run of the reconciliation loop, it keeps failing with the nodeport allocated error. The fix is to switch to `get-or-create` method that creates only if GET call did not succeed.

```
➜  temp kubectl apply -f nodeport.yaml
service/my-service created
➜  temp kubectl apply -f nodeport.yaml
service/my-service unchanged
➜  temp kubectl create -f nodeport.yaml
The Service "my-service" is invalid: spec.ports[0].nodePort: Invalid value: 30007: provided port is already allocated
```

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3263

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->

### Improvements
k8s: fixed bug with nodeport handling for clusters that have external connectivity with fixed port
