### PR TITLE
tests: make metrics_reporter_test more reliable

### DIFF
--- a/tests/python/simple_http_server/simple_http_server.py
+++ b/tests/python/simple_http_server/simple_http_server.py
@@ -2,7 +2,6 @@ import http.server
 import socketserver
 import json
 import signal
-import sys
 
 
 class PrintingHandler(http.server.BaseHTTPRequestHandler):
@@ -30,6 +29,7 @@ class PrintingHandler(http.server.BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-type", "application/json")
         self.end_headers()
+
         # print request content
         req = {}
         req['method'] = self.command
@@ -40,6 +40,10 @@ class PrintingHandler(http.server.BaseHTTPRequestHandler):
                 req['content_length']).decode('ascii')
 
         print(json.dumps(req), flush=True)
+
+
+class ReuseAddressTcpServer(socketserver.TCPServer):
+    allow_reuse_address = True
 
 
 def main():
@@ -55,7 +59,7 @@ def main():
 
     parser = generate_options()
     options, _ = parser.parse_known_args()
-    with socketserver.TCPServer(("", options.port), PrintingHandler) as httpd:
+    with ReuseAddressTcpServer(("", options.port), PrintingHandler) as httpd:
 
         def _stop(*args):
             httpd.server_close()

--- a/tests/rptest/services/http_server.py
+++ b/tests/rptest/services/http_server.py
@@ -44,7 +44,7 @@ class HttpServer(BackgroundThreadService):
         node.account.ssh(f"mkdir -p {HttpServer.LOG_DIR}", allow_fail=False)
 
         cmd = f"python3 {HttpServer.SCRIPT} --port {self.port}"
-        cmd += f" | tee {HttpServer.STDOUT_CAPTURE} &"
+        cmd += f" | tee -a {HttpServer.STDOUT_CAPTURE} &"
 
         self.logger.debug(f"Starting HTTP server {self.url}")
         for line in node.account.ssh_capture(cmd):


### PR DESCRIPTION
## Cover letter

    tests: make metrics_reporter_test more reliable
    
    ...and extend it to check that cluster parameters
    survive a restart.
    
    This test was previously starting redpanda twice: once
    implicitly in setUp, then again implicitly in the test.
    
    Depending on the speed of the test node, this could
    result in a failure where on the initial startup, a
    report is sent with a different cluster uuid+timestamp
    than on subsequent startup.  Presumably this corresponds
    to a config batch that is generated but never committed
    because the nodes are restart so soon after when
    the test starts.
    
    Fix this by only starting redpanda once, and add an explicit
    test that on restart (/after/ the system has been up long enough
    to send several reports and presumably have committed its original
    config message), these metric fields do not change.
    
    Fixes: https://github.com/vectorizedio/redpanda/issues/3514

## Release notes

* none
