### PR TITLE
Partition bytes metrics

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -102,6 +102,16 @@ void replicated_partition_probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _records_fetched; },
           sm::description("Total number of records fetched"),
           labels),
+        sm::make_total_bytes(
+          "bytes_produced_total",
+          [this] { return _bytes_produced; },
+          sm::description("Total number of bytes produced"),
+          labels),
+        sm::make_total_bytes(
+          "bytes_fetched_total",
+          [this] { return _bytes_fetched; },
+          sm::description("Total number of bytes fetched"),
+          labels),
       });
 }
 partition_probe make_materialized_partition_probe() {
@@ -110,6 +120,8 @@ partition_probe make_materialized_partition_probe() {
         void setup_metrics(const model::ntp&) final {}
         void add_records_fetched(uint64_t) final {}
         void add_records_produced(uint64_t) final {}
+        void add_bytes_fetched(uint64_t) final {}
+        void add_bytes_produced(uint64_t) final {}
     };
     return partition_probe(std::make_unique<impl>());
 }

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -26,6 +26,8 @@ public:
     struct impl {
         virtual void add_records_produced(uint64_t) = 0;
         virtual void add_records_fetched(uint64_t) = 0;
+        virtual void add_bytes_produced(uint64_t) = 0;
+        virtual void add_bytes_fetched(uint64_t) = 0;
         virtual void setup_metrics(const model::ntp&) = 0;
         virtual ~impl() noexcept = default;
     };
@@ -44,6 +46,13 @@ public:
     void add_records_fetched(uint64_t num_records) {
         return _impl->add_records_fetched(num_records);
     }
+    void add_bytes_produced(uint64_t bytes) {
+        return _impl->add_bytes_produced(bytes);
+    }
+
+    void add_bytes_fetched(uint64_t bytes) {
+        return _impl->add_bytes_fetched(bytes);
+    }
 
 private:
     std::unique_ptr<impl> _impl;
@@ -56,11 +65,15 @@ public:
 
     void add_records_fetched(uint64_t cnt) final { _records_fetched += cnt; }
     void add_records_produced(uint64_t cnt) final { _records_produced += cnt; }
+    void add_bytes_fetched(uint64_t cnt) final { _bytes_fetched += cnt; }
+    void add_bytes_produced(uint64_t cnt) final { _bytes_produced += cnt; }
 
 private:
     const partition& _partition;
     uint64_t _records_produced{0};
     uint64_t _records_fetched{0};
+    uint64_t _bytes_produced{0};
+    uint64_t _bytes_fetched{0};
     ss::metrics::metric_groups _metrics;
 };
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -97,6 +97,7 @@ static ss::future<read_result> read_from_partition(
           kafka_batch_serializer(), deadline ? *deadline : model::no_timeout);
         data = std::make_unique<iobuf>(std::move(result.data));
         part.probe().add_records_fetched(result.record_count);
+        part.probe().add_bytes_fetched(data->size_bytes());
         if (result.record_count > 0) {
             // Reader should live at least until this point to hold on to the
             // segment locks so that prefix truncation doesn't happen.

--- a/tests/rptest/tests/partition_metrics_test.py
+++ b/tests/rptest/tests/partition_metrics_test.py
@@ -1,0 +1,97 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.mark.resource import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
+from rptest.services.rpk_consumer import RpkConsumer
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+
+
+class PartitionMetricsTest(RedpandaTest):
+    """
+    Produce and consume some data then confirm partition metrics
+    """
+    topics = (TopicSpec(), )
+
+    def __init__(self, test_context):
+        super(PartitionMetricsTest, self).__init__(test_context=test_context)
+
+    def _bytes_produced(self):
+        return self._sum_metrics(
+            "vectorized_cluster_partition_bytes_produced_total")
+
+    def _records_produced(self):
+        return self._sum_metrics(
+            "vectorized_cluster_partition_records_produced")
+
+    def _bytes_fetched(self):
+        return self._sum_metrics(
+            "vectorized_cluster_partition_bytes_fetched_total")
+
+    def _records_fetched(self):
+        return self._sum_metrics(
+            "vectorized_cluster_partition_records_fetched")
+
+    def _sum_metrics(self, metric_name):
+
+        family = self.redpanda.metrics_sample(metric_name,
+                                              nodes=self.redpanda.nodes)
+        total = 0
+        for sample in family.samples:
+            self.redpanda.logger.info(
+                f"value: {sample.family} - {sample.value}")
+            total += sample.value
+
+        return total
+
+    @cluster(num_nodes=3)
+    def test_partition_metrics(self):
+        num_records = 10240
+        records_size = 512
+
+        # initially all metrics have to be equal to 0
+        assert self._bytes_produced() == 0
+        assert self._records_produced() == 0
+
+        assert self._bytes_fetched() == 0
+        assert self._records_fetched() == 0
+
+        # Produce some data (10240 records * 512 bytes = 5MB of data)
+        kafka_tools = KafkaCliTools(self.redpanda)
+        kafka_tools.produce(self.topic, num_records, records_size, acks=-1)
+
+        rec_produced = self._records_produced()
+        self.redpanda.logger.info(f"records produced: {rec_produced}")
+        assert rec_produced == num_records
+        bytes_produced = self._bytes_produced()
+        self.redpanda.logger.info(f"bytes produced: {bytes_produced}")
+        # bytes produced should be bigger than sent records size because of
+        # batch headers overhead
+        assert bytes_produced >= num_records * records_size
+
+        # fetch metrics shouldn't change
+        assert self._bytes_fetched() == 0
+        assert self._records_fetched() == 0
+
+        # read all messages
+        rpk = RpkTool(self.redpanda)
+        rpk.consume(self.topic, n=num_records)
+
+        rec_fetched = self._records_fetched()
+        self.redpanda.logger.info(f"records fetched: {rec_fetched}")
+
+        bytes_fetched = self._bytes_fetched()
+        self.redpanda.logger.info(f"bytes fetched: {bytes_fetched}")
+
+        assert bytes_fetched == bytes_produced
+        assert rec_fetched == rec_produced


### PR DESCRIPTION
## Cover letter
Added metrics counting total produced and fetched bytes per partition.
This metric gives users accurate insight into how much data are written to or read from the partition.

### Improvements

* Ability to monitor bytes read/written to the partition
