### PR TITLE
coverage: expose the test's unique folder coverage dashboard

### DIFF
--- a/tools/coverage_dash.py
+++ b/tools/coverage_dash.py
@@ -155,7 +155,7 @@ tr:nth-child(even) {
 
         html_template += f"""
   <tr>
-    <td><a href="{duck_test}/index.html">{test_signature}</a></td>
+    <td><a href="{duck_test}/">{test_signature}</a></td>
     <td>{f_cov}</td>
     <td>{l_cov}</td>
     <td>{r_cov}</td>


### PR DESCRIPTION
## Cover letter

We are creating a new pipeline in buildkite that runs code coverage on all our ducktape tests. See vectorizedio/vtools#407 for details.

Two files are created for each test, index.html and coverage.json, which provide detailed information on a test's code coverage.
Both files are listed in the buildkite artifacts tab which is a lot of content to display for 200+ ducktape tests. Instead display the containing directory, then on the buildkite-side we can make the files downloadable. This will reduce the number of artifacts to display in the buildkite tab.
