### PR TITLE
[v21.11.x] kafka: limit bytes in many-partition fetch

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -541,6 +541,13 @@ configuration::configuration()
       "Fail-safe maximum throttle delay on kafka requests",
       {.visibility = visibility::tunable},
       60'000ms)
+  , kafka_max_bytes_per_fetch(
+      *this,
+      "kafka_max_bytes_per_fetch",
+      "Limit fetch responses to this many bytes, even if total of partition "
+      "bytes limits is higher",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      64_MiB)
   , raft_io_timeout_ms(
       *this,
       "raft_io_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -133,6 +133,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> kvstore_flush_interval;
     property<size_t> kvstore_max_segment_size;
     property<std::chrono::milliseconds> max_kafka_throttle_delay_ms;
+    property<size_t> kafka_max_bytes_per_fetch;
     property<std::chrono::milliseconds> raft_io_timeout_ms;
     property<std::chrono::milliseconds> join_retry_timeout_ms;
     property<std::chrono::milliseconds> raft_timeout_now_timeout_ms;


### PR DESCRIPTION
## Cover letter

Backport of https://github.com/vectorizedio/redpanda/pull/3420

Mitigates https://github.com/vectorizedio/redpanda/issues/3409

## Release notes

### Improvements

- Consuming from a very large number of partitions at once is now subject to a per-request size limit, reducing the risk of exhausting memory if a client specifies a partition count and per-partition size limit that is greater than available RAM. The size limit per-fetch is set via the kafka_max_bytes_per_fetch configuration property, default 64MiB.
