### PR TITLE
Fixed decommissioned node being removed to early

### DIFF
--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -65,7 +65,6 @@ metadata_dissemination_service::metadata_dissemination_service(
         (void)ss::with_gate(
           _bg, [this] { return dispatch_disseminate_leadership(); });
     });
-    _dispatch_timer.arm(_dissemination_interval);
 
     for (auto& seed : config::node().seed_servers()) {
         _seed_servers.push_back(seed.addr);
@@ -136,6 +135,7 @@ ss::future<> metadata_dissemination_service::start() {
           return update_metadata_with_retries(std::move(addresses));
       });
 
+    _dispatch_timer.arm(_dissemination_interval);
     return ss::make_ready_future<>();
 }
 

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -328,16 +328,16 @@ ss::future<> metadata_dissemination_service::dispatch_one_update(
         ss::this_shard_id(),
         target_id,
         _dissemination_interval,
-        [this, &meta, target_id](
+        [this, updates = meta.updates, target_id](
           metadata_dissemination_rpc_client_protocol proto) mutable {
             vlog(
               clusterlog.trace,
               "Sending {} metadata updates to {}",
-              meta.updates.size(),
+              updates,
               target_id);
             return proto
               .update_leadership(
-                update_leadership_request{meta.updates},
+                update_leadership_request{std::move(updates)},
                 rpc::client_opts(
                   _dissemination_interval + rpc::clock_type::now()))
               .then(&rpc::get_ctx_data<update_leadership_reply>);

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -287,6 +287,11 @@ void metadata_dissemination_service::collect_pending_updates() {
             if (!_pending_updates.contains(id)) {
                 _pending_updates.emplace(id, update_retry_meta{ntp_leaders{}});
             }
+            vlog(
+              clusterlog.trace,
+              "new metadata update {} for {}",
+              ntp_leader,
+              id);
             _pending_updates[id].updates.push_back(ntp_leader);
         }
     }
@@ -304,6 +309,7 @@ void metadata_dissemination_service::cleanup_finished_updates() {
         }
     }
     for (auto id : _to_remove) {
+        vlog(clusterlog.trace, "node {} update finished", id);
         _pending_updates.erase(id);
     }
 }

--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -10,6 +10,8 @@
 #include "cluster/metadata_dissemination_service.h"
 
 #include "cluster/cluster_utils.h"
+#include "cluster/health_monitor_frontend.h"
+#include "cluster/health_monitor_types.h"
 #include "cluster/logger.h"
 #include "cluster/members_table.h"
 #include "cluster/metadata_cache.h"
@@ -50,13 +52,15 @@ metadata_dissemination_service::metadata_dissemination_service(
   ss::sharded<partition_leaders_table>& leaders,
   ss::sharded<members_table>& members,
   ss::sharded<topic_table>& topics,
-  ss::sharded<rpc::connection_cache>& clients)
+  ss::sharded<rpc::connection_cache>& clients,
+  ss::sharded<health_monitor_frontend>& health_monitor)
   : _raft_manager(raft_manager)
   , _partition_manager(partition_manager)
   , _leaders(leaders)
   , _members_table(members)
   , _topics(topics)
   , _clients(clients)
+  , _health_monitor(health_monitor)
   , _self(make_self_broker(config::node()))
   , _dissemination_interval(
       config::shard_local_cfg().metadata_dissemination_interval_ms)
