### PR TITLE
Backport pr3271 to v21.11.x (redpanda/cluster: Improve logging for leader_balancer)

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -230,7 +230,7 @@ ss::future<ss::stop_iteration> leader_balancer::balance() {
     auto transfer = strategy.find_movement(muted_groups());
     if (!transfer) {
         vlog(
-          clusterlog.info,
+          clusterlog.debug,
           "No leadership balance improvements found with total delta {}, "
           "number of muted groups {}",
           error,


### PR DESCRIPTION
## Cover letter

Backport #3271 

* Reduce log level to debug for initiatiating transfer

Fixes #3269

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

### Improvements

* redpanda/cluster: Improve logging for leader_balancer