### PR TITLE
Cloud storage: unique archived segment names

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -166,6 +166,7 @@ private:
     model::revision_id _rev;
     cloud_storage::remote& _remote;
     ss::lw_shared_ptr<cluster::partition> _partition;
+    model::term_id _start_term;
     archival_policy _policy;
     s3::bucket_name _bucket;
     /// Remote manifest contains representation of the data stored in S3 (it

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -666,7 +666,8 @@ static void test_partial_upload_impl(
       .is_compacted = false,
       .size_bytes = 1, // doesn't matter
       .base_offset = model::offset(0),
-      .committed_offset = last_uploaded_offset};
+      .committed_offset = last_uploaded_offset,
+      .ntp_revision = manifest.get_revision_id()};
 
     manifest.add(s1name, segment_meta);
 
@@ -675,13 +676,17 @@ static void test_partial_upload_impl(
 
     // Generate segment urls
     auto url1 = "/"
-                + manifest
-                    .get_remote_segment_path(segment_name(ssx::sformat(
+                + cloud_storage::manifest::generate_remote_segment_path(
+                    manifest.get_ntp(),
+                    segment_meta.ntp_revision,
+                    segment_name(ssx::sformat(
                       "{}-1-v1.log", last_uploaded_offset() + 1)))()
                     .string();
     auto url2 = "/"
-                + manifest
-                    .get_remote_segment_path(segment_name(ssx::sformat(
+                + cloud_storage::manifest::generate_remote_segment_path(
+                    manifest.get_ntp(),
+                    segment_meta.ntp_revision,
+                    segment_name(ssx::sformat(
                       "{}-1-v1.log", next_uploaded_offset() + 1)))()
                     .string();
     vlog(

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -37,45 +37,6 @@ using namespace archival;
 
 inline ss::logger test_log("test"); // NOLINT
 
-static constexpr std::string_view manifest_payload = R"json({
-    "version": 1,
-    "namespace": "kafka",
-    "topic": "test-topic",
-    "partition": 42,
-    "revision": 0,
-    "last_offset": 1004,
-    "segments": {
-        "0-1-v1.log": {
-            "is_compacted": false,
-            "size_bytes": 100,
-            "committed_offset": 2,
-            "base_offset": 0
-        },
-        "1000-4-v1.log": {
-            "is_compacted": false,
-            "size_bytes": 200,
-            "committed_offset": 1004,
-            "base_offset": 3
-        }
-    }
-})json";
-static constexpr std::string_view manifest_with_deleted_segment = R"json({
-    "version": 1,
-    "namespace": "kafka",
-    "topic": "test-topic",
-    "partition": 42,
-    "revision": 0,
-    "last_offset": 4,
-    "segments": {
-        "1000-4-v1.log": {
-            "is_compacted": false,
-            "size_bytes": 200,
-            "committed_offset": 1004,
-            "base_offset": 3
-        }
-    }
-})json";
-
 static const auto manifest_namespace = model::ns("kafka");      // NOLINT
 static const auto manifest_topic = model::topic("test-topic");  // NOLINT
 static const auto manifest_partition = model::partition_id(42); // NOLINT
@@ -89,32 +50,8 @@ static const ss::sstring manifest_url = ssx::sformat(        // NOLINT
   manifest_ntp.path(),
   manifest_revision());
 
-// NOLINTNEXTLINE
-static const ss::sstring segment1_url
-  = "/3ed95428/kafka/test-topic/42_0/0-1-v1.log";
-// NOLINTNEXTLINE
-static const ss::sstring segment2_url
-  = "/0bbed744/kafka/test-topic/42_0/1000-4-v1.log";
-
-static const std::vector<s3_imposter_fixture::expectation>
-  default_expectations({
-    s3_imposter_fixture::expectation{
-      .url = manifest_url, .body = ss::sstring(manifest_payload)},
-    s3_imposter_fixture::expectation{.url = segment1_url, .body = "segment1"},
-    s3_imposter_fixture::expectation{.url = segment2_url, .body = "segment2"},
-  });
-
 static storage::ntp_config get_ntp_conf() {
     return storage::ntp_config(manifest_ntp, "base-dir");
-}
-
-static cloud_storage::manifest load_manifest(std::string_view v) {
-    cloud_storage::manifest m;
-    iobuf i;
-    i.append(v.data(), v.size());
-    auto s = make_iobuf_input_stream(std::move(i));
-    m.update(std::move(s)).get();
-    return std::move(m);
 }
 
 /// Compare two json objects logically by parsing them first and then going
@@ -163,60 +100,9 @@ void log_upload_candidate(const archival::upload_candidate& up) {
       up.source->offsets().dirty_offset);
 }
 
-FIXTURE_TEST(test_download_manifest, s3_imposter_fixture) { // NOLINT
-    set_expectations_and_listen(default_expectations);
-    auto [arch_conf, remote_conf] = get_configurations();
-    service_probe probe(service_metrics_disabled::yes);
-    cloud_storage::remote remote(
-      remote_conf.connection_limit, remote_conf.client_config);
-    archival::ntp_archiver archiver(
-      get_ntp_conf(), arch_conf, remote, nullptr, probe);
-    auto action = ss::defer([&archiver] { archiver.stop().get(); });
-    retry_chain_node fib;
-    auto res = archiver.download_manifest(fib).get0();
-    BOOST_REQUIRE(res == cloud_storage::download_result::success);
-    auto expected = load_manifest(manifest_payload);
-    BOOST_REQUIRE(expected == archiver.get_remote_manifest()); // NOLINT
-}
-
-FIXTURE_TEST(test_upload_manifest, s3_imposter_fixture) { // NOLINT
-    set_expectations_and_listen(default_expectations);
-    auto [arch_conf, remote_conf] = get_configurations();
-    service_probe probe(service_metrics_disabled::yes);
-    cloud_storage::remote remote(
-      remote_conf.connection_limit, remote_conf.client_config);
-    archival::ntp_archiver archiver(
-      get_ntp_conf(), arch_conf, remote, nullptr, probe);
-    auto action = ss::defer([&archiver] { archiver.stop().get(); });
-    auto pm = const_cast<cloud_storage::manifest*>( // NOLINT
-      &archiver.get_remote_manifest());
-    pm->add(
-      segment_name("0-1-v1.log"),
-      {
-        .is_compacted = false,
-        .size_bytes = 100, // NOLINT
-        .base_offset = model::offset(0),
-        .committed_offset = model::offset(2),
-      });
-    pm->add(
-      segment_name("1000-4-v1.log"),
-      {
-        .is_compacted = false,
-        .size_bytes = 200, // NOLINT
-        .base_offset = model::offset(3),
-        .committed_offset = model::offset(1004),
-      });
-    retry_chain_node fib;
-    auto res = archiver.upload_manifest(fib).get0();
-    BOOST_REQUIRE(res == cloud_storage::upload_result::success);
-    auto req = get_requests().front();
-    // NOLINTNEXTLINE
-    BOOST_REQUIRE(compare_json_objects(req.content, manifest_payload));
-}
-
 // NOLINTNEXTLINE
 FIXTURE_TEST(test_upload_segments, archiver_fixture) {
-    set_expectations_and_listen(default_expectations);
+    set_expectations_and_listen({});
     auto [arch_conf, remote_conf] = get_configurations();
     service_probe probe(service_metrics_disabled::yes);
     cloud_storage::remote remote(
@@ -254,31 +140,38 @@ FIXTURE_TEST(test_upload_segments, archiver_fixture) {
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
 
     for (auto [url, req] : get_targets()) {
-        vlog(test_log.error, "{}", url);
+        vlog(test_log.info, "{} {}", req._method, req._url);
     }
     BOOST_REQUIRE_EQUAL(get_requests().size(), 3);
-    BOOST_REQUIRE(get_targets().count(manifest_url)); // NOLINT
+
+    cloud_storage::manifest manifest;
     {
+        BOOST_REQUIRE(get_targets().count(manifest_url)); // NOLINT
         auto it = get_targets().find(manifest_url);
         const auto& [url, req] = *it;
+        BOOST_REQUIRE_EQUAL(req._method, "PUT"); // NOLINT
         verify_manifest_content(req.content);
-        BOOST_REQUIRE(req._method == "PUT"); // NOLINT
+        manifest = load_manifest(req.content);
     }
-    BOOST_REQUIRE(get_targets().count(segment1_url)); // NOLINT
+
     {
-        auto it = get_targets().find(segment1_url);
+        segment_name segment1_name{"0-1-v1.log"};
+        auto segment1_url = get_segment_path(manifest, segment1_name);
+        auto it = get_targets().find("/" + segment1_url().string());
+        BOOST_REQUIRE(it != get_targets().end());
         const auto& [url, req] = *it;
-        auto name = url.substr(url.size() - std::strlen("#-#-v#.log"));
-        verify_segment(manifest_ntp, archival::segment_name(name), req.content);
-        BOOST_REQUIRE(req._method == "PUT"); // NOLINT
+        BOOST_REQUIRE_EQUAL(req._method, "PUT"); // NOLINT
+        verify_segment(manifest_ntp, segment1_name, req.content);
     }
-    BOOST_REQUIRE(get_targets().count(segment2_url)); // NOLINT
+
     {
-        auto it = get_targets().find(segment2_url);
+        segment_name segment2_name{"1000-4-v1.log"};
+        auto segment2_url = get_segment_path(manifest, segment2_name);
+        auto it = get_targets().find("/" + segment2_url().string());
+        BOOST_REQUIRE(it != get_targets().end());
         const auto& [url, req] = *it;
-        auto name = url.substr(url.size() - std::strlen("#-#-v#.log"));
-        verify_segment(manifest_ntp, archival::segment_name(name), req.content);
-        BOOST_REQUIRE(req._method == "PUT"); // NOLINT
+        BOOST_REQUIRE_EQUAL(req._method, "PUT"); // NOLINT
+        verify_segment(manifest_ntp, segment2_name, req.content);
     }
 
     BOOST_REQUIRE(part->archival_meta_stm());
@@ -472,9 +365,6 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     std::vector<s3_imposter_fixture::expectation> expectations({
       s3_imposter_fixture::expectation{
         .url = manifest_url, .body = ss::sstring(old_str.str())},
-      s3_imposter_fixture::expectation{.url = segment1_url, .body = "segment1"},
-      s3_imposter_fixture::expectation{.url = segment2_url, .body = "segment2"},
-      s3_imposter_fixture::expectation{.url = segment3_url, .body = "segment3"},
     });
 
     set_expectations_and_listen(expectations);
@@ -497,9 +387,11 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
 
     for (auto req : get_requests()) {
-        vlog(test_log.error, "{}", req._url);
+        vlog(test_log.info, "{} {}", req._method, req._url);
     }
     BOOST_REQUIRE_EQUAL(get_requests().size(), 4);
+
+    cloud_storage::manifest manifest;
     {
         auto [begin, end] = get_targets().equal_range(manifest_url);
         size_t len = std::distance(begin, end);
@@ -509,17 +401,16 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
             auto key = it->second._method;
             BOOST_REQUIRE(expected.contains(key));
             expected.erase(key);
+
+            if (key == "PUT") {
+                manifest = load_manifest(it->second.content);
+            }
         }
         BOOST_REQUIRE(expected.empty());
     }
-    {
-        auto [begin, end] = get_targets().equal_range(segment2_url);
-        size_t len = std::distance(begin, end);
-        BOOST_REQUIRE_EQUAL(len, 1);
-        BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT
-    }
-    {
-        auto [begin, end] = get_targets().equal_range(segment1_url);
+    for (const segment_name& name : {s1name, s2name}) {
+        auto url = get_segment_path(manifest, name);
+        auto [begin, end] = get_targets().equal_range("/" + url().string());
         size_t len = std::distance(begin, end);
         BOOST_REQUIRE_EQUAL(len, 1);
         BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT
@@ -674,35 +565,23 @@ static void test_partial_upload_impl(
     std::stringstream old_str;
     manifest.serialize(old_str);
 
-    // Generate segment urls
-    auto url1 = "/"
-                + cloud_storage::manifest::generate_remote_segment_path(
-                    manifest.get_ntp(),
-                    segment_meta.ntp_revision,
-                    segment_name(ssx::sformat(
-                      "{}-1-v1.log", last_uploaded_offset() + 1)))()
-                    .string();
-    auto url2 = "/"
-                + cloud_storage::manifest::generate_remote_segment_path(
-                    manifest.get_ntp(),
-                    segment_meta.ntp_revision,
-                    segment_name(ssx::sformat(
-                      "{}-1-v1.log", next_uploaded_offset() + 1)))()
-                    .string();
+    segment_name s2name{
+      ssx::sformat("{}-1-v1.log", last_uploaded_offset() + 1)};
+    segment_name s3name{
+      ssx::sformat("{}-1-v1.log", next_uploaded_offset() + 1)};
+
     vlog(
       test_log.debug,
-      "Expected segment upload urls {} and {}, last_uploaded_offset: {}, "
+      "Expected segment names {} and {}, last_uploaded_offset: {}, "
       "last_stable_offset: {}",
-      url1,
-      url2,
+      s2name,
+      s3name,
       last_uploaded_offset,
       lso);
 
     std::vector<s3_imposter_fixture::expectation> expectations({
       s3_imposter_fixture::expectation{
         .url = manifest_url, .body = ss::sstring(old_str.str())},
-      s3_imposter_fixture::expectation{.url = url1, .body = "segment1"},
-      s3_imposter_fixture::expectation{.url = url2, .body = "segment2"},
     });
 
     test.set_expectations_and_listen(expectations);
@@ -726,9 +605,10 @@ static void test_partial_upload_impl(
     BOOST_REQUIRE_EQUAL(res.num_failed, 0);
 
     for (auto req : test.get_requests()) {
-        vlog(test_log.error, "{}", req._url);
+        vlog(test_log.info, "{} {}", req._method, req._url);
     }
     BOOST_REQUIRE_EQUAL(test.get_requests().size(), 3);
+
     {
         auto [begin, end] = test.get_targets().equal_range(manifest_url);
         size_t len = std::distance(begin, end);
@@ -738,16 +618,24 @@ static void test_partial_upload_impl(
             auto key = it->second._method;
             BOOST_REQUIRE(expected.contains(key));
             expected.erase(key);
+
+            if (key == "PUT") {
+                manifest = load_manifest(it->second.content);
+            }
         }
         BOOST_REQUIRE(expected.empty());
     }
+
+    ss::sstring url2 = "/" + get_segment_path(manifest, s2name)().string();
+
     {
-        auto [begin, end] = test.get_targets().equal_range(url1);
+        auto [begin, end] = test.get_targets().equal_range(url2);
         size_t len = std::distance(begin, end);
         BOOST_REQUIRE_EQUAL(len, 1);
         BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT
 
-        // check that the uploaded log contains the right offsets
+        // check that the uploaded log contains the right
+        // offsets
         auto stats = calculate_segment_stats(begin->second);
 
         BOOST_REQUIRE_EQUAL(stats.min_offset, base_upl1);
@@ -774,17 +662,26 @@ static void test_partial_upload_impl(
             BOOST_REQUIRE(expected.contains(key));
             auto i = expected.find(key);
             expected.erase(i);
+
+            if (key == "PUT") {
+                auto new_manifest = load_manifest(it->second.content);
+                if (new_manifest.size() > manifest.size()) {
+                    manifest = new_manifest;
+                }
+            }
         }
         BOOST_REQUIRE(expected.empty());
     }
+
     {
-        auto [begin, end] = test.get_targets().equal_range(url1);
+        auto [begin, end] = test.get_targets().equal_range(url2);
         size_t len = std::distance(begin, end);
         BOOST_REQUIRE_EQUAL(len, 1);
         BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT
     }
     {
-        auto [begin, end] = test.get_targets().equal_range(url2);
+        ss::sstring url3 = "/" + get_segment_path(manifest, s3name)().string();
+        auto [begin, end] = test.get_targets().equal_range(url3);
         size_t len = std::distance(begin, end);
         BOOST_REQUIRE_EQUAL(len, 1);
         BOOST_REQUIRE(begin->second._method == "PUT"); // NOLINT

--- a/src/v/archival/tests/service_fixture.h
+++ b/src/v/archival/tests/service_fixture.h
@@ -81,6 +81,8 @@ private:
 
     ss::socket_address _server_addr;
     ss::shared_ptr<ss::httpd::http_server_control> _server;
+
+    std::unique_ptr<ss::httpd::handler_base> _handler;
     /// Contains saved requests
     std::vector<ss::httpd::request> _requests;
     /// Contains all accessed target urls
@@ -172,7 +174,7 @@ public:
     storage::api& get_local_storage_api();
     /// \brief Init storage api for tests that require only storage
     /// The method doesn't add topics, only creates segments in data_dir
-    void init_storage_api_local(std::vector<segment_desc>& segm);
+    void init_storage_api_local(const std::vector<segment_desc>& segm);
 
     std::vector<segment_layout> get_layouts(const model::ntp& ntp) const {
         return layouts.find(ntp)->second;
@@ -196,3 +198,8 @@ private:
 
 std::tuple<archival::configuration, cloud_storage::configuration>
 get_configurations();
+
+cloud_storage::manifest load_manifest(std::string_view v);
+
+archival::remote_segment_path
+get_segment_path(const cloud_storage::manifest&, const archival::segment_name&);

--- a/src/v/cloud_storage/manifest.cc
+++ b/src/v/cloud_storage/manifest.cc
@@ -20,6 +20,7 @@
 #include "model/metadata.h"
 #include "model/timestamp.h"
 #include "ssx/sformat.h"
+#include "storage/fs_utils.h"
 #include "storage/ntp_config.h"
 
 #include <seastar/core/coroutine.hh>
@@ -46,19 +47,6 @@ namespace cloud_storage {
 std::ostream& operator<<(std::ostream& s, const manifest_path_components& c) {
     fmt::print(
       s, "{{{}: {}-{}-{}-{}}}", c._origin, c._ns, c._topic, c._part, c._rev);
-    return s;
-}
-
-std::ostream& operator<<(std::ostream& s, const segment_path_components& c) {
-    fmt::print(
-      s,
-      "{{{}: {}-{}-{}-{}-{}}}",
-      c._origin,
-      c._ns,
-      c._topic,
-      c._part,
-      c._rev,
-      c._name);
     return s;
 }
 
@@ -131,119 +119,37 @@ get_manifest_path_components(const std::filesystem::path& path) {
     return std::nullopt;
 }
 
-/// Parse segment file name
-/// \return offset and success flag
-std::optional<model::offset>
-get_base_offset(const std::filesystem::path& path) {
-    auto stem = path.stem().string();
-    // parse offset component
-    auto ix_off = stem.find('-');
-    if (ix_off == std::string::npos) {
+std::optional<segment_name_components>
+parse_segment_name(const segment_name& name) {
+    auto parsed = storage::segment_path::parse_segment_filename(name);
+    if (!parsed) {
         return std::nullopt;
     }
-    int64_t off = 0;
-    auto eo = std::from_chars(stem.data(), stem.data() + ix_off, off);
-    if (eo.ec != std::errc()) {
-        return std::nullopt;
-    }
-    return model::offset(off);
-}
-
-/// Parse segment file name
-/// \return offset, term id, and success flag
-std::tuple<model::offset, model::term_id, bool>
-parse_segment_name(const std::filesystem::path& path) {
-    static constexpr auto bad_result = std::make_tuple(
-      model::offset(), model::term_id(), false);
-    auto stem = path.stem().string();
-    // parse offset component
-    auto ix_off = stem.find('-');
-    if (ix_off == std::string::npos) {
-        return bad_result;
-    }
-    int64_t off = 0;
-    auto eo = std::from_chars(stem.data(), stem.data() + ix_off, off);
-    if (eo.ec != std::errc()) {
-        return bad_result;
-    }
-    // parse term id
-    auto ix_term = stem.find('-', ix_off + 1);
-    if (ix_term == std::string::npos) {
-        return bad_result;
-    }
-    int64_t term = 0;
-    auto et = std::from_chars(
-      stem.data() + ix_off + 1, stem.data() + ix_term, term);
-    if (et.ec != std::errc()) {
-        return bad_result;
-    }
-    return std::make_tuple(model::offset(off), model::term_id(term), true);
-}
-
-std::optional<segment_path_components>
-get_segment_path_components(const std::filesystem::path& path) {
-    enum {
-        ix_prefix,
-        ix_namespace,
-        ix_topic,
-        ix_part_rev,
-        ix_segment_name,
-        total_components
+    return segment_name_components{
+      .base_offset = parsed->base_offset,
+      .term = parsed->term,
     };
-    segment_path_components res;
-    res._origin = path;
-    if (path.has_parent_path() == false) {
-        // Shortcut, we're dealing with the segment name from manifest
-        auto [off, term, ok] = parse_segment_name(path);
-        if (!ok) {
-            return std::nullopt;
-        }
-        res._name = segment_name(path.string());
-        res._base_offset = off;
-        res._term = term;
-        return res;
-    }
-    int ix = 0;
-    for (const auto& c : path) {
-        ss::sstring p = c.string();
-        switch (ix++) {
-        case ix_prefix:
-            break;
-        case ix_namespace:
-            res._ns = model::ns(std::move(p));
-            break;
-        case ix_topic:
-            res._topic = model::topic(std::move(p));
-            break;
-        case ix_part_rev:
-            if (!parse_partition_and_revision(p, res)) {
-                return std::nullopt;
-            }
-            break;
-        case ix_segment_name:
-            res._name = cloud_storage::segment_name(std::move(p));
-            break;
-        }
-    }
-    if (ix != total_components) {
-        return std::nullopt;
-    }
-    auto [off, term, ok] = parse_segment_name(path);
-    if (!ok) {
-        return std::nullopt;
-    }
-    res._base_offset = off;
-    res._term = term;
-    res._is_full = true;
-    return res;
 }
 
-std::ostream& operator<<(std::ostream& o, const manifest::key& key) {
-    fmt::print(
-      o,
-      "{{{}}}",
-      std::visit([](auto&& k) { return std::filesystem::path(k()); }, key));
-    return o;
+remote_segment_path generate_remote_segment_path(
+  const model::ntp& ntp,
+  model::revision_id rev_id,
+  const segment_name& name,
+  model::term_id archiver_term) {
+    vassert(
+      rev_id != model::revision_id(),
+      "ntp {}: ntp revision must be known for segment {}",
+      ntp,
+      name);
+
+    auto path = ssx::sformat("{}_{}/{}", ntp.path(), rev_id(), name());
+    uint32_t hash = xxhash_32(path.data(), path.size());
+    if (archiver_term != model::term_id{}) {
+        return remote_segment_path(
+          fmt::format("{:08x}/{}.{}", hash, path, archiver_term()));
+    } else {
+        return remote_segment_path(fmt::format("{:08x}/{}", hash, path));
+    }
 }
 
 manifest::manifest()
@@ -287,26 +193,14 @@ remote_manifest_path manifest::get_manifest_path() const {
 
 remote_segment_path manifest::generate_remote_segment_path(
   const model::ntp ntp, model::revision_id rev_id, const segment_name& name) {
+    vassert(
+      rev_id != model::revision_id(),
+      "ntp {}: ntp revision must be known for segment {}",
+      ntp,
+      name);
     auto path = ssx::sformat("{}_{}/{}", ntp.path(), rev_id(), name());
     uint32_t hash = xxhash_32(path.data(), path.size());
     return remote_segment_path(fmt::format("{:08x}/{}", hash, path));
-}
-
-remote_segment_path
-manifest::get_remote_segment_path(const segment_name& name) const {
-    return generate_remote_segment_path(_ntp, _rev, name);
-}
-
-remote_segment_path
-manifest::get_remote_segment_path(const manifest::key& key) const {
-    if (std::holds_alternative<remote_segment_path>(key)) {
-        // The 'name' contains full path instead of a log segment file name.
-        // For instance, '6fab5988/kafka/redpanda-test/5_6/80651-2-v1.log'
-        // instead of just '80651-2-v1.log'. This can happen if the manifest was
-        // generated during recovery process.
-        return std::get<remote_segment_path>(key);
-    }
-    return get_remote_segment_path(std::get<segment_name>(key));
 }
 
 const model::ntp& manifest::get_ntp() const { return _ntp; }
@@ -314,6 +208,11 @@ const model::ntp& manifest::get_ntp() const { return _ntp; }
 const model::offset manifest::get_last_offset() const { return _last_offset; }
 
 model::revision_id manifest::get_revision_id() const { return _rev; }
+
+remote_segment_path manifest::generate_segment_path(
+  const segment_name& name, const segment_meta& meta) const {
+    return generate_remote_segment_path(_ntp, meta.ntp_revision, name);
+}
 
 manifest::const_iterator manifest::begin() const { return _segments.begin(); }
 
@@ -329,48 +228,22 @@ manifest::const_reverse_iterator manifest::rend() const {
 
 size_t manifest::size() const { return _segments.size(); }
 
-bool manifest::contains(const manifest::key& obj) const {
-    return _segments.contains(obj);
+bool manifest::contains(const segment_name& name) const {
+    return _segments.contains(name);
 }
 
-bool manifest::add(const segment_name& key, const segment_meta& meta) {
-    auto [it, ok] = _segments.insert(std::make_pair(key, meta));
-    _last_offset = std::max(meta.committed_offset, _last_offset);
-    return ok;
-}
-
-bool manifest::add(const remote_segment_path& key, const segment_meta& meta) {
-    auto res = get_segment_path_components(key());
-    if (
-      _ntp.ns == res->_ns && _ntp.tp.topic == res->_topic
-      && _ntp.tp.partition == res->_part && _rev == res->_rev) {
-        // discard the full remote path and save only segment_name
-        auto path = get_remote_segment_path(res->_name);
-        if (path == key) {
-            return add(res->_name, meta);
-        }
+bool manifest::add(const segment_name& name, const segment_meta& meta) {
+    auto [it, ok] = _segments.insert(std::make_pair(name, meta));
+    if (ok && it->second.ntp_revision == model::revision_id{}) {
+        it->second.ntp_revision = _rev;
     }
-    auto [it, ok] = _segments.insert(std::make_pair(key, meta));
     _last_offset = std::max(meta.committed_offset, _last_offset);
     return ok;
 }
 
-const manifest::segment_meta* manifest::get(const manifest::key& key) const {
-    auto it = _segments.find(key);
+const manifest::segment_meta* manifest::get(const segment_name& name) const {
+    auto it = _segments.find(name);
     if (it == _segments.end()) {
-        // Check if the remote_segment_path is equal to some segment_name
-        if (std::holds_alternative<remote_segment_path>(key)) {
-            const auto& path = std::get<remote_segment_path>(key);
-            auto res = get_segment_path_components(path);
-            if (
-              _ntp.ns == res->_ns && _ntp.tp.topic == res->_topic
-              && _ntp.tp.partition == res->_part && _rev == res->_rev) {
-                auto reconstructed = get_remote_segment_path(res->_name);
-                if (path == reconstructed) {
-                    return get(res->_name);
-                }
-            }
-        }
         return nullptr;
     }
     return &it->second;
@@ -412,15 +285,6 @@ ss::future<> manifest::update(ss::input_stream<char> is) {
     co_return;
 }
 
-static manifest::key string_to_key(const char* s) {
-    auto len = std::strlen(s);
-    auto c = std::count(s, s + len, '/');
-    if (c == 0) {
-        return segment_name(s);
-    }
-    return remote_segment_path(std::filesystem::path(s));
-}
-
 void manifest::update(const rapidjson::Document& m) {
     using namespace rapidjson;
     auto ver = model::partition_id(m["version"].GetInt());
@@ -437,7 +301,7 @@ void manifest::update(const rapidjson::Document& m) {
     if (m.HasMember("segments")) {
         const auto& s = m["segments"].GetObject();
         for (auto it = s.MemberBegin(); it != s.MemberEnd(); it++) {
-            auto name = string_to_key(it->name.GetString());
+            auto name = manifest::key{it->name.GetString()};
             auto coffs = it->value["committed_offset"].GetInt64();
             auto boffs = it->value["base_offset"].GetInt64();
             auto size_bytes = it->value["size_bytes"].GetInt64();
@@ -456,6 +320,11 @@ void manifest::update(const rapidjson::Document& m) {
                 delta_offset = model::offset(
                   it->value["delta_offset"].GetInt64());
             }
+            model::revision_id ntp_revision = _rev;
+            if (it->value.HasMember("ntp_revision")) {
+                ntp_revision = model::revision_id(
+                  it->value["ntp_revision"].GetInt64());
+            }
             segment_meta meta{
               .is_compacted = it->value["is_compacted"].GetBool(),
               .size_bytes = static_cast<size_t>(size_bytes),
@@ -464,7 +333,7 @@ void manifest::update(const rapidjson::Document& m) {
               .base_timestamp = base_timestamp,
               .max_timestamp = max_timestamp,
               .delta_offset = delta_offset,
-            };
+              .ntp_revision = ntp_revision};
             tmp.insert(std::make_pair(name, meta));
         }
     }
@@ -503,11 +372,7 @@ void manifest::serialize(std::ostream& out) const {
         w.Key("segments");
         w.StartObject();
         for (const auto& [sn, meta] : _segments) {
-            if (std::holds_alternative<segment_name>(sn)) {
-                w.Key(std::get<segment_name>(sn)().c_str());
-            } else {
-                w.Key(std::get<remote_segment_path>(sn)().c_str());
-            }
+            w.Key(sn());
             w.StartObject();
             w.Key("is_compacted");
             w.Bool(meta.is_compacted);
@@ -528,6 +393,15 @@ void manifest::serialize(std::ostream& out) const {
             if (meta.delta_offset != model::offset::min()) {
                 w.Key("delta_offset");
                 w.Int64(meta.delta_offset());
+            }
+            if (meta.ntp_revision != _rev) {
+                vassert(
+                  meta.ntp_revision != model::revision_id(),
+                  "ntp {}: missing ntp_revision for segment {} in the manifest",
+                  _ntp,
+                  sn);
+                w.Key("ntp_revision");
+                w.Int64(meta.ntp_revision());
             }
             w.EndObject();
         }

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -130,6 +130,7 @@ public:
         model::offset delta_offset;
 
         model::revision_id ntp_revision;
+        model::term_id archiver_term;
 
         auto operator<=>(const segment_meta&) const = default;
     };
@@ -148,10 +149,6 @@ public:
 
     /// Manifest object name in S3
     remote_manifest_path get_manifest_path() const override;
-
-    /// Segment file name in S3
-    static remote_segment_path generate_remote_segment_path(
-      const model::ntp, model::revision_id, const segment_name&);
 
     /// Get NTP
     const model::ntp& get_ntp() const;

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -40,40 +40,26 @@ struct manifest_path_components {
     model::revision_id _rev;
 };
 
-/// Information contained inside the segment path
-///
-/// The struct can contain information obtained from the full
-/// S3 segment path. In this case it will have all fields properly
-/// set (_origin, _ns, _topic, _part, _rev). It can also be created using
-/// segment name only. In this case the _is_full field will be set
-/// to false and some fields wouldn't be set (_origin, _ns, _topic, _part,
-/// _rev).
-struct segment_path_components : manifest_path_components {
-    bool _is_full;
-    cloud_storage::segment_name _name;
-    model::offset _base_offset;
-    model::term_id _term;
-};
-
 std::ostream& operator<<(std::ostream& s, const manifest_path_components& c);
-
-std::ostream& operator<<(std::ostream& s, const segment_path_components& c);
 
 /// Parse partition manifest path and return components
 std::optional<manifest_path_components>
 get_manifest_path_components(const std::filesystem::path& path);
 
-/// Parse segment path and return components
-std::optional<segment_path_components>
-get_segment_path_components(const std::filesystem::path& path);
+struct segment_name_components {
+    model::offset base_offset;
+    model::term_id term;
+};
 
-/// Parse base offset from the segment path or segment name
-std::optional<model::offset> get_base_offset(const std::filesystem::path& path);
+std::optional<segment_name_components>
+parse_segment_name(const segment_name& name);
 
-/// Parse segment file name
-/// \return offset, term id, and success flag
-std::tuple<model::offset, model::term_id, bool>
-parse_segment_name(const std::filesystem::path& path);
+/// Segment file name in S3
+remote_segment_path generate_remote_segment_path(
+  const model::ntp&,
+  model::revision_id,
+  const segment_name&,
+  model::term_id archiver_term);
 
 struct serialized_json_stream {
     ss::input_stream<char> stream;
@@ -143,10 +129,12 @@ public:
         model::timestamp max_timestamp;
         model::offset delta_offset;
 
+        model::revision_id ntp_revision;
+
         auto operator<=>(const segment_meta&) const = default;
     };
 
-    using key = std::variant<segment_name, remote_segment_path>;
+    using key = segment_name;
     using value = segment_meta;
     using segment_map = std::map<key, value>;
     using const_iterator = segment_map::const_iterator;
@@ -164,8 +152,6 @@ public:
     /// Segment file name in S3
     static remote_segment_path generate_remote_segment_path(
       const model::ntp, model::revision_id, const segment_name&);
-    remote_segment_path get_remote_segment_path(const segment_name& name) const;
-    remote_segment_path get_remote_segment_path(const key& name) const;
 
     /// Get NTP
     const model::ntp& get_ntp() const;
@@ -176,6 +162,9 @@ public:
     /// Get revision
     model::revision_id get_revision_id() const;
 
+    remote_segment_path
+    generate_segment_path(const segment_name&, const segment_meta&) const;
+
     /// Return iterator to the begining(end) of the segments list
     const_iterator begin() const;
     const_iterator end() const;
@@ -183,28 +172,14 @@ public:
     const_reverse_iterator rend() const;
     size_t size() const;
 
-    /// Check if the manifest contains particular path
-    ///
-    /// The manifest may contain two types of keys
-    /// 1. Segment names like `193984-4-v1.log`
-    /// 2. Full segment paths like
-    /// `f28dac93/kafka/mytopic/12_32/193984-4-v1.log`
-    /// This overloads handles the second case.
-    bool contains(const key& path) const;
+    /// Check if the manifest contains particular segment
+    bool contains(const segment_name& name) const;
 
     /// Add new segment to the manifest
-    bool add(const segment_name& key, const segment_meta& meta);
-
-    /// Add new segment to the manifest
-    bool add(const remote_segment_path& key, const segment_meta& meta);
+    bool add(const segment_name& name, const segment_meta& meta);
 
     /// Get segment if available or nullopt
-    ///
-    /// The manifest may contain two types of keys
-    /// 1. Segment names like `193984-4-v1.log`
-    /// 2. Full segment paths like
-    /// `f28dac93/kafka/mytopic/12_32/193984-4-v1.log`
-    const segment_meta* get(const key& path) const;
+    const segment_meta* get(const segment_name& name) const;
 
     /// Get insert iterator for segments set
     std::insert_iterator<segment_map> get_insert_iterator();
@@ -301,7 +276,5 @@ private:
     std::optional<cluster::topic_configuration> _topic_config;
     model::revision_id _rev;
 };
-
-std::ostream& operator<<(std::ostream& o, const manifest::key& k);
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -118,7 +118,7 @@ class manifest final : public base_manifest {
 public:
     struct segment_meta {
         using value_t = segment_meta;
-        static constexpr serde::version_t redpanda_serde_version = 0;
+        static constexpr serde::version_t redpanda_serde_version = 1;
         static constexpr serde::version_t redpanda_serde_compat_version = 0;
 
         bool is_compacted;

--- a/src/v/cloud_storage/offset_translation_layer.h
+++ b/src/v/cloud_storage/offset_translation_layer.h
@@ -26,13 +26,8 @@ namespace cloud_storage {
 /// It consumes information stored in the manifest.
 class offset_translator final {
 public:
-    offset_translator() = default;
-    offset_translator(const offset_translator&) = delete;
-    offset_translator(offset_translator&&) = delete;
-    offset_translator& operator=(const offset_translator&) = delete;
-    offset_translator& operator=(offset_translator&&) = delete;
-
-    void update(const manifest& m);
+    offset_translator(model::offset initial_delta)
+      : _initial_delta(initial_delta) {}
 
     /// Copy source stream into the destination stream
     ///
@@ -41,7 +36,6 @@ public:
     /// The caller is responsible for patching the segement file name and
     /// passing correct base_offset of the original segment.
     ss::future<uint64_t> copy_stream(
-      remote_segment_path path,
       ss::input_stream<char> src,
       ss::output_stream<char> dst,
       retry_chain_node& fib) const;
@@ -49,16 +43,9 @@ public:
     /// Get segment name adjusted for all removed offsets
     segment_name get_adjusted_segment_name(
       const segment_name& s, retry_chain_node& fib) const;
-    remote_segment_path get_adjusted_segment_name(
-      const remote_segment_path& s, retry_chain_node& fib) const;
 
 private:
-    std::filesystem::path get_adjusted_segment_name(
-      std::filesystem::path s,
-      const manifest::segment_meta& m,
-      retry_chain_node& fib) const;
-
-    std::optional<std::reference_wrapper<const manifest>> _manifest;
+    model::offset _initial_delta;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -3,7 +3,6 @@
 #include "bytes/iobuf_istreambuf.h"
 #include "cloud_storage/logger.h"
 #include "cloud_storage/manifest.h"
-#include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/types.h"
 #include "config/configuration.h"
 #include "hashing/xx.h"
@@ -229,10 +228,9 @@ partition_downloader::build_offset_map(const recovery_material& mat) {
                     continue;
                 }
             }
-            auto path = manifest.get_remote_segment_path(segm.first);
             offset_map.insert_or_assign(
               segm.second.base_offset,
-              segment{.path = path, .meta = segm.second});
+              segment{.name = segm.first, .meta = segm.second});
         }
     }
     co_return std::move(offset_map);
@@ -253,13 +251,7 @@ partition_downloader::download_log(const remote_manifest_path& manifest_key) {
     auto offset_map = co_await build_offset_map(mat);
     manifest target(_ntpc.ntp(), _ntpc.get_revision());
     for (const auto& kv : offset_map) {
-        // Original manifests contain short names (e.g. 1029-4-v1.log).
-        // This is because they belong to the same revision and the details are
-        // encoded in the manifest itself.
-        // To create a compound manifest we need to add full names (e.g.
-        // 6fab5988/kafka/redpanda-test/5_6/80651-2-v1.log). Otherwise the
-        // information in the manifest won't be suffecient.
-        target.add(kv.second.path, kv.second.meta);
+        target.add(kv.second.name, kv.second.meta);
     }
     if (cst_log.is_enabled(ss::log_level::debug)) {
         std::stringstream ostr;
@@ -347,11 +339,7 @@ partition_downloader::download_log_with_capped_size(
     vlog(_ctxlog.info, "Starting log download with size limit at {}", max_size);
     gate_guard guard(_gate);
     size_t total_size = 0;
-    struct download {
-        remote_segment_path fname;
-        size_t size_bytes;
-    };
-    std::deque<download> staged_downloads;
+    std::deque<segment> staged_downloads;
     for (auto it = offset_map.rbegin(); it != offset_map.rend(); it++) {
         const auto& meta = it->second.meta;
         if (total_size > max_size) {
@@ -359,20 +347,16 @@ partition_downloader::download_log_with_capped_size(
               _ctxlog.debug,
               "Max size {} reached, skipping {}",
               total_size,
-              it->second.path);
+              it->second.name);
             break;
         } else {
             vlog(
               _ctxlog.debug,
               "Found {}, total log size {}",
-              it->second.path,
+              it->second.name,
               total_size);
         }
-        auto fname = it->second.path;
-        staged_downloads.push_front({
-          .fname = fname,
-          .size_bytes = meta.size_bytes,
-        });
+        staged_downloads.push_front(it->second);
         total_size += meta.size_bytes;
     }
     download_part dlpart{
@@ -383,18 +367,10 @@ partition_downloader::download_log_with_capped_size(
     co_await ss::max_concurrent_for_each(
       staged_downloads,
       max_concurrency,
-      [this, &manifest, &dlpart](download& dl) -> ss::future<> {
+      [this, &dlpart](const segment& s) -> ss::future<> {
           retry_chain_node fib(&_rtcnode);
           retry_chain_logger dllog(cst_log, fib);
-          vlog(
-            dllog.debug,
-            "Starting download, fname: {} of size: {}, fs prefix: {}, "
-            "destination: {}",
-            dl.fname,
-            dl.size_bytes,
-            dlpart.part_prefix,
-            dlpart.dest_prefix);
-          co_await download_file(dl.fname, manifest, dlpart);
+          co_await download_segment_file(s, dlpart);
           ++dlpart.num_files;
       });
     co_return dlpart;
@@ -414,8 +390,7 @@ partition_downloader::download_log_with_capped_time(
     auto time_threshold = model::to_timestamp(
       model::timestamp_clock::now() - retention_time);
 
-    std::deque<remote_segment_path> staged_downloads;
-
+    std::deque<segment> staged_downloads;
     for (auto it = offset_map.rbegin(); it != offset_map.rend(); it++) {
         const auto& meta = it->second.meta;
         if (
@@ -426,18 +401,17 @@ partition_downloader::download_log_with_capped_time(
               "Time threshold {} reached at {}, skipping {}",
               time_threshold,
               meta.max_timestamp,
-              it->second.path);
+              it->second.name);
             break;
         } else {
             vlog(
               _ctxlog.debug,
               "Found {}, max_timestamp {} is within the time threshold {}",
-              it->second.path,
+              it->second.name,
               meta.max_timestamp,
               time_threshold);
         }
-        auto fname = it->second.path;
-        staged_downloads.push_front(fname);
+        staged_downloads.push_front(it->second);
     }
     download_part dlpart = {
       .part_prefix = std::filesystem::path(prefix.string() + "_part"),
@@ -447,17 +421,10 @@ partition_downloader::download_log_with_capped_time(
     co_await ss::max_concurrent_for_each(
       staged_downloads,
       max_concurrency,
-      [this, &manifest, &dlpart](
-        const remote_segment_path& fname) -> ss::future<> {
+      [this, &dlpart](const segment& s) -> ss::future<> {
           retry_chain_node fib(&_rtcnode);
           retry_chain_logger dllog(cst_log, fib);
-          vlog(
-            dllog.debug,
-            "Starting download, fname: {}, fs prefix: {}, dest: {}",
-            fname,
-            dlpart.part_prefix,
-            dlpart.dest_prefix);
-          co_await download_file(fname, manifest, dlpart);
+          co_await download_segment_file(s, dlpart);
           ++dlpart.num_files;
       });
     co_return dlpart;
@@ -527,33 +494,28 @@ open_output_file_stream(const std::filesystem::path& path) {
     co_return std::move(stream);
 }
 
-ss::future<> partition_downloader::download_file(
-  const remote_segment_path& remote_location,
-  const manifest& manifest,
-  const partition_downloader::download_part& part) {
-    offset_translator otl;
-    otl.update(manifest);
+ss::future<> partition_downloader::download_segment_file(
+  const segment& segm, const download_part& part) {
+    auto remote_path = manifest::generate_remote_segment_path(
+      _ntpc.ntp(), segm.meta.ntp_revision, segm.name);
 
     vlog(
       _ctxlog.info,
-      "Downloading segment {} -> {}",
-      remote_location,
+      "Downloading segment {} of size: {}, fs prefix: {}",
+      remote_path,
       part.part_prefix.string());
 
-    auto adjusted_path = otl.get_adjusted_segment_name(
-      remote_location, _rtcnode)();
-    auto localpath = part.part_prefix / adjusted_path.filename();
+    offset_translator otl{segm.meta.delta_offset};
+
+    auto localpath = part.part_prefix
+                     / std::string{
+                       otl.get_adjusted_segment_name(segm.name, _rtcnode)()};
 
     if (co_await ss::file_exists(localpath.string())) {
         // we don't need to re-download file if it's already on disk
         // and the size is matching the one in manifest
         auto sz = co_await ss::file_size(localpath.string());
-        auto meta = manifest.get(remote_location);
-        vassert(
-          meta != nullptr,
-          "Can't find segment meta in the manifest {}",
-          remote_location);
-        if (sz == meta->size_bytes) {
+        if (sz == segm.meta.size_bytes) {
             vlog(
               _ctxlog.info,
               "The local file {} is already downloaded and its size matches "
@@ -569,18 +531,18 @@ ss::future<> partition_downloader::download_file(
         co_await ss::remove_file(localpath.string());
     }
 
-    auto stream = [this, part, remote_location, localpath, &otl](
+    auto stream = [this, part, remote_path, localpath, otl](
                     uint64_t len,
                     ss::input_stream<char> in) -> ss::future<uint64_t> {
         vlog(
           _ctxlog.info,
           "Copying s3 path {} to local location {}",
-          remote_location,
+          remote_path,
           localpath.string());
         co_await ss::recursive_touch_directory(part.part_prefix.string());
         auto fs = co_await open_output_file_stream(localpath);
         auto actual_len = co_await otl.copy_stream(
-          remote_location, std::move(in), std::move(fs), _rtcnode);
+          std::move(in), std::move(fs), _rtcnode);
         vlog(
           _ctxlog.debug,
           "Log segment downloaded. {} bytes expected, {} bytes after "
@@ -591,12 +553,12 @@ ss::future<> partition_downloader::download_file(
     };
 
     auto result = co_await _remote->download_segment(
-      _bucket, remote_location, manifest, stream, _rtcnode);
+      _bucket, remote_path, stream, _rtcnode);
 
     if (result != download_result::success) {
         // The individual segment might be missing for varios reasons but
         // it shouldn't prevent us from restoring the remaining data
-        vlog(_ctxlog.error, "Failed segment download for {}", remote_location);
+        vlog(_ctxlog.error, "Failed segment download for {}", remote_path);
     }
 
     co_return;

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -496,8 +496,8 @@ open_output_file_stream(const std::filesystem::path& path) {
 
 ss::future<> partition_downloader::download_segment_file(
   const segment& segm, const download_part& part) {
-    auto remote_path = manifest::generate_remote_segment_path(
-      _ntpc.ntp(), segm.meta.ntp_revision, segm.name);
+    auto remote_path = generate_remote_segment_path(
+      _ntpc.ntp(), segm.meta.ntp_revision, segm.name, segm.meta.archiver_term);
 
     vlog(
       _ctxlog.info,

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cloud_storage/manifest.h"
+#include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/remote.h"
 #include "cloud_storage/types.h"
 #include "model/record.h"
@@ -112,20 +113,18 @@ private:
         size_t num_files;
     };
 
-    /// Download file to the target location
+    struct segment {
+        segment_name name;
+        manifest::segment_meta meta;
+    };
+
+    /// Download segment file to the target location
     ///
     /// The downloaded file will have a custom suffix
     /// which has to be changed. The downloaded file path
     /// is returned by the futue.
-    ss::future<> download_file(
-      const remote_segment_path& target,
-      const manifest& manifest,
-      const download_part& part);
-
-    struct segment {
-        remote_segment_path path;
-        manifest::segment_meta meta;
-    };
+    ss::future<>
+    download_segment_file(const segment& segm, const download_part& part);
 
     using offset_map_t = absl::btree_map<model::offset, segment>;
 

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -107,10 +107,9 @@ public:
     /// \param manifest is a manifest that should have the segment metadata
     ss::future<upload_result> upload_segment(
       const s3::bucket_name& bucket,
-      const segment_name& exposed_name,
+      const remote_segment_path& segment_path,
       uint64_t content_length,
       const reset_input_stream& reset_str,
-      manifest& manifest,
       retry_chain_node& parent);
 
     /// \brief Download segment from S3
@@ -123,8 +122,7 @@ public:
     /// \param manifest is a manifest that should have the segment metadata
     ss::future<download_result> download_segment(
       const s3::bucket_name& bucket,
-      const manifest::key& name,
-      const manifest& manifest,
+      const remote_segment_path& path,
       const try_consume_stream& cons_str,
       retry_chain_node& parent);
 

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -55,7 +55,7 @@ public:
       cache& cache,
       s3::bucket_name bucket,
       const manifest& m,
-      manifest::key path,
+      const manifest::key& name,
       retry_chain_node& parent);
 
     remote_segment(const remote_segment&) = delete;
@@ -103,8 +103,14 @@ private:
     remote& _api;
     cache& _cache;
     s3::bucket_name _bucket;
-    const manifest& _manifest;
-    manifest::key _path;
+    const model::ntp& _ntp;
+    remote_segment_path _path;
+
+    model::term_id _term;
+    model::offset _base_rp_offset;
+    model::offset _base_offset_delta;
+    model::offset _max_rp_offset;
+
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
     /// Notifies the background hydration fiber
@@ -190,7 +196,6 @@ private:
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
     model::term_id _term;
-    model::offset _initial_delta;
     model::offset _cur_rp_offset;
     model::offset _cur_delta;
     size_t _bytes_consumed{0};

--- a/src/v/cloud_storage/tests/common_def.h
+++ b/src/v/cloud_storage/tests/common_def.h
@@ -11,22 +11,6 @@
 #include <boost/test/tools/interface.hpp>
 
 namespace cloud_storage {
-static constexpr std::string_view manifest_payload = R"json({
-    "version": 1,
-    "namespace": "test-ns",
-    "topic": "test-topic",
-    "partition": 42,
-    "revision": 0,
-    "last_offset": 1004,
-    "segments": {
-        "1-2-v1.log": {
-            "is_compacted": false,
-            "size_bytes": 100,
-            "committed_offset": 2,
-            "base_offset": 1
-        }
-    }
-})json";
 static const auto manifest_namespace = model::ns("test-ns");    // NOLINT
 static const auto manifest_topic = model::topic("test-topic");  // NOLINT
 static const auto manifest_partition = model::partition_id(42); // NOLINT
@@ -35,21 +19,11 @@ static const auto manifest_ntp = model::ntp(                    // NOLINT
   manifest_topic,
   manifest_partition);
 static const auto manifest_revision = model::revision_id(0); // NOLINT
-static const ss::sstring manifest_url = ssx::sformat(        // NOLINT
+static const auto archiver_term = model::term_id{123};
+static const ss::sstring manifest_url = ssx::sformat( // NOLINT
   "20000000/meta/{}_{}/manifest.json",
   manifest_ntp.path(),
   manifest_revision());
-// NOLINTNEXTLINE
-static const ss::sstring segment_url
-  = "ce4fd1a3/test-ns/test-topic/42_0/1-2-v1.log";
-
-static const std::vector<s3_imposter_fixture::expectation>
-  default_expectations({
-    s3_imposter_fixture::expectation{
-      .url = "/" + manifest_url, .body = ss::sstring(manifest_payload)},
-    s3_imposter_fixture::expectation{
-      .url = "/" + segment_url, .body = "segment1"},
-  });
 
 inline iobuf iobuf_deep_copy(const iobuf& i) {
     iobuf res;

--- a/src/v/cloud_storage/tests/manifest_test.cc
+++ b/src/v/cloud_storage/tests/manifest_test.cc
@@ -87,10 +87,14 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_path) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_segment_path) {
-    auto path = manifest::generate_remote_segment_path(
-      manifest_ntp, model::revision_id(0), segment_name("22-11-v1.log"));
+    auto path = generate_remote_segment_path(
+      manifest_ntp,
+      model::revision_id(0),
+      segment_name("22-11-v1.log"),
+      model::term_id{123});
     // use pre-calculated murmur hash value from full ntp path + file name
-    BOOST_REQUIRE_EQUAL(path, "2bea9275/test-ns/test-topic/42_0/22-11-v1.log");
+    BOOST_REQUIRE_EQUAL(
+      path, "2bea9275/test-ns/test-topic/42_0/22-11-v1.log.123");
 }
 
 SEASTAR_THREAD_TEST_CASE(test_empty_manifest_update) {

--- a/src/v/cloud_storage/tests/manifest_test.cc
+++ b/src/v/cloud_storage/tests/manifest_test.cc
@@ -48,7 +48,7 @@ static constexpr std::string_view complete_manifest_json = R"json({
     "revision": 1,
     "last_offset": 39,
     "segments": {
-        "10-1-v1.log": { 
+        "10-1-v1.log": {
             "is_compacted": false,
             "size_bytes": 1024,
             "base_offset": 10,
@@ -61,7 +61,7 @@ static constexpr std::string_view complete_manifest_json = R"json({
             "committed_offset": 29,
             "max_timestamp": 1234567890
         },
-        "01234567/test-ns/test-topic/42_1/30-1-v1.log": {
+        "30-1-v1.log": {
             "is_compacted": false,
             "size_bytes": 4096,
             "base_offset": 30,
@@ -87,8 +87,8 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_path) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_segment_path) {
-    manifest m(manifest_ntp, model::revision_id(0));
-    auto path = m.get_remote_segment_path(segment_name("22-11-v1.log"));
+    auto path = manifest::generate_remote_segment_path(
+      manifest_ntp, model::revision_id(0), segment_name("22-11-v1.log"));
     // use pre-calculated murmur hash value from full ntp path + file name
     BOOST_REQUIRE_EQUAL(path, "2bea9275/test-ns/test-topic/42_0/22-11-v1.log");
 }
@@ -99,13 +99,6 @@ SEASTAR_THREAD_TEST_CASE(test_empty_manifest_update) {
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
       path, "20000000/meta/test-ns/test-topic/42_0/manifest.json");
-}
-
-static ss::sstring key_to_string(const manifest::key& key) {
-    if (std::holds_alternative<segment_name>(key)) {
-        return std::get<segment_name>(key)();
-    }
-    return std::get<remote_segment_path>(key)().string();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
@@ -127,7 +120,7 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
          model::offset(29),
          model::timestamp(1234567890),
          model::timestamp(1234567890)}},
-      {"01234567/test-ns/test-topic/42_1/30-1-v1.log",
+      {"30-1-v1.log",
        manifest::segment_meta{
          false,
          4096,
@@ -137,7 +130,7 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
          model::timestamp(1234567890)}},
     };
     for (const auto& actual : m) {
-        auto it = expected.find(key_to_string(actual.first));
+        auto it = expected.find(actual.first());
         BOOST_REQUIRE(it != expected.end());
         BOOST_REQUIRE_EQUAL(it->second.base_offset, actual.second.base_offset);
         BOOST_REQUIRE_EQUAL(
@@ -160,6 +153,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
         .base_offset = model::offset(10),
         .committed_offset = model::offset(19),
         .max_timestamp = model::timestamp::missing(),
+        .ntp_revision = model::revision_id(0),
       });
     m.add(
       segment_name("20-1-v1.log"),
@@ -169,6 +163,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
         .base_offset = model::offset(20),
         .committed_offset = model::offset(29),
         .max_timestamp = model::timestamp::missing(),
+        .ntp_revision = model::revision_id(3),
       });
     auto [is, size] = m.serialize();
     iobuf buf;
@@ -194,8 +189,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_difference) {
         auto c = a.difference(b);
         BOOST_REQUIRE(c.size() == 1);
         auto res = *c.begin();
-        BOOST_REQUIRE(
-          std::get<segment_name>(res.first) == segment_name("3-3-v1.log"));
+        BOOST_REQUIRE(res.first == segment_name("3-3-v1.log"));
     }
     // check that set difference is not symmetrical
     b.add(segment_name("3-3-v1.log"), {});
@@ -246,71 +240,21 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_name_parsing_failure_4) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_segment_name_parsing) {
-    std::filesystem::path path = "3587-1-v1.log";
-    auto res = cloud_storage::get_segment_path_components(path);
-    BOOST_REQUIRE_EQUAL(res->_origin, path);
-    BOOST_REQUIRE_EQUAL(res->_is_full, false);
-    BOOST_REQUIRE_EQUAL(res->_name, path.string());
-    BOOST_REQUIRE_EQUAL(res->_base_offset(), 3587);
-    BOOST_REQUIRE_EQUAL(res->_term(), 1);
+    segment_name name{"3587-1-v1.log"};
+    auto res = parse_segment_name(name);
+    BOOST_REQUIRE(res);
+    BOOST_REQUIRE_EQUAL(res->base_offset(), 3587);
+    BOOST_REQUIRE_EQUAL(res->term(), 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_segment_name_parsing_failure_1) {
-    std::filesystem::path path = "-1-v1.log";
-    auto res = cloud_storage::get_segment_path_components(path);
+    segment_name name{"-1-v1.log"};
+    auto res = parse_segment_name(name);
     BOOST_REQUIRE(res.has_value() == false);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_segment_name_parsing_failure_2) {
-    std::filesystem::path path = "abc-1-v1.log";
-    auto res = cloud_storage::get_segment_path_components(path);
+    segment_name name{"abc-1-v1.log"};
+    auto res = parse_segment_name(name);
     BOOST_REQUIRE(res.has_value() == false);
-}
-
-SEASTAR_THREAD_TEST_CASE(test_segment_path_parsing) {
-    std::filesystem::path path
-      = "034b2193/kafka/redpanda-test/3_2/3587-1-v1.log";
-    auto res = cloud_storage::get_segment_path_components(path);
-    BOOST_REQUIRE(res.has_value());
-    BOOST_REQUIRE_EQUAL(res->_origin, path);
-    BOOST_REQUIRE_EQUAL(res->_ns(), "kafka");
-    BOOST_REQUIRE_EQUAL(res->_topic(), "redpanda-test");
-    BOOST_REQUIRE_EQUAL(res->_part(), 3);
-    BOOST_REQUIRE_EQUAL(res->_rev(), 2);
-    BOOST_REQUIRE_EQUAL(res->_is_full, true);
-    BOOST_REQUIRE_EQUAL(res->_name, path.filename().string());
-    BOOST_REQUIRE_EQUAL(res->_base_offset(), 3587);
-    BOOST_REQUIRE_EQUAL(res->_term(), 1);
-}
-
-SEASTAR_THREAD_TEST_CASE(test_segment_path_parsing_failure_1) {
-    std::filesystem::path path = "034b2193/kafka/redpanda-test/_/3587-1-v1.log";
-    auto res = cloud_storage::get_segment_path_components(path);
-    BOOST_REQUIRE(!res.has_value());
-}
-
-SEASTAR_THREAD_TEST_CASE(test_segment_path_parsing_failure_2) {
-    std::filesystem::path path
-      = "034b2193/kafka/redpanda-test/3_2/foo-bar-v1.log";
-    auto res = cloud_storage::get_segment_path_components(path);
-    BOOST_REQUIRE(!res.has_value());
-}
-
-SEASTAR_THREAD_TEST_CASE(test_segment_path_parsing_failure_3) {
-    std::filesystem::path path = "034b2193/kafka/redpanda-test/3_2";
-    auto res = cloud_storage::get_segment_path_components(path);
-    BOOST_REQUIRE(!res.has_value());
-}
-
-SEASTAR_THREAD_TEST_CASE(test_segment_path_parsing_failure_4) {
-    std::filesystem::path path = "034b2193/redpanda-test/3_2/3587-1-v1.log";
-    auto res = cloud_storage::get_segment_path_components(path);
-    BOOST_REQUIRE(!res.has_value());
-}
-
-SEASTAR_THREAD_TEST_CASE(test_segment_path_parsing_failure_5) {
-    std::filesystem::path path
-      = "00000000/meta/kafka/redpanda-test/3_2/manifest.log";
-    auto res = cloud_storage::get_segment_path_components(path);
-    BOOST_REQUIRE(!res.has_value());
 }

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -56,7 +56,7 @@ inline ss::logger test_log("test"); // NOLINT
 
 FIXTURE_TEST(
   test_remote_segment_successful_download, cloud_storage_fixture) { // NOLINT
-    set_expectations_and_listen(default_expectations);
+    set_expectations_and_listen({});
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
     remote remote(s3_connection_limit(10), conf);
@@ -129,7 +129,7 @@ FIXTURE_TEST(test_remote_segment_timeout, cloud_storage_fixture) { // NOLINT
 FIXTURE_TEST(
   test_remote_segment_batch_reader_single_batch,
   cloud_storage_fixture) { // NOLINT
-    set_expectations_and_listen(default_expectations);
+    set_expectations_and_listen({});
     auto conf = get_configuration();
     auto bucket = s3::bucket_name("bucket");
     remote remote(s3_connection_limit(10), conf);

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -135,18 +135,8 @@ void s3_imposter_fixture::set_routes(
         s3_imposter_fixture& fixture;
     };
     auto hd = ss::make_shared<content_handler>(expectations, *this);
-    for (const auto& [path, _] : expectations) {
-        auto get_handler = new function_handler(
-          [hd](const_req req, reply& repl) { return hd->handle(req, repl); },
-          "txt");
-        auto put_handler = new function_handler(
-          [hd](const_req req, reply& repl) { return hd->handle(req, repl); },
-          "txt");
-        auto del_handler = new function_handler(
-          [hd](const_req req, reply& repl) { return hd->handle(req, repl); },
-          "txt");
-        r.add(operation_type::GET, url(path), get_handler);
-        r.add(operation_type::PUT, url(path), put_handler);
-        r.add(operation_type::DELETE, url(path), del_handler);
-    }
+    _handler = std::make_unique<function_handler>(
+      [hd](const_req req, reply& repl) { return hd->handle(req, repl); },
+      "txt");
+    r.add_default_handler(_handler.get());
 }

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -76,6 +76,8 @@ private:
 
     ss::socket_address _server_addr;
     ss::shared_ptr<ss::httpd::http_server_control> _server;
+
+    std::unique_ptr<ss::httpd::handler_base> _handler;
     /// Contains saved requests
     std::vector<ss::httpd::request> _requests;
     /// Contains all accessed target urls

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -29,7 +29,7 @@ using remote_metrics_disabled
 /// expected format: <base-offset>-<term-id>-<revision>.log
 using segment_name = named_type<ss::sstring, struct archival_segment_name_t>;
 /// Segment path in S3, expected format:
-/// <prefix>/<ns>/<topic>/<part-id>_<rev>/<base-offset>-<term-id>-<revision>.log
+/// <prefix>/<ns>/<topic>/<part-id>_<rev>/<base-offset>-<term-id>-<revision>.log.<archiver-term>
 using remote_segment_path
   = named_type<std::filesystem::path, struct archival_remote_segment_path_t>;
 using remote_manifest_path

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -36,8 +36,9 @@ struct archival_metadata_stm::segment
   : public serde::
       envelope<segment, serde::version<0>, serde::compat_version<0>> {
     // ntp_revision is needed to reconstruct full remote path of
-    // the segment.
-    model::revision_id ntp_revision;
+    // the segment. Deprecated because ntp_revision is now part of
+    // segment_meta.
+    model::revision_id ntp_revision_deprecated;
     cloud_storage::segment_name name;
     cloud_storage::manifest::segment_meta meta;
 };
@@ -59,24 +60,15 @@ archival_metadata_stm::segments_from_manifest(
   const cloud_storage::manifest& manifest) {
     std::vector<segment> segments;
     segments.reserve(manifest.size());
-    for (const auto& [key, meta] : manifest) {
-        model::revision_id ntp_revision;
-        cloud_storage::segment_name segment_name;
-        ss::visit(
-          key,
-          [&](const cloud_storage::remote_segment_path& path) {
-              auto components = get_segment_path_components(path);
-              vassert(components, "can't parse remote segment path {}", path);
-              ntp_revision = components->_rev;
-              segment_name = components->_name;
-          },
-          [&](const cloud_storage::segment_name& name) {
-              ntp_revision = manifest.get_revision_id();
-              segment_name = name;
-          });
+    for (auto [name, meta] : manifest) {
+        if (meta.ntp_revision == model::revision_id{}) {
+            meta.ntp_revision = manifest.get_revision_id();
+        }
 
         segments.push_back(segment{
-          .ntp_revision = ntp_revision, .name = segment_name, .meta = meta});
+          .ntp_revision_deprecated = meta.ntp_revision,
+          .name = std::move(name),
+          .meta = meta});
     }
 
     std::sort(
@@ -284,19 +276,17 @@ model::offset archival_metadata_stm::max_collectible_offset() {
 }
 
 void archival_metadata_stm::apply_add_segment(const segment& segment) {
-    if (segment.ntp_revision == _manifest.get_revision_id()) {
-        _manifest.add(segment.name, segment.meta);
-    } else {
-        auto path = cloud_storage::manifest::generate_remote_segment_path(
-          _raft->ntp(), segment.ntp_revision, segment.name);
-        _manifest.add(path, segment.meta);
+    auto meta = segment.meta;
+    if (meta.ntp_revision == model::revision_id{}) {
+        // metadata serialized by old versions of redpanda doesn't have the
+        // ntp_revision field.
+        meta.ntp_revision = segment.ntp_revision_deprecated;
     }
+    _manifest.add(segment.name, segment.meta);
 
     // NOTE: here we don't take into account possibility of holes in the
     // remote offset range. Archival tries to upload segments in order, and
     // if for some reason is a hole, there are no mechanisms for correcting it.
-
-    const cloud_storage::manifest::segment_meta& meta = segment.meta;
 
     if (_start_offset == model::offset{} || meta.base_offset < _start_offset) {
         _start_offset = meta.base_offset;

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -31,6 +31,7 @@ import json
 import traceback
 import uuid
 import sys
+import re
 
 NTP = namedtuple("NTP", ['ns', 'topic', 'partition', 'revision'])
 
@@ -782,6 +783,10 @@ class ArchivalTest(RedpandaTest):
         """Get MD5 checksums of log segments stored in S3 (minio). The paths are
         normalized (<namespace>/<topic>/<partition>_<rev>/...)."""
         def normalize(path):
+            # strip archiver term id from the segment path
+            match = re.search(r'.log(\.\d+)$', path)
+            if match:
+                path = path[:-len(match[1])]
             return path[9:]  # 8-character hash + /
 
         def included(path):


### PR DESCRIPTION
## Cover letter

Fixes #3272 

To ensure that segments in the cloud storage are not overwritten by concurrent archivers running on different nodes, we append archiver term id as a suffix for segment paths. As raft guarantees that in each term there will be only one leader, this ensures segment path uniqueness.

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->

### Bug fixes
* Fixed data loss in shadow indexing archived data that could occur after quick partition leadership transfer back and forth between two nodes. Compatibility note: previous redpanda versions won't be able to read shadow indexing data archived by newer versions.