@@ -315,15 +319,44 @@ void metadata_dissemination_service::cleanup_finished_updates() {
 }
 
 ss::future<> metadata_dissemination_service::dispatch_disseminate_leadership() {
-    collect_pending_updates();
-    return ss::parallel_for_each(
-             _pending_updates.begin(),
-             _pending_updates.end(),
-             [this](broker_updates_t::value_type& br_update) {
-                 return dispatch_one_update(br_update.first, br_update.second);
-             })
+    /**
+     * Use currently available health report snapshot to update leadership
+     * information. If snapshot would contain stale data they will be ignored by
+     * term check in partition leaders table
+     */
+    return _health_monitor.local()
+      .get_current_cluster_health_snapshot(cluster_report_filter{})
+      .then([this](cluster_health_report report) {
+          return update_leaders_with_health_report(std::move(report));
+      })
+      .then([this] {
+          collect_pending_updates();
+          return ss::parallel_for_each(
+            _pending_updates.begin(),
+            _pending_updates.end(),
+            [this](broker_updates_t::value_type& br_update) {
+                return dispatch_one_update(br_update.first, br_update.second);
+            });
+      })
       .then([this] { cleanup_finished_updates(); })
       .finally([this] { _dispatch_timer.arm(_dissemination_interval); });
+}
+
+ss::future<> metadata_dissemination_service::update_leaders_with_health_report(
+  cluster_health_report report) {
+    for (auto& node_report : report.node_reports) {
+        co_await _leaders.invoke_on_all(
+          [node_report](partition_leaders_table& leaders) {
+              for (auto& tp : node_report.topics) {
+                  for (auto& p : tp.partitions) {
+                      leaders.update_partition_leader(
+                        model::ntp(tp.tp_ns.ns, tp.tp_ns.tp, p.id),
+                        p.term,
+                        p.leader_id);
+                  }
+              }
+          });
+    }
 }
 
 ss::future<> metadata_dissemination_service::dispatch_one_update(

--- a/src/v/cluster/metadata_dissemination_service.h
+++ b/src/v/cluster/metadata_dissemination_service.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/fwd.h"
+#include "cluster/health_monitor_types.h"
 #include "cluster/metadata_dissemination_types.h"
 #include "config/tls_config.h"
 #include "model/fundamental.h"
@@ -77,7 +78,8 @@ public:
       ss::sharded<partition_leaders_table>&,
       ss::sharded<members_table>&,
       ss::sharded<topic_table>&,
-      ss::sharded<rpc::connection_cache>&);
+      ss::sharded<rpc::connection_cache>&,
+      ss::sharded<health_monitor_frontend>&);
 
     void disseminate_leadership(
       model::ntp, model::term_id, std::optional<model::node_id>);
@@ -127,12 +129,15 @@ private:
     ss::future<>
       update_metadata_with_retries(std::vector<net::unresolved_address>);
 
+    ss::future<> update_leaders_with_health_report(cluster_health_report);
+
     ss::sharded<raft::group_manager>& _raft_manager;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     ss::sharded<partition_leaders_table>& _leaders;
     ss::sharded<members_table>& _members_table;
     ss::sharded<topic_table>& _topics;
     ss::sharded<rpc::connection_cache>& _clients;
+    ss::sharded<health_monitor_frontend>& _health_monitor;
     model::broker _self;
     std::chrono::milliseconds _dissemination_interval;
     config::tls_config _rpc_tls_config;

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -166,6 +166,10 @@ public:
 
     bool is_update_in_progress(const model::ntp&) const;
 
