### PR TITLE
Backport pr3358 pr3361 to v21.11.x

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:groovy-20210325
+FROM ubuntu:impish-20211102
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive

--- a/tests/rptest/services/kaf_consumer.py
+++ b/tests/rptest/services/kaf_consumer.py
@@ -26,7 +26,7 @@ class KafConsumer(BackgroundThreadService):
         self._stopping.clear()
         try:
             partition = None
-            cmd = "kaf consume -b %s --offset newest %s" % (
+            cmd = "kaf consume -b %s -f --offset newest %s" % (
                 self._redpanda.brokers(), self._topic)
             for line in node.account.ssh_capture(cmd):
                 if self._stopping.is_set():

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -918,7 +918,7 @@ class SchemaRegistryTest(RedpandaTest):
 
         # Expose into StressTest
         logger = self.logger
-        python = "python3.8"
+        python = "python3"
         script_name = "schema_registry_test_helper.py"
 
         dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
## Cover letter

The ducktape tests run on Ubuntu groovy, but it's gone away. Use Ubuntu impish instead.

Backport #3358 #3361 

Also backport a commit from #3066 due to failing `rptest.tests.wait_for_local_consumer_test`

## Release notes

* none
