### PR TITLE
Delay prefix truncation of offset translator until segments are deleted

### DIFF
--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -167,10 +167,8 @@ ss::future<> id_allocator_stm::apply(model::record_batch b) {
         _processed++;
         if (_processed > _log_capacity) {
             return _c
-              ->write_snapshot(raft::write_snapshot_cfg(
-                _next_snapshot,
-                iobuf(),
-                raft::write_snapshot_cfg::should_prefix_truncate::no))
+              ->write_snapshot(
+                raft::write_snapshot_cfg(_next_snapshot, iobuf()))
               .then([this] {
                   _next_snapshot = _insync_offset;
                   _processed = 0;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -89,14 +89,14 @@ static ss::future<read_result> read_from_partition(
 
     reader_config.strict_max_bytes = config.strict_max_bytes;
     auto rdr = co_await part.make_reader(reader_config);
-    auto result = co_await std::move(rdr.reader)
-                    .consume(
-                      kafka_batch_serializer(),
-                      deadline ? *deadline : model::no_timeout);
+    auto result = co_await rdr.reader.consume(
+      kafka_batch_serializer(), deadline ? *deadline : model::no_timeout);
     auto data = std::make_unique<iobuf>(std::move(result.data));
     std::vector<cluster::rm_stm::tx_range> aborted_transactions;
     part.probe().add_records_fetched(result.record_count);
     if (result.record_count > 0) {
+        // Reader should live at least until this point to hold on to the
+        // segment locks so that prefix truncation doesn't happen.
         aborted_transactions = co_await part.aborted_transactions(
           result.base_offset, result.last_offset, std::move(rdr.ot_state));
     }

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1742,15 +1742,19 @@ ss::future<> consensus::truncate_to_latest_snapshot() {
     }
     // we have to prefix truncate config manage at exactly last offset included
     // in snapshot as this is the offset of configuration included in snapshot
-    // metadata
-    return _configuration_manager.prefix_truncate(_last_snapshot_index)
+    // metadata.
+    //
+    // We truncate the log before truncating offset translator to wait for
+    // readers that started reading from the start of the log before we advanced
+    // _last_snapshot_index and thus can still need offset translation info.
+    return _log
+      .truncate_prefix(storage::truncate_prefix_config(
+        details::next_offset(_last_snapshot_index), _scheduling.default_iopc))
       .then([this] {
-          return _offset_translator.prefix_truncate(_last_snapshot_index);
+          return _configuration_manager.prefix_truncate(_last_snapshot_index);
       })
       .then([this] {
-          return _log.truncate_prefix(storage::truncate_prefix_config(
-            details::next_offset(_last_snapshot_index),
-            _scheduling.default_iopc));
+          return _offset_translator.prefix_truncate(_last_snapshot_index);
       })
       .then([this] {
           // when log was prefix truncate flushed offset should be equal to at
@@ -1781,6 +1785,8 @@ ss::future<> consensus::do_hydrate_snapshot(storage::snapshot_reader& reader) {
         return _configuration_manager
           .add(_last_snapshot_index, std::move(metadata.latest_configuration))
           .then([this, delta = metadata.log_start_delta]() mutable {
+              _probe.configuration_update();
+
               if (delta < offset_translator_delta(0)) {
                   delta = offset_translator_delta(
                     _configuration_manager.offset_delta(_last_snapshot_index));
@@ -1794,11 +1800,8 @@ ss::future<> consensus::do_hydrate_snapshot(storage::snapshot_reader& reader) {
               return _offset_translator.prefix_truncate_reset(
                 _last_snapshot_index, delta);
           })
-          .then([this] {
-              _probe.configuration_update();
-              _log.set_collectible_offset(_last_snapshot_index);
-              return truncate_to_latest_snapshot();
-          });
+          .then([this] { return truncate_to_latest_snapshot(); })
+          .then([this] { _log.set_collectible_offset(_last_snapshot_index); });
     });
 }
 
@@ -1907,31 +1910,49 @@ ss::future<install_snapshot_reply> consensus::finish_snapshot(
 }
 
 ss::future<> consensus::write_snapshot(write_snapshot_cfg cfg) {
-    return _op_lock.with([this, cfg = std::move(cfg)]() mutable {
-        // do nothing, we already have snapshot for this offset
-        // MUST be checked under the _op_lock
-        if (cfg.last_included_index <= _last_snapshot_index) {
-            return ss::now();
-        }
-        auto max_offset = cfg.should_truncate ? _commit_index
-                                              : last_visible_index();
+    model::offset last_included_index = cfg.last_included_index;
+    bool updated = co_await _op_lock.with(
+      [this, cfg = std::move(cfg)]() mutable {
+          // do nothing, we already have snapshot for this offset
+          // MUST be checked under the _op_lock
+          if (cfg.last_included_index <= _last_snapshot_index) {
+              return ss::make_ready_future<bool>(false);
+          }
 
-        vassert(
-          cfg.last_included_index <= max_offset,
-          "Can not take snapshot, requested offset: {} is greater than max "
-          "snapshot offset: {}",
-          cfg.last_included_index,
-          _commit_index);
+          auto max_offset = last_visible_index();
+          vassert(
+            cfg.last_included_index <= max_offset,
+            "Can not take snapshot, requested offset: {} is greater than max "
+            "snapshot offset: {}",
+            cfg.last_included_index,
+            max_offset);
 
-        return do_write_snapshot(cfg.last_included_index, std::move(cfg.data))
-          .then([this, should_truncate = cfg.should_truncate] {
-              if (!should_truncate) {
-                  return ss::now();
-              }
-              return truncate_to_latest_snapshot();
+          return do_write_snapshot(cfg.last_included_index, std::move(cfg.data))
+            .then([] { return true; });
+      });
+
+    if (!updated) {
+        co_return;
+    }
+
+    // Release the lock when truncating the log because it can take some
+    // time while we wait for readers to be evicted.
+    co_await _log.truncate_prefix(storage::truncate_prefix_config(
+      details::next_offset(last_included_index), _scheduling.default_iopc));
+
+    co_await _op_lock.with([this, last_included_index] {
+        return _configuration_manager.prefix_truncate(last_included_index)
+          .then([this, last_included_index] {
+              return _offset_translator.prefix_truncate(last_included_index);
           })
-          .then([this] { _log.set_collectible_offset(_last_snapshot_index); });
+          .then([this, last_included_index] {
+              // when log was prefix truncate flushed offset should be
+              // equal to at least last snapshot index
+              _flushed_offset = std::max(last_included_index, _flushed_offset);
+          });
     });
+
+    _log.set_collectible_offset(last_included_index);
 }
 
 ss::future<>
@@ -1972,11 +1993,6 @@ consensus::do_write_snapshot(model::offset last_included_index, iobuf&& data) {
           // update consensus state
           _last_snapshot_index = last_included_index;
           _last_snapshot_term = term;
-          // update configuration manager
-          return _configuration_manager.prefix_truncate(_last_snapshot_index)
-            .then([this] {
-                return _offset_translator.prefix_truncate(_last_snapshot_index);
-            });
       });
 }
 

--- a/src/v/raft/log_eviction_stm.cc
+++ b/src/v/raft/log_eviction_stm.cc
@@ -87,10 +87,8 @@ log_eviction_stm::handle_deletion_notification(model::offset last_evicted) {
           }
 
           return f.then([this, last_evicted]() {
-              return _raft->write_snapshot(write_snapshot_cfg(
-                last_evicted,
-                iobuf(),
-                write_snapshot_cfg::should_prefix_truncate::no));
+              return _raft->write_snapshot(
+                write_snapshot_cfg(last_evicted, iobuf()));
           });
       });
 }

--- a/src/v/raft/tests/append_entries_test.cc
+++ b/src/v/raft/tests/append_entries_test.cc
@@ -595,9 +595,7 @@ FIXTURE_TEST(test_snapshot_recovery, raft_test_fixture) {
     for (auto& [_, member] : gr.get_members()) {
         member.consensus
           ->write_snapshot(raft::write_snapshot_cfg(
-            get_leader_raft(gr)->committed_offset(),
-            iobuf{},
-            raft::write_snapshot_cfg::should_prefix_truncate::yes))
+            get_leader_raft(gr)->committed_offset(), iobuf{}))
           .get0();
     }
     gr.enable_node(disabled_id);
@@ -648,9 +646,7 @@ FIXTURE_TEST(test_snapshot_recovery_last_config, raft_test_fixture) {
     for (auto& [_, member] : gr.get_members()) {
         member.consensus
           ->write_snapshot(raft::write_snapshot_cfg(
-            get_leader_raft(gr)->committed_offset(),
-            iobuf{},
-            raft::write_snapshot_cfg::should_prefix_truncate::yes))
+            get_leader_raft(gr)->committed_offset(), iobuf{}))
           .get0();
     }
     gr.enable_node(disabled_id);

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -435,27 +435,14 @@ struct install_snapshot_reply {
  * Configuration describing snapshot that is going to be taken at current node.
  */
 struct write_snapshot_cfg {
-    using should_prefix_truncate = ss::bool_class<struct prefix_truncate_tag>;
-
     write_snapshot_cfg(model::offset last_included_index, iobuf data)
-      : write_snapshot_cfg(
-        last_included_index, std::move(data), should_prefix_truncate::yes) {}
-
-    write_snapshot_cfg(
-      model::offset last_included_index,
-      iobuf data,
-      should_prefix_truncate truncate)
       : last_included_index(last_included_index)
-      , data(std::move(data))
-      , should_truncate(truncate) {}
+      , data(std::move(data)) {}
 
     // last applied offset
     model::offset last_included_index;
     // snapshot content
     iobuf data;
-    // are we going to prefix truncate the log right after persisting the
-    // snapshot
-    should_prefix_truncate should_truncate;
 };
 
 struct timeout_now_request {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -218,8 +218,12 @@ disk_log_impl::monitor_eviction(ss::abort_source& as) {
 
 void disk_log_impl::set_collectible_offset(model::offset o) {
     vlog(
-      gclog.debug, "[{}] setting max collectible offset {}", config().ntp(), o);
-    _max_collectible_offset = o;
+      gclog.debug,
+      "[{}] setting max collectible offset {}, prev offset {}",
+      config().ntp(),
+      o,
+      _max_collectible_offset);
+    _max_collectible_offset = std::max(_max_collectible_offset, o);
 }
 
 bool disk_log_impl::is_front_segment(const segment_set::type& ptr) const {

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -174,6 +174,7 @@ public:
     }
     /**
      * Controlls the max offset that may be evicted by log retention policy
+     * This offset is non-decreasing.
      */
     void set_collectible_offset(model::offset o) {
         return _impl->set_collectible_offset(o);

--- a/src/v/storage/mem_log_impl.cc
+++ b/src/v/storage/mem_log_impl.cc
@@ -306,7 +306,7 @@ struct mem_log_impl final : log::impl {
     }
 
     void set_collectible_offset(model::offset o) final {
-        _max_collectible_offset = o;
+        _max_collectible_offset = std::max(_max_collectible_offset, o);
     }
 
     ss::future<> update_configuration(ntp_config::default_overrides o) final {

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -79,13 +79,14 @@ model::offset offset_translator_state::to_log_offset(
     model::offset min_data_offset
       = min_log_offset
         - model::offset(_last_offset2batch.begin()->second.next_delta);
-    vassert(
-      data_offset >= min_data_offset,
-      "ntp {}: data offset {} must be inside translation range (starting at "
-      "{})",
-      _ntp,
-      data_offset,
-      min_data_offset);
+    if (data_offset < min_data_offset) {
+        throw std::runtime_error{fmt::format(
+          "ntp {}: data offset {} is outside the translation range (starting "
+          "at {})",
+          _ntp,
+          data_offset,
+          min_data_offset)};
+    }
 
     model::offset search_start = std::max(
       std::max(hint, data_offset), min_log_offset);


### PR DESCRIPTION
## Cover letter

Fetch request could crash redpanda when prefix truncation happened after reading data but before the call to `aborted_transactions`. To delay prefix truncation we:
1. extend the reader lifetime to the part.aborted_transactions call.
2. Make sure that prefix truncation happens after `log.truncate_prefix`: this means that we wait until all readers in the affected range are finished.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3323.

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
### Bug fixes
* Fix rare crash that could happen when log segments eviction happened concurrently with fetching near the start of the log (issue #3323).