### PR TITLE
[v21.11.x] kafka: probe to send group offset to prometheus

### DIFF
--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace kafka {
+class group_offset_probe {
+public:
+    explicit group_offset_probe(model::offset& offset) noexcept
+      : _offset(offset) {}
+
+    void setup_metrics(
+      const kafka::group_id& group_id, const model::topic_partition& tp) {
+        namespace sm = ss::metrics;
+
+        if (config::shard_local_cfg().disable_metrics()) {
+            return;
+        }
+
+        auto group_label = sm::label("group");
+        auto topic_label = sm::label("topic");
+        auto partition_label = sm::label("partition");
+        std::vector<sm::label_instance> labels{
+          group_label(group_id()),
+          topic_label(tp.topic()),
+          partition_label(tp.partition())};
+        _metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka:group"),
+          {sm::make_gauge(
+            "offset",
+            [this] { return _offset; },
+            sm::description("Group topic partition offset"),
+            labels)});
+    }
+
+private:
+    model::offset& _offset;
+    ss::metrics::metric_groups _metrics;
+};
+
+} // namespace kafka

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -183,6 +183,14 @@ class RpkTool:
             cmd += ["-o", f"{n}"]
         return self._run_topic(cmd)
 
+    def group_seek_to(self, group, to):
+        cmd = ["seek", group, "--to", to]
+        self._run_group(cmd)
+
+    def group_seek_to_group(self, group, to_group):
+        cmd = ["seek", group, "--to-group", to_group]
+        self._run_group(cmd)
+
     def wasm_deploy(self, script, name, description):
         cmd = [
             self._rpk_binary(), 'wasm', 'deploy', script, '--brokers',
@@ -202,6 +210,13 @@ class RpkTool:
     def _run_topic(self, cmd, stdin=None, timeout=None):
         cmd = [
             self._rpk_binary(), "topic", "--brokers",
+            self._redpanda.brokers()
+        ] + cmd
+        return self._execute(cmd, stdin=stdin, timeout=timeout)
+
+    def _run_group(self, cmd, stdin=None, timeout=None):
+        cmd = [
+            self._rpk_binary(), "group", "--brokers",
             self._redpanda.brokers()
         ] + cmd
         return self._execute(cmd, stdin=stdin, timeout=timeout)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -592,7 +592,8 @@ class RedpandaService(Service):
         that exactly one (family, sample) match the query. All values for the
         sample across the requested set of nodes are returned in a flat array.
 
-        An exception will be raised unless exactly one (family, sample) matches.
+        None will be returned if less than one (family, sample) matches.
+        An exception will be raised if more than one (family, sample) matches.
 
         Example:
 
@@ -625,8 +626,7 @@ class RedpandaService(Service):
                         MetricSample(family.name, sample.name, node,
                                      sample.value, sample.labels))
         if not sample_values:
-            raise Exception(
-                f"No metric sample matching '{sample_pattern}' found")
+            return None
         return MetricSamples(sample_values)
 
     def read_configuration(self, node):

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -276,61 +276,92 @@ class GroupMetricsTest(RedpandaTest):
 
         admin = Admin(redpanda=self.redpanda)
 
-        def get_offset_with_node_from_metric(group):
-            metric = self.redpanda.metrics_sample("kafka_group_offset")
-            if metric is None:
-                return None
-            metric = metric.label_filter(dict(group=group))
-            return metric.samples
-
-        def get_group_leader():
+        def get_group_partition():
             return admin.get_partitions(namespace="kafka_internal",
                                         topic="group",
-                                        partition=0)['leader_id']
+                                        partition=0)
 
-        def check_metric_from_node(node):
-            metrics_offsets = get_offset_with_node_from_metric(group)
-            if metrics_offsets == None:
+        def get_group_leader():
+            return get_group_partition()['leader_id']
+
+        def metrics_from_single_node(node):
+            """
+            Check that metrics are produced only by the given node.
+            """
+            metrics = self.redpanda.metrics_sample("kafka_group_offset")
+            if not metrics:
+                self.logger.debug("No metrics found")
                 return False
+            metrics = metrics.label_filter(dict(group=group)).samples
+            for metric in metrics:
+                self.logger.debug(
+                    f"Retrieved metric from node={metric.node.account.hostname}: {metric}"
+                )
             return all([
                 metric.node.account.hostname == node.account.hostname
-                for metric in metrics_offsets
+                for metric in metrics
             ])
 
-        def transfer_completed(new_leader_node):
-            return self.redpanda.nodes[get_group_leader() - 1].account.hostname \
-                    == new_leader_node.account.hostname
+        def transfer_leadership(new_leader):
+            """
+            Request leadership transfer of the internal consumer group partition
+            and check that it completes successfully.
+            """
+            self.logger.debug(
+                f"Transferring leadership to {new_leader.account.hostname}")
+            admin.transfer_leadership_to(namespace="kafka_internal",
+                                         topic="group",
+                                         partition=0,
+                                         target=self.redpanda.idx(new_leader))
+            for _ in range(3):  # re-check a few times
+                leader = self.redpanda.get_node(get_group_leader())
+                if leader == new_leader:
+                    return True
+                time.sleep(1)
+            return False
 
