### PR TITLE
raft: fix noisy warning on leadership transfer

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2589,7 +2589,7 @@ consensus::prepare_transfer_leadership(vnode target_rni) {
             co_return make_error_code(errc::timeout);
         }
         vlog(
-          _ctxlog.warn,
+          _ctxlog.info,
           "transfer leadership: finished waiting on node {} "
           "recovery",
           target_rni);


### PR DESCRIPTION

## Cover letter

This message is normal - the fact that it was in
there at WARN-level was a typo.

## Release notes

### Improvements

* Logging verbosity during leadership transfer is decreased.
