### PR TITLE
rpk: add admin.GetLeaderID

### DIFF
--- a/src/go/rpk/pkg/api/admin/admin.go
+++ b/src/go/rpk/pkg/api/admin/admin.go
@@ -131,6 +131,15 @@ var rng = func() func(int) int {
 	}
 }()
 
+// GetLeaderID returns the broker ID of the leader of the Admin API
+func (a *AdminAPI) GetLeaderID() (*int, error) {
+	pa, err := a.GetPartition("redpanda", "controller", 0)
+	if err != nil {
+		return nil, err
+	}
+	return &pa.LeaderID, nil
+}
+
 // sendAny sends a single request to one of the client's urls and unmarshals
 // the body into into, which is expected to be a pointer to a struct.
 func (a *AdminAPI) sendAny(method, path string, body, into interface{}) error {

--- a/src/go/rpk/pkg/api/admin/api_partition.go
+++ b/src/go/rpk/pkg/api/admin/api_partition.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const partitionsEndpoint = "/v1/partitions"
+
+// Replica contains the information of a partition replica
+type Replica struct {
+	NodeID int `json:"node_id"`
+	Core   int `json:"core"`
+}
+
+// Partition is the information returned from the Redpanda admin partitions endpoints.
+type Partition struct {
+	Namespace   string    `json:"ns"`
+	Topic       string    `json:"topic"`
+	PartitionID int       `json:"partition_id"`
+	Status      string    `json:"status"`
+	LeaderID    int       `json:"leader_id"`
+	RaftGroupID int       `json:"raft_group_id"`
+	Replicas    []Replica `json:"replicas"`
+}
+
+// GetPartition returns detailed partition information
+func (a *AdminAPI) GetPartition(
+	namespace, topic string, partition int,
+) (Partition, error) {
+	var pa Partition
+	return pa, a.sendAny(
+		http.MethodGet,
+		fmt.Sprintf("%s/%s/%s/%d", partitionsEndpoint, namespace, topic, partition),
+		nil,
+		&pa)
+}


### PR DESCRIPTION
## Cover letter

This PR adds an `admin.GetLeaderID` method which returns the broker ID of the leader of the Admin API.
The intention is to use this method to send write requests directly to the leader instead of having to broadcast requests to all brokers.

ref: https://github.com/vectorizedio/redpanda/pull/3565