### PR TITLE
Fix x core move bootstrap

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -240,7 +240,7 @@ std::vector<topic_table::delta> calculate_bootstrap_deltas(
         // partition with correct offset
         if (auto next = std::next(it); next != deltas.rend()) {
             if (
-              next->type == op_t::update_finished
+              (next->type == op_t::update_finished || next->type == op_t::add)
               && !has_local_replicas(self, next->new_assignment.replicas)) {
                 break;
             }

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -347,6 +347,41 @@ class PartitionMovementTest(EndToEndTest):
             self._move_and_verify()
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
 
+    @cluster(num_nodes=5, log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS)
+    def test_bootstrapping_after_move(self):
+        """
+        Move partitions with active consumer / producer
+        """
+        self.start_redpanda(num_nodes=3)
+        spec = TopicSpec(name="topic", partition_count=3, replication_factor=3)
+        self.client().create_topic(spec)
+        self.topic = spec.name
+        self.start_producer(1)
+        self.start_consumer(1)
+        self.await_startup()
+        # execute single move
+        self._move_and_verify()
+        self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
+
+        # snapshot offsets
+        rpk = RpkTool(self.redpanda)
+        partitions = rpk.describe_topic(spec.name)
+        offset_map = {}
+        for p in partitions:
+            offset_map[p.id] = p.high_watermark
+
+        # restart all the nodes
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+
+        def offsets_are_recovered():
+
+            return all([
+                offset_map[p.id] == p.high_watermark
+                for p in rpk.describe_topic(spec.name)
+            ])
+
+        wait_until(offsets_are_recovered, 30, 2)
+
     @cluster(num_nodes=3)
     def test_invalid_destination(self):
         """


### PR DESCRIPTION
## Cover letter

When replica is moved x-cores `cluster::controller_backend` has to
establish its initial revision on given node to use exactly the same
data folder as the replica was using previously.

When bootstrapping controller backend we look for the first operation
that created a partition replica on given node to establish the
revision_id. Fixed error that caused bootstrap process to never finish.

The addition operation preceding update containing x-core update should
terminate lookup. Previously the addition operation was added to
bootstrap deltas on target core preventing the rest of bootstrap logic
from finding replica initial revision.

### Improvements

* Fixed error preventing redpanda from starting if the only partition movement operation involved x-core move
