### PR TITLE
Wasm backports for data streams technical preview

### DIFF
--- a/src/js/modules/supervisors/Repository.ts
+++ b/src/js/modules/supervisors/Repository.ts
@@ -143,8 +143,8 @@ class Repository {
       // Coprocessor return a Map with values
       for (const [key, value] of resultRecordBatch) {
         value.records = value.records.map((record) => {
-          record.length = calculateRecordLength(record);
           record.valueLen = record.value.length;
+          record.length = calculateRecordLength(record);
           return record;
         });
         value.header.sizeBytes = calculateRecordBatchSize(value.records);

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -171,35 +171,6 @@ ss::future<> update_broker_client(
       });
 }
 
-std::vector<topic_result> create_topic_results(
-  const std::vector<model::topic_namespace>& topics, errc error_code) {
-    std::vector<topic_result> results;
-    results.reserve(topics.size());
-    std::transform(
-      std::cbegin(topics),
-      std::cend(topics),
-      std::back_inserter(results),
-      [error_code](const model::topic_namespace& t) {
-          return topic_result(t, error_code);
-      });
-    return results;
-}
-
-std::vector<topic_result> create_topic_results(
-  const std::vector<custom_assignable_topic_configuration>& requests,
-  errc error_code) {
-    std::vector<topic_result> results;
-    results.reserve(requests.size());
-    std::transform(
-      requests.cbegin(),
-      requests.cend(),
-      std::back_inserter(results),
-      [error_code](const custom_assignable_topic_configuration& r) {
-          return topic_result(r.cfg.tp_ns, error_code);
-      });
-    return results;
-}
-
 model::broker make_self_broker(const config::node_config& node_cfg) {
     auto kafka_addr = node_cfg.advertised_kafka_api();
     auto rpc_addr = node_cfg.advertised_rpc_api();

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -200,4 +200,20 @@ ss::future<std::error_code> replicate_and_wait(
 std::vector<custom_assignable_topic_configuration>
   without_custom_assignments(std::vector<topic_configuration>);
 
+inline bool has_non_replicable_op_type(const topic_table_delta& d) {
+    using op_t = topic_table_delta::op_type;
+    switch (d.type) {
+    case op_t::add_non_replicable:
+    case op_t::del_non_replicable:
+        return true;
+    case op_t::add:
+    case op_t::del:
+    case op_t::update:
+    case op_t::update_finished:
+    case op_t::update_properties:
+        return false;
+    }
+    __builtin_unreachable();
+}
+
 } // namespace cluster

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -25,6 +25,23 @@
 
 #include <utility>
 
+namespace detail {
+
+template<typename T, typename Fn>
+std::vector<cluster::topic_result>
+create_topic_results(const std::vector<T>& topics, Fn fn) {
+    std::vector<cluster::topic_result> results;
+    results.reserve(topics.size());
+    std::transform(
+      topics.cbegin(),
+      topics.cend(),
+      std::back_inserter(results),
+      [&fn](const T& t) { return fn(t); });
+    return results;
+}
+
+} // namespace detail
+
 namespace config {
 struct configuration;
 }
@@ -47,22 +64,35 @@ CONCEPT(requires requires(const T& req) {
 // clang-format on
 std::vector<topic_result> create_topic_results(
   const std::vector<T>& requests, errc error_code) {
-    std::vector<topic_result> results;
-    results.reserve(requests.size());
-    std::transform(
-      std::cbegin(requests),
-      std::cend(requests),
-      std::back_inserter(results),
-      [error_code](const T& r) { return topic_result(r.tp_ns, error_code); });
-    return results;
+    return detail::create_topic_results(requests, [error_code](const T& r) {
+        return topic_result(r.tp_ns, error_code);
+    });
 }
 
-std::vector<topic_result> create_topic_results(
-  const std::vector<custom_assignable_topic_configuration>& requests,
-  errc error_code);
+inline std::vector<topic_result> create_topic_results(
+  const std::vector<model::topic_namespace>& topics, errc error_code) {
+    return detail::create_topic_results(
+      topics, [error_code](const model::topic_namespace& t) {
+          return topic_result(t, error_code);
+      });
+}
 
-std::vector<topic_result> create_topic_results(
-  const std::vector<model::topic_namespace>& topics, errc error_code);
+inline std::vector<topic_result> create_topic_results(
+  const std::vector<custom_assignable_topic_configuration>& requests,
+  errc error_code) {
+    return detail::create_topic_results(
+      requests, [error_code](const custom_assignable_topic_configuration& r) {
+          return topic_result(r.cfg.tp_ns, error_code);
+      });
+}
+
+inline std::vector<topic_result> create_topic_results(
+  const std::vector<non_replicable_topic>& requests, errc error_code) {
+    return detail::create_topic_results(
+      requests, [error_code](const non_replicable_topic& nrt) {
+          return topic_result(nrt.name, error_code);
+      });
+}
 
 ss::future<> update_broker_client(
   model::node_id,

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -22,6 +22,11 @@
             "output_type": "create_topics_reply"
         },
         {
+            "name": "create_non_replicable_topics",
+            "input_type": "create_non_replicable_topics_request",
+            "output_type": "create_non_replicable_topics_reply"
+        },
+        {
             "name": "finish_partition_update",
             "input_type": "finish_partition_update_request",
             "output_type": "finish_partition_update_reply"

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -373,6 +373,14 @@ ss::future<> controller_backend::reconcile_ntp(deltas_t& deltas) {
     bool stop = false;
     auto it = deltas.begin();
     while (!(stop || it == deltas.end())) {
+        if (has_non_replicable_op_type(*it)) {
+            /// This if statement has nothing to do with correctness and is only
+            /// here to reduce the amount of uncessecary logging emitted by the
+            /// controller_backend for events that it eventually will not handle
+            /// anyway.
+            ++it;
+            continue;
+        }
         try {
             auto ec = co_await execute_partitition_op(*it);
             if (ec) {

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -100,17 +100,11 @@ private:
       raft::group_id,
       model::revision_id,
       std::vector<model::broker>);
-    ss::future<std::error_code>
-      create_non_replicable_partition(model::ntp, model::revision_id);
-    ss::future<>
-      add_to_shard_table(model::ntp, ss::shard_id, model::revision_id);
     ss::future<> add_to_shard_table(
       model::ntp, raft::group_id, ss::shard_id, model::revision_id);
     ss::future<>
       remove_from_shard_table(model::ntp, raft::group_id, model::revision_id);
     ss::future<> delete_partition(model::ntp, model::revision_id);
-    ss::future<>
-      delete_non_replicable_partition(model::ntp, model::revision_id);
     ss::future<std::error_code> update_partition_replica_set(
       const model::ntp&,
       const std::vector<model::broker_shard>&,

--- a/src/v/cluster/non_replicable_topics_frontend.cc
+++ b/src/v/cluster/non_replicable_topics_frontend.cc
@@ -92,7 +92,7 @@ void non_replicable_topics_frontend::topic_creation_exception(
 
 ss::future<> non_replicable_topics_frontend::create_non_replicable_topics(
   std::vector<cluster::non_replicable_topic> topics,
-  model::timeout_clock::time_point timeout) {
+  model::timeout_clock::duration timeout) {
     std::vector<ss::future<>> all;
     std::vector<cluster::non_replicable_topic> todos;
     for (auto& topic : topics) {
@@ -107,7 +107,7 @@ ss::future<> non_replicable_topics_frontend::create_non_replicable_topics(
     }
     if (!todos.empty()) {
         auto f = _topics_frontend.local()
-                   .create_non_replicable_topics(todos, timeout)
+                   .autocreate_non_replicable_topics(todos, timeout)
                    .then(
                      [this](const std::vector<cluster::topic_result>& result) {
                          topic_creation_resolved(result);

--- a/src/v/cluster/non_replicable_topics_frontend.h
+++ b/src/v/cluster/non_replicable_topics_frontend.h
@@ -60,7 +60,7 @@ public:
     /// command completes.
     ss::future<> create_non_replicable_topics(
       std::vector<cluster::non_replicable_topic>,
-      model::timeout_clock::time_point timeout);
+      model::timeout_clock::duration timeout);
 
 private:
     void topic_creation_resolved(const std::vector<cluster::topic_result>&);

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -87,6 +87,20 @@ service::create_topics(create_topics_request&& r, rpc::streaming_context&) {
       });
 }
 
+ss::future<create_non_replicable_topics_reply>
+service::create_non_replicable_topics(
+  create_non_replicable_topics_request&& r, rpc::streaming_context&) {
+    return ss::with_scheduling_group(
+             get_scheduling_group(),
+             [this, r = std::move(r)]() mutable {
+                 return _topics_frontend.local().create_non_replicable_topics(
+                   std::move(r.topics), model::time_from_now(r.timeout));
+             })
+      .then([](std::vector<topic_result> res) {
+          return create_non_replicable_topics_reply{std::move(res)};
+      });
+}
+
 std::pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
 service::fetch_metadata_and_cfg(const std::vector<topic_result>& res) {
     std::vector<model::topic_metadata> md;

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -40,6 +40,9 @@ public:
     virtual ss::future<create_topics_reply>
     create_topics(create_topics_request&&, rpc::streaming_context&) override;
 
+    ss::future<create_non_replicable_topics_reply> create_non_replicable_topics(
+      create_non_replicable_topics_request&&, rpc::streaming_context&) final;
+
     ss::future<configuration_update_reply> update_node_configuration(
       configuration_update_request&&, rpc::streaming_context&) final;
 

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -68,7 +68,7 @@ public:
         set_configuration("disable_metrics", true);
     }
 
-    ~cluster_test_fixture() {
+    virtual ~cluster_test_fixture() {
         std::filesystem::remove_all(std::filesystem::path(_base_dir));
     }
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -62,9 +62,6 @@ const model::topic& topic_table::topic_metadata::get_source_topic() const {
 }
 const topic_configuration_assignment&
 topic_table::topic_metadata::get_configuration() const {
-    vassert(
-      is_topic_replicable(),
-      "Query for configuration on a non-replicable topic");
     return configuration;
 }
 
@@ -389,9 +386,6 @@ topic_table::apply(create_non_replicable_topic_cmd cmd, model::offset o) {
 
     auto ca = tp->second.configuration;
     ca.cfg.tp_ns = new_non_rep_topic;
-    for (auto& assignment : ca.assignments) {
-        assignment.group = raft::group_id(-1);
-    }
 
     auto [itr, success] = _topics_hierarchy.try_emplace(
       source,
@@ -489,6 +483,14 @@ std::optional<topic_configuration>
 topic_table::get_topic_cfg(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {
         return it->second.configuration.cfg;
+    }
+    return {};
+}
+
+std::optional<std::vector<partition_assignment>>
+topic_table::get_topic_assignments(model::topic_namespace_view tp) const {
+    if (auto it = _topics.find(tp); it != _topics.end()) {
+        return it->second.configuration.assignments;
     }
     return {};
 }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -585,7 +585,7 @@ bool topic_table::contains(
 std::optional<cluster::partition_assignment>
 topic_table::get_partition_assignment(const model::ntp& ntp) const {
     auto it = _topics.find(model::topic_namespace_view(ntp));
-    if (it == _topics.end() || !it->second.is_topic_replicable()) {
+    if (it == _topics.end()) {
         return {};
     }
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -161,16 +161,24 @@ topic_table::apply(create_partition_cmd cmd, model::offset offset) {
 ss::future<std::error_code>
 topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
     auto tp = _topics.find(model::topic_namespace_view(cmd.key));
-    if (tp == _topics.end() || !tp->second.is_topic_replicable()) {
+    if (tp == _topics.end()) {
         return ss::make_ready_future<std::error_code>(errc::topic_not_exists);
     }
+    if (!tp->second.is_topic_replicable()) {
+        return ss::make_ready_future<std::error_code>(
+          errc::topic_operation_error);
+    }
+    auto find_partition = [](
+                            std::vector<partition_assignment>& assignments,
+                            model::partition_id p_id) {
+        return std::find_if(
+          assignments.begin(),
+          assignments.end(),
+          [p_id](const partition_assignment& p_as) { return p_id == p_as.id; });
+    };
 
-    auto current_assignment_it = std::find_if(
-      tp->second.configuration.assignments.begin(),
-      tp->second.configuration.assignments.end(),
-      [p_id = cmd.key.tp.partition](partition_assignment& p_as) {
-          return p_id == p_as.id;
-      });
+    auto current_assignment_it = find_partition(
+      tp->second.configuration.assignments, cmd.key.tp.partition);
 
     if (current_assignment_it == tp->second.configuration.assignments.end()) {
         return ss::make_ready_future<std::error_code>(
@@ -193,6 +201,39 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
     // replace partition replica set
     current_assignment_it->replicas = cmd.value;
 
+    /// Update all non_replicable topics to have the same 'in-progress' state
+    auto found = _topics_hierarchy.find(model::topic_namespace_view(cmd.key));
+    if (found != _topics_hierarchy.end()) {
+        for (const auto& cs : found->second) {
+            /// Insert non-replicable topic into the 'update_in_progress' set
+            auto [_, success] = _update_in_progress.insert(
+              model::ntp(cs.ns, cs.tp, current_assignment_it->id));
+            vassert(
+              success,
+              "non_replicable topic {}-{} already in _update_in_progress set",
+              cs.tp,
+              current_assignment_it->id);
+            /// For each child topic of the to-be-moved source, update its new
+            /// replica assignment to reflect the change
+            auto sfound = _topics.find(cs);
+            vassert(
+              sfound != _topics.end(),
+              "Non replicable topic must exist: {}",
+              cs);
+            auto assignment_it = find_partition(
+              sfound->second.configuration.assignments,
+              current_assignment_it->id);
+            vassert(
+              assignment_it != sfound->second.configuration.assignments.end(),
+              "Non replicable partition doesn't exist: {}-{}",
+              cs,
+              current_assignment_it->id);
+            /// The new assignments of the non_replicable topic/partition must
+            /// match the source topic
+            assignment_it->replicas = cmd.value;
+        }
+    }
+
     // calculate deleta for backend
     model::ntp ntp(tp->first.ns, tp->first.tp, current_assignment_it->id);
     _pending_deltas.emplace_back(
@@ -210,8 +251,12 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
 ss::future<std::error_code>
 topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
     auto tp = _topics.find(model::topic_namespace_view(cmd.key));
-    if (tp == _topics.end() || !tp->second.is_topic_replicable()) {
+    if (tp == _topics.end()) {
         return ss::make_ready_future<std::error_code>(errc::topic_not_exists);
+    }
+    if (!tp->second.is_topic_replicable()) {
+        return ss::make_ready_future<std::error_code>(
+          errc::topic_operation_error);
     }
 
     // calculate deleta for backend
@@ -239,6 +284,22 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
       .id = current_assignment_it->id,
       .replicas = std::move(cmd.value),
     };
+
+    /// Remove child non_replicable topics out of the 'update_in_progress' set
+    auto found = _topics_hierarchy.find(model::topic_namespace_view(cmd.key));
+    if (found != _topics_hierarchy.end()) {
+        for (const auto& cs : found->second) {
+            bool erased = _update_in_progress.erase(
+                            model::ntp(cs.ns, cs.tp, cmd.key.tp.partition))
+                          > 0;
+            if (!erased) {
+                vlog(
+                  clusterlog.error,
+                  "non_replicable_topic expected to exist in "
+                  "update_in_progress set");
+            }
+        }
+    }
 
     // notify backend about finished update
     _pending_deltas.emplace_back(

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -137,6 +137,12 @@ public:
     std::optional<topic_configuration>
       get_topic_cfg(model::topic_namespace_view) const;
 
+    ///\brief Returns partition assignments of single topic.
+    ///
+    /// If topic does not exists it returns an empty optional
+    std::optional<std::vector<partition_assignment>>
+      get_topic_assignments(model::topic_namespace_view) const;
+
     ///\brief Returns topics timestamp type
     ///
     /// If topic does not exists it returns an empty optional

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -164,6 +164,8 @@ public:
 
     const underlying_t& topics_map() const { return _topics; }
 
+    const hierarchy_t& hierarchy_map() const { return _topics_hierarchy; }
+
     bool is_update_in_progress(const model::ntp&) const;
 
 private:

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -76,8 +76,7 @@ private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
     ss::future<> update_leaders_with_estimates(std::vector<ntp_leader> leaders);
-    void update_allocations(const create_topic_cmd&);
-    void update_allocations(const create_partition_cmd&);
+    void update_allocations(std::vector<partition_assignment>);
     void deallocate_topic(const model::topic_metadata&);
     void reallocate_partition(
       const std::vector<model::broker_shard>&,

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -71,7 +71,11 @@ public:
       model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_result>> create_non_replicable_topics(
-      std::vector<non_replicable_topic>, model::timeout_clock::time_point);
+      std::vector<non_replicable_topic> topics,
+      model::timeout_clock::time_point timeout);
+
+    ss::future<std::vector<topic_result>> autocreate_non_replicable_topics(
+      std::vector<non_replicable_topic>, model::timeout_clock::duration);
 
     ss::future<bool> validate_shard(model::node_id node, uint32_t shard) const;
 
@@ -94,6 +98,13 @@ private:
       model::node_id,
       std::vector<topic_configuration>,
       model::timeout_clock::duration);
+
+    ss::future<std::vector<topic_result>>
+    dispatch_create_non_replicable_to_leader(
+      model::node_id leader,
+      std::vector<non_replicable_topic> topics,
+      model::timeout_clock::duration timeout);
+
     ss::future<std::error_code> do_update_data_policy(
       topic_properties_update&, model::timeout_clock::time_point);
     ss::future<topic_result> do_update_topic_properties(

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -478,6 +478,50 @@ adl<cluster::create_topics_request>::from(iobuf_parser& in) {
     return cluster::create_topics_request{std::move(configs), timeout};
 }
 
+void adl<cluster::create_non_replicable_topics_request>::to(
+  iobuf& out, cluster::create_non_replicable_topics_request&& r) {
+    reflection::serialize(
+      out,
+      cluster::create_non_replicable_topics_request::current_version,
+      std::move(r.topics),
+      r.timeout);
+}
+
+cluster::create_non_replicable_topics_request
+adl<cluster::create_non_replicable_topics_request>::from(iobuf_parser& in) {
+    auto version = adl<int8_t>{}.from(in);
+    vassert(
+      version == cluster::create_non_replicable_topics_request::current_version,
+      "Unexpected version: {} (expected: {})",
+      version,
+      cluster::create_non_replicable_topics_request::current_version);
+    auto topics = adl<std::vector<cluster::non_replicable_topic>>().from(in);
+    auto timeout = adl<model::timeout_clock::duration>().from(in);
+    return cluster::create_non_replicable_topics_request{
+      std::move(topics), timeout};
+}
+
+void adl<cluster::create_non_replicable_topics_reply>::to(
+  iobuf& out, cluster::create_non_replicable_topics_reply&& r) {
+    reflection::serialize(
+      out,
+      cluster::create_non_replicable_topics_reply::current_version,
+      std::move(r.results));
+}
+
+cluster::create_non_replicable_topics_reply
+adl<cluster::create_non_replicable_topics_reply>::from(iobuf_parser& in) {
+    auto version = adl<int8_t>{}.from(in);
+    vassert(
+      version == cluster::create_non_replicable_topics_reply::current_version,
+      "Unexpected version: {} (expected: {})",
+      version,
+      cluster::create_non_replicable_topics_reply::current_version);
+    auto results = adl<std::vector<cluster::topic_result>>().from(in);
+    return cluster::create_non_replicable_topics_reply{
+      .results = std::move(results)};
+}
+
 void adl<cluster::create_topics_reply>::to(
   iobuf& out, cluster::create_topics_reply&& r) {
     reflection::serialize(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -767,6 +767,17 @@ struct config_status_reply {
     errc error;
 };
 
+struct create_non_replicable_topics_request {
+    static constexpr int8_t current_version = 1;
+    std::vector<non_replicable_topic> topics;
+    model::timeout_clock::duration timeout;
+};
+
+struct create_non_replicable_topics_reply {
+    static constexpr int8_t current_version = 1;
+    std::vector<topic_result> results;
+};
+
 } // namespace cluster
 namespace std {
 template<>
@@ -814,6 +825,18 @@ struct adl<cluster::create_topics_request> {
     void to(iobuf&, cluster::create_topics_request&&);
     cluster::create_topics_request from(iobuf);
     cluster::create_topics_request from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::create_non_replicable_topics_request> {
+    void to(iobuf&, cluster::create_non_replicable_topics_request&&);
+    cluster::create_non_replicable_topics_request from(iobuf_parser&);
+};
+
+template<>
+struct adl<cluster::create_non_replicable_topics_reply> {
+    void to(iobuf&, cluster::create_non_replicable_topics_reply&&);
+    cluster::create_non_replicable_topics_reply from(iobuf_parser&);
 };
 
 template<>

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -23,6 +23,7 @@ v_cc_library(
     script_dispatcher.cc
     event_handler.cc
     partition.cc
+    partition_manager.cc
   DEPS
     v::rpc
     v::model

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -22,6 +22,7 @@ v_cc_library(
     event_listener.cc
     script_dispatcher.cc
     event_handler.cc
+    partition.cc
   DEPS
     v::rpc
     v::model

--- a/src/v/coproc/CMakeLists.txt
+++ b/src/v/coproc/CMakeLists.txt
@@ -24,6 +24,7 @@ v_cc_library(
     event_handler.cc
     partition.cc
     partition_manager.cc
+    reconciliation_backend.cc
   DEPS
     v::rpc
     v::model

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -49,7 +49,8 @@ ss::future<> api::start() {
       std::ref(_rs.topic_table),
       std::ref(_rs.shard_table),
       std::ref(_rs.partition_manager),
-      std::ref(_rs.cp_partition_manager));
+      std::ref(_rs.cp_partition_manager),
+      std::ref(_pacemaker));
 
     co_await _reconciliation_backend.invoke_on_all(
       &coproc::reconciliation_backend::start);

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -15,6 +15,7 @@
 #include "coproc/event_handler.h"
 #include "coproc/event_listener.h"
 #include "coproc/pacemaker.h"
+#include "coproc/partition_manager.h"
 #include "coproc/reconciliation_backend.h"
 
 #include <seastar/core/coroutine.hh>
@@ -42,10 +43,15 @@ api::api(
 api::~api() = default;
 
 ss::future<> api::start() {
+    co_await _partition_manager.start(std::ref(_rs.storage));
+    co_await _partition_manager.invoke_on_all(
+      &coproc::partition_manager::start);
+
     co_await _reconciliation_backend.start(
       std::ref(_rs.topic_table),
       std::ref(_rs.shard_table),
-      std::ref(_rs.storage));
+      std::ref(_rs.partition_manager),
+      std::ref(_partition_manager));
     co_await _reconciliation_backend.invoke_on_all(
       &coproc::reconciliation_backend::start);
 
@@ -63,13 +69,13 @@ ss::future<> api::start() {
 }
 
 ss::future<> api::stop() {
-    auto f = ss::now();
     if (_listener) {
-        f = _listener->stop();
+        co_await _listener->stop();
     }
-    return f.then([this] { return _pacemaker.stop(); }).then([this] {
-        return _mt_frontend.stop();
-    });
+    co_await _pacemaker.stop();
+    co_await _mt_frontend.stop();
+    co_await _reconciliation_backend.stop();
+    co_await _partition_manager.stop();
 }
 
 } // namespace coproc

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -17,6 +17,7 @@
 #include "coproc/pacemaker.h"
 #include "coproc/partition_manager.h"
 #include "coproc/reconciliation_backend.h"
+#include "coproc/script_database.h"
 #include "coproc/script_dispatcher.h"
 
 #include <seastar/core/coroutine.hh>
@@ -56,6 +57,7 @@ ss::future<> api::start() {
     co_await _reconciliation_backend.invoke_on_all(
       &coproc::reconciliation_backend::start);
 
+    co_await _sdb.start_single();
     co_await _mt_frontend.start_single(std::ref(_rs.topics_frontend));
     co_await _pacemaker.start(_engine_addr, std::ref(_rs));
     co_await _pacemaker.invoke_on_all(&coproc::pacemaker::start);
@@ -64,7 +66,8 @@ ss::future<> api::start() {
     vassert(!_dispatcher, "nullptr expected");
     vassert(!_wasm_async_handler, "nullptr expected");
     _listener = std::make_unique<wasm::event_listener>(_as);
-    _dispatcher = std::make_unique<wasm::script_dispatcher>(_pacemaker, _as);
+    _dispatcher = std::make_unique<wasm::script_dispatcher>(
+      _pacemaker, _sdb, _as);
     _wasm_async_handler = std::make_unique<coproc::wasm::async_event_handler>(
       std::ref(*_dispatcher));
     _listener->register_handler(
@@ -77,6 +80,7 @@ ss::future<> api::stop() {
     co_await _listener->stop();
     co_await _pacemaker.stop();
     co_await _mt_frontend.stop();
+    co_await _sdb.stop();
 }
 
 } // namespace coproc

--- a/src/v/coproc/api.cc
+++ b/src/v/coproc/api.cc
@@ -52,7 +52,8 @@ ss::future<> api::start() {
       std::ref(_rs.shard_table),
       std::ref(_rs.partition_manager),
       std::ref(_rs.cp_partition_manager),
-      std::ref(_pacemaker));
+      std::ref(_pacemaker),
+      std::ref(_sdb));
 
     co_await _reconciliation_backend.invoke_on_all(
       &coproc::reconciliation_backend::start);

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -15,8 +15,10 @@
 #include "coproc/fwd.h"
 #include "coproc/sys_refs.h"
 #include "utils/unresolved_address.h"
-namespace coproc {
 
+#include <seastar/core/abort_source.hh>
+
+namespace coproc {
 class api {
 public:
     api(
@@ -40,16 +42,17 @@ public:
 private:
     unresolved_address _engine_addr;
 
-    std::unique_ptr<wasm::event_listener> _listener; /// one instance
-    ss::sharded<pacemaker> _pacemaker;               /// one per core
+    ss::sharded<pacemaker> _pacemaker; /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
     ss::sharded<reconciliation_backend>
       _reconciliation_backend; /// one per core
 
     sys_refs _rs;
+    ss::abort_source _as;
 
-    // Event handlers
+    std::unique_ptr<wasm::script_dispatcher> _dispatcher;
+    std::unique_ptr<wasm::event_listener> _listener;
     std::unique_ptr<wasm::async_event_handler> _wasm_async_handler;
 };
 

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -43,7 +43,8 @@ private:
     std::unique_ptr<wasm::event_listener> _listener; /// one instance
     ss::sharded<pacemaker> _pacemaker;               /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
-      _mt_frontend; /// one instance
+      _mt_frontend;                                    /// one instance
+    ss::sharded<partition_manager> _partition_manager; /// one per core
     ss::sharded<reconciliation_backend>
       _reconciliation_backend; /// one per core
 

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -42,7 +42,8 @@ public:
 private:
     unresolved_address _engine_addr;
 
-    ss::sharded<pacemaker> _pacemaker; /// one per core
+    ss::sharded<wasm::script_database> _sdb; // one instance
+    ss::sharded<pacemaker> _pacemaker;       /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
     ss::sharded<reconciliation_backend>

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -39,7 +39,6 @@ public:
 
 private:
     unresolved_address _engine_addr;
-    sys_refs _rs;
 
     std::unique_ptr<wasm::event_listener> _listener; /// one instance
     ss::sharded<pacemaker> _pacemaker;               /// one per core
@@ -47,6 +46,8 @@ private:
       _mt_frontend; /// one instance
     ss::sharded<reconciliation_backend>
       _reconciliation_backend; /// one per core
+
+    sys_refs _rs;
 
     // Event handlers
     std::unique_ptr<wasm::async_event_handler> _wasm_async_handler;

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -26,7 +26,8 @@ public:
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::topics_frontend>&,
       ss::sharded<cluster::metadata_cache>&,
-      ss::sharded<cluster::partition_manager>&) noexcept;
+      ss::sharded<cluster::partition_manager>&,
+      ss::sharded<coproc::partition_manager>&) noexcept;
 
     ~api();
 
@@ -43,8 +44,7 @@ private:
     std::unique_ptr<wasm::event_listener> _listener; /// one instance
     ss::sharded<pacemaker> _pacemaker;               /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
-      _mt_frontend;                                    /// one instance
-    ss::sharded<partition_manager> _partition_manager; /// one per core
+      _mt_frontend; /// one instance
     ss::sharded<reconciliation_backend>
       _reconciliation_backend; /// one per core
 

--- a/src/v/coproc/api.h
+++ b/src/v/coproc/api.h
@@ -22,6 +22,8 @@ public:
     api(
       unresolved_address,
       ss::sharded<storage::api>&,
+      ss::sharded<cluster::topic_table>&,
+      ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::topics_frontend>&,
       ss::sharded<cluster::metadata_cache>&,
       ss::sharded<cluster::partition_manager>&) noexcept;
@@ -42,6 +44,8 @@ private:
     ss::sharded<pacemaker> _pacemaker;               /// one per core
     ss::sharded<cluster::non_replicable_topics_frontend>
       _mt_frontend; /// one instance
+    ss::sharded<reconciliation_backend>
+      _reconciliation_backend; /// one per core
 
     // Event handlers
     std::unique_ptr<wasm::async_event_handler> _wasm_async_handler;

--- a/src/v/coproc/errc.h
+++ b/src/v/coproc/errc.h
@@ -63,7 +63,9 @@ enum class errc {
     topic_does_not_exist,
     invalid_topic,
     materialized_topic,
-    script_id_does_not_exist
+    script_id_does_not_exist,
+    partition_not_exists,
+    partition_already_exists
 };
 
 struct errc_category final : public std::error_category {
@@ -83,6 +85,10 @@ struct errc_category final : public std::error_category {
             return "Topic is already a materialized topic";
         case errc::script_id_does_not_exist:
             return "Could not find coprocessor with matching script_id";
+        case errc::partition_not_exists:
+            return "Partition missing from coproc::partition_manager";
+        case errc::partition_already_exists:
+            return "Partition alreday exists in coproc::partition_manager";
         default:
             return "Undefined coprocessor error encountered";
         }

--- a/src/v/coproc/errc.h
+++ b/src/v/coproc/errc.h
@@ -86,9 +86,9 @@ struct errc_category final : public std::error_category {
         case errc::script_id_does_not_exist:
             return "Could not find coprocessor with matching script_id";
         case errc::partition_not_exists:
-            return "Partition missing from coproc::partition_manager";
+            return "Partition not found";
         case errc::partition_already_exists:
-            return "Partition alreday exists in coproc::partition_manager";
+            return "Partition already exists";
         default:
             return "Undefined coprocessor error encountered";
         }

--- a/src/v/coproc/event_handler.cc
+++ b/src/v/coproc/event_handler.cc
@@ -10,15 +10,14 @@
 
 #include "coproc/event_handler.h"
 
+#include "coproc/script_dispatcher.h"
 #include "utils/gate_guard.h"
 #include "vlog.h"
 
 namespace coproc::wasm {
 
-async_event_handler::async_event_handler(
-  ss::abort_source& abort_source, ss::sharded<pacemaker>& pacemaker)
-  : _abort_source(abort_source)
-  , _dispatcher(pacemaker, _abort_source) {}
+async_event_handler::async_event_handler(script_dispatcher& dispatcher)
+  : _dispatcher(dispatcher) {}
 
 ss::future<> async_event_handler::start() { co_return; }
 

--- a/src/v/coproc/event_handler.h
+++ b/src/v/coproc/event_handler.h
@@ -77,9 +77,6 @@ public:
     process(absl::btree_map<script_id, parsed_event> wsas) override;
 
 private:
-    /// Set of known script ids to be active
-    absl::btree_set<script_id> _active_ids;
-
     ss::gate _gate;
 
     /// Used to make requests to the wasm engine

--- a/src/v/coproc/event_handler.h
+++ b/src/v/coproc/event_handler.h
@@ -10,13 +10,14 @@
 
 #pragma once
 
+#include "coproc/fwd.h"
 #include "coproc/logger.h"
-#include "coproc/script_dispatcher.h"
 #include "coproc/wasm_event.h"
 #include "seastarx.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
 
 #include <absl/container/btree_map.h>
 #include <absl/container/btree_set.h>
@@ -64,8 +65,7 @@ public:
 
 class async_event_handler final : public event_handler {
 public:
-    explicit async_event_handler(
-      ss::abort_source& abort_source, ss::sharded<pacemaker>& pacemaker);
+    explicit async_event_handler(script_dispatcher&);
 
     ss::future<> start() override;
     ss::future<> stop() override;
@@ -80,13 +80,10 @@ private:
     /// Set of known script ids to be active
     absl::btree_set<script_id> _active_ids;
 
-    /// Pass it tot script_dispatcher
-    ss::abort_source& _abort_source;
-
     ss::gate _gate;
 
     /// Used to make requests to the wasm engine
-    script_dispatcher _dispatcher;
+    script_dispatcher& _dispatcher;
 };
 
 class data_policy_event_handler final : public event_handler {

--- a/src/v/coproc/event_listener.cc
+++ b/src/v/coproc/event_listener.cc
@@ -59,8 +59,9 @@ ss::future<> event_listener::stop() {
       });
 }
 
-event_listener::event_listener()
-  : _client(make_client()) {}
+event_listener::event_listener(ss::abort_source& as)
+  : _client(make_client())
+  , _abort_source(as) {}
 
 ss::future<> event_listener::start() {
     co_await ss::parallel_for_each(
@@ -97,8 +98,6 @@ void event_listener::register_handler(event_type type, event_handler* handler) {
       "Register new handler for wasm_event_type: {}",
       coproc_type_as_string_view(type));
 }
-
-ss::abort_source& event_listener::get_abort_source() { return _abort_source; }
 
 static ss::future<std::vector<model::record_batch>>
 decompress_wasm_events(model::record_batch_reader::data_t events) {

--- a/src/v/coproc/event_listener.h
+++ b/src/v/coproc/event_listener.h
@@ -35,7 +35,7 @@ namespace coproc::wasm {
 class event_listener {
 public:
     /// class constructor
-    event_listener();
+    explicit event_listener(ss::abort_source&);
 
     /// To be invoked once on redpanda::application startup
     ///
@@ -68,7 +68,7 @@ private:
 
     /// Primitives used to manage the poll loop
     ss::gate _gate;
-    ss::abort_source _abort_source;
+    ss::abort_source& _abort_source;
 
     /// Current offset into the 'coprocessor_internal_topic'
     model::offset _offset{0};

--- a/src/v/coproc/exception.h
+++ b/src/v/coproc/exception.h
@@ -31,6 +31,21 @@ private:
     ss::sstring _msg;
 };
 
+/// Not necessarily a fatal error, explicity handle these events as theres no
+/// way to ensure handles to partitions aren't in use before
+/// partition::shutdown() is called
+class partition_shutdown_exception final : public exception {
+public:
+    partition_shutdown_exception(model::ntp ntp, ss::sstring msg) noexcept
+      : exception(std::move(msg))
+      , _ntp(std::move(ntp)) {}
+
+    const model::ntp& ntp() const { return _ntp; }
+
+private:
+    model::ntp _ntp;
+};
+
 /// Root exception type for classes of exceptions that are only thrown by
 /// actions interpreted by coprocessors themselves
 class script_exception : public exception {

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -21,6 +21,7 @@ class reconciliation_backend;
 
 namespace wasm {
 
+class script_database;
 class script_dispatcher;
 class async_event_handler;
 class event_listener;

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -17,6 +17,7 @@ class api;
 class pacemaker;
 class script_context;
 class partition_manager;
+class reconciliation_backend;
 
 namespace wasm {
 

--- a/src/v/coproc/fwd.h
+++ b/src/v/coproc/fwd.h
@@ -16,6 +16,7 @@ namespace coproc {
 class api;
 class pacemaker;
 class script_context;
+class partition_manager;
 
 namespace wasm {
 

--- a/src/v/coproc/pacemaker.cc
+++ b/src/v/coproc/pacemaker.cc
@@ -280,4 +280,10 @@ bool pacemaker::local_script_id_exists(script_id id) {
     return _scripts.find(id) != _scripts.end();
 }
 
+bool pacemaker::is_up_to_date() const {
+    return std::all_of(_scripts.cbegin(), _scripts.cend(), [](const auto& p) {
+        return p.second->is_up_to_date();
+    });
+}
+
 } // namespace coproc

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -122,6 +122,30 @@ public:
     /// returns a handle to the reconnect transport
     shared_script_resources& resources() { return _shared_res; }
 
+    /// Calls the function while materialized topic is on the denylist
+    ///
+    /// Its not enough to add the topic to the denylist, it must also be
+    /// checked that all fibers are respecting this, i.e. don't have in-progress
+    /// writes to these topics. After the function has been invoked the topic
+    /// will be removed from the blacklist.
+    template<typename Fn>
+    ss::future<>
+    with_hold(const model::ntp& source, const model::ntp& materialized, Fn fn) {
+        _shared_res.in_progress_deletes.emplace(materialized);
+        std::vector<ss::future<>> fs;
+        for (auto& [_, script] : _scripts) {
+            fs.emplace_back(script->remove_output(source, materialized));
+        }
+        /// When this future completes, it can safely be assumed that all fibers
+        /// are respecting the new addition to the blacklist
+        co_await ss::when_all_succeed(fs.begin(), fs.end());
+        co_await fn();
+        _shared_res.log_mtx.erase(materialized);
+        /// Releases the barrier, if any fibers wish to recreate the topic its
+        /// safe to do so now
+        _shared_res.in_progress_deletes.erase(materialized);
+    }
+
 private:
     void do_add_source(
       script_id,

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -113,6 +113,21 @@ public:
     ss::future<errc> wait_for_script(script_id);
 
     /**
+     * Restarts a partition. Useful after source partition is moved.
+     */
+    using script_inputs_t
+      = absl::flat_hash_map<script_id, std::vector<topic_namespace_policy>>;
+    ss::future<absl::flat_hash_map<script_id, errc>>
+      restart_partition(model::ntp, script_inputs_t);
+
+    /**
+     * Removes partition from any active scripts that may be processing it
+     *
+     * @returns Ids of scripts that were reading from this partition
+     */
+    ss::future<std::vector<script_id>> shutdown_partition(model::ntp);
+
+    /**
      * @returns true if a matching script id exists on 'this' shard
      */
     bool local_script_id_exists(script_id);

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -154,6 +154,12 @@ public:
         _shared_res.in_progress_deletes.erase(materialized);
     }
 
+    /// True if all fibers on this shard have no more data to consume
+    ///
+    /// Only useful for testing in the case where all input has been produced to
+    /// all input topics up front
+    bool is_up_to_date() const;
+
 private:
     void do_add_source(
       script_id,

--- a/src/v/coproc/pacemaker.h
+++ b/src/v/coproc/pacemaker.h
@@ -133,7 +133,7 @@ public:
     ss::future<>
     with_hold(const model::ntp& source, const model::ntp& materialized, Fn fn) {
         _shared_res.in_progress_deletes.emplace(materialized);
-        std::vector<ss::future<>> fs;
+        std::vector<ss::future<errc>> fs;
         for (auto& [_, script] : _scripts) {
             fs.emplace_back(
               script->remove_output(source, materialized)
@@ -142,6 +142,7 @@ public:
                       coproclog.info,
                       "Script shutdown during barriers emplacement: {}",
                       ex);
+                    return errc::success;
                 }));
         }
         /// When this future completes, it can safely be assumed that all fibers

--- a/src/v/coproc/partition.cc
+++ b/src/v/coproc/partition.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/partition.h"
+
+#include "storage/log.h"
+
+namespace coproc {
+
+partition::partition(
+  storage::log log, ss::lw_shared_ptr<cluster::partition> source) noexcept
+  : _log(log)
+  , _source(source) {}
+
+ss::future<model::record_batch_reader>
+partition::make_reader(storage::log_reader_config config) {
+    return ss::try_with_gate(
+      _gate, [this, config] { return _log.make_reader(config); });
+}
+
+storage::log_appender
+partition::make_appender(storage::log_append_config write_cfg) {
+    _gate.check();
+    return _log.make_appender(write_cfg);
+}
+
+ss::future<std::optional<storage::timequery_result>>
+partition::timequery(storage::timequery_config cfg) {
+    return ss::try_with_gate(
+      _gate, [this, cfg] { return _log.timequery(cfg); });
+}
+
+} // namespace coproc

--- a/src/v/coproc/partition.h
+++ b/src/v/coproc/partition.h
@@ -50,6 +50,9 @@ public:
     ss::future<std::optional<storage::timequery_result>>
       timequery(storage::timequery_config);
 
+    /// \brief get a handle to the source partition
+    ss::lw_shared_ptr<cluster::partition> source_partition() { return _source; }
+
 private:
     ss::gate _gate;
     storage::log _log;

--- a/src/v/coproc/partition.h
+++ b/src/v/coproc/partition.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/partition.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/gate.hh>
+
+namespace coproc {
+
+class partition {
+public:
+    partition(storage::log, ss::lw_shared_ptr<cluster::partition>) noexcept;
+
+    ss::future<> start() { return ss::now(); }
+    ss::future<> stop() { return _gate.close(); }
+
+    model::offset start_offset() const { return _log.offsets().start_offset; }
+    model::offset dirty_offset() const { return _log.offsets().dirty_offset; }
+
+    const model::ntp& source() const { return _source->ntp(); }
+    const model::ntp& ntp() const { return _log.config().ntp(); }
+    const storage::ntp_config& config() const { return _log.config(); }
+    bool is_leader() const { return _source->is_leader(); }
+    model::revision_id get_revision_id() const {
+        return _log.config().get_revision();
+    }
+
+    /// \brief Returns a reader that enters the \ref _gate when it performs
+    /// operations
+    ss::future<model::record_batch_reader>
+      make_reader(storage::log_reader_config);
+
+    /// \brief Returns an appender that ensures appends will not occur after
+    /// future returned from stop() resolves
+    storage::log_appender make_appender(storage::log_append_config);
+
+    /// \brief Invokes the timequery method on the \ref _log within the context
+    /// of the \ref gate
+    ss::future<std::optional<storage::timequery_result>>
+      timequery(storage::timequery_config);
+
+private:
+    ss::gate _gate;
+    storage::log _log;
+    ss::lw_shared_ptr<cluster::partition> _source;
+};
+
+} // namespace coproc

--- a/src/v/coproc/partition_manager.cc
+++ b/src/v/coproc/partition_manager.cc
@@ -77,6 +77,7 @@ ss::future<> partition_manager::remove(const model::ntp& ntp) {
           ntp));
     }
 
+    vlog(coproclog.info, "Removing materialized log: {}", ntp);
     auto partition = found->second;
     _ntp_table.erase(found);
     _unmanage_watchers.notify(ntp, ntp.tp.partition);

--- a/src/v/coproc/partition_manager.cc
+++ b/src/v/coproc/partition_manager.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/partition_manager.h"
+
+#include "cluster/logger.h"
+#include "cluster/partition.h"
+#include "coproc/logger.h"
+#include "storage/api.h"
+#include "vlog.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace coproc {
+
+partition_manager::partition_manager(
+  ss::sharded<storage::api>& storage) noexcept
+  : _storage(storage.local()) {}
+
+ss::lw_shared_ptr<partition>
+partition_manager::get(const model::ntp& ntp) const {
+    if (auto it = _ntp_table.find(ntp); it != _ntp_table.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+ss::future<> partition_manager::manage(
+  storage::ntp_config ntp_cfg, ss::lw_shared_ptr<cluster::partition> src) {
+    auto holder = _gate.hold();
+    storage::log log = co_await _storage.log_mgr().manage(std::move(ntp_cfg));
+    vlog(
+      coproclog.info,
+      "Non replicable log created manage completed, ntp: {}, rev: {}, {} "
+      "segments, {} bytes",
+      log.config().ntp(),
+      log.config().get_revision(),
+      log.segment_count(),
+      log.size_bytes());
+
+    auto nrp = ss::make_lw_shared<partition>(log, src);
+    auto [_, success] = _ntp_table.emplace(log.config().ntp(), nrp);
+    vassert(
+      success,
+      "coproc::partition_manager contained item for key that was expected to "
+      "not exist");
+    _manage_watchers.notify(nrp->ntp(), nrp);
+    co_await nrp->start();
+}
+
+ss::future<> partition_manager::stop_partitions() {
+    co_await _gate.close();
+    auto partitions = std::exchange(_ntp_table, {});
+    co_await ss::parallel_for_each(
+      partitions, [this](ntp_table_container::value_type& e) {
+          return do_shutdown(e.second);
+      });
+}
+
+ss::future<> partition_manager::remove(const model::ntp& ntp) {
+    auto holder = _gate.hold();
+    auto found = _ntp_table.find(ntp);
+
+    if (found == _ntp_table.end()) {
+        throw std::invalid_argument(fmt_with_ctx(
+          ssx::sformat,
+          "Can not remove non_replicable partition. NTP {} is not "
+          "present in partition manager: ",
+          ntp));
+    }
+
+    auto partition = found->second;
+    _ntp_table.erase(found);
+    _unmanage_watchers.notify(ntp, ntp.tp.partition);
+    co_await partition->stop();
+    co_await _storage.log_mgr().remove(ntp);
+}
+
+ss::future<>
+partition_manager::do_shutdown(ss::lw_shared_ptr<partition> partition) {
+    try {
+        auto ntp = partition->ntp();
+        co_await partition->stop();
+        co_await _storage.log_mgr().shutdown(std::move(ntp));
+    } catch (...) {
+        vassert(
+          false,
+          "error shutting down non replicable partition {},  "
+          "non_replicable partition manager state: {}, error: {} - "
+          "terminating redpanda",
+          partition->ntp(),
+          *this,
+          std::current_exception());
+    }
+}
+
+cluster::notification_id_type partition_manager::register_manage_notification(
+  const model::ns& ns, const model::topic& topic, manage_cb_t cb) {
+    cluster::ntp_callbacks<manage_cb_t> init;
+    init.register_notify(
+      ns, topic, [&cb](ss::lw_shared_ptr<partition> p) { cb(p); });
+    for (auto& e : _ntp_table) {
+        init.notify(e.first, e.second);
+    }
+    return _manage_watchers.register_notify(ns, topic, std::move(cb));
+}
+
+std::ostream& operator<<(std::ostream& os, const partition_manager& nr_pm) {
+    fmt::print(os, "{ntp_count: {}}", nr_pm._ntp_table.size());
+    return os;
+}
+
+} // namespace coproc

--- a/src/v/coproc/partition_manager.h
+++ b/src/v/coproc/partition_manager.h
@@ -57,6 +57,15 @@ public:
         _unmanage_watchers.unregister_notify(id);
     }
 
+    /*
+     * read-only interface to partitions.
+     *
+     * note that users of this interface must take care not to hold iterators
+     * across scheduling events as the underlying table may be modified and
+     * invalidate iterators.
+     */
+    const ntp_table_container& partitions() const { return _ntp_table; }
+
 private:
     ss::future<> do_shutdown(ss::lw_shared_ptr<partition>);
 

--- a/src/v/coproc/partition_manager.h
+++ b/src/v/coproc/partition_manager.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/ntp_callbacks.h"
+#include "cluster/partition.h"
+#include "coproc/partition.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/gate.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+namespace coproc {
+
+class partition_manager {
+public:
+    using ntp_table_container
+      = absl::flat_hash_map<model::ntp, ss::lw_shared_ptr<partition>>;
+    using manage_cb_t
+      = ss::noncopyable_function<void(ss::lw_shared_ptr<partition>)>;
+    using unmanage_cb_t = ss::noncopyable_function<void(model::partition_id)>;
+
+    explicit partition_manager(ss::sharded<storage::api>& storage) noexcept;
+
+    ss::future<> start() { return ss::now(); }
+    ss::future<> stop_partitions();
+
+    ss::lw_shared_ptr<partition> get(const model::ntp& ntp) const;
+    ss::future<>
+      manage(storage::ntp_config, ss::lw_shared_ptr<cluster::partition>);
+
+    ss::future<> remove(const model::ntp&);
+
+    /// Recieve updates when a partition with matching ns, topic is added
+    cluster::notification_id_type register_manage_notification(
+      const model::ns& ns, const model::topic& topic, manage_cb_t cb);
+
+    /// Recieve updates when a partition with matching ns, topic is removed
+    cluster::notification_id_type register_unmanage_notification(
+      const model::ns& ns, const model::topic& topic, unmanage_cb_t cb) {
+        return _unmanage_watchers.register_notify(ns, topic, std::move(cb));
+    }
+    void unregister_manage_notification(cluster::notification_id_type id) {
+        _manage_watchers.unregister_notify(id);
+    }
+    void unregister_unmanage_notification(cluster::notification_id_type id) {
+        _unmanage_watchers.unregister_notify(id);
+    }
+
+private:
+    ss::future<> do_shutdown(ss::lw_shared_ptr<partition>);
+
+private:
+    ntp_table_container _ntp_table;
+    cluster::ntp_callbacks<manage_cb_t> _manage_watchers;
+    cluster::ntp_callbacks<unmanage_cb_t> _unmanage_watchers;
+
+    ss::gate _gate;
+    storage::api& _storage;
+
+    friend std::ostream& operator<<(std::ostream&, const partition_manager&);
+};
+
+} // namespace coproc

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/reconciliation_backend.h"
+
+#include "cluster/cluster_utils.h"
+#include "cluster/shard_table.h"
+#include "cluster/topic_table.h"
+#include "coproc/logger.h"
+#include "coproc/pacemaker.h"
+#include "storage/api.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace coproc {
+
+reconciliation_backend::reconciliation_backend(
+  ss::sharded<cluster::topic_table>& topics,
+  ss::sharded<cluster::shard_table>& shard_table,
+  ss::sharded<storage::api>& storage) noexcept
+  : _self(model::node_id(config::node().node_id))
+  , _data_directory(config::node().data_directory().as_sstring())
+  , _topics(topics)
+  , _shard_table(shard_table)
+  , _storage(storage) {
+    _retry_timer.set_callback([this] {
+        (void)within_context([this]() { return fetch_and_reconcile(); });
+    });
+}
+
+template<typename Fn>
+ss::future<> reconciliation_backend::within_context(Fn&& fn) {
+    try {
+        return ss::with_gate(
+          _gate, [this, fn = std::forward<Fn>(fn)]() mutable {
+              if (!_as.abort_requested()) {
+                  return _mutex.with(
+                    [fn = std::forward<Fn>(fn)]() mutable { return fn(); });
+              }
+              return ss::now();
+          });
+    } catch (const ss::gate_closed_exception& ex) {
+        vlog(coproclog.debug, "Timer fired during shutdown: {}", ex);
+    }
+    return ss::now();
+}
+
+ss::future<> reconciliation_backend::start() {
+    _id_cb = _topics.local().register_delta_notification(
+      [this](std::vector<update_t> deltas) {
+          return within_context([this, deltas = std::move(deltas)]() mutable {
+              for (auto& d : deltas) {
+                  auto ntp = d.ntp;
+                  _topic_deltas[ntp].push_back(std::move(d));
+              }
+              return fetch_and_reconcile();
+          });
+      });
+    return ss::now();
+}
+
+ss::future<> reconciliation_backend::stop() {
+    _as.request_abort();
+    _topics.local().unregister_delta_notification(_id_cb);
+    return _gate.close();
+}
+
+ss::future<std::vector<reconciliation_backend::update_t>>
+reconciliation_backend::process_events_for_ntp(
+  model::ntp ntp, std::vector<update_t> updates) {
+    std::vector<update_t> retries;
+    for (auto& d : updates) {
+        vlog(coproclog.trace, "executing ntp: {} op: {}", d.ntp, d);
+        auto err = co_await process_update(d);
+        vlog(coproclog.info, "partition operation {} result {}", d, err);
+        if (err != errc::success) {
+            /// In this case the source topic exists but its
+            /// associated partition doesn't, so try again
+            retries.push_back(std::move(d));
+        }
+    }
+    co_return retries;
+}
+
+ss::future<> reconciliation_backend::fetch_and_reconcile() {
+    using deltas_cache = decltype(_topic_deltas);
+    auto deltas = std::exchange(_topic_deltas, {});
+    deltas_cache retry_cache;
+    co_await ss::parallel_for_each(
+      deltas.begin(),
+      deltas.end(),
+      [this, &retry_cache](deltas_cache::value_type& p) -> ss::future<> {
+          auto retries = co_await process_events_for_ntp(p.first, p.second);
+          if (!retries.empty()) {
+              retry_cache[p.first] = std::move(retries);
+          }
+      });
+    if (!retry_cache.empty()) {
+        vlog(
+          coproclog.warn,
+          "There were recoverable errors when processing events, retrying");
+        std::swap(_topic_deltas, retry_cache);
+        if (!_retry_timer.armed()) {
+            _retry_timer.arm(
+              model::timeout_clock::now() + retry_timeout_interval);
+        }
+    }
+}
+
+ss::future<std::error_code> reconciliation_backend::process_update(update_t) {
+    co_return errc::success;
+}
+
+} // namespace coproc

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/fwd.h"
+#include "cluster/topic_table.h"
+#include "coproc/fwd.h"
+#include "storage/fwd.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+
+#include <absl/container/node_hash_map.h>
+
+namespace coproc {
+
+class reconciliation_backend {
+public:
+    explicit reconciliation_backend(
+      ss::sharded<cluster::topic_table>&,
+      ss::sharded<cluster::shard_table>&,
+      ss::sharded<storage::api>&) noexcept;
+
+    /// Starts the reconciliation loop
+    ///
+    /// Listens for events emitted from the topics table
+    ss::future<> start();
+
+    /// Stops the reconciliation loop
+    ss::future<> stop();
+
+private:
+    using update_t = cluster::topic_table::delta;
+    ss::future<std::error_code> process_update(update_t);
+    ss::future<std::vector<update_t>>
+      process_events_for_ntp(model::ntp, std::vector<update_t>);
+
+    ss::future<> fetch_and_reconcile();
+
+    template<typename Fn>
+    ss::future<> within_context(Fn&&);
+
+private:
+    cluster::notification_id_type _id_cb;
+    model::node_id _self;
+    ss::sstring _data_directory;
+    absl::node_hash_map<model::ntp, std::vector<update_t>> _topic_deltas;
+
+    mutex _mutex;
+    ss::gate _gate;
+    ss::abort_source _as;
+    ss::timer<model::timeout_clock> _retry_timer;
+
+    ss::sharded<cluster::topic_table>& _topics;
+    ss::sharded<cluster::shard_table>& _shard_table;
+    ss::sharded<storage::api>& _storage;
+};
+
+} // namespace coproc

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -31,7 +31,8 @@ public:
       ss::sharded<cluster::topic_table>&,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::partition_manager>&,
-      ss::sharded<partition_manager>&) noexcept;
+      ss::sharded<partition_manager>&,
+      ss::sharded<pacemaker>&) noexcept;
 
     /// Starts the reconciliation loop
     ///
@@ -77,6 +78,7 @@ private:
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::partition_manager>& _cluster_pm;
     ss::sharded<partition_manager>& _coproc_pm;
+    ss::sharded<pacemaker>& _pacemaker;
 };
 
 } // namespace coproc

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -14,7 +14,6 @@
 #include "cluster/topic_table.h"
 #include "coproc/fwd.h"
 #include "storage/fwd.h"
-#include "utils/mutex.h"
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
@@ -44,11 +43,12 @@ public:
 
 private:
     using update_t = cluster::topic_table::delta;
-    ss::future<std::error_code> process_update(update_t);
-    ss::future<std::vector<update_t>>
-      process_events_for_ntp(model::ntp, std::vector<update_t>);
+    using events_cache_t
+      = absl::node_hash_map<model::ntp, std::vector<update_t>>;
 
-    ss::future<> fetch_and_reconcile();
+    ss::future<> fetch_and_reconcile(events_cache_t);
+    ss::future<> process_updates(model::ntp, std::vector<update_t>);
+    ss::future<std::error_code> process_update(model::ntp, update_t);
 
     ss::future<>
     delete_non_replicable_partition(model::ntp ntp, model::revision_id rev);
@@ -57,22 +57,17 @@ private:
     ss::future<> add_to_shard_table(
       model::ntp ntp, ss::shard_id shard, model::revision_id revision);
 
-    template<typename Fn>
-    ss::future<> within_context(Fn&&);
+    void enqueue_events(std::vector<update_t>);
+    ss::future<> process_loop();
 
 private:
-    static constexpr auto retry_timeout_interval = std::chrono::milliseconds(
-      100);
-
     cluster::notification_id_type _id_cb;
     model::node_id _self;
     ss::sstring _data_directory;
-    absl::node_hash_map<model::ntp, std::vector<update_t>> _topic_deltas;
+    events_cache_t _topic_deltas;
 
-    mutex _mutex;
     ss::gate _gate;
     ss::abort_source _as;
-    ss::timer<model::timeout_clock> _retry_timer;
 
     ss::sharded<cluster::topic_table>& _topics;
     ss::sharded<cluster::shard_table>& _shard_table;

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -46,6 +46,13 @@ private:
 
     ss::future<> fetch_and_reconcile();
 
+    ss::future<>
+    delete_non_replicable_partition(model::ntp ntp, model::revision_id rev);
+    ss::future<std::error_code>
+    create_non_replicable_partition(model::ntp ntp, model::revision_id rev);
+    ss::future<> add_to_shard_table(
+      model::ntp ntp, ss::shard_id shard, model::revision_id revision);
+
     template<typename Fn>
     ss::future<> within_context(Fn&&);
 

--- a/src/v/coproc/reconciliation_backend.h
+++ b/src/v/coproc/reconciliation_backend.h
@@ -21,6 +21,8 @@
 
 #include <absl/container/node_hash_map.h>
 
+#include <chrono>
+
 namespace coproc {
 
 class reconciliation_backend {
@@ -28,7 +30,8 @@ public:
     explicit reconciliation_backend(
       ss::sharded<cluster::topic_table>&,
       ss::sharded<cluster::shard_table>&,
-      ss::sharded<storage::api>&) noexcept;
+      ss::sharded<cluster::partition_manager>&,
+      ss::sharded<partition_manager>&) noexcept;
 
     /// Starts the reconciliation loop
     ///
@@ -57,6 +60,9 @@ private:
     ss::future<> within_context(Fn&&);
 
 private:
+    static constexpr auto retry_timeout_interval = std::chrono::milliseconds(
+      100);
+
     cluster::notification_id_type _id_cb;
     model::node_id _self;
     ss::sstring _data_directory;
@@ -69,7 +75,8 @@ private:
 
     ss::sharded<cluster::topic_table>& _topics;
     ss::sharded<cluster::shard_table>& _shard_table;
-    ss::sharded<storage::api>& _storage;
+    ss::sharded<cluster::partition_manager>& _cluster_pm;
+    ss::sharded<partition_manager>& _coproc_pm;
 };
 
 } // namespace coproc

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -122,6 +122,7 @@ ss::future<> script_context::send_request(
                 .frontend = _resources.rs.mt_frontend,
                 .pm = _resources.rs.cp_partition_manager,
                 .inputs = _routes,
+                .denylist = _resources.in_progress_deletes,
                 .locks = _resources.log_mtx};
               return write_materialized(
                 std::move(reply.value().data.resps), args);

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -118,7 +118,9 @@ ss::future<> script_context::send_request(
           if (reply) {
               output_write_args args{
                 .id = _id,
-                .rs = _resources.rs,
+                .metadata = _resources.rs.metadata_cache,
+                .frontend = _resources.rs.mt_frontend,
+                .storage = _resources.rs.storage,
                 .inputs = _routes,
                 .locks = _resources.log_mtx};
               return write_materialized(

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -167,4 +167,16 @@ ss::future<> script_context::send_request(
       });
 }
 
+bool script_context::is_up_to_date() const {
+    for (const auto& [_, src] : _routes) {
+        const auto highest = src->rctx.input->last_stable_offset();
+        for (const auto& [_, o] : src->wctx.offsets) {
+            if (o < highest) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 } // namespace coproc

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -120,7 +120,7 @@ ss::future<> script_context::send_request(
                 .id = _id,
                 .metadata = _resources.rs.metadata_cache,
                 .frontend = _resources.rs.mt_frontend,
-                .storage = _resources.rs.storage,
+                .pm = _resources.rs.cp_partition_manager,
                 .inputs = _routes,
                 .locks = _resources.log_mtx};
               return write_materialized(

--- a/src/v/coproc/script_context.cc
+++ b/src/v/coproc/script_context.cc
@@ -168,6 +168,13 @@ ss::future<> script_context::send_request(
 }
 
 bool script_context::is_up_to_date() const {
+    if (_routes.empty()) {
+        /// Since this method is only used for unit tests, its never desired to
+        /// return true in the case the script is technically "up to date"
+        /// because it contains no work. It is likely due to recieve data to
+        /// process shortly.
+        return false;
+    }
     for (const auto& [_, src] : _routes) {
         const auto highest = src->rctx.input->last_stable_offset();
         for (const auto& [_, o] : src->wctx.offsets) {

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -77,6 +77,13 @@ public:
      */
     ss::future<> shutdown();
 
+    /// Query for particular route
+    inline ss::lw_shared_ptr<coproc::source>
+    get_route(const model::ntp& ntp) const {
+        auto f = _routes.find(ntp);
+        return f != _routes.end() ? f->second : nullptr;
+    }
+
     /// Returns copy of active routes
     routes_t get_routes() const { return _routes; }
 

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "coproc/errc.h"
 #include "coproc/exception.h"
 #include "coproc/script_context_router.h"
 #include "coproc/shared_script_resources.h"
@@ -25,7 +26,7 @@
 
 namespace coproc {
 
-/// Raised when futures enqueued by \ref remove_output were failed to be
+/// Raised when futures enqueued by an async update were failed to be
 /// fufilled due to shutdown before the event occurring
 class wait_future_stranded final : public exception {
     using exception::exception;
@@ -82,7 +83,7 @@ public:
     /// Clean-up associated resources with removed output
     ///
     /// This is to be invoked after a materialized topic is deleted
-    ss::future<>
+    ss::future<errc>
     remove_output(const model::ntp& source, const model::ntp& materialized);
 
     /// Returns true if fiber is up to date with all of its inputs
@@ -91,18 +92,50 @@ public:
     /// offsets for respective tracked partitions
     bool is_up_to_date() const;
 
+    /// Start ingestion on the interested ntp.
+    ///
+    /// Useful for the cases where an input partition was moved or updated.
+    ss::future<errc> start_processing_ntp(const model::ntp&, read_context&&);
+
+    /// Stop ingestion on the interested ntp.
+    ///
+    /// Useful for the cases where an input partition is to be moved or updated.
+    ss::future<errc> stop_processing_ntp(const model::ntp&);
+
 private:
     ss::future<> do_execute();
 
     ss::future<> process_reply(process_batch_reply);
     void notify_waiters();
 
+    ss::future<ss::stop_iteration> process_send_write(rpc::transport*);
+
+private:
+    /// State to track in-progress ntp modifications
     struct update {
-        model::ntp source;
-        std::vector<ss::promise<>> ps;
+        std::vector<ss::promise<errc>> ps;
+        virtual ~update() = default;
+        virtual errc handle(const model::ntp&, routes_t&) = 0;
     };
 
-    ss::future<ss::stop_iteration> process_send_write(rpc::transport*);
+    struct insert_update final : public update {
+        /// New input topic is inserted after initial start
+        read_context rctx;
+        explicit insert_update(read_context) noexcept;
+        errc handle(const model::ntp&, routes_t&) final;
+    };
+
+    struct remove_update final : public update {
+        /// Existing input topic is removed after initial start
+        errc handle(const model::ntp&, routes_t&) final;
+    };
+
+    struct output_remove_update final : public update {
+        /// Materialized topic (output topic) removed
+        model::ntp source;
+        explicit output_remove_update(model::ntp) noexcept;
+        errc handle(const model::ntp&, routes_t&) final;
+    };
 
 private:
     /// Killswitch for in-process reads
@@ -112,7 +145,7 @@ private:
     ss::gate _gate;
 
     /// Allows the ability to asynchronously remove items from the router map
-    absl::node_hash_map<model::ntp, update> _updates;
+    absl::node_hash_map<model::ntp, std::unique_ptr<update>> _updates;
 
     // Reference to resources shared across all script_contexts on 'this'
     // shard

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -85,6 +85,12 @@ public:
     ss::future<>
     remove_output(const model::ntp& source, const model::ntp& materialized);
 
+    /// Returns true if fiber is up to date with all of its inputs
+    ///
+    /// This is when the stored offsets currently match the input logs dirty
+    /// offsets for respective tracked partitions
+    bool is_up_to_date() const;
+
 private:
     ss::future<> do_execute();
 

--- a/src/v/coproc/script_context.h
+++ b/src/v/coproc/script_context.h
@@ -94,9 +94,6 @@ public:
 private:
     ss::future<> do_execute();
 
-    ss::future<>
-      send_request(supervisor_client_protocol, process_batch_request);
-
     ss::future<> process_reply(process_batch_reply);
     void notify_waiters();
 
@@ -104,6 +101,8 @@ private:
         model::ntp source;
         std::vector<ss::promise<>> ps;
     };
+
+    ss::future<ss::stop_iteration> process_send_write(rpc::transport*);
 
 private:
     /// Killswitch for in-process reads

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -240,6 +240,14 @@ static ss::future<> process_one_reply(
             "error",
             e.id));
     }
+    if (args.denylist.contains(e.ntp)) {
+        /// The script attempted to write to a blacklisted ntp, meaning that
+        /// this ntp has been marked for deletion. Ignore this particular
+        /// portion of the request, until the ntp leaves the denlylist (after it
+        /// has been fully torn down). If the script later responds with this
+        /// ntp, it will be eventually re-created.
+        co_return;
+    }
     /// Possible filter response
     if (e.ntp == e.source) {
         /// If the reader is empty, then the wasm engine returned a nil

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -178,7 +178,7 @@ static ss::future<> maybe_make_materialized_log(
       [topics = std::move(topics)](
         cluster::non_replicable_topics_frontend& mtfe) mutable {
           return mtfe.create_non_replicable_topics(
-            std::move(topics), model::no_timeout);
+            std::move(topics), model::max_duration);
       });
 }
 

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -124,7 +124,7 @@ static ss::future<> do_write_materialized_partition(
 }
 
 static ss::future<ss::lw_shared_ptr<partition>>
-get_partition(partition_manager& pm, const model::ntp& ntp) {
+get_partition(partition_manager& pm, model::ntp ntp) {
     auto found = pm.get(ntp);
     if (found) {
         /// Log exists, do nothing and return it
@@ -133,8 +133,9 @@ get_partition(partition_manager& pm, const model::ntp& ntp) {
     /// In the case the storage::log has not been created, but the topic has.
     /// Retry again.
     co_await ss::sleep(100ms);
-    throw log_not_yet_created_exception(fmt::format(
-      "Materialized topic created but underlying log doesn't yet exist", ntp));
+    throw log_not_yet_created_exception(ssx::sformat(
+      "Materialized topic created but underlying log doesn't yet exist: {}",
+      ntp));
 }
 
 static ss::future<> maybe_make_materialized_log(

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -318,6 +318,11 @@ write_materialized(output_write_inputs replies, output_write_args args) {
               throw ex;
           } catch (const malformed_batch_exception& ex) {
               throw engine_protocol_failure(args.id, ex.what());
+          } catch (const cluster::non_replicable_topic_creation_exception& ex) {
+              vlog(
+                coproclog.warn,
+                "Failed to create non_replicable topic: {}",
+                ex);
           } catch (const coproc::exception& ex) {
               /// For any type of failure the offset will not be touched,
               /// the read phase will always read from the global min of all

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -122,7 +122,7 @@ static ss::future<> maybe_make_materialized_log(
   model::topic_namespace new_materialized,
   bool is_leader,
   output_write_args args) {
-    const auto& cache = args.rs.metadata_cache.local();
+    const auto& cache = args.metadata.local();
     if (cache.get_topic_cfg(new_materialized)) {
         if (cache.get_source_topic(new_materialized)) {
             /// Log already exists
@@ -153,7 +153,7 @@ static ss::future<> maybe_make_materialized_log(
     /// All requests are debounced, therefore if multiple entities attempt to
     /// create a materialzied topic, all requests will wait for the first to
     /// complete.
-    co_return co_await args.rs.mt_frontend.invoke_on(
+    co_return co_await args.frontend.invoke_on(
       cluster::non_replicable_topics_frontend_shard,
       [topics = std::move(topics)](
         cluster::non_replicable_topics_frontend& mtfe) mutable {
@@ -180,7 +180,7 @@ static ss::future<> write_materialized_partition(
           return maybe_make_materialized_log(
                    source, new_materialized, input->is_leader(), args)
             .then([args, ntp, reader = std::move(reader)]() mutable {
-                auto found = args.rs.storage.local().log_mgr().get(ntp);
+                auto found = args.storage.local().log_mgr().get(ntp);
                 if (found) {
                     return do_write_materialized_partition(
                       *found, std::move(reader));

--- a/src/v/coproc/script_context_backend.h
+++ b/src/v/coproc/script_context_backend.h
@@ -11,8 +11,9 @@
 
 #pragma once
 
+#include "cluster/fwd.h"
+#include "coproc/fwd.h"
 #include "coproc/script_context_router.h"
-#include "coproc/sys_refs.h"
 #include "coproc/types.h"
 #include "utils/mutex.h"
 
@@ -27,7 +28,9 @@ using output_write_inputs = std::vector<process_batch_reply::data>;
 /// Arugments to pass to 'write_materialized', trivially copyable
 struct output_write_args {
     coproc::script_id id;
-    sys_refs& rs;
+    ss::sharded<cluster::metadata_cache>& metadata;
+    ss::sharded<cluster::non_replicable_topics_frontend>& frontend;
+    ss::sharded<storage::api>& storage;
     routes_t& inputs;
     absl::node_hash_map<model::ntp, mutex>& locks;
 };

--- a/src/v/coproc/script_context_backend.h
+++ b/src/v/coproc/script_context_backend.h
@@ -20,6 +20,7 @@
 #include <seastar/core/future.hh>
 
 #include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
 
 namespace coproc {
 /// The outputs from a 'process_batch' call to a wasm engine
@@ -32,6 +33,7 @@ struct output_write_args {
     ss::sharded<cluster::non_replicable_topics_frontend>& frontend;
     ss::sharded<coproc::partition_manager>& pm;
     routes_t& inputs;
+    absl::node_hash_set<model::ntp>& denylist;
     absl::node_hash_map<model::ntp, mutex>& locks;
 };
 

--- a/src/v/coproc/script_context_backend.h
+++ b/src/v/coproc/script_context_backend.h
@@ -30,7 +30,7 @@ struct output_write_args {
     coproc::script_id id;
     ss::sharded<cluster::metadata_cache>& metadata;
     ss::sharded<cluster::non_replicable_topics_frontend>& frontend;
-    ss::sharded<storage::api>& storage;
+    ss::sharded<coproc::partition_manager>& pm;
     routes_t& inputs;
     absl::node_hash_map<model::ntp, mutex>& locks;
 };

--- a/src/v/coproc/script_context_frontend.cc
+++ b/src/v/coproc/script_context_frontend.cc
@@ -12,6 +12,7 @@
 #include "coproc/script_context_frontend.h"
 
 #include "cluster/partition.h"
+#include "coproc/exception.h"
 #include "coproc/logger.h"
 #include "coproc/reference_window_consumer.hpp"
 #include "model/fundamental.h"
@@ -85,20 +86,30 @@ ss::future<std::optional<process_batch_request::data>>
 read_ntp(input_read_args args, ss::lw_shared_ptr<source> ctx) {
     storage::log_reader_config cfg = get_reader(
       args.abort_src, ctx->rctx, ctx->wctx);
-    auto rbr = co_await ctx->rctx.input->make_reader(cfg);
-    auto read_result = co_await std::move(rbr).for_each_ref(
-      coproc::reference_window_consumer(
-        high_offset_tracker(), storage::internal::decompress_batch_consumer()),
-      model::no_timeout);
-    auto& [info, nrbr] = read_result;
-    if (info.size == 0) {
-        co_return std::nullopt;
+    try {
+        auto rbr = co_await ctx->rctx.input->make_reader(cfg);
+        auto read_result = co_await std::move(rbr).for_each_ref(
+          coproc::reference_window_consumer(
+            high_offset_tracker(),
+            storage::internal::decompress_batch_consumer()),
+          model::no_timeout);
+        auto& [info, nrbr] = read_result;
+        if (info.size > 0) {
+            ctx->rctx.last_read = info.last + model::offset{1};
+            co_return process_batch_request::data{
+              .ids = std::vector<script_id>{args.id},
+              .ntp = ctx->rctx.input->ntp(),
+              .reader = std::move(nrbr)};
+        }
+    } catch (const ss::gate_closed_exception&) {
+        throw partition_shutdown_exception(
+          ctx->rctx.input->ntp(),
+          fmt::format(
+            "Partition {} shutdown while script {} was attempting to read",
+            ctx->rctx.input->ntp(),
+            args.id));
     }
-    ctx->rctx.last_read = info.last + model::offset{1};
-    co_return process_batch_request::data{
-      .ids = std::vector<script_id>{args.id},
-      .ntp = ctx->rctx.input->ntp(),
-      .reader = std::move(nrbr)};
+    co_return std::nullopt;
 }
 
 ss::future<std::vector<process_batch_request::data>>

--- a/src/v/coproc/script_database.h
+++ b/src/v/coproc/script_database.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "coproc/types.h"
+
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
+
+#include <vector>
+
+namespace coproc::wasm {
+/// In memory cache of all coprocessors of all coprocessors
+///
+/// Useful when its necessary to redeploy or reference a shutdown or partitally
+/// shutdown coprocessor for its metadata
+class script_database {
+public:
+    struct script_metadata {
+        iobuf source;
+        std::vector<topic_namespace_policy> inputs;
+    };
+
+    using underlying_t = absl::node_hash_map<script_id, script_metadata>;
+    using inverted_lookup_t = absl::node_hash_map<
+      model::topic_namespace,
+      absl::node_hash_set<script_id>,
+      model::topic_namespace_hash,
+      model::topic_namespace_eq>;
+    using const_iterator = underlying_t::const_iterator;
+    using const_inv_iterator = inverted_lookup_t::const_iterator;
+
+    /// Querying
+    /// ... by scripts
+    bool exists(script_id id) { return _db.contains(id); }
+    const_iterator find(script_id id) const { return _db.find(id); }
+    const_iterator cbegin() const { return _db.cbegin(); }
+    const_iterator cend() const { return _db.cend(); }
+
+    /// ... by topic/namespace
+    bool exists(model::topic_namespace_view tnv) const {
+        return _by_input.contains(tnv);
+    }
+    const_inv_iterator find(model::topic_namespace_view tnv) const {
+        return _by_input.find(tnv);
+    }
+    const_inv_iterator inv_cbegin() const { return _by_input.cbegin(); }
+    const_inv_iterator inv_cend() const { return _by_input.cend(); }
+
+    underlying_t::size_type size() const { return _db.size(); }
+    inverted_lookup_t::size_type unique_inputs() const {
+        return _by_input.size();
+    }
+
+    /// Removal
+    bool remove_script(script_id id) {
+        auto found = _db.find(id);
+        if (found == _db.end()) {
+            return false;
+        }
+        for (const auto& e : found->second.inputs) {
+            _by_input.erase(e.tn);
+        }
+        _db.erase(found);
+        return true;
+    }
+    void clear() {
+        _db.clear();
+        _by_input.clear();
+    }
+
+    /// Addition
+    bool add_script(
+      script_id id, iobuf source, std::vector<topic_namespace_policy> inputs) {
+        script_metadata meta{.source = std::move(source), .inputs = inputs};
+        auto [_, success] = _db.emplace(id, std::move(meta));
+        if (!success) {
+            return false;
+        }
+        for (auto& input : inputs) {
+            auto found = _by_input.find(input.tn);
+            if (found == _by_input.end()) {
+                absl::node_hash_set<script_id> ns;
+                ns.emplace(id);
+                _by_input.emplace(std::move(input.tn), std::move(ns));
+            } else {
+                found->second.emplace(id);
+            }
+        }
+        return true;
+    }
+
+private:
+    underlying_t _db;
+    inverted_lookup_t _by_input;
+};
+
+/// \brief script_database is a sharded service that only exists on shard 0.
+/// Use this as its 'home_shard' when calling 'invoke_on'
+static constexpr ss::shard_id script_database_main_shard = 0;
+
+} // namespace coproc::wasm

--- a/src/v/coproc/shared_script_resources.h
+++ b/src/v/coproc/shared_script_resources.h
@@ -20,6 +20,7 @@
 #include <seastar/core/semaphore.hh>
 
 #include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
 
 #include <chrono>
 
@@ -49,6 +50,9 @@ struct shared_script_resources {
     /// NOTE: Pointer stability is explicity requested due to the way iterators
     /// to elements within the collection are used
     absl::node_hash_map<model::ntp, mutex> log_mtx;
+
+    /// Set partitions that are in the middle of being deleted
+    absl::node_hash_set<model::ntp> in_progress_deletes;
 
     /// References to other redpanda components
     sys_refs& rs;

--- a/src/v/coproc/sys_refs.h
+++ b/src/v/coproc/sys_refs.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/fwd.h"
+#include "coproc/fwd.h"
 #include "seastarx.h"
 #include "storage/fwd.h"
 
@@ -29,6 +30,7 @@ struct sys_refs {
     ss::sharded<cluster::topics_frontend>& topics_frontend;
     ss::sharded<cluster::metadata_cache>& metadata_cache;
     ss::sharded<cluster::partition_manager>& partition_manager;
+    ss::sharded<coproc::partition_manager>& cp_partition_manager;
 };
 
 } // namespace coproc

--- a/src/v/coproc/sys_refs.h
+++ b/src/v/coproc/sys_refs.h
@@ -23,6 +23,8 @@ namespace coproc {
 /// leverage
 struct sys_refs {
     ss::sharded<storage::api>& storage;
+    ss::sharded<cluster::topic_table>& topic_table;
+    ss::sharded<cluster::shard_table>& shard_table;
     ss::sharded<cluster::non_replicable_topics_frontend>& mt_frontend;
     ss::sharded<cluster::topics_frontend>& topics_frontend;
     ss::sharded<cluster::metadata_cache>& metadata_cache;

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ rp_test(
   SOURCES
     ${fixture_srcs}
     retry_logic_tests.cc
+    partition_movement_tests.cc
     topic_ingestion_policy_tests.cc
     failure_recovery_tests.cc
     pacemaker_tests.cc

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set(fixture_srcs
     utils/supervisor.cc
     utils/wasm_event_generator.cc
     utils/batch_utils.cc
+    fixtures/coproc_cluster_fixture.cc
     fixtures/coproc_test_fixture.cc
     fixtures/coproc_bench_fixture.cc
     fixtures/fiber_mock_fixture.cc

--- a/src/v/coproc/tests/CMakeLists.txt
+++ b/src/v/coproc/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ rp_test(
     topic_ingestion_policy_tests.cc
     failure_recovery_tests.cc
     pacemaker_tests.cc
+    autocreate_topic_tests.cc
     coproc_bench_tests.cc
     offset_storage_utils_tests.cc
     wasm_event_tests.cc

--- a/src/v/coproc/tests/autocreate_topic_tests.cc
+++ b/src/v/coproc/tests/autocreate_topic_tests.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Vectorized, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "coproc/partition_manager.h"
+#include "coproc/tests/fixtures/coproc_cluster_fixture.h"
+#include "test_utils/async.h"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test_log.hpp>
+
+ss::future<bool> partition_exists(application* app, const model::ntp& ntp) {
+    /// A non_replicable partition is considered to exist if it exists in the
+    /// shard table, partition manager and storage
+    auto shard = app->shard_table.local().shard_for(ntp);
+    if (!shard) {
+        co_return false;
+    }
+    auto p_exists = co_await app->cp_partition_manager.invoke_on(
+      *shard,
+      [ntp](coproc::partition_manager& pm) { return (bool)pm.get(ntp); });
+    if (!p_exists) {
+        co_return false;
+    }
+    auto log_exists = co_await app->storage.invoke_on(
+      *shard,
+      [ntp](storage::api& api) { return (bool)api.log_mgr().get(ntp); });
+    if (!log_exists) {
+        co_return false;
+    }
+    co_return true;
+}
+
+FIXTURE_TEST(autocreate_non_replicable_topic_test, coproc_cluster_fixture) {
+    /// Start the test with a new cluster with 3 nodes
+    auto n = 3;
+    for (auto i = 0; i < n; ++i) {
+        create_node_application(model::node_id(i));
+    }
+    wait_for_all_members(5s).get();
+    for (auto i = 0; i < n; ++i) {
+        wait_for_controller_leadership(model::node_id(i)).get();
+    }
+
+    /// Find a node thats NOT the leader and make the request there
+    auto leader_id = get_node_application(model::node_id(0))
+                       ->controller->get_partition_leaders()
+                       .local()
+                       .get_leader(model::controller_ntp);
+    BOOST_REQUIRE(leader_id.has_value());
+    auto non_leader_id = model::node_id((*leader_id + 1) % n);
+    auto leader = get_node_application(*leader_id);
+    auto non_leader = get_node_application(non_leader_id);
+
+    /// Create test topic
+    cluster::non_replicable_topic nrt{
+      .source = model::topic_namespace(
+        model::kafka_namespace, model::topic("test")),
+      .name = model::topic_namespace(
+        model::kafka_namespace, model::topic("test-materialized"))};
+    auto n_partitions = 3;
+    cluster::topic_configuration cfg(nrt.source.ns, nrt.source.tp, 3, 1);
+    auto secf
+      = non_leader->controller->get_topics_frontend().local().autocreate_topics(
+        {cfg}, 10s);
+    auto ec = secf.get();
+    BOOST_REQUIRE_EQUAL(ec.size(), 1);
+    BOOST_REQUIRE_EQUAL(ec[0].tp_ns, nrt.source);
+    BOOST_REQUIRE_EQUAL(ec[0].ec, cluster::errc::success);
+
+    /// Create non_replicable topic on a node thats NOT the leader
+    auto ecf = non_leader->controller->get_topics_frontend()
+                 .local()
+                 .autocreate_non_replicable_topics({nrt}, 25s);
+    ec = ecf.get();
+    BOOST_REQUIRE_EQUAL(ec.size(), 1);
+    BOOST_REQUIRE_EQUAL(ec[0].tp_ns, nrt.name);
+    BOOST_REQUIRE_EQUAL(ec[0].ec, cluster::errc::success);
+
+    /// Where to look for the partitions
+    std::vector<std::pair<model::node_id, model::ntp>> partition_mapping;
+    auto& leaders_table = leader->controller->get_partition_leaders().local();
+    for (auto i = 0; i < n_partitions; ++i) {
+        model::ntp src_ntp(
+          nrt.source.ns, nrt.source.tp, model::partition_id(i));
+        model::ntp nrt_ntp(nrt.name.ns, nrt.name.tp, model::partition_id(i));
+        /// Quick verify that non_replicable topics match their sources
+        auto src_leader = leaders_table.get_leader(src_ntp);
+        auto nrt_leader = leaders_table.get_leader(src_ntp);
+        BOOST_REQUIRE(src_leader.has_value());
+        BOOST_REQUIRE(nrt_leader.has_value());
+        BOOST_REQUIRE_EQUAL(*src_leader, *nrt_leader);
+        partition_mapping.emplace_back(*nrt_leader, nrt_ntp);
+    }
+    tests::cooperative_spin_wait_with_timeout(15s, [this, partition_mapping]() {
+        return ss::map_reduce(
+          partition_mapping.begin(),
+          partition_mapping.end(),
+          [this](const auto& p) {
+              return partition_exists(get_node_application(p.first), p.second);
+          },
+          true,
+          std::logical_and<>());
+    }).get();
+}

--- a/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_cluster_fixture.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc_cluster_fixture.h"
+
+#include "coproc/tests/utils/event_publisher_utils.h"
+
+coproc_cluster_fixture::coproc_cluster_fixture() noexcept
+  : cluster_test_fixture()
+  , coproc_api_fixture() {
+    set_configuration("enable_coproc", true);
+}
+
+ss::future<>
+coproc_cluster_fixture::enable_coprocessors(std::vector<deploy> copros) {
+    std::vector<coproc::script_id> ids;
+    std::vector<ss::future<>> wait;
+    std::transform(
+      copros.cbegin(),
+      copros.cend(),
+      std::back_inserter(ids),
+      [](const deploy& d) { return coproc::script_id(d.id); });
+    co_await coproc_api_fixture::enable_coprocessors(std::move(copros));
+    auto node_ids = get_node_ids();
+    co_await ss::parallel_for_each(
+      node_ids, [this, ids](const model::node_id& node_id) {
+          application* app = get_node_application(node_id);
+          return ss::parallel_for_each(ids, [this, app](coproc::script_id id) {
+              return coproc::wasm::wait_for_copro(
+                app->coprocessing->get_pacemaker(), id);
+          });
+      });
+}
+
+application* coproc_cluster_fixture::create_node_application(
+  model::node_id node_id,
+  int kafka_port,
+  int rpc_port,
+  int proxy_port,
+  int schema_reg_port,
+  int coproc_supervisor_port) {
+    application* app = cluster_test_fixture::create_node_application(
+      node_id,
+      kafka_port,
+      rpc_port,
+      proxy_port,
+      schema_reg_port,
+      coproc_supervisor_port);
+    _instances.emplace(
+      node_id,
+      std::make_unique<supervisor_test_fixture>(
+        coproc_supervisor_port + node_id()));
+    return app;
+}
+
+std::vector<model::node_id> coproc_cluster_fixture::get_node_ids() {
+    std::vector<model::node_id> ids;
+    std::transform(
+      _instances.cbegin(),
+      _instances.cend(),
+      std::back_inserter(ids),
+      [](const auto& p) { return p.first; });
+    return ids;
+}

--- a/src/v/coproc/tests/fixtures/coproc_cluster_fixture.h
+++ b/src/v/coproc/tests/fixtures/coproc_cluster_fixture.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/tests/cluster_test_fixture.h"
+#include "coproc/tests/fixtures/coproc_test_fixture.h"
+#include "coproc/tests/fixtures/supervisor_test_fixture.h"
+
+#include <absl/container/flat_hash_map.h>
+
+/// A cluster_test_fixture with a kafka::client and convienence methods from
+/// coproc_api_fixture useful for multi-node coproc unit tests
+class coproc_cluster_fixture
+  : public cluster_test_fixture
+  , public coproc_api_fixture {
+public:
+    using wasm_ptr = std::unique_ptr<supervisor_test_fixture>;
+
+    /// Class constructor
+    ///
+    /// Calls superclass constructors and ensures 'enable_coproc' is true
+    coproc_cluster_fixture() noexcept;
+
+    /// Calls coproc_api_fixture superclass method with same name
+    ///
+    /// Additionally this method waits until the coprocessors are deployed
+    /// within the coproc::pacemaker on all instances of rp that belong to the
+    /// cluster_test_fixture
+    ss::future<> enable_coprocessors(std::vector<deploy>);
+
+    /// Calls cluster_test_fixture superclass method with same name
+    ///
+    /// Additionally instantiates an instance of the wasm engine used for
+    /// testing and places it in the \ref instances map
+    application* create_node_application(
+      model::node_id node_id,
+      int kafka_port = 9092,
+      int rpc_port = 11000,
+      int proxy_port = 8082,
+      int schema_reg_port = 8081,
+      int coproc_supervisor_port = 43189);
+
+private:
+    std::vector<model::node_id> get_node_ids();
+
+private:
+    absl::flat_hash_map<model::node_id, wasm_ptr> _instances;
+};

--- a/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
+++ b/src/v/coproc/tests/fixtures/coproc_test_fixture.cc
@@ -15,6 +15,7 @@
 #include "coproc/api.h"
 #include "coproc/event_handler.h"
 #include "coproc/logger.h"
+#include "coproc/pacemaker.h"
 #include "coproc/tests/utils/event_publisher_utils.h"
 #include "coproc/tests/utils/kafka_publish_consumer.h"
 #include "kafka/client/client.h"

--- a/src/v/coproc/tests/fixtures/coproc_test_fixture.h
+++ b/src/v/coproc/tests/fixtures/coproc_test_fixture.h
@@ -33,6 +33,9 @@ public:
     coproc_api_fixture();
     ~coproc_api_fixture();
 
+    /// Starts the client and creates the internal copro topic
+    ss::future<> start();
+
     /// Higher level abstraction of 'publish_events'
     ///
     /// Maps tuple to proper encoded wasm record and calls 'publish_events'

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -164,7 +164,7 @@ coproc::output_write_args fiber_mock_fixture::make_output_write_args(state& s) {
       .id = _id,
       .metadata = shared_res.rs.metadata_cache,
       .frontend = shared_res.rs.mt_frontend,
-      .storage = shared_res.rs.storage,
+      .pm = shared_res.rs.cp_partition_manager,
       .inputs = s.routes,
       .locks = shared_res.log_mtx};
 }

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -162,7 +162,9 @@ coproc::output_write_args fiber_mock_fixture::make_output_write_args(state& s) {
     auto& shared_res = app.coprocessing->get_pacemaker().local().resources();
     return coproc::output_write_args{
       .id = _id,
-      .rs = shared_res.rs,
+      .metadata = shared_res.rs.metadata_cache,
+      .frontend = shared_res.rs.mt_frontend,
+      .storage = shared_res.rs.storage,
       .inputs = s.routes,
       .locks = shared_res.log_mtx};
 }

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -166,6 +166,7 @@ coproc::output_write_args fiber_mock_fixture::make_output_write_args(state& s) {
       .frontend = shared_res.rs.mt_frontend,
       .pm = shared_res.rs.cp_partition_manager,
       .inputs = s.routes,
+      .denylist = shared_res.in_progress_deletes,
       .locks = shared_res.log_mtx};
 }
 

--- a/src/v/coproc/tests/fixtures/supervisor_test_fixture.h
+++ b/src/v/coproc/tests/fixtures/supervisor_test_fixture.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "coproc/tests/utils/supervisor.h"
 #include "rpc/test/rpc_integration_fixture.h"
+#include "vassert.h"
 
 /// Use this test fixture when you want to start a coproc::supervisor up.
 /// Optionally query the internal state of the c++ 'wasm' engine with the
@@ -28,9 +29,16 @@ public:
           })
           .get();
         _coprocessors.start().get();
-        register_service<coproc::supervisor>(
-          std::ref(_coprocessors), std::ref(_delay_heartbeat));
-        start_server();
+        try {
+            register_service<coproc::supervisor>(
+              std::ref(_coprocessors), std::ref(_delay_heartbeat));
+            start_server();
+        } catch (const std::exception& ex) {
+            vassert(
+              false,
+              "Exception in supervisor_test_fixture constructor: {}",
+              ex);
+        }
     }
 
     ~supervisor_test_fixture() override {

--- a/src/v/coproc/tests/fixtures/supervisor_test_fixture.h
+++ b/src/v/coproc/tests/fixtures/supervisor_test_fixture.h
@@ -19,8 +19,8 @@
 /// provided methods
 class supervisor_test_fixture : public rpc_sharded_integration_fixture {
 public:
-    supervisor_test_fixture()
-      : rpc_sharded_integration_fixture(43189) {
+    explicit supervisor_test_fixture(uint32_t port = 43189)
+      : rpc_sharded_integration_fixture(port) {
         configure_server();
         _delay_heartbeat.start().get();
         _delay_heartbeat

--- a/src/v/coproc/tests/pacemaker_tests.cc
+++ b/src/v/coproc/tests/pacemaker_tests.cc
@@ -10,6 +10,7 @@
 
 #include "coproc/api.h"
 #include "coproc/pacemaker.h"
+#include "coproc/partition_manager.h"
 #include "coproc/tests/fixtures/coproc_test_fixture.h"
 #include "coproc/tests/utils/batch_utils.h"
 #include "coproc/tests/utils/coprocessor.h"
@@ -162,4 +163,86 @@ FIXTURE_TEST(test_copro_auto_deregister_function, coproc_test_fixture) {
         return root_fixture()->app.coprocessing->get_pacemaker().map_reduce0(
           std::move(map), true, std::logical_and<>());
     }).get();
+}
+
+/// Ensures that a deletion of a materialized topic doesn't conflict
+/// with an active coprocessor producing onto it. Furthermore asserts the topic
+/// exists at tests end and contains all expected records.
+FIXTURE_TEST(test_copro_delete_topic, coproc_test_fixture) {
+    model::topic_namespace tbd(model::kafka_namespace, model::topic("tbd"));
+    setup({{tbd.tp, 4}}).get();
+    auto id = coproc::script_id(59);
+    // Use the earliest policy so that when the topic is re-created processing
+    // begins at 0, so that the full amount of records can be asserted at tests
+    // end
+    enable_coprocessors(
+      {{.id = id(),
+        .data{
+          .tid = copro_typeid::identity_coprocessor,
+          .topics = {{tbd.tp, coproc::topic_ingestion_policy::earliest}}}}})
+      .get();
+
+    /// Find shard of one of the partitions
+    model::partition_id target_pid(0);
+    auto shard = root_fixture()->app.shard_table.local().shard_for(
+      model::ntp(tbd.ns, tbd.tp, target_pid));
+    BOOST_CHECK(shard.has_value());
+    info("On shard: {}", *shard);
+
+    /// Setup listeners to inject the deletion
+    model::ntp target(
+      tbd.ns,
+      to_materialized_topic(tbd.tp, identity_coprocessor::identity_topic),
+      target_pid);
+    auto f = root_fixture()
+               ->app.cp_partition_manager
+               .invoke_on(
+                 *shard,
+                 [this, target](coproc::partition_manager& pm) {
+                     ss::promise<> p;
+                     auto f = p.get_future();
+                     auto id = pm.register_manage_notification(
+                       target.ns,
+                       target.tp.topic,
+                       [this, p = std::move(p)](
+                         ss::lw_shared_ptr<coproc::partition>) mutable {
+                           p.set_value();
+                       });
+                     return f.then(
+                       [id, &pm] { pm.unregister_manage_notification(id); });
+                 })
+               .then([this, target] {
+                   model::topic_namespace tp{target.ns, target.tp.topic};
+                   info("Deleting topic: {} ", tp);
+                   return root_fixture()->delete_topic(tp).then(
+                     [this, tp] { info("Topic {} deleted", tp); });
+               });
+
+    // Push some data across input topic....
+    const std::size_t total_records = 10000;
+    std::vector<ss::future<>> fs;
+    fs.reserve(4);
+    for (auto i = 0; i < 4; ++i) {
+        info("Producing onto: {}-{}", tbd, i);
+        fs.emplace_back(produce(
+          model::ntp(tbd.ns, tbd.tp, model::partition_id(i)),
+          make_random_batch(total_records)));
+    }
+    ss::when_all_succeed(fs.begin(), fs.end()).get();
+    info("All produced onto: {}", tbd);
+    f.get();
+
+    /// Wait until all data is recieved on output topic, which should have been
+    /// recreated and fully processed from the earliest offset
+    for (auto i = 0; i < 4; ++i) {
+        auto results = consume(
+                         model::ntp(
+                           tbd.ns,
+                           to_materialized_topic(
+                             tbd.tp, identity_coprocessor::identity_topic),
+                           model::partition_id(i)),
+                         total_records)
+                         .get();
+        BOOST_CHECK_EQUAL(num_records(results), total_records);
+    }
 }

--- a/src/v/coproc/tests/partition_movement_tests.cc
+++ b/src/v/coproc/tests/partition_movement_tests.cc
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "coproc/partition_manager.h"
+#include "coproc/tests/fixtures/coproc_bench_fixture.h"
+#include "coproc/tests/fixtures/coproc_cluster_fixture.h"
+#include "coproc/tests/utils/batch_utils.h"
+#include "coproc/tests/utils/coprocessor.h"
+#include "kafka/client/client.h"
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test_log.hpp>
+
+using copro_typeid = coproc::registry::type_identifier;
+
+/// Test moves across shards on same node works
+FIXTURE_TEST(test_move_source_topic, coproc_test_fixture) {
+    model::topic mvp("mvp");
+    setup({{mvp, 4}}).get();
+
+    auto id = coproc::script_id(443920);
+    enable_coprocessors(
+      {{.id = id(),
+        .data{
+          .tid = copro_typeid::identity_coprocessor,
+          .topics = {{mvp, coproc::topic_ingestion_policy::latest}}}}})
+      .get();
+
+    /// Push sample data onto all partitions
+    std::vector<ss::future<>> fs;
+    for (auto i = 0; i < 4; ++i) {
+        model::ntp input_ntp(
+          model::kafka_namespace, mvp, model::partition_id(i));
+        auto f = produce(input_ntp, make_random_batch(40));
+        fs.emplace_back(std::move(f));
+    }
+    ss::when_all_succeed(fs.begin(), fs.end()).get();
+
+    /// Wait until the materialized topic has come into existance
+    model::ntp origin_ntp(model::kafka_namespace, mvp, model::partition_id(0));
+    model::ntp target_ntp = origin_ntp;
+    target_ntp.tp.topic = to_materialized_topic(
+      mvp, identity_coprocessor::identity_topic);
+    auto r = consume(target_ntp, 40).get();
+    BOOST_REQUIRE(num_records(r) == 40);
+    auto shard = root_fixture()->app.shard_table.local().shard_for(target_ntp);
+    BOOST_REQUIRE(shard);
+
+    /// Choose target and calculate where to move it to
+    const ss::shard_id next_shard = (*shard + 1) % ss::smp::count;
+    info("Current target shard {} and next shard {}", *shard, next_shard);
+    model::broker_shard bs{
+      .node_id = model::node_id(config::node().node_id), .shard = next_shard};
+
+    /// Move the input onto the new desired target
+    auto& topics_fe = root_fixture()->app.controller->get_topics_frontend();
+    auto ec = topics_fe.local()
+                .move_partition_replicas(origin_ntp, {bs}, model::no_timeout)
+                .get();
+    info("Error code: {}", ec);
+    BOOST_REQUIRE(!ec);
+
+    /// Wait until the shard table is updated with the new shard
+    tests::cooperative_spin_wait_with_timeout(
+      10s,
+      [this, target_ntp, next_shard] {
+          auto s = root_fixture()->app.shard_table.local().shard_for(
+            target_ntp);
+          return s && *s == next_shard;
+      })
+      .get();
+
+    /// Issue a read from the target shard, and expect the topic content
+    info("Draining from shard....{}", bs.shard);
+    r = consume(target_ntp, 40).get();
+    BOOST_CHECK_EQUAL(num_records(r), 40);
+
+    /// Finally, ensure there is no materialized partition on original shard
+    auto logf = root_fixture()->app.storage.invoke_on(
+      *shard, [origin_ntp](storage::api& api) {
+          return api.log_mgr().get(origin_ntp).has_value();
+      });
+    auto cpmf = root_fixture()->app.cp_partition_manager.invoke_on(
+      *shard, [origin_ntp](coproc::partition_manager& pm) {
+          return (bool)pm.get(origin_ntp);
+      });
+    BOOST_CHECK(!logf.get0());
+    BOOST_CHECK(!cpmf.get0());
+}
+
+bool partition_exists_on_node(
+  cluster_test_fixture* ctf, model::broker_shard bs, const model::ntp& ntp) {
+    auto n1 = ctf->get_node_application(model::node_id(0))
+                ->controller->get_partition_leaders()
+                .local()
+                .get_leader(ntp);
+    if (!n1 || (*n1 != bs.node_id)) {
+        return false;
+    }
+    auto s1 = ctf->get_node_application(bs.node_id);
+    auto shard = s1->shard_table.local().shard_for(ntp);
+    return bs.shard == *shard;
+}
+
+FIXTURE_TEST(test_move_topic_across_nodes, coproc_cluster_fixture) {
+    const auto n = 3;
+    for (auto i = 0; i < n; ++i) {
+        create_node_application(model::node_id(i));
+    }
+    wait_for_all_members(5s).get();
+    for (auto i = 0; i < n; ++i) {
+        wait_for_controller_leadership(model::node_id(i)).get();
+    }
+    start().get();
+
+    /// Find leader node
+    auto leader_node_id = get_node_application(model::node_id(0))
+                            ->controller->get_partition_leaders()
+                            .local()
+                            .get_leader(model::controller_ntp);
+    BOOST_REQUIRE(leader_node_id.has_value());
+    auto leader = get_node_application(*leader_node_id);
+
+    /// Create topic
+    auto n_partitions = 3;
+    model::topic_namespace tp(model::kafka_namespace, model::topic("source"));
+    cluster::topic_configuration tcfg(tp.ns, tp.tp, n_partitions, 1);
+    auto oec = leader->controller->get_topics_frontend()
+                 .local()
+                 .autocreate_topics({tcfg}, 5s)
+                 .get();
+    BOOST_REQUIRE_EQUAL(oec.size(), 1);
+    BOOST_REQUIRE_EQUAL(oec[0].ec, cluster::errc::success);
+    BOOST_REQUIRE_EQUAL(oec[0].tp_ns, tp);
+
+    /// Deploy coprocessor
+    auto id = coproc::script_id(440);
+    enable_coprocessors(
+      {{.id = id(),
+        .data{
+          .tid = copro_typeid::identity_coprocessor,
+          .topics = {{tp.tp, coproc::topic_ingestion_policy::earliest}}}}})
+      .get();
+
+    /// Push some sample data
+    std::vector<ss::future<>> fs;
+    for (auto i = 0; i < n_partitions; ++i) {
+        model::ntp input_ntp(
+          model::kafka_namespace, tp.tp, model::partition_id(i));
+        auto f = produce(input_ntp, make_random_batch(40));
+        fs.emplace_back(std::move(f));
+    }
+    ss::when_all_succeed(fs.begin(), fs.end()).get();
+
+    /// Push consume all materialized log data from target partition
+    model::ntp source_ntp(tp.ns, tp.tp, model::partition_id(0));
+    model::ntp materialized_ntp(
+      tp.ns,
+      to_materialized_topic(tp.tp, identity_coprocessor::identity_topic),
+      model::partition_id(0));
+    auto r = consume(materialized_ntp, 40).get();
+    BOOST_REQUIRE(num_records(r) == 40);
+
+    /// Finally move the source topic after all processing by coproc has been
+    /// completed. To do this, first find out what model::broker_shard the
+    /// source_ntp exists on, then attempt to move it to the node with the next
+    /// node/shard id (mod n)
+    auto topic_leader_id
+      = leader->controller->get_partition_leaders().local().get_leader(
+        source_ntp);
+    BOOST_REQUIRE(topic_leader_id);
+    auto topic_leader = get_node_application(*topic_leader_id);
+    auto origin_shard = topic_leader->shard_table.local().shard_for(source_ntp);
+    BOOST_REQUIRE(origin_shard.has_value());
+    model::broker_shard old_bs{
+      .node_id = *topic_leader_id, .shard = *origin_shard};
+    model::broker_shard new_bs{
+      .node_id = model::node_id((*topic_leader_id + 1) % n),
+      .shard = ss::shard_id((*origin_shard + 1) % n)};
+
+    info("Old broker_shard {} moving to new broker_shard {}", old_bs, new_bs);
+    auto& topics_fe = leader->controller->get_topics_frontend();
+    auto ec = topics_fe.local()
+                .move_partition_replicas(
+                  source_ntp, {new_bs}, model::timeout_clock::now() + 5s)
+                .get();
+    info("Error code: {}", ec);
+    BOOST_REQUIRE(!ec);
+
+    /// Wait until the move occurs
+    info("Waiting for move of {} to {}", source_ntp, new_bs);
+    tests::cooperative_spin_wait_with_timeout(
+      10s,
+      [this, source_ntp, new_bs]() {
+          return ss::make_ready_future<bool>(
+            partition_exists_on_node(this, new_bs, source_ntp));
+      })
+      .get();
+
+    /// Wait until the materialized moves also occurred
+    info("Waiting for move of {} to {}", materialized_ntp, new_bs);
+    tests::cooperative_spin_wait_with_timeout(
+      10s,
+      [this, materialized_ntp, new_bs]() {
+          return ss::make_ready_future<bool>(
+            partition_exists_on_node(this, new_bs, materialized_ntp));
+      })
+      .get();
+
+    /// Try to consume from the materialized partition
+    get_client().update_metadata().get();
+    r = consume(materialized_ntp, 40).get();
+    BOOST_REQUIRE(num_records(r) == 40);
+
+    /// Verify no reminents exist on old broker/shard
+    auto logf = get_node_application(old_bs.node_id)
+                  ->storage.invoke_on(
+                    old_bs.shard, [source_ntp](storage::api& api) {
+                        return api.log_mgr().get(source_ntp).has_value();
+                    });
+    BOOST_CHECK(!logf.get());
+}

--- a/src/v/coproc/tests/utils/event_publisher_utils.h
+++ b/src/v/coproc/tests/utils/event_publisher_utils.h
@@ -9,6 +9,7 @@
  */
 
 #pragma once
+#include "coproc/types.h"
 #include "kafka/client/client.h"
 #include "model/record_batch_reader.h"
 
@@ -28,5 +29,8 @@ publish_events(kafka::client::client&, model::record_batch_reader);
 /// Performs additional validation ensuring that the topic is created with the
 /// expected parameters, if validation fails, this will assert
 ss::future<> create_coproc_internal_topic(kafka::client::client&);
+
+/// Resolves when \ref id is fully registered within the fixtures pacemaker
+ss::future<> wait_for_copro(ss::sharded<coproc::pacemaker>&, coproc::script_id);
 
 } // namespace coproc::wasm

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -309,7 +309,7 @@ struct fetch_plan {
 
 ss::future<read_result> read_from_ntp(
   cluster::partition_manager&,
-  cluster::metadata_cache&,
+  coproc::partition_manager&,
   const model::ntp&,
   fetch_config,
   bool,

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -66,7 +66,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
   model::isolation_level isolation_lvl,
   cluster::partition_manager& mgr) {
     auto kafka_partition = make_partition_proxy(
-      ntp, octx.rctx.metadata_cache(), mgr);
+      ntp, mgr, octx.rctx.coproc_partition_manager().local());
     if (!kafka_partition) {
         co_return list_offsets_response::make_partition(
           ntp.tp.partition, error_code::unknown_topic_or_partition);

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -12,6 +12,7 @@
 
 #include "cluster/metadata_cache.h"
 #include "cluster/partition.h"
+#include "coproc/fwd.h"
 #include "model/fundamental.h"
 #include "storage/translating_reader.h"
 #include "storage/types.h"
@@ -101,6 +102,6 @@ partition_proxy make_partition_proxy(Args&&... args) {
 }
 
 std::optional<partition_proxy> make_partition_proxy(
-  const model::ntp&, cluster::metadata_cache&, cluster::partition_manager&);
+  const model::ntp&, cluster::partition_manager&, coproc::partition_manager&);
 
 } // namespace kafka

--- a/src/v/kafka/server/protocol.cc
+++ b/src/v/kafka/server/protocol.cc
@@ -50,6 +50,7 @@ protocol::protocol(
   ss::sharded<cluster::security_frontend>& sec_fe,
   ss::sharded<cluster::controller_api>& controller_api,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
+  ss::sharded<coproc::partition_manager>& coproc_partition_manager,
   ss::sharded<v8_engine::data_policy_table>& data_policy_table,
   std::optional<qdc_monitor::config> qdc_config) noexcept
   : _smp_group(smp)
@@ -71,6 +72,7 @@ protocol::protocol(
   , _security_frontend(sec_fe)
   , _controller_api(controller_api)
   , _tx_gateway_frontend(tx_gateway_frontend)
+  , _coproc_partition_manager(coproc_partition_manager)
   , _data_policy_table(data_policy_table) {
     if (qdc_config) {
         _qdc_mon.emplace(*qdc_config);

--- a/src/v/kafka/server/protocol.h
+++ b/src/v/kafka/server/protocol.h
@@ -13,6 +13,7 @@
 
 #include "cluster/fwd.h"
 #include "config/configuration.h"
+#include "coproc/fwd.h"
 #include "kafka/latency_probe.h"
 #include "kafka/server/fetch_metadata_cache.hh"
 #include "kafka/server/fwd.h"
@@ -47,6 +48,7 @@ public:
       ss::sharded<cluster::security_frontend>&,
       ss::sharded<cluster::controller_api>&,
       ss::sharded<cluster::tx_gateway_frontend>&,
+      ss::sharded<coproc::partition_manager>&,
       ss::sharded<v8_engine::data_policy_table>&,
       std::optional<qdc_monitor::config>) noexcept;
 
@@ -76,6 +78,9 @@ public:
     }
     kafka::group_router& group_router() { return _group_router.local(); }
     cluster::shard_table& shard_table() { return _shard_table.local(); }
+    ss::sharded<coproc::partition_manager>& coproc_partition_manager() {
+        return _coproc_partition_manager;
+    }
     ss::sharded<cluster::partition_manager>& partition_manager() {
         return _partition_manager;
     }
@@ -143,6 +148,7 @@ private:
     ss::sharded<cluster::security_frontend>& _security_frontend;
     ss::sharded<cluster::controller_api>& _controller_api;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
+    ss::sharded<coproc::partition_manager>& _coproc_partition_manager;
     ss::sharded<v8_engine::data_policy_table>& _data_policy_table;
     std::optional<qdc_monitor> _qdc_mon;
     kafka::fetch_metadata_cache _fetch_metadata_cache;

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -122,6 +122,10 @@ public:
 
     cluster::shard_table& shards() { return _conn->server().shard_table(); }
 
+    ss::sharded<coproc::partition_manager>& coproc_partition_manager() {
+        return _conn->server().coproc_partition_manager();
+    }
+
     ss::sharded<cluster::partition_manager>& partition_manager() {
         return _conn->server().partition_manager();
     }

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -172,7 +172,7 @@ FIXTURE_TEST(read_from_ntp_max_bytes, redpanda_thread_fixture) {
             [&octx, ntp, config](cluster::partition_manager& pm) {
                 return kafka::read_from_ntp(
                   pm,
-                  octx.rctx.metadata_cache(),
+                  octx.rctx.coproc_partition_manager().local(),
                   ntp,
                   config,
                   true,

--- a/src/v/kafka/server/tests/find_coordinator_test.cc
+++ b/src/v/kafka/server/tests/find_coordinator_test.cc
@@ -49,28 +49,3 @@ FIXTURE_TEST(find_coordinator, redpanda_thread_fixture) {
     BOOST_TEST(resp.data.host == "127.0.0.1");
     BOOST_TEST(resp.data.port == 9092);
 }
-
-FIXTURE_TEST(
-  find_coordinator_for_non_replicatable_topic, redpanda_thread_fixture) {
-    wait_for_controller_leadership().get();
-    model::topic_namespace src{model::kafka_namespace, model::topic("src")};
-    model::topic_namespace dst{model::kafka_namespace, model::topic("dst")};
-    add_topic(src).get();
-    add_non_replicable_topic(std::move(src), std::move(dst)).get();
-
-    auto client = make_kafka_client().get0();
-    client.connect().get();
-    kafka::find_coordinator_request req("src");
-    kafka::find_coordinator_request req2("dst");
-    std::vector<kafka::find_coordinator_response> resps;
-    resps.push_back(client.dispatch(req, kafka::api_version(1)).get0());
-    resps.push_back(client.dispatch(req2, kafka::api_version(1)).get0());
-    client.stop().then([&client] { client.shutdown(); }).get();
-
-    for (const auto& r : resps) {
-        BOOST_TEST(r.data.error_code == kafka::error_code::none);
-        BOOST_TEST(r.data.node_id == model::node_id(1));
-        BOOST_TEST(r.data.host == "127.0.0.1");
-        BOOST_TEST(r.data.port == 9092);
-    }
-}

--- a/src/v/model/timeout_clock.h
+++ b/src/v/model/timeout_clock.h
@@ -27,4 +27,12 @@ static constexpr timeout_clock::time_point no_timeout
 static constexpr timeout_clock::duration max_duration
   = timeout_clock::duration::max();
 
+inline model::timeout_clock::time_point
+time_from_now(model::timeout_clock::duration d) {
+    /// Saturate now() + duration at no_timeout, avoid overflow
+    const auto now = model::timeout_clock::now();
+    const auto remaining = model::no_timeout - now;
+    return d < remaining ? now + d : model::no_timeout;
+}
+
 } // namespace model

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -157,6 +157,10 @@
                 "core": {
                     "type": "long",
                     "description": "core"
+                },
+                "materialized": {
+                    "type": "boolean",
+                    "description": "materialized"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "cluster/fwd.h"
 #include "config/endpoint_tls_config.h"
+#include "coproc/partition_manager.h"
 #include "model/metadata.h"
 #include "seastarx.h"
 
@@ -38,6 +39,7 @@ public:
     explicit admin_server(
       admin_server_cfg,
       ss::sharded<cluster::partition_manager>&,
+      ss::sharded<coproc::partition_manager>&,
       cluster::controller*,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::metadata_cache>&);
@@ -110,6 +112,7 @@ private:
     ss::http_server _server;
     admin_server_cfg _cfg;
     ss::sharded<cluster::partition_manager>& _partition_manager;
+    ss::sharded<coproc::partition_manager>& _cp_partition_manager;
     cluster::controller* _controller;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -411,6 +411,7 @@ void application::configure_admin_server() {
       _admin,
       admin_server_cfg_from_global_cfg(_scheduling_groups),
       std::ref(partition_manager),
+      std::ref(cp_partition_manager),
       controller.get(),
       std::ref(shard_table),
       std::ref(metadata_cache))

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -785,6 +785,8 @@ void application::wire_up_redpanda_services() {
           coprocessing,
           config::node().coproc_supervisor_server(),
           std::ref(storage),
+          std::ref(controller->get_topics_state()),
+          std::ref(shard_table),
           std::ref(controller->get_topics_frontend()),
           std::ref(metadata_cache),
           std::ref(partition_manager));

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1167,6 +1167,7 @@ void application::start_redpanda() {
             controller->get_security_frontend(),
             controller->get_api(),
             tx_gateway_frontend,
+            cp_partition_manager,
             data_policies,
             qdc_config);
           s.set_protocol(std::move(proto));

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -74,6 +74,7 @@ public:
     ss::sharded<cluster::shard_table> shard_table;
     ss::sharded<storage::api> storage;
     std::unique_ptr<coproc::api> coprocessing;
+    ss::sharded<coproc::partition_manager> cp_partition_manager;
     ss::sharded<cluster::partition_manager> partition_manager;
     ss::sharded<raft::recovery_throttle> recovery_throttle;
     ss::sharded<raft::group_manager> raft_group_manager;

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -284,7 +284,8 @@ public:
           .source = std::move(tp_ns_src), .name = std::move(tp_ns)};
         return app.controller->get_topics_frontend()
           .local()
-          .create_non_replicable_topics({std::move(nrt)}, model::no_timeout)
+          .autocreate_non_replicable_topics(
+            {std::move(nrt)}, model::max_duration)
           .then([this](std::vector<cluster::topic_result> results) {
               return wait_for_topics(std::move(results));
           });

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -20,9 +20,11 @@
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
 #include "config/node_config.h"
+#include "coproc/api.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
+#include "kafka/server/protocol.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "model/timeout_clock.h"
@@ -99,6 +101,7 @@ public:
           app.controller->get_security_frontend(),
           app.controller->get_api(),
           app.tx_gateway_frontend,
+          app.cp_partition_manager,
           app.data_policies,
           std::nullopt);
     }

--- a/src/v/rpc/test/rpc_integration_fixture.h
+++ b/src/v/rpc/test/rpc_integration_fixture.h
@@ -96,13 +96,11 @@ class rpc_base_integration_fixture {
 public:
     explicit rpc_base_integration_fixture(uint16_t port)
       : _listen_address("127.0.0.1", port)
-      , _ssg(ss::create_smp_service_group({5000}).get0()) {
-        _sg = ss::create_scheduling_group("rpc scheduling group", 200).get0();
-    }
+      , _ssg(ss::create_smp_service_group({5000}).get0())
+      , _sg(ss::default_scheduling_group()) {}
 
     virtual ~rpc_base_integration_fixture() {
         destroy_smp_service_group(_ssg).get0();
-        destroy_scheduling_group(_sg).get0();
     }
 
     virtual void start_server() = 0;
@@ -156,6 +154,7 @@ public:
       std::optional<ss::tls::credentials_builder> credentials = std::nullopt,
       ss::tls::reload_callback&& cb = {}) override {
         rpc::server_configuration scfg("unit_test_rpc");
+        scfg.disable_metrics = rpc::metrics_disabled::yes;
         auto resolved = rpc::resolve_dns(_listen_address).get();
         scfg.addrs.emplace_back(
           resolved,
@@ -203,6 +202,7 @@ public:
       std::optional<ss::tls::credentials_builder> credentials = std::nullopt,
       ss::tls::reload_callback&& cb = {}) override {
         rpc::server_configuration scfg("unit_test_rpc_sharded");
+        scfg.disable_metrics = rpc::metrics_disabled::yes;
         auto resolved = rpc::resolve_dns(_listen_address).get();
         scfg.addrs.emplace_back(
           resolved,

--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -1,0 +1,127 @@
+# Copyright 2020 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from rptest.services.admin import Admin
+from ducktape.utils.util import wait_until
+
+
+class PartitionMovementMixin():
+    @staticmethod
+    def _random_partition(metadata):
+        topic = random.choice(metadata)
+        partition = random.choice(topic["partitions"])
+        return topic["topic"], partition["partition"]
+
+    @staticmethod
+    def _choose_replacement(admin, assignments):
+        """
+        Does not produce assignments that contain duplicate nodes. This is a
+        limitation in redpanda raft implementation.
+        """
+        replication_factor = len(assignments)
+        node_ids = lambda x: set([a["node_id"] for a in x])
+
+        assert replication_factor >= 1
+        assert len(node_ids(assignments)) == replication_factor
+
+        # remove random assignment(s). we allow no changes to be made to
+        # exercise the code paths responsible for dealing with no-ops.
+        num_replacements = random.randint(0, replication_factor)
+        selected = random.sample(assignments, num_replacements)
+        for assignment in selected:
+            assignments.remove(assignment)
+
+        # choose a valid random replacement
+        replacements = []
+        brokers = admin.get_brokers()
+        while len(assignments) != replication_factor:
+            broker = random.choice(brokers)
+            node_id = broker["node_id"]
+            if node_id in node_ids(assignments):
+                continue
+            core = random.randint(0, broker["num_cores"] - 1)
+            replacement = dict(node_id=node_id, core=core)
+            assignments.append(replacement)
+            replacements.append(replacement)
+
+        return selected, replacements
+
+    @staticmethod
+    def _get_assignments(admin, topic, partition):
+        res = admin.get_partitions(topic, partition)
+
+        def normalize(a):
+            return dict(node_id=a["node_id"], core=a["core"])
+
+        return [normalize(a) for a in res["replicas"]]
+
+    @staticmethod
+    def _equal_assignments(r0, r1):
+        def to_tuple(a):
+            return a["node_id"], a["core"]
+
+        r0 = [to_tuple(a) for a in r0]
+        r1 = [to_tuple(a) for a in r1]
+        return set(r0) == set(r1)
+
+    def _get_current_partitions(self, admin, topic, partition_id):
+        def keep(p):
+            return p["ns"] == "kafka" and p["topic"] == topic and p[
+                "partition_id"] == partition_id
+
+        result = []
+        for node in self.redpanda.nodes:
+            node_id = self.redpanda.idx(node)
+            partitions = admin.get_partitions(node=node)
+            partitions = filter(keep, partitions)
+            for partition in partitions:
+                result.append(dict(node_id=node_id, core=partition["core"]))
+        return result
+
+    def _move_and_verify(self):
+        admin = Admin(self.redpanda)
+
+        # choose a random topic-partition
+        metadata = self.redpanda.describe_topics()
+        topic, partition = self._random_partition(metadata)
+        self.logger.info(f"selected topic-partition: {topic}-{partition}")
+
+        # get the partition's replica set, including core assignments. the kafka
+        # api doesn't expose core information, so we use the redpanda admin api.
+        assignments = self._get_assignments(admin, topic, partition)
+        self.logger.info(f"assignments for {topic}-{partition}: {assignments}")
+
+        # build new replica set by replacing a random assignment
+        selected, replacements = self._choose_replacement(admin, assignments)
+        self.logger.info(
+            f"replacement for {topic}-{partition}:{len(selected)}: {selected} -> {replacements}"
+        )
+        self.logger.info(
+            f"new assignments for {topic}-{partition}: {assignments}")
+
+        r = admin.set_partition_replicas(topic, partition, assignments)
+
+        def status_done():
+            info = admin.get_partitions(topic, partition)
+            self.logger.info(
+                f"current assignments for {topic}-{partition}: {info}")
+            converged = self._equal_assignments(info["replicas"], assignments)
+            return converged and info["status"] == "done"
+
+        # wait until redpanda reports complete
+        wait_until(status_done, timeout_sec=90, backoff_sec=2)
+
+        def derived_done():
+            info = self._get_current_partitions(admin, topic, partition)
+            self.logger.info(
+                f"derived assignments for {topic}-{partition}: {info}")
+            return self._equal_assignments(info, assignments)
+
+        wait_until(derived_done, timeout_sec=90, backoff_sec=2)

--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -85,28 +85,8 @@ class PartitionMovementMixin():
                 result.append(dict(node_id=node_id, core=partition["core"]))
         return result
 
-    def _move_and_verify(self):
+    def _wait_post_move(self, topic, partition, assignments):
         admin = Admin(self.redpanda)
-
-        # choose a random topic-partition
-        metadata = self.redpanda.describe_topics()
-        topic, partition = self._random_partition(metadata)
-        self.logger.info(f"selected topic-partition: {topic}-{partition}")
-
-        # get the partition's replica set, including core assignments. the kafka
-        # api doesn't expose core information, so we use the redpanda admin api.
-        assignments = self._get_assignments(admin, topic, partition)
-        self.logger.info(f"assignments for {topic}-{partition}: {assignments}")
-
-        # build new replica set by replacing a random assignment
-        selected, replacements = self._choose_replacement(admin, assignments)
-        self.logger.info(
-            f"replacement for {topic}-{partition}:{len(selected)}: {selected} -> {replacements}"
-        )
-        self.logger.info(
-            f"new assignments for {topic}-{partition}: {assignments}")
-
-        r = admin.set_partition_replicas(topic, partition, assignments)
 
         def status_done():
             info = admin.get_partitions(topic, partition)
@@ -125,3 +105,33 @@ class PartitionMovementMixin():
             return self._equal_assignments(info, assignments)
 
         wait_until(derived_done, timeout_sec=90, backoff_sec=2)
+
+    def _do_move_and_verify(self, topic, partition):
+        admin = Admin(self.redpanda)
+
+        # get the partition's replica set, including core assignments. the kafka
+        # api doesn't expose core information, so we use the redpanda admin api.
+        assignments = self._get_assignments(admin, topic, partition)
+        self.logger.info(f"assignments for {topic}-{partition}: {assignments}")
+
+        # build new replica set by replacing a random assignment
+        selected, replacements = self._choose_replacement(admin, assignments)
+        self.logger.info(
+            f"replacement for {topic}-{partition}:{len(selected)}: {selected} -> {replacements}"
+        )
+        self.logger.info(
+            f"new assignments for {topic}-{partition}: {assignments}")
+
+        r = admin.set_partition_replicas(topic, partition, assignments)
+
+        self._wait_post_move(topic, partition, assignments)
+
+        return (topic, partition, assignments)
+
+    def _move_and_verify(self):
+        # choose a random topic-partition
+        metadata = self.redpanda.describe_topics()
+        topic, partition = self._random_partition(metadata)
+        self.logger.info(f"selected topic-partition: {topic}-{partition}")
+
+        self._do_move_and_verify(topic, partition)

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -20,13 +20,14 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.services.admin import Admin
+from rptest.tests.partition_movement import PartitionMovementMixin
 from rptest.services.honey_badger import HoneyBadger
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.kaf_producer import KafProducer
 from rptest.services.rpk_consumer import RpkConsumer
 
 
-class PartitionMovementTest(EndToEndTest):
+class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     """
     Basic partition movement tests. Each test builds a number of topics and then
     performs a series of random replica set changes. After each change a
@@ -48,119 +49,6 @@ class PartitionMovementTest(EndToEndTest):
             },
             **kwargs)
         self._ctx = ctx
-
-    @staticmethod
-    def _random_partition(metadata):
-        topic = random.choice(metadata)
-        partition = random.choice(topic["partitions"])
-        return topic["topic"], partition["partition"]
-
-    @staticmethod
-    def _choose_replacement(admin, assignments):
-        """
-        Does not produce assignments that contain duplicate nodes. This is a
-        limitation in redpanda raft implementation.
-        """
-        replication_factor = len(assignments)
-        node_ids = lambda x: set([a["node_id"] for a in x])
-
-        assert replication_factor >= 1
-        assert len(node_ids(assignments)) == replication_factor
-
-        # remove random assignment(s). we allow no changes to be made to
-        # exercise the code paths responsible for dealing with no-ops.
-        num_replacements = random.randint(0, replication_factor)
-        selected = random.sample(assignments, num_replacements)
-        for assignment in selected:
-            assignments.remove(assignment)
-
-        # choose a valid random replacement
-        replacements = []
-        brokers = admin.get_brokers()
-        while len(assignments) != replication_factor:
-            broker = random.choice(brokers)
-            node_id = broker["node_id"]
-            if node_id in node_ids(assignments):
-                continue
-            core = random.randint(0, broker["num_cores"] - 1)
-            replacement = dict(node_id=node_id, core=core)
-            assignments.append(replacement)
-            replacements.append(replacement)
-
-        return selected, replacements
-
-    @staticmethod
-    def _get_assignments(admin, topic, partition):
-        res = admin.get_partitions(topic, partition)
-
-        def normalize(a):
-            return dict(node_id=a["node_id"], core=a["core"])
-
-        return [normalize(a) for a in res["replicas"]]
-
-    @staticmethod
-    def _equal_assignments(r0, r1):
-        def to_tuple(a):
-            return a["node_id"], a["core"]
-
-        r0 = [to_tuple(a) for a in r0]
-        r1 = [to_tuple(a) for a in r1]
-        return set(r0) == set(r1)
-
-    def _get_current_partitions(self, admin, topic, partition_id):
-        def keep(p):
-            return p["ns"] == "kafka" and p["topic"] == topic and p[
-                "partition_id"] == partition_id
-
-        result = []
-        for node in self.redpanda.nodes:
-            node_id = self.redpanda.idx(node)
-            partitions = admin.get_partitions(node=node)
-            partitions = filter(keep, partitions)
-            for partition in partitions:
-                result.append(dict(node_id=node_id, core=partition["core"]))
-        return result
-
-    def _move_and_verify(self):
-        admin = Admin(self.redpanda)
-
-        # choose a random topic-partition
-        metadata = self.redpanda.describe_topics()
-        topic, partition = self._random_partition(metadata)
-        self.logger.info(f"selected topic-partition: {topic}-{partition}")
-
-        # get the partition's replica set, including core assignments. the kafka
-        # api doesn't expose core information, so we use the redpanda admin api.
-        assignments = self._get_assignments(admin, topic, partition)
-        self.logger.info(f"assignments for {topic}-{partition}: {assignments}")
-
-        # build new replica set by replacing a random assignment
-        selected, replacements = self._choose_replacement(admin, assignments)
-        self.logger.info(
-            f"replacement for {topic}-{partition}:{len(selected)}: {selected} -> {replacements}"
-        )
-        self.logger.info(
-            f"new assignments for {topic}-{partition}: {assignments}")
-
-        r = admin.set_partition_replicas(topic, partition, assignments)
-
-        def status_done():
-            info = admin.get_partitions(topic, partition)
-            self.logger.info(
-                f"current assignments for {topic}-{partition}: {info}")
-            converged = self._equal_assignments(info["replicas"], assignments)
-            return converged and info["status"] == "done"
-
-        # wait until redpanda reports complete
-        wait_until(status_done, timeout_sec=90, backoff_sec=2)
-
-        def derived_done():
-            info = self._get_current_partitions(admin, topic, partition)
-            self.logger.info(
-                f"derived assignments for {topic}-{partition}: {info}")
-            return self._equal_assignments(info, assignments)
-
-        wait_until(derived_done, timeout_sec=90, backoff_sec=2)
 
     @cluster(num_nodes=3)
     def test_moving_not_fully_initialized_partition(self):

--- a/tests/rptest/tests/wasm_filter_test.py
+++ b/tests/rptest/tests/wasm_filter_test.py
@@ -12,7 +12,8 @@ from ducktape.mark.resource import cluster
 from ducktape.mark import ignore
 from rptest.clients.types import TopicSpec
 from rptest.wasm.wasm_build_tool import WasmTemplateRepository
-from rptest.wasm.wasm_test import WasmTest, WasmScript, random_string
+from rptest.wasm.wasm_test import WasmTest
+from rptest.wasm.wasm_script import WasmScript, random_string
 from rptest.clients.rpk import RpkTool
 from rptest.wasm.topic import construct_materialized_topic
 from rptest.wasm.native_kafka_consumer import NativeKafkaConsumer

--- a/tests/rptest/tests/wasm_identity_test.py
+++ b/tests/rptest/tests/wasm_identity_test.py
@@ -13,7 +13,8 @@ from rptest.clients.types import TopicSpec
 from rptest.wasm.topic import construct_materialized_topic, get_source_topic
 from rptest.wasm.topics_result_set import materialized_result_set_compare
 from rptest.wasm.wasm_build_tool import WasmTemplateRepository
-from rptest.wasm.wasm_test import WasmScript, WasmTest
+from rptest.wasm.wasm_test import WasmTest
+from rptest.wasm.wasm_script import WasmScript
 
 
 class WasmIdentityTest(WasmTest):

--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -1,0 +1,198 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import random
+from functools import partial
+
+from rptest.services.admin import Admin
+from rptest.services.verifiable_consumer import VerifiableConsumer
+
+from ducktape.mark.resource import cluster
+from ducktape.mark import ignore
+from ducktape.utils.util import wait_until
+
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.clients.rpk import RpkTool
+
+from rptest.wasm.wasm_build_tool import WasmTemplateRepository, WasmBuildTool
+from rptest.wasm.topic import construct_materialized_topic
+from rptest.wasm.wasm_script import WasmScript
+
+from rptest.tests.partition_movement import PartitionMovementMixin
+from rptest.clients.types import TopicSpec
+
+
+class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
+    """
+    Tests to ensure that the materialized partition movement feature
+    is working as expected. This feature has materialized topics move to
+    where their respective sources are moved to.
+    """
+    def __init__(self, ctx, *args, **kvargs):
+        super(WasmPartitionMovementTest, self).__init__(
+            ctx,
+            *args,
+            extra_rp_conf={
+                # Disable leader balancer, as this test is doing its own
+                # partition movement and the balancer would interfere
+                'enable_leader_balancer': False,
+                'enable_coproc': True,
+                'developer_mode': True,
+                'auto_create_topics_enabled': False
+            },
+            **kvargs)
+        self._ctx = ctx
+        self._rpk_tool = None
+        self._build_tool = None
+        self.result_data = []
+        self.mconsumer = None
+
+    def start_redpanda_nodes(self, nodes):
+        self.start_redpanda(num_nodes=nodes)
+        self._rpk_tool = RpkTool(self.redpanda)
+        self._build_tool = WasmBuildTool(self._rpk_tool)
+
+    def restart_random_redpanda_node(self):
+        node = random.sample(self.redpanda.nodes, 1)[0]
+        self.logger.info(f"Randomly killing redpanda node: {node.name}")
+        self.redpanda.restart_nodes(node)
+
+    def _deploy_identity_copro(self, inputs, outputs):
+        script = WasmScript(inputs=inputs,
+                            outputs=outputs,
+                            script=WasmTemplateRepository.IDENTITY_TRANSFORM)
+
+        self._build_tool.build_test_artifacts(script)
+
+        self._rpk_tool.wasm_deploy(
+            script.get_artifact(self._build_tool.work_dir), script.name,
+            "ducktape")
+
+    def _verify_materialized_assignments(self, topic, partition, assignments):
+        admin = Admin(self.redpanda)
+        massignments = self._get_assignments(admin, topic, partition)
+        self.logger.info(
+            f"materialized assignments for {topic}-{partition}: {massignments}"
+        )
+
+        self._wait_post_move(topic, partition, assignments)
+
+    def _grab_input(self, topic):
+        metadata = self.redpanda.describe_topics()
+        selected = [x for x in metadata if x['topic'] == topic]
+        assert len(selected) == 1
+        partition = random.choice(selected[0]["partitions"])
+        return selected[0]["topic"], partition["partition"]
+
+    def _on_data_consumed(self, record, node):
+        self.result_data.append(record["value"])
+
+    def _start_mconsumer(self, materialized_topic):
+        self.mconsumer = VerifiableConsumer(
+            self.test_context,
+            num_nodes=1,
+            redpanda=self.redpanda,
+            topic=materialized_topic,
+            group_id="test_group",
+            on_record_consumed=self._on_data_consumed)
+        self.mconsumer.start()
+
+    def _await_consumer(self, limit, timeout):
+        wait_until(
+            lambda: self.mconsumer.total_consumed() >= limit,
+            timeout_sec=timeout,
+            err_msg=
+            "Timeout of after %ds while awaiting delivery of %d materialized records, recieved: %d"
+            % (timeout, limit, self.mconsumer.total_consumed()))
+        self.mconsumer.stop()
+
+    def _prime_env(self):
+        output_topic = "identity_output2"
+        self.start_redpanda_nodes(3)
+        spec = TopicSpec(name="topic2",
+                         partition_count=3,
+                         replication_factor=3)
+        self.redpanda.create_topic(spec)
+        self._deploy_identity_copro([spec.name], [output_topic])
+        self.topic = spec.name
+        self.start_producer(num_nodes=1, throughput=10000)
+        self.start_consumer(1)
+        self.await_startup(min_records=500)
+        materialized_topic = construct_materialized_topic(
+            spec.name, output_topic)
+
+        def topic_created():
+            metadata = self.redpanda.describe_topics()
+            self.logger.info(f"metadata: {metadata}")
+            return any([x['topic'] == materialized_topic for x in metadata])
+
+        wait_until(topic_created, timeout_sec=30, backoff_sec=2)
+
+        self._start_mconsumer(materialized_topic)
+        t, p = self._grab_input(spec.name)
+        return {
+            'topic': t,
+            'partition': p,
+            'materialized_topic': materialized_topic
+        }
+
+    @cluster(num_nodes=6)
+    def test_dynamic(self):
+        """
+        Move partitions with active consumer / producer
+        """
+        s = self._prime_env()
+        for _ in range(5):
+            _, partition, assignments = self._do_move_and_verify(
+                s['topic'], s['partition'])
+            self._verify_materialized_assignments(s['materialized_topic'],
+                                                  partition, assignments)
+
+        # Vaidate input
+        self.run_validation(min_records=500,
+                            enable_idempotence=False,
+                            consumer_timeout_sec=90)
+
+        # Wait for all output
+        self._await_consumer(self.consumer.total_consumed(), 90)
+
+        # Validate number of records & their content
+        self.logger.info(
+            f'A: {self.mconsumer.total_consumed()} B: {self.consumer.total_consumed()}'
+        )
+        assert self.mconsumer.total_consumed() == self.consumer.total_consumed(
+        )
+        # Since the identity copro was deployed, contents of logs should be identical
+        assert set(self.records_consumed) == set(self.result_data)
+
+    @cluster(num_nodes=6)
+    def test_dynamic_with_failure(self):
+        s = self._prime_env()
+        _, partition, assignments = self._do_move_and_verify(
+            s['topic'], s['partition'])
+
+        # Crash a node before verifying, it has a fixed amount of seconds to restart
+        n = random.sample(self.redpanda.nodes, 1)[0]
+        self.redpanda.restart_nodes(n)
+
+        self._verify_materialized_assignments(s['materialized_topic'],
+                                              partition, assignments)
+
+        self.run_validation(min_records=500,
+                            enable_idempotence=False,
+                            consumer_timeout_sec=90)
+
+        # Wait for all output
+        self._await_consumer(self.consumer.total_consumed(), 90)
+
+        # GTE due to the fact that upon error, copro may re-processed already processed
+        # data depending on when offsets were checkpointed
+        assert self.mconsumer.total_consumed() >= self.consumer.total_consumed(
+        )

--- a/tests/rptest/wasm/wasm_script.py
+++ b/tests/rptest/wasm/wasm_script.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Vectorized, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import string
+import uuid
+import os
+
+
+def random_string(N):
+    return ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for _ in range(N))
+
+
+class WasmScript:
+    def __init__(self, inputs=[], outputs=[], script=None):
+        self.name = random_string(10)
+        self.inputs = inputs
+        self.outputs = outputs
+        self.script = script
+        self.dir_name = str(uuid.uuid4())
+
+    def get_artifact(self, build_dir):
+        artifact = os.path.join(build_dir, self.dir_name, "dist",
+                                f"{self.dir_name}.js")
+        if not os.path.exists(artifact):
+            raise Exception(f"Artifact {artifact} was not built")
+        return artifact

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -7,16 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import os
-import uuid
-import random
-import string
-
 from kafka import TopicPartition
 
 from rptest.wasm.topic import get_source_topic
 from rptest.wasm.native_kafka_consumer import NativeKafkaConsumer
 from rptest.wasm.cli_kafka_producer import CliKafkaProducer
+from rptest.wasm.wasm_script import WasmScript
 
 from rptest.wasm.topic import construct_materialized_topic
 from rptest.wasm.wasm_build_tool import WasmBuildTool
@@ -33,28 +29,6 @@ from functools import reduce
 
 def flat_map(fn, ll):
     return reduce(lambda acc, x: acc + fn(x), ll, [])
-
-
-def random_string(N):
-    return ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for _ in range(N))
-
-
-class WasmScript:
-    def __init__(self, inputs=[], outputs=[], script=None):
-        self.name = random_string(10)
-        self.inputs = inputs
-        self.outputs = outputs
-        self.script = script
-        self.dir_name = str(uuid.uuid4())
-
-    def get_artifact(self, build_dir):
-        artifact = os.path.join(build_dir, self.dir_name, "dist",
-                                f"{self.dir_name}.js")
-        if not os.path.exists(artifact):
-            raise Exception(f"Artifact {artifact} was not built")
-        return artifact
 
 
 class WasmTest(RedpandaTest):


### PR DESCRIPTION
## Wasm changes backports for 21.11.x

NOTE: There were manual conflict resolutions in this PR performed, albeit they were small and simple to perform. This was due to the fact that there were collisions with the `net::` namespace [PR](https://github.com/vectorizedio/redpanda/pull/3350)  introduced by @dotnwat and the ducktape [error log detection work](https://github.com/vectorizedio/redpanda/pull/3226) done by @jcsp. Merging at least #3350 in would have led to the need to transitively include additional PRs, greatly expanding the footprint of what we haven't tested in 21.11.x so far.

The files I manually resolved were: 
- `coproc/api.h` 
- `tests/rptest/tests/partition_movement_test.py` 
- `tests/rptest/tests/wasm_filter_test.py`
- `tests/rptest/tests/wasm_identity_test.py`

## Release notes

- Backport #3128 
- Backport #3180
- Backport #3193
- Backport #3254
- Backport #3264
- Backport #3340
- Backport #3411
- Backport #3493
- Backport #3212
- Backport #3576

### Features

- See the milestone for [Data streams v1 technical preview](https://github.com/vectorizedio/redpanda/milestone/5)

### edits
Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/1a9234f9280b69727bd5cb3a9a8708aaef929415..00383ba8f2deeb30b736b8e5cc0ed601d8a22a96)
- Resolved an error in merging partition_movement_test updates