### PR TITLE
Fix archival upload data corruption

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -292,6 +292,7 @@ static ss::future<> get_file_range(
               archival_log.error,
               "Can't read segment file, error: {}",
               res.error());
+            throw std::system_error(res.error());
         } else {
             bytes_to_skip = scan_from + res.value();
             vlog(
@@ -362,6 +363,7 @@ static ss::future<> get_file_range(
               archival_log.error,
               "Can't read segment file, error: {}",
               res.error());
+            throw std::system_error(res.error());
         } else {
             stop_at = scan_from + res.value();
             vlog(

--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -18,6 +18,8 @@
 #include "storage/ntp_config.h"
 #include "storage/segment_set.h"
 
+#include <seastar/core/io_priority_class.hh>
+
 namespace archival {
 
 struct upload_candidate {
@@ -45,7 +47,8 @@ public:
       model::ntp ntp,
       service_probe& svc_probe,
       ntp_level_probe& ntp_probe,
-      std::optional<segment_time_limit> limit = std::nullopt);
+      std::optional<segment_time_limit> limit = std::nullopt,
+      ss::io_priority_class io_priority = ss::default_priority_class());
 
     /// \brief regurn next upload candidate
     ///
@@ -84,6 +87,7 @@ private:
     ntp_level_probe& _ntp_probe;
     std::optional<segment_time_limit> _upload_limit;
     std::optional<ss::lowres_clock::time_point> _upload_deadline;
+    ss::io_priority_class _io_priority;
 };
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -54,7 +54,12 @@ ntp_archiver::ntp_archiver(
   , _rev(ntp.get_revision())
   , _remote(remote)
   , _partition(std::move(part))
-  , _policy(_ntp, _svc_probe, std::ref(_probe), conf.time_limit)
+  , _policy(
+      _ntp,
+      _svc_probe,
+      std::ref(_probe),
+      conf.time_limit,
+      conf.upload_io_priority)
   , _bucket(conf.bucket_name)
   , _manifest(_ntp, _rev)
   , _gate()


### PR DESCRIPTION
## Cover letter

The data corruption bug manifested as a truncated segment in S3. This happens only if the `cloud_storage_segment_max_upload_interval_sec` option is enabled. Also there is another problem that this PR fixes. The archival subsystem uses default I/O priority for small reads from segments before the segments get uploaded. This PR makes them use the right I/O priority (same as the rest of the archival subsystem).

## Release notes

N/A
