### PR TITLE
rptest: tolerate NTP errors for rpk bundle

### DIFF
--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -86,6 +86,8 @@ class RpkClusterTest(RedpandaTest):
                 # dmidecode doesn't work in ducktape containers, ignore
                 # errors about it.
                 continue
+            if re.match('.* error querying .*\.ntp\..* i\/o timeout', l):
+                self.logger.error(f"Non-fatal transitory NTP error: {l}")
             else:
                 self.logger.error(f"Bad output line: {l}")
                 filtered_errors.append(l)


### PR DESCRIPTION
## Cover letter

Make the rpk bundle tests resilient to NTP errors. 

Fix #2802

## Release notes
* none

