### PR TITLE
Fix some `lowres_clock` use cases 

### DIFF
--- a/src/v/archival/types.cc
+++ b/src/v/archival/types.cc
@@ -10,6 +10,7 @@
 
 #include "archival/types.h"
 
+#include <fmt/chrono.h>
 #include <fmt/format.h>
 
 namespace archival {
@@ -17,7 +18,7 @@ namespace archival {
 std::ostream&
 operator<<(std::ostream& o, const std::optional<segment_time_limit>& tl) {
     if (tl) {
-        fmt::print(o, "{}", tl.value()().count());
+        fmt::print(o, "{}", std::chrono::milliseconds(tl.value()));
     } else {
         fmt::print(o, "N/A");
     }
@@ -31,10 +32,10 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
       "segment_upload_timeout: {}, "
       "manifest_upload_timeout: {}, time_limit: {}}}",
       cfg.bucket_name,
-      cfg.interval.count(),
-      cfg.initial_backoff.count(),
-      cfg.segment_upload_timeout.count(),
-      cfg.manifest_upload_timeout.count(),
+      std::chrono::milliseconds(cfg.interval),
+      std::chrono::milliseconds(cfg.initial_backoff),
+      std::chrono::milliseconds(cfg.segment_upload_timeout),
+      std::chrono::milliseconds(cfg.manifest_upload_timeout),
       cfg.time_limit);
     return o;
 }

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -409,7 +409,9 @@ partition_downloader::download_log_with_capped_time(
     vlog(
       _ctxlog.info,
       "Starting log download with time limit of {}s",
-      retention_time.count() / 1000);
+      std::chrono::duration_cast<std::chrono::milliseconds>(retention_time)
+          .count()
+        / 1000);
     gate_guard guard(_gate);
     auto time_threshold = model::to_timestamp(
       model::timestamp_clock::now() - retention_time);

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -26,6 +26,7 @@
 
 #include <boost/beast/http/error.hpp>
 #include <boost/beast/http/field.hpp>
+#include <fmt/chrono.h>
 
 #include <exception>
 #include <variant>
@@ -194,9 +195,9 @@ ss::future<download_result> remote::download_manifest(
         case error_outcome::retry:
             vlog(
               ctxlog.debug,
-              "Downloading manifest from {}, {}ms backoff required",
+              "Downloading manifest from {}, {} backoff required",
               bucket,
-              retry_permit.delay.count());
+              std::chrono::milliseconds(retry_permit.delay));
             _probe.manifest_download_backoff();
             co_await ss::sleep_abortable(retry_permit.delay, _as);
             retry_permit = fib.retry();
@@ -271,10 +272,10 @@ ss::future<upload_result> remote::upload_manifest(
         case error_outcome::retry:
             vlog(
               ctxlog.debug,
-              "Uploading manifest {} to {}, {}ms backoff required",
+              "Uploading manifest {} to {}, {} backoff required",
               path,
               bucket,
-              permit.delay.count());
+              std::chrono::milliseconds(permit.delay));
             _probe.manifest_upload_backoff();
             co_await ss::sleep_abortable(permit.delay, _as);
             permit = fib.retry();
@@ -359,10 +360,10 @@ ss::future<upload_result> remote::upload_segment(
         case error_outcome::retry:
             vlog(
               ctxlog.debug,
-              "Uploading segment {} to {}, {}ms backoff required",
+              "Uploading segment {} to {}, {} backoff required",
               path,
               bucket,
-              permit.delay.count());
+              std::chrono::milliseconds(permit.delay));
             _probe.upload_backoff();
             co_await ss::sleep_abortable(permit.delay, _as);
             permit = fib.retry();
@@ -432,9 +433,9 @@ ss::future<download_result> remote::download_segment(
         case error_outcome::retry:
             vlog(
               ctxlog.debug,
-              "Downloading segment from {}, {}ms backoff required",
+              "Downloading segment from {}, {} backoff required",
               bucket,
-              permit.delay.count());
+              std::chrono::milliseconds(permit.delay));
             _probe.download_backoff();
             co_await ss::sleep_abortable(permit.delay, _as);
             permit = fib.retry();
@@ -524,9 +525,9 @@ ss::future<download_result> remote::list_objects(
         case error_outcome::retry:
             vlog(
               ctxlog.debug,
-              "Listing objects in {}, {}ms backoff required",
+              "Listing objects in {}, {} backoff required",
               bucket,
-              permit.delay.count());
+              std::chrono::milliseconds(permit.delay));
             _probe.download_backoff();
             co_await ss::sleep_abortable(permit.delay, _as);
             permit = fib.retry();

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -545,7 +545,7 @@ void adl<model::timeout_clock::duration>::to(iobuf& out, duration dur) {
     // This is a clang bug that cause ss::cpu_to_le to become ambiguous
     // because rep has type of long long
     // adl<rep>{}.to(out, dur.count());
-    adl<uint64_t>{}.to(out, dur.count());
+    adl<uint64_t>{}.to(out, std::chrono::milliseconds(dur).count());
 }
 
 model::timeout_clock::duration

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -13,6 +13,10 @@
 #include "kafka/server/logger.h"
 #include "vlog.h"
 
+#include <fmt/chrono.h>
+
+#include <chrono>
+
 namespace kafka {
 using clock = quota_manager::clock;
 using throttle_delay = quota_manager::throttle_delay;
@@ -59,30 +63,30 @@ throttle_delay quota_manager::record_tp_and_throttle(
 
     auto rate = it->second.tp_rate.record_and_measure(bytes, now);
 
-    uint64_t delay_ms = 0;
+    std::chrono::milliseconds delay_ms(0);
     if (rate > _target_tp_rate) {
         auto diff = rate - _target_tp_rate;
-        double delay
-          = (diff / _target_tp_rate)
-            * (double)std::chrono::duration_cast<std::chrono::milliseconds>(
-                it->second.tp_rate.window_size())
-                .count();
-        delay_ms = static_cast<uint64_t>(delay);
+        double delay = (diff / _target_tp_rate)
+                       * (double)std::chrono::milliseconds(
+                           it->second.tp_rate.window_size())
+                           .count();
+        delay_ms = std::chrono::milliseconds(static_cast<uint64_t>(delay));
     }
-    if (delay_ms > (uint64_t)_max_delay.count()) {
+    std::chrono::milliseconds max_delay_ms(_max_delay);
+    if (delay_ms > max_delay_ms) {
         vlog(
           klog.info,
           "Found data rate for window of: {} bytes. Client:{}, Estimated "
-          "backpressure delay of {}ms. Limiting to {}ms backpressure delay",
+          "backpressure delay of {}. Limiting to {} backpressure delay",
           rate,
           cid,
           delay_ms,
-          _max_delay.count());
-        delay_ms = _max_delay.count();
+          max_delay_ms);
+        delay_ms = max_delay_ms;
     }
 
     auto prev = it->second.delay;
-    it->second.delay = std::chrono::milliseconds(delay_ms);
+    it->second.delay = delay_ms;
 
     throttle_delay res{};
     res.first_violation = prev.count() == 0;

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -121,8 +121,10 @@ static heartbeat_requests requests_for_range(
                   "{}",
                   rni,
                   ptr->group(),
-                  last_heartbeat.time_since_epoch().count(),
-                  last_sent_append_entries_req_timesptamp.time_since_epoch()
+                  std::chrono::milliseconds(last_heartbeat.time_since_epoch())
+                    .count(),
+                  std::chrono::milliseconds(
+                    last_sent_append_entries_req_timesptamp.time_since_epoch())
                     .count());
                 // we already sent heartbeat, skip it
                 return;

--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -175,7 +175,8 @@ std::ostream& operator<<(std::ostream& o, const configuration& c) {
     o << "{access_key:" << c.access_key << ",region:" << c.region()
       << ",secret_key:****"
       << ",access_point_uri:" << c.uri() << ",server_addr:" << c.server_addr
-      << ",max_idle_time:" << c.max_idle_time.count() << "}";
+      << ",max_idle_time:" << std::chrono::milliseconds(c.max_idle_time).count()
+      << "}";
     return o;
 }
 

--- a/src/v/storage/snapshot.cc
+++ b/src/v/storage/snapshot.cc
@@ -53,7 +53,9 @@ snapshot_manager::start_snapshot(ss::sstring target) {
     auto filename = fmt::format(
       "{}.partial.{}.{}",
       _partial_prefix,
-      ss::lowres_system_clock::now().time_since_epoch().count(),
+      std::chrono::milliseconds(
+        ss::lowres_system_clock::now().time_since_epoch())
+        .count(),
       random_generators::gen_alphanum_string(4));
 
     auto path = _dir / filename;

--- a/src/v/utils/retry_chain_node.h
+++ b/src/v/utils/retry_chain_node.h
@@ -146,6 +146,7 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
+#include <chrono>
 #include <variant>
 
 /// Retry strategy
@@ -196,6 +197,9 @@ struct retry_permit {
 /// timeout value have to be smaller that the one of the parent node.
 class retry_chain_node {
 public:
+    using milliseconds_uint16_t
+      = std::chrono::duration<uint16_t, std::chrono::milliseconds::period>;
+
     /// Create a head of the chain without backoff
     retry_chain_node();
     /// Creates a head with the provided deadline and
@@ -328,8 +332,8 @@ private:
     uint16_t _num_children{0};
     /// Index of the next child node (used to generate ids)
     uint16_t _fanout_id{0};
-    /// Initial backoff value ms
-    uint16_t _backoff;
+    /// Initial backoff value
+    milliseconds_uint16_t _backoff;
     /// Deadline for retry attempts
     ss::lowres_clock::time_point _deadline;
     /// optional parent node or (if root) abort source for all fibers

--- a/src/v/utils/to_string.h
+++ b/src/v/utils/to_string.h
@@ -30,9 +30,9 @@ std::ostream& operator<<(std::ostream& os, const std::optional<T>& opt) {
     return os << "{nullopt}";
 }
 
-static inline std::ostream&
+inline std::ostream&
 operator<<(std::ostream& o, const ss::lowres_clock::duration& d) {
-    fmt::print(o, "{}", d.count());
+    fmt::print(o, "{}", std::chrono::milliseconds(d).count());
     return o;
 }
 


### PR DESCRIPTION
## Cover letter

According to [this](https://groups.google.com/g/seastar-dev/c/6oGX3y_pwGo/m/bbtw_V_NCwAJ) precision of the `seastar::lowers_clock` might change in the future. This PR fixes some cases when we assume that the duration stores milliseconds internally.

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/c6b05ac2cddffcc93582c2e315ad86c26b31d856..1d89eed63f71e01824863d5b1d0c448403129061)
- rebase with dev

## Release notes


* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
