### PR TITLE
Container does not get removed from pod when sidecar is disabled

### DIFF
--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -117,6 +117,7 @@ func (r *StatefulSetResource) rollingUpdate(
 	opts := []patch.CalculateOption{
 		patch.IgnoreStatusFields(),
 		ignoreKubernetesTokenVolumeMounts(),
+		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
 		ignoreDefaultToleration(),
 		ignoreExistingVolumes(volumes),
 	}
@@ -127,6 +128,9 @@ func (r *StatefulSetResource) rollingUpdate(
 		// should be deleted it needs to have the original last applied
 		// annotation in place. See TestPatchCalculation_PodRemoved for detailed
 		// explanation
+		artificialPod.ObjectMeta = pod.ObjectMeta
+		artificialPod.TypeMeta = pod.TypeMeta
+		artificialPod.Annotations = template.Annotations
 		err = patch.DefaultAnnotator.SetLastAppliedAnnotation(&pod)
 		if err != nil {
 			return fmt.Errorf("setting lastapplied annotation %w", err)

--- a/src/go/k8s/pkg/resources/statefulset_update.go
+++ b/src/go/k8s/pkg/resources/statefulset_update.go
@@ -123,6 +123,14 @@ func (r *StatefulSetResource) rollingUpdate(
 
 	for i := range podList.Items {
 		pod := podList.Items[i]
+		// we need to do this to enable 3-way merge. To evaluate which items
+		// should be deleted it needs to have the original last applied
+		// annotation in place. See TestPatchCalculation_PodRemoved for detailed
+		// explanation
+		err = patch.DefaultAnnotator.SetLastAppliedAnnotation(&pod)
+		if err != nil {
+			return fmt.Errorf("setting lastapplied annotation %w", err)
+		}
 
 		patchResult, err := patch.DefaultPatchMaker.Calculate(&pod, &artificialPod, opts...)
 		if err != nil {

--- a/src/go/k8s/pkg/resources/statefulset_update_test.go
+++ b/src/go/k8s/pkg/resources/statefulset_update_test.go
@@ -3,6 +3,7 @@ package resources // nolint:testpackage // needed to test private method
 import (
 	"testing"
 
+	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -54,4 +55,59 @@ func TestShouldUpdate_AnnotationChange(t *testing.T) {
 	update, err = shouldUpdate(false, stsWithAnnotation, stsWithAnnotation)
 	require.NoError(t, err)
 	require.False(t, update)
+}
+
+// I am keeping this test in place to document how does 3-way merge patch behave
+// when it cannot retrieve original configuration from an annotation. Looking at
+// the description in docs
+// https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#merge-patch-calculation
+// to be able to calculate what lines should be removed, it requires the
+// original configuration to compute it
+func TestPatchCalculation_PodRemoved(t *testing.T) {
+	podWithOneContainer := corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "test",
+					Image:   "nginx",
+					Command: []string{"nginx"},
+				},
+			},
+		},
+	}
+	podWithTwoContainers := corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "test",
+					Image:   "nginx",
+					Command: []string{"nginx"},
+				},
+				{
+					Name:    "test2",
+					Image:   "nginx",
+					Command: []string{"nginx"},
+				},
+			},
+		},
+	}
+
+	opts := []patch.CalculateOption{
+		patch.IgnoreStatusFields(),
+		ignoreKubernetesTokenVolumeMounts(),
+		ignoreDefaultToleration(),
+	}
+	patchResult, err := patch.DefaultPatchMaker.Calculate(&podWithTwoContainers, &podWithOneContainer, opts...)
+	require.NoError(t, err)
+	// this case, the 3-way merge runs without knowing the original
+	// configuration so it cannot create diff removing the pod
+	require.True(t, patchResult.IsEmpty())
+
+	err = patch.DefaultAnnotator.SetLastAppliedAnnotation(&podWithTwoContainers)
+	require.NoError(t, err)
+	patchResult, err = patch.DefaultPatchMaker.Calculate(&podWithTwoContainers, &podWithOneContainer, opts...)
+	require.NoError(t, err)
+	// this time there's last applied annotation that we set so 3-way merge has
+	// the original configuration and computes diff that removes the pod
+	require.False(t, patchResult.IsEmpty())
 }

--- a/src/go/k8s/tests/e2e/update/05-add-sidecar.yaml
+++ b/src/go/k8s/tests/e2e/update/05-add-sidecar.yaml
@@ -1,0 +1,16 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster
+spec:
+  configuration:
+    sidecars:
+      rpkStatus:
+        enabled: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 30M
+          requests:
+            cpu: 200m
+            memory: 30M

--- a/src/go/k8s/tests/e2e/update/05-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/05-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: update-cluster-0
+spec:
+  containers:
+    - name: redpanda
+    - name: rpk-status

--- a/src/go/k8s/tests/e2e/update/05-remove-sidecar.yaml
+++ b/src/go/k8s/tests/e2e/update/05-remove-sidecar.yaml
@@ -1,0 +1,9 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: update-cluster
+spec:
+  configuration:
+    sidecars:
+      rpkStatus:
+        enabled: false

--- a/src/go/k8s/tests/e2e/update/06-assert.yaml
+++ b/src/go/k8s/tests/e2e/update/06-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: update-cluster-0
+spec:
+  containers:
+    - name: redpanda


### PR DESCRIPTION
## Cover letter

We use 3-way merge for comparing pods but we don't set last-applied annotation on the pod because pods are managed by sts and not us. Because of that, 3-way merge cannot evaluate items to be deleted when computing patch.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3467

## Release notes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
### Improvements
k8s: fixed bug when pod restart was not triggered after sidecar container was removed from custom resource