### PR TITLE
redpanda: fix some clang-tidy warnings

### DIFF
--- a/src/v/bytes/details/io_fragment.h
+++ b/src/v/bytes/details/io_fragment.h
@@ -109,6 +109,7 @@ public:
     char* get_current() { return _buf.get_write() + _used_bytes; }
     char* get_write() { return _buf.get_write(); }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes,misc-non-private-member-variables-in-classes)
     safe_intrusive_list_hook hook;
 
 private:

--- a/src/v/bytes/details/io_iterator_consumer.h
+++ b/src/v/bytes/details/io_iterator_consumer.h
@@ -52,7 +52,7 @@ public:
         const_iterator;
 
     io_iterator_consumer(
-      io_const_iterator begin, io_const_iterator end) noexcept
+      io_const_iterator const& begin, io_const_iterator const& end) noexcept
       : _frag(begin)
       , _frag_end(end) {
         if (_frag != _frag_end) {

--- a/src/v/bytes/details/io_placeholder.h
+++ b/src/v/bytes/details/io_placeholder.h
@@ -24,7 +24,7 @@ public:
     io_placeholder() noexcept = default;
 
     io_placeholder(
-      iterator iter, size_t initial_index, size_t max_size_to_write)
+      iterator const& iter, size_t initial_index, size_t max_size_to_write)
       : _iter(iter)
       , _byte_index(initial_index)
       , _remaining_size(max_size_to_write) {}

--- a/src/v/bytes/iobuf.h
+++ b/src/v/bytes/iobuf.h
@@ -79,7 +79,7 @@ public:
       : _frags(std::move(x._frags))
       , _size(x._size)
 #ifndef NDEBUG
-      , _verify_shard(std::move(x._verify_shard))
+      , _verify_shard(x._verify_shard)
 #endif
     {
         x._frags = container{};

--- a/src/v/likely.h
+++ b/src/v/likely.h
@@ -22,5 +22,7 @@
 // branch in a codebase is likely counterproductive; however, annotating
 // specific branches that are both hot and consistently mispredicted is likely
 // to yield performance improvements.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define likely(cond) __builtin_expect(!!(cond), true)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define unlikely(cond) __builtin_expect(!!(cond), false)

--- a/src/v/reflection/to_tuple.h
+++ b/src/v/reflection/to_tuple.h
@@ -19,6 +19,7 @@
 
 namespace reflection {
 
+// clang-format off
 template<typename T>
 inline auto to_tuple(T& t) {
     constexpr auto const a = arity<T>();
@@ -36,43 +37,43 @@ inline auto to_tuple(T& t) {
     } else if constexpr (a == 4) {
         auto& [p1, p2, p3, p4] = t;
         return std::tie(p1, p2, p3, p4);
-    } else if constexpr (a == 5) {
+    } else if constexpr (a == 5) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5] = t;
         return std::tie(p1, p2, p3, p4, p5);
-    } else if constexpr (a == 6) {
+    } else if constexpr (a == 6) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6] = t;
         return std::tie(p1, p2, p3, p4, p5, p6);
-    } else if constexpr (a == 7) {
+    } else if constexpr (a == 7) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7] = t;
         return std::tie(p1, p2, p3, p4, p5, p6, p7);
-    } else if constexpr (a == 8) {
+    } else if constexpr (a == 8) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8] = t;
         return std::tie(p1, p2, p3, p4, p5, p6, p7, p8);
-    } else if constexpr (a == 9) {
+    } else if constexpr (a == 9) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9] = t;
         return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9);
-    } else if constexpr (a == 10) {
+    } else if constexpr (a == 10) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10] = t;
         return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
-    } else if constexpr (a == 11) {
+    } else if constexpr (a == 11) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11] = t;
         return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);
-    } else if constexpr (a == 12) {
+    } else if constexpr (a == 12) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12] = t;
         return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);
-    } else if constexpr (a == 13) {
+    } else if constexpr (a == 13) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13] = t;
         return std::tie(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);
-    } else if constexpr (a == 14) {
+    } else if constexpr (a == 14) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14] = t;
         return std::tie(
           p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);
-    } else if constexpr (a == 15) {
+    } else if constexpr (a == 15) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15]
           = t;
         return std::tie(
           p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);
