### PR TITLE
test: fix ducktape linter errors

### DIFF
--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -11,7 +11,7 @@ import subprocess
 import time
 import json
 
-from ducktape.utils.util import wait_until
+from rptest.util import wait_until_result
 
 
 class KafkaCat:
@@ -71,15 +71,13 @@ class KafkaCat:
         if not timeout_sec:
             return self._get_partition_leader(topic, partition)
 
-        leader = [None]
-
         def get_leader():
-            res = self._get_partition_leader(topic, partition)
-            leader[0] = res
-            return leader[0][0] is not None
+            leader = self._get_partition_leader(topic, partition)
+            return leader[0] is not None, leader
 
-        wait_until(get_leader, timeout_sec=timeout_sec, backoff_sec=2)
-        return leader[0]
+        return wait_until_result(get_leader,
+                                 timeout_sec=timeout_sec,
+                                 backoff_sec=2)
 
     def _get_partition_leader(self, topic, partition):
         topic_meta = None

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -135,7 +135,7 @@ class RpkTool:
         # message rather than sigkilling the remote process.
         out = self._run_topic(cmd, stdin=msg, timeout=timeout + 0.5)
 
-        offset = re.search("at offset (\d+)", out).group(1)
+        offset = re.search(r"at offset (\d+)", out).group(1)
         return int(offset)
 
     def describe_topic(self, topic):

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -163,8 +163,8 @@ class RpkTool:
     def describe_topic_configs(self, topic):
         cmd = ['describe', topic, '-c']
         output = self._run_topic(cmd)
-        if "not found" in output:
-            return None
+        assert "not found" not in output, \
+                f"Cannot describe configs for unknown topic {topic}"
         lines = output.splitlines()
         res = {}
         for line in lines:

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -135,8 +135,9 @@ class RpkTool:
         # message rather than sigkilling the remote process.
         out = self._run_topic(cmd, stdin=msg, timeout=timeout + 0.5)
 
-        offset = re.search(r"at offset (\d+)", out).group(1)
-        return int(offset)
+        m = re.search(r"at offset (\d+)", out)
+        assert m, f"Reported offset not found in: {out}"
+        return int(m.group(1))
 
     def describe_topic(self, topic):
         cmd = ['describe', topic, '-p']

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -352,7 +352,7 @@ class ArchivalTest(RedpandaTest):
         # timeout but also on raft and current high_watermark. So we can
         # expect that the bucket won't have 9 segments with 1000 offsets.
         # The actual segments will be larger.
-        for i in range(0, 10):
+        for _ in range(0, 10):
             self.kafka_tools.produce(self.topic, 1000, 1024)
             time.sleep(1)
         time.sleep(5)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -501,13 +501,13 @@ class ClusterConfigTest(RedpandaTest):
         Test import/export of string fields, make sure they don't end
         up with extraneous quotes
         """
-        version_a, text = self._export_import_modify(
+        version_a, _ = self._export_import_modify(
             "cloud_storage_access_key:\n",
             "cloud_storage_access_key: foobar\n")
         self._wait_for_version_sync(version_a)
         self._check_value_everywhere("cloud_storage_access_key", "foobar")
 
-        version_b, text = self._export_import_modify(
+        version_b, _ = self._export_import_modify(
             "cloud_storage_access_key: foobar\n",
             "cloud_storage_access_key: \"foobaz\"")
         self._wait_for_version_sync(version_b)
@@ -537,8 +537,7 @@ class ClusterConfigTest(RedpandaTest):
             m = re.match(
                 r"^(\d+)\s+(\d+)\s+(true|false)\s+\[(.*)\]\s+\[(.*)\]$", l)
             assert m is not None
-            node_id, config_version, needs_restart, invalid, unknown = m.groups(
-            )
+            node_id, *_ = m.groups()
 
             node = self.redpanda.nodes[i]
             assert int(node_id) == self.redpanda.idx(node)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -306,12 +306,6 @@ class ClusterConfigTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def test_valid_settings(self):
-        # TODO
-
-        pass
-
-    @cluster(num_nodes=3)
-    def test_valid_settings(self):
         """
         Bulk exercise of all config settings & the schema endpoint:
         - for all properties in the schema, set them with a valid non-default value

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -410,7 +410,7 @@ class ClusterConfigTest(RedpandaTest):
             import_stdout = self.rpk.cluster_config_import(file.name, all)
 
         last_line = import_stdout.strip().split("\n")[-1]
