### PR TITLE
test: disable leadership balancing in test

### DIFF
--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -180,8 +180,12 @@ class GroupMetricsTest(RedpandaTest):
         assert gr_2_metrics_offsets[metric_key] == 0
 
         self.redpanda.delete_topic(topic)
-        metrics_offsets = self._get_offset_from_metrics(group_1)
-        assert metrics_offsets is None
+
+        def metrics_gone():
+            metrics_offsets = self._get_offset_from_metrics(group_1)
+            return metrics_offsets is None
+
+        wait_until(metrics_gone, timeout_sec=30, backoff_sec=5)
 
     @cluster(num_nodes=3)
     def test_multiple_topics_and_partitions(self):

--- a/tests/rptest/tests/group_membership_test.py
+++ b/tests/rptest/tests/group_membership_test.py
@@ -127,7 +127,8 @@ class GroupMetricsTest(RedpandaTest):
     def __init__(self, ctx, *args, **kwargs):
 
         # Require internal_kafka topic to have an increased replication factor
-        extra_rp_conf = dict(default_topic_replications=3, )
+        extra_rp_conf = dict(default_topic_replications=3,
+                             enable_leader_balancer=False)
         super(GroupMetricsTest, self).__init__(test_context=ctx,
                                                num_brokers=3,
                                                extra_rp_conf=extra_rp_conf)


### PR DESCRIPTION
## Cover letter

It seems that leadership rebalancing was causing some of the rpk
operations to be a bit flaky. There may be an opportunity here to add
some retrying into rpk/franz-go.

rptest.clients.rpk.RpkException: RpkException<command
/var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-07ad15334ccea297e-1/vectorized/redpanda/vbuild/debug/clang/dist/local/redpanda/bin/rpk
group --brokers docker_n_14:9092,docker_n_6:9092,docker_n_5:9092 seek g2
--to start returned 1, output: , error: unable to list all offsets
successfully: NOT_LEADER_FOR_PARTITION: This server is not the leader
for that topic-partition.

Fixes: #3443

## Release notes

* None