### PR TITLE
[v21.11.x] cloud_storage: ensure readers only destroyed in remote_partition

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -592,14 +592,18 @@ size_t remote_segment_batch_reader::produce(model::record_batch batch) {
 }
 
 ss::future<> remote_segment_batch_reader::stop() {
-    vlog(_ctxlog.debug, "remote_segment_batch_reader::close");
+    vlog(_ctxlog.debug, "remote_segment_batch_reader::stop");
     co_await _gate.close();
     if (_parser) {
-        vlog(
-          _ctxlog.debug, "remote_segment_batch_reader::close - parser-close");
+        vlog(_ctxlog.debug, "remote_segment_batch_reader::stop - parser-close");
         co_await _parser->close();
         _parser.reset();
     }
+    _stopped = true;
+}
+
+remote_segment_batch_reader::~remote_segment_batch_reader() noexcept {
+    vassert(_stopped, "Destroyed without stopping");
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -152,7 +152,7 @@ public:
     remote_segment_batch_reader(const remote_segment_batch_reader&) = delete;
     remote_segment_batch_reader& operator=(const remote_segment_batch_reader&)
       = delete;
-    ~remote_segment_batch_reader() noexcept = default;
+    ~remote_segment_batch_reader() noexcept;
 
     ss::future<result<ss::circular_buffer<model::record_batch>>> read_some(
       model::timeout_clock::time_point, storage::offset_translator_state&);
@@ -182,19 +182,20 @@ private:
 
     ss::lw_shared_ptr<remote_segment> _seg;
     storage::log_reader_config _config;
-    std::unique_ptr<storage::continuous_batch_parser> _parser;
     ss::circular_buffer<model::record_batch> _ringbuf;
     std::optional<std::reference_wrapper<storage::offset_translator_state>>
       _cur_ot_state;
     size_t _total_size{0};
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
+    std::unique_ptr<storage::continuous_batch_parser> _parser;
     model::term_id _term;
     model::offset _initial_delta;
     model::offset _cur_rp_offset;
     model::offset _cur_delta;
     size_t _bytes_consumed{0};
     ss::gate _gate;
+    bool _stopped{false};
 };
 
 } // namespace cloud_storage


### PR DESCRIPTION
## Cover letter

Backport of https://github.com/vectorizedio/redpanda/pull/3401

Fixes: #3378

## Release notes

* none