### PR TITLE
Adjusting cobra help text

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/cmd/generate/prometheus.go
@@ -85,10 +85,7 @@ especify an arbitrary config file.`,
 		&nodeAddrs,
 		"node-addrs",
 		[]string{},
-		fmt.Sprintf(`
-A comma-delimited list of the addresses (<host:port>) of all the redpanda nodes
-in a cluster. The port must be the one configured for the nodes' admin API
-(%d by default)`,
+		fmt.Sprintf(`A comma-delimited list of the addresses (<host>:<port>) of all the redpanda nodes in a cluster. The port must be the one configured for the nodes' admin API (%d by default)`,
 			config.DefaultAdminPort,
 		))
 	command.Flags().StringVar(

--- a/src/go/rpk/pkg/cli/cmd/group/seek.go
+++ b/src/go/rpk/pkg/cli/cmd/group/seek.go
@@ -117,11 +117,11 @@ Seek group G to the beginning of a topic it was not previously consuming:
 		},
 	}
 
-	cmd.Flags().StringVar(&to, "to", "", "where to seek (start, end, unix second|millisecond|nanosecond)")
-	cmd.Flags().StringVar(&toGroup, "to-group", "", "seek to the commits of another group")
-	cmd.Flags().StringVar(&toFile, "to-file", "", "seek to offsets as specified in the file")
-	cmd.Flags().StringArrayVar(&topics, "topics", nil, "only seek these topics, if any are specified")
-	cmd.Flags().BoolVar(&allowNewTopics, "allow-new-topics", false, "allow seeking to new topics not currently consumed (implied with --to-group or --to-file)")
+	cmd.Flags().StringVar(&to, "to", "", "Where to seek (start, end, unix second | millisecond | nanosecond)")
+	cmd.Flags().StringVar(&toGroup, "to-group", "", "Seek to the commits of another group")
+	cmd.Flags().StringVar(&toFile, "to-file", "", "Seek to offsets as specified in the file")
+	cmd.Flags().StringArrayVar(&topics, "topics", nil, "Only seek these topics, if any are specified")
+	cmd.Flags().BoolVar(&allowNewTopics, "allow-new-topics", false, "Allow seeking to new topics not currently consumed (implied with --to-group or --to-file)")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cmd/topic/config.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/config.go
@@ -127,10 +127,10 @@ valid, but does not apply it.
 		},
 	}
 
-	cmd.Flags().StringArrayVarP(&sets, "set", "s", nil, "key=value pair to set (repeatable)")
-	cmd.Flags().StringArrayVarP(&deletions, "delete", "d", nil, "key to delete (repeatable)")
-	cmd.Flags().StringArrayVar(&appends, "append", nil, "key=value; value to append to a list-of-values key (repeatable)")
-	cmd.Flags().StringArrayVar(&subtracts, "subtract", nil, "key=value; value to remove from list-of-values key (repeatable)")
+	cmd.Flags().StringArrayVarP(&sets, "set", "s", nil, "key=value; Pair to set (repeatable)")
+	cmd.Flags().StringArrayVarP(&deletions, "delete", "d", nil, "Key to delete (repeatable)")
+	cmd.Flags().StringArrayVar(&appends, "append", nil, "key=value; Value to append to a list-of-values key (repeatable)")
+	cmd.Flags().StringArrayVar(&subtracts, "subtract", nil, "key=value; Value to remove from list-of-values key (repeatable)")
 
 	cmd.Flags().BoolVar(&dry, "dry", false, "dry run: validate the alter request, but do not apply")
 

--- a/src/go/rpk/pkg/cli/cmd/topic/consume.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/consume.go
@@ -113,21 +113,21 @@ func NewConsumeCommand(fs afero.Fs) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&offset, "offset", "o", "start", "offset to consume from / to (start, end, 47, +2, -3)")
-	cmd.Flags().Int32SliceVarP(&c.partitions, "partitions", "p", nil, "comma delimited list of specific partitions to consume")
-	cmd.Flags().BoolVarP(&c.regex, "regex", "r", false, "parse topics as regex; consume any topic that matches any expression")
+	cmd.Flags().StringVarP(&offset, "offset", "o", "start", "Offset to consume from / to (start, end, 47, +2, -3)")
+	cmd.Flags().Int32SliceVarP(&c.partitions, "partitions", "p", nil, "Comma delimited list of specific partitions to consume")
+	cmd.Flags().BoolVarP(&c.regex, "regex", "r", false, "Parse topics as regex; consume any topic that matches any expression")
 
 	cmd.Flags().StringVarP(&c.group, "group", "g", "", "group to use for consuming (incompatible with -p)")
-	cmd.Flags().StringVarP(&c.balancer, "balancer", "b", "cooperative-sticky", "group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky)")
+	cmd.Flags().StringVarP(&c.balancer, "balancer", "b", "cooperative-sticky", "Group balancer to use if group consuming (range, roundrobin, sticky, cooperative-sticky)")
 
