### PR TITLE
Update remaining (void)with_gate calls to spawn_with_gate helper

### DIFF
--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -124,7 +124,7 @@ ss::future<> persisted_stm::do_make_snapshot() {
 }
 
 void persisted_stm::make_snapshot_in_background() {
-    (void)ss::with_gate(_gate, [this] { return make_snapshot(); });
+    ssx::spawn_with_gate(_gate, [this] { return make_snapshot(); });
 }
 
 ss::future<> persisted_stm::make_snapshot() {

--- a/src/v/coproc/reconciliation_backend.cc
+++ b/src/v/coproc/reconciliation_backend.cc
@@ -115,7 +115,7 @@ ss::future<> reconciliation_backend::start() {
           }
       });
     if (!_gate.is_closed()) {
-        (void)ss::with_gate(_gate, [this] {
+        ssx::spawn_with_gate(_gate, [this] {
             return ss::do_until(
               [this] { return _as.abort_requested(); },
               [this] { return fetch_and_reconcile(std::move(_topic_deltas)); });

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -214,7 +214,7 @@ void group_manager::handle_leader_change(
   model::term_id term,
   ss::lw_shared_ptr<cluster::partition> part,
   std::optional<model::node_id> leader) {
-    (void)with_gate(_gate, [this, term, part = std::move(part), leader] {
+    ssx::spawn_with_gate(_gate, [this, term, part = std::move(part), leader] {
         if (auto it = _partitions.find(part->ntp()); it != _partitions.end()) {
             /*
              * In principle a race could occur by which a validate_group_status

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -319,7 +319,7 @@ void heartbeat_manager::process_reply(
 }
 
 void heartbeat_manager::dispatch_heartbeats() {
-    (void)with_gate(_bghbeats, [this] {
+    ssx::background = ssx::spawn_with_gate_then(_bghbeats, [this] {
         return _lock.with([this] {
             return do_dispatch_heartbeats().finally([this] {
                 if (!_bghbeats.is_closed()) {

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -320,14 +320,15 @@ void heartbeat_manager::process_reply(
 
 void heartbeat_manager::dispatch_heartbeats() {
     ssx::background = ssx::spawn_with_gate_then(_bghbeats, [this] {
-        return _lock.with([this] {
-            return do_dispatch_heartbeats().finally([this] {
-                if (!_bghbeats.is_closed()) {
-                    _heartbeat_timer.arm(next_heartbeat_timeout());
-                }
-            });
-        });
-    }).handle_exception([](const std::exception_ptr& e) {
+                          return _lock.with([this] {
+                              return do_dispatch_heartbeats().finally([this] {
+                                  if (!_bghbeats.is_closed()) {
+                                      _heartbeat_timer.arm(
+                                        next_heartbeat_timeout());
+                                  }
+                              });
+                          });
+                      }).handle_exception([](const std::exception_ptr& e) {
         vlog(hbeatlog.warn, "Error dispatching heartbeats - {}", e);
     });
     // update last


### PR DESCRIPTION
## Cover letter

Leaving out the one that is already touched in https://github.com/vectorizedio/redpanda/pull/3567

These were missed in the original spawn_with_gate PR because they're using an unqualified `with_gate`.  Refactor them to use the new helpers to get clean handling of shutdown exceptions across the board.

## Release notes

* none
