### PR TITLE
admin_server: add versioned cluster_view api

### DIFF
--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -109,7 +109,7 @@ private:
       do_dispatch_configuration_update(model::broker, model::broker);
 
     template<typename Cmd>
-    ss::future<std::error_code> dispatch_updates_to_cores(Cmd);
+    ss::future<std::error_code> dispatch_updates_to_cores(model::offset, Cmd);
 
     ss::future<std::error_code>
       apply_raft_configuration_batch(model::record_batch);

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -37,13 +37,16 @@ public:
 
     bool contains(model::node_id) const;
 
-    void update_brokers(const std::vector<model::broker>&);
+    void update_brokers(model::offset, const std::vector<model::broker>&);
 
-    std::error_code apply(decommission_node_cmd);
-    std::error_code apply(recommission_node_cmd);
+    std::error_code apply(model::offset, decommission_node_cmd);
+    std::error_code apply(model::offset, recommission_node_cmd);
+
+    model::revision_id version() const { return _version; }
 
 private:
     using broker_cache_t = absl::flat_hash_map<model::node_id, broker_ptr>;
     broker_cache_t _brokers;
+    model::revision_id _version;
 };
 } // namespace cluster

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -8,6 +8,21 @@
     ],
     "apis": [
         {
+            "path": "/v1/cluster_view",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get cluster view",
+                    "type": "cluster_view",
+                    "nickname": "get_cluster_view",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
+        },
+        {
             "path": "/v1/brokers",
             "operations": [
                 {
@@ -93,6 +108,22 @@
         }
     ],
     "models": {
+        "cluster_view": {
+            "id": "cluster_view",
+            "description": "Cluster view",
+            "properties": {
+                "version": {
+                    "type": "long",
+                    "description": "cluster view version"
+                },
+                "brokers": {
+                    "type": "array",
+                    "items": {
+                        "type": "broker"
+                    }
+                }
+            }
+        },
         "broker": {
             "id": "broker",
             "description": "Broker information",

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -164,6 +164,12 @@ class Admin:
         """
         return self._request('get', "brokers", node=node).json()
 
+    def get_cluster_view(self, node):
+        """
+        Return cluster_view.
+        """
+        return self._request('get', "cluster_view", node=node).json()
+
     def decommission_broker(self, id, node=None):
         """
         Decommission broker

--- a/tests/rptest/tests/cluster_view_test.py
+++ b/tests/rptest/tests/cluster_view_test.py
@@ -1,0 +1,89 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import time
+
+import requests
+import json
+from ducktape.mark import ignore
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.redpanda import RedpandaService
+from rptest.tests.end_to_end import EndToEndTest
+
+
+class ClusterViewTest(EndToEndTest):
+    @cluster(num_nodes=3)
+    def test_view_changes_on_add(self):
+        self.redpanda = RedpandaService(self.test_context, 3)
+        # start single node cluster
+        self.redpanda.start(nodes=[self.redpanda.nodes[0]])
+
+        admin = Admin(self.redpanda)
+
+        seed = None
+
+        def rp1_started():
+            nonlocal seed
+            try:
+                #{"version": 0, "brokers": [{"node_id": 1, "num_cores": 3, "membership_status": "active", "is_alive": true}]}
+                seed = admin.get_cluster_view(self.redpanda.nodes[0])
+                self.redpanda.logger.info(
+                    f"view from {self.redpanda.nodes[0]}: {json.dumps(seed)}")
+                return len(seed["brokers"]) == 1
+            except requests.exceptions.RequestException as e:
+                self.redpanda.logger.debug(f"admin API isn't available ({e})")
+                return False
+
+        wait_until(
+            rp1_started,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Cant get cluster view from {self.redpanda.nodes[0]}")
+
+        self.redpanda.start_node(self.redpanda.nodes[1])
+        self.redpanda.start_node(self.redpanda.nodes[2])
+
+        def rest_started():
+            try:
+                last = None
+                ids = None
+                for i in range(0, 3):
+                    view = admin.get_cluster_view(self.redpanda.nodes[i])
+                    self.redpanda.logger.info(
+                        f"view from {self.redpanda.nodes[i]}: {json.dumps(view)}"
+                    )
+                    if view["version"] <= seed["version"]:
+                        return False
+                    if len(view["brokers"]) != 3:
+                        return False
+                    if last == None:
+                        last = view
+                        ids = set(
+                            map(lambda broker: broker["node_id"],
+                                view["brokers"]))
+                    if last["version"] != view["version"]:
+                        return False
+                    if not ids.issubset(
+                            map(lambda broker: broker["node_id"],
+                                view["brokers"])):
+                        return False
+                return True
+            except requests.exceptions.RequestException as e:
+                self.redpanda.logger.debug(f"admin API isn't available ({e})")
+                return False
+
+        wait_until(rest_started,
+                   timeout_sec=30,
+                   backoff_sec=1,
+                   err_msg="Cant get cluster view from {self.redpanda.nodes}")


### PR DESCRIPTION
## Cover letter

v1/cluster_view is similar to v1/brokers; it also returns a list of brokers but unlike the latter it encodes it inside an object so it's possible to return additional information; the current iteration of the API includes a version of a view:

- to avoid the ABA problem
- to simplify the comparison of views from different nodes

## Release notes

* none