### PR TITLE
Backport pr3411 to v21.11.x (wasm: Fix bug for incorrect calculation of record batch size)

### DIFF
--- a/src/js/modules/supervisors/Repository.ts
+++ b/src/js/modules/supervisors/Repository.ts
@@ -143,8 +143,8 @@ class Repository {
       // Coprocessor return a Map with values
       for (const [key, value] of resultRecordBatch) {
         value.records = value.records.map((record) => {
-          record.length = calculateRecordLength(record);
           record.valueLen = record.value.length;
+          record.length = calculateRecordLength(record);
           return record;
         });
         value.header.sizeBytes = calculateRecordBatchSize(value.records);


### PR DESCRIPTION
## Cover letter

Backport #3411
- js: Set valueLen before calculating record size
- js/test: record & batch length properly updated

Fixes #3407 

## Release Notes

- Fixes crash when batches longer then a certain threshold are produced