### PR TITLE
backport 3425  (archival: Make upload loop more resilent)

### DIFF
--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -436,11 +436,11 @@ uint64_t scheduler_service_impl::estimate_backlog_size() {
 
 ss::future<> scheduler_service_impl::run_uploads() {
     gate_guard g(_gate);
-    try {
-        static constexpr ss::lowres_clock::duration initial_backoff = 100ms;
-        static constexpr ss::lowres_clock::duration max_backoff = 10s;
-        ss::lowres_clock::duration backoff = initial_backoff;
-        while (!_gate.is_closed()) {
+    static constexpr ss::lowres_clock::duration initial_backoff = 100ms;
+    static constexpr ss::lowres_clock::duration max_backoff = 10s;
+    ss::lowres_clock::duration backoff = initial_backoff;
+    while (!_as.abort_requested() && !_gate.is_closed()) {
+        try {
             int quota = _queue.size();
             std::vector<ss::future<ntp_archiver::batch_result>> flist;
 
@@ -504,21 +504,17 @@ ss::future<> scheduler_service_impl::run_uploads() {
                 }
                 continue;
             }
+        } catch (const ss::sleep_aborted&) {
+            vlog(_rtclog.debug, "Upload loop aborted");
+        } catch (const ss::gate_closed_exception&) {
+            vlog(_rtclog.debug, "Upload loop aborted (gate closed)");
+        } catch (const ss::abort_requested_exception&) {
+            vlog(_rtclog.debug, "Upload loop aborted (abort requested)");
+        } catch (...) {
+            vlog(
+              _rtclog.error, "Upload loop error: {}", std::current_exception());
         }
-    } catch (const ss::sleep_aborted&) {
-        vlog(_rtclog.debug, "Upload loop aborted");
-    } catch (const ss::gate_closed_exception&) {
-        vlog(_rtclog.debug, "Upload loop aborted (gate closed)");
-    } catch (const ss::abort_requested_exception&) {
-        vlog(_rtclog.debug, "Upload loop aborted (abort requested)");
-    } catch (...) {
-        vlog(_rtclog.error, "Upload loop error: {}", std::current_exception());
     }
-    // The loop can be stopped by gate or abort_source (if it was waiting inside
-    // sleep_abortable)
-    vassert(
-      _as.abort_requested() || _gate.is_closed(),
-      "Upload loop is not stopped properly");
 }
 
 } // namespace archival::internal


### PR DESCRIPTION
## Cover letter

Handle all exceptions in the upload loop. If one of the archivers will
throw an exception which is not the expected kind just add the message
to the log. On the next iteration we will proceed with different set of
archivers so broken archiver won't cause unavailability for all
partitions.

This change is supposed to make transient errors less severe. For
instance, it is possible for the log to get truncated while the archiver
is trying to upload it. It's safe to assume that this archiver can retry
after a while. The archiver would be pushed to the back of the upload
queue so it won't be retried right away.