-    } else if constexpr (a == 16) {
+    } else if constexpr (a == 16) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16]
           = t;
         return std::tie(
@@ -92,7 +93,7 @@ inline auto to_tuple(T& t) {
           p14,
           p15,
           p16);
-    } else if constexpr (a == 17) {
+    } else if constexpr (a == 17) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17]
           = t;
         return std::tie(
@@ -113,7 +114,7 @@ inline auto to_tuple(T& t) {
           p15,
           p16,
           p17);
-    } else if constexpr (a == 18) {
+    } else if constexpr (a == 18) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18]
           = t;
         return std::tie(
@@ -135,7 +136,7 @@ inline auto to_tuple(T& t) {
           p16,
           p17,
           p18);
-    } else if constexpr (a == 19) {
+    } else if constexpr (a == 19) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19]
           = t;
         return std::tie(
@@ -158,7 +159,7 @@ inline auto to_tuple(T& t) {
           p17,
           p18,
           p19);
-    } else if constexpr (a == 20) {
+    } else if constexpr (a == 20) { // NOLINT(cppcoreguidelines-avoid-magic-numbers)
         auto& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20]
           = t;
         return std::tie(
@@ -184,5 +185,6 @@ inline auto to_tuple(T& t) {
           p20);
     }
 }
+// clang-format on
 
 } // namespace reflection

--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -81,7 +81,7 @@ send_reply(ss::lw_shared_ptr<server_context_impl> ctx, netbuf buf) {
         return ss::make_ready_future<>();
     }
     return ctx->res.conn->write(std::move(view))
-      .handle_exception([ctx](std::exception_ptr e) {
+      .handle_exception([ctx = std::move(ctx)](std::exception_ptr e) {
           vlog(rpclog.info, "Error dispatching method: {}", e);
           ctx->res.conn->shutdown_input();
       });

--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -17,6 +17,12 @@
 #include <exception>
 
 namespace rpc {
+
+/*
+ * the size threshold above which a reply message will use compression.
+ */
+static constexpr size_t reply_min_compression_bytes = 1024;
+
 struct server_context_impl final : streaming_context {
     server_context_impl(server::resources s, header h)
       : res(std::move(s))
@@ -63,7 +69,7 @@ ss::future<> simple_protocol::apply(server::resources rs) {
 
 ss::future<>
 send_reply(ss::lw_shared_ptr<server_context_impl> ctx, netbuf buf) {
-    buf.set_min_compression_bytes(1024);
+    buf.set_min_compression_bytes(reply_min_compression_bytes);
     buf.set_compression(rpc::compression_type::zstd);
     buf.set_correlation_id(ctx->get_header().correlation_id);
 

--- a/src/v/utils/hdr_hist.h
+++ b/src/v/utils/hdr_hist.h
@@ -45,6 +45,8 @@ inline hdr_histogram_ptr make_unique_hdr_histogram(
 // Potentially VERY expensive object. At default granularity is about 4k bytes
 class hdr_hist {
 public:
+    static constexpr int64_t us_per_hour = 3600000000;
+
     using clock_type = std::chrono::high_resolution_clock;
     /// \brief move-only type to tracking durations
     /// if hdr_hist ptr goes out of scope, it will detach itself
@@ -105,7 +107,7 @@ public:
     };
 
     hdr_hist(
-      int64_t max_value = 3600000000,
+      int64_t max_value = us_per_hour,
       int64_t min = 1,
       int32_t significant_figures = 1)
       : _hist(hist_internal::make_unique_hdr_histogram(

--- a/src/v/utils/hdr_hist.h
+++ b/src/v/utils/hdr_hist.h
@@ -106,7 +106,7 @@ public:
         friend std::ostream& operator<<(std::ostream& o, const measurement&);
     };
 
-    hdr_hist(
+    explicit hdr_hist(
       int64_t max_value = us_per_hour,
       int64_t min = 1,
       int32_t significant_figures = 1)

--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -180,6 +180,12 @@ protected:
     type _value;
 };
 
+template<typename T, typename Tag, typename IsConstexpr>
+inline std::ostream&
+operator<<(std::ostream& o, const base_named_type<T, Tag, IsConstexpr>& t) {
+    return o << "{" << t() << "}";
+};
+
 } // namespace detail
 
 template<typename T, typename Tag>
@@ -196,10 +202,4 @@ struct hash<named_type<T, Tag>> {
         return std::hash<T>()(x);
     }
 };
-
-template<typename T, typename Tag>
-inline ostream& operator<<(ostream& o, const ::named_type<T, Tag>& t) {
-    return o << "{" << t() << "}";
-};
-
 } // namespace std

--- a/src/v/vassert.h
+++ b/src/v/vassert.h
@@ -33,6 +33,7 @@ static dummyassert g_assert_log;
  * }
  *
  */
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define vassert(x, msg, args...)                                               \
     do {                                                                       \
         /*The !(x) is not an error. see description above*/                    \


### PR DESCRIPTION
## Cover letter

Fixes an assortment of clang-tidy warnings. Once the tree is mostly free of warnings we can consider turning it on in CI / cmake.

## Release notes

* None
