### PR TITLE
ducktape: remove minor version for python command

### DIFF
--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -925,7 +925,7 @@ class SchemaRegistryTest(RedpandaTest):
 
         # Expose into StressTest
         logger = self.logger
-        python = "python3.8"
+        python = "python3"
         script_name = "schema_registry_test_helper.py"
 
         dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
## Cover letter

Use `python3` instead of `python3.x`

## Release notes

* none
