### PR TITLE
Reduce tx p99 latency by 2.6x by adding early return from quorum ack

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -902,7 +902,7 @@ rm_stm::replicate_tx(model::batch_identity bid, model::record_batch_reader br) {
     auto r = co_await _c->replicate(
       _mem_state.term,
       std::move(br),
-      raft::replicate_options(raft::consistency_level::leader_ack));
+      raft::replicate_options(raft::consistency_level::tx_ack));
     if (!r) {
         if (_mem_state.estimated.contains(bid.pid)) {
             // an error during replication, preventin tx from progress

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1761,6 +1761,7 @@ kafka::error_code map_store_offset_error_code(std::error_code ec) {
         case raft::errc::group_not_exists:
         case raft::errc::replicate_first_stage_exception:
         case raft::errc::transfer_to_current_leader:
+        case raft::errc::oplock_exception:
             return error_code::unknown_server_error;
         }
     }

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -494,7 +494,7 @@ recovery_batch_consumer::operator()(model::record_batch batch) {
           batch, group::commit_tx_record_version);
 
         auto [group_it, _] = st.groups.try_emplace(cmd.cmd.group_id);
-        group_it->second.commit(cmd.pid);
+        group_it->second.commit(batch.last_offset(), cmd.pid);
 
         return ss::make_ready_future<ss::stop_iteration>(
           ss::stop_iteration::no);

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -37,9 +37,10 @@ void group_stm::update_prepared(
     } else if (!inserted && prepared_it->second.pid.epoch < tx.pid.epoch) {
         vlog(
           cluster::txlog.warn,
-          "a logged tx {} overwrites prev logged tx {}",
+          "a logged tx {} overwrites prev logged tx {} offset: {}",
           val.pid,
-          prepared_it->second.pid);
+          prepared_it->second.pid,
+          offset);
         prepared_it->second.pid = tx.pid;
         prepared_it->second.offsets.clear();
     }
@@ -56,7 +57,7 @@ void group_stm::update_prepared(
     }
 }
 
-void group_stm::commit(model::producer_identity pid) {
+void group_stm::commit(model::offset offset, model::producer_identity pid) {
     auto prepared_it = _prepared_txs.find(pid.get_id());
     if (prepared_it == _prepared_txs.end()) {
         // missing prepare may happen when the consumer log gets truncated
@@ -65,9 +66,10 @@ void group_stm::commit(model::producer_identity pid) {
     } else if (prepared_it->second.pid.epoch != pid.epoch) {
         vlog(
           cluster::txlog.warn,
-          "a comitting tx {} doesn't match ongoing tx {}",
+          "a comitting tx {} doesn't match ongoing tx {} offset: {}",
           pid,
-          prepared_it->second.pid);
+          prepared_it->second.pid,
+          offset);
         return;
     }
 

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -123,7 +123,7 @@ public:
       model::topic_partition, model::offset, group_log_offset_metadata&&);
     void remove_offset(model::topic_partition);
     void update_prepared(model::offset, group_log_prepared_tx);
-    void commit(model::producer_identity);
+    void commit(model::offset, model::producer_identity);
     void abort(model::producer_identity, model::tx_seq);
     void try_set_fence(model::producer_id id, model::producer_epoch epoch) {
         auto [fence_it, _] = _fence_pid_epoch.try_emplace(id, epoch);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -355,7 +355,8 @@ private:
     ss::future<result<replicate_result>> dispatch_replicate(
       append_entries_request,
       std::vector<ss::semaphore_units<>>,
-      absl::flat_hash_map<vnode, follower_req_seq>);
+      absl::flat_hash_map<vnode, follower_req_seq>,
+      ss::lw_shared_ptr<leader_ack_result>);
     /**
      * Hydrate the consensus state with the data from the snapshot
      */

--- a/src/v/raft/errc.h
+++ b/src/v/raft/errc.h
@@ -39,6 +39,7 @@ enum class errc : int16_t {
     replicate_batcher_cache_error,
     group_not_exists,
     replicate_first_stage_exception,
+    oplock_exception
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "raft::errc"; }
@@ -93,6 +94,8 @@ struct errc_category final : public std::error_category {
         case errc::replicate_first_stage_exception:
             return "unable to finish replicate since exception was thrown in "
                    "first phase";
+        case errc::oplock_exception:
+            return "unable to take op lock";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -85,7 +85,8 @@ public:
     replicate_entries_stm(
       consensus*,
       append_entries_request,
-      absl::flat_hash_map<vnode, follower_req_seq>);
+      absl::flat_hash_map<vnode, follower_req_seq>,
+      ss::lw_shared_ptr<leader_ack_result>);
     ~replicate_entries_stm();
 
     /// caller have to pass semaphore units, the apply call will do the
@@ -121,6 +122,7 @@ private:
     model::offset _dirty_offset;
     model::offset _initial_committed_offset;
     ss::lw_shared_ptr<std::vector<ss::semaphore_units<>>> _units;
+    ss::lw_shared_ptr<leader_ack_result> _leader_outcome;
 };
 
 } // namespace raft

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -94,6 +94,9 @@ std::ostream& operator<<(std::ostream& o, const consistency_level& l) {
     case consistency_level::no_ack:
         o << "consistency_level::no_ack";
         break;
+    case consistency_level::tx_ack:
+        o << "consistency_level::tx_ack";
+        break;
     default:
         o << "unknown consistency_level";
     }

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -22,6 +22,7 @@
 #include "raft/fwd.h"
 #include "raft/group_configuration.h"
 #include "reflection/async_adl.h"
+#include "utils/available_promise.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/condition-variable.hh>
@@ -324,8 +325,12 @@ struct replicate_stages {
     // requested consistency level
     ss::future<result<replicate_result>> replicate_finished;
 };
+// leader_ack like replicate result calculated along the quorum_ack code path
+struct leader_ack_result {
+    available_promise<result<replicate_result>> offset;
+};
 
-enum class consistency_level { quorum_ack, leader_ack, no_ack };
+enum class consistency_level { quorum_ack, leader_ack, no_ack, tx_ack };
 
 struct replicate_options {
     explicit replicate_options(consistency_level l)

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -297,7 +297,7 @@ log_reader::do_load_slice(model::timeout_clock::time_point timeout) {
           if (!recs) {
               set_end_of_stream();
               vlog(
-                stlog.info,
+                stlog.trace,
                 "stopped reading stream: {}",
                 recs.error().message());
               return _iterator.close().then(

--- a/src/v/utils/available_promise.h
+++ b/src/v/utils/available_promise.h
@@ -20,8 +20,10 @@ public:
     ss::future<T> get_future() { return _promise.get_future(); }
 
     void set_value(T&& value) {
-        _available = true;
-        _promise.set_value(std::move(value));
+        if (likely(!_available)) {
+            _available = true;
+            _promise.set_value(std::move(value));
+        }
     }
 
     bool available() { return _available; }


### PR DESCRIPTION
## Cover letter

Redpanda transactions use an access pattern in which consistency level constantly switches from acks=all to acks=1 and back. Unfortunately this behavior has negative latency impact.
    
Introducing a new consistency level: tx_ack which uses acks=quorum code path but returns control flow as soon as data hits disk. With this level we transactions has latency profile of acks=1 without the negative impact of the switching.
    
It reduces pathological case from p99=42ms to p99=16ms

## Release notes

* none

### Improvements

* Improve p99 latency of transactions