### PR TITLE
Made `min_free_memory` parameter of background reclaimer configurable

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -511,6 +511,12 @@ configuration::configuration()
       "Length of time above which growth is reset",
       {.visibility = visibility::tunable},
       10'000ms)
+  , reclaim_batch_cache_min_free(
+      *this,
+      "reclaim_batch_cache_min_free",
+      "Free memory limit that will be kept by batch cache background reclaimer",
+      {.visibility = visibility::tunable},
+      64_MiB)
   , auto_create_topics_enabled(
       *this,
       "auto_create_topics_enabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -128,6 +128,7 @@ struct configuration final : public config_store {
     property<size_t> reclaim_max_size;
     property<std::chrono::milliseconds> reclaim_growth_window;
     property<std::chrono::milliseconds> reclaim_stable_window;
+    property<size_t> reclaim_batch_cache_min_free;
     property<bool> auto_create_topics_enabled;
     property<bool> enable_pid_file;
     property<std::chrono::milliseconds> kvstore_flush_interval;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -457,6 +457,8 @@ manager_config_from_global_config(scheduling_groups& sgs) {
         .stable_window = config::shard_local_cfg().reclaim_stable_window(),
         .min_size = config::shard_local_cfg().reclaim_min_size(),
         .max_size = config::shard_local_cfg().reclaim_max_size(),
+        .min_free_memory
+        = config::shard_local_cfg().reclaim_batch_cache_min_free(),
       },
       config::shard_local_cfg().readers_cache_eviction_timeout_ms(),
       sgs.compaction_sg());


### PR DESCRIPTION
## Cover letter

Made `min_free_memory` property of batch cache background reclaimer configurable. The background reclaimer working in the batch cache release some of the batch cache memory to prevent the synchronous reclaimer from being called during memory allocation. This effectively reduce allocation latency and prevent reactor from stalling (reclaim process is synchronous).

Previously redpanda used constant threshold to control the minimum size of free memory that was maintained by background reclaimer. In some scenarios when available memory is really large f.e. 512GB the old 64MB threshold may not be enough to provide continuous memory to allow reclaim free allocation.

Made the background reclaimer free memory threshold configurable so that we can adapt it to different scenarios.



## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

We will be able to tune the background reclaimer to better work with nodes which have a lot of RAM memory f.e. 0.5 TB

-->
