### PR TITLE
schema_registry: Bump swagger version to 1.0.0

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy Schema Registry",
-    "version": "v21.12.1"
+    "version": "1.0.0"
   },
   "host": "{{Host}}",
   "basePath": "/",


### PR DESCRIPTION
## Cover letter

Bring `dev` into line with `v21.11.x`

The previous version was going to be a source of confusion; there's
no need for the swagger version to align with the Redpanda version.

Signed-off-by: Ben Pope <ben@vectorized.io>
(cherry picked from commit d9605442637cabac690189f70f7914458f976048)

## Release notes

* none