### PR TITLE
tests/dockerfile: use impish instead of groovy

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:groovy-20210325
+FROM ubuntu:impish-20211102
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Cover letter

Ducktape test image was using the now EOL ubuntu version groovy

## Release notes

* none
