### PR TITLE
[admin] Fix self leadership transfer

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1760,6 +1760,7 @@ kafka::error_code map_store_offset_error_code(std::error_code ec) {
         case raft::errc::replicate_batcher_cache_error:
         case raft::errc::group_not_exists:
         case raft::errc::replicate_first_stage_exception:
+        case raft::errc::transfer_to_current_leader:
             return error_code::unknown_server_error;
         }
     }

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2635,7 +2635,7 @@ consensus::do_transfer_leadership(std::optional<model::node_id> target) {
     if (*target == _self.id()) {
         vlog(_ctxlog.warn, "Cannot transfer leadership to self");
         return seastar::make_ready_future<std::error_code>(
-          make_error_code(errc::not_leader));
+          make_error_code(errc::transfer_to_current_leader));
     }
 
     auto conf = _configuration_manager.get_latest();

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -30,6 +30,7 @@ enum class errc : int16_t {
     configuration_change_in_progress,
     node_does_not_exists,
     leadership_transfer_in_progress,
+    transfer_to_current_leader,
     node_already_exists,
     invalid_configuration_update,
     not_voter,
@@ -72,6 +73,8 @@ struct errc_category final : public std::error_category {
             return "Node does not exists in configuration";
         case errc::leadership_transfer_in_progress:
             return "Node is currently transferring leadership";
+        case errc::transfer_to_current_leader:
+            return "Target for leadership transfer is current leader";
         case errc::node_already_exists:
             return "Node does already exists in configuration";
         case errc::invalid_configuration_update:

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -400,6 +400,8 @@ ss::future<> admin_server::throw_on_error(
             throw ss::httpd::base_exception(
               fmt::format("Not ready: {}", ec.message()),
               ss::httpd::reply::status_type::service_unavailable);
+        case raft::errc::transfer_to_current_leader:
+            co_return;
         case raft::errc::not_leader:
             throw co_await redirect_to_leader(req, ntp);
         default:

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -103,6 +103,15 @@ class LeadershipTransferTest(RedpandaTest):
 
         return partition[0]
 
+    @cluster(num_nodes=3)
+    def test_self_transfer(self):
+        admin = Admin(self.redpanda)
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                leader = admin.get_partitions(topic, partition)['leader_id']
+                admin.partition_transfer_leadership("kafka", topic, partition,
+                                                    leader)
+
 
 class AutomaticLeadershipBalancingTest(RedpandaTest):
     # number cores = 3 (default)


### PR DESCRIPTION
## Cover letter

### Problem
I got in `raft_availability_test.RaftAvailabilityTest.test_leader_transfers_recovery.acks=-1` error:
```
Max retries exceeded with url: /v1/partitions/kafka/topic-xvvoavvzqf/0/transfer_leadership?target=1 (Caused by ResponseError('too many 503 error responses')) 
```

@jcsp investigated to this error and found:

the new leader is node 1, the intended destination.  So somehow, the leadership transfer is being done, but the client is receiving the wrong status code.

That old leader is stepping down while in the middle of doing the leadership transfer
`INFO  2022-01-10 11:47:00,964 [sh## Cover letter

### Problem
I got in `raft_availability_test.RaftAvailabilityTest.test_leader_transfers_recovery.acks=-1` error:
```
Max retries exceeded with url: /v1/partitions/kafka/topic-xvvoavvzqf/0/transfer_leadership?target=1 (Caused by ResponseError('too many 503 error responses')) 
```

@jcsp investigated to this error and found:

the new leader is node 1, the intended destination.  So somehow, the leadership transfer is being done, but the client is receiving the wrong status code.

That old leader is stepping down while in the middle of doing the leadership transfer
`INFO  2022-01-10 11:47:00,964 [shard 1] raft - [group_id:1, {kafka/topic-xvvoavvzqf/0}] consensus.cc:134 - Stepping down as leader in term 15, dirty offset 91754`

Then subsequently, the client retries, and is getting redirected to the new leader (good) but then the new leader is also responding 503, because of this in consensus.cc
```
    if (*target == _self.id()) {
        vlog(_ctxlog.warn, "Cannot transfer leadership to self");
        return seastar::make_ready_future<std::error_code>(
          make_error_code(errc::not_leader));
    }
```
The admin API interprets not_leader as a 503.  In this case, not_leader isn't really the right error, we should be returning some kind of "no op" error internally and a 200 to the client (if they ask to transfer leadership to the current leader, that should just be a success)

### Solution:
Return 200 in situation when user try to transfer leadership to current