### PR TITLE
Fixed deadlock in persisted STM

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -123,6 +123,10 @@ ss::future<> persisted_stm::do_make_snapshot() {
     _last_snapshot_offset = std::max(_last_snapshot_offset, offset);
 }
 
+void persisted_stm::make_snapshot_in_background() {
+    (void)ss::with_gate(_gate, [this] { return make_snapshot(); });
+}
+
 ss::future<> persisted_stm::make_snapshot() {
     return _op_lock.with([this]() {
         auto f = wait_for_snapshot_hydrated();

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -86,10 +86,11 @@ public:
     static constexpr const int8_t snapshot_version = 1;
     explicit persisted_stm(ss::sstring, ss::logger&, raft::consensus*);
 
-    ss::future<> make_snapshot() final;
+    void make_snapshot_in_background() final;
     ss::future<> ensure_snapshot_exists(model::offset) final;
     model::offset max_collectible_offset() override;
 
+    ss::future<> make_snapshot();
     /*
      * Usually start() acts as a barrier and we don't call any methods on the
      * object before start returns control flow.

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -697,7 +697,7 @@ ss::future<> disk_log_impl::new_segment(
                 }
                 _segs.add(std::move(h));
                 _probe.segment_created();
-                return _stm_manager->make_snapshot();
+                _stm_manager->make_snapshot_in_background();
             });
       });
 }

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -37,7 +37,7 @@ public:
     // offset already exists
     virtual ss::future<> ensure_snapshot_exists(model::offset) = 0;
     // hints stm_manager that now it's a good time to make a snapshot
-    virtual ss::future<> make_snapshot() = 0;
+    virtual void make_snapshot_in_background() = 0;
     // lets the stm control snapshotting and log eviction by limiting
     // log eviction attempts to offsets not greater than this.
     virtual model::offset max_collectible_offset() = 0;
@@ -82,12 +82,10 @@ public:
         return f;
     }
 
-    ss::future<> make_snapshot() {
-        auto f = ss::now();
-        for (auto stm : _stms) {
-            f = f.then([stm]() { return stm->make_snapshot(); });
+    void make_snapshot_in_background() {
+        for (auto& stm : _stms) {
+            stm->make_snapshot_in_background();
         }
-        return f;
     }
 
     model::offset max_collectible_offset() {

--- a/tests/rptest/tests/multi_restarts_with_archival_test.py
+++ b/tests/rptest/tests/multi_restarts_with_archival_test.py
@@ -1,0 +1,109 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from time import sleep
+import uuid
+import sys
+
+from ducktape.mark.resource import cluster
+from ducktape.mark import matrix
+from rptest.archival.s3_client import S3Client
+from ducktape.utils.util import wait_until
+from rptest.clients.types import TopicSpec
+from rptest.clients.default import DefaultClient
+from rptest.clients.rpk import RpkTool
+from rptest.tests.end_to_end import EndToEndTest
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.rpk_producer import RpkProducer
+
+
+class MultiRestartTest(EndToEndTest):
+
+    log_segment_size = 5048576  # 5MB
+    log_compaction_interval_ms = 25000
+
+    s3_host_name = "minio-s3"
+    s3_access_key = "panda-user"
+    s3_secret_key = "panda-secret"
+    s3_region = "panda-region"
+    s3_topic_name = "panda-topic"
+
+    def __init__(self, test_context):
+        self.s3_bucket_name = f"panda-bucket-{uuid.uuid1()}"
+        self._extra_rp_conf = dict(
+            cloud_storage_enabled=True,
+            cloud_storage_access_key=MultiRestartTest.s3_access_key,
+            cloud_storage_secret_key=MultiRestartTest.s3_secret_key,
+            cloud_storage_region=MultiRestartTest.s3_region,
+            cloud_storage_bucket=self.s3_bucket_name,
+            cloud_storage_disable_tls=True,
+            cloud_storage_api_endpoint=MultiRestartTest.s3_host_name,
+            cloud_storage_api_endpoint_port=9000,
+            cloud_storage_reconciliation_interval_ms=500,
+            cloud_storage_max_connections=5,
+            log_compaction_interval_ms=self.log_compaction_interval_ms,
+            log_segment_size=self.log_segment_size,
+        )
+
+        super(MultiRestartTest,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf=self._extra_rp_conf)
+
+        self.s3_client = S3Client(
+            region='panda-region',
+            access_key=u"panda-user",
+            secret_key=u"panda-secret",
+            endpoint=f'http://{MultiRestartTest.s3_host_name}:9000',
+            logger=self.logger)
+
+    def setUp(self):
+        self.s3_client.empty_bucket(self.s3_bucket_name)
+        self.s3_client.create_bucket(self.s3_bucket_name)
+
+        super(MultiRestartTest, self).setUp()
+
+    def tearDown(self):
+        self.s3_client.empty_bucket(self.s3_bucket_name)
+        super().tearDown()
+
+    @cluster(num_nodes=5)
+    def test_recovery_after_multiple_restarts(self):
+        self.start_redpanda(3, extra_rp_conf=self._extra_rp_conf)
+        spec = TopicSpec(partition_count=60, replication_factor=3)
+
+        DefaultClient(self.redpanda).create_topic(spec)
+        self.topic = spec.name
+
+        rpk = RpkTool(self.redpanda)
+        rpk.alter_topic_config(spec.name, 'redpanda.remote.write', 'true')
+        rpk.alter_topic_config(spec.name, 'redpanda.remote.read', 'true')
+
+        self.start_producer(1, throughput=100)
+        self.start_consumer(1)
+        self.await_startup()
+
+        def no_under_replicated_partitions():
+            metric_sample = self.redpanda.metrics_sample("under_replicated")
+            for s in metric_sample.samples:
+                if s.value > 0:
+                    return False
+            return True
+
+        # restart all the nodes and wait for recovery
+        for i in range(0, 10):
+            for n in self.redpanda.nodes:
+                self.redpanda.signal_redpanda(n)
+                self.redpanda.start_node(n)
+            wait_until(no_under_replicated_partitions, 30, 2)
+
+        self.run_validation(enable_idempotence=False,
+                            producer_timeout_sec=60,
+                            consumer_timeout_sec=180)


### PR DESCRIPTION
## Cover letter

The `storage::snapshotable_stm` interfaces clearly states that the
`make_snapshot` function is called to give an stm implementation a hint
on when to create a snapshot. There is requirement to wait for a
snapshot to be taken before returning from `disk_log_impl::new_segment`
function.

Now `snapshotable_stm::maybe_take_snapshot` returns `void` and it is up
to the implementation on what to do when the function is called.
Peristed stm implementation is dispatching taking a snapshot in
background fiber.

This change fixes an issue described in #3582, as the deadlock was
caused by the fiber applying batches and appending batches to wait for
stm lock. Currently as the snapshot is taken in the background the
deadlock is impossible to occur.

Fixes: #3528

## Release notes

* fixed possible deadlock of raft groups
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
