### PR TITLE
k8s/docs: add guide for local env with external connectivity

### DIFF
--- a/src/go/k8s/config/samples/one_node_external.yaml
+++ b/src/go/k8s/config/samples/one_node_external.yaml
@@ -1,0 +1,29 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: one-node-external
+spec:
+  image: "vectorized/redpanda"
+  version: "latest"
+  replicas: 1
+  resources:
+    requests:
+      cpu: 1
+      memory: 1.2Gi
+    limits:
+      cpu: 1
+      memory: 1.2Gi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+    - port: 9092
+    - external:
+        enabled: true
+        subdomain: local.rp
+      port: 30001
+    pandaproxyApi:
+    - port: 8082
+    adminApi:
+    - port: 9644
+    developerMode: true

--- a/src/go/k8s/docs/external-connectivity-localhost.md
+++ b/src/go/k8s/docs/external-connectivity-localhost.md
@@ -1,0 +1,64 @@
+1. Create kind cluster, be aware that port 30001 is expected to be free on your machine otherwise the creation will fail. Start new cluster with `kind create cluster --config docs/kind-external.yaml`
+```
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30001
+    hostPort: 30001
+```
+2. Install cert-manager
+```
+helm repo add jetstack https://charts.jetstack.io && \
+helm repo update && \
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.2.0 \
+  --set installCRDs=true
+```
+3. Get Latest version of the operator
+```
+export VERSION=$(curl -s https://api.github.com/repos/vectorizedio/redpanda/releases/latest | jq -r .tag_name)
+```
+4. Install CRDs
+```
+kubectl apply \
+-k https://github.com/vectorizedio/redpanda/src/go/k8s/config/crd?ref=$VERSION
+```
+5. Install redpanda operator
+```
+helm repo add redpanda https://charts.vectorized.io/ && \
+helm repo update && 
+helm install \
+redpanda-operator \
+redpanda/redpanda-operator \
+--namespace redpanda-system \
+--create-namespace \
+--version $VERSION
+```
+6. Create a namespace for your cluster
+```
+kubectl create ns chat-with-me
+```
+7. Install one node cluster
+```
+kubectl apply \
+-n chat-with-me \
+-f https://raw.githubusercontent.com/vectorizedio/redpanda/dev/src/go/k8s/config/samples/one_node_external.yaml
+```
+8. Etc/hosts
+Make sure 0.local.rp is mapped to 127.0.0.1 on your system. It should contain line similar to this one:
+```
+127.0.0.1 0.local.rp
+```
+9. Create topic with 5 partitions
+```
+rpk --brokers localhost:30001 topic create chat-rooms -p 5
+```
+10. List topics
+```
+rpk --brokers localhost:30001 topic list
+```

--- a/src/go/k8s/docs/kind-external.yaml
+++ b/src/go/k8s/docs/kind-external.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30001
+    hostPort: 30001


### PR DESCRIPTION
## Cover letter
This documents how to use kind and k8s operator locally. 

I've tested it on fedora and mac.

It will work after 21.11.3 or 21.12.1 is released.

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
* none