### PR TITLE
[transaction] Add mark tx expired request to admin_api

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -30,6 +30,8 @@
 #include <absl/container/btree_set.h>
 #include <absl/container/flat_hash_map.h>
 
+#include <system_error>
+
 namespace cluster {
 
 /**
@@ -232,6 +234,8 @@ public:
       = absl::btree_map<model::producer_identity, rm_stm::transaction_info>;
     ss::future<result<transaction_set>> get_transactions();
 
+    ss::future<std::error_code> mark_expired(model::producer_identity pid);
+
 protected:
     ss::future<> handle_eviction() override;
 
@@ -277,6 +281,8 @@ private:
     ss::future<> try_abort_old_tx(model::producer_identity);
     ss::future<> do_try_abort_old_tx(model::producer_identity);
     void try_arm(time_point_type);
+
+    ss::future<std::error_code> do_mark_expired(model::producer_identity pid);
 
     bool is_known_session(model::producer_identity pid) const {
         auto is_known = false;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -48,6 +48,7 @@ enum class tx_errc {
     partition_not_found,
     stm_not_found,
     partition_not_exists,
+    pid_not_found,
     // when a request times out a client should not do any assumptions about its
     // effect. the request may time out before reaching the server, the request
     // may be successuly processed or may fail and the reply times out
@@ -86,6 +87,8 @@ struct tx_errc_category final : public std::error_category {
             return "Stm not found";
         case tx_errc::partition_not_exists:
             return "Partition not exists";
+        case tx_errc::pid_not_found:
+            return "Pid not found";
         case tx_errc::timeout:
             return "Timeout";
         case tx_errc::conflict:

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -169,6 +169,52 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/partitions/{namespace}/{topic}/{partition}/mark_transaction_expired",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Mark transaction expired for partition",
+                    "type": "void",
+                    "nickname": "mark_transaction_expired",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "id",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "epoch",
+                            "in": "query",
+                            "required": true,
+                            "type": "integer"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -194,6 +194,18 @@ class Admin:
         path = f"partitions/{namespace}/{topic}/{partition}/transactions"
         return self._request('get', path, node=node).json()
 
+    def mark_transaction_expired(self,
+                                 topic,
+                                 partition,
+                                 pid,
+                                 namespace,
+                                 node=None):
+        """
+        Mark transaction expired for partition
+        """
+        path = f"partitions/{namespace}/{topic}/{partition}/mark_transaction_expired?id={pid['id']}&epoch={pid['epoch']}"
+        return self._request("post", path, node=node)
+
     def set_partition_replicas(self,
                                topic,
                                partition,

--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -161,3 +161,55 @@ class TxAdminTest(RedpandaTest):
                     assert (self.extract_pid(tx) in expected_pids)
                     assert (tx['status'] == 'ongoing')
                     assert (tx['timeout_ms'] == -1)
+
+    @cluster(num_nodes=3)
+    def test_mark_transaction_expired(self):
+        producer1 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+        })
+        producer2 = ck.Producer({
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '1',
+        })
+        producer1.init_transactions()
+        producer2.init_transactions()
+        producer1.begin_transaction()
+        producer2.begin_transaction()
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                producer1.produce(topic.name, '0', '0', partition)
+                producer2.produce(topic.name, '0', '1', partition)
+
+        producer1.flush()
+        producer2.flush()
+
+        expected_pids = None
+
+        txs_info = self.admin.get_transactions(topic.name, partition, "kafka")
+
+        expected_pids = set(
+            map(self.extract_pid, txs_info['active_transactions']))
+        assert (len(expected_pids) == 2)
+
+        abort_tx = list(expected_pids)[0]
+        expected_pids.discard(abort_tx)
+
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                self.admin.mark_transaction_expired(topic.name, partition, {
+                    "id": abort_tx[0],
+                    "epoch": abort_tx[1]
+                }, "kafka")
+
+                txs_info = self.admin.get_transactions(topic.name, partition,
+                                                       "kafka")
+                assert ('expired_transactions' not in txs_info)
+
+                assert (len(expected_pids) == len(
+                    txs_info['active_transactions']))
+                for tx in txs_info['active_transactions']:
+                    assert (self.extract_pid(tx) in expected_pids)
+                    assert (tx['status'] == 'ongoing')
+                    assert (tx['timeout_ms'] == 60000)


### PR DESCRIPTION
## Cover letter

Implement new request for `admin_api` to mark transaction ([id, epoch]) expired for partition
User can send it to any node, and it will redirect request to leader for partition.

request gets `id` and `epoch` for pid like query params.
 
Fixes #2987 