### PR TITLE
Add verifiable franz-go producer/consumer to ducktape

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -93,6 +93,10 @@ RUN git -C /opt clone https://github.com/Shopify/sarama.git && \
 RUN go install github.com/twmb/kcl@latest && \
     mv /root/go/bin/kcl /usr/local/bin/
 
+# Should fork to redpanda repo
+RUN git -C /opt clone https://github.com/jcsp/si-verifier.git && \
+    cd /opt/si-verifier && go mod tidy && go build
+
 # Expose port 8080 for any http examples within clients
 EXPOSE 8080
 

--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -246,6 +246,15 @@ class S3Client:
                                 ETag=resp['ETag'][1:-1],
                                 ContentLength=resp['ContentLength'])
 
+    def delete_bucket(self, name):
+        try:
+            self._cli.delete_bucket(Bucket=name)
+        except Exception:
+            self.logger.warn("Error deleting bucket, contents:")
+            for o in self.list_objects(name):
+                self.logger.warn(f"  {o.Key}")
+            raise
+
     def write_object_to_file(self, bucket, key, dest_path):
         """Get object and write it to file"""
         resp = self._get_object(bucket, key)

--- a/tests/rptest/services/franz_go_verifiable_services.py
+++ b/tests/rptest/services/franz_go_verifiable_services.py
@@ -1,0 +1,193 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+import threading
+from ducktape.services.background_thread import BackgroundThreadService
+
+# The franz-go root directory
+TESTS_DIR = os.path.join("/opt", "si-verifier")
+
+from enum import Enum
+
+
+class ServiceStatus(Enum):
+    SETUP = 1
+    RUNNING = 2
+    FINISH = 3
+
+
+class FranzGoVerifiableService(BackgroundThreadService):
+    def __init__(self, context, redpanda, topic, msg_size, nodes):
+        self.custom_nodes = nodes is not None
+
+        if nodes:
+            num_nodes = 0
+        else:
+            num_nodes = 1
+
+        super(FranzGoVerifiableService, self).__init__(context,
+                                                       num_nodes=num_nodes)
+
+        if nodes:
+            assert not self.nodes
+            self.nodes = nodes
+
+        self._redpanda = redpanda
+        self._topic = topic
+        self._msg_size = msg_size
+        self._stopping = threading.Event()
+        self._exception = None
+        self.status = ServiceStatus.SETUP
+        self._pid = None
+
+    def _worker(self, idx, node):
+        pass
+
+    def stop_node(self, node):
+        self._stopping.set()
+
+        if self.status is ServiceStatus.RUNNING:
+            try:
+                if self._pid is not None:
+                    self.logger.debug("Killing pid %s" % {self._pid})
+                    node.account.signal(self._pid, 9, allow_fail=True)
+                else:
+                    self.logger.debug("Killing si-verifier")
+                    node.account.kill_process("si-verifier",
+                                              clean_shutdown=False)
+            except RemoteCommandError as e:
+                if b"No such process" in e.msg:
+                    pass
+                else:
+                    raise
+
+        if self._exception is not None:
+            raise self._exception
+
+    def allocate_nodes(self):
+        if self.custom_nodes:
+            return
+        else:
+            return super(FranzGoVerifiableService, self).allocate_nodes()
+
+    def free_all(self):
+        if self.custom_nodes:
+            return
+        else:
+            return super(FranzGoVerifiableService, self).free_all()
+
+
+class FranzGoVerifiableSeqConsumer(FranzGoVerifiableService):
+    def __init__(self, context, redpanda, topic, msg_size, nodes=None):
+        super(FranzGoVerifiableSeqConsumer,
+              self).__init__(context, redpanda, topic, msg_size, nodes)
+
+    def _worker(self, idx, node):
+        self.status = ServiceStatus.RUNNING
+        self._stopping.clear()
+        try:
+            while not self._stopping.is_set():
+                cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs 0 --rand_read_msgs 0 --seq_read=1' % (
+                    f"{TESTS_DIR}/si-verifier", self._redpanda.brokers(),
+                    self._topic, self._msg_size)
+
+                for line in node.account.ssh_capture(cmd):
+                    if self._pid is None:
+                        self._pid = line.strip()
+
+                    self.logger.debug(line.rstrip())
+                    if self._stopping.is_set():
+                        break
+        except Exception as ex:
+            if self._stopping.is_set():
+                pass
+            else:
+                self._exception = ex
+                raise ex
+        finally:
+            self.status = ServiceStatus.FINISH
+
+
+class FranzGoVerifiableRandomConsumer(FranzGoVerifiableService):
+    def __init__(self,
+                 context,
+                 redpanda,
+                 topic,
+                 msg_size,
+                 rand_read_msgs,
+                 parallel,
+                 nodes=None):
+        super(FranzGoVerifiableRandomConsumer,
+              self).__init__(context, redpanda, topic, msg_size, nodes)
+        self._rand_read_msgs = rand_read_msgs
+        self._parallel = parallel
+
+    def _worker(self, idx, node):
+        self.status = ServiceStatus.RUNNING
+        self._stopping.clear()
+        try:
+            while not self._stopping.is_set():
+                cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs 0 --rand_read_msgs %s --parallel %s --seq_read=0' % (
+                    f"{TESTS_DIR}/si-verifier", self._redpanda.brokers(),
+                    self._topic, self._msg_size, self._rand_read_msgs,
+                    self._parallel)
+
+                for line in node.account.ssh_capture(cmd):
+                    if self._pid is None:
+                        self._pid = line.strip()
+
+                    self.logger.debug(line.rstrip())
+                    if self._stopping.is_set():
+                        break
+        except Exception as ex:
+            if self._stopping.is_set():
+                pass
+            else:
+                self._exception = ex
+                raise ex
+        finally:
+            self.status = ServiceStatus.FINISH
+
+
+class FranzGoVerifiableProducer(FranzGoVerifiableService):
+    def __init__(self,
+                 context,
+                 redpanda,
+                 topic,
+                 msg_size,
+                 msg_count,
+                 nodes=None):
+        super(FranzGoVerifiableProducer,
+              self).__init__(context, redpanda, topic, msg_size, nodes)
+        self._msg_count = msg_count
+
+    def _worker(self, idx, node):
+        self.status = ServiceStatus.RUNNING
+        self._stopping.clear()
+        try:
+            cmd = 'echo $$ ; %s --brokers %s --topic %s --msg_size %s --produce_msgs %s --rand_read_msgs 0 --seq_read=0' % (
+                f"{TESTS_DIR}/si-verifier", self._redpanda.brokers(),
+                self._topic, self._msg_size, self._msg_count)
+
+            for line in node.account.ssh_capture(cmd):
+                if self._pid is None:
+                    self._pid = line.strip()
+
+                self.logger.debug(line.rstrip())
+                if self._stopping.is_set():
+                    break
+        except Exception as ex:
+            if self._stopping.is_set():
+                pass
+            else:
+                self._exception = ex
+                raise ex
+        finally:
+            self.status = ServiceStatus.FINISH

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -230,7 +230,21 @@ class RedpandaService(Service):
 
         node.account.signal(pid, signal, allow_fail=False)
 
