### PR TITLE
Fix group metrics leadership transfer test

### DIFF
--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -297,7 +297,6 @@ class GroupMetricsTest(RedpandaTest):
                     == new_leader_node.account.hostname
 
         leader_node = self.redpanda.nodes[get_group_leader() - 1]
-        check_metric_from_node(leader_node)
 
         # Check transfer leadership to another node
         for i in range(3):

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -241,7 +241,6 @@ class GroupMetricsTest(RedpandaTest):
 
     @cluster(num_nodes=7)
     def test_leadership_transfer(self):
-        rpk = RpkTool(self.redpanda)
         topics = list(filter(lambda x: x.partition_count > 1, self.topics))
         group = "g0"
 


### PR DESCRIPTION
## Cover letter

Split wait phase and adds logging. A few clean-ups, too. It's not clear this will fix the issue (perhaps the implicitly longer timeout will) but it will hopefully get us some more context on the failure. Will repeat CI several times manually.

Fixes: https://github.com/vectorizedio/redpanda/issues/3394

## Release notes
* None