### PR TITLE
k8s: fix how schema reg node cert is mounted

### DIFF
--- a/src/go/k8s/pkg/resources/certmanager/pki.go
+++ b/src/go/k8s/pkg/resources/certmanager/pki.go
@@ -169,6 +169,7 @@ func (r *PkiReconciler) prepareAPI(
 		return []resources.Resource{}, nil
 	}
 
+	// TODO(#3550): Do not create rootIssuer if nodeSecretRef is passed and mTLS is disabled
 	toApplyRoot, rootIssuerRef := r.prepareRoot(rootCertSuffix)
 	toApply = append(toApply, toApplyRoot...)
 	nodeIssuerRef = rootIssuerRef

--- a/src/go/k8s/pkg/resources/certmanager/pki_test.go
+++ b/src/go/k8s/pkg/resources/certmanager/pki_test.go
@@ -1,0 +1,115 @@
+package certmanager_test
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/stretchr/testify/require"
+	"github.com/vectorizedio/redpanda/src/go/k8s/apis/redpanda/v1alpha1"
+	"github.com/vectorizedio/redpanda/src/go/k8s/pkg/resources/certmanager"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSchemaRegistryCerts(t *testing.T) {
+	testcases := []struct {
+		name                   string
+		cluster                v1alpha1.Cluster
+		expectedClientCertName string
+		expectedNodeCertName   string
+	}{
+		{
+			name: "SchemaRegistry: When NodeSecretRef is used",
+			cluster: v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "redpanda",
+					Name:      "fake-cluster",
+				},
+				Spec: v1alpha1.ClusterSpec{
+					Configuration: v1alpha1.RedpandaConfig{
+						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
+							TLS: &v1alpha1.SchemaRegistryAPITLS{
+								Enabled: true,
+								NodeSecretRef: &v1.ObjectReference{
+									Namespace: "other-namespace",
+									Name:      "custom-secret-ref",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedClientCertName: "fake-cluster-schema-registry-client",
+			expectedNodeCertName:   "custom-secret-ref",
+		},
+		{
+			name: "SchemaRegistry: When IssuerRef is used",
+			cluster: v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "redpanda",
+					Name:      "fake-cluster",
+				},
+				Spec: v1alpha1.ClusterSpec{
+					Configuration: v1alpha1.RedpandaConfig{
+						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
+							TLS: &v1alpha1.SchemaRegistryAPITLS{
+								Enabled: true,
+								IssuerRef: &cmmeta.ObjectReference{
+									Group: "certmanager",
+									Kind:  "ClusterIssuer",
+									Name:  "cluster-issuer",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedClientCertName: "fake-cluster-schema-registry-client",
+			expectedNodeCertName:   "fake-cluster-schema-registry-node",
+		},
+		{
+			// TODO(#3550): refactor how methods used to get APIs node and client certificates behiave when
+			// TLS ot mTLS are disabled. Currently they always return a NamespacedName pointing to the a
+			// default certificate but that certificate doesn't exist.
+			// A better approach might be to return a certificate or secret object which could be nil in case
+			// TLS or mTLS are disabled.
+			name: "SchemaRegistry: When TLS and mTLS are disabled",
+			cluster: v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "redpanda",
+					Name:      "fake-cluster-with-no-mtls",
+				},
+				Spec: v1alpha1.ClusterSpec{
+					Configuration: v1alpha1.RedpandaConfig{
+						SchemaRegistry: &v1alpha1.SchemaRegistryAPI{
+							TLS: &v1alpha1.SchemaRegistryAPITLS{
+								RequireClientAuth: false,
+								Enabled:           false,
+							},
+						},
+					},
+				},
+			},
+			expectedClientCertName: "fake-cluster-with-no-mtls-schema-registry-client",
+			expectedNodeCertName:   "fake-cluster-with-no-mtls-schema-registry-node",
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			pki := certmanager.NewPki(nil, &tt.cluster, "FQDN", "clusterFQDN", nil, logr.Discard())
+			// Client cert
+			clientCert := pki.SchemaRegistryAPIClientCert()
+			require.NotNil(t, clientCert)
+			require.Equal(t, tt.expectedClientCertName, clientCert.Name)
+			require.Equal(t, tt.cluster.ObjectMeta.Namespace, clientCert.Namespace)
+
+			// Node cert
+			nodeCert := pki.SchemaRegistryAPINodeCert()
+			require.NotNil(t, nodeCert)
+			require.Equal(t, tt.expectedNodeCertName, nodeCert.Name)
+			require.Equal(t, tt.cluster.ObjectMeta.Namespace, nodeCert.Namespace)
+		})
+	}
+}

--- a/src/go/k8s/pkg/resources/certmanager/schemaregistry_api.go
+++ b/src/go/k8s/pkg/resources/certmanager/schemaregistry_api.go
@@ -20,6 +20,13 @@ const (
 
 // SchemaRegistryAPINodeCert returns the namespaced name for the SchemaRegistry API certificate used by nodes
 func (r *PkiReconciler) SchemaRegistryAPINodeCert() types.NamespacedName {
+	schemaRegistryTLSListener := getTLSListener(schemaRegistryAPIListeners(r.pandaCluster))
+	if schemaRegistryTLSListener != nil && schemaRegistryTLSListener.GetTLS() != nil && schemaRegistryTLSListener.GetTLS().NodeSecretRef != nil {
+		return types.NamespacedName{
+			Name:      schemaRegistryTLSListener.GetTLS().NodeSecretRef.Name,
+			Namespace: r.pandaCluster.Namespace,
+		}
+	}
 	return types.NamespacedName{Name: r.pandaCluster.Name + "-" + schemaRegistryAPINodeCert, Namespace: r.pandaCluster.Namespace}
 }
 

--- a/src/go/k8s/tests/README.md
+++ b/src/go/k8s/tests/README.md
@@ -13,3 +13,22 @@ To run a single e2e test
 ```
 TEST_NAME=testname make e2e-tests
 ```
+
+Useful flags for debugging that can be set via `KUTTL_TEST_FLAGS` env var
+
+```
+--skip-cluster-delete
+If set, do not delete the mocked control plane or kind cluster.
+
+--skip-delete
+If set, do not delete resources created during tests (helpful for debugging test failures, implies --skip-cluster-delete).
+To run a single e2e test and keep the kind cluster and the kutt
+```
+
+For example:
+
+```
+KUTTL_TEST_FLAGS="--skip-cluster-delete --skip-delete" \ 
+  TEST_NAME=create-topic-given-cm-secret-client-auth \
+  make e2e-tests
+```

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/00-create-cluster-issuer.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/00-create-cluster-issuer.yaml
@@ -24,6 +24,12 @@ metadata:
   namespace: given-cert
 spec:
   isCA: true
+  # Needed because certs signed by this CA get the `issuer` field filed based on this.
+  # If issuer field is empty, curl will complain with `SSL: couldn't get X509-issuer name`
+  # To verify issuer of a cert use: `openssl x509 -noout -issuer`
+  subject:
+    organizations:
+      - vectorized-test.io
   dnsNames:
     - "cluster.local"
   issuerRef:
@@ -52,7 +58,10 @@ metadata:
   namespace: given-cert
 spec:
   dnsNames:
+    # Kafka API
     - "*.cluster-tls.given-cert.svc.cluster.local"
+    # Schema Registry API
+    - "cluster-tls-cluster.given-cert.svc.cluster.local"
   issuerRef:
     kind: Issuer
     name: cluster-tls-root-issuer

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/01-redpanda-cluster.yaml
@@ -24,6 +24,13 @@ spec:
         nodeSecretRef:
           name: cluster-tls-node-certificate
           namespace: given-cert
+    schemaRegistry:
+      port: 8081
+      tls:
+        enabled: true
+        nodeSecretRef:
+          name: cluster-tls-node-certificate
+          namespace: given-cert
     adminApi:
     - port: 9644
     developerMode: true

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/04-assert.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-tls
+  namespace: given-cert
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cert-secret/04-create-schema.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cert-secret/04-create-schema.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-tls
+  namespace: given-cert
+spec:
+  template:
+    spec:
+      volumes:
+      - name: tlscert
+        secret:
+          defaultMode: 420
+          secretName: cluster-tls-node-certificate
+      containers:
+      - name: rpk
+        image: localhost/redpanda:dev
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+        - /bin/bash
+        - -c
+        args:
+        - >
+          curl -vv --silent --cacert /etc/tls/certs/schema-registry/ca.crt
+          -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json"
+          --data '{"schema": "{\"type\": \"string\"}" }'
+          https://cluster-tls-cluster.$POD_NAMESPACE.svc.cluster.local.:8081/subjects/Kafka-value/versions
+        volumeMounts:
+        - mountPath: /etc/tls/certs/schema-registry
+          name: tlscert
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1
+
+---

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/00-create-certificate.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/00-create-certificate.yaml
@@ -50,8 +50,11 @@ metadata:
   namespace: cert-manager
 spec:
   dnsNames:
+    # Kakfa API
     - "*.cluster-tls-secret.given-cert-secret.svc.cluster.local"
+    # Schema registry API
+    - "cluster-tls-secret-cluster.given-cert-secret.svc.cluster.local"
   issuerRef:
     kind: Issuer
     name: cluster-tls-secret-root-issuer
-  secretName: cluster-tls-secret-node-certificate 
+  secretName: cluster-tls-secret-node-certificate

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/01-redpanda-cluster.yaml
@@ -25,6 +25,14 @@ spec:
         nodeSecretRef:
           name: cluster-tls-secret-node-certificate
           namespace: cert-manager
+    schemaRegistry:
+      port: 8081
+      tls:
+        enabled: true
+        requireClientAuth: true
+        nodeSecretRef:
+          name: cluster-tls-secret-node-certificate
+          namespace: cert-manager
     adminApi:
     - port: 9644
     developerMode: true

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/04-assert.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-client-tls
+  namespace: given-cert-secret
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/04-create-schema.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-cm-secret-client-auth/04-create-schema.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-client-tls
+  namespace: given-cert-secret
+spec:
+  template:
+    spec:
+      volumes:
+        - name: tlscert
+          secret:
+            defaultMode: 420
+            secretName: cluster-tls-secret-schema-registry-client
+        - name: tlscertca
+          secret:
+            defaultMode: 420
+            secretName: cluster-tls-secret-node-certificate
+      containers:
+        - name: rpk
+          image: localhost/redpanda:dev
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - >
+              curl -vv --silent
+              --cacert /etc/tls/certs/schema-registry/ca/ca.crt
+              --cert /etc/tls/certs/schema-registry/tls.crt
+              --key /etc/tls/certs/schema-registry/tls.key
+              -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json"
+              --data '{"schema": "{\"type\": \"string\"}" }'
+              https://cluster-tls-secret-cluster.$POD_NAMESPACE.svc.cluster.local.:8081/subjects/Kafka-value/versions
+          volumeMounts:
+            - mountPath: /etc/tls/certs/schema-registry
+              name: tlscert
+            - mountPath: /etc/tls/certs/schema-registry/ca
+              name: tlscertca
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/00-create-cluster-issuer.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/00-create-cluster-issuer.yaml
@@ -15,6 +15,12 @@ metadata:
   namespace: cert-manager # ns allows us to generate ClusterIssuer
 spec:
   isCA: true
+  # Needed because certs signed by this CA get the `issuer` field filed based on this.
+  # If issuer field is empty, curl will complain with `SSL: couldn't get X509-issuer name`
+  # To verify issuer of a cert use: `openssl x509 -noout -issuer`
+  subject:
+    organizations:
+      - vectorized-test.io
   dnsNames:
     - "cluster.local"
   issuerRef:

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/01-redpanda-cluster.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/01-redpanda-cluster.yaml
@@ -26,6 +26,13 @@ spec:
         issuerRef:
           name: cluster-tls-root-issuer
           kind: ClusterIssuer
+    schemaRegistry:
+      port: 8081
+      tls:
+        enabled: true
+        issuerRef:
+          name: cluster-tls-root-issuer
+          kind: ClusterIssuer
     adminApi:
     - port: 9644
     developerMode: true

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/04-assert.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/04-assert.yaml
@@ -1,0 +1,19 @@
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-tls
+status:
+  conditions:
+    - status: "True"
+      type: Complete
+  succeeded: 1
+
+---
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app.kubernetes.io/name=redpanda
+  tail: -1

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/04-create-schema.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/04-create-schema.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-schema-with-tls
+spec:
+  template:
+    spec:
+      volumes:
+      - name: tlscert
+        secret:
+          defaultMode: 420
+          secretName: cluster-tls-schema-registry-node
+      containers:
+      - name: rpk
+        image: localhost/redpanda:dev
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+        - /bin/bash
+        - -c
+        args:
+        - >
+          curl -vv --silent --cacert /etc/tls/certs/schema-registry/ca.crt
+          -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json"
+          --data '{"schema": "{\"type\": \"string\"}" }'
+          https://cluster-tls-cluster.$POD_NAMESPACE.svc.cluster.local.:8081/subjects/Kafka-value/versions
+        volumeMounts:
+        - mountPath: /etc/tls/certs/schema-registry
+          name: tlscert
+      restartPolicy: Never
+  backoffLimit: 6
+  parallelism: 1
+  completions: 1
+
+---


### PR DESCRIPTION
## Cover letter

Previously, when a NodeSecretRef was used to configure the Schema
Registry TLS certificate, the operator was trying to mount a secret with
the default certificate name instead of using the secret referenced by
NodeSecretRef.

Fixes #3494


