### PR TITLE
config: fix config_cache.yaml encoding of string values (centralized config)

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -321,7 +321,12 @@ ss::future<config_manager::preload_result> config_manager::preload() {
         preload_local(key, value, std::ref(result));
 
         // Store raw values in the result
-        result.raw_values[key] = YAML::Dump(value);
+
+        if (value.IsScalar()) {
+            result.raw_values[key] = value.Scalar();
+        } else {
+            result.raw_values[key] = YAML::Dump(value);
+        }
 
         // Broadcast value to all shards
         co_await ss::smp::invoke_on_all(


### PR DESCRIPTION
## Cover letter

Fix string escaping in config_cache.yaml
    
This had a subtle bug where setting and getting
an individual value worked fine, but any other
non-default string values were messed up in
the process.  Noticed while touching cloud
username+password fields.

## Release notes

* none (Central config was not enabled in user systems yet.)