### PR TITLE
cluster: safety checks on partition counts when creating/expanding topics.

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -66,7 +66,13 @@ controller::controller(
 ss::future<> controller::wire_up() {
     return _as.start()
       .then([this] { return _members_table.start(); })
-      .then([this] { return _partition_allocator.start_single(); })
+      .then([this] {
+          return _partition_allocator.start_single(
+            std::ref(_members_table),
+            config::shard_local_cfg().topic_memory_per_partition.bind(),
+            config::shard_local_cfg().topic_fds_per_partition.bind(),
+            config::shard_local_cfg().segment_fallocation_step.bind());
+      })
       .then([this] { return _credentials.start(); })
       .then([this] { return _authorizer.start(); })
       .then([this] { return _tp_state.start(); });

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -9,13 +9,18 @@
 
 #include "cluster/scheduling/partition_allocator.h"
 
-#include "cluster/fwd.h"
 #include "cluster/logger.h"
+#include "cluster/members_table.h"
 #include "cluster/scheduling/constraints.h"
 #include "cluster/types.h"
+#include "config/configuration.h"
 #include "model/metadata.h"
+#include "storage/segment_appender.h"
+#include "units.h"
+#include "utils/human.h"
 
 #include <absl/container/node_hash_set.h>
+#include <sys/resource.h>
 
 #include <algorithm>
 #include <exception>
@@ -24,9 +29,17 @@
 
 namespace cluster {
 
-partition_allocator::partition_allocator()
+partition_allocator::partition_allocator(
+  ss::sharded<members_table>& members,
+  config::binding<std::optional<size_t>> memory_per_partition,
+  config::binding<std::optional<int32_t>> fds_per_partition,
+  config::binding<size_t> fallocation_step)
   : _state(std::make_unique<allocation_state>())
-  , _allocation_strategy(simple_allocation_strategy()) {}
+  , _allocation_strategy(simple_allocation_strategy())
+  , _members(members)
+  , _memory_per_partition(memory_per_partition)
+  , _fds_per_partition(fds_per_partition)
+  , _fallocation_step(fallocation_step) {}
 
 allocation_constraints default_constraints() {
     allocation_constraints req;
@@ -72,12 +85,176 @@ partition_allocator::allocate_partition(partition_constraints p_constraints) {
     return std::move(replicas).finish();
 }
 
+/**
+ * Check cluster-wide limits on total partition count vs available
+ * system resources.  This is the 'sanity' check that the user doesn't
+ * try and create a million partitions with only 8192 file handles, etc.
+ * Without this check, a partition creation command could make a redpanda
+ * cluster unavailable by exhausting available resources.
+ *
+ * - These limits are heuristic, and are configurable/disable-able via
+ * configuration properties.  That's different to the limits we enforce per-node
+ * deeper inside the allocator, which are concrete limits that may not be
+ * exceeded.
+ *
+ * - We intentionally do this coarse global check rather than trying to
+ * carefully fit partitions into any available disk space etc, to avoid getting
+ * into situations where the partitions *only just* fit.  Partitions
+ * need to fit into the worst case node size, worst case node memory,
+ * to enable migrating partitions around during failures/rebalance/
+ * decommissions.
+ *
+ * - These heuristic limits are not correct for heterogeneous clusters
+ * in general: we behave as if all nodes are as small as
+ * the smallest node.  A more general set of per-node limits may
+ * be added in future, as/when we can handle heterogeneous edge
+ * cases more cleanly (like decommissioning a large node and dealing
+ * with partitions that cannot be re-accommodated on smaller peers).
+ */
+std::error_code partition_allocator::check_cluster_limits(
+  allocation_request const& request) const {
+    if (_members.local().all_brokers().empty()) {
+        // Empty members table, we're probably running in a unit test
+        return errc::success;
+    }
+    // Calculate how many partition-replicas already exist, so that we can
+    // check if the new topic would take us past any limits.
+    uint64_t existent_partitions{0};
+    for (const auto& i : _state->allocation_nodes()) {
+        existent_partitions += uint64_t(i.second->allocated_partitions());
+    }
+
+    // Partition-replicas requested
+    uint64_t create_count{0};
+    for (const auto& i : request.partitions) {
+        create_count += uint64_t(i.replication_factor);
+    }
+
+    uint64_t proposed_total_partitions = existent_partitions + create_count;
+
+    // Gather information about system-wide resource sizes
+    uint32_t min_core_count = 0;
+    uint64_t min_memory_bytes = 0;
+    uint64_t min_disk_bytes = 0;
+    auto all_brokers = _members.local().all_brokers();
+    for (const auto& b : all_brokers) {
+        if (min_core_count == 0) {
+            min_core_count = b->properties().cores;
+        } else {
+            min_core_count = std::min(min_core_count, b->properties().cores);
+        }
+
+        // In redpanda <= 21.11.x, available_memory_gb and available_disk_gb
+        // are not populated.  If they're zero we skip the check later.
+        if (min_memory_bytes == 0) {
+            min_memory_bytes = b->properties().available_memory_gb * 1_GiB;
+        } else if (b->properties().available_memory_gb > 0) {
+            min_memory_bytes = std::min(
+              min_memory_bytes, b->properties().available_memory_gb * 1_GiB);
+        }
+
+        if (min_disk_bytes == 0) {
+            min_disk_bytes = b->properties().available_disk_gb * 1_GiB;
+        } else if (b->properties().available_disk_gb > 0) {
+            min_disk_bytes = std::min(
+              min_disk_bytes, b->properties().available_disk_gb * 1_GiB);
+        }
+    }
+
+    // The effective values are the node count times the smallest node's
+    // resources: this avoids wrongly assuming the system will handle partition
+    // counts that only fit when scheduled onto certain nodes.
+    uint64_t effective_cpu_count = all_brokers.size() * min_core_count;
+    uint64_t effective_cluster_memory = all_brokers.size() * min_memory_bytes;
+    uint64_t effective_cluster_disk = all_brokers.size() * min_disk_bytes;
+
+    vlog(
+      clusterlog.debug,
+      "Effective cluster resources: CPU={} memory={} disk={}",
+      effective_cpu_count,
+      human::bytes(effective_cluster_memory),
+      human::bytes(effective_cluster_disk));
+
+    // Refuse to create a partition count that would violate the per-core
+    // limit.
+    const uint64_t core_limit = effective_cpu_count
+                                * allocation_node::max_allocations_per_core;
+    if (proposed_total_partitions > core_limit) {
+        vlog(
+          clusterlog.warn,
+          "Refusing to create {} partitions, exceeds core limit {}",
+          create_count,
+          effective_cpu_count * allocation_node::max_allocations_per_core);
+        return errc::topic_invalid_partitions;
+    }
+
+    // Refuse to create partitions that would violate the configured
+    // memory per partition.
+    auto memory_per_partition_replica = _memory_per_partition();
+    if (memory_per_partition_replica.has_value()) {
+        const uint64_t memory_limit = effective_cluster_memory
+                                      / memory_per_partition_replica.value();
+
+        if (memory_limit > 0 && proposed_total_partitions > memory_limit) {
+            vlog(
+              clusterlog.warn,
+              "Refusing to create {} partitions, exceeds memory limit {}",
+              create_count,
+              memory_limit);
+            return errc::topic_invalid_partitions;
+        }
+    }
+
+    // Refuse to create partitions that would exhaust our nfiles ulimit
+    auto fds_per_partition_replica = _fds_per_partition();
+    if (fds_per_partition_replica.has_value()) {
+        struct rlimit nofile = {0, 0};
+        if (getrlimit(RLIMIT_NOFILE, &nofile) == 0) {
+            if (nofile.rlim_cur != RLIM_INFINITY) {
+                const uint64_t fds_limit = (all_brokers.size()
+                                            * nofile.rlim_cur)
+                                           / fds_per_partition_replica.value();
+                if (proposed_total_partitions > fds_limit) {
+                    vlog(
+                      clusterlog.warn,
+                      "Refusing to create {} partitions, exceeds FD limit {}",
+                      create_count,
+                      fds_limit);
+                    return errc::topic_invalid_partitions;
+                }
+            }
+        } else {
+            // Unclear if this can ever happen, but let's be graceful.
+            vlog(clusterlog.warn, "Error {} querying file handle limit", errno);
+        }
+    }
+
+    // Refuse to create partitions if there isn't enough space to at least
+    // falloc the first part of a segment for each partition
+    uint64_t disk_limit = effective_cluster_disk / _fallocation_step();
+    if (disk_limit > 0 && (proposed_total_partitions > disk_limit)) {
+        vlog(
+          clusterlog.warn,
+          "Refusing to create {} partitions, exceeds disk limit {}",
+          create_count,
+          disk_limit);
+        return errc::topic_invalid_partitions;
+    }
+
+    return errc::success;
+}
+
 result<allocation_units>
 partition_allocator::allocate(allocation_request request) {
     vlog(
       clusterlog.trace,
       "allocation request for {} partitions",
       request.partitions.size());
+
+    auto cluster_errc = check_cluster_limits(request);
+    if (cluster_errc) {
+        return cluster_errc;
+    }
 
     intermediate_allocation<partition_assignment> assignments(
       *_state, request.partitions.size());

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -69,8 +69,8 @@ SEASTAR_THREAD_TEST_CASE(broker_metadata_rt_test) {
       "test",
       model::broker_properties{
         .cores = 8,
-        .available_memory = 1024,
-        .available_disk = static_cast<uint32_t>(10000000000),
+        .available_memory_gb = 1024,
+        .available_disk_gb = static_cast<uint32_t>(10000000000),
         .mount_paths = {"/", "/var/lib"},
         .etc_props = {{"max_segment_size", "1233451"}}});
     auto d = serialize_roundtrip_rpc(std::move(b));
@@ -81,9 +81,9 @@ SEASTAR_THREAD_TEST_CASE(broker_metadata_rt_test) {
     BOOST_REQUIRE_EQUAL(d.kafka_advertised_listeners()[0].address.port(), 9092);
     BOOST_REQUIRE_EQUAL(d.rpc_address().host(), "172.0.1.2");
     BOOST_REQUIRE_EQUAL(d.properties().cores, 8);
-    BOOST_REQUIRE_EQUAL(d.properties().available_memory, 1024);
+    BOOST_REQUIRE_EQUAL(d.properties().available_memory_gb, 1024);
     BOOST_REQUIRE_EQUAL(
-      d.properties().available_disk, static_cast<uint32_t>(10000000000));
+      d.properties().available_disk_gb, static_cast<uint32_t>(10000000000));
     BOOST_REQUIRE_EQUAL(
       d.properties().mount_paths, std::vector<ss::sstring>({"/", "/var/lib"}));
     BOOST_REQUIRE_EQUAL(d.properties().etc_props.size(), 1);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -121,6 +121,18 @@ configuration::configuration()
       "Interval for which all coprocessor offsets are flushed to disk",
       {.visibility = visibility::tunable},
       300000ms) // five minutes
+  , topic_memory_per_partition(
+      *this,
+      "topic_memory_per_partition",
+      "Required memory per partition when creating topics",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1_MiB)
+  , topic_fds_per_partition(
+      *this,
+      "topic_fds_per_partition",
+      "Required file handles per partition when creating topics",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10)
   , seed_server_meta_topic_partitions(
       *this, "seed_server_meta_topic_partitions")
   , raft_heartbeat_interval_ms(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -55,6 +55,10 @@ struct configuration final : public config_store {
     property<std::size_t> coproc_max_batch_size;
     property<std::chrono::milliseconds> coproc_offset_flush_interval_ms;
 
+    // Controller
+    property<std::optional<std::size_t>> topic_memory_per_partition;
+    property<std::optional<int32_t>> topic_fds_per_partition;
+
     // Raft
     deprecated_property seed_server_meta_topic_partitions;
     property<std::chrono::milliseconds> raft_heartbeat_interval_ms;

--- a/src/v/model/adl_serde.cc
+++ b/src/v/model/adl_serde.cc
@@ -71,8 +71,8 @@ net::unresolved_address adl<net::unresolved_address>::from(iobuf_parser& in) {
 void adl<model::broker_properties>::to(
   iobuf& out, const model::broker_properties& prop) {
     adl<uint32_t>{}.to(out, prop.cores);
-    adl<uint32_t>{}.to(out, prop.available_memory);
-    adl<uint32_t>{}.to(out, prop.available_disk);
+    adl<uint32_t>{}.to(out, prop.available_memory_gb);
+    adl<uint32_t>{}.to(out, prop.available_disk_gb);
     adl<std::vector<ss::sstring>>{}.to(out, prop.mount_paths);
     type vec;
     vec.reserve(prop.etc_props.size());

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -46,16 +46,16 @@ using initial_revision_id
 
 struct broker_properties {
     uint32_t cores;
-    uint32_t available_memory;
-    uint32_t available_disk;
+    uint32_t available_memory_gb;
+    uint32_t available_disk_gb;
     std::vector<ss::sstring> mount_paths;
     // key=value properties in /etc/redpanda/machine_properties.yaml
     std::unordered_map<ss::sstring, ss::sstring> etc_props;
 
     bool operator==(const broker_properties& other) const {
         return cores == other.cores
-               && available_memory == other.available_memory
-               && available_disk == other.available_disk
+               && available_memory_gb == other.available_memory_gb
+               && available_disk_gb == other.available_disk_gb
                && mount_paths == other.mount_paths
                && etc_props == other.etc_props;
     }
@@ -370,8 +370,8 @@ struct hash<model::broker_properties> {
     size_t operator()(const model::broker_properties& b) const {
         size_t h = 0;
         boost::hash_combine(h, std::hash<uint32_t>()(b.cores));
-        boost::hash_combine(h, std::hash<uint32_t>()(b.available_memory));
-        boost::hash_combine(h, std::hash<uint32_t>()(b.available_disk));
+        boost::hash_combine(h, std::hash<uint32_t>()(b.available_memory_gb));
+        boost::hash_combine(h, std::hash<uint32_t>()(b.available_disk_gb));
         for (const auto& path : b.mount_paths) {
             boost::hash_combine(h, std::hash<ss::sstring>()(path));
         }

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -191,8 +191,8 @@ std::ostream& operator<<(std::ostream& o, const model::broker_properties& b) {
       o,
       "{{cores {}, mem_available {}, disk_available {}}}",
       b.cores,
-      b.available_memory,
-      b.available_disk,
+      b.available_memory_gb,
+      b.available_disk_gb,
       b.mount_paths,
       b.etc_props);
     return o;

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -242,6 +242,12 @@ class RedpandaService(Service):
 
         self.config_file_lock = threading.Lock()
 
+    def set_resource_settings(self, rs):
+        self._resource_settings = rs
+
+    def set_extra_rp_conf(self, conf):
+        self._extra_rp_conf = conf
+
     def sasl_enabled(self):
         return self._extra_rp_conf and self._extra_rp_conf.get(
             "enable_sasl", False)

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -28,7 +28,7 @@ class RedpandaTest(Test):
                  extra_rp_conf=dict(),
                  enable_pp=False,
                  enable_sr=False,
-                 num_cores=3):
+                 resource_settings=None):
         super(RedpandaTest, self).__init__(test_context)
         self.scale = Scale(test_context)
         self.redpanda = RedpandaService(test_context,
@@ -36,7 +36,7 @@ class RedpandaTest(Test):
                                         extra_rp_conf=extra_rp_conf,
                                         enable_pp=enable_pp,
                                         enable_sr=enable_sr,
-                                        num_cores=num_cores)
+                                        resource_settings=resource_settings)
         self._client = DefaultClient(self.redpanda)
 
     @property

--- a/tests/rptest/tests/resource_limits_test.py
+++ b/tests/rptest/tests/resource_limits_test.py
@@ -1,0 +1,130 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.clients.rpk import RpkTool, RpkException
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import ResourceSettings
+from rptest.services.cluster import cluster
+
+
+class ResourceLimitsTest(RedpandaTest):
+    """
+    Tests the limits that are imposed on partition counts during topic
+    creation, to prevent users from overwhelming available system
+    resources with too many partitions.
+    """
+    def setUp(self):
+        # Override parent setUp so that we don't start redpanda until each test,
+        # enabling each test case to customize its ResourceSettings
+        pass
+
+    @cluster(num_nodes=3)
+    def test_memory_limited(self):
+        """
+        Check enforcement of the RAM-per-partition threshold
+        """
+        self.redpanda.set_resource_settings(
+            ResourceSettings(memory_mb=1024, num_cpus=1))
+        self.redpanda.set_extra_rp_conf({
+            # Use a larger than default memory per partition, so that a 1GB system can be
+            # tested without creating 1000 partitions (which overwhelms debug redpanda
+            # builds because they're much slower than the real product)
+            'topic_memory_per_partition':
+            10 * 1024 * 1024,
+        })
+
+        self.redpanda.start()
+
+        rpk = RpkTool(self.redpanda)
+
+        # Three nodes, each with 1GB memory, replicas=3, should
+        # result in an effective limit of 1024 with the default
+        # threshold of 1MB per topic.
+        try:
+            rpk.create_topic("toobig", partitions=110, replicas=3)
+        except RpkException as e:
+            assert 'INVALID_PARTITIONS' in e.msg
+        else:
+            assert False
+
+        # Should succeed
+        rpk.create_topic("okay", partitions=55, replicas=3)
+
+        # Trying to grow the partition count in violation of the limit should fail
+        try:
+            rpk.add_topic_partitions("okay", 55)
+        except RpkException as e:
+            assert 'INVALID_PARTITIONS' in e.msg
+        else:
+            assert False
+
+        # Growing the partition count within the limit should succeed
+        rpk.add_topic_partitions("okay", 10)
+
+    @cluster(num_nodes=3)
+    def test_cpu_limited(self):
+        """
+        Check enforcement of the partitions-per-core
+        """
+        self.redpanda.set_resource_settings(ResourceSettings(num_cpus=1))
+
+        self.redpanda.set_extra_rp_conf({
+            # Disable memory limit: on a test node the physical memory can easily
+            # be the limiting factor
+            'topic_memory_per_partition': None,
+            # Disable FD enforcement: tests running on workstations may have low ulimits
+            'topic_fds_per_partition': None
+        })
+
+        self.redpanda.start()
+
+        rpk = RpkTool(self.redpanda)
+
+        # Three nodes, each with 1 core, 7000 partition-replicas
+        # per core, so with replicas=3, 7000 partitions should be the limit
+        try:
+            rpk.create_topic("toobig", partitions=8000, replicas=3)
+        except RpkException as e:
+            assert 'INVALID_PARTITIONS' in e.msg
+        else:
+            assert False
+
+        try:
+            rpk.create_topic("okay", partitions=6000, replicas=3)
+        except RpkException as e:
+            # Because this many partitions will overwhelm a debug build
+            # of redpanda, we tolerate exceptions, as long as the exception
+            # isn't about the partition count specifically.
+            #
+            # It would be better to execute this part of the test conditionally
+            # on release builds only.
+            assert 'INVALID_PARTITIONS' not in e.msg
+
+    @cluster(num_nodes=3)
+    def test_fd_limited(self):
+        self.redpanda.set_resource_settings(ResourceSettings(nfiles=1000))
+        self.redpanda.set_extra_rp_conf({
+            # Disable memory limit: on a test node the physical memory can easily
+            # be the limiting factor
+            'topic_memory_per_partition': None,
+        })
+        self.redpanda.start()
+
+        rpk = RpkTool(self.redpanda)
+
+        # Default 10 fds per partition, we set ulimit down to 1000, so 100 should be the limit
+        try:
+            rpk.create_topic("toobig", partitions=110, replicas=3)
+        except RpkException as e:
+            assert 'INVALID_PARTITIONS' in e.msg
+        else:
+            assert False
+
+        # Should succeed
+        rpk.create_topic("okay", partitions=90, replicas=3)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -21,6 +21,7 @@ from ducktape.services.background_thread import BackgroundThreadService
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import ResourceSettings
 
 
 def create_topic_names(count):
@@ -67,7 +68,7 @@ class SchemaRegistryTest(RedpandaTest):
             enable_pp=True,
             enable_sr=True,
             extra_rp_conf={"auto_create_topics_enabled": False},
-            num_cores=1)
+            resource_settings=ResourceSettings(num_cpus=1))
 
         http.client.HTTPConnection.debuglevel = 1
         http.client.print = lambda *args: self.logger.debug(" ".join(args))


### PR DESCRIPTION
## Cover letter


Previously, redpanda would always do its best to create the number of partitions requested, and fail in difficult ways if we ran out of system resources.  This could result in badly broken systems that didn't work well enough to remove the partitions that had been created.

This PR adds "guardrails" to the partition creation process:
- Enforce a RAM-per-partition limit
- Enforce an FDs-per-partition limit
- Enforce the existing partitions-per-core limit explicitly before trying to schedule partitions
- Check that there is enough disk space to falloc the first part of at least one segment per partition.

To make all this work, the previously zero ram+disk fields in `broker_properties` are brought into service.  These are unfortunately small uint32_t fields, and we don't have great ways for changing encodings right now, so store the values in GB instead of bytes, which works for today's practical-sized systems.

There is some new test machinery in the form of `ResourceSettings` argument to the redpanda service, for controlling CPU/memory/nfiles limits in one place.  That enables writing real tests that check the various limits.  The disk space limit is not tested, because creating test infrastructure with smaller drives is a larger project.

Fixes https://github.com/vectorizedio/redpanda/issues/3337 https://github.com/vectorizedio/redpanda/issues/3274

TODO:
- `invalid_partitions` seems to me the correct error to return, but clients (both Kafka and franz-go) print this error as "Number of partitions is below 1." which is confusing.  @twmb as our resident protocol expert, do you have thoughts on better ways to surface an "I don't have enough resources for this" type of error on topic creation?
- The default 1MB-per-partition may not be conservative enough for shadow indexing (we saw instability with 10-20k partitions on nodes that had 60gb of ram, but that was while testing builds which also had memory leaks and were subject to interntionally nasty random read workloads)

## Release notes

### Improvements

* Creating topics with larger partition counts is made safer, by validating that the cluster has sufficient resources to fulfil the request before trying to create partitions.  New checks for sufficient RAM and sufficient file handles can be overridden if necessary with the new `topic_memory_per_partition` and `topic_fds_per_partition` settings respectively.  The defaults are to require 1MB of RAM and 10 open file handles per partition.  This functionality helps to avoid situations where a redpanda cluster can become unstable when the partitions created outstrip available system resources.
