### PR TITLE
tests,rpc: update for BadLogLines test failures

### DIFF
--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -144,6 +144,16 @@ simple_protocol::dispatch_method_once(header h, net::server::resources rs) {
                           "Timing out request on gate_closed_exception "
                           "(shutting down)");
                         reply_buf.set_status(rpc::status::request_timeout);
+                    } catch (const ss::broken_condition_variable& e) {
+                        rpclog.debug(
+                          "Timing out request on broken_condition_variable "
+                          "(shutting down)");
+                        reply_buf.set_status(rpc::status::request_timeout);
+                    } catch (const ss::abort_requested_exception& e) {
+                        rpclog.debug(
+                          "Timing out request on abort_requested_exception "
+                          "(shutting down)");
+                        reply_buf.set_status(rpc::status::request_timeout);
                     } catch (...) {
                         rpclog.error(
                           "Service handler threw an exception: {}",

--- a/tests/rptest/tests/cluster_metadata_test.py
+++ b/tests/rptest/tests/cluster_metadata_test.py
@@ -13,6 +13,7 @@ from ducktape.utils.util import wait_until
 from ducktape.mark import matrix
 from rptest.clients.rpk import RpkTool
 from rptest.services.failure_injector import FailureInjector, FailureSpec
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.tests.redpanda_test import RedpandaTest
 
 
@@ -33,7 +34,7 @@ class MetadataTest(RedpandaTest):
         returned_node_ids = [n.id for n in nodes]
         assert sorted(all_ids) == sorted(returned_node_ids)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(failure=['isolate', 'stop'], node=['follower', 'controller'])
     def test_metadata_request_does_not_contain_failed_node(
             self, failure, node):

--- a/tests/rptest/tests/rpk_config_test.py
+++ b/tests/rptest/tests/rpk_config_test.py
@@ -10,7 +10,7 @@
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk_remote import RpkRemoteTool
-from rptest.services.redpanda import RedpandaService
+from rptest.services.redpanda import RedpandaService, RESTART_LOG_ALLOW_LIST
 
 import yaml
 import random
@@ -174,7 +174,7 @@ tune_swappiness: false
 
                 assert actual_config['rpk'] == expected_config
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_config_change_then_restart_node(self):
         for node in self.redpanda.nodes:
             rpk = RpkRemoteTool(self.redpanda, node)


### PR DESCRIPTION
## Cover letter

- RpkConfigTest needed an allow list when restarting nodes
- Rare misleading shutdown errors from `simple_protocol::dispatch_method_once` are silenced

## Release notes

* none