### PR TITLE
wasm: Fix bug for incorrect calculation of record batch size

### DIFF
--- a/src/js/modules/supervisors/Repository.ts
+++ b/src/js/modules/supervisors/Repository.ts
@@ -143,8 +143,8 @@ class Repository {
       // Coprocessor return a Map with values
       for (const [key, value] of resultRecordBatch) {
         value.records = value.records.map((record) => {
-          record.length = calculateRecordLength(record);
           record.valueLen = record.value.length;
+          record.length = calculateRecordLength(record);
           return record;
         });
         value.header.sizeBytes = calculateRecordBatchSize(value.records);


### PR DESCRIPTION
It was observed with some inputs the wasm engine was returning incorrectly formatted batches. Assertions were fired by redpanda explicitly pointing out the issue.

The calculation for the size of a record batch was done without taking into account the size of the value of the newly mutated record. The fix is quite simple, just update the value length before calculating the records size. 

Linking to issue #3407