### PR TITLE
[backport v21.11.x-si-testing] cloud_storage: fix file descriptor leak

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -356,14 +356,33 @@ void remote_partition::gc_stale_materialized_segments(bool force_collection) {
     for (auto& st : _materialized) {
         if (
           now - st.atime > stm_max_idle_time
-          && !st.segment->download_in_progress() && st.segment.owned()) {
-            vlog(
-              _ctxlog.debug,
-              "reader for segment with base offset {} is stale",
-              st.offset_key);
-            // this will delete and unlink the object from
-            // _materialized collection
-            offsets.push_back(st.offset_key);
+          && !st.segment->download_in_progress()) {
+            if (st.segment.owned()) {
+                vlog(
+                  _ctxlog.debug,
+                  "reader for segment with base offset {} is stale",
+                  st.offset_key);
+                // this will delete and unlink the object from
+                // _materialized collection
+                offsets.push_back(st.offset_key);
+            } else {
+                vlog(
+                  _ctxlog.debug,
+                  "Materialized segment {} not stale: {} {} {} {} readers={}",
+                  st.manifest_key,
+                  now - st.atime > stm_max_idle_time,
+                  st.segment->download_in_progress(),
+                  st.segment.owned(),
+                  st.segment.use_count(),
+                  st.readers.size());
+
+                // Readers hold a reference to the segment, so for the
+                // segment.owned() check to pass, we need to clear them out.
+                while (!st.readers.empty()) {
+                    evict_reader(std::move(st.readers.front()));
+                    st.readers.pop_front();
+                }
+            }
         }
     }
     vlog(_ctxlog.debug, "found {} eviction candidates ", offsets.size());


### PR DESCRIPTION
**Cherry pick of https://github.com/vectorizedio/redpanda/pull/3392 into the si-testing branch**


The garbage collection of remote_segment objects
was conditional on the reference count in the
segment's sharded_ptr being 1 (i.e. nothing else
is using it).

This is not true if there are entries in the `readers`
attribute of materialized_segment_state, because
readers hold a reference to the segment.

Deal with this by proactively evicting readers
from any materialized_segment_state objects
whose atime makes them elegible for removal.

Fixes: https://github.com/vectorizedio/redpanda/issues/3334

Signed-off-by: John Spray <jcs@vectorized.io>
(cherry picked from commit 42945cbb43916750e467aa43d31b5d7425d7709f)

## Cover letter

Describe in plain language the motivation (bug, feature, etc.) behind the change in this PR and how the included commits address it.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
