### PR TITLE
Pandaproxy consumer improvements

### DIFF
--- a/docs/www/configuration.md
+++ b/docs/www/configuration.md
@@ -393,6 +393,10 @@ pandaproxy:
       name: external
       port: 8083
 
+  # How long to wait for an idle consumer before removing it.
+  # Default: 60000
+  consumer_instance_timeout_ms: 60000
+
 # The REST API client
 pandaproxy_client:
   # List of address and port of the brokers

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -102,8 +102,9 @@ ss::future<> client::stop() noexcept {
     co_await _gate.close();
     co_await catch_and_log([this]() { return _producer.stop(); });
     for (auto& [id, group] : _consumers) {
-        for (auto& consumer : group) {
-            co_await catch_and_log([consumer]() { return consumer->leave(); });
+        while (!group.empty()) {
+            auto c = *group.begin();
+            co_await catch_and_log([c]() { return c->leave(); });
         }
     }
     co_await catch_and_log([this]() { return _brokers.stop(); });

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -104,7 +104,11 @@ ss::future<> client::stop() noexcept {
     for (auto& [id, group] : _consumers) {
         while (!group.empty()) {
             auto c = *group.begin();
-            co_await catch_and_log([c]() { return c->leave(); });
+            co_await catch_and_log([c]() {
+                // The consumer is constructed with an on_stopped which erases
+                // istelf from the map after leave() completes.
+                return c->leave();
+            });
         }
     }
     co_await catch_and_log([this]() { return _brokers.stop(); });
@@ -355,13 +359,17 @@ client::create_consumer(const group_id& group_id, member_id name) {
             _config);
       })
       .then([this, group_id, name](shared_broker_t coordinator) mutable {
+          auto on_stopped = [this, group_id](const member_id& name) {
+              _consumers[group_id].erase(name);
+          };
           return make_consumer(
             _config,
             _topic_cache,
             _brokers,
             std::move(coordinator),
             std::move(group_id),
-            std::move(name));
+            std::move(name),
+            std::move(on_stopped));
       })
       .then([this, group_id](shared_consumer_t c) {
           auto name = c->name();

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -179,8 +179,16 @@ ss::future<> client::mitigate_error(std::exception_ptr ex) {
             return _wait_or_start_update_metadata();
         }
         default:
-            // TODO(Ben): Maybe vassert
-            vlog(kclog.warn, "partition_error: ", ex);
+            vlog(kclog.warn, "partition_error: {}", ex);
+            return ss::make_exception_future(ex);
+        }
+    } catch (const topic_error& ex) {
+        switch (ex.error) {
+        case error_code::unknown_topic_or_partition:
+            vlog(kclog.debug, "topic_error: {}", ex);
+            return _wait_or_start_update_metadata();
+        default:
+            vlog(kclog.warn, "topic_error: {}", ex);
             return ss::make_exception_future(ex);
         }
     } catch (const ss::gate_closed_exception&) {

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -121,6 +121,9 @@ public:
     ss::future<member_id>
     create_consumer(const group_id& g_id, member_id name = kafka::no_member);
 
+    ss::future<shared_consumer_t>
+    get_consumer(const group_id& g_id, const member_id& m_id);
+
     ss::future<> remove_consumer(const group_id& g_id, const member_id& m_id);
 
     ss::future<> subscribe_consumer(
@@ -173,9 +176,6 @@ private:
     /// \brief Handle errors by performing an action that may fix the cause of
     /// the error
     ss::future<> mitigate_error(std::exception_ptr ex);
-
-    ss::future<shared_consumer_t>
-    get_consumer(const group_id& g_id, const member_id& m_id);
 
     /// \brief Apply metadata update
     ss::future<> apply(metadata_response res);

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -127,6 +127,8 @@ ss::future<> consumer::stop() {
       .finally([me{shared_from_this()}] {});
 }
 
+ss::future<> consumer::initialize() { return join(); }
+
 ss::future<> consumer::join() {
     _timer.cancel();
     auto req_builder = [me{shared_from_this()}]() {
@@ -458,7 +460,7 @@ ss::future<shared_consumer_t> make_consumer(
       std::move(coordinator),
       std::move(group_id),
       std::move(name));
-    return c->join().then([c]() mutable { return std::move(c); });
+    return c->initialize().then([c]() mutable { return std::move(c); });
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/consumer.cc
+++ b/src/v/kafka/client/consumer.cc
@@ -84,6 +84,21 @@ reduce_fetch_response(fetch_response result, fetch_response val) {
 
 } // namespace detail
 
+consumer::consumer(
+  const configuration& config,
+  topic_cache& topic_cache,
+  brokers& brokers,
+  shared_broker_t coordinator,
+  kafka::group_id group_id,
+  kafka::member_id name)
+  : _config(config)
+  , _topic_cache(topic_cache)
+  , _brokers(brokers)
+  , _coordinator(std::move(coordinator))
+  , _group_id(std::move(group_id))
+  , _name(std::move(name))
+  , _topics() {}
+
 void consumer::start() {
     vlog(kclog.info, "Consumer: {}: start", *this);
     _timer.set_callback([me{shared_from_this()}]() {

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -118,7 +118,7 @@ private:
     shared_broker_t _coordinator;
     ss::abort_source _as;
     ss::gate _gate{};
-    ss::timer<> _timer;
+    ss::timer<> _heartbeat_timer;
 
     kafka::group_id _group_id;
     generation_id _generation_id{no_generation};

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -39,20 +39,20 @@ class consumer final : public ss::enable_lw_shared_from_this<consumer> {
     using broker_reqs_t = absl::node_hash_map<shared_broker_t, fetch_request>;
 
 public:
+    /// \brief Construct a consumer
+    ///
+    /// \param coordinator - The coordinator broker for this group. There should
+    /// be no other owners, as it is used for the long-poll fetch.
+    ///
+    /// \param name - If this is unknowm_member_id, then the name is generated
+    /// by the broker.
     consumer(
       const configuration& config,
       topic_cache& topic_cache,
       brokers& brokers,
       shared_broker_t coordinator,
       group_id group_id,
-      member_id name)
-      : _config(config)
-      , _topic_cache(topic_cache)
-      , _brokers(brokers)
-      , _coordinator(std::move(coordinator))
-      , _group_id(std::move(group_id))
-      , _name(std::move(name))
-      , _topics() {}
+      member_id name);
 
     const kafka::group_id& group_id() const { return _group_id; }
     const kafka::member_id& member_id() const { return _member_id; }

--- a/src/v/kafka/client/consumer.h
+++ b/src/v/kafka/client/consumer.h
@@ -62,7 +62,7 @@ public:
     const std::vector<model::topic>& topics() const { return _topics; }
     const assignment_t& assignment() const { return _assignment; }
 
-    ss::future<> join();
+    ss::future<> initialize();
     ss::future<leave_group_response> leave();
     ss::future<> subscribe(std::vector<model::topic> topics);
     ss::future<offset_fetch_response>
@@ -82,6 +82,7 @@ private:
 
     void on_leader_join(const join_group_response& res);
 
+    ss::future<> join();
     ss::future<> sync();
 
     ss::future<std::vector<metadata_response::topic>>

--- a/src/v/pandaproxy/error.cc
+++ b/src/v/pandaproxy/error.cc
@@ -52,6 +52,9 @@ struct reply_error_category final : std::error_category {
             return "subject_version_soft_deleted";
         case reply_error_code::subject_version_not_deleted:
             return "subject_version_not_deleted";
+        case reply_error_code::consumer_already_exists:
+            return "Consumer with specified consumer ID already exists in the "
+                   "specified consumer group.";
         case reply_error_code::schema_empty:
             return "Empty schema";
         case reply_error_code::schema_version_invalid:

--- a/src/v/pandaproxy/error.h
+++ b/src/v/pandaproxy/error.h
@@ -40,6 +40,7 @@ enum class reply_error_code : uint16_t {
     subject_not_deleted = 40405,
     subject_version_soft_deleted = 40406,
     subject_version_not_deleted = 40407,
+    consumer_already_exists = 40902,
     schema_empty = 42201,
     schema_version_invalid = 42202,
     compatibility_level_invalid = 42203,

--- a/src/v/pandaproxy/rest/configuration.cc
+++ b/src/v/pandaproxy/rest/configuration.cc
@@ -9,10 +9,13 @@
 
 #include "configuration.h"
 
+#include "config/base_property.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
 #include "model/metadata.h"
 #include "units.h"
+
+#include <chrono>
 
 namespace pandaproxy::rest {
 using namespace std::chrono_literals;
@@ -47,6 +50,12 @@ configuration::configuration()
       "api_doc_dir",
       "API doc directory",
       config::required::no,
-      "/usr/share/redpanda/proxy-api-doc") {}
+      "/usr/share/redpanda/proxy-api-doc")
+  , consumer_instance_timeout(
+      *this,
+      "consumer_instance_timeout_ms",
+      "How long to wait for an idle consumer before removing it",
+      config::required::no,
+      std::chrono::minutes{5}) {}
 
 } // namespace pandaproxy::rest

--- a/src/v/pandaproxy/rest/configuration.h
+++ b/src/v/pandaproxy/rest/configuration.h
@@ -32,6 +32,7 @@ struct configuration final : public config::config_store {
     config::one_or_many_property<model::broker_endpoint>
       advertised_pandaproxy_api;
     config::property<ss::sstring> api_doc_dir;
+    config::property<std::chrono::milliseconds> consumer_instance_timeout;
 
     configuration();
     explicit configuration(const YAML::Node& cfg);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -364,6 +364,10 @@ void application::hydrate_config(const po::variables_map& cfg) {
         } else {
             set_local_kafka_client_config(_proxy_client_config, config::node());
         }
+        // override pandaparoxy_client.consumer_session_timeout_ms with
+        // pandaproxy.consumer_instance_timeout_ms
+        _proxy_client_config->consumer_session_timeout.set_value(
+          _proxy_config->consumer_instance_timeout.value());
         _proxy_config->for_each(config_printer("pandaproxy"));
         _proxy_client_config->for_each(config_printer("pandaproxy_client"));
     }


### PR DESCRIPTION
## Cover letter

* Pandaproxy: Creating a consumer with an existing name now fails with `{"error_code": 40902}`
* Pandaproxy: An inactive consumer is now timed out after `pandaproxy.consumer_instance_timeout_ms`

Fix #3581 
Fix #3583 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/d68a8769bec8e149a9f56543c568f81a9707dcae..7b6f41575238bad34d67856dee097ab1c3ea8901)
 * Added documentation for the most interesting `consumer` constructor params
 * Made the code that destroys timers in `consumer::stop` more explicit and added a comment
 * Documented the loop that destroys consumers in `client::stop()`

## Release notes

### Improvements

* Pandaproxy: Creating a consumer with an existing name now fails with `{"error_code": 40902}`
* Pandaproxy: An inactive consumer is now timed out after `pandaproxy.consumer_instance_timeout_ms`
