### PR TITLE
ssx: add spawn_with_gate, spawn_with_gate_then, background

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -370,7 +370,7 @@ ss::future<> controller_backend::fetch_deltas() {
 }
 
 void controller_backend::start_topics_reconciliation_loop() {
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _as.local().abort_requested(); },
           [this] {
@@ -394,7 +394,7 @@ void controller_backend::start_topics_reconciliation_loop() {
 }
 
 void controller_backend::housekeeping() {
-    (void)ss::with_gate(_gate, [this] {
+    ssx::background = ssx::spawn_with_gate_then(_gate, [this] {
         auto f = ss::now();
         if (!_topic_deltas.empty() && _topics_sem.available_units() > 0) {
             f = reconcile_topics();

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -394,21 +394,22 @@ void controller_backend::start_topics_reconciliation_loop() {
 }
 
 void controller_backend::housekeeping() {
-    ssx::background = ssx::spawn_with_gate_then(_gate, [this] {
-        auto f = ss::now();
-        if (!_topic_deltas.empty() && _topics_sem.available_units() > 0) {
-            f = reconcile_topics();
-        }
-        return f.finally([this] {
-            if (!_gate.is_closed()) {
-                _housekeeping_timer.arm(_housekeeping_timer_interval);
+    ssx::background
+      = ssx::spawn_with_gate_then(_gate, [this] {
+            auto f = ss::now();
+            if (!_topic_deltas.empty() && _topics_sem.available_units() > 0) {
+                f = reconcile_topics();
             }
+            return f.finally([this] {
+                if (!_gate.is_closed()) {
+                    _housekeeping_timer.arm(_housekeeping_timer_interval);
+                }
+            });
+        }).handle_exception([](const std::exception_ptr& e) {
+            // we ignore the exception as controller backend will retry in next
+            // loop
+            vlog(clusterlog.warn, "error during reconciliation - {}", e);
         });
-    }).handle_exception([](const std::exception_ptr& e) {
-        // we ignore the exception as controller backend will retry in next
-        // loop
-        vlog(clusterlog.warn, "error during reconciliation - {}", e);
-    });
 }
 
 ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -171,7 +171,7 @@ health_manager::ensure_topic_replication(model::topic_namespace_view topic) {
 }
 
 void health_manager::tick() {
-    (void)ss::try_with_gate(
+    ssx::background = ssx::spawn_with_gate_then(
       _gate,
       [this]() -> ss::future<> {
           /*
@@ -207,7 +207,6 @@ void health_manager::tick() {
 
           _timer.arm(_tick_interval);
       })
-      .handle_exception_type([](const ss::gate_closed_exception&) {})
       .handle_exception([this](const std::exception_ptr& e) {
           vlog(clusterlog.info, "Health manager caught error {}", e);
           _timer.arm(_tick_interval * 2);

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -171,46 +171,45 @@ health_manager::ensure_topic_replication(model::topic_namespace_view topic) {
 }
 
 void health_manager::tick() {
-    ssx::background = ssx::spawn_with_gate_then(
-      _gate,
-      [this]() -> ss::future<> {
-          /*
-           * only active on the controller leader
-           */
-          auto cluster_leader = _leaders.local().get_leader(
-            model::controller_ntp);
-          if (cluster_leader != _self) {
-              vlog(clusterlog.trace, "Health: skipping tick as non-leader");
-              co_return;
-          }
+    ssx::background
+      = ssx::spawn_with_gate_then(_gate, [this]() -> ss::future<> {
+            /*
+             * only active on the controller leader
+             */
+            auto cluster_leader = _leaders.local().get_leader(
+              model::controller_ntp);
+            if (cluster_leader != _self) {
+                vlog(clusterlog.trace, "Health: skipping tick as non-leader");
+                co_return;
+            }
 
-          // Only ensure replication if we have a big enough cluster, to avoid
-          // spamming log with replication complaints on single node cluster
-          if (_members.local().all_brokers().size() >= 3) {
-              /*
-               * we try to be conservative here. if something goes wrong we'll
-               * back off and wait before trying to fix replication for any
-               * other internal topics.
-               */
-              auto ok = co_await ensure_topic_replication(
-                model::kafka_group_nt);
+            // Only ensure replication if we have a big enough cluster, to avoid
+            // spamming log with replication complaints on single node cluster
+            if (_members.local().all_brokers().size() >= 3) {
+                /*
+                 * we try to be conservative here. if something goes wrong we'll
+                 * back off and wait before trying to fix replication for any
+                 * other internal topics.
+                 */
+                auto ok = co_await ensure_topic_replication(
+                  model::kafka_group_nt);
 
-              if (ok) {
-                  ok = co_await ensure_topic_replication(
-                    model::id_allocator_nt);
-              }
+                if (ok) {
+                    ok = co_await ensure_topic_replication(
+                      model::id_allocator_nt);
+                }
 
-              if (ok) {
-                  ok = co_await ensure_topic_replication(model::tx_manager_nt);
-              }
-          }
+                if (ok) {
+                    ok = co_await ensure_topic_replication(
+                      model::tx_manager_nt);
+                }
+            }
 
-          _timer.arm(_tick_interval);
-      })
-      .handle_exception([this](const std::exception_ptr& e) {
-          vlog(clusterlog.info, "Health manager caught error {}", e);
-          _timer.arm(_tick_interval * 2);
-      });
+            _timer.arm(_tick_interval);
+        }).handle_exception([this](const std::exception_ptr& e) {
+            vlog(clusterlog.info, "Health manager caught error {}", e);
+            _timer.arm(_tick_interval * 2);
+        });
 }
 
 } // namespace cluster

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -191,7 +191,7 @@ health_monitor_backend::abortable_refresh_request::abortable_refresh_request(
 ss::future<std::error_code>
 health_monitor_backend::abortable_refresh_request::abortable_await(
   ss::future<std::error_code> f) {
-    (void)std::move(f).then_wrapped(
+    ssx::background = std::move(f).then_wrapped(
       [self = shared_from_this()](ss::future<std::error_code> f) {
           if (self->finished) {
               return;
@@ -390,7 +390,7 @@ void health_monitor_backend::tick() {
         return;
     }
 
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         // make sure that ticks will have fixed interval
         auto next_tick = ss::lowres_clock::now() + tick_interval();
         return collect_cluster_health().finally([this, next_tick] {

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -118,12 +118,12 @@ void members_backend::handle_single_update(
 
 void members_backend::start_reconciliation_loop() {
     ssx::background = ssx::spawn_with_gate_then(_bg, [this] {
-        return reconcile().finally([this] {
-            if (!_as.local().abort_requested()) {
-                _retry_timer.arm(_retry_timeout);
-            }
-        });
-    }).handle_exception([](const std::exception_ptr& e) {
+                          return reconcile().finally([this] {
+                              if (!_as.local().abort_requested()) {
+                                  _retry_timer.arm(_retry_timeout);
+                              }
+                          });
+                      }).handle_exception([](const std::exception_ptr& e) {
         // just log an exception, will retry
         vlog(
           clusterlog.trace,

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -59,7 +59,7 @@ ss::future<> members_backend::stop() {
 }
 
 void members_backend::start() {
-    (void)ss::with_gate(_bg, [this] {
+    ssx::spawn_with_gate(_bg, [this] {
         return ss::do_until(
           [this] { return _as.local().abort_requested(); },
           [this] { return handle_updates(); });
@@ -117,7 +117,7 @@ void members_backend::handle_single_update(
 }
 
 void members_backend::start_reconciliation_loop() {
-    (void)ss::with_gate(_bg, [this] {
+    ssx::background = ssx::spawn_with_gate_then(_bg, [this] {
         return reconcile().finally([this] {
             if (!_as.local().abort_requested()) {
                 _retry_timer.arm(_retry_timeout);

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -84,9 +84,8 @@ ss::future<> members_manager::start() {
     }
 
     if (is_already_member()) {
-        ssx::spawn_with_gate(_gate, [this] {
-            return maybe_update_current_node_configuration();
-        });
+        ssx::spawn_with_gate(
+          _gate, [this] { return maybe_update_current_node_configuration(); });
     } else {
         join_raft0();
     }

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -122,7 +122,7 @@ ss::future<> metrics_reporter::stop() {
 }
 
 void metrics_reporter::report_metrics() {
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return do_report_metrics().finally([this] {
             if (!_gate.is_closed()) {
                 _tick_timer.arm(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1087,7 +1087,7 @@ void rm_stm::track_tx(
 
 void rm_stm::abort_old_txes() {
     _is_autoabort_active = true;
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return _state_lock.hold_read_lock().then(
           [this](ss::basic_rwlock<>::holder unit) mutable {
               return do_abort_old_txes().finally([this, u = std::move(unit)] {

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -162,7 +162,7 @@ void leader_balancer::trigger_balance() {
         return;
     }
 
-    (void)ss::try_with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return ss::repeat([this] {
                    if (_as.local().abort_requested()) {
                        return ss::make_ready_future<ss::stop_iteration>(
@@ -183,7 +183,7 @@ void leader_balancer::trigger_balance() {
               _timer.cancel();
               _timer.arm(_idle_timeout());
           });
-    }).handle_exception_type([](const ss::gate_closed_exception&) {});
+    });
 }
 
 ss::future<ss::stop_iteration> leader_balancer::balance() {

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -70,7 +70,7 @@ ss::future<> event_listener::start() {
           return type_and_handler.second->start();
       });
 
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _abort_source.abort_requested(); },
           [this] {

--- a/src/v/coproc/pacemaker.cc
+++ b/src/v/coproc/pacemaker.cc
@@ -49,7 +49,7 @@ rpc::backoff_policy wasm_transport_backoff() {
 }
 
 void pacemaker::save_routes() {
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         all_routes routes;
         routes.reserve(_scripts.size());
         for (auto& [id, script] : _scripts) {
@@ -154,7 +154,7 @@ std::vector<errc> pacemaker::add_source(
     const auto [_, success] = _scripts.emplace(id, std::move(script_ctx));
     vassert(success, "Double coproc insert detected");
     vlog(coproclog.debug, "Adding source with id: {}", id);
-    (void)ss::with_gate(_gate, [this, id] {
+    ssx::spawn_with_gate(_gate, [this, id] {
         fire_updates(id, errc::success);
         auto found = _scripts.find(id);
         if (found == _scripts.end()) {

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -291,32 +291,34 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                     /**
                      * second stage processed in background.
                      */
-                    ssx::background = ssx::spawn_with_gate_then(
-                      _rs.conn_gate(),
-                      [this, f = std::move(f), seq, correlation]() mutable {
-                          return f.then(
-                            [this, seq, correlation](response_ptr r) mutable {
-                                r->set_correlation(correlation);
-                                _responses.insert({seq, std::move(r)});
-                                return process_next_response();
-                            });
-                      })
-                      .handle_exception([self](std::exception_ptr e) {
-                          // ssx::spawn_with_gate already caught shutdown-like
-                          // exceptions, so we should only be taking this
-                          // path for real errors.  That also means
-                          // that on shutdown we don't bother to call
-                          // shutdown_input on the connection, so rely
-                          // on any future reader to check the abort
-                          // source before considering reading the connection.
-                          vlog(
-                            klog.info,
-                            "Detected error processing request: {}",
-                            e);
-                          self->_rs.probe().service_error();
-                          self->_rs.conn->shutdown_input();
-                      })
-                      .finally([s = std::move(s), self] {});
+                    ssx::background
+                      = ssx::spawn_with_gate_then(
+                          _rs.conn_gate(),
+                          [this, f = std::move(f), seq, correlation]() mutable {
+                              return f.then([this, seq, correlation](
+                                              response_ptr r) mutable {
+                                  r->set_correlation(correlation);
+                                  _responses.insert({seq, std::move(r)});
+                                  return process_next_response();
+                              });
+                          })
+                          .handle_exception([self](std::exception_ptr e) {
+                              // ssx::spawn_with_gate already caught
+                              // shutdown-like exceptions, so we should only be
+                              // taking this path for real errors.  That also
+                              // means that on shutdown we don't bother to call
+                              // shutdown_input on the connection, so rely
+                              // on any future reader to check the abort
+                              // source before considering reading the
+                              // connection.
+                              vlog(
+                                klog.info,
+                                "Detected error processing request: {}",
+                                e);
+                              self->_rs.probe().service_error();
+                              self->_rs.conn->shutdown_input();
+                          })
+                          .finally([s = std::move(s), self] {});
                     return d;
                 })
                 .handle_exception([self](std::exception_ptr e) {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -195,7 +195,7 @@ void group_manager::handle_topic_delta(
         return;
     }
 
-    (void)ss::with_gate(_gate, [this, tps = std::move(tps)]() mutable {
+    ssx::background = ssx::spawn_with_gate_then(_gate, [this, tps = std::move(tps)]() mutable {
         return ss::do_with(
           std::move(tps),
           [this](const std::vector<model::topic_partition>& tps) {

--- a/src/v/raft/append_entries_buffer.cc
+++ b/src/v/raft/append_entries_buffer.cc
@@ -61,16 +61,12 @@ ss::future<> append_entries_buffer::stop() {
 }
 
 void append_entries_buffer::start() {
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _gate.is_closed(); },
           [this] {
               return _enqueued.wait([this] { return !_requests.empty(); })
-                .then([this] { return flush(); })
-                .handle_exception_type(
-                  [](const ss::broken_condition_variable&) {
-                      // ignore exception, we are about to stop
-                  });
+                .then([this] { return flush(); });
           });
     });
 }

--- a/src/v/raft/event_manager.cc
+++ b/src/v/raft/event_manager.cc
@@ -14,7 +14,7 @@
 namespace raft {
 
 ss::future<> event_manager::start() {
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _gate.is_closed(); },
           [this] {

--- a/src/v/raft/log_eviction_stm.cc
+++ b/src/v/raft/log_eviction_stm.cc
@@ -34,7 +34,7 @@ ss::future<> log_eviction_stm::start() {
 ss::future<> log_eviction_stm::stop() { return _gate.close(); }
 
 void log_eviction_stm::monitor_log_eviction() {
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _gate.is_closed(); },
           [this] {

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -288,7 +288,7 @@ ss::future<> mux_state_machine<T...>::apply(model::record_batch b) {
                 if (
                   _persist_last_applied
                   && last_offset > _c->read_last_applied()) {
-                    (void)ss::with_gate(_gate, [this, last_offset] {
+                    ssx::spawn_with_gate(_gate, [this, last_offset] {
                         return _c->write_last_applied(last_offset);
                     });
                 }

--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -27,7 +27,7 @@ state_machine::state_machine(
 
 ss::future<> state_machine::start() {
     vlog(_log.info, "Starting state machine for ntp={}", _raft->ntp());
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return ss::do_until(
           [this] { return _gate.is_closed(); }, [this] { return apply(); });
     });

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -180,31 +180,32 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
 }
 
 void transport::dispatch_send() {
-    ssx::background = ssx::spawn_with_gate_then(_dispatch_gate, [this]() mutable {
-        return ss::do_until(
-          [this] {
-              return _requests_queue.empty()
-                     || _requests_queue.begin()->first
-                          > (_last_seq + sequence_t(1));
-          },
-          [this] {
-              auto it = _requests_queue.begin();
-              _last_seq = it->first;
-              auto buffer = std::move(it->second->buffer).get();
-              auto units = std::move(it->second->resource_units);
-              auto v = std::move(*buffer).as_scattered();
-              auto msg_size = v.size();
-              _requests_queue.erase(it->first);
-              return _out.write(std::move(v))
-                .finally([this, msg_size, units = std::move(units)] {
-                    _probe.add_bytes_sent(msg_size);
-                });
-          });
-    }).handle_exception([this](std::exception_ptr e) {
-        vlog(rpclog.info, "Error dispatching socket write:{}", e);
-        _probe.request_error();
-        fail_outstanding_futures();
-    });
+    ssx::background
+      = ssx::spawn_with_gate_then(_dispatch_gate, [this]() mutable {
+            return ss::do_until(
+              [this] {
+                  return _requests_queue.empty()
+                         || _requests_queue.begin()->first
+                              > (_last_seq + sequence_t(1));
+              },
+              [this] {
+                  auto it = _requests_queue.begin();
+                  _last_seq = it->first;
+                  auto buffer = std::move(it->second->buffer).get();
+                  auto units = std::move(it->second->resource_units);
+                  auto v = std::move(*buffer).as_scattered();
+                  auto msg_size = v.size();
+                  _requests_queue.erase(it->first);
+                  return _out.write(std::move(v))
+                    .finally([this, msg_size, units = std::move(units)] {
+                        _probe.add_bytes_sent(msg_size);
+                    });
+              });
+        }).handle_exception([this](std::exception_ptr e) {
+            vlog(rpclog.info, "Error dispatching socket write:{}", e);
+            _probe.request_error();
+            fail_outstanding_futures();
+        });
 }
 
 ss::future<> transport::do_reads() {

--- a/src/v/storage/backlog_controller.cc
+++ b/src/v/storage/backlog_controller.cc
@@ -10,8 +10,8 @@
 
 #include "config/configuration.h"
 #include "prometheus/prometheus_sanitize.h"
-#include "ssx/sformat.h"
 #include "ssx/future-util.h"
+#include "ssx/sformat.h"
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -11,9 +11,9 @@
 
 #include "bytes/iobuf_parser.h"
 #include "model/adl_serde.h"
+#include "ssx/future-util.h"
 #include "utils/gate_guard.h"
 #include "utils/to_string.h"
-#include "ssx/future-util.h"
 #include "vassert.h"
 
 #include <seastar/core/coroutine.hh>

--- a/src/v/storage/batch_cache.cc
+++ b/src/v/storage/batch_cache.cc
@@ -13,6 +13,7 @@
 #include "model/adl_serde.h"
 #include "utils/gate_guard.h"
 #include "utils/to_string.h"
+#include "ssx/future-util.h"
 #include "vassert.h"
 
 #include <seastar/core/coroutine.hh>
@@ -370,7 +371,7 @@ void batch_cache_index::truncate(model::offset offset) {
 }
 
 void batch_cache::background_reclaimer::start() {
-    (void)ss::with_gate(_gate, [this] {
+    ssx::spawn_with_gate(_gate, [this] {
         return ss::with_scheduling_group(
           _sg, [this] { return reclaim_loop(); });
     });

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -78,7 +78,7 @@ ss::future<> kvstore::start() {
           _started = true;
 
           // Flushing background fiber
-          (void)ss::with_gate(_gate, [this] {
+          ssx::spawn_with_gate(_gate, [this] {
               return ss::do_until(
                 [this] { return _gate.is_closed(); },
                 [this] {

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -279,10 +279,9 @@ readers_cache::dispose_entries(intrusive_list<entry, &entry::_hook> entries) {
 
 void readers_cache::dispose_in_background(
   intrusive_list<entry, &entry::_hook> entries) {
-        ssx::spawn_with_gate(
-          _gate, [this, entries = std::move(entries)]() mutable {
-              return dispose_entries(std::move(entries));
-          });
+    ssx::spawn_with_gate(_gate, [this, entries = std::move(entries)]() mutable {
+        return dispose_entries(std::move(entries));
+    });
 }
 
 void readers_cache::dispose_in_background(entry* e) {

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -11,6 +11,7 @@
 #include "storage/readers_cache.h"
 
 #include "model/fundamental.h"
+#include "ssx/future-util.h"
 #include "storage/types.h"
 #include "utils/gate_guard.h"
 #include "utils/mutex.h"
@@ -32,7 +33,7 @@ readers_cache::readers_cache(
     _probe.setup_metrics(_ntp);
     // setup eviction timer
     _eviction_timer.set_callback([this] {
-        (void)ss::with_gate(_gate, [this] {
+        ssx::spawn_with_gate(_gate, [this] {
             return maybe_evict().finally([this] {
                 if (!_gate.is_closed()) {
                     _eviction_timer.arm(_eviction_timeout);
@@ -278,19 +279,27 @@ readers_cache::dispose_entries(intrusive_list<entry, &entry::_hook> entries) {
 
 void readers_cache::dispose_in_background(
   intrusive_list<entry, &entry::_hook> entries) {
-    try {
-        (void)ss::with_gate(
+        ssx::spawn_with_gate(
           _gate, [this, entries = std::move(entries)]() mutable {
               return dispose_entries(std::move(entries));
           });
-    } catch (const ss::gate_closed_exception& e) {
-        vlog(stlog.debug, "gate closed while disposing reader");
-    }
 }
 
 void readers_cache::dispose_in_background(entry* e) {
-    try {
-        (void)ss::with_gate(_gate, [this, e] {
+    if (_gate.is_closed()) {
+        /**
+         * since gate is closed and we failed to call finally on the reader we
+         * add it back to _readers list, it will be gracefully closed in
+         * `readers_cache::close`.
+         * NOTE:
+         * _readers intrusive list is supposed to keep resusable readers but
+         * when gate closed exception is thrwon we are certain that no more
+         * oprations will be executed on the cache so we can reuse the _readers
+         * list to gracefully shutdown readers.
+         */
+        _readers.push_back(*e);
+    } else {
+        ssx::spawn_with_gate(_gate, [this, e] {
             return e->reader->finally().finally([this, e] {
                 vlog(
                   stlog.trace,
@@ -303,19 +312,6 @@ void readers_cache::dispose_in_background(entry* e) {
                 delete e; // NOLINT
             });
         });
-    } catch (const ss::gate_closed_exception& ex) {
-        vlog(stlog.debug, "gate closed while disposing reader");
-        /**
-         * since gate is closed and we failed to call finally on the reader we
-         * add it back to _readers list, it will be gracefully closed in
-         * `readers_cache::close`.
-         * NOTE:
-         * _readers intrusive list is supposed to keep resusable readers but
-         * when gate closed exception is thrwon we are certain that no more
-         * oprations will be executed on the cache so we can reuse the _readers
-         * list to gracefully shutdown readers.
-         */
-        _readers.push_back(*e);
     }
 }
 

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -11,6 +11,7 @@
 
 #include "compression/compression.h"
 #include "config/configuration.h"
+#include "ssx/future-util.h"
 #include "storage/compacted_index_writer.h"
 #include "storage/fs_utils.h"
 #include "storage/fwd.h"
@@ -22,7 +23,6 @@
 #include "storage/segment_utils.h"
 #include "storage/types.h"
 #include "storage/version.h"
-#include "ssx/future-util.h"
 #include "utils/file_sanitizer.h"
 #include "vassert.h"
 #include "vlog.h"

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -22,6 +22,7 @@
 #include "storage/segment_utils.h"
 #include "storage/types.h"
 #include "storage/version.h"
+#include "ssx/future-util.h"
 #include "utils/file_sanitizer.h"
 #include "vassert.h"
 #include "vlog.h"
@@ -213,7 +214,7 @@ void segment::release_appender_in_background(readers_cache* readers_cache) {
                ? std::exchange(_cache, std::nullopt)
                : std::nullopt;
     auto i = std::exchange(_compaction_index, std::nullopt);
-    (void)ss::with_gate(
+    ssx::spawn_with_gate(
       _gate,
       [this,
        readers_cache,


### PR DESCRIPTION
## Cover letter

When we run a background task, it's usually with `(void)` to silence the compiler warning about the unused future.  Add `ssx::background` (@BenPope 's idea) to handle these more explicitly.

There are many places we run background fibers in redpanda, within a gate.  There are hard-to-reproduce bugs when these fibers encounter shutdown-time exceptions like the gate being closed.  Adding a helper function enables callers to spawn off these background fibers without having to remember to type out boilerplate for catching shutdown exceptions, and also avoid any catch-all exception logging from complaining to the log on shutdown.

The spawn_with_gate_then variant is for cases where a background fiber should ignore shutdown exceptions, but the caller would like to get the resulting future back, e.g. for handling other types of exception (usually this means logging unexpected exceptions).

**TODO**
- [x] Extend use to other subsystems beyond initial use in src/v/cluster
- [x] ~~Figure out why ssx::spawn_with_gate won't compile when used in tx_gateway_frontend.cc, when used around futures returned by the `with` helper in that file.~~ (turned out these futures were returning values even though they were used in the context of a background fiber)

Fixes https://github.com/vectorizedio/redpanda/issues/2911

## Release notes

### Improvements

* Various error-level log messages are fixed