### PR TITLE
Fix patching PDB resources

### DIFF
--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/banzaicloud/k8s-objectmatcher v1.5.1
+	github.com/banzaicloud/k8s-objectmatcher v1.7.0
 	github.com/go-logr/logr v0.4.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/jetstack/cert-manager v1.2.0

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -91,8 +91,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/avast/retry-go v2.6.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.25.43/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.34.30/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
-github.com/banzaicloud/k8s-objectmatcher v1.5.1 h1:u3Ic1JzIUQe0pGGjVQJvCWTNa+t9CiW49IPPovYqAss=
-github.com/banzaicloud/k8s-objectmatcher v1.5.1/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
+github.com/banzaicloud/k8s-objectmatcher v1.7.0 h1:6ufo47TaPC0jXJPg8d8/oooCy1ma3vEfM0J8ZbomKaw=
+github.com/banzaicloud/k8s-objectmatcher v1.7.0/go.mod h1:DSctpi6o9FqTfX7RluuEBeRLUahoDC7JavCeuu6Y+sg=
 github.com/beevik/ntp v0.3.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -1059,7 +1059,6 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 k8s.io/api v0.18.0/go.mod h1:q2HRQkfDzHMBZL9l/y9rH63PkQl4vae0xRT+8prbrK8=
 k8s.io/api v0.18.6/go.mod h1:eeyxr+cwCjMdLAmr2W3RyDI0VvTawSg/3RFFBEnmZGI=
 k8s.io/api v0.19.0/go.mod h1:I1K45XlvTrDjmj5LoM5LuP/KYrhWbjUKT/SoPG0qTjw=
-k8s.io/api v0.19.2/go.mod h1:IQpK0zFQ1xc5iNIQPqzgoOwuFugaYHK4iCknlAQP9nI=
 k8s.io/api v0.21.4 h1:WtDkzTAuI31WZKDPeIYpEUA+WeUfXAmA7gwj6nzFfbc=
 k8s.io/api v0.21.4/go.mod h1:fTVGP+M4D8+00FN2cMnJqk/eb/GH53bvmNs2SVTmpFk=
 k8s.io/apiextensions-apiserver v0.18.0/go.mod h1:18Cwn1Xws4xnWQNC00FLq1E350b9lUF+aOdIWDOZxgo=

--- a/src/go/k8s/pkg/resources/cluster_service.go
+++ b/src/go/k8s/pkg/resources/cluster_service.go
@@ -76,7 +76,8 @@ func (r *ClusterServiceResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error while fetching Service resource: %w", err)
 	}
-	return Update(ctx, &svc, obj, r.Client, r.logger)
+	_, err = Update(ctx, &svc, obj, r.Client, r.logger)
+	return err
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -118,7 +118,8 @@ func (r *ConfigMapResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error while fetching ConfigMap resource: %w", err)
 	}
-	return Update(ctx, &cm, obj, r.Client, r.logger)
+	_, err = Update(ctx, &cm, obj, r.Client, r.logger)
+	return err
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/headless_service.go
+++ b/src/go/k8s/pkg/resources/headless_service.go
@@ -78,7 +78,8 @@ func (r *HeadlessServiceResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error while fetching Service resource: %w", err)
 	}
-	return Update(ctx, &svc, obj, r.Client, r.logger)
+	_, err = Update(ctx, &svc, obj, r.Client, r.logger)
+	return err
 }
 
 // obj returns resource managed client.Object

--- a/src/go/k8s/pkg/resources/ingress.go
+++ b/src/go/k8s/pkg/resources/ingress.go
@@ -86,7 +86,8 @@ func (r *IngressResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error while fetching Ingress resource: %w", err)
 	}
-	return Update(ctx, &ingress, obj, r.Client, r.logger)
+	_, err = Update(ctx, &ingress, obj, r.Client, r.logger)
+	return err
 }
 
 func (r *IngressResource) obj() (k8sclient.Object, error) {

--- a/src/go/k8s/pkg/resources/node_port_service.go
+++ b/src/go/k8s/pkg/resources/node_port_service.go
@@ -75,7 +75,8 @@ func (r *NodePortServiceResource) Ensure(ctx context.Context) error {
 	}
 
 	copyPorts(obj.(*corev1.Service), &svc)
-	return Update(ctx, &svc, obj, r.Client, r.logger)
+	_, err = Update(ctx, &svc, obj, r.Client, r.logger)
+	return err
 }
 
 func copyPorts(newSvc, currentSvc *corev1.Service) {

--- a/src/go/k8s/pkg/resources/pdb.go
+++ b/src/go/k8s/pkg/resources/pdb.go
@@ -73,7 +73,8 @@ func (r *PDBResource) Ensure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error while fetching Service resource: %w", err)
 	}
-	return Update(ctx, &pdb, obj, r.Client, r.logger)
+	_, err = Update(ctx, &pdb, obj, r.Client, r.logger)
+	return err
 }
 
 func (r *PDBResource) obj() (k8sclient.Object, error) {

--- a/src/go/k8s/pkg/resources/pdb_test.go
+++ b/src/go/k8s/pkg/resources/pdb_test.go
@@ -79,6 +79,12 @@ func TestEnsure_PDB(t *testing.T) {
 			err = c.Get(context.Background(), pdb.Key(), actual)
 			assert.NoError(t, err, tt.name)
 			assert.Equal(t, tt.expectedObject.Spec, actual.Spec)
+
+			// retrieved object and new object should produce no diff and thus
+			// not be updated
+			updated, err := res.Update(context.TODO(), actual, actual, c, ctrl.Log.WithName("test"))
+			assert.NoError(t, err)
+			assert.False(t, updated)
 		})
 	}
 }

--- a/src/go/k8s/pkg/resources/resource.go
+++ b/src/go/k8s/pkg/resources/resource.go
@@ -126,6 +126,7 @@ func Update(
 	opts := []patch.CalculateOption{
 		patch.IgnoreStatusFields(),
 		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
+		patch.IgnorePDBSelector(),
 	}
 	patchResult, err := patch.DefaultPatchMaker.Calculate(current, modified, opts...)
 	if err != nil {

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -166,7 +166,7 @@ func (r *StatefulSetResource) updateStatefulSet(
 	current *appsv1.StatefulSet,
 	modified *appsv1.StatefulSet,
 ) error {
-	err := Update(ctx, current, modified, r.Client, r.logger)
+	_, err := Update(ctx, current, modified, r.Client, r.logger)
 	if err != nil && strings.Contains(err.Error(), "spec: Forbidden: updates to statefulset spec for fields other than") {
 		// REF: https://github.com/kubernetes/kubernetes/issues/69041#issuecomment-723757166
 		// https://www.giffgaff.io/tech/resizing-statefulset-persistent-volumes-with-zero-downtime


### PR DESCRIPTION
## Cover letter
PDB was constantly trying to be patched because of the way how apimachinery libs internally work. This was fixed in newer version of the objectmatcher library so bumping it and ignoring the selector fixes the issue.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3301

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
### Improvements
k8s: fixed a bug with attempting to patch PDB selector when not required