-    def start_node(self, node, override_cfg_params=None):
+    def lsof_node(self, node: ClusterNode):
+        """
+        Get the list of open files for a running node
+        :return: yields strings
+        """
+        first = True
+        for line in node.account.ssh_capture(
+                f"lsof -nP -p {self.redpanda_pid(node)}"):
+            if first:
+                # First line is a header, skip it
+                first = False
+                continue
+            yield line.split()[-1]
+
+    def start_node(self, node, override_cfg_params=None, timeout=None):
         """
         Start a single instance of redpanda. This function will not return until
         redpanda appears to have started successfully. If redpanda does not
@@ -247,9 +261,12 @@ class RedpandaService(Service):
 
         self.start_redpanda(node)
 
+        if timeout is None:
+            timeout = self.READY_TIMEOUT_SEC
+
         wait_until(
             lambda: Admin.ready(node).get("status") == "ready",
-            timeout_sec=RedpandaService.READY_TIMEOUT_SEC,
+            timeout_sec=timeout,
             err_msg=f"Redpanda service {node.account.hostname} failed to start",
             retry_on_exc=True)
         self._started.append(node)
@@ -299,17 +316,19 @@ class RedpandaService(Service):
             "rp_install_path_root", None)
         return f"{rp_install_path_root}/bin/{name}"
 
-    def stop_node(self, node):
+    def stop_node(self, node, timeout=None):
         pids = self.pids(node)
 
         for pid in pids:
             node.account.signal(pid, signal.SIGTERM, allow_fail=False)
 
-        timeout_sec = 30
-        wait_until(lambda: len(self.pids(node)) == 0,
-                   timeout_sec=timeout_sec,
-                   err_msg="Redpanda node failed to stop in %d seconds" %
-                   timeout_sec)
+        if timeout is None:
+            timeout = 30
+
+        wait_until(
+            lambda: len(self.pids(node)) == 0,
+            timeout_sec=timeout,
+            err_msg=f"Redpanda node failed to stop in {timeout} seconds")
         if node in self._started:
             self._started.remove(node)
 
@@ -393,12 +412,16 @@ class RedpandaService(Service):
         self.logger.debug(conf)
         node.account.create_file(RedpandaService.CONFIG_FILE, conf)
 
-    def restart_nodes(self, nodes, override_cfg_params=None):
+    def restart_nodes(self,
+                      nodes,
+                      override_cfg_params=None,
+                      start_timeout=None,
+                      stop_timeout=None):
         nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
         for node in nodes:
-            self.stop_node(node)
+            self.stop_node(node, timeout=stop_timeout)
         for node in nodes:
-            self.start_node(node, override_cfg_params)
+            self.start_node(node, override_cfg_params, timeout=start_timeout)
 
     def registered(self, node):
         """

