### PR TITLE
archival: Use stable paths in S3 bucket

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -61,7 +61,7 @@ ntp_archiver::ntp_archiver(
       conf.time_limit,
       conf.upload_io_priority)
   , _bucket(conf.bucket_name)
-  , _manifest(_ntp, model::revision_id(_rev()))
+  , _manifest(_ntp, _rev)
   , _gate()
   , _initial_backoff(conf.initial_backoff)
   , _segment_upload_timeout(conf.segment_upload_timeout)
@@ -146,7 +146,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
     retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
 
     auto path = cloud_storage::generate_remote_segment_path(
-      _ntp, model::revision_id(_rev()), candidate.exposed_name, _start_term);
+      _ntp, _rev, candidate.exposed_name, _start_term);
 
     vlog(ctxlog.debug, "Uploading segment {} to {}", candidate, path);
 
@@ -263,7 +263,7 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
         .base_timestamp = upload.base_timestamp,
         .max_timestamp = upload.max_timestamp,
         .delta_offset = delta,
-        .ntp_revision = model::revision_id(_rev()),
+        .ntp_revision = _rev,
         .archiver_term = _start_term,
       },
       .name = upload.exposed_name, .delta = offset - base,

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -45,6 +45,12 @@ using namespace std::chrono_literals;
 /// The 'ntp_archiver' is responsible for manifest manitpulations and
 /// generation of per-ntp candidate set. The actual file uploads are
 /// handled by 'archiver_service'.
