### PR TITLE
codeowners: add ztlpn to cloud_storage group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,7 +39,7 @@ licenses           @senior7515 @dswang
 /src/js                @andresaristizabal
 /src/v/archival        @lazin               @lenaan         @ztlpn
 /src/v/bytes           @dotnwat
-/src/v/cloud_storage   @lazin               @lenaan
+/src/v/cloud_storage   @lazin               @lenaan         @ztlpn
 /src/v/cluster         @mmaslankaprv        @ztlpn          @vadimplh
 /src/v/compression     @dotnwat
 /src/v/config          @mmaslankaprv


### PR DESCRIPTION
## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
* none