### PR TITLE
storage: use segment fallocate size from config

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -13,6 +13,7 @@
 #include "config/node_config.h"
 #include "model/metadata.h"
 #include "storage/chunk_cache.h"
+#include "storage/segment_appender.h"
 #include "units.h"
 
 #include <cstdint>
@@ -618,6 +619,15 @@ configuration::configuration()
       "How many additional reads to issue ahead of current read location",
       {.example = "1", .visibility = visibility::tunable},
       10)
+  , segment_fallocation_step(
+      *this,
+      "segment_fallocation_step",
+      "Size for segments fallocation",
+      {.needs_restart = needs_restart::no,
+       .example = "32768",
+       .visibility = visibility::tunable},
+      32_MiB,
+      storage::segment_appender::validate_fallocation_step)
   , max_compacted_log_segment_size(
       *this,
       "max_compacted_log_segment_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -146,6 +146,7 @@ struct configuration final : public config_store {
     property<size_t> append_chunk_size;
     property<size_t> storage_read_buffer_size;
     property<int16_t> storage_read_readahead_count;
+    property<size_t> segment_fallocation_step;
     property<size_t> max_compacted_log_segment_size;
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -638,7 +638,9 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
                          path,
                          sanitize_fileops,
                          internal::number_of_chunks_from_config(ntpc),
-                         pc)
+                         pc,
+                         config::shard_local_cfg()
+                           .segment_fallocation_step.bind())
                   .then([seg](segment_appender_ptr a) {
                       return ss::make_ready_future<ss::lw_shared_ptr<segment>>(
                         ss::make_lw_shared<segment>(

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -319,13 +319,14 @@ ss::future<> segment_appender::do_next_adaptive_fallocation() {
                    _prev_head_write->available_units() == 1,
                    "Unexpected pending head write {}",
                    *this);
-                 // step - compute step rounded to 4096; this is needed because
-                 // during a truncation the follow up fallocation might not be
-                 // page aligned
-                 auto step = _opts.falloc_step;
-                 if (_fallocation_offset % 4096 != 0) {
+                 // step - compute step rounded to alignment(4096); this is
+                 // needed because during a truncation the follow up fallocation
+                 // might not be page aligned
+                 auto step = _opts.falloc_step();
+                 if (_fallocation_offset % fallocation_alignment != 0) {
                      // add left over bytes to a full page
-                     step += 4096 - (_fallocation_offset % 4096);
+                     step += fallocation_alignment
+                             - (_fallocation_offset % fallocation_alignment);
                  }
                  vassert(
                    _fallocation_offset >= _committed_offset,

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -104,7 +104,8 @@ ss::future<segment_appender_ptr> make_segment_appender(
   const std::filesystem::path& path,
   storage::debug_sanitize_files debug,
   size_t number_of_chunks,
-  ss::io_priority_class iopc);
+  ss::io_priority_class iopc,
+  config::binding<size_t> fallocate_size);
 
 size_t number_of_chunks_from_config(const storage::ntp_config&);
 

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -35,7 +35,10 @@ spill_key_index::spill_key_index(
   ss::io_priority_class p,
   size_t max_memory)
   : compacted_index_writer::impl(std::move(name))
-  , _appender(std::move(index_file), segment_appender::options(p, 1))
+  , _appender(
+      std::move(index_file),
+      segment_appender::options(
+        p, 1, config::shard_local_cfg().segment_fallocation_step.bind()))
   , _max_mem(max_memory) {}
 
 spill_key_index::~spill_key_index() {

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -46,7 +46,9 @@ struct context {
         fidx = ss::file(ss::make_shared(file_io_sanitizer(std::move(fidx))));
 
         auto appender = std::make_unique<segment_appender>(
-          fd, segment_appender::options(ss::default_priority_class(), 1));
+          fd,
+          segment_appender::options(
+            ss::default_priority_class(), 1, config::mock_binding(16_KiB)));
         auto indexer = segment_index(
           base_name + ".index", std::move(fidx), base, 4096);
         auto reader = segment_reader(


### PR DESCRIPTION
## Cover letter

"Today, redpanda fallocates 32M whenever necessary. We currently inject one raft message into every partition when a topic is created. If I create a topic with 1000 partitions, 32G of my disk is eaten.
The fallocate was chosen to be 32M, and large sizes are beneficial, but it may be useful to have this size be a configuration option" (#2876)

Fixes #2876

## Release notes

### Features

- The minimum disk space allocation size is now configurable via the `segment_fallocation_step` property.  The default is unchanged from the previous behavior (32MB).  You may wish to decrease this property if creating large numbers of partitions on systems with limited disk space.
