### PR TITLE
rpk: try to send write requests to Leader but fallback to broadcast to all brokers

### DIFF
--- a/src/go/rpk/pkg/api/admin/admin_test.go
+++ b/src/go/rpk/pkg/api/admin/admin_test.go
@@ -39,6 +39,7 @@ func TestCreateUser(t *testing.T) {
 	urls := []string{}
 
 	for i := 0; i < int(nNodes); i++ {
+		n := i
 		ts := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				b, err := ioutil.ReadAll(r.Body)
@@ -46,7 +47,11 @@ func TestCreateUser(t *testing.T) {
 				require.Exactly(t, bs, b)
 				// Have only one server return OK, to simulate a single
 				// node being the leader and being able to respond.
-				w.WriteHeader(http.StatusOK)
+				if n == 0 {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
 			}),
 		)
 		defer ts.Close()
@@ -68,11 +73,18 @@ func TestDeleteUser(t *testing.T) {
 	urls := []string{}
 
 	for i := 0; i < int(nNodes); i++ {
+		n := i
 		ts := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Exactly(t, "/v1/security/users/Lola", r.URL.Path)
 
-				w.WriteHeader(http.StatusOK)
+				// Have only one server return OK, to simulate a single
+				// node being the leader and being able to respond.
+				if n == 0 {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
 			}),
 		)
 		defer ts.Close()

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -35,7 +35,7 @@ func (a *AdminAPI) Brokers() ([]Broker, error) {
 
 // DecommissionBroker issues a decommission request for the given broker.
 func (a *AdminAPI) DecommissionBroker(node int) error {
-	return a.sendAll(
+	return a.sendToLeader(
 		http.MethodPut,
 		fmt.Sprintf("%s/%d/decommission", brokersEndpoint, node),
 		nil,
@@ -45,7 +45,7 @@ func (a *AdminAPI) DecommissionBroker(node int) error {
 
 // RecommissionBroker issues a recommission request for the given broker.
 func (a *AdminAPI) RecommissionBroker(node int) error {
-	return a.sendAll(
+	return a.sendToLeader(
 		http.MethodPut,
 		fmt.Sprintf("%s/%d/recommission", brokersEndpoint, node),
 		nil,

--- a/src/go/rpk/pkg/api/admin/api_broker.go
+++ b/src/go/rpk/pkg/api/admin/api_broker.go
@@ -35,7 +35,7 @@ func (a *AdminAPI) Brokers() ([]Broker, error) {
 
 // DecommissionBroker issues a decommission request for the given broker.
 func (a *AdminAPI) DecommissionBroker(node int) error {
-	return a.sendAny(
+	return a.sendAll(
 		http.MethodPut,
 		fmt.Sprintf("%s/%d/decommission", brokersEndpoint, node),
 		nil,
@@ -45,7 +45,7 @@ func (a *AdminAPI) DecommissionBroker(node int) error {
 
 // RecommissionBroker issues a recommission request for the given broker.
 func (a *AdminAPI) RecommissionBroker(node int) error {
-	return a.sendAny(
+	return a.sendAll(
 		http.MethodPut,
 		fmt.Sprintf("%s/%d/recommission", brokersEndpoint, node),
 		nil,

--- a/src/go/rpk/pkg/api/admin/api_node_config.go
+++ b/src/go/rpk/pkg/api/admin/api_node_config.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import "net/http"
+
+type NodeConfig struct {
+	NodeID int `json:"node_id"`
+	//TODO: add the rest of the fields
+}
+
+// NodeConfig returns a single node configuration.
+// It's expected to be called from an AdminAPI with a single broker URL,
+// otherwise the method will return an error.
+func (a *AdminAPI) GetNodeConfig() (NodeConfig, error) {
+	var nodeconfig NodeConfig
+	return nodeconfig, a.sendOne(http.MethodGet, "/v1/node_config", nil, &nodeconfig)
+}

--- a/src/go/rpk/pkg/api/admin/api_partition.go
+++ b/src/go/rpk/pkg/api/admin/api_partition.go
@@ -1,0 +1,44 @@
+// Copyright 2021 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Replica contains the information of a partition replica
+type Replica struct {
+	NodeID int `json:"node_id"`
+	Core   int `json:"core"`
+}
+
+// Partition is the information returned from the Redpanda admin partitions endpoints.
+type Partition struct {
+	Namespace   string    `json:"ns"`
+	Topic       string    `json:"topic"`
+	PartitionID int       `json:"partition_id"`
+	Status      string    `json:"status"`
+	LeaderID    int       `json:"leader_id"`
+	RaftGroupID int       `json:"raft_group_id"`
+	Replicas    []Replica `json:"replicas"`
+}
+
+// GetPartition returns detailed partition information
+func (a *AdminAPI) GetPartition(
+	namespace, topic string, partition int,
+) (Partition, error) {
+	var pa Partition
+	return pa, a.sendAny(
+		http.MethodGet,
+		fmt.Sprintf("/v1/partitions/%s/%s/%d", namespace, topic, partition),
+		nil,
+		&pa)
+}

--- a/src/go/rpk/pkg/api/admin/api_user.go
+++ b/src/go/rpk/pkg/api/admin/api_user.go
@@ -47,7 +47,7 @@ func (a *AdminAPI) CreateUser(username, password, mechanism string) error {
 		Password:  password,
 		Algorithm: mechanism,
 	}
-	return a.sendAll(http.MethodPost, usersEndpoint, u, nil)
+	return a.sendToLeader(http.MethodPost, usersEndpoint, u, nil)
 }
 
 // DeleteUser deletes the given username, if it exists.
@@ -56,7 +56,7 @@ func (a *AdminAPI) DeleteUser(username string) error {
 		return errors.New("invalid empty username")
 	}
 	path := usersEndpoint + "/" + url.PathEscape(username)
-	return a.sendAll(http.MethodDelete, path, nil, nil)
+	return a.sendToLeader(http.MethodDelete, path, nil, nil)
 }
 
 // ListUsers returns the current users.

--- a/src/go/rpk/pkg/api/admin/api_user.go
+++ b/src/go/rpk/pkg/api/admin/api_user.go
@@ -47,7 +47,7 @@ func (a *AdminAPI) CreateUser(username, password, mechanism string) error {
 		Password:  password,
 		Algorithm: mechanism,
 	}
-	return a.sendAny(http.MethodPost, usersEndpoint, u, nil)
+	return a.sendAll(http.MethodPost, usersEndpoint, u, nil)
 }
 
 // DeleteUser deletes the given username, if it exists.
@@ -56,7 +56,7 @@ func (a *AdminAPI) DeleteUser(username string) error {
 		return errors.New("invalid empty username")
 	}
 	path := usersEndpoint + "/" + url.PathEscape(username)
-	return a.sendAny(http.MethodDelete, path, nil, nil)
+	return a.sendAll(http.MethodDelete, path, nil, nil)
 }
 
 // ListUsers returns the current users.


### PR DESCRIPTION
As of v21.11.1, the Redpanda admin API redirects requests to the leader based
on certain assumptions about all nodes listening on the same admin port, and
that the admin API is available on the same IP address as the internal RPC
interface.
These limitations come from the fact that nodes don't currently share info
with each other about where they're actually listening for the admin API.

Unfortunately this assumptions do not match all environments in which
Redpanda is deployed, hence, we need to reintroduce logic in RPK to either
route the write requests to the leader or broadcast them to all brokers.

## How it works

- When the AdminAPI is initialized, rpk tries to map each of the broker URLs
  to their respective broker ID using the `/v1/node_config` endpoint and saves
  the mapping in memory.
- When sending a write request, rpk will query what's the ID of the leader and will
  send the request to that broker using the mapping created on initialization
- When the mapping is not possible on initalization, or when the client has only 
  one broker, the request is broadcasted to all brokers.


This PR partially reverts f993afdd1b6019548486e4ea41b27b2feb2f525d