+    bool has_updates_in_progress() const {
+        return !_update_in_progress.empty();
+    }
+
 private:
     struct waiter {
         explicit waiter(uint64_t id)

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1816,6 +1816,10 @@ group::offset_commit_stages group::store_offsets(offset_commit_request&& r) {
         result<raft::replicate_result> r) mutable {
           auto error = error_code::none;
           if (!r) {
+              vlog(
+                _ctxlog.info,
+                "Storing committed offset failed - {}",
+                r.error().message());
               error = map_store_offset_error_code(r.error());
           }
           if (in_state(group_state::dead)) {

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1733,7 +1733,7 @@ group::store_txn_offsets(txn_offset_commit_request r) {
 }
 
 kafka::error_code map_store_offset_error_code(std::error_code ec) {
-    if (ec.category() == raft::errc_category()) {
+    if (ec.category() == raft::error_category()) {
         switch (raft::errc(ec.value())) {
         case raft::errc::success:
             return error_code::none;

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -103,6 +103,7 @@ cluster::begin_group_tx_reply make_begin_tx_reply(cluster::tx_errc);
 cluster::prepare_group_tx_reply make_prepare_tx_reply(cluster::tx_errc);
 cluster::commit_group_tx_reply make_commit_tx_reply(cluster::tx_errc);
 cluster::abort_group_tx_reply make_abort_tx_reply(cluster::tx_errc);
+kafka::error_code map_store_offset_error_code(std::error_code);
 
 /// \brief A Kafka group.
 ///

--- a/src/v/kafka/server/tests/error_mapping_test.cc
+++ b/src/v/kafka/server/tests/error_mapping_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "kafka/server/errors.h"
+#include "kafka/server/group.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -42,5 +43,23 @@ BOOST_AUTO_TEST_CASE(mapping_unknow_error) {
       kafka::error_code::unknown_server_error);
     BOOST_REQUIRE_EQUAL(
       kafka::map_topic_error_code(static_cast<cluster::errc>(-33)),
+      kafka::error_code::unknown_server_error);
+};
+
+BOOST_AUTO_TEST_CASE(mapping_offset_commit_error) {
+    BOOST_REQUIRE_EQUAL(
+      kafka::map_store_offset_error_code(raft::errc::success),
+      kafka::error_code::none);
+    BOOST_REQUIRE_EQUAL(
+      kafka::map_store_offset_error_code(raft::errc::shutting_down),
+      kafka::error_code::request_timed_out);
+    BOOST_REQUIRE_EQUAL(
+      kafka::map_store_offset_error_code(raft::errc::timeout),
+      kafka::error_code::request_timed_out);
+    BOOST_REQUIRE_EQUAL(
+      kafka::map_store_offset_error_code(raft::errc::not_leader),
+      kafka::error_code::not_coordinator);
+    BOOST_REQUIRE_EQUAL(
+      kafka::map_store_offset_error_code(raft::errc::leader_append_failed),
       kafka::error_code::unknown_server_error);
 };

--- a/src/v/raft/follower_stats.cc
+++ b/src/v/raft/follower_stats.cc
@@ -35,9 +35,16 @@ void follower_stats::update_with_configuration(const group_configuration& cfg) {
         it->second.is_learner = false;
     });
 
-    absl::erase_if(_followers, [&cfg](const container_t::value_type& p) {
-        return !cfg.contains(p.first);
-    });
+    for (auto it = _followers.begin(); it != _followers.end();) {
+        // if follower is not present in configuration brake condition variable
+        // and remove
+        if (!cfg.contains(it->first)) {
+            it->second.follower_state_change.broken();
+            _followers.erase(it++);
+            continue;
+        }
+        ++it;
+    }
 }
 
 ss::future<ss::semaphore_units<>>

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -716,7 +716,8 @@ void application::wire_up_redpanda_services() {
       std::ref(controller->get_partition_leaders()),
       std::ref(controller->get_members_table()),
       std::ref(controller->get_topics_state()),
-      std::ref(_raft_connection_cache))
+      std::ref(_raft_connection_cache),
+      std::ref(controller->get_health_monitor()))
       .get();
 
     if (archival_storage_enabled()) {

--- a/tests/rptest/services/failure_injector.py
+++ b/tests/rptest/services/failure_injector.py
@@ -28,7 +28,7 @@ class FailureSpec:
         self.node = node
 
     def __str__(self):
-        return f"type: {self.type}, length: {self.length} seconds, node: {self.node}"
+        return f"type: {self.type}, length: {self.length} seconds, node: {self.node.account.hostname}"
 
 
 class FailureInjector:

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -34,11 +34,11 @@ ALLOWED_REPLICATION = [1, 3]
 
 
 class NodeOperationFuzzyTest(EndToEndTest):
-    def generate_random_workload(self, count, skip_nodes):
+    def generate_random_workload(self, count, skip_nodes, available_nodes):
         op_types = [ADD, DECOMMISSION]
         tp_op_types = [ADD_TOPIC, DELETE_TOPIC]
         # current state
-        active_nodes = [1, 2, 3, 4, 5]
+        active_nodes = list(available_nodes)
         decommissioned_nodes = []
         operations = []
         topics = []
@@ -128,7 +128,6 @@ class NodeOperationFuzzyTest(EndToEndTest):
                 "group_topic_partitions": 3,
                 "default_topic_replications": 3,
             })
-        self.active_nodes = set([1, 2, 3, 4, 5])
 
         self.redpanda.start()
         # create some topics
@@ -140,7 +139,20 @@ class NodeOperationFuzzyTest(EndToEndTest):
         self.start_producer(1, throughput=100)
         self.start_consumer(1)
         self.await_startup()
+        self.active_nodes = set(
+            [self.redpanda.idx(n) for n in self.redpanda.nodes])
+        # collect current mapping
+        self.ids_mapping = {}
+        for n in self.redpanda.nodes:
+            self.ids_mapping[self.redpanda.idx(n)] = self.redpanda.idx(n)
+        self.next_id = sorted(list(self.ids_mapping.keys()))[-1] + 1
+        self.redpanda.logger.info(f"Initial ids mapping: {self.ids_mapping}")
         NODE_OP_TIMEOUT = 360
+
+        def get_next_id():
+            id = self.next_id
+            self.next_id += 1
+            return id
 
         def failure_injector_loop():
             f_injector = FailureInjector(self.redpanda)
@@ -153,8 +165,8 @@ class NodeOperationFuzzyTest(EndToEndTest):
                     node = random.choice(self.redpanda.nodes)
                 else:
                     #kill/termianate only active nodes (not to influence the test outcome)
-                    idx = random.choice(list(self.active_nodes)) - 1
-                    node = self.redpanda.nodes[idx]
+                    idx = random.choice(list(self.active_nodes))
+                    node = self.redpanda.get_node(idx)
 
                 f_injector.inject_failure(
                     FailureSpec(node=node, type=f_type, length=length))
@@ -170,13 +182,15 @@ class NodeOperationFuzzyTest(EndToEndTest):
             finjector_thread.daemon = True
             finjector_thread.start()
 
-        def decommission(node_id):
-            self.logger.info(f"decommissioning node: {node_id}")
+        def decommission(idx):
+            node_id = self.ids_mapping[idx]
+            self.logger.info(f"decommissioning node: {idx} with id: {node_id}")
 
             def decommissioned():
                 try:
                     admin = Admin(self.redpanda)
                     # if broker is already draining, it is suceess
+
                     brokers = admin.get_brokers()
                     for b in brokers:
                         if b['node_id'] == node_id and b[
@@ -199,7 +213,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
             def node_removed():
                 admin = Admin(self.redpanda)
                 try:
-                    brokers = admin.get_brokers(node=self.redpanda.nodes[0])
+                    brokers = admin.get_brokers()
                     for b in brokers:
                         if b['node_id'] == node_id:
                             return False
@@ -227,18 +241,37 @@ class NodeOperationFuzzyTest(EndToEndTest):
 
             return node_replicas
 
-        def restart_node(node_id, cleanup=True):
-            self.logger.info(f"restarting node: {node_id}")
-            self.redpanda.stop_node(self.redpanda.nodes[node_id - 1])
+        def seed_servers_for(idx):
+            seeds = map(
+                lambda n: {
+                    "address": n.account.hostname,
+                    "port": 33145
+                }, self.redpanda.nodes)
+
+            return list(
+                filter(
+                    lambda n: n['address'] != self.redpanda.get_node(idx).
+                    account.hostname, seeds))
+
+        def add_node(idx, cleanup=True):
+            id = get_next_id()
+            self.logger.info(f"adding node: {idx} back with new id: {id}")
+            self.ids_mapping[idx] = id
+            self.redpanda.stop_node(self.redpanda.get_node(idx))
             if cleanup:
-                self.redpanda.clean_node(self.redpanda.nodes[node_id - 1],
+                self.redpanda.clean_node(self.redpanda.get_node(idx),
                                          preserve_logs=True)
-            self.redpanda.start_node(self.redpanda.nodes[node_id - 1])
+            # we do not reuse previous node ids and override seed server list
+            self.redpanda.start_node(self.redpanda.get_node(idx),
+                                     override_cfg_params={
+                                         "node_id": id,
+                                         "seed_servers": seed_servers_for(idx)
+                                     })
 
             def has_new_replicas():
                 per_node = replicas_per_node()
                 self.logger.info(f"replicas per node: {per_node}")
-                return node_id in per_node
+                return id in per_node
 
             wait_until(has_new_replicas,
                        timeout_sec=NODE_OP_TIMEOUT,
@@ -277,20 +310,22 @@ class NodeOperationFuzzyTest(EndToEndTest):
                 self.redpanda.logger.warn(f"error while listing topics - {e}")
                 return False
 
-        work = self.generate_random_workload(10, skip_nodes=set())
+        work = self.generate_random_workload(10,
+                                             skip_nodes=set(),
+                                             available_nodes=self.active_nodes)
         self.redpanda.logger.info(f"node operations to execute: {work}")
         for op in work:
             op_type = op[0]
-            self.logger.info(f"executing - {op}")
-
+            self.logger.info(
+                f"executing - {op} - current ids: {self.ids_mapping}")
             if op_type == ADD:
-                id = op[1]
-                self.active_nodes.add(id)
-                restart_node(id)
+                idx = op[1]
+                self.active_nodes.add(idx)
+                add_node(idx)
             if op_type == DECOMMISSION:
-                id = op[1]
-                self.active_nodes.remove(id)
-                decommission(id)
+                idx = op[1]
+                self.active_nodes.remove(idx)
+                decommission(idx)
             elif op_type == ADD_TOPIC:
                 spec = TopicSpec(name=op[1],
                                  replication_factor=op[2],


### PR DESCRIPTION
## Cover letter

This PR contains a major fix related with node decommissioning.

### Waiting for all partition configuration changes

Wait for all pending partition configuration changes to finish before performing the removal of decommissioned node. Previously it might have happen that the node was removed before all the partitions were drained and safely removed from it.  The problem manifested itself only when controller leadership changed during node decommissioning. In this case the new raft0 leader might already seen updated metadata i.e. the one which doesn't contain the node that is being removed but configuration change may still be in progress in `controller_backend`. Members backend is not aware of this as current partition configuration doesn't contain the decommissioned node already so it does not require monitoring. Waiting for all the partition operations to finish guarantee that in progress changes will be finished before performing the final removal step of decommissioned node.

### Test improvements

This PR improves node operations fuzzy test by not reusing Node ids. 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Related to #3312 
Fixes: #3328, #3277

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.



-->
### Improvements

* Fixes for node decommissioning in face of failures