### PR TITLE
s3: define BOOST_ASIO_HAS_STD_INVOKE_RESULT

### DIFF
--- a/src/v/s3/CMakeLists.txt
+++ b/src/v/s3/CMakeLists.txt
@@ -10,6 +10,8 @@ v_cc_library(
     Seastar::seastar
     v::bytes
     v::net
+  DEFINES
+    -DBOOST_ASIO_HAS_STD_INVOKE_RESULT
 )
 add_subdirectory(tests)
 add_subdirectory(test_client)


### PR DESCRIPTION
## Cover letter

This makes asio use invoke_result instead of result_of for c++20 compatibility (clang-13 has removed it)

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes

* none
