### PR TITLE
archival: fine-tune WARN logs on errors

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -356,9 +356,14 @@ ss::future<ntp_archiver::batch_result> ntp_archiver::wait_all_scheduled_uploads(
         if (_partition->archival_meta_stm()) {
             retry_chain_node rc_node(
               _manifest_upload_timeout, _initial_backoff, &parent);
-            if (!co_await _partition->archival_meta_stm()->add_segments(
-                  _manifest, rc_node)) {
-                vlog(ctxlog.warn, "archival metadata STM update failed");
+            auto result
+              = co_await _partition->archival_meta_stm()->add_segments(
+                _manifest, rc_node);
+            if (!result && result != cluster::errc::not_leader) {
+                vlog(
+                  ctxlog.warn,
+                  "archival metadata STM update failed: {}",
+                  result);
             }
         }
 

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -34,7 +34,7 @@ public:
 
     /// Add the difference between manifests to the raft log, replicate it and
     /// wait until it is applied to the STM.
-    ss::future<bool>
+    ss::future<std::error_code>
     add_segments(const cloud_storage::manifest&, retry_chain_node&);
 
     /// A set of archived segments. NOTE: manifest can be out-of-date if this
@@ -46,7 +46,7 @@ public:
     ss::future<> stop() override;
 
 private:
-    ss::future<bool>
+    ss::future<std::error_code>
     do_add_segments(const cloud_storage::manifest&, retry_chain_node&);
 
     ss::future<> apply(model::record_batch batch) override;


### PR DESCRIPTION
## Cover letter

Topic creation and topic leader change with shadow indexing enabled generated a lot of WARN log messages even in successful cases. This PR propagates error code from replication and logs only dangerous errors.

Fixes: #3310

## Release notes

* none