### PR TITLE
admin: improve leader redirect heuristic

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -9,6 +9,7 @@
 
 import time
 import os
+import socket
 import signal
 import tempfile
 import shutil
@@ -120,10 +121,9 @@ class MetricSamples:
 def one_or_many(value):
     """
     Helper for reading `one_or_many_property` configs when
-    they are expected to hold a single value.
+    we only care about getting one value out
     """
     if isinstance(value, list):
-        assert len(value) == 1
         return value[0]
     else:
         return value
@@ -152,6 +152,11 @@ class RedpandaService(Service):
 
     # Where we put a compressed binary if saving it after failure
     EXECUTABLE_SAVE_PATH = "/tmp/redpanda.tar.gz"
+
+    # When configuring multiple listeners for testing, a secondary port to use
+    # instead of the default.
+    KAFKA_ALTERNATE_PORT = 9093
+    ADMIN_ALTERNATE_PORT = 9647
 
     logs = {
         "redpanda_start_stdout_stderr": {
@@ -503,12 +508,19 @@ class RedpandaService(Service):
     def write_conf_file(self, node, override_cfg_params):
         node_info = {self.idx(n): n for n in self.nodes}
 
+        # Grab the IP to use it as an alternative listener address, to
+        # exercise code paths that deal with multiple listeners
+        node_ip = socket.gethostbyname(node.account.hostname)
+
         conf = self.render("redpanda.yaml",
                            node=node,
                            data_dir=RedpandaService.DATA_DIR,
                            cluster=RedpandaService.CLUSTER_NAME,
                            nodes=node_info,
                            node_id=self.idx(node),
+                           node_ip=node_ip,
+                           kafka_alternate_port=self.KAFKA_ALTERNATE_PORT,
+                           admin_alternate_port=self.ADMIN_ALTERNATE_PORT,
                            enable_rp=self._enable_rp,
                            enable_pp=self._enable_pp,
                            enable_sr=self._enable_sr,

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -20,13 +20,20 @@ redpanda:
     address: "{{node.account.hostname}}"
     port: 33145
   kafka_api:
-    - address: "{{node.account.hostname}}"
+    - name: dnslistener
+      address: "{{node.account.hostname}}"
       port: 9092
+    - name: iplistener
+      address: "{{node_ip}}"
+      port: {{kafka_alternate_port}}
   admin:
     - address: 127.0.0.1
       port: 9644
     - address: "{{node.account.hostname}}"
       port: 9644
+    - name: iplistener
+      address: "{{node_ip}}"
+      port: {{admin_alternate_port}}
 
   # for librdkafka
   auto_create_topics_enabled: true


### PR DESCRIPTION
## Cover letter

Previously we guessed that the leader would
have an admin API listener on their internal RPC
address, and that it would be on the same port as
the local node's first admin listener.

This worked fine when using internal pod IPs,
but falls down under other circumstances.  This
was okay, because we already fell down (with a 400)
on non-leader requests.

However, it was more problematic when updating rpk,
because rpk doesn't know whether it's sending
a redirect-able request or not.

We can make the redirection smarter, to handle the
typical case where both admin and kafka have
two listeners, one on an internal name and one
on an external name:
- Compare the incoming request's Host header to
  the local node's kafka listeners to find which
  kafka-equivalent address the client was using (i.e.
  is it an internal or external request?)
- Pick the same index in the peer's array of kafka
  advertised addresses.  On simple uniform internal+external
  configs like in our cloud, that will reliably select
  the peer's appropriate internal/external DNS name
  for us to redirect the admin API request to.

## Release notes

### Improvements

* Admin API requests sent to non-leader nodes are redirected more reliably to the leader