### PR TITLE
coproc: Fix for race condition in coproc_topic_delete test

### DIFF
--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -168,6 +168,13 @@ ss::future<> script_context::send_request(
 }
 
 bool script_context::is_up_to_date() const {
+    if (_routes.empty()) {
+        /// Since this method is only used for unit tests, its never desired to
+        /// return true in the case the script is technically "up to date"
+        /// because it contains no work. It is likely due to recieve data to
+        /// process shortly.
+        return false;
+    }
     for (const auto& [_, src] : _routes) {
         const auto highest = src->rctx.input->last_stable_offset();
         for (const auto& [_, o] : src->wctx.offsets) {


### PR DESCRIPTION
A failure has been observed one time when building a recent PR:
```
../../../src/v/coproc/tests/pacemaker_tests.cc(262): [1;31;49"test_copro_delete_topic": check !in_pm.get() has failed
```
Here is where that assertion had [failed](https://github.com/vectorizedio/redpanda/blob/dev/src/v/coproc/tests/pacemaker_tests.cc#L262)

Upon further investigation it has been observed that the underlying cause is the test proceeding when it should have continued to wait due to a condition returned by a method called `script_context::is_up_to_date`.

The test deletes a materialized topic while fibers are concurrently producing onto it. The `is_up_to_date` method returns `true` even if there are no inputs. The bug is that the test proceeds to believe it has reached a condition where the materialized topic delete occurred after all processing was done, due to the logic in `is_up_to_date`. Later on the fiber produces onto that topic which re-creates it and assertions that verify those topics should not exist fail.

The fix is to modify the logic of `is_up_to_date` to not return true if there are no inputs.

This has been tested 200 times on my local machine with success on all runs