+///
+/// Note that archiver uses initial revision of the partition, not the
+/// current one. The revision of the partition can change when the partition
+/// is moved between the nodes. To make all object names stable inside
+/// the S3 bucket we're using initial revision. The revision that the
+/// topic was assigned when it was just created.
 class ntp_archiver {
 public:
     /// Iterator type used to retrieve candidates for upload
@@ -74,7 +80,7 @@ public:
     const model::ntp& get_ntp() const;
 
     /// Get revision id
-    model::revision_id get_revision_id() const;
+    model::initial_revision_id get_revision_id() const;
 
     /// Get timestamp
     const ss::lowres_clock::time_point get_last_upload_time() const;
@@ -163,7 +169,7 @@ private:
     service_probe& _svc_probe;
     ntp_level_probe _probe;
     model::ntp _ntp;
-    model::revision_id _rev;
+    model::initial_revision_id _rev;
     cloud_storage::remote& _remote;
     ss::lw_shared_ptr<cluster::partition> _partition;
     model::term_id _start_term;

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -233,7 +233,7 @@ ss::lw_shared_ptr<ntp_archiver> scheduler_service_impl::get_upload_candidate() {
 }
 
 ss::future<> scheduler_service_impl::upload_topic_manifest(
-  model::topic_namespace topic_ns, model::revision_id rev) {
+  model::topic_namespace topic_ns, model::initial_revision_id rev) {
     gate_guard gg(_gate);
     auto cfg = _topic_table.local().get_topic_cfg(topic_ns);
     if (!cfg) {
@@ -247,7 +247,7 @@ ss::future<> scheduler_service_impl::upload_topic_manifest(
               _topic_manifest_upload_timeout, _initial_backoff, &_rtcnode);
             retry_chain_logger ctxlog(archival_log, fib);
             vlog(ctxlog.info, "Uploading topic manifest {}", topic_ns);
-            cloud_storage::topic_manifest tm(*cfg, rev);
+            cloud_storage::topic_manifest tm(*cfg, model::revision_id(rev()));
             auto key = tm.get_manifest_path();
             vlog(ctxlog.debug, "Topic manifest object key is '{}'", key);
             auto res = co_await _remote.local().upload_manifest(

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -247,7 +247,7 @@ ss::future<> scheduler_service_impl::upload_topic_manifest(
               _topic_manifest_upload_timeout, _initial_backoff, &_rtcnode);
             retry_chain_logger ctxlog(archival_log, fib);
             vlog(ctxlog.info, "Uploading topic manifest {}", topic_ns);
-            cloud_storage::topic_manifest tm(*cfg, model::revision_id(rev()));
+            cloud_storage::topic_manifest tm(*cfg, rev);
             auto key = tm.get_manifest_path();
             vlog(ctxlog.debug, "Topic manifest object key is '{}'", key);
             auto res = co_await _remote.local().upload_manifest(

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -170,7 +170,7 @@ private:
     ss::future<> remove_archivers(std::vector<model::ntp> to_remove);
     ss::future<> create_archivers(std::vector<model::ntp> to_create);
     ss::future<> upload_topic_manifest(
-      model::topic_namespace topic_ns, model::revision_id rev);
+      model::topic_namespace topic_ns, model::initial_revision_id rev);
     /// Adds archiver to the reconciliation loop after fetching its manifest.
     ss::future<ss::stop_iteration>
     add_ntp_archiver(ss::lw_shared_ptr<ntp_archiver> archiver);

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -44,8 +44,8 @@ static const auto manifest_ntp = model::ntp(                    // NOLINT
   manifest_namespace,
   manifest_topic,
   manifest_partition);
-static const auto manifest_revision = model::revision_id(0); // NOLINT
-static const ss::sstring manifest_url = ssx::sformat(        // NOLINT
+static const auto manifest_revision = model::initial_revision_id(0); // NOLINT
+static const ss::sstring manifest_url = ssx::sformat(                // NOLINT
   "/10000000/meta/{}_{}/manifest.json",
   manifest_ntp.path(),
   manifest_revision());

--- a/src/v/cloud_storage/manifest.cc
+++ b/src/v/cloud_storage/manifest.cc
@@ -66,7 +66,7 @@ static bool parse_partition_and_revision(
     if (e.ec != std::errc()) {
         return false;
     }
-    comp._rev = model::revision_id(res);
+    comp._rev = model::initial_revision_id(res);
     return true;
 }
 
@@ -128,11 +128,11 @@ parse_segment_name(const segment_name& name) {
 
 remote_segment_path generate_remote_segment_path(
   const model::ntp& ntp,
-  model::revision_id rev_id,
+  model::initial_revision_id rev_id,
   const segment_name& name,
   model::term_id archiver_term) {
     vassert(
-      rev_id != model::revision_id(),
+      rev_id != model::initial_revision_id(),
       "ntp {}: ntp revision must be known for segment {}",
       ntp,
       name);
@@ -152,7 +152,7 @@ manifest::manifest()
   , _rev()
   , _last_offset(0) {}
 
-manifest::manifest(model::ntp ntp, model::revision_id rev)
+manifest::manifest(model::ntp ntp, model::initial_revision_id rev)
   : _ntp(std::move(ntp))
   , _rev(rev)
   , _last_offset(0) {}
@@ -168,7 +168,7 @@ manifest::manifest(model::ntp ntp, model::revision_id rev)
 // backend and other S3 API implementations might benefit from that.
 
 static remote_manifest_path generate_partition_manifest_path(
-  const model::ntp& ntp, model::revision_id rev) {
+  const model::ntp& ntp, model::initial_revision_id rev) {
     // NOTE: the idea here is to split all possible hash values into
     // 16 bins. Every bin should have lowest 28-bits set to 0.
     // As result, for segment names all prefixes are possible, but
@@ -190,7 +190,7 @@ const model::ntp& manifest::get_ntp() const { return _ntp; }
 
 const model::offset manifest::get_last_offset() const { return _last_offset; }
 
-model::revision_id manifest::get_revision_id() const { return _rev; }
+model::initial_revision_id manifest::get_revision_id() const { return _rev; }
 
 remote_segment_path manifest::generate_segment_path(
   const segment_name& name, const segment_meta& meta) const {
@@ -218,7 +218,7 @@ bool manifest::contains(const segment_name& name) const {
 
 bool manifest::add(const segment_name& name, const segment_meta& meta) {
     auto [it, ok] = _segments.insert(std::make_pair(name, meta));
-    if (ok && it->second.ntp_revision == model::revision_id{}) {
+    if (ok && it->second.ntp_revision == model::initial_revision_id{}) {
         it->second.ntp_revision = _rev;
     }
     _last_offset = std::max(meta.committed_offset, _last_offset);
@@ -276,7 +276,7 @@ void manifest::update(const json::Document& m) {
     auto ns = model::ns(m["namespace"].GetString());
     auto tp = model::topic(m["topic"].GetString());
     auto pt = model::partition_id(m["partition"].GetInt());
-    _rev = model::revision_id(m["revision"].GetInt());
+    _rev = model::initial_revision_id(m["revision"].GetInt());
     _ntp = model::ntp(ns, tp, pt);
     _last_offset = model::offset(m["last_offset"].GetInt64());
     segment_map tmp;
@@ -302,9 +302,9 @@ void manifest::update(const json::Document& m) {
                 delta_offset = model::offset(
                   it->value["delta_offset"].GetInt64());
             }
-            model::revision_id ntp_revision = _rev;
+            model::initial_revision_id ntp_revision = _rev;
             if (it->value.HasMember("ntp_revision")) {
-                ntp_revision = model::revision_id(
+                ntp_revision = model::initial_revision_id(
                   it->value["ntp_revision"].GetInt64());
             }
             model::term_id archiver_term;
@@ -384,7 +384,7 @@ void manifest::serialize(std::ostream& out) const {
             }
             if (meta.ntp_revision != _rev) {
                 vassert(
-                  meta.ntp_revision != model::revision_id(),
+                  meta.ntp_revision != model::initial_revision_id(),
                   "ntp {}: missing ntp_revision for segment {} in the manifest",
                   _ntp,
                   sn);
@@ -412,7 +412,7 @@ bool manifest::delete_permanently(const segment_name& name) {
 }
 
 topic_manifest::topic_manifest(
-  const cluster::topic_configuration& cfg, model::revision_id rev)
+  const cluster::topic_configuration& cfg, model::initial_revision_id rev)
   : _topic_config(cfg)
   , _rev(rev) {}
 
@@ -486,7 +486,7 @@ void topic_manifest::update(const json::Document& m) {
         }
     }
     _topic_config = conf;
-    _rev = model::revision_id(rev);
+    _rev = model::initial_revision_id(rev);
 }
 
 serialized_json_stream topic_manifest::serialize() const {

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -36,7 +36,7 @@ struct manifest_path_components {
     model::ns _ns;
     model::topic _topic;
     model::partition_id _part;
-    model::revision_id _rev;
+    model::initial_revision_id _rev;
 };
 
 std::ostream& operator<<(std::ostream& s, const manifest_path_components& c);
@@ -56,7 +56,7 @@ parse_segment_name(const segment_name& name);
 /// Segment file name in S3
 remote_segment_path generate_remote_segment_path(
   const model::ntp&,
-  model::revision_id,
+  model::initial_revision_id,
   const segment_name&,
   model::term_id archiver_term);
 
@@ -128,7 +128,7 @@ public:
         model::timestamp max_timestamp;
         model::offset delta_offset;
 
-        model::revision_id ntp_revision;
+        model::initial_revision_id ntp_revision;
         model::term_id archiver_term;
 
         auto operator<=>(const segment_meta&) const = default;
@@ -144,7 +144,7 @@ public:
     manifest();
 
     /// Create manifest for specific ntp
-    explicit manifest(model::ntp ntp, model::revision_id rev);
+    explicit manifest(model::ntp ntp, model::initial_revision_id rev);
 
     /// Manifest object name in S3
     remote_manifest_path get_manifest_path() const override;
@@ -156,7 +156,7 @@ public:
     const model::offset get_last_offset() const;
 
     /// Get revision
-    model::revision_id get_revision_id() const;
+    model::initial_revision_id get_revision_id() const;
 
     remote_segment_path
     generate_segment_path(const segment_name&, const segment_meta&) const;
@@ -219,7 +219,7 @@ private:
     void update(const json::Document& m);
 
     model::ntp _ntp;
-    model::revision_id _rev;
+    model::initial_revision_id _rev;
     segment_map _segments;
     model::offset _last_offset;
 };
@@ -228,7 +228,7 @@ class topic_manifest final : public base_manifest {
 public:
     /// Create manifest for specific ntp
     explicit topic_manifest(
-      const cluster::topic_configuration& cfg, model::revision_id rev);
+      const cluster::topic_configuration& cfg, model::initial_revision_id rev);
 
     /// Create empty manifest that supposed to be updated later
     topic_manifest();
@@ -259,10 +259,10 @@ public:
         return manifest_type::partition;
     };
 
-    model::revision_id get_revision() const noexcept { return _rev; }
+    model::initial_revision_id get_revision() const noexcept { return _rev; }
 
     /// Change topic-manifest revision
-    void set_revision(model::revision_id id) noexcept { _rev = id; }
+    void set_revision(model::initial_revision_id id) noexcept { _rev = id; }
 
 private:
     /// Update manifest content from json document that supposed to be generated
@@ -270,7 +270,7 @@ private:
     void update(const json::Document& m);
 
     std::optional<cluster::topic_configuration> _topic_config;
-    model::revision_id _rev;
+    model::initial_revision_id _rev;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -249,7 +249,7 @@ partition_downloader::download_log(const remote_manifest_path& manifest_key) {
       retention);
     auto mat = co_await find_recovery_material(manifest_key);
     auto offset_map = co_await build_offset_map(mat);
-    manifest target(_ntpc.ntp(), _ntpc.get_revision());
+    manifest target(_ntpc.ntp(), _ntpc.get_initial_revision());
     for (const auto& kv : offset_map) {
         target.add(kv.second.name, kv.second.meta);
     }
@@ -314,8 +314,8 @@ partition_downloader::download_log(const remote_manifest_path& manifest_key) {
     // Upload topic manifest for re-created topic (here we don't prevent
     // other partitions of the same topic to read old topic manifest if the
     // revision is different).
-    if (mat.topic_manifest.get_revision() != _ntpc.get_revision()) {
-        mat.topic_manifest.set_revision(_ntpc.get_revision());
+    if (mat.topic_manifest.get_revision() != _ntpc.get_initial_revision()) {
+        mat.topic_manifest.set_revision(_ntpc.get_initial_revision());
         upl_result = co_await _remote->upload_manifest(
           _bucket, mat.topic_manifest, _rtcnode);
         if (upl_result != upload_result::success) {
@@ -435,7 +435,7 @@ partition_downloader::download_log_with_capped_time(
 ss::future<manifest>
 partition_downloader::download_manifest(const remote_manifest_path& key) {
     vlog(_ctxlog.info, "Downloading manifest {}", key);
-    manifest manifest(_ntpc.ntp(), _ntpc.get_revision());
+    manifest manifest(_ntpc.ntp(), _ntpc.get_initial_revision());
     auto result = co_await _remote->download_manifest(
       _bucket, key, manifest, _rtcnode);
     if (result != download_result::success) {

--- a/src/v/cloud_storage/tests/common_def.h
+++ b/src/v/cloud_storage/tests/common_def.h
@@ -18,7 +18,7 @@ static const auto manifest_ntp = model::ntp(                    // NOLINT
   manifest_namespace,
   manifest_topic,
   manifest_partition);
-static const auto manifest_revision = model::revision_id(0); // NOLINT
+static const auto manifest_revision = model::initial_revision_id(0); // NOLINT
 static const auto archiver_term = model::term_id{123};
 static const ss::sstring manifest_url = ssx::sformat( // NOLINT
   "20000000/meta/{}_{}/manifest.json",

--- a/src/v/cloud_storage/tests/manifest_test.cc
+++ b/src/v/cloud_storage/tests/manifest_test.cc
@@ -80,7 +80,7 @@ inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_manifest_path) {
-    manifest m(manifest_ntp, model::revision_id(0));
+    manifest m(manifest_ntp, model::initial_revision_id(0));
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
       path, "20000000/meta/test-ns/test-topic/42_0/manifest.json");
@@ -89,7 +89,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_path) {
 SEASTAR_THREAD_TEST_CASE(test_segment_path) {
     auto path = generate_remote_segment_path(
       manifest_ntp,
-      model::revision_id(0),
+      model::initial_revision_id(0),
       segment_name("22-11-v1.log"),
       model::term_id{123});
     // use pre-calculated murmur hash value from full ntp path + file name
@@ -148,7 +148,7 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
-    manifest m(manifest_ntp, model::revision_id(0));
+    manifest m(manifest_ntp, model::initial_revision_id(0));
     m.add(
       segment_name("10-1-v1.log"),
       {
@@ -157,7 +157,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
         .base_offset = model::offset(10),
         .committed_offset = model::offset(19),
         .max_timestamp = model::timestamp::missing(),
-        .ntp_revision = model::revision_id(0),
+        .ntp_revision = model::initial_revision_id(0),
       });
     m.add(
       segment_name("20-1-v1.log"),
@@ -167,7 +167,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
         .base_offset = model::offset(20),
         .committed_offset = model::offset(29),
         .max_timestamp = model::timestamp::missing(),
-        .ntp_revision = model::revision_id(3),
+        .ntp_revision = model::initial_revision_id(3),
       });
     auto [is, size] = m.serialize();
     iobuf buf;
@@ -182,11 +182,11 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_manifest_difference) {
-    manifest a(manifest_ntp, model::revision_id(0));
+    manifest a(manifest_ntp, model::initial_revision_id(0));
     a.add(segment_name("1-1-v1.log"), {});
     a.add(segment_name("2-2-v1.log"), {});
     a.add(segment_name("3-3-v1.log"), {});
-    manifest b(manifest_ntp, model::revision_id(0));
+    manifest b(manifest_ntp, model::initial_revision_id(0));
     b.add(segment_name("1-1-v1.log"), {});
     b.add(segment_name("2-2-v1.log"), {});
     {
@@ -316,12 +316,12 @@ SEASTAR_THREAD_TEST_CASE(test_segment_meta_serde_compat) {
       .base_timestamp = timestamp,
       .max_timestamp = timestamp,
       .delta_offset = model::offset{7},
-      .ntp_revision = model::revision_id{42},
+      .ntp_revision = model::initial_revision_id{42},
       .archiver_term = model::term_id{123},
     };
 
     cloud_storage::manifest::segment_meta meta_wo_new_fields = meta_new;
-    meta_wo_new_fields.ntp_revision = model::revision_id{};
+    meta_wo_new_fields.ntp_revision = model::initial_revision_id{};
     meta_wo_new_fields.archiver_term = model::term_id{};
 
     old::segment_meta_v0 meta_old{

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -62,7 +62,7 @@ FIXTURE_TEST(
     remote remote(s3_connection_limit(10), conf);
     manifest m(manifest_ntp, manifest_revision);
     auto name = segment_name("1-2-v1.log");
-    model::revision_id segment_ntp_revision{777};
+    model::initial_revision_id segment_ntp_revision{777};
     iobuf segment_bytes = generate_segment(model::offset(1), 20);
     uint64_t clen = segment_bytes.size_bytes();
     auto action = ss::defer([&remote] { remote.stop().get(); });

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -14,6 +14,7 @@
 #include "cloud_storage/manifest.h"
 #include "cloud_storage/remote.h"
 #include "cluster/persisted_stm.h"
+#include "model/metadata.h"
 #include "utils/mutex.h"
 #include "utils/prefix_logger.h"
 #include "utils/retry_chain_node.h"

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -40,26 +40,33 @@ topic_table::transform_topics(Func&& f) const {
 topic_table::topic_metadata::topic_metadata(
   topic_configuration_assignment c, model::revision_id rid) noexcept
   : configuration(std::move(c))
-  , _id_or_topic(rid) {}
+  , _source_topic(std::nullopt)
+  , _revision(rid) {}
 
 topic_table::topic_metadata::topic_metadata(
-  topic_configuration_assignment c, model::topic st) noexcept
+  topic_configuration_assignment c,
+  model::revision_id rid,
+  model::topic st) noexcept
   : configuration(std::move(c))
-  , _id_or_topic(std::move(st)) {}
+  , _source_topic(st)
+  , _revision(rid) {}
 
 bool topic_table::topic_metadata::is_topic_replicable() const {
-    return std::holds_alternative<model::revision_id>(_id_or_topic);
+    return _source_topic.has_value() == false;
 }
+
 model::revision_id topic_table::topic_metadata::get_revision() const {
     vassert(
       is_topic_replicable(), "Query for revision_id on a non-replicable topic");
-    return std::get<model::revision_id>(_id_or_topic);
+    return _revision;
 }
+
 const model::topic& topic_table::topic_metadata::get_source_topic() const {
     vassert(
       !is_topic_replicable(), "Query for source_topic on a replicable topic");
-    return std::get<model::topic>(_id_or_topic);
+    return _source_topic.value();
 }
+
 const topic_configuration_assignment&
 topic_table::topic_metadata::get_configuration() const {
     return configuration;
@@ -460,7 +467,8 @@ topic_table::apply(create_non_replicable_topic_cmd cmd, model::offset o) {
           "Duplicate non_replicable_topic detected when it shouldn't exist");
     }
     _topics.insert(
-      {new_non_rep_topic, topic_metadata(std::move(ca), source.tp)});
+      {new_non_rep_topic,
+       topic_metadata(std::move(ca), model::revision_id(o()), source.tp)});
     notify_waiters();
     co_return make_error_code(errc::success);
 }
@@ -605,6 +613,19 @@ topic_table::get_partition_assignment(const model::ntp& ntp) const {
 
 bool topic_table::is_update_in_progress(const model::ntp& ntp) const {
     return _update_in_progress.contains(ntp);
+}
+
+std::optional<model::initial_revision_id>
+topic_table::get_initial_revision(model::topic_namespace_view tp) const {
+    if (auto it = _topics.find(tp); it != _topics.end()) {
+        return model::initial_revision_id(it->second.get_revision()());
+    }
+    return std::nullopt;
+}
+
+std::optional<model::initial_revision_id>
+topic_table::get_initial_revision(const model::ntp& ntp) const {
+    return get_initial_revision(model::topic_namespace_view(ntp));
 }
 
 } // namespace cluster

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -68,7 +68,8 @@ topic_configuration::topic_configuration(
 storage::ntp_config topic_configuration::make_ntp_config(
   const ss::sstring& work_dir,
   model::partition_id p_id,
-  model::revision_id rev) const {
+  model::revision_id rev,
+  model::initial_revision_id init_rev) const {
     auto has_overrides = properties.has_overrides() || is_internal();
     std::unique_ptr<storage::ntp_config::default_overrides> overrides = nullptr;
 
@@ -89,11 +90,12 @@ storage::ntp_config topic_configuration::make_ntp_config(
                                       ? *properties.shadow_indexing
                                       : model::shadow_indexing_mode::disabled});
     }
-    return storage::ntp_config(
+    return {
       model::ntp(tp_ns.ns, tp_ns.tp, p_id),
       work_dir,
       std::move(overrides),
-      rev);
+      rev,
+      init_rev};
 }
 
 model::topic_metadata topic_configuration_assignment::get_metadata() const {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -411,7 +411,10 @@ struct topic_configuration {
       int16_t replication_factor);
 
     storage::ntp_config make_ntp_config(
-      const ss::sstring&, model::partition_id, model::revision_id) const;
+      const ss::sstring&,
+      model::partition_id,
+      model::revision_id,
+      model::initial_revision_id) const;
 
     bool is_internal() const {
         return tp_ns.ns == model::kafka_internal_namespace;

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -19,6 +19,7 @@
 #include "coproc/pacemaker.h"
 #include "coproc/partition_manager.h"
 #include "coproc/script_database.h"
+#include "model/metadata.h"
 #include "storage/api.h"
 
 #include <seastar/core/coroutine.hh>
@@ -362,8 +363,13 @@ reconciliation_backend::create_non_replicable_partition(
               ? errc::success
               : errc::partition_not_exists;
         }
+        // Non-replicated topics are not integrated with shadow indexing yet,
+        // so the initial_revision_id is set to invalid value.
         auto ntp_cfg = tt_md->second.get_configuration().cfg.make_ntp_config(
-          _data_directory, ntp.tp.partition, rev);
+          _data_directory,
+          ntp.tp.partition,
+          rev,
+          model::initial_revision_id{-1});
         co_await _coproc_pm.local().manage(std::move(ntp_cfg), src_partition);
     } else if (copro_partition->get_revision_id() < rev) {
         co_return errc::partition_already_exists;

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -35,6 +35,15 @@ using node_id = named_type<int32_t, struct node_id_model_type>;
  * first created and then removed, raft configuration
  */
 using revision_id = named_type<int64_t, struct revision_id_model_type>;
+
+/**
+ * Revision id that the partition had when the topic was just created.
+ * The revision_id of the partition might change when the partition is moved
+ * between the nodes.
+ */
+using initial_revision_id
+  = named_type<int64_t, struct initial_revision_id_model_type>;
+
 struct broker_properties {
     uint32_t cores;
     uint32_t available_memory;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -75,10 +75,26 @@ public:
       , _overrides(std::move(overrides))
       , _revision_id(id) {}
 
+    ntp_config(
+      model::ntp n,
+      ss::sstring base_dir,
+      std::unique_ptr<default_overrides> overrides,
+      model::revision_id id,
+      model::initial_revision_id initial_id) noexcept
+      : _ntp(std::move(n))
+      , _base_dir(std::move(base_dir))
+      , _overrides(std::move(overrides))
+      , _revision_id(id)
+      , _initial_rev(initial_id) {}
+
     const model::ntp& ntp() const { return _ntp; }
     model::ntp& ntp() { return _ntp; }
 
     model::revision_id get_revision() const { return _revision_id; }
+
+    model::initial_revision_id get_initial_revision() const {
+        return _initial_rev;
+    }
 
     const ss::sstring& base_directory() const { return _base_dir; }
     ss::sstring& base_directory() { return _base_dir; }
@@ -148,6 +164,14 @@ private:
      * than once (i.e. created, deleted and then created again)
      */
     model::revision_id _revision_id{0};
+
+    /**
+     * A number indicating an initial revision of the NTP. The revision
+     * of the NTP might change when the partition is moved between the
+     * nodes. The initial revision is the revision_id that was assigned
+     * to the topic when it was created.
+     */
+    model::initial_revision_id _initial_rev{0};
 
     // in storage/types.cc
     friend std::ostream& operator<<(std::ostream&, const ntp_config&);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -68,14 +68,27 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
 }
 
 std::ostream& operator<<(std::ostream& o, const ntp_config& v) {
-    o << "{ntp:" << v.ntp() << ", base_dir:" << v.base_directory()
-      << ", overrides:";
     if (v.has_overrides()) {
-        o << v.get_overrides();
+        fmt::print(
+          o,
+          "{{ntp: {}, base_dir: {}, overrides: {}, revision: {}, "
+          "initial_revision: {}}}",
+          v.ntp(),
+          v.base_directory(),
+          v.get_overrides(),
+          v.get_revision(),
+          v.get_initial_revision());
     } else {
-        o << "nullptr";
+        fmt::print(
+          o,
+          "{{ntp: {}, base_dir: {}, overrides: nullptr, revision: {}, "
+          "initial_revision: {}}}",
+          v.ntp(),
+          v.base_directory(),
+          v.get_revision(),
+          v.get_initial_revision());
     }
-    return o << "}";
+    return o;
 }
 
 std::ostream& operator<<(std::ostream& o, const truncate_config& cfg) {


### PR DESCRIPTION
## Cover letter

Currently, the revision-id is used as part of the segment path and manifest path in S3. This creates the following issue: if the partition was moved, the revision id increases. So the archiver for the subsystem can't find the original manifest in the S3 and some subset of the data can be re-uploaded. Also, shadow indexing can't 'see' some segments.

The issue in #3316 was also caused by this. During the raft bootstrap the moved raft group the initial revision id is assigned first. But after the partition assignment is applied the revision id increases and this can cause inconsistency in manifest versions during archival_metadata_stm sync.

The solution is to always use initial revision id in the archival/SI. The initial revision id is assigned during topic creation and never changes. It's obtained via the `topic_table` the manifest and all paths has this value instead of revision id (which could change).

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/05a78b60385364c21f267bddf18c06c4cf1eff33..8caa4d21188d671813c3ce0222e6cbe6baa6d749)
- Code review fixes
- Add ducktape test that reproduces the problem

Change in [force push](https://github.com/vectorizedio/redpanda/compare/8caa4d21188d671813c3ce0222e6cbe6baa6d749..b9ff3a96bf2802368222f2f9658e5a0c07504740)
- Code review fixes
- Rebase with dev

Change in [force push](https://github.com/vectorizedio/redpanda/compare/b9ff3a96bf2802368222f2f9658e5a0c07504740..4295b9c9d97b2ecd6750302fac82d35aee942709)
- Code review fixes
- Remove the test (it will be re-introduced in a different PR)

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/bb06a4b8d7022ac053a89bfa8690819c293c3781..00fde037c09c423866fcf5e63479f9cf2b2bd43a)
- Rebase with dev

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/00fde037c09c423866fcf5e63479f9cf2b2bd43a..21736c64f21d6947b351ff1d0f61ee8166aa6faa)
- Fix code review issue

<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3316

## Release notes

*none
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
