### PR TITLE
cloud_storage: backport pr3356

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -124,7 +124,10 @@ static error_outcome categorize_error(
             // This is a short read error that can be caused by the abrupt TLS
             // shutdown. The content of the received buffer is discarded in this
             // case and http client receives an empty buffer.
-            vlog(ctxlog.warn, "Short Read detected, retrying {}", err.what());
+            vlog(
+              ctxlog.info,
+              "Server disconnected: '{}', retrying HTTP request",
+              err.what());
         }
     } catch (...) {
         vlog(ctxlog.error, "Unexpected error {}", std::current_exception());

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -247,10 +247,10 @@ ss::future<> client::response_stream::shutdown() { return _client->stop(); }
 /// Return failed future if ec is set, otherwise return future in ready state
 static ss::future<iobuf>
 fail_on_error(prefix_logger& ctxlog, const boost::beast::error_code& ec) {
-    if (!ec) {
+    if (!ec.failed()) {
         return ss::make_ready_future<iobuf>(iobuf());
     }
-    vlog(ctxlog.error, "'{}' error triggered", ec);
+    vlog(ctxlog.debug, "'{}' error triggered", ec);
     boost::system::system_error except(ec);
     return ss::make_exception_future<iobuf>(except);
 }


### PR DESCRIPTION
Backport of  #3356

## Cover letter

Downgrade log message severity in case of http client disconnect since it's a normal mode of operation.
Fixes: #3333

## Release notes

### Improvements

* Fine-tune logging
