### PR TITLE
k8s: use specified external port for kafka-api config

### DIFF
--- a/src/go/k8s/pkg/resources/configmap.go
+++ b/src/go/k8s/pkg/resources/configmap.go
@@ -179,7 +179,7 @@ func (r *ConfigMapResource) createConfiguration(
 		cr.KafkaApi = append(cr.KafkaApi, config.NamedSocketAddress{
 			SocketAddress: config.SocketAddress{
 				Address: "0.0.0.0",
-				Port:    calculateExternalPort(internalListener.Port),
+				Port:    calculateExternalPort(internalListener.Port, r.pandaCluster.ExternalListener().Port),
 			},
 			Name: ExternalListenerName,
 		})
@@ -364,9 +364,12 @@ func buildInType(value string) bool {
 }
 
 // calculateExternalPort can calculate external Kafka API port based on the internal Kafka API port
-func calculateExternalPort(kafkaInternalPort int) int {
+func calculateExternalPort(kafkaInternalPort, specifiedExternalPort int) int {
 	if kafkaInternalPort < 0 || kafkaInternalPort > 65535 {
 		return 0
+	}
+	if specifiedExternalPort != 0 {
+		return specifiedExternalPort
 	}
 	return kafkaInternalPort + 1
 }
@@ -436,7 +439,7 @@ func (r *ConfigMapResource) preparePandaproxy(cfgRpk *config.Config) {
 			config.NamedSocketAddress{
 				SocketAddress: config.SocketAddress{
 					Address: "0.0.0.0",
-					Port:    calculateExternalPort(internal.Port),
+					Port:    calculateExternalPort(internal.Port, 0),
 				},
 				Name: PandaproxyPortExternalName,
 			})


### PR DESCRIPTION
(cherry picked from commit 77245a2cef544c8a19a49453895b75969fd1e516)

## Cover letter
We changed the port to point to specified external port but there was still one place with hardcoded kafkaApi +1.

Fixes #3383

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
k8s: fixed bug in external port binding when port is specified in configuration