--- a/tests/rptest/tests/franz_go_verifiable_test.py
+++ b/tests/rptest/tests/franz_go_verifiable_test.py
@@ -20,11 +20,6 @@ from rptest.services.franz_go_verifiable_services import FranzGoVerifiableProduc
 
 
 class FranzGoVerifiableTest(RedpandaTest):
-    """
-    Start a kaf-based producer and consumer, then wait until the consumer has
-    observed a certain number of produced records.
-    """
-
     MSG_SIZE = 120000
 
     topics = (TopicSpec(partition_count=100, replication_factor=3), )

--- a/tests/rptest/tests/franz_go_verifiable_test.py
+++ b/tests/rptest/tests/franz_go_verifiable_test.py
@@ -13,61 +13,118 @@ from ducktape.cluster.cluster_spec import ClusterSpec
 
 import time
 import random
+import uuid
 
+from rptest.archival.s3_client import S3Client
+from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.franz_go_verifiable_services import FranzGoVerifiableProducer, FranzGoVerifiableSeqConsumer, FranzGoVerifiableRandomConsumer
 
 
-class FranzGoVerifiableTest(RedpandaTest):
+class SiWithFranzGoTest(RedpandaTest):
     MSG_SIZE = 120000
+
+    segment_size = 16 * 1048576
+    s3_host_name = "minio-s3"
+    s3_access_key = "panda-user"
+    s3_secret_key = "panda-secret"
+    s3_region = "panda-region"
+    s3_topic_name = "panda-topic"
 
     topics = (TopicSpec(partition_count=100, replication_factor=3), )
 
     def __init__(self, ctx):
