### PR TITLE
c/metadata_dissemination: fix applying updates from health

### DIFF
--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -155,10 +155,6 @@ public:
     /// Checks if it has given partition
     bool contains(model::topic_namespace_view, model::partition_id) const;
 
-    /// Updates partition leader and notify waiters if needed
-    void update_partition_leader(
-      const model::ntp&, model::term_id, std::optional<model::node_id>);
-
     std::optional<partition_assignment>
     get_partition_assignment(const model::ntp&) const;
 


### PR DESCRIPTION
## Cover letter

 c/metadata_dissemination: fix applying updates from health

Node health reports may disagree with one another about
leadership in a particular term, if some of them claim
that it's null (because they've seen the term in their
own log after restart, but not yet received an append_entries
from the leader).

To avoid a rogue node health report resetting the leadership
of a topic to null, ignore health report leadership
information if it claims a null leader.

Non-null claims are always believable, because of the term:
if they're out of date, then they were still correct for
the term they claim, and we ignore those out of date
terms in partition_leaders_table::update_partition_leader.

Fixes #3486 

## Release notes

* none