### PR TITLE
kafka: limit bytes in many-partition fetch

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -541,6 +541,13 @@ configuration::configuration()
       "Fail-safe maximum throttle delay on kafka requests",
       {.visibility = visibility::tunable},
       60'000ms)
+  , kafka_max_bytes_per_fetch(
+      *this,
+      "kafka_max_bytes_per_fetch",
+      "Limit fetch responses to this many bytes, even if total of partition "
+      "bytes limits is higher",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      64_MiB)
   , raft_io_timeout_ms(
       *this,
       "raft_io_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -133,6 +133,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> kvstore_flush_interval;
     property<size_t> kvstore_max_segment_size;
     property<std::chrono::milliseconds> max_kafka_throttle_delay_ms;
+    property<size_t> kafka_max_bytes_per_fetch;
     property<std::chrono::milliseconds> raft_io_timeout_ms;
     property<std::chrono::milliseconds> join_retry_timeout_ms;
     property<std::chrono::milliseconds> raft_timeout_now_timeout_ms;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -331,7 +331,30 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
   std::vector<ntp_fetch_config> ntp_fetch_configs,
   bool foreign_read,
   std::optional<model::timeout_clock::time_point> deadline) {
-    return ssx::parallel_transform(
+    size_t total_max_bytes = 0;
+    size_t total_max_bytes_strict = 0;
+    for (const auto& c : ntp_fetch_configs) {
+        total_max_bytes += c.cfg.max_bytes;
+        total_max_bytes_strict += c.cfg.strict_max_bytes;
+    }
+
+    auto max_bytes_per_fetch
+      = config::shard_local_cfg().kafka_max_bytes_per_fetch();
+    if (total_max_bytes > max_bytes_per_fetch) {
+        auto per_partition = max_bytes_per_fetch / ntp_fetch_configs.size();
+        vlog(
+          klog.info,
+          "Fetch requested very large response ({}), clamping each partition's "
+          "max_bytes to {} bytes",
+          total_max_bytes,
+          per_partition);
+
+        for (auto& c : ntp_fetch_configs) {
+            c.cfg.max_bytes = per_partition;
+        }
+    }
+
+    auto results = co_await ssx::parallel_transform(
       std::move(ntp_fetch_configs),
       [&cluster_pm, &coproc_pm, deadline, foreign_read](
         const ntp_fetch_config& ntp_cfg) {
@@ -343,6 +366,17 @@ static ss::future<std::vector<read_result>> fetch_ntps_in_parallel(
                 return res;
             });
       });
+
+    size_t total_size = 0;
+    for (const auto& r : results) {
+        total_size += r.data_size_bytes();
+    }
+    vlog(
+      klog.debug,
+      "fetch_ntps_in_parallel: for {} partitions returning {} total bytes",
+      results.size(),
+      total_size);
+    co_return results;
 }
 
 /**


### PR DESCRIPTION
## Cover letter
    
This is a partial fix to the general issue that fetch
responses can request very large amounts of data by
specifying a modest max_bytes (e.g. default 10MB) per
partition, but fetching from a large number of partitions.
    
This change protects from the most straightforward
way the issue is hit in testing, where the messages
and batch sizes aren't too big but the user has simply
created thousands of partitions, played some data in, and
then tried to consume from their topic.  One can still
overshoot memory when batch sizes are larger.

Related to, but does not fully fix, https://github.com/vectorizedio/redpanda/issues/3409

## Release notes

### Improvements

* Consuming from a very large number of partitions at once is now subject to a per-request size limit, reducing the risk of exhausting memory if a client specifies a partition count and per-partition size limit that is greater than available RAM.  The size limit per-fetch is set via the `kafka_max_bytes_per_fetch` configuration property, default 64MiB.

