### PR TITLE
chore: fix various clang-tidy warnings

### DIFF
--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -25,8 +25,9 @@
 using bytes = ss::basic_sstring<
   uint8_t,  // Must be different from char to not leak to std::string_view
   uint32_t, // size type - 4 bytes - 4GB max - don't use a size_t or any 64-bit
-  31,       // short string optimization size
-  false     // not null terminated
+  31, // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+      // short string optimization size
+  false // not null terminated
   >;
 
 using bytes_view = std::basic_string_view<uint8_t>;
@@ -102,8 +103,8 @@ inline iobuf bytes_to_iobuf(const bytes& in) {
     return out;
 }
 
+// NOLINTNEXTLINE(cert-dcl58-cpp): hash<> specialization
 namespace std {
-
 template<>
 struct hash<bytes_view> {
     size_t operator()(bytes_view v) const {
@@ -112,10 +113,13 @@ struct hash<bytes_view> {
           {reinterpret_cast<const char*>(v.data()), v.size()});
     }
 };
-
-std::ostream& operator<<(std::ostream& os, const bytes_view& b);
-
 } // namespace std
+
+// FIXME: remove overload from std::
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+namespace std {
+std::ostream& operator<<(std::ostream& os, const bytes_view& b);
+}
 
 inline size_t bytes_type_hash::operator()(const bytes_view& k) const {
     return absl::Hash<bytes_view>{}(k);
@@ -144,6 +148,7 @@ bytes_type_eq::operator()(const bytes& lhs, const iobuf& rhs) const {
     const size_t max = lhs.size();
     while (iobuf_it != iobuf_end && bytes_idx < max) {
         const char r_c = *iobuf_it;
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
         const char l_c = lhs[bytes_idx];
         if (l_c != r_c) {
             return false;

--- a/src/v/kafka/protocol/batch_reader.cc
+++ b/src/v/kafka/protocol/batch_reader.cc
@@ -35,7 +35,8 @@ public:
 
     int32_t size_bytes() const { return _size_bytes; }
     int32_t record_bytes() const {
-        return _size_bytes - model::packed_record_batch_header_size;
+        return _size_bytes
+               - static_cast<int32_t>(model::packed_record_batch_header_size);
     }
     model::offset last_offset() const {
         return _base_offset + model::offset{_last_offset_delta};

--- a/src/v/kafka/protocol/kafka_batch_adapter.cc
+++ b/src/v/kafka/protocol/kafka_batch_adapter.cc
@@ -56,11 +56,12 @@ model::record_batch_header kafka_batch_adapter::read_header(iobuf_parser& in) {
     // Note:
     //   if you change this, please remember to change batch_consumer.h
     int32_t size_bytes
-      = batch_length - internal::kafka_header_size
-        + model::packed_record_batch_header_size
-        // Kafka *does not* include the first 2 fields in the size calculation
-        // they build the types bottoms up, not top down
-        + sizeof(base_offset) + sizeof(batch_length);
+      = batch_length - static_cast<int32_t>(internal::kafka_header_size)
+        + static_cast<int32_t>(
+          model::packed_record_batch_header_size
+          // Kafka *does not* include the first 2 fields in the size calculation
+          // they build the types bottoms up, not top down
+          + sizeof(base_offset) + sizeof(batch_length));
 
     auto record_count = in.consume_be_type<int32_t>();
     auto header = model::record_batch_header{

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -14,7 +14,7 @@ void group_stm::remove_offset(const model::topic_partition& key) {
 }
 
 void group_stm::update_offset(
-  model::topic_partition key,
+  const model::topic_partition& key,
   model::offset offset,
   group_log_offset_metadata&& meta) {
     _offsets[key] = logged_metadata{

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -87,7 +87,7 @@ void group_stm::commit(model::producer_identity pid) {
 void group_stm::abort(
   model::producer_identity pid, [[maybe_unused]] model::tx_seq tx_seq) {
     auto prepared_it = _prepared_txs.find(pid.get_id());
-    if (prepared_it == _prepared_txs.end()) {
+    if (prepared_it == _prepared_txs.end()) { // NOLINT(bugprone-branch-clone)
         return;
     } else if (prepared_it->second.pid.epoch != pid.epoch) {
         return;

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -9,7 +9,7 @@ void group_stm::overwrite_metadata(group_log_group_metadata&& metadata) {
     _is_loaded = true;
 }
 
-void group_stm::remove_offset(model::topic_partition key) {
+void group_stm::remove_offset(const model::topic_partition& key) {
     _offsets.erase(key);
 }
 

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -121,7 +121,7 @@ public:
 
     void update_offset(
       model::topic_partition, model::offset, group_log_offset_metadata&&);
-    void remove_offset(model::topic_partition);
+    void remove_offset(const model::topic_partition&);
     void update_prepared(model::offset, group_log_prepared_tx);
     void commit(model::producer_identity);
     void abort(model::producer_identity, model::tx_seq);

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -120,7 +120,9 @@ public:
     }
 
     void update_offset(
-      model::topic_partition, model::offset, group_log_offset_metadata&&);
+      const model::topic_partition&,
+      model::offset,
+      group_log_offset_metadata&&);
     void remove_offset(const model::topic_partition&);
     void update_prepared(model::offset, group_log_prepared_tx);
     void commit(model::producer_identity);

--- a/src/v/kafka/server/handlers/add_offsets_to_txn.cc
+++ b/src/v/kafka/server/handlers/add_offsets_to_txn.cc
@@ -67,7 +67,7 @@ add_offsets_to_txn_handler::handle(request_context ctx, ss::smp_service_group) {
             }
             add_offsets_to_txn_response res;
             res.data = data;
-            return ctx.respond(std::move(res));
+            return ctx.respond(res);
         });
     });
 }

--- a/src/v/kafka/server/handlers/add_partitions_to_txn.cc
+++ b/src/v/kafka/server/handlers/add_partitions_to_txn.cc
@@ -48,10 +48,11 @@ ss::future<response_ptr> add_partitions_to_txn_handler::handle(
             tx_request, config::shard_local_cfg().create_topic_timeout_ms())
           .then([&ctx](cluster::add_paritions_tx_reply tx_response) {
               add_partitions_to_txn_response_data data;
-              for (auto tx_topic : tx_response.results) {
+              for (auto& tx_topic : tx_response.results) {
                   add_partitions_to_txn_topic_result topic{
-                    .name = tx_topic.name};
-                  for (auto tx_partition : tx_topic.results) {
+                    .name = std::move(tx_topic.name),
+                  };
+                  for (const auto& tx_partition : tx_topic.results) {
                       add_partitions_to_txn_partition_result partition{
                         .partition_index = tx_partition.partition_index};
                       switch (tx_partition.error_code) {

--- a/src/v/kafka/server/handlers/add_partitions_to_txn.cc
+++ b/src/v/kafka/server/handlers/add_partitions_to_txn.cc
@@ -35,9 +35,11 @@ ss::future<response_ptr> add_partitions_to_txn_handler::handle(
           .producer_id = request.data.producer_id,
           .producer_epoch = request.data.producer_epoch};
         tx_request.topics.reserve(request.data.topics.size());
-        for (auto topic : request.data.topics) {
+        for (auto& topic : request.data.topics) {
             cluster::add_paritions_tx_request::topic tx_topic{
-              .name = topic.name, .partitions = topic.partitions};
+              .name = std::move(topic.name),
+              .partitions = std::move(topic.partitions),
+            };
             tx_request.topics.push_back(tx_topic);
         }
 

--- a/src/v/kafka/server/handlers/add_partitions_to_txn.cc
+++ b/src/v/kafka/server/handlers/add_partitions_to_txn.cc
@@ -78,7 +78,7 @@ ss::future<response_ptr> add_partitions_to_txn_handler::handle(
                             = error_code::unknown_server_error;
                           break;
                       }
-                      topic.results.push_back(std::move(partition));
+                      topic.results.push_back(partition);
                   }
                   data.results.push_back(std::move(topic));
               }

--- a/src/v/kafka/server/handlers/end_txn.cc
+++ b/src/v/kafka/server/handlers/end_txn.cc
@@ -62,7 +62,7 @@ ss::future<response_ptr> end_txn_handler::handle(
               }
               end_txn_response response;
               response.data = data;
-              return ctx.respond(std::move(response));
+              return ctx.respond(response);
           });
     });
 }

--- a/src/v/kafka/server/handlers/find_coordinator.cc
+++ b/src/v/kafka/server/handlers/find_coordinator.cc
@@ -60,7 +60,7 @@ handle_ntp(request_context& ctx, std::optional<model::ntp> ntp) {
       .get_leader(*ntp, timeout)
       .then(
         [&ctx](model::node_id leader) { return handle_leader(ctx, leader); })
-      .handle_exception([&ctx]([[maybe_unused]] std::exception_ptr e) {
+      .handle_exception([&ctx](const std::exception_ptr&) {
           return ctx.respond(
             find_coordinator_response(error_code::coordinator_not_available));
       });

--- a/src/v/kafka/server/handlers/init_producer_id.cc
+++ b/src/v/kafka/server/handlers/init_producer_id.cc
@@ -72,7 +72,7 @@ ss::future<response_ptr> init_producer_id_handler::handle(
                       break;
                   }
 
-                  return ctx.respond(std::move(reply));
+                  return ctx.respond(reply);
               });
         }
 
@@ -115,7 +115,7 @@ ss::future<response_ptr> init_producer_id_handler::handle(
                   reply.data.error_code = error_code::broker_not_available;
               }
 
-              return ctx.respond(std::move(reply));
+              return ctx.respond(reply);
           });
     });
 }


### PR DESCRIPTION
## Cover letter

Fixes clang-tidy warnings in `src/v/kafka`. Once this sub-tree is clang-tidy warning free we'll enable these static checks in CI.

## Release notes

* None
