### PR TITLE
init_producer_id: change IDEMPOTENT_WRITE on CLUSTER for CLUSTER_NAME to WRITE on ANY TOPIC (KIP-679)

### DIFF
--- a/src/v/kafka/server/handlers/init_producer_id.cc
+++ b/src/v/kafka/server/handlers/init_producer_id.cc
@@ -76,12 +76,25 @@ ss::future<response_ptr> init_producer_id_handler::handle(
               });
         }
 
-        if (!ctx.authorized(
-              security::acl_operation::idempotent_write,
-              security::default_cluster_name)) {
-            init_producer_id_response reply;
-            reply.data.error_code = error_code::cluster_authorization_failed;
-            return ctx.respond(reply);
+        bool permitted = false;
+        auto topics = ctx.metadata_cache().all_topics();
+        for (auto& tp_ns : topics) {
+            permitted = ctx.authorized(
+              security::acl_operation::write, tp_ns.tp, authz_quiet{true});
+            if (permitted) {
+                break;
+            }
+        }
+
+        if (!permitted) {
+            if (!ctx.authorized(
+                  security::acl_operation::idempotent_write,
+                  security::default_cluster_name)) {
+                init_producer_id_response reply;
+                reply.data.error_code
+                  = error_code::cluster_authorization_failed;
+                return ctx.respond(reply);
+            }
         }
 
         return ctx.id_allocator_frontend()

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -472,14 +472,6 @@ produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
         }
     }
 