-	cmd.Flags().Int32Var(&c.fetchMaxBytes, "fetch-max-bytes", 1<<20, "maximum amount of bytes per fetch request per broker")
-	cmd.Flags().DurationVar(&c.fetchMaxWait, "fetch-max-wait", 5*time.Second, "maximum amount of time to wait when fetching from a broker before the broker replies")
-	cmd.Flags().BoolVar(&c.readCommitted, "read-committed", false, "opt in to reading only committed offsets")
+	cmd.Flags().Int32Var(&c.fetchMaxBytes, "fetch-max-bytes", 1<<20, "Maximum amount of bytes per fetch request per broker")
+	cmd.Flags().DurationVar(&c.fetchMaxWait, "fetch-max-wait", 5*time.Second, "Maximum amount of time to wait when fetching from a broker before the broker replies")
+	cmd.Flags().BoolVar(&c.readCommitted, "read-committed", false, "Opt in to reading only committed offsets")
 
-	cmd.Flags().StringVarP(&format, "format", "f", "json", "output format (see --help for details)")
-	cmd.Flags().IntVarP(&c.num, "num", "n", 0, "quit after consuming this number of records (0 is unbounded)")
-	cmd.Flags().BoolVar(&c.pretty, "pretty-print", true, "pretty print each record over multiple lines (for -f json)")
-	cmd.Flags().BoolVar(&c.metaOnly, "meta-only", false, "print all record info except the record value (for -f json)")
+	cmd.Flags().StringVarP(&format, "format", "f", "json", "Output format (see --help for details)")
+	cmd.Flags().IntVarP(&c.num, "num", "n", 0, "Quit after consuming this number of records (0 is unbounded)")
+	cmd.Flags().BoolVar(&c.pretty, "pretty-print", true, "Pretty print each record over multiple lines (for -f json)")
+	cmd.Flags().BoolVar(&c.metaOnly, "meta-only", false, "Print all record info except the record value (for -f json)")
 
 	// Deprecated.
 	cmd.Flags().BoolVar(new(bool), "commit", false, "")

--- a/src/go/rpk/pkg/cli/cmd/topic/create.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/create.go
@@ -97,9 +97,9 @@ the cleanup.policy=compact config option set.
 			}
 		},
 	}
-	cmd.Flags().StringArrayVarP(&configKVs, "topic-config", "c", nil, "key=value config parameters (repeatable; e.g. -c cleanup.policy=compact)")
-	cmd.Flags().Int32VarP(&partitions, "partitions", "p", 1, "number of partitions to create per topic")
-	cmd.Flags().Int16VarP(&replicas, "replicas", "r", -1, "replication factor; if -1, this will be the broker's default.replication.factor")
+	cmd.Flags().StringArrayVarP(&configKVs, "topic-config", "c", nil, "key=value; Config parameters (repeatable; e.g. -c cleanup.policy=compact)")
+	cmd.Flags().Int32VarP(&partitions, "partitions", "p", 1, "Number of partitions to create per topic")
+	cmd.Flags().Int16VarP(&replicas, "replicas", "r", -1, "Replication factor; if -1, this will be the broker's default.replication.factor")
 	cmd.Flags().BoolVarP(&dry, "dry", "d", false, "dry run: validate the topic creation request; do not create topics")
 
 	// Sept 2021

--- a/src/go/rpk/pkg/cli/cmd/topic/produce.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/produce.go
@@ -152,8 +152,8 @@ func NewProduceCommand(fs afero.Fs) *cobra.Command {
 	}
 
 	// The following flags require parsing before we initialize our client.
-	cmd.Flags().StringVarP(&compression, "compression", "z", "snappy", "compression to use for producing batches (none, gzip, snapy, lz4, zstd)")
-	cmd.Flags().IntVar(&acks, "acks", -1, "number of acks required for producing (-1=all, 0=none, 1=leader)")
+	cmd.Flags().StringVarP(&compression, "compression", "z", "snappy", "Compression to use for producing batches (none, gzip, snapy, lz4, zstd)")
+	cmd.Flags().IntVar(&acks, "acks", -1, "Number of acks required for producing (-1=all, 0=none, 1=leader)")
 	cmd.Flags().DurationVar(&timeout, "delivery-timeout", 0, "per-record delivery timeout, if non-zero, min 1s")
 	cmd.Flags().Int32VarP(&partition, "partition", "p", -1, "partition to directly produce to, if non-negative (also allows %p parsing to set partitions)")
 
@@ -165,8 +165,8 @@ func NewProduceCommand(fs afero.Fs) *cobra.Command {
 		"Produced to partition %p at offset %o with timestamp %d.\n",
 		"what to write to stdout when a record is successfully produced",
 	)
-	cmd.Flags().StringArrayVarP(&recHeaders, "header", "H", nil, "headers in format key:value to add to each record (repeatable)")
-	cmd.Flags().StringVarP(&key, "key", "k", "", "a fixed key to use for each record (parsed input keys take precedence)")
+	cmd.Flags().StringArrayVarP(&recHeaders, "header", "H", nil, "Headers in format key:value to add to each record (repeatable)")
+	cmd.Flags().StringVarP(&key, "key", "k", "", "A fixed key to use for each record (parsed input keys take precedence)")
 
 	// Deprecated
 	cmd.Flags().IntVarP(new(int), "num", "n", 1, "")


### PR DESCRIPTION
We created a python script that autogen docs for rpk based on the texts retrieved from `rpk [command] -h` generated by Cobra. 
This script is living in a private tooling repo for now.

This PR adapts some texts in Cobra CLI to better reflect the expected output in the docs and to avoid unexpected results. 