### PR TITLE
tests: extend BadLogLines checks

### DIFF
--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -301,7 +301,9 @@ void heartbeat_manager::process_reply(
         auto it = _consensus_groups.find(m.group);
         if (it == _consensus_groups.end()) {
             vlog(
-              hbeatlog.error, "Could not find consensus for group:{}", m.group);
+              hbeatlog.debug,
+              "Could not find consensus for group:{} (shutting down?)",
+              m.group);
             continue;
         }
         vlog(hbeatlog.trace, "Heartbeat reply from node: {} - {}", n, m);

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -50,7 +50,8 @@ DEFAULT_LOG_ALLOW_LIST = [
 # Log errors that are expected in tests that restart nodes mid-test
 RESTART_LOG_ALLOW_LIST = [
     re.compile(
-        "(raft|rpc) - .*(disconnected_endpoint|Connection reset by peer)"),
+        "(raft|rpc) - .*(disconnected_endpoint|Broken pipe|Connection reset by peer)"
+    ),
     re.compile(
         "raft - .*recovery append entries error.*client_request_timeout"),
 ]

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -387,7 +387,8 @@ class RedpandaService(Service):
                 f"Scanning node {node.account.hostname} log for errors...")
 
             for line in node.account.ssh_capture(
-                    f"grep ERROR {RedpandaService.STDOUT_STDERR_CAPTURE}"):
+                    f"grep -e ERROR -e Segmentation\ fault -e [Aa]ssert {RedpandaService.STDOUT_STDERR_CAPTURE}"
+            ):
                 line = line.strip()
 
                 allowed = False

--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -15,16 +15,19 @@ from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
-from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, RESTART_LOG_ALLOW_LIST
 
 
 class NodesDecommissioningTest(EndToEndTest):
     """
     Basic nodes decommissioning test.
     """
-    @cluster(num_nodes=6)
+    @cluster(
+        num_nodes=6,
+        # A decom can look like a restart in terms of logs from peers dropping
+        # connections with it
+        log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommissioning_working_node(self):
-
         self.start_redpanda(num_nodes=4)
         topics = []
         for partition_count in range(1, 5):


### PR DESCRIPTION
## Cover letter

- Include an example bad log line in the exception string, so that it's easier for folks triaging test failures to see it without trawling log.  They still need to do that when there are multiple bad log lines.
- Detect assertions and segmentation faults in logs
- Update one of the allow-lists for an intermittent test failure.

Fixes https://github.com/vectorizedio/redpanda/issues/3546

## Release notes

* none

