### PR TITLE
v21.11.x backport pr3299

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -696,6 +696,60 @@
         }
       }
     },
+    "/subjects/{subject}/versions/{version}/referencedBy": {
+      "get": {
+        "summary": "Retrieve a list of schema ids that reference the subject and version.",
+        "operationId": "get_subject_versions_version_referenced_by",
+        "parameters": [
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                  "type": "integer"
+              }
+            }
+          },
+          "404": {
+            "description": "Schema not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "422": {
+            "description": "Invalid version",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
     "/compatibility/subjects/{subject}/versions/{version}": {
       "post": {
         "summary": "Test compatibility of a schema for the subject and version.",

--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy Schema Registry",
-    "version": "0.0.5"
+    "version": "1.0.0"
   },
   "host": "{{Host}}",
   "basePath": "/",

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -58,6 +58,10 @@ ss::future<ctx_server<service>::reply_t> get_subject_versions_version(
 ss::future<ctx_server<service>::reply_t> get_subject_versions_version_schema(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t>
+get_subject_versions_version_referenced_by(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> delete_subject(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -99,6 +99,11 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       wrap(gate, es, get_subject_versions_version_schema)});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::
+        get_subject_versions_version_referenced_by,
+      wrap(gate, es, get_subject_versions_version_referenced_by)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::delete_subject,
       wrap(gate, es, delete_subject)});
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -76,6 +76,10 @@ public:
     ///\brief Return whether there are any references to a subject version.
     ss::future<bool> is_referenced(const subject& sub, schema_version ver);
 
+    ///\brief Return the schema_ids that reference a subject version.
+    ss::future<std::vector<schema_id>>
+    referenced_by(const subject& sub, std::optional<schema_version> ver);
+
     ///\brief Delete a subject.
     ss::future<std::vector<schema_version>> delete_subject(
       seq_marker marker, const subject& sub, permanent_delete permanent);

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -310,6 +310,21 @@ public:
           });
     }
 
+    std::vector<schema_id>
+    referenced_by(const subject& sub, schema_version ver) {
+        std::vector<schema_id> references;
+        for (const auto& s : _subjects) {
+            for (const auto& v : s.second.versions) {
+                for (const auto& r : v.refs) {
+                    if (r.sub == sub && r.version == ver) {
+                        references.emplace_back(v.id);
+                    }
+                }
+            }
+        }
+        return references;
+    }
+
     ///\brief Delete a subject.
     result<std::vector<schema_version>> delete_subject(
       seq_marker marker, const subject& sub, permanent_delete permanent) {

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -17,6 +17,7 @@ rp_test(
   BINARY_NAME pandaproxy_schema_registry_single_thread
   SOURCES
     one_shot.cc
+    sharded_store.cc
     consume_to_store.cc
     compatibility_store.cc
     compatibility_3rdparty.cc

--- a/src/v/pandaproxy/schema_registry/test/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/test/sharded_store.cc
@@ -1,0 +1,72 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/sharded_store.h"
+
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/protobuf.h"
+#include "pandaproxy/schema_registry/test/compatibility_protobuf.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/unit_test.hpp>
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+SEASTAR_THREAD_TEST_CASE(test_sharded_store_referenced_by) {
+    pps::sharded_store store;
+    store.start(ss::default_smp_service_group()).get();
+    auto stop_store = ss::defer([&store]() { store.stop().get(); });
+
+    const pps::schema_version ver1{1};
+
+    // Insert simple
+    auto referenced_schema = pps::canonical_schema{
+      pps::subject{"simple.proto"}, simple};
+    auto sch1 = store
+                  .upsert(
+                    pps::seq_marker{
+                      std::nullopt,
+                      std::nullopt,
+                      ver1,
+                      pps::seq_marker_key_type::schema},
+                    referenced_schema,
+                    pps::schema_id{1},
+                    ver1,
+                    pps::is_deleted::no)
+                  .get();
+
+    // Insert referenced
+    auto importing_schema = pps::canonical_schema{
+      pps::subject{"imported.proto"},
+      imported,
+      {{"simple", pps::subject{"simple.proto"}, ver1}}};
+
+    auto sch2 = store
+                  .upsert(
+                    pps::seq_marker{
+                      std::nullopt,
+                      std::nullopt,
+                      ver1,
+                      pps::seq_marker_key_type::schema},
+                    importing_schema,
+                    pps::schema_id{2},
+                    ver1,
+                    pps::is_deleted::no)
+                  .get();
+
+    auto referenced_by
+      = store.referenced_by(referenced_schema.sub(), ver1).get();
+
+    BOOST_REQUIRE_EQUAL(referenced_by.size(), 1);
+    BOOST_REQUIRE_EQUAL(referenced_by[0], pps::schema_id{2});
+}

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -218,6 +218,13 @@ class SchemaRegistryTest(RedpandaTest):
                              f"subjects/{subject}/versions/{version}",
                              headers=headers)
 
+    def _get_subjects_subject_versions_version_referenced_by(
+            self, subject, version, headers=HTTP_GET_HEADERS):
+        return self._request(
+            "GET",
+            f"subjects/{subject}/versions/{version}/referencedBy",
+            headers=headers)
+
     def _get_subjects_subject_versions(self,
                                        subject,
                                        deleted=False,
@@ -1000,3 +1007,9 @@ class SchemaRegistryTest(RedpandaTest):
         self.logger.info(result_raw)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.text.strip() == simple_proto_def.strip()
+
+        result_raw = self._get_subjects_subject_versions_version_referenced_by(
+            "simple", 1)
+        self.logger.info(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json() == [2]


### PR DESCRIPTION
## Cover letter

Backport #3299 

The difference is that I've been more conservative with the version number: instead of `v21.12.1`, which doesn't make sense now, I've made it `1.0.0`.

Support ` GET /subjects/{subject}/versions/{version}/referencedBy`

Swagger available at: https://app.swaggerhub.com/apis/BenPope/pandaproxy-schema-registry/1.0.0

## Release notes

### Features

* schema_registry: Support `GET /subjects/{subject}/versions/{version}/referencedBy`