### PR TITLE
redpanda/cluster: Improve logging for leader_balancer

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -263,7 +263,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
     auto transfer = strategy.find_movement(muted_groups());
     if (!transfer) {
         vlog(
-          clusterlog.info,
+          clusterlog.debug,
           "No leadership balance improvements found with total delta {}, "
           "number of muted groups {}",
           error,


### PR DESCRIPTION
## Cover letter

* Reduce log level to debug for initiatiating transfer
* Log info for successful transfer

Fixes #3269

Signed-off-by: Ben Pope <ben@vectorized.io>

Unrelated Failures:
```
npm ERR! code ETIMEDOUT
  | npm ERR! errno ETIMEDOUT
  | npm ERR! network request to https://registry.npmjs.org/rewire failed, reason: connect ETIMEDOUT 104.16.24.35:443
```
And:
```
npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
  | npm WARN deprecated chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
  | npm WARN deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
  | npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
  | npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
  | npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.2 (node_modules/chokidar/node_modules/fsevents):
  | npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
  | npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@^1.2.7 (node_modules/watchpack-chokidar2/node_modules/chokidar/node_modules/fsevents):
  | npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.13: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
  |  
  | npm ERR! Unexpected end of JSON input while parsing near '...a+rf8Dt9ndqiZOSaKIq7g'
```
And:
```
curl: (28) Failed to connect to github.com port 443: Connection timed out
  | curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443
  | task: Failed to run task "rp:run-ducktape-tests": task: Failed to run task "rp:init-ducktape-containers": task: Failed to run task "dev:install-docker-compose": exit status 35
```

## Release notes

### Improvements

* redpanda/cluster: Improve logging for leader_balancer