-    /*
-     * Authorization
-     *
-     * Note that in kafka authorization is performed based on
-     * transactional id, producer id, and idempotency. Redpanda does not
-     * yet support these features, so we reject all such requests as if
-     * authorization failed.
-     */
     if (request.has_transactional) {
         if (!ctx.are_transactions_enabled()) {
             return process_result_stages::single_stage(
@@ -500,14 +492,6 @@ produce_handler::handle(request_context ctx, ss::smp_service_group ssg) {
         // ProducerId authorization</kafka>
 
     } else if (request.has_idempotent) {
-        if (!ctx.authorized(
-              security::acl_operation::idempotent_write,
-              security::default_cluster_name)) {
-            return process_result_stages::single_stage(
-              ctx.respond(request.make_error_response(
-                error_code::cluster_authorization_failed)));
-        }
-
         if (!ctx.is_idempotence_enabled()) {
             return process_result_stages::single_stage(
               ctx.respond(request.make_error_response(

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -94,9 +94,6 @@ public:
         }
 
         if (acls.empty()) {
-            if (operation == acl_operation::idempotent_write) {
-                return true;
-            }
             return bool(_allow_empty_matches);
         }
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -583,6 +583,18 @@ class RedpandaService(Service):
         cfg = self.read_configuration(node)
         return f"{node.account.hostname}:{one_or_many(cfg['redpanda']['kafka_api'])['port']}"
 
+    def admin_endpoint(self, node):
+        assert node in self._started
+        return f"{node.account.hostname}:9644"
+
+    def admin_endpoints_list(self):
+        brokers = [self.admin_endpoint(n) for n in self._started]
+        random.shuffle(brokers)
+        return brokers
+
+    def admin_endpoints(self):
+        return ",".join(self.admin_endpoints_list())
+
     def brokers(self, limit=None):
         return ",".join(self.brokers_list(limit))
 

--- a/tests/rptest/tests/scramful_eos_test.py
+++ b/tests/rptest/tests/scramful_eos_test.py
@@ -1,0 +1,178 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+from time import sleep
+
+from confluent_kafka import (Producer, KafkaException)
+
+TOPIC_AUTHORIZATION_FAILED = 29
+TRANSACTIONAL_ID_AUTHORIZATION_FAILED = 53
+
+
+def on_delivery(err, msg):
+    if err is not None:
+        raise KafkaException(err)
+
+
+class ScramfulEosTest(RedpandaTest):
+    topics = [TopicSpec(name="topic1")]
+
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_idempotence": True,
+            "enable_transactions": True,
+            "id_allocator_replication": 3,
+            "transaction_coordinator_replication": 3,
+            "id_allocator_replication": 3,
+            "default_topic_replications": 3,
+            "default_topic_partitions": 1,
+            "enable_leader_balancer": False,
+            "enable_auto_rebalance_on_node_add": False,
+            "enable_sasl": True
+        }
+
+        super(ScramfulEosTest, self).__init__(test_context=test_context,
+                                              extra_rp_conf=extra_rp_conf)
+
+    def retry(self, func, retries, accepted_error_code):
+        while True:
+            retries -= 1
+            try:
+                func()
+                break
+            except KafkaException as e:
+                if retries == 0:
+                    raise e
+                assert e.args[0].code(
+                ) == accepted_error_code, f"only {accepted_error_code} error code is expected"
+                sleep(1)
+
+    def write_by_bob(self, algorithm):
+        producer = Producer({
+            "bootstrap.servers": self.redpanda.brokers(),
+            "enable.idempotence": True,
+            "retries": 5,
+            "sasl.mechanism": algorithm,
+            "security.protocol": "SASL_PLAINTEXT",
+            "sasl.username": "bob",
+            "sasl.password": "bob"
+        })
+        producer.produce("topic1",
+                         key="key1".encode('utf-8'),
+                         value="value1".encode('utf-8'),
+                         callback=on_delivery)
+        producer.flush()
+
+    @cluster(num_nodes=3)
+    def test_idempotent_write_fails(self):
+        username, password, algorithm = self.redpanda.SUPERUSER_CREDENTIALS
+
+        rpk = RpkTool(self.redpanda)
+        rpk.sasl_create_user("bob", "bob", algorithm)
+
+        try:
+            self.write_by_bob(algorithm)
+            assert False, "bob should not have access to topic1"
+        except AssertionError as e:
+            raise e
+        except KafkaException as e:
+            assert e.args[0].code(
+            ) == TOPIC_AUTHORIZATION_FAILED, "TOPIC_AUTHORIZATION_FAILED error is expected"
+
+    @cluster(num_nodes=3)
+    def test_idempotent_write_passes_1(self):
+        username, password, algorithm = self.redpanda.SUPERUSER_CREDENTIALS
+
+        rpk = RpkTool(self.redpanda)
+        rpk.sasl_create_user("bob", "bob", algorithm)
+        rpk.sasl_allow_principal("User:bob", ["write", "read", "describe"],
+                                 "topic", "topic1", username, password,
+                                 algorithm)
+        self.retry(lambda: self.write_by_bob(algorithm), 5,
+                   TOPIC_AUTHORIZATION_FAILED)
+
+    @cluster(num_nodes=3)
+    def test_idempotent_write_passes_2(self):
+        username, password, algorithm = self.redpanda.SUPERUSER_CREDENTIALS
+
+        rpk = RpkTool(self.redpanda)
+        rpk.sasl_create_user("bob", "bob", algorithm)
+        rpk.sasl_allow_principal("User:bob", ["write", "read", "describe"],
+                                 "topic", "*", username, password, algorithm)
+        self.retry(lambda: self.write_by_bob(algorithm), 5,
+                   TOPIC_AUTHORIZATION_FAILED)
+
+    def init_by_bob(self, tx_id, algorithm):
+        producer = Producer({
+            "bootstrap.servers": self.redpanda.brokers(),
+            "enable.idempotence": True,
+            "retries": 5,
+            "sasl.mechanism": algorithm,
+            "transactional.id": tx_id,
+            "security.protocol": "SASL_PLAINTEXT",
+            "sasl.username": "bob",
+            "sasl.password": "bob"
+        })
+        producer.init_transactions()
+
+    @cluster(num_nodes=3)
+    def test_tx_init_fails(self):
+        username, password, algorithm = self.redpanda.SUPERUSER_CREDENTIALS
+
+        rpk = RpkTool(self.redpanda)
+        rpk.sasl_create_user("bob", "bob", algorithm)
+        rpk.sasl_allow_principal("User:bob", ["write", "read", "describe"],
+                                 "topic", "topic1", username, password,
+                                 algorithm)
+
+        try:
+            self.init_by_bob("tx-id-1", algorithm)
+            assert False, "bob should not have access to txns"
+        except AssertionError as e:
+            raise e
+        except KafkaException as e:
+            assert e.args[0].code(
+            ) == TRANSACTIONAL_ID_AUTHORIZATION_FAILED, "TRANSACTIONAL_ID_AUTHORIZATION_FAILED is expected"
+
+    @cluster(num_nodes=3)
+    def test_tx_init_passes_1(self):
+        username, password, algorithm = self.redpanda.SUPERUSER_CREDENTIALS
+
+        rpk = RpkTool(self.redpanda)
+        rpk.sasl_create_user("bob", "bob", algorithm)
+        rpk.sasl_allow_principal("User:bob", ["write", "read", "describe"],
+                                 "topic", "topic1", username, password,
+                                 algorithm)
+        rpk.sasl_allow_principal("User:bob", ["write", "describe"],
+                                 "transactional-id", "tx-id-1", username,
+                                 password, algorithm)
+
+        self.retry(lambda: self.init_by_bob("tx-id-1", algorithm), 5,
+                   TRANSACTIONAL_ID_AUTHORIZATION_FAILED)
+
+    @cluster(num_nodes=3)
+    def test_tx_init_passes_2(self):
+        username, password, algorithm = self.redpanda.SUPERUSER_CREDENTIALS
+
+        rpk = RpkTool(self.redpanda)
+        rpk.sasl_create_user("bob", "bob", algorithm)
+        rpk.sasl_allow_principal("User:bob", ["write", "read", "describe"],
+                                 "topic", "topic1", username, password,
+                                 algorithm)
+        rpk.sasl_allow_principal("User:bob", ["write", "describe"],
+                                 "transactional-id", "*", username, password,
+                                 algorithm)
+
+        self.retry(lambda: self.init_by_bob("tx-id-2", algorithm), 5,
+                   TRANSACTIONAL_ID_AUTHORIZATION_FAILED)

--- a/tests/rptest/tests/scramless_eos_test.py
+++ b/tests/rptest/tests/scramless_eos_test.py
@@ -1,0 +1,67 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.rpk import RpkTool
+
+from confluent_kafka import (Producer, KafkaException)
+
+
+def on_delivery(err, msg):
+    if err is not None:
+        raise KafkaException(err)
+
+
+class ScramlessEosTest(RedpandaTest):
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_idempotence": True,
+            "enable_transactions": True,
+            "id_allocator_replication": 3,
+            "transaction_coordinator_replication": 3,
+            "id_allocator_replication": 3,
+            "default_topic_replications": 3,
+            "default_topic_partitions": 1,
+            "enable_leader_balancer": False,
+            "enable_auto_rebalance_on_node_add": False
+        }
+
+        super(ScramlessEosTest, self).__init__(test_context=test_context,
+                                               extra_rp_conf=extra_rp_conf)
+
+    @cluster(num_nodes=3)
+    def test_idempotent_write_passes(self):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic("topic1")
+
+        producer = Producer({
+            "bootstrap.servers": self.redpanda.brokers(),
+            "enable.idempotence": True,
+            "retries": 5
+        })
+        producer.produce("topic1",
+                         key="key1".encode('utf-8'),
+                         value="value1".encode('utf-8'),
+                         callback=on_delivery)
+        producer.flush()
+
+    @cluster(num_nodes=3)
+    def test_tx_init_passes(self):
+        rpk = RpkTool(self.redpanda)
+        rpk.create_topic("topic1")
+
+        producer = Producer({
+            "bootstrap.servers": self.redpanda.brokers(),
+            "enable.idempotence": True,
+            "transactional.id": "tx-id-1",
+            "retries": 5
+        })
+        producer.init_transactions()


### PR DESCRIPTION
## Cover letter

Kafka clients enabled EOS (exactly once semantic) by default in version 3.0 ([KIP-679](https://cwiki.apache.org/confluence/display/KAFKA/KIP-679%3A+Producer+will+enable+the+strongest+delivery+guarantee+by+default)).

It could be a breaking change. Image a customer who doesn't use EOS and who hasn't configured authorization for it (IDEMPOTENT_WRITE): when they update to a new Kafka version the `init_producer_id` request starts failing with auth errors. To avoid this problem Kafka devs changed init_producer_id ACLs:

A. In `ProduceRequest` handler, they removed the `IDEMPOTENT_WRITE` access check since it already has the `WRITE` access check on topics.
B. In `InitProduceIdRequest` handler, if the producer will get authorized if it has `WRITE` access on ANY topic.

Altering Redpanda ACLs to avoid the same problem.

Fixes #3366

## Release notes

* none