-        m = re.match("^.+new config version (\d+).*$", last_line)
+        m = re.match(r"^.+new config version (\d+).*$", last_line)
 
         self.logger.debug(f"_import status: {last_line}")
 
@@ -535,7 +535,7 @@ class ClusterConfigTest(RedpandaTest):
 
         for i, l in enumerate(lines):
             m = re.match(
-                "^(\d+)\s+(\d+)\s+(true|false)\s+\[(.*)\]\s+\[(.*)\]$", l)
+                r"^(\d+)\s+(\d+)\s+(true|false)\s+\[(.*)\]\s+\[(.*)\]$", l)
             assert m is not None
             node_id, config_version, needs_restart, invalid, unknown = m.groups(
             )

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -454,6 +454,7 @@ class ClusterConfigTest(RedpandaTest):
         # RPK should give us a valid yaml document
         version_a, text = self._export_import_modify("kafka_qdc_enable: false",
                                                      "kafka_qdc_enable: true")
+        assert version_a is not None
         self._wait_for_version_sync(version_a)
 
         # Default should not have included tunables
@@ -465,6 +466,8 @@ class ClusterConfigTest(RedpandaTest):
         # Clear a setting, it should revert to its default
         version_b, text = self._export_import_modify("kafka_qdc_enable: true",
                                                      "")
+        assert version_b is not None
+
         assert version_b > version_a
         self._wait_for_version_sync(version_b)
         self._check_value_everywhere("kafka_qdc_enable", False)
@@ -478,6 +481,8 @@ class ClusterConfigTest(RedpandaTest):
             "kafka_qdc_depth_alpha: 0.8",
             "kafka_qdc_depth_alpha: 1.5",
             all=True)
+        assert version_c is not None
+
         assert version_c > version_b
         self._wait_for_version_sync(version_c)
         self._check_value_everywhere("kafka_qdc_depth_alpha", 1.5)
@@ -485,6 +490,8 @@ class ClusterConfigTest(RedpandaTest):
         # Check that clearing a tunable with --all works
         version_d, text = self._export_import_modify(
             "kafka_qdc_depth_alpha: 1.5", "", all=True)
+        assert version_d is not None
+
         assert version_d > version_c
         self._wait_for_version_sync(version_d)
         self._check_value_everywhere("kafka_qdc_depth_alpha", 0.8)

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -416,9 +416,8 @@ class ClusterConfigTest(RedpandaTest):
 
         if m is None and allow_noop:
             return None
-        elif m is None:
-            assert m is not None
 
+        assert m is not None, f"Config version not found: {last_line}"
         version = int(m.group(1))
         return version
 

--- a/tests/rptest/tests/cluster_metadata_test.py
+++ b/tests/rptest/tests/cluster_metadata_test.py
@@ -38,7 +38,7 @@ class MetadataTest(RedpandaTest):
     def test_metadata_request_does_not_contain_failed_node(
             self, failure, node):
         """
-        Check if broker list returned from metadata request does not contain node 
+        Check if broker list returned from metadata request does not contain node
         which is not alive
         """
         # validate initial conditions

--- a/tests/rptest/tests/fetch_after_deletion_test.py
+++ b/tests/rptest/tests/fetch_after_deletion_test.py
@@ -15,10 +15,8 @@ from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.clients.default import DefaultClient
 from rptest.clients.rpk import RpkTool
 from rptest.util import (
-    Scale,
     produce_until_segments,
     wait_for_segments_removal,
 )
@@ -57,7 +55,7 @@ class FetchAfterDeleteTest(RedpandaTest):
         topic = TopicSpec(partition_count=1,
                           replication_factor=3,
                           cleanup_policy=TopicSpec.CLEANUP_DELETE)
-        DefaultClient(self.redpanda).create_topic(topic)
+        self.client().create_topic(topic)
 
         kafka_tools = KafkaCliTools(self.redpanda)
 

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -49,7 +49,7 @@ class MetricsReporterTest(RedpandaTest):
         for _ in range(0, total_topics):
             partitions = random.randint(1, 8)
             total_partitions += partitions
