### PR TITLE
cloud_storage: suppress warning on successfull topic creation

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -203,9 +203,21 @@ ss::future<download_result> remote::download_manifest(
             break;
         case error_outcome::fail:
             result = download_result::failed;
+            vlog(
+              ctxlog.warn,
+              "Failed downloading manifest from {} {}, manifest at {}",
+              bucket,
+              *result,
+              path);
             break;
         case error_outcome::notfound:
             result = download_result::notfound;
+            vlog(
+              ctxlog.debug,
+              "Manifest from {} {}, manifest at {} not found",
+              bucket,
+              *result,
+              path);
             break;
         }
     }
@@ -218,13 +230,6 @@ ss::future<download_result> remote::download_manifest(
           bucket,
           path);
         result = download_result::timedout;
-    } else {
-        vlog(
-          ctxlog.warn,
-          "Downloading manifest from {} {}, manifest at {} not available",
-          bucket,
-          *result,
-          path);
     }
     co_return *result;
 }


### PR DESCRIPTION
Backport of https://github.com/vectorizedio/redpanda/pull/3445

When topic is created with Shadow Indexing enabled, ntp_archiver starts
and tries to download a manifest from S3 before the manifest is
uploaded. That's a normal situation and should not create warnings.
Remote.cc now only logs errors about timeouts and retries, a decision
how to handle not_found happens on a higher level where we have a
context about situation.

(cherry picked from commit c71925ddf6a071cfe7fec138012edd12e036c5fd)