-        super(FranzGoVerifiableTest, self).__init__(test_context=ctx,
-                                                    num_brokers=3)
+        self.s3_bucket_name = f"panda-bucket-{uuid.uuid1()}"
+        super(SiWithFranzGoTest, self).__init__(
+            test_context=ctx,
+            num_brokers=3,
+            extra_rp_conf={
+                # Disable prometheus metrics, because we are doing lots
+                # of restarts with lots of partitions, and current high
+                # metric counts make that sometimes cause reactor stalls
+                # during shutdown on debug builds.
+                'disable_metrics': True,
+
+                # We will run relatively large number of partitions
+                # and want it to work with slow debug builds and
+                # on noisy developer workstations: relax the raft
+                # intervals
+                'election_timeout_ms': 5000,
+                'raft_heartbeat_interval_ms': 500,
+
+                # Cloud storage config
+                'log_segment_size': self.segment_size,
+                'cloud_storage_enabled': True,
+                'cloud_storage_access_key': self.s3_access_key,
+                'cloud_storage_secret_key': self.s3_secret_key,
+                'cloud_storage_region': self.s3_region,
+                'cloud_storage_bucket': self.s3_bucket_name,
+                'cloud_storage_disable_tls': True,
+                'cloud_storage_api_endpoint': self.s3_host_name,
+                'cloud_storage_api_endpoint_port': 9000,
+                'cloud_storage_cache_size': self.segment_size * 10
+            })
 
         self.redpanda_nodes = self.redpanda.nodes
+
+        self.s3client = S3Client(
+            region=self.s3_region,
+            access_key=self.s3_access_key,
+            secret_key=self.s3_secret_key,
+            endpoint=f"http://{self.s3_host_name}:9000",
+            logger=self.logger,
+        )
+        self.s3client.create_bucket(self.s3_bucket_name)
+
         self._node_for_franz_go = ctx.cluster.alloc(
             ClusterSpec.simple_linux(1))
 
-        self._producer = FranzGoVerifiableProducer(
-            ctx, self.redpanda, self.topic, FranzGoVerifiableTest.MSG_SIZE,
-            1000000000, self._node_for_franz_go)
+        self._producer = FranzGoVerifiableProducer(ctx, self.redpanda,
+                                                   self.topic,
+                                                   SiWithFranzGoTest.MSG_SIZE,
+                                                   1000000000,
+                                                   self._node_for_franz_go)
         self._seq_consumer = FranzGoVerifiableSeqConsumer(
-            ctx, self.redpanda, self.topic, FranzGoVerifiableTest.MSG_SIZE,
+            ctx, self.redpanda, self.topic, SiWithFranzGoTest.MSG_SIZE,
             self._node_for_franz_go)
         self._rand_consumer = FranzGoVerifiableRandomConsumer(
-            ctx, self.redpanda, self.topic, FranzGoVerifiableTest.MSG_SIZE,
-            10000, 20, self._node_for_franz_go)
+            ctx, self.redpanda, self.topic, SiWithFranzGoTest.MSG_SIZE, 10000,
+            20, self._node_for_franz_go)
+
+    def tearDown(self):
+        failed_deletions = self.s3client.empty_bucket(self.s3_bucket_name)
+        assert len(failed_deletions) == 0
+        self.s3client.delete_bucket(self.s3_bucket_name)
 
     # In the future producer will signal about json creation
     def _create_json_file(self):
-        small_producer = FranzGoVerifiableProducer(
-            self.test_context, self.redpanda, self.topic,
-            FranzGoVerifiableTest.MSG_SIZE, 1000, self._node_for_franz_go)
+        small_producer = FranzGoVerifiableProducer(self.test_context,
+                                                   self.redpanda, self.topic,
+                                                   SiWithFranzGoTest.MSG_SIZE,
+                                                   10000,
+                                                   self._node_for_franz_go)
         small_producer.start()
         small_producer.wait()
 
-    @cluster(num_nodes=4)
-    def test_without_producer_in_background(self):
+    @cluster(num_nodes=5)
+    def test_with_all_type_of_loads_and_si(self):
+
+        rpk = RpkTool(self.redpanda)
+        rpk.alter_topic_config(self.topic, 'redpanda.remote.write', 'true')
+        rpk.alter_topic_config(self.topic, 'redpanda.remote.read', 'true')
+        rpk.alter_topic_config(self.topic, 'retention.bytes',
+                               str(self.segment_size * 2))
+
         # Need create json file for consumer at first
         self._create_json_file()
 