-            DefaultClient(self.redpanda).create_topic(
+            self.client().create_topic(
                 [TopicSpec(partition_count=partitions, replication_factor=3)])
 
         # create topics

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -20,7 +20,7 @@ class RedpandaTest(Test):
 
     # List of topics to be created automatically when the cluster starts. Each
     # topic is defined by an instance of a TopicSpec.
-    topics = ()
+    topics = []
 
     def __init__(self,
                  test_context,

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -124,7 +124,7 @@ class RetentionPolicyTest(RedpandaTest):
     @cluster(num_nodes=3)
     def test_timequery_after_segments_eviction(self):
         """
-        Test checking if the offset returned by time based index is 
+        Test checking if the offset returned by time based index is
         valid during applying log cleanup policy
         """
         segment_size = 1048576

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -86,7 +86,7 @@ class RpkClusterTest(RedpandaTest):
                 # dmidecode doesn't work in ducktape containers, ignore
                 # errors about it.
                 continue
-            if re.match('.* error querying .*\.ntp\..* i\/o timeout', l):
+            if re.match(r".* error querying .*\.ntp\..* i\/o timeout", l):
                 self.logger.error(f"Non-fatal transitory NTP error: {l}")
             else:
                 self.logger.error(f"Bad output line: {l}")

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -106,7 +106,6 @@ class RpkClusterTest(RedpandaTest):
 
     @cluster(num_nodes=3)
     def test_get_config(self):
-        rpk_bin = self.redpanda.find_binary('rpk')
         node = self.redpanda.nodes[0]
 
         config_output = self._rpk.admin_config_print(node)

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -18,7 +18,7 @@ from rptest.tests.end_to_end import EndToEndTest
 
 class ScalingUpTest(EndToEndTest):
     """
-    Adding nodes to the cluster should result in partition reallocations to new 
+    Adding nodes to the cluster should result in partition reallocations to new
     nodes
     """
     @cluster(num_nodes=5)

--- a/tests/rptest/tests/simple_e2e_test.py
+++ b/tests/rptest/tests/simple_e2e_test.py
@@ -16,7 +16,7 @@ class SimpleEndToEndTest(EndToEndTest):
     @cluster(num_nodes=6)
     def test_correctness_while_evicitng_log(self):
         '''
-        Validate that all the records will be delivered to consumers when there 
+        Validate that all the records will be delivered to consumers when there
         are multiple producers and log is evicted
         '''
         # use small segment size to enable log eviction

--- a/tests/rptest/tests/topic_autocreate_test.py
+++ b/tests/rptest/tests/topic_autocreate_test.py
@@ -37,7 +37,7 @@ class TopicAutocreateTest(RedpandaTest):
         try:
             # Use rpk rather than kafka CLI because rpk errors out promptly
             self.rpk.produce(auto_topic, "foo", "bar")
-        except Exception as e:
+        except Exception:
             # The write failed, and shouldn't have created a topic
             assert auto_topic not in self.kafka_tools.list_topics()
         else:

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -751,7 +751,7 @@ class RevShiftCheck(FastCheck):
     It's same as fast check only it created additionall dummy topic before running
     topic recovery or before creating initial topic.
     It can test three different cases:
-    - new initial topic revision is equal to old topic revision (paths in the bucket 
+    - new initial topic revision is equal to old topic revision (paths in the bucket
       are the same in old and new clusters).
     - new initial revision is greater than the old one
     - new initial revision is less than the old one
@@ -945,10 +945,10 @@ class SizeBasedRetention(BaseCase):
 class TimeBasedRetention(BaseCase):
     """Check time-based restore process.
     The test runs as follows:
-    We generate 20MB of data (per partition). Than we're downloading the partition 
+    We generate 20MB of data (per partition). Than we're downloading the partition
     manifests and patch them. For every partition we're changing the max_timestamp
     of first 10MB of segments.
-    Then we're running the topic recovery with time-based retention policy and 
+    Then we're running the topic recovery with time-based retention policy and
     expect that only last 10MB will be downloaded.
     The test can be configured to shift 'max_timestamp' fields to the past or
     to remove them. The later case is needed to check the situation when we have
@@ -1087,7 +1087,7 @@ class MovedPartitionRestore(BaseCase):
     same as the topic has) and all revisions which are larger are also candidates.
 
     If data is moved the recovery algorithm should be able to find the parition
-    manifest anyway.    
+    manifest anyway.
     """
     def __init__(self, s3_client, kafka_tools, rpk_client, s3_bucket, logger,
                  topics, move_data):
@@ -1197,7 +1197,7 @@ class CascadingRestore(BaseCase):
     might be different for different segments. Also, there could be more than
     one partition manifest that belong to the same topic in the bucket.
     To mitigate this recovery algorithm creates an aggregate partition manifest
-    that contains segment paths instead of names (e.g. 
+    that contains segment paths instead of names (e.g.
     b525cddd/kafka/panda-topic/0_9/4109-1-v1.log). When the new manifest is
     created the recovery uses it instead of the original manifests. When
     the topic is recovered this manifests is used by archival subsystem. It
@@ -1461,7 +1461,7 @@ class TopicRecoveryTest(RedpandaTest):
                         timeout=datetime.timedelta(minutes=1)):
         """This method waits until the topic is created.
         It uses rpk describe topic command. The topic is
-        considered to be recovered only if the leader is 
+        considered to be recovered only if the leader is
         elected.
         The method is time bound.
         """
@@ -1684,7 +1684,7 @@ class TopicRecoveryTest(RedpandaTest):
     @ignore  # https://github.com/vectorizedio/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_size_based_retention(self):
-        """Test topic recovery with size based retention policy. 
+        """Test topic recovery with size based retention policy.
         It's tests handling of the situation when only subset of the data needs to
         be recovered due to retention."""
         topics = [
@@ -1700,7 +1700,7 @@ class TopicRecoveryTest(RedpandaTest):
     @ignore  # https://github.com/vectorizedio/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_time_based_retention(self):
-        """Test topic recovery with time based retention policy. 
+        """Test topic recovery with time based retention policy.
         It's tests handling of the situation when only subset of the data needs to
         be recovered due to retention. This test uses manifests with max_timestamp
         set properly."""
@@ -1717,7 +1717,7 @@ class TopicRecoveryTest(RedpandaTest):
     @ignore  # https://github.com/vectorizedio/redpanda/issues/2569
     @cluster(num_nodes=3)
     def test_time_based_retention_with_legacy_manifest(self):
-        """Test topic recovery with time based retention policy. 
+        """Test topic recovery with time based retention policy.
         It's tests handling of the situation when only subset of the data needs to
         be recovered due to retention. This test uses manifests without max_timestamp
         field."""

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -282,7 +282,7 @@ def _find_checksum_matches(baseline_per_host, restored_per_host,
 def _gen_manifest_path(ntp, rev):
     x = xxhash.xxh32()
     path = f"{ntp.ns}/{ntp.topic}/{ntp.partition}_{rev}"
-    x.update(path)
+    x.update(path.encode('ascii'))
     hash = x.hexdigest()[0] + '0000000'
     return f"{hash}/meta/{path}/manifest.json"
 
@@ -290,7 +290,7 @@ def _gen_manifest_path(ntp, rev):
 def _gen_segment_path(ntp, rev, name):
     x = xxhash.xxh32()
     path = f"{ntp.ns}/{ntp.topic}/{ntp.partition}_{rev}/{name}"
-    x.update(path)
+    x.update(path.encode('ascii'))
     hash = x.hexdigest()
     return f"{hash}/{path}"
 


### PR DESCRIPTION
## Cover letter

One reservation about using Python as a basis for our test suite is that a lack of static typing makes it difficult to refactor and evolve the code base. However, static linters like `pyright` appear to do quite a good job of handling basic tasks like finding call sites affected by a change to a method (it does a lot of other great stuff).

The problem with static analysis is that our code base contains several hundred warnings and errors. This patch drops the warning/error count down by about 75, so there is still work to be done. But it's all fairly mechanical. Once the noise is eliminated pyright can be used to improve significantly some common developer tasks like refactoring.

## Release notes

* None