### PR TITLE
ducky: change producer in sarama compat test

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apt update && \
     apt install -y \
       bind9-utils \
       bind9-dnsutils \
+      bsdmainutils \
       build-essential \
       curl \
       default-jdk \

--- a/tests/rptest/services/rpk_producer.py
+++ b/tests/rptest/services/rpk_producer.py
@@ -15,18 +15,24 @@ class RpkProducer(BackgroundThreadService):
                  topic,
                  msg_size,
                  msg_count,
-                 acks=None):
+                 acks=None,
+                 printable=False):
         super(RpkProducer, self).__init__(context, num_nodes=1)
         self._redpanda = redpanda
         self._topic = topic
         self._msg_size = msg_size
         self._msg_count = msg_count
         self._acks = acks
+        self._printable = printable
         self._stopping = Event()
 
     def _worker(self, _idx, node):
         rpk_binary = self._redpanda.find_binary("rpk")
-        cmd = f"dd if=/dev/urandom bs={self._msg_size} count={self._msg_count} | {rpk_binary} topic --brokers {self._redpanda.brokers()} produce --compression none --key test {self._topic} -f '%V{{{self._msg_size}}}%v'"
+        cmd = f"dd if=/dev/urandom bs={self._msg_size} count={self._msg_count}"
+        if self._printable:
+            cmd += ' | hexdump -e "1/1 \\"%02x\\""'
+
+        cmd += f" | {rpk_binary} topic --brokers {self._redpanda.brokers()} produce --compression none --key test {self._topic} -f '%V{{{self._msg_size}}}%v'"
         if self._acks is not None:
             cmd += f" --acks {self._acks}"
 

--- a/tests/rptest/tests/compatibility/sarama_test.py
+++ b/tests/rptest/tests/compatibility/sarama_test.py
@@ -11,7 +11,7 @@ import random
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
-from rptest.services.kaf_producer import KafProducer
+from rptest.services.rpk_producer import RpkProducer
 from rptest.services.compatibility.example_runner import ExampleRunner
 import rptest.services.compatibility.sarama_examples as SaramaExamples
 from rptest.tests.redpanda_test import RedpandaTest
@@ -91,7 +91,13 @@ class SaramaTest(RedpandaTest):
         example = ExampleRunner(self._ctx,
                                 sarama_example,
                                 timeout_sec=self._timeout)
-        producer = KafProducer(self._ctx, self.redpanda, self.topic, count)
+        producer = RpkProducer(self._ctx,
+                               self.redpanda,
+                               self.topic,
+                               4,
+                               count,
+                               acks=-1,
+                               printable=True)
 
         def until_partitions():
             storage = self.redpanda.storage()


### PR DESCRIPTION
## Cover letter

In #3444 , the debug log showed two problems:
1. The KafProducer received the response `Tried to send a message to a replica that is not the leader for some partition` when sending a few records. The records were eventually sent but they were never consumed. Kaf uses Sarama underneath and Sarama producers are known to be sensitive to responses such as leader-does-not-exist.
2. The Sarama consumer read a few records that were never logged by KafProducer.

My hunch is that the Sarama client within Kaf is causing problem1 so this PR replaces KafProducer with RpkProducer. Time will tell if the client is truly the issue.
From the debug log, it is unclear if problem1 led to problem2.

Changes from force-push ` fe86037 `:
- Add comment to clarify the need for a customized value generator in RpkProducer
- Edit the commit message to also clarify the need for a customized value generator in RpkProducer

Changes from force-push `456472e`:
- Add bsdmainutils to Dockerfile for hexdump command
- Use hexdump to clip the output from /dev/urandom into human-readable text
- Extend RpkProducer with a printable flag to generate human-readable text

Closes #3444 