### PR TITLE
cloud_storage: Limit remote partition concurrency

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -332,7 +332,7 @@ ss::future<> remote_partition::start() {
     (void)run_eviction_loop();
 
     _stm_timer.set_callback([this] {
-        gc_stale_materialized_segments();
+        gc_stale_materialized_segments(false);
         if (!_as.abort_requested()) {
             _stm_timer.rearm(_stm_jitter());
         }
@@ -362,19 +362,27 @@ ss::future<> remote_partition::run_eviction_loop() {
     vlog(_ctxlog.debug, "remote partition eviction loop stopped");
 }
 
-void remote_partition::gc_stale_materialized_segments() {
+void remote_partition::gc_stale_materialized_segments(bool force_collection) {
+    // The remote_segment instances are materialized on demand. They are
+    // collected after some period of inactivity.
+    // To prevent high memory consumption in some corner cases the
+    // materialization of the new remote_segment triggers GC. The idea is
+    // that remote_partition should have only one remote_segment in materialized
+    // state when it's constantly in use and zero if not in use.
     vlog(
       _ctxlog.debug,
       "collecting stale materialized segments, {} segments materialized, {} "
       "segments total",
       _materialized.size(),
       _segments.size());
+
     auto now = ss::lowres_clock::now();
+    auto max_idle = force_collection ? stm_max_idle_time : 0ms;
+
     std::vector<model::offset> offsets;
     for (auto& st : _materialized) {
-        if (
-          now - st.atime > stm_max_idle_time
-          && !st.segment->download_in_progress()) {
+        auto deadline = st.atime + max_idle;
+        if (now >= deadline && !st.segment->download_in_progress()) {
             if (st.segment.owned()) {
                 vlog(
                   _ctxlog.debug,
@@ -534,6 +542,9 @@ std::unique_ptr<remote_segment_batch_reader> remote_partition::borrow_reader(
             return st->borrow_reader(config, part->_ctxlog);
         }
     };
+    if (std::holds_alternative<offloaded_segment_ptr>(st)) {
+        gc_stale_materialized_segments(true);
+    }
     return std::visit(
       visit_materialize_make_reader{
         .state = st, .part = this, .config = config, .offset_key = key},

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -93,7 +93,7 @@ private:
 
     ss::future<> run_eviction_loop();
 
-    void gc_stale_materialized_segments();
+    void gc_stale_materialized_segments(bool force_collection);
 
     friend struct offloaded_segment_state;
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -573,6 +573,7 @@ remote_segment_batch_reader::init_parser() {
 }
 
 size_t remote_segment_batch_reader::produce(model::record_batch batch) {
+    ss::gate::holder h(_gate);
     vlog(_ctxlog.debug, "remote_segment_batch_reader::produce");
     _total_size += batch.size_bytes();
     _ringbuf.push_back(std::move(batch));


### PR DESCRIPTION
## Cover letter

Limit concurrency in the remote_partition by forcing GC when new reader is created. The GC process can't remove readers which are actively used.

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->


## Release notes

* none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
