### PR TITLE
[V21.11.x-si-testing] Early backport of fixes for large partitions counts

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -306,7 +306,8 @@ void archiver_fixture::initialize_shard(
                        storage::ntp_config(d.ntp, data_dir.string()),
                        d.base_offset,
                        d.term,
-                       ss::default_priority_class())
+                       ss::default_priority_class(),
+                       storage::default_segment_readahead_size)
                      .get0();
         vlog(fixt_log.trace, "write random batches to segment");
         auto layout = write_random_batches(

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -307,8 +307,8 @@ void archiver_fixture::initialize_shard(
                        d.base_offset,
                        d.term,
                        ss::default_priority_class(),
-                       storage::default_segment_readahead_size,
-                       storage::default_segment_readahead_count)
+                       128_KiB,
+                       10)
                      .get0();
         vlog(fixt_log.trace, "write random batches to segment");
         auto layout = write_random_batches(

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -307,7 +307,8 @@ void archiver_fixture::initialize_shard(
                        d.base_offset,
                        d.term,
                        ss::default_priority_class(),
-                       storage::default_segment_readahead_size)
+                       storage::default_segment_readahead_size,
+                       storage::default_segment_readahead_count)
                      .get0();
         vlog(fixt_log.trace, "write random batches to segment");
         auto layout = write_random_batches(

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -25,8 +25,6 @@
 
 namespace cloud_storage {
 
-static constexpr size_t default_read_buffer_size = 128_KiB;
-static constexpr unsigned default_readahead = 10;
 static constexpr size_t default_write_buffer_size = 128_KiB;
 static constexpr unsigned default_writebehind = 10;
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -577,14 +577,18 @@ size_t remote_segment_batch_reader::produce(model::record_batch batch) {
 }
 
 ss::future<> remote_segment_batch_reader::stop() {
-    vlog(_ctxlog.debug, "remote_segment_batch_reader::close");
+    vlog(_ctxlog.debug, "remote_segment_batch_reader::stop");
     co_await _gate.close();
     if (_parser) {
-        vlog(
-          _ctxlog.debug, "remote_segment_batch_reader::close - parser-close");
+        vlog(_ctxlog.debug, "remote_segment_batch_reader::stop - parser-close");
         co_await _parser->close();
         _parser.reset();
     }
+    _stopped = true;
+}
+
+remote_segment_batch_reader::~remote_segment_batch_reader() noexcept {
+    vassert(_stopped, "Destroyed without stopping");
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -13,6 +13,7 @@
 #include "cloud_storage/cache_service.h"
 #include "cloud_storage/logger.h"
 #include "cloud_storage/types.h"
+#include "config/configuration.h"
 #include "model/fundamental.h"
 #include "resource_mgmt/io_priority.h"
 #include "storage/parser.h"
@@ -141,8 +142,9 @@ remote_segment::data_stream(size_t pos, ss::io_priority_class io_priority) {
     ss::gate::holder g(_gate);
     co_await hydrate();
     ss::file_input_stream_options options{};
-    options.buffer_size = default_read_buffer_size;
-    options.read_ahead = default_readahead;
+    options.buffer_size = config::shard_local_cfg().storage_read_buffer_size();
+    options.read_ahead
+      = config::shard_local_cfg().storage_read_readahead_count();
     options.io_priority_class = io_priority;
     auto data_stream = ss::make_file_input_stream(
       _data_file, pos, std::move(options));

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -158,7 +158,7 @@ public:
     remote_segment_batch_reader(const remote_segment_batch_reader&) = delete;
     remote_segment_batch_reader& operator=(const remote_segment_batch_reader&)
       = delete;
-    ~remote_segment_batch_reader() noexcept = default;
+    ~remote_segment_batch_reader() noexcept;
 
     ss::future<result<ss::circular_buffer<model::record_batch>>> read_some(
       model::timeout_clock::time_point, storage::offset_translator_state&);
@@ -188,18 +188,19 @@ private:
 
     ss::lw_shared_ptr<remote_segment> _seg;
     storage::log_reader_config _config;
-    std::unique_ptr<storage::continuous_batch_parser> _parser;
     ss::circular_buffer<model::record_batch> _ringbuf;
     std::optional<std::reference_wrapper<storage::offset_translator_state>>
       _cur_ot_state;
     size_t _total_size{0};
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
+    std::unique_ptr<storage::continuous_batch_parser> _parser;
     model::term_id _term;
     model::offset _cur_rp_offset;
     model::offset _cur_delta;
     size_t _bytes_consumed{0};
     ss::gate _gate;
+    bool _stopped{false};
 };
 
 } // namespace cloud_storage

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -593,6 +593,18 @@ configuration::configuration()
       {.example = "32768", .visibility = visibility::tunable},
       16_KiB,
       storage::internal::chunk_cache::validate_chunk_size)
+  , storage_read_buffer_size(
+      *this,
+      "storage_read_buffer_size",
+      "Size of each read buffer (one per in-flight read, per log segment)",
+      {.example = "31768", .visibility = visibility::tunable},
+      128_KiB)
+  , storage_read_readahead_count(
+      *this,
+      "storage_read_readahead_count",
+      "How many additional reads to issue ahead of current read location",
+      {.example = "1", .visibility = visibility::tunable},
+      10)
   , max_compacted_log_segment_size(
       *this,
       "max_compacted_log_segment_size",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -541,6 +541,13 @@ configuration::configuration()
       "Fail-safe maximum throttle delay on kafka requests",
       {.visibility = visibility::tunable},
       60'000ms)
+  , kafka_max_bytes_per_fetch(
+      *this,
+      "kafka_max_bytes_per_fetch",
+      "Limit fetch responses to this many bytes, even if total of partition "
+      "bytes limits is higher",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      64_MiB)
   , raft_io_timeout_ms(
       *this,
       "raft_io_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -142,6 +142,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> segment_appender_flush_timeout_ms;
     property<std::chrono::milliseconds> fetch_session_eviction_timeout_ms;
     property<size_t> append_chunk_size;
+    property<size_t> storage_read_buffer_size;
+    property<int16_t> storage_read_readahead_count;
     property<size_t> max_compacted_log_segment_size;
     property<int16_t> id_allocator_log_capacity;
     property<int16_t> id_allocator_batch_size;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -133,6 +133,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> kvstore_flush_interval;
     property<size_t> kvstore_max_segment_size;
     property<std::chrono::milliseconds> max_kafka_throttle_delay_ms;
+    property<size_t> kafka_max_bytes_per_fetch;
     property<std::chrono::milliseconds> raft_io_timeout_ms;
     property<std::chrono::milliseconds> join_retry_timeout_ms;
     property<std::chrono::milliseconds> raft_timeout_now_timeout_ms;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -693,7 +693,9 @@ ss::future<> disk_log_impl::new_segment(
   model::offset o, model::term_id t, ss::io_priority_class pc) {
     vassert(
       o() >= 0 && t() >= 0, "offset:{} and term:{} must be initialized", o, t);
-    return _manager.make_log_segment(config(), o, t, pc)
+    return _manager
+      .make_log_segment(
+        config(), o, t, pc, storage::default_segment_readahead_size)
       .then([this](ss::lw_shared_ptr<segment> handles) mutable {
           return remove_empty_segments().then(
             [this, h = std::move(handles)]() mutable {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -695,7 +695,12 @@ ss::future<> disk_log_impl::new_segment(
       o() >= 0 && t() >= 0, "offset:{} and term:{} must be initialized", o, t);
     return _manager
       .make_log_segment(
-        config(), o, t, pc, storage::default_segment_readahead_size)
+        config(),
+        o,
+        t,
+        pc,
+        storage::default_segment_readahead_size,
+        storage::default_segment_readahead_count)
       .then([this](ss::lw_shared_ptr<segment> handles) mutable {
           return remove_empty_segments().then(
             [this, h = std::move(handles)]() mutable {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -9,6 +9,7 @@
 
 #include "storage/disk_log_impl.h"
 
+#include "config/configuration.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
@@ -699,8 +700,8 @@ ss::future<> disk_log_impl::new_segment(
         o,
         t,
         pc,
-        storage::default_segment_readahead_size,
-        storage::default_segment_readahead_count)
+        config::shard_local_cfg().storage_read_buffer_size(),
+        config::shard_local_cfg().storage_read_readahead_count())
       .then([this](ss::lw_shared_ptr<segment> handles) mutable {
           return remove_empty_segments().then(
             [this, h = std::move(handles)]() mutable {

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -257,6 +257,7 @@ ss::future<> kvstore::roll() {
                  ss::default_priority_class(),
                  record_version_type::v1,
                  default_segment_readahead_size,
+                 default_segment_readahead_count,
                  _conf.sanitize_fileops,
                  std::nullopt)
           .then([this](ss::lw_shared_ptr<segment> seg) {
@@ -297,6 +298,7 @@ ss::future<> kvstore::roll() {
                        ss::default_priority_class(),
                        record_version_type::v1,
                        default_segment_readahead_size,
+                       default_segment_readahead_count,
                        _conf.sanitize_fileops,
                        std::nullopt)
                 .then([this](ss::lw_shared_ptr<segment> seg) {

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -228,7 +228,9 @@ ss::future<log> log_manager::do_manage(ntp_config cfg) {
                  _config.sanitize_fileops,
                  cfg.is_compacted(),
                  [this, cache_enabled] { return create_cache(cache_enabled); },
-                 _abort_source)
+                 _abort_source,
+                 config::shard_local_cfg().storage_read_buffer_size(),
+                 config::shard_local_cfg().storage_read_readahead_count())
           .then([this, cfg = std::move(cfg)](segment_set segments) mutable {
               auto l = storage::make_disk_backed_log(
                 std::move(cfg), *this, std::move(segments), _kvstore);

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -144,22 +144,27 @@ ss::future<> log_manager::housekeeping() {
           }
       });
 }
+
+/**
+ *
+ * @param read_buf_size size of underlying ss::input_stream's buffer
+ */
 ss::future<ss::lw_shared_ptr<segment>> log_manager::make_log_segment(
   const ntp_config& ntp,
   model::offset base_offset,
   model::term_id term,
   ss::io_priority_class pc,
-  record_version_type version,
-  size_t buf_size) {
+  size_t read_buf_size,
+  record_version_type version) {
     return ss::with_gate(
-      _open_gate, [this, &ntp, base_offset, term, pc, version, buf_size] {
+      _open_gate, [this, &ntp, base_offset, term, pc, version, read_buf_size] {
           return make_segment(
             ntp,
             base_offset,
             term,
             pc,
             version,
-            buf_size,
+            read_buf_size,
             _config.sanitize_fileops,
             create_cache(ntp.cache_enabled()));
       });

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -155,9 +155,11 @@ ss::future<ss::lw_shared_ptr<segment>> log_manager::make_log_segment(
   model::term_id term,
   ss::io_priority_class pc,
   size_t read_buf_size,
+  unsigned read_ahead,
   record_version_type version) {
     return ss::with_gate(
-      _open_gate, [this, &ntp, base_offset, term, pc, version, read_buf_size] {
+      _open_gate,
+      [this, &ntp, base_offset, term, pc, version, read_buf_size, read_ahead] {
           return make_segment(
             ntp,
             base_offset,
@@ -165,6 +167,7 @@ ss::future<ss::lw_shared_ptr<segment>> log_manager::make_log_segment(
             pc,
             version,
             read_buf_size,
+            read_ahead,
             _config.sanitize_fileops,
             create_cache(ntp.cache_enabled()));
       });

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -194,8 +194,8 @@ public:
       model::offset,
       model::term_id,
       ss::io_priority_class pc,
-      record_version_type = record_version_type::v1,
-      size_t buffer_size = default_segment_readahead_size);
+      size_t read_buffer_size,
+      record_version_type = record_version_type::v1);
 
     const log_config& config() const { return _config; }
 

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -195,6 +195,7 @@ public:
       model::term_id,
       ss::io_priority_class pc,
       size_t read_buffer_size,
+      unsigned read_ahead,
       record_version_type = record_version_type::v1);
 
     const log_config& config() const { return _config; }

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -35,6 +35,7 @@ struct segment_closed_exception final : std::exception {
 };
 
 constexpr size_t default_segment_readahead_size = 128 * 1024;
+constexpr unsigned default_segment_readahead_count = 10;
 
 class segment {
 public:
@@ -212,7 +213,8 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   const std::filesystem::path& path,
   debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache,
-  size_t buf_size);
+  size_t buf_size,
+  unsigned read_ahead);
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(
   const ntp_config& ntpc,
@@ -221,6 +223,7 @@ ss::future<ss::lw_shared_ptr<segment>> make_segment(
   ss::io_priority_class pc,
   record_version_type version,
   size_t buf_size,
+  unsigned read_ahead,
   debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache);
 

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -212,7 +212,7 @@ ss::future<ss::lw_shared_ptr<segment>> open_segment(
   const std::filesystem::path& path,
   debug_sanitize_files sanitize_fileops,
   std::optional<batch_cache_index> batch_cache,
-  size_t buf_size = default_segment_readahead_size);
+  size_t buf_size);
 
 ss::future<ss::lw_shared_ptr<segment>> make_segment(
   const ntp_config& ntpc,

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -34,9 +34,6 @@ struct segment_closed_exception final : std::exception {
     }
 };
 
-constexpr size_t default_segment_readahead_size = 128 * 1024;
-constexpr unsigned default_segment_readahead_count = 10;
-
 class segment {
 public:
     struct offset_tracker {

--- a/src/v/storage/segment_reader.cc
+++ b/src/v/storage/segment_reader.cc
@@ -23,11 +23,13 @@ segment_reader::segment_reader(
   ss::sstring filename,
   ss::file data_file,
   size_t file_size,
-  size_t buffer_size) noexcept
+  size_t buffer_size,
+  unsigned read_ahead) noexcept
   : _filename(std::move(filename))
   , _data_file(std::move(data_file))
   , _file_size(file_size)
-  , _buffer_size(buffer_size) {}
+  , _buffer_size(buffer_size)
+  , _read_ahead(read_ahead) {}
 
 ss::input_stream<char>
 segment_reader::data_stream(size_t pos, const ss::io_priority_class& pc) {
@@ -39,7 +41,7 @@ segment_reader::data_stream(size_t pos, const ss::io_priority_class& pc) {
     ss::file_input_stream_options options;
     options.buffer_size = _buffer_size;
     options.io_priority_class = pc;
-    options.read_ahead = 10;
+    options.read_ahead = _read_ahead;
     return make_file_input_stream(
       _data_file, pos, _file_size - pos, std::move(options));
 }
@@ -61,7 +63,7 @@ ss::input_stream<char> segment_reader::data_stream(
     ss::file_input_stream_options options;
     options.buffer_size = _buffer_size;
     options.io_priority_class = pc;
-    options.read_ahead = 10;
+    options.read_ahead = _read_ahead;
     return make_file_input_stream(
       _data_file, pos_begin, pos_end - pos_begin, std::move(options));
 }

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -32,7 +32,8 @@ public:
       ss::sstring filename,
       ss::file,
       size_t file_size,
-      size_t buffer_size) noexcept;
+      size_t buffer_size,
+      unsigned read_ahead) noexcept;
     ~segment_reader() noexcept = default;
     segment_reader(segment_reader&&) noexcept = default;
     segment_reader& operator=(segment_reader&&) noexcept = default;
@@ -72,6 +73,7 @@ private:
     ss::file _data_file;
     size_t _file_size{0};
     size_t _buffer_size{0};
+    unsigned _read_ahead{0};
 
     friend std::ostream& operator<<(std::ostream&, const segment_reader&);
 };

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -354,7 +354,11 @@ static ss::future<segment_set::underlying_t> open_segments(
                     // not a reader filename
                     return ss::make_ready_future<>();
                 }
-                return open_segment(path, sanitize_fileops, cache_factory())
+                return open_segment(
+                         path,
+                         sanitize_fileops,
+                         cache_factory(),
+                         default_segment_readahead_size)
                   .then([&segs](ss::lw_shared_ptr<segment> p) {
                       segs.push_back(std::move(p));
                   });

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -358,7 +358,8 @@ static ss::future<segment_set::underlying_t> open_segments(
                          path,
                          sanitize_fileops,
                          cache_factory(),
-                         default_segment_readahead_size)
+                         default_segment_readahead_size,
+                         default_segment_readahead_count)
                   .then([&segs](ss::lw_shared_ptr<segment> p) {
                       segs.push_back(std::move(p));
                   });

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -321,16 +321,27 @@ static ss::future<segment_set::underlying_t> open_segments(
   ss::sstring dir,
   debug_sanitize_files sanitize_fileops,
   std::function<std::optional<batch_cache_index>()> cache_factory,
-  ss::abort_source& as) {
+  ss::abort_source& as,
+  size_t buf_size,
+  unsigned read_ahead) {
     using segs_type = segment_set::underlying_t;
     return ss::do_with(
       segs_type{},
-      [&as, cache_factory, sanitize_fileops, dir = std::move(dir)](
-        segs_type& segs) {
+      [&as,
+       cache_factory,
+       sanitize_fileops,
+       dir = std::move(dir),
+       buf_size,
+       read_ahead](segs_type& segs) {
           auto f = directory_walker::walk(
             dir,
-            [&as, cache_factory, dir, sanitize_fileops, &segs](
-              ss::directory_entry seg) {
+            [&as,
+             cache_factory,
+             dir,
+             sanitize_fileops,
+             &segs,
+             buf_size,
+             read_ahead](ss::directory_entry seg) {
                 // abort if requested
                 if (as.abort_requested()) {
                     return ss::now();
@@ -358,8 +369,8 @@ static ss::future<segment_set::underlying_t> open_segments(
                          path,
                          sanitize_fileops,
                          cache_factory(),
-                         default_segment_readahead_size,
-                         default_segment_readahead_count)
+                         buf_size,
+                         read_ahead)
                   .then([&segs](ss::lw_shared_ptr<segment> p) {
                       segs.push_back(std::move(p));
                   });
@@ -380,11 +391,23 @@ ss::future<segment_set> recover_segments(
   debug_sanitize_files sanitize_fileops,
   bool is_compaction_enabled,
   std::function<std::optional<batch_cache_index>()> cache_factory,
-  ss::abort_source& as) {
+  ss::abort_source& as,
+  size_t read_buf_size,
+  unsigned read_readahead_count) {
     return ss::recursive_touch_directory(path.string())
-      .then([&as, cache_factory, sanitize_fileops, path = std::move(path)] {
+      .then([&as,
+             cache_factory,
+             sanitize_fileops,
+             path = std::move(path),
+             read_buf_size,
+             read_readahead_count] {
           return open_segments(
-            path.string(), sanitize_fileops, cache_factory, as);
+            path.string(),
+            sanitize_fileops,
+            cache_factory,
+            as,
+            read_buf_size,
+            read_readahead_count);
       })
       .then([&as, is_compaction_enabled](segment_set::underlying_t segs) {
           auto segments = segment_set(std::move(segs));

--- a/src/v/storage/segment_set.h
+++ b/src/v/storage/segment_set.h
@@ -92,7 +92,9 @@ ss::future<segment_set> recover_segments(
   debug_sanitize_files sanitize_fileops,
   bool is_compaction_enabled,
   std::function<std::optional<batch_cache_index>()> batch_cache_factory,
-  ss::abort_source& as);
+  ss::abort_source& as,
+  size_t read_buf_size,
+  unsigned read_readahead_count);
 
 std::ostream& operator<<(std::ostream&, const segment_set&);
 

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -424,8 +424,8 @@ ss::future<> do_swap_data_file_handles(
                   s->reader().filename(),
                   std::move(fd),
                   size,
-                  default_segment_readahead_size,
-                  default_segment_readahead_count);
+                  config::shard_local_cfg().storage_read_buffer_size(),
+                  config::shard_local_cfg().storage_read_readahead_count());
                 // update partition size probe
                 pb.delete_segment(*s.get());
                 std::swap(s->reader(), r);
@@ -621,8 +621,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
       path.string(),
       std::move(reader_fd),
       segment_size,
-      default_segment_readahead_size,
-      default_segment_readahead_count);
+      config::shard_local_cfg().storage_read_buffer_size(),
+      config::shard_local_cfg().storage_read_readahead_count());
 
     // build an empty index for the segment
     auto index_name = path;

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -424,7 +424,8 @@ ss::future<> do_swap_data_file_handles(
                   s->reader().filename(),
                   std::move(fd),
                   size,
-                  default_segment_readahead_size);
+                  default_segment_readahead_size,
+                  default_segment_readahead_count);
                 // update partition size probe
                 pb.delete_segment(*s.get());
                 std::swap(s->reader(), r);
@@ -620,7 +621,8 @@ ss::future<ss::lw_shared_ptr<segment>> make_concatenated_segment(
       path.string(),
       std::move(reader_fd),
       segment_size,
-      default_segment_readahead_size);
+      default_segment_readahead_size,
+      default_segment_readahead_count);
 
     // build an empty index for the segment
     auto index_name = path;

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -76,7 +76,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                   model::offset(10),
                   model::term_id(1),
                   ss::default_priority_class(),
-                  storage::default_segment_readahead_size)
+                  storage::default_segment_readahead_size,
+                  storage::default_segment_readahead_count)
                  .get0();
     seg->close().get();
 
@@ -87,7 +88,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    model::offset(20),
                    model::term_id(1),
                    ss::default_priority_class(),
-                   storage::default_segment_readahead_size)
+                   storage::default_segment_readahead_size,
+                   storage::default_segment_readahead_count)
                   .get0();
     write_batches(seg3);
     seg3->close().get();
@@ -97,7 +99,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    model::offset(2),
                    model::term_id(1),
                    ss::default_priority_class(),
-                   storage::default_segment_readahead_size)
+                   storage::default_segment_readahead_size,
+                   storage::default_segment_readahead_count)
                   .get0();
     write_garbage(seg4->appender());
     seg4->close().get();

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -75,7 +75,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                   ntps[0],
                   model::offset(10),
                   model::term_id(1),
-                  ss::default_priority_class())
+                  ss::default_priority_class(),
+                  storage::default_segment_readahead_size)
                  .get0();
     seg->close().get();
 
@@ -85,7 +86,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    ntps[2],
                    model::offset(20),
                    model::term_id(1),
-                   ss::default_priority_class())
+                   ss::default_priority_class(),
+                   storage::default_segment_readahead_size)
                   .get0();
     write_batches(seg3);
     seg3->close().get();
@@ -94,7 +96,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    ntps[3],
                    model::offset(2),
                    model::term_id(1),
-                   ss::default_priority_class())
+                   ss::default_priority_class(),
+                   storage::default_segment_readahead_size)
                   .get0();
     write_garbage(seg4->appender());
     seg4->close().get();

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -55,6 +55,9 @@ ntp_config config_from_ntp(const model::ntp& ntp) {
     return ntp_config(ntp, "test.dir");
 }
 
+constexpr size_t default_segment_readahead_size = 128 * 1024;
+constexpr unsigned default_segment_readahead_count = 10;
+
 SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
     auto conf = make_config();
     storage::api store(
@@ -76,8 +79,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                   model::offset(10),
                   model::term_id(1),
                   ss::default_priority_class(),
-                  storage::default_segment_readahead_size,
-                  storage::default_segment_readahead_count)
+                  default_segment_readahead_size,
+                  default_segment_readahead_count)
                  .get0();
     seg->close().get();
 
@@ -88,8 +91,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    model::offset(20),
                    model::term_id(1),
                    ss::default_priority_class(),
-                   storage::default_segment_readahead_size,
-                   storage::default_segment_readahead_count)
+                   default_segment_readahead_size,
+                   default_segment_readahead_count)
                   .get0();
     write_batches(seg3);
     seg3->close().get();
@@ -99,8 +102,8 @@ SEASTAR_THREAD_TEST_CASE(test_can_load_logs) {
                    model::offset(2),
                    model::term_id(1),
                    ss::default_priority_class(),
-                   storage::default_segment_readahead_size,
-                   storage::default_segment_readahead_count)
+                   default_segment_readahead_size,
+                   default_segment_readahead_count)
                   .get0();
     write_garbage(seg4->appender());
     seg4->close().get();

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -53,7 +53,7 @@ struct context {
           base_name,
           ss::open_file_dma(base_name, ss::open_flags::ro).get0(),
           appender->file_byte_offset(),
-          128);
+          128_KiB);
         _seg = ss::make_lw_shared<segment>(
           segment::offset_tracker(model::term_id(0), base),
           std::move(reader),

--- a/src/v/storage/tests/log_replayer_test.cc
+++ b/src/v/storage/tests/log_replayer_test.cc
@@ -53,7 +53,8 @@ struct context {
           base_name,
           ss::open_file_dma(base_name, ss::open_flags::ro).get0(),
           appender->file_byte_offset(),
-          128_KiB);
+          128_KiB,
+          10);
         _seg = ss::make_lw_shared<segment>(
           segment::offset_tracker(model::term_id(0), base),
           std::move(reader),


### PR DESCRIPTION
## Cover letter

This is a backport of as-yet-unmerged PRs needed to unblock SI testing:
https://github.com/vectorizedio/redpanda/pull/3421
https://github.com/vectorizedio/redpanda/pull/3420
https://github.com/vectorizedio/redpanda/pull/3401

These will need proper backporting to v21.11.x when merged to master & our testing is done.


## Release notes

* none