### PR TITLE
Fix disk space issues

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -31,7 +31,7 @@ static constexpr size_t default_write_buffer_size = 128_KiB;
 static constexpr unsigned default_writebehind = 10;
 
 struct cache_item {
-    ss::input_stream<char> body;
+    ss::file body;
     size_t size;
 };
 
@@ -54,17 +54,7 @@ public:
     /// Get cached value as a stream if it exists on disk
     ///
     /// \param key is a cache key
-    /// \param file_pos is an offset to start from in the returned stream
-    /// \param io_priority is an io priority of the resulting stream
-    /// \param read_buffer_size is a buffer size of the returned stream
-    /// \param readahead is a readahead parameter of the returned stream
-    ss::future<std::optional<cache_item>> get(
-      std::filesystem::path key,
-      size_t file_pos = 0,
-      ss::io_priority_class io_priority
-      = priority_manager::local().shadow_indexing_priority(),
-      size_t read_buffer_size = default_read_buffer_size,
-      unsigned int readahead = default_readahead);
+    ss::future<std::optional<cache_item>> get(std::filesystem::path key);
 
     /// Add new value to the cache, overwrite if it's already exist
     ///

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -330,6 +330,9 @@ ss::future<> remote_partition::run_eviction_loop() {
         }
     } catch (const ss::broken_condition_variable&) {
     }
+    for (auto& rs : _eviction_list) {
+        co_await std::visit([](auto&& rs) { return rs->stop(); }, rs);
+    }
     vlog(_ctxlog.debug, "remote partition eviction loop stopped");
 }
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -578,11 +578,7 @@ remote_segment_batch_reader::init_parser() {
       0, priority_manager::local().shadow_indexing_priority());
     auto parser = std::make_unique<storage::continuous_batch_parser>(
       std::make_unique<remote_segment_batch_consumer>(
-        _config,
-        *this,
-        _seg->get_term(),
-        _seg->get_ntp(),
-        *_seg->get_retry_chain_node()),
+        _config, *this, _seg->get_term(), _seg->get_ntp(), _rtc),
       std::move(stream));
     co_return parser;
 }

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -531,6 +531,7 @@ ss::future<result<ss::circular_buffer<model::record_batch>>>
 remote_segment_batch_reader::read_some(
   model::timeout_clock::time_point deadline,
   storage::offset_translator_state& ot_state) {
+    ss::gate::holder h(_gate);
     if (_ringbuf.empty()) {
         if (!_parser) {
             // remote_segment_batch_reader shouldn't be used concurrently
@@ -592,6 +593,7 @@ size_t remote_segment_batch_reader::produce(model::record_batch batch) {
 
 ss::future<> remote_segment_batch_reader::stop() {
     vlog(_ctxlog.debug, "remote_segment_batch_reader::close");
+    co_await _gate.close();
     if (_parser) {
         vlog(
           _ctxlog.debug, "remote_segment_batch_reader::close - parser-close");

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -89,9 +89,7 @@ public:
     data_stream(size_t pos, ss::io_priority_class);
 
     /// Hydrate the segment
-    ///
-    /// Method returns key of the segment in cache.
-    ss::future<std::filesystem::path> hydrate();
+    ss::future<> hydrate();
 
     retry_chain_node* get_retry_chain_node() { return &_rtc; }
 
@@ -112,12 +110,12 @@ private:
     /// Notifies the background hydration fiber
     ss::condition_variable _bg_cvar;
 
-    using expiry_handler
-      = std::function<void(ss::promise<std::filesystem::path>&)>;
+    using expiry_handler = std::function<void(ss::promise<ss::file>&)>;
 
     /// List of fibers that wait for the segment to be hydrated
-    ss::expiring_fifo<ss::promise<std::filesystem::path>, expiry_handler>
-      _wait_list;
+    ss::expiring_fifo<ss::promise<ss::file>, expiry_handler> _wait_list;
+
+    ss::file _data_file;
 };
 
 class remote_segment_batch_consumer;

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -194,6 +194,7 @@ private:
     model::offset _cur_rp_offset;
     model::offset _cur_delta;
     size_t _bytes_consumed{0};
+    ss::gate _gate;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -357,10 +357,13 @@ static std::vector<model::record_batch_header> scan_remote_partition(
       manifest, api, *imposter.cache, bucket);
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
 
+    partition->start().get();
+
     auto reader = partition->make_reader(reader_config).get().reader;
 
     auto headers_read
       = reader.consume(test_consumer(), model::no_timeout).get();
+    std::move(reader).release();
 
     return headers_read;
 }
@@ -903,6 +906,8 @@ scan_remote_partition_incrementally(
     auto partition = ss::make_lw_shared<remote_partition>(
       manifest, api, *imposter.cache, bucket);
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
+
+    partition->start().get();
 
     std::vector<model::record_batch_header> headers;
 


### PR DESCRIPTION
## Cover letter

This PR improves handling of opened files inside remote_partition.
It changes cache interface in order to return `ss::file` instead of `ss::input_stream` and caches the file inside the remote_segment. It also fixes the race condition that occurs if we're stopping the reader while reads are present.
It also adds extra safety check by linking components using `retry_chain_node` instances properly.

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/84e433b910050ebe4af006e5470063fa09a48ab5..d179b2c34635620f3e68ce1833cf6554583b0ee9)
- rebase with dev

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3334 #3324 

## Release notes

*none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
