### PR TITLE
raft: Earlier heartbeat manager shutdown

### DIFF
--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -47,6 +47,7 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+    ss::future<> stop_heartbeats();
 
     ss::future<ss::lw_shared_ptr<raft::consensus>> create_group(
       raft::group_id id, std::vector<model::broker> nodes, storage::log log);

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -134,6 +134,8 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    bool is_stopped() const { return _bghbeats.is_closed(); }
+
 private:
     void dispatch_heartbeats();
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -580,7 +580,7 @@ void application::wire_up_redpanda_services() {
 
     // cluster
     syschecks::systemd_message("Adding raft client cache").get();
-    construct_service(_raft_connection_cache).get();
+    construct_service(_connection_cache).get();
     syschecks::systemd_message("Building shard-lookup tables").get();
     construct_service(shard_table).get();
 
@@ -607,7 +607,7 @@ void application::wire_up_redpanda_services() {
         _scheduling_groups.raft_sg(),
         config::shard_local_cfg().raft_heartbeat_interval_ms(),
         config::shard_local_cfg().raft_heartbeat_timeout_ms(),
-        std::ref(_raft_connection_cache),
+        std::ref(_connection_cache),
         std::ref(storage),
         std::ref(recovery_throttle))
       .get();
@@ -667,7 +667,7 @@ void application::wire_up_redpanda_services() {
     construct_single_service(
       controller,
       std::move(_config_preload),
-      _raft_connection_cache,
+      _connection_cache,
       partition_manager,
       shard_table,
       storage,
@@ -718,7 +718,7 @@ void application::wire_up_redpanda_services() {
       std::ref(controller->get_partition_leaders()),
       std::ref(controller->get_members_table()),
       std::ref(controller->get_topics_state()),
-      std::ref(_raft_connection_cache),
+      std::ref(_connection_cache),
       std::ref(controller->get_health_monitor()))
       .get();
 
@@ -867,7 +867,7 @@ void application::wire_up_redpanda_services() {
       std::ref(partition_manager),
       std::ref(shard_table),
       std::ref(metadata_cache),
-      std::ref(_raft_connection_cache),
+      std::ref(_connection_cache),
       std::ref(controller->get_partition_leaders()),
       std::ref(controller))
       .get();
@@ -877,7 +877,7 @@ void application::wire_up_redpanda_services() {
     construct_service(
       rm_group_frontend,
       std::ref(metadata_cache),
-      std::ref(_raft_connection_cache),
+      std::ref(_connection_cache),
       std::ref(controller->get_partition_leaders()),
       controller.get(),
       std::ref(coordinator_ntp_mapper),
@@ -895,7 +895,7 @@ void application::wire_up_redpanda_services() {
       std::ref(partition_manager),
       std::ref(shard_table),
       std::ref(metadata_cache),
-      std::ref(_raft_connection_cache),
+      std::ref(_connection_cache),
       std::ref(controller->get_partition_leaders()),
       controller.get())
       .get();
@@ -913,7 +913,7 @@ void application::wire_up_redpanda_services() {
       std::ref(partition_manager),
       std::ref(shard_table),
       std::ref(metadata_cache),
-      std::ref(_raft_connection_cache),
+      std::ref(_connection_cache),
       std::ref(controller->get_partition_leaders()),
       controller.get(),
       std::ref(id_allocator_frontend),

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -138,7 +138,7 @@ private:
     scheduling_groups _scheduling_groups;
     ss::logger _log;
 
-    ss::sharded<rpc::connection_cache> _raft_connection_cache;
+    ss::sharded<rpc::connection_cache> _connection_cache;
     ss::sharded<kafka::group_manager> _group_manager;
     ss::sharded<net::server> _rpc;
     ss::sharded<admin_server> _admin;


### PR DESCRIPTION
## Cover letter

    Currently, the `group_manager::stop` call does shut down
    heartbeat_manager before it clears out consensus groups, but
    the consensus groups are actually cleared out much earlier
    by partition_manager's shutdown routine.
    
    This change causes partition_manager to stop
    heartbeat_manager before it clears out all the
    `consensus` instances, so that heartbeat_manager
    doesn't keep running with nowhere to put its results.

## Release notes

* none