### PR TITLE
rpc: Wrap ZSTD_error_memory_allocation to std::bad_alloc & catch exceptions from dispatch

### DIFF
--- a/src/v/compression/stream_zstd.cc
+++ b/src/v/compression/stream_zstd.cc
@@ -26,8 +26,12 @@
 
 namespace compression {
 [[gnu::cold]] static void throw_zstd_err(size_t rc) {
-    ss::throw_with_backtrace<std::runtime_error>(
-      fmt::format("ZSTD error:{}", ZSTD_getErrorName(rc)));
+    if (rc == ZSTD_error_memory_allocation) {
+        ss::throw_with_backtrace<std::bad_alloc>();
+    } else {
+        ss::throw_with_backtrace<std::runtime_error>(
+          fmt::format("ZSTD error:{}", ZSTD_getErrorName(rc)));
+    }
 }
 static void throw_if_error(size_t rc) {
     if (unlikely(ZSTD_isError(rc))) {

--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -100,63 +100,66 @@ simple_protocol::dispatch_method_once(header h, net::server::resources rs) {
 
     // background!
     ssx::background
-      = ssx::spawn_with_gate_then(rs.conn_gate(), [this, method_id, rs, ctx]() mutable {
-        auto it = std::find_if(
-          _services.begin(),
-          _services.end(),
-          [method_id](std::unique_ptr<service>& srvc) {
-              return srvc->method_from_id(method_id) != nullptr;
-          });
-        if (unlikely(it == _services.end())) {
-            rs.probe().method_not_found();
-            netbuf reply_buf;
-            reply_buf.set_status(rpc::status::method_not_found);
-            return send_reply(ctx, std::move(reply_buf)).then([ctx]() mutable {
-                ctx->signal_body_parse();
-            });
-        }
-
-        method* m = it->get()->method_from_id(method_id);
-
-        return m->handle(ctx->res.conn->input(), *ctx)
-          .then_wrapped([ctx, m, l = ctx->res.hist().auto_measure(), rs](
-                          ss::future<netbuf> fut) mutable {
-              netbuf reply_buf;
-              try {
-                  reply_buf = fut.get0();
-                  reply_buf.set_status(rpc::status::success);
-              } catch (const rpc_internal_body_parsing_exception& e) {
-                  // We have to distinguish between exceptions thrown by the
-                  // service handler and the one caused by the corrupted
-                  // payload. Data corruption on the wire may lead to the
-                  // situation where connection is not longer usable and so it
-                  // have to be terminated.
-                  ctx->pr.set_exception(e);
-                  return ss::now();
-              } catch (const ss::timed_out_error& e) {
-                  reply_buf.set_status(rpc::status::request_timeout);
-              } catch (const ss::gate_closed_exception& e) {
-                  // gate_closed is typical during shutdown.  Treat
-                  // it like a timeout: request was not erroneous
-                  // but we will not give a rseponse.
-                  rpclog.debug("Timing out request on gate_closed_exception "
-                               "(shutting down)");
-                  reply_buf.set_status(rpc::status::request_timeout);
-              } catch (...) {
-                  rpclog.error(
-                    "Service handler threw an exception: {}",
-                    std::current_exception());
-                  rs.probe().service_error();
-                  reply_buf.set_status(rpc::status::server_error);
-              }
-              return send_reply(ctx, std::move(reply_buf))
-                .finally([m, l = std::move(l)]() mutable {
-                    m->probes.latency_hist().record(std::move(l));
+      = ssx::spawn_with_gate_then(
+          rs.conn_gate(),
+          [this, method_id, rs, ctx]() mutable {
+              auto it = std::find_if(
+                _services.begin(),
+                _services.end(),
+                [method_id](std::unique_ptr<service>& srvc) {
+                    return srvc->method_from_id(method_id) != nullptr;
                 });
+              if (unlikely(it == _services.end())) {
+                  rs.probe().method_not_found();
+                  netbuf reply_buf;
+                  reply_buf.set_status(rpc::status::method_not_found);
+                  return send_reply(ctx, std::move(reply_buf))
+                    .then([ctx]() mutable { ctx->signal_body_parse(); });
+              }
+
+              method* m = it->get()->method_from_id(method_id);
+
+              return m->handle(ctx->res.conn->input(), *ctx)
+                .then_wrapped([ctx, m, l = ctx->res.hist().auto_measure(), rs](
+                                ss::future<netbuf> fut) mutable {
+                    netbuf reply_buf;
+                    try {
+                        reply_buf = fut.get0();
+                        reply_buf.set_status(rpc::status::success);
+                    } catch (const rpc_internal_body_parsing_exception& e) {
+                        // We have to distinguish between exceptions thrown by
+                        // the service handler and the one caused by the
+                        // corrupted payload. Data corruption on the wire may
+                        // lead to the situation where connection is not longer
+                        // usable and so it have to be terminated.
+                        ctx->pr.set_exception(e);
+                        return ss::now();
+                    } catch (const ss::timed_out_error& e) {
+                        reply_buf.set_status(rpc::status::request_timeout);
+                    } catch (const ss::gate_closed_exception& e) {
+                        // gate_closed is typical during shutdown.  Treat
+                        // it like a timeout: request was not erroneous
+                        // but we will not give a rseponse.
+                        rpclog.debug(
+                          "Timing out request on gate_closed_exception "
+                          "(shutting down)");
+                        reply_buf.set_status(rpc::status::request_timeout);
+                    } catch (...) {
+                        rpclog.error(
+                          "Service handler threw an exception: {}",
+                          std::current_exception());
+                        rs.probe().service_error();
+                        reply_buf.set_status(rpc::status::server_error);
+                    }
+                    return send_reply(ctx, std::move(reply_buf))
+                      .finally([m, l = std::move(l)]() mutable {
+                          m->probes.latency_hist().record(std::move(l));
+                      });
+                });
+          })
+          .handle_exception([](const std::exception_ptr& e) {
+              rpclog.error("Error dispatching: {}", e);
           });
-    }).handle_exception([](const std::exception_ptr& e) {
-        rpclog.error("Error dispatching: {}", e);
-    });
 
     return fut;
 }


### PR DESCRIPTION
## Cover letter

Wrap ZSTD_error_memory_allocation to std::bad_alloc and catch it in rpc::simple_protocol

## Release notes
* Replace ZSTD allocation_error to bad_alloc
* Catch all exception in fiber inside rps_simple_protocol