### PR TITLE
Fix metadata brokers list

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -111,9 +111,9 @@ ss::future<std::vector<broker_ptr>> metadata_cache::all_alive_brokers() const {
 
     std::set<model::node_id> brokers_with_health;
     for (auto& st : res.value()) {
+        brokers_with_health.insert(st.id);
         if (st.is_alive) {
             auto broker = _members_table.local().get_broker(st.id);
-            brokers_with_health.insert(st.id);
             if (broker) {
                 brokers.push_back(std::move(*broker));
             }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -272,7 +272,7 @@ class RpkTool:
 
         cmd = [
             self._rpk_binary(), 'cluster', 'info', '--brokers',
-            self._redpanda.brokers(1)
+            self._redpanda.brokers()
         ]
         output = self._execute(cmd, stdin=None, timeout=timeout)
         parsed = map(_parse_out, output.splitlines())

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -447,14 +447,23 @@ class RedpandaService(Service):
                     f"registered: peer {peer.name} admin API not yet available ({e})"
                 )
                 return False
+            found = None
+            for b in admin_brokers:
+                if b['node_id'] == idx:
+                    found = b
+                    break
 
-            found = idx in [b['node_id'] for b in admin_brokers]
             if not found:
                 self.logger.info(
                     f"registered: node {node.name} not yet found in peer {peer.name}'s broker list ({admin_brokers})"
                 )
                 return False
             else:
+                if not found['is_alive']:
+                    self.logger.info(
+                        f"registered: node {node.name} found in {peer.name}'s broker list ({admin_brokers}) but not yet marked as alive"
+                    )
+                    return False
                 self.logger.debug(
                     f"registered: node {node.name} now visible in peer {peer.name}'s broker list ({admin_brokers})"
                 )

--- a/tests/rptest/tests/cluster_metadata_test.py
+++ b/tests/rptest/tests/cluster_metadata_test.py
@@ -1,0 +1,81 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from ducktape.mark import matrix
+from rptest.clients.rpk import RpkTool
+from rptest.services.failure_injector import FailureInjector, FailureSpec
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class MetadataTest(RedpandaTest):
+    def controller_present(self):
+        return self.redpanda.controller() is not None
+
+    @cluster(num_nodes=3)
+    def test_metadata_request_contains_all_brokers(self):
+        """
+        Check if broker list returned from metadata request is complete
+        """
+        wait_until(lambda: self.controller_present, 10, 1)
+        rpk = RpkTool(self.redpanda)
+        nodes = rpk.cluster_info()
+        assert len(nodes) == 3
+        all_ids = [self.redpanda.idx(n) for n in self.redpanda.nodes]
+        returned_node_ids = [n.id for n in nodes]
+        assert sorted(all_ids) == sorted(returned_node_ids)
+
+    @cluster(num_nodes=3)
+    @matrix(failure=['isolate', 'stop'], node=['follower', 'controller'])
+    def test_metadata_request_does_not_contain_failed_node(
+            self, failure, node):
+        """
+        Check if broker list returned from metadata request does not contain node 
+        which is not alive
+        """
+        # validate initial conditions
+        wait_until(lambda: self.controller_present, 10, 1)
+        rpk = RpkTool(self.redpanda)
+        nodes = rpk.cluster_info()
+        assert len(nodes) == 3
+        redpanda_ids = [self.redpanda.idx(n) for n in self.redpanda.nodes]
+        node_ids = [n.id for n in nodes]
+        assert sorted(redpanda_ids) == sorted(node_ids)
+
+        def get_node():
+            if node == 'controller':
+                return self.redpanda.controller()
+            else:
+                n = self.redpanda.nodes[0]
+                while n == self.redpanda.controller():
+                    n = random.choice(self.redpanda.nodes)
+                return n
+
+        node = get_node()
+        node_id = self.redpanda.idx(node)
+        self.redpanda.logger.info(
+            f"Injecting failure on node {node.account.hostname} with id: {node_id}",
+        )
+        with FailureInjector(self.redpanda) as fi:
+            if failure == "isolate":
+                fi.inject_failure(
+                    FailureSpec(FailureSpec.FAILURE_ISOLATE, node))
+            else:
+                self.redpanda.stop_node(node)
+
+            rpk = RpkTool(self.redpanda)
+
+            def contains_only_alive_nodes():
+                nodes = rpk.cluster_info()
+                returned_ids = [n.id for n in nodes]
+                return len(nodes) == 2 and node_id not in returned_ids
+
+            wait_until(contains_only_alive_nodes, 30, 1)


### PR DESCRIPTION
## Cover letter

A bug in `cluster::metadata_cache` caused redpanda to always return all brokers even if some of them are down. This leads to situation in which some of the clients return an error as they can not communicate with the broker that is supposed to be responding. 

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3432

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.
-->

### Improvements

* Fixed listing brokers when some of the nodes are down
* Fixed describing groups when some of the nodes are down