-        self._seq_consumer.start()
-        self._rand_consumer.start()
-
-        for i in range(30):
-            node_for_restart = random.randrange(len(self.redpanda_nodes))
-            self.redpanda.restart_nodes(self.redpanda_nodes[node_for_restart],
-                                        start_timeout=200)
-            time.sleep(30)
-
-    @cluster(num_nodes=4)
-    def test_with_all_type_of_loads(self):
-        # Need create json file for consumer at first
-        self._create_json_file()
+        # Verify that we really enabled shadow indexing correctly, such
+        # that some objects were written
+        objects = list(self.s3client.list_objects(self.s3_bucket_name))
+        assert len(objects) > 0
+        for o in objects:
+            self.logger.info(f"S3 object: {o.Key}, {o.ContentLength}")
 
         self._producer.start()
 

--- a/tests/rptest/tests/franz_go_verifiable_test.py
+++ b/tests/rptest/tests/franz_go_verifiable_test.py
@@ -1,0 +1,74 @@
+# Copyright 2022 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+from ducktape.cluster.cluster_spec import ClusterSpec
+
+import time
+import random
+
+from rptest.clients.types import TopicSpec
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.franz_go_verifiable_services import FranzGoVerifiableProducer, FranzGoVerifiableSeqConsumer, FranzGoVerifiableRandomConsumer
+
+
+class FranzGoVerifiableTest(RedpandaTest):
+    """
+    Start a kaf-based producer and consumer, then wait until the consumer has
+    observed a certain number of produced records.
+    """
+
+    MSG_SIZE = 120000
+
+    topics = (TopicSpec(partition_count=100, replication_factor=3), )
+
+    def __init__(self, ctx):
+        super(FranzGoVerifiableTest, self).__init__(test_context=ctx,
+                                                    num_brokers=3)
+
+        self.redpanda_nodes = self.redpanda.nodes
+        self._node_for_franz_go = ctx.cluster.alloc(
+            ClusterSpec.simple_linux(1))
+
+        self._producer = FranzGoVerifiableProducer(
+            ctx, self.redpanda, self.topic, FranzGoVerifiableTest.MSG_SIZE,
+            10000000, self._node_for_franz_go)
+        self._seq_consumer = FranzGoVerifiableSeqConsumer(
+            ctx, self.redpanda, self.topic, FranzGoVerifiableTest.MSG_SIZE,
+            self._node_for_franz_go)
+        self._rand_consumer = FranzGoVerifiableRandomConsumer(
+            ctx, self.redpanda, self.topic, FranzGoVerifiableTest.MSG_SIZE,
+            10000, 20, self._node_for_franz_go)
+
+    # In the future producer will signal about json creation
+    def _create_json_file(self):
+        small_producer = FranzGoVerifiableProducer(
+            self.test_context, self.redpanda, self.topic,
+            FranzGoVerifiableTest.MSG_SIZE, 1000, self._node_for_franz_go)
+        small_producer.start()
+        small_producer.wait()
+
+    @cluster(num_nodes=4)
+    def test_simple(self):
+        # Need create json file for consumer at first
+        self._create_json_file()
+
+        self._producer.start()
+
+        # Produce some data
+        time.sleep(60)
+
+        self._seq_consumer.start()
+        self._rand_consumer.start()
+
+        for i in range(30):
+            node_for_restart = random.randrange(len(self.redpanda_nodes))
+            self.redpanda.restart_nodes(self.redpanda_nodes[node_for_restart])
+            time.sleep(10)


### PR DESCRIPTION
Add Franz go verifiable consumer/producer (https://github.com/jcsp/si-verifier) services to ducktape.

We should run producer and consumer on the same node, because producer creates json file which consumer uses for validation.

This pt contains 3 new services:

- `FranzGoVerifiableSeqConsumer` - sequential consumer. It reads and validates all data from all partition for topic
- `FranzGoVerifiableRandomConsumer` - random consumer. Reads and validates data from random offset. User can set hpw many random reads will work with `parallel` settings
- `FranzGoVerifiableProducer` - producer. It produce data to redpanda and create json file for validation

TODO:

- [ ] clone it to vectorized org
- [ ] add si into test
- [ ] signal from producer about creating json file
- [ ] Add test with retention (How will si-verifier work)