-        leader_node = self.redpanda.nodes[get_group_leader() - 1]
+        def partition_ready():
+            """
+            All replicas present and known leader
+            """
+            partition = get_group_partition()
+            self.logger.debug(f"XXXXX: {partition}")
+            return len(
+                partition['replicas']) == 3 and partition['leader_id'] >= 0
 
-        # Check transfer leadership to another node
-        for i in range(3):
-            new_leader_node = random.choice(
-                list(filter(lambda x: x != leader_node, self.redpanda.nodes)))
+        def select_next_leader():
+            """
+            Select a leader different than the current leader
+            """
+            wait_until(partition_ready, timeout_sec=30, backoff_sec=5)
+            partition = get_group_partition()
+            replicas = partition['replicas']
+            assert len(replicas) == 3
+            leader = partition['leader_id']
+            assert leader >= 0
+            replicas = filter(lambda r: r["node_id"] != leader, replicas)
+            new_leader = random.choice(list(replicas))['node_id']
+            return self.redpanda.get_node(new_leader)
 
-            admin.transfer_leadership_to(
-                namespace="kafka_internal",
-                topic="group",
-                partition=0,
-                target=self.redpanda.idx(new_leader_node))
+        # repeat the following test a few times.
+        #
+        #  1. transfer leadership to a new node
+        #  2. check that new leader reports metrics
+        #  3. check that prev leader does not report
+        #
+        # note that here reporting does not mean that the node does not report
+        # any metrics but that it does not report metrics for consumer groups
+        # for which it is not leader.
+        for _ in range(4):
+            new_leader = select_next_leader()
 
-            wait_until(lambda: transfer_completed(new_leader_node) and
-                       check_metric_from_node(new_leader_node),
+            wait_until(lambda: transfer_leadership(new_leader),
                        timeout_sec=30,
                        backoff_sec=5)
 
-            leader_node = new_leader_node
-
-        # Check transfer leadership to same node
-        admin.transfer_leadership_to(namespace="kafka_internal",
-                                     topic="group",
-                                     partition=0,
-                                     target=self.redpanda.idx(leader_node))
-
-        wait_until(lambda: transfer_completed(leader_node) and
-                   check_metric_from_node(leader_node),
-                   timeout_sec=30,
-                   backoff_sec=5)
+            wait_until(lambda: metrics_from_single_node(new_leader),
+                       timeout_sec=30,
+                       backoff_sec=5)
 
         for host in producers + consumers:
             host.stop()

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -246,7 +246,6 @@ class GroupMetricsTest(RedpandaTest):
 
     @cluster(num_nodes=7)
     def test_leadership_transfer(self):
-        rpk = RpkTool(self.redpanda)
         topics = list(filter(lambda x: x.partition_count > 1, self.topics))
         group = "g0"
 

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -302,7 +302,6 @@ class GroupMetricsTest(RedpandaTest):
                     == new_leader_node.account.hostname
 
         leader_node = self.redpanda.nodes[get_group_leader() - 1]
-        check_metric_from_node(leader_node)
 
         # Check transfer leadership to another node
         for i in range(3):

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -180,8 +180,12 @@ class GroupMetricsTest(RedpandaTest):
         assert gr_2_metrics_offsets[metric_key] == 0
 
         self.redpanda.delete_topic(topic)
-        metrics_offsets = self._get_offset_from_metrics(group_1)
-        assert metrics_offsets is None
+
+        def metrics_gone():
+            metrics_offsets = self._get_offset_from_metrics(group_1)
+            return metrics_offsets is None
+
+        wait_until(metrics_gone, timeout_sec=30, backoff_sec=5)
 
     @cluster(num_nodes=3)
     def test_multiple_topics_and_partitions(self):

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -127,7 +127,8 @@ class GroupMetricsTest(RedpandaTest):
     def __init__(self, ctx, *args, **kwargs):
 
         # Require internal_kafka topic to have an increased replication factor
-        extra_rp_conf = dict(default_topic_replications=3, )
+        extra_rp_conf = dict(default_topic_replications=3,
+                             enable_leader_balancer=False)
         super(GroupMetricsTest, self).__init__(test_context=ctx,
                                                num_brokers=3,
                                                extra_rp_conf=extra_rp_conf)


### PR DESCRIPTION
## Cover letter

Backport of https://github.com/vectorizedio/redpanda/pull/3181 , https://github.com/vectorizedio/redpanda/pull/3462 , https://github.com/vectorizedio/redpanda/pull/3482

To monitor group status we need to push offset for each topic partition to prometheus
According to topic partition offset we can calculate group lag

Fixes: https://github.com/vectorizedio/redpanda/issues/1275

## Release notes

kafka server send group topic partition offset metric to prometheus