### PR TITLE
kafka: map cluster::topic_not_found to kafka:unkonwn_topic

### DIFF
--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -32,6 +32,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::topic_already_exists:
         return error_code::topic_already_exists;
     case cluster::errc::topic_not_exists:
+        return error_code::unknown_topic_or_partition;
     case cluster::errc::source_topic_still_in_use:
         return error_code::cluster_authorization_failed;
     case cluster::errc::timeout:


### PR DESCRIPTION
## Cover letter

Topic deletion result from controller incorrectly mapped to an authorization
failure instead of the kafka error corresponding to a unknown topic or partition.

Fixes: #3079
Fixes: #3382

## Release notes

* Fixed incorrect return error code for topic deletion when topic does not exist.