### PR TITLE
backport 3308: Stop partition_record_batch_reader_impl

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -116,6 +116,10 @@ public:
                 co_return storage_t{};
             }
             while (co_await maybe_reset_reader()) {
+                if (_partition->_as.abort_requested()) {
+                    co_await set_end_of_stream();
+                    co_return storage_t{};
+                }
                 vlog(
                   _ctxlog.debug,
                   "Invoking 'read_some' on current log reader with config: {}",


### PR DESCRIPTION

## Cover letter

The partition_record_batch_reader_impl component is not stopping when
the underlying remote_partition is stopped. This manifested in the
following situation during failure. The reader stuck in an infinite loop
first. Then the remote_partition was stopped, but the infinite loop
didn't. It continued to consume CPU even when the entire topic was
deleted.

Thic PR fixes this by checking the abort_source inside the
remote_partition. 

Fixes #3305



<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
