### PR TITLE
kafka: avoid reinterpret_cast for request/response headers

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -219,7 +219,7 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
             // protect against shutdown behavior
             return ss::make_ready_future<>();
         }
-        auto remaining = size - sizeof(raw_request_header)
+        auto remaining = size - request_header_size
                          - hdr.client_id_buffer.size();
         return read_iobuf_exactly(_rs.conn->input(), remaining)
           .then([this, hdr = std::move(hdr), sres = std::move(sres)](

--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -74,7 +74,7 @@ parse_header(ss::input_stream<char>& src) {
       });
 }
 
-size_t parse_size_buffer(ss::temporary_buffer<char>& buf) {
+size_t parse_size_buffer(ss::temporary_buffer<char> buf) {
     auto* raw = reinterpret_cast<const int32_t*>(buf.get());
     int32_t size = ss::be_to_cpu(*raw);
     if (size < 0) {
@@ -89,7 +89,7 @@ ss::future<std::optional<size_t>> parse_size(ss::input_stream<char>& src) {
           if (!buf) {
               return std::nullopt;
           }
-          return parse_size_buffer(buf);
+          return parse_size_buffer(std::move(buf));
       });
 }
 

--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -23,7 +23,7 @@ ss::future<std::optional<request_header>>
 parse_header(ss::input_stream<char>& src) {
     constexpr int16_t no_client_id = -1;
 
-    auto buf = co_await src.read_exactly(sizeof(raw_request_header));
+    auto buf = co_await src.read_exactly(request_header_size);
 
     if (src.eof()) {
         co_return std::nullopt;

--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -75,8 +75,10 @@ parse_header(ss::input_stream<char>& src) {
 }
 
 size_t parse_size_buffer(ss::temporary_buffer<char> buf) {
-    auto* raw = reinterpret_cast<const int32_t*>(buf.get());
-    int32_t size = ss::be_to_cpu(*raw);
+    iobuf data;
+    data.append(std::move(buf));
+    request_reader reader(std::move(data));
+    auto size = reader.read_int32();
     if (size < 0) {
         throw std::runtime_error("kafka::parse_size_buffer is negative");
     }

--- a/src/v/kafka/server/protocol_utils.cc
+++ b/src/v/kafka/server/protocol_utils.cc
@@ -79,13 +79,11 @@ size_t parse_size_buffer(ss::temporary_buffer<char> buf) {
 }
 
 ss::future<std::optional<size_t>> parse_size(ss::input_stream<char>& src) {
-    return src.read_exactly(sizeof(int32_t))
-      .then([](ss::temporary_buffer<char> buf) -> std::optional<size_t> {
-          if (!buf) {
-              return std::nullopt;
-          }
-          return parse_size_buffer(std::move(buf));
-      });
+    auto buf = co_await src.read_exactly(sizeof(int32_t));
+    if (!buf) {
+        co_return std::nullopt;
+    }
+    co_return parse_size_buffer(std::move(buf));
 }
 
 ss::scattered_message<char> response_as_scattered(response_ptr response) {

--- a/src/v/kafka/server/protocol_utils.h
+++ b/src/v/kafka/server/protocol_utils.h
@@ -26,7 +26,7 @@ namespace kafka {
 // TODO: move to iobuf_parser
 ss::future<std::optional<request_header>> parse_header(ss::input_stream<char>&);
 
-size_t parse_size_buffer(ss::temporary_buffer<char>&);
+size_t parse_size_buffer(ss::temporary_buffer<char>);
 ss::future<std::optional<size_t>> parse_size(ss::input_stream<char>&);
 
 ss::scattered_message<char> response_as_scattered(response_ptr response);

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -34,19 +34,9 @@
 
 namespace kafka {
 
-// Fields may not be byte-aligned since we work
-// with the underlying network buffer.
-struct [[gnu::packed]] raw_request_header {
-    ss::unaligned<int16_t> api_key;
-    ss::unaligned<int16_t> api_version;
-    ss::unaligned<correlation_id::type> correlation;
-    ss::unaligned<int16_t> client_id_size;
-};
-
-struct [[gnu::packed]] raw_response_header {
-    ss::unaligned<int32_t> size;
-    ss::unaligned<correlation_id::type> correlation;
-};
+constexpr auto request_header_size = sizeof(int16_t) + sizeof(int16_t)
+                                     + sizeof(correlation_id::type)
+                                     + sizeof(int16_t);
 
 struct request_header {
     api_key key;

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -63,7 +63,7 @@ get_request_context(kafka::protocol& proto, ss::input_stream<char>&& input) {
                 [&proto, &input, size](
                   std::optional<kafka::request_header> oheader) {
                     auto header = std::move(oheader.value());
-                    auto remaining = size - sizeof(kafka::raw_request_header)
+                    auto remaining = size - kafka::request_header_size
                                      - header.client_id_buffer.size();
                     /*
                      * read the request body

--- a/src/v/kafka/server/tests/request_parser_test.cc
+++ b/src/v/kafka/server/tests/request_parser_test.cc
@@ -31,7 +31,7 @@ static ss::future<iobuf> get_request(ss::input_stream<char>& input) {
           if (!buf) { // eof?
               return ss::make_ready_future<iobuf>(iobuf());
           }
-          auto size = kafka::parse_size_buffer(buf);
+          auto size = kafka::parse_size_buffer(buf.clone());
           vlog(rlog.info, "read: {}, size of kafka is:{}", buf.size(), size);
           return input.read_exactly(size).then(
             [size_buf = std::move(buf)](
@@ -55,7 +55,7 @@ get_request_context(kafka::protocol& proto, ss::input_stream<char>&& input) {
          */
         return input.read_exactly(sizeof(int32_t))
           .then([&proto, &input](ss::temporary_buffer<char> buf) {
-              auto size = kafka::parse_size_buffer(buf);
+              auto size = kafka::parse_size_buffer(std::move(buf));
               /*
                * ready the request header
                */


### PR DESCRIPTION
## Cover letter

Fix some observed UBSAN unaligned accesses that began to pop up after replacing the deprecated ss::unaligned_cast with reinterept_cast. The fix is to read the header contents off the wire using the normal kafka request/response decoder/encoder rather than using packed structures and pointer aliasing.

Fixes #2916 

## Release notes

* None
