### PR TITLE
pandaproxy: Fix a crash when publishing multiple protobof schema

### DIFF
--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -35,9 +35,10 @@ using server = ctx_server<service>;
 
 template<typename Handler>
 auto wrap(ss::gate& g, one_shot& os, Handler h) {
-    return [&g, &os, h{std::move(h)}](
+    return [&g, &os, _h{std::move(h)}](
              server::request_t rq,
              server::reply_t rp) -> ss::future<server::reply_t> {
+        auto h{_h};
         auto units = co_await os();
         auto guard = gate_guard(g);
         co_return co_await h(std::move(rq), std::move(rp));

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -179,8 +179,7 @@ ss::future<bool> sharded_store::upsert(
       deleted);
 }
 
-ss::future<subject_schema>
-sharded_store::has_schema(const canonical_schema& schema) {
+ss::future<subject_schema> sharded_store::has_schema(canonical_schema schema) {
     auto versions = co_await get_versions(schema.sub(), include_deleted::no);
 
     try {
@@ -214,7 +213,7 @@ sharded_store::has_schema(const canonical_schema& schema) {
 }
 
 ss::future<canonical_schema_definition>
-sharded_store::get_schema_definition(const schema_id& id) {
+sharded_store::get_schema_definition(schema_id id) {
     co_return co_await _store.invoke_on(
       shard_for(id), _smp_opts, [id](store& s) {
           return s.get_schema_definition(id).value();
@@ -234,9 +233,7 @@ sharded_store::get_schema_subject_versions(schema_id id) {
 }
 
 ss::future<subject_schema> sharded_store::get_subject_schema(
-  const subject& sub,
-  std::optional<schema_version> version,
-  include_deleted inc_del) {
+  subject sub, std::optional<schema_version> version, include_deleted inc_del) {
     auto v_id = co_await _store.invoke_on(
       shard_for(sub), _smp_opts, [sub, version, inc_del](store& s) {
           return s.get_subject_version_id(sub, version, inc_del).value();
@@ -268,21 +265,22 @@ sharded_store::get_subjects(include_deleted inc_del) {
 }
 
 ss::future<std::vector<schema_version>>
-sharded_store::get_versions(const subject& sub, include_deleted inc_del) {
+sharded_store::get_versions(subject sub, include_deleted inc_del) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub, inc_del](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}, inc_del](store& s) {
           return s.get_versions(sub, inc_del).value();
       });
 }
 
-ss::future<bool>
-sharded_store::is_referenced(const subject& sub, schema_version ver) {
-    auto map = [&sub, ver](store& s) { return s.is_referenced(sub, ver); };
+ss::future<bool> sharded_store::is_referenced(subject sub, schema_version ver) {
+    auto map = [sub{std::move(sub)}, ver](store& s) {
+        return s.is_referenced(sub, ver);
+    };
     co_return co_await _store.map_reduce0(map, false, std::logical_or<>{});
 }
 
 ss::future<std::vector<schema_id>> sharded_store::referenced_by(
-  const subject& sub, std::optional<schema_version> opt_ver) {
+  subject sub, std::optional<schema_version> opt_ver) {
     schema_version ver;
     if (opt_ver.has_value()) {
         ver = *opt_ver;
@@ -293,7 +291,9 @@ ss::future<std::vector<schema_id>> sharded_store::referenced_by(
         ver = versions.back();
     }
 
-    auto map = [&sub, ver](store& s) { return s.referenced_by(sub, ver); };
+    auto map = [sub{std::move(sub)}, ver](store& s) {
+        return s.referenced_by(sub, ver);
+    };
     auto reduce = [](std::vector<schema_id> acc, std::vector<schema_id> refs) {
         acc.insert(acc.end(), refs.begin(), refs.end());
         return acc;
@@ -305,49 +305,50 @@ ss::future<std::vector<schema_id>> sharded_store::referenced_by(
 }
 
 ss::future<std::vector<schema_version>> sharded_store::delete_subject(
-  seq_marker marker, const subject& sub, permanent_delete permanent) {
+  seq_marker marker, subject sub, permanent_delete permanent) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [marker, sub, permanent](store& s) {
+      shard_for(sub),
+      _smp_opts,
+      [marker, sub{std::move(sub)}, permanent](store& s) {
           return s.delete_subject(marker, sub, permanent).value();
       });
 }
 
-ss::future<is_deleted> sharded_store::is_subject_deleted(const subject& sub) {
+ss::future<is_deleted> sharded_store::is_subject_deleted(subject sub) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}](store& s) {
           return s.is_subject_deleted(sub).value();
       });
 }
 
-ss::future<is_deleted> sharded_store::is_subject_version_deleted(
-  const subject& sub, const schema_version ver) {
+ss::future<is_deleted>
+sharded_store::is_subject_version_deleted(subject sub, schema_version ver) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub, ver](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}, ver](store& s) {
           return s.is_subject_version_deleted(sub, ver).value();
       });
 }
 
 ss::future<std::vector<seq_marker>>
-sharded_store::get_subject_written_at(const subject& sub) {
+sharded_store::get_subject_written_at(subject sub) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}](store& s) {
           return s.store::get_subject_written_at(sub).value();
       });
 }
 
 ss::future<std::vector<seq_marker>>
-sharded_store::get_subject_version_written_at(
-  const subject& sub, schema_version ver) {
+sharded_store::get_subject_version_written_at(subject sub, schema_version ver) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub, ver](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}, ver](store& s) {
           return s.get_subject_version_written_at(sub, ver).value();
       });
 }
 
 ss::future<bool>
-sharded_store::delete_subject_version(const subject& sub, schema_version ver) {
+sharded_store::delete_subject_version(subject sub, schema_version ver) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub, ver](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}, ver](store& s) {
           return s.delete_subject_version(sub, ver).value();
       });
 }
@@ -356,10 +357,10 @@ ss::future<compatibility_level> sharded_store::get_compatibility() {
     co_return _store.local().get_compatibility().value();
 }
 
-ss::future<compatibility_level> sharded_store::get_compatibility(
-  const subject& sub, default_to_global fallback) {
+ss::future<compatibility_level>
+sharded_store::get_compatibility(subject sub, default_to_global fallback) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), [sub, fallback](store& s) {
+      shard_for(sub), [sub{std::move(sub)}, fallback](store& s) {
           return s.get_compatibility(sub, fallback).value();
       });
 }
@@ -374,16 +375,18 @@ sharded_store::set_compatibility(compatibility_level compatibility) {
 }
 
 ss::future<bool> sharded_store::set_compatibility(
-  seq_marker marker, const subject& sub, compatibility_level compatibility) {
+  seq_marker marker, subject sub, compatibility_level compatibility) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [marker, sub, compatibility](store& s) {
+      shard_for(sub),
+      _smp_opts,
+      [marker, sub{std::move(sub)}, compatibility](store& s) {
           return s.set_compatibility(marker, sub, compatibility).value();
       });
 }
 
-ss::future<bool> sharded_store::clear_compatibility(const subject& sub) {
+ss::future<bool> sharded_store::clear_compatibility(subject sub) {
     co_return co_await _store.invoke_on(
-      shard_for(sub), _smp_opts, [sub](store& s) {
+      shard_for(sub), _smp_opts, [sub{std::move(sub)}](store& s) {
           return s.clear_compatibility(sub).value();
       });
 }
@@ -402,7 +405,7 @@ ss::future<sharded_store::insert_subject_result> sharded_store::insert_subject(
     auto [version, inserted] = co_await _store.invoke_on(
       shard_for(sub),
       _smp_opts,
-      [sub, refs{std::move(refs)}, id](store& s) mutable {
+      [sub{std::move(sub)}, refs{std::move(refs)}, id](store& s) mutable {
           return s.insert_subject(sub, std::move(refs), id);
       });
     co_return insert_subject_result{version, inserted};
@@ -456,7 +459,7 @@ ss::future<> sharded_store::maybe_update_max_schema_id(schema_id id) {
 }
 
 ss::future<bool> sharded_store::is_compatible(
-  schema_version version, const canonical_schema& new_schema) {
+  schema_version version, canonical_schema new_schema) {
     // Lookup the version_ids
     const auto& sub = new_schema.sub();
     const auto versions = co_await _store.invoke_on(

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -98,12 +98,13 @@ ss::future<> sharded_store::validate_schema(canonical_schema schema) {
 
 ss::future<valid_schema>
 sharded_store::make_valid_schema(canonical_schema schema) {
+    // This method seems to confuse clang 12.0.1
+    // See #3596 for details, especially if modifying it.
     switch (schema.type()) {
     case schema_type::avro:
         co_return make_avro_schema_definition(schema.def().raw()()).value();
     case schema_type::protobuf:
-        co_return co_await make_protobuf_schema_definition(
-          *this, std::move(schema));
+        co_return co_await make_protobuf_schema_definition(*this, schema);
     case schema_type::json:
         throw as_exception(invalid_schema_type(schema.type()));
     }

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -50,11 +50,10 @@ public:
       schema_version version,
       is_deleted deleted);
 
-    ss::future<subject_schema> has_schema(const canonical_schema& schema);
+    ss::future<subject_schema> has_schema(canonical_schema schema);
 
     ///\brief Return a schema definition by id.
-    ss::future<canonical_schema_definition>
-    get_schema_definition(const schema_id& id);
+    ss::future<canonical_schema_definition> get_schema_definition(schema_id id);
 
     ///\brief Return a list of subject-versions for the shema id.
     ss::future<std::vector<subject_version>>
@@ -62,7 +61,7 @@ public:
 
     ///\brief Return a schema by subject and version (or latest).
     ss::future<subject_schema> get_subject_schema(
-      const subject& sub,
+      subject sub,
       std::optional<schema_version> version,
       include_deleted inc_dec);
 
@@ -71,52 +70,51 @@ public:
 
     ///\brief Return a list of versions and associated schema_id.
     ss::future<std::vector<schema_version>>
-    get_versions(const subject& sub, include_deleted inc_del);
+    get_versions(subject sub, include_deleted inc_del);
 
     ///\brief Return whether there are any references to a subject version.
-    ss::future<bool> is_referenced(const subject& sub, schema_version ver);
+    ss::future<bool> is_referenced(subject sub, schema_version ver);
 
     ///\brief Return the schema_ids that reference a subject version.
     ss::future<std::vector<schema_id>>
-    referenced_by(const subject& sub, std::optional<schema_version> ver);
+    referenced_by(subject sub, std::optional<schema_version> ver);
 
     ///\brief Delete a subject.
-    ss::future<std::vector<schema_version>> delete_subject(
-      seq_marker marker, const subject& sub, permanent_delete permanent);
+    ss::future<std::vector<schema_version>>
+    delete_subject(seq_marker marker, subject sub, permanent_delete permanent);
 
-    ss::future<is_deleted> is_subject_deleted(const subject& sub);
+    ss::future<is_deleted> is_subject_deleted(subject sub);
 
-    ss::future<is_deleted> is_subject_version_deleted(
-      const subject& sub, const schema_version version);
+    ss::future<is_deleted>
+    is_subject_version_deleted(subject sub, schema_version version);
+
+    ///\brief Get sequence number history (errors out if not soft-deleted)
+    ss::future<std::vector<seq_marker>> get_subject_written_at(subject sub);
 
     ///\brief Get sequence number history (errors out if not soft-deleted)
     ss::future<std::vector<seq_marker>>
-    get_subject_written_at(const subject& sub);
-
-    ///\brief Get sequence number history (errors out if not soft-deleted)
-    ss::future<std::vector<seq_marker>>
-    get_subject_version_written_at(const subject& sub, schema_version version);
+    get_subject_version_written_at(subject sub, schema_version version);
 
     ///\brief Delete a subject version
     ss::future<bool>
-    delete_subject_version(const subject& sub, schema_version version);
+    delete_subject_version(subject sub, schema_version version);
 
     ///\brief Get the global compatibility level.
     ss::future<compatibility_level> get_compatibility();
 
     ///\brief Get the compatibility level for a subject, or fallback to global.
     ss::future<compatibility_level>
-    get_compatibility(const subject& sub, default_to_global fallback);
+    get_compatibility(subject sub, default_to_global fallback);
 
     ///\brief Set the global compatibility level.
     ss::future<bool> set_compatibility(compatibility_level compatibility);
 
     ///\brief Set the compatibility level for a subject.
     ss::future<bool> set_compatibility(
-      seq_marker marker, const subject& sub, compatibility_level compatibility);
+      seq_marker marker, subject sub, compatibility_level compatibility);
 
     ///\brief Clear the compatibility level for a subject.
-    ss::future<bool> clear_compatibility(const subject& sub);
+    ss::future<bool> clear_compatibility(subject sub);
 
     ///\brief Check if the provided schema is compatible with the subject and
     /// version, according the the current compatibility.
@@ -124,7 +122,7 @@ public:
     /// If the compatibility level is transitive, then all versions are checked,
     /// otherwise checks are against the version provided and newer.
     ss::future<bool>
-    is_compatible(schema_version version, const canonical_schema& new_schema);
+    is_compatible(schema_version version, canonical_schema new_schema);
 
 private:
     ss::future<bool>

--- a/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_protobuf.cc
@@ -142,6 +142,27 @@ SEASTAR_THREAD_TEST_CASE(test_protobuf_referenced) {
       = pps::make_protobuf_schema_definition(store.store, schema3).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_protobuf_well_known) {
+    simple_sharded_store store;
+
+    auto schema1 = pps::canonical_schema{
+      pps::subject{"empty.proto"},
+      pps::canonical_schema_definition{
+        R"(syntax =  "proto3";)", pps::schema_type::protobuf}};
+    auto schema2 = pps::canonical_schema{
+      pps::subject{"google/protobuf/timestamp.proto"},
+      pps::canonical_schema_definition{
+        R"(syntax =  "proto3"; package google.protobuf; message Timestamp { int64 seconds = 1;  int32 nanos = 2; })",
+        pps::schema_type::protobuf}};
+    auto sch1 = store.insert(schema1, pps::schema_version{1});
+    auto sch2 = store.insert(schema2, pps::schema_version{1});
+
+    auto valid_empty
+      = pps::make_protobuf_schema_definition(store.store, schema1).get();
+    auto valid_timestamp
+      = pps::make_protobuf_schema_definition(store.store, schema2).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_protobuf_compatibility_empty) {
     BOOST_REQUIRE(check_compatible(
       pps::compatibility_level::full,

--- a/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
+++ b/src/v/pandaproxy/schema_registry/test/post_subjects_subject_version.cc
@@ -120,3 +120,25 @@ FIXTURE_TEST(
           R"({"error_code":422,"message":")"));
     }
 }
+
+FIXTURE_TEST(
+  schema_registry_post_subjects_subject_version_many_proto,
+  pandaproxy_test_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Connecting client");
+    auto client = make_schema_reg_client();
+
+    for (auto i = 0; i < 10; ++i) {
+        info("Post a schema as key (expect schema_id=1)");
+        auto res = post_schema(client, pps::subject{"test-key"}, R"(
+{
+  "schema": "syntax = \"proto3\"; message Simple { string i = 1; }",
+  "schemaType": "PROTOBUF"
+})");
+        BOOST_REQUIRE_EQUAL(res.body, R"({"id":1})");
+        BOOST_REQUIRE_EQUAL(
+          res.headers.at(boost::beast::http::field::content_type),
+          to_header_value(ppj::serialization_format::schema_registry_v1_json));
+    }
+}

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -470,6 +470,24 @@ class SchemaRegistryTest(RedpandaTest):
         # assert result["schema"] == json.dumps(schema_def)
 
     @cluster(num_nodes=3)
+    def test_post_subjects_subject_versions_version_many(self):
+        """
+        Verify posting a schema many times
+        """
+
+        topic = create_topic_names(1)[0]
+        subject = f"{topic}-key"
+        schema_1_data = json.dumps({"schema": schema1_def})
+
+        # Post the same schema many times.
+        for _ in range(20):
+            result_raw = self._post_subjects_subject_versions(
+                subject=subject, data=schema_1_data)
+            self.logger.debug(result_raw)
+            assert result_raw.status_code == requests.codes.ok
+            assert result_raw.json()["id"] == 1
+
+    @cluster(num_nodes=3)
     def test_post_subjects_subject(self):
         """
         Verify posting a schema


### PR DESCRIPTION
## Cover letter

Fix #3559 

This is a logical continuation of work done in #3214 and addresses a similar bug.

Address some CPP Core guidelines:
* [cpp core guideline CP.51](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#cp51-do-not-use-capturing-lambdas-that-are-coroutines)
* [cpp core guideline CP.53](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#cp53-parameters-to-coroutines-should-not-be-passed-by-reference)

Fix the bug:

* Made a copy of a `schema` to prevent a crash.

### Notes for reviewer

CP.51 was fixed by copying captures to the coroutine frame.

It's probably worth pointing out that this trick works because seastar awaitable are `std::suspend_never initial_suspend() noexcept`.

And for posterity: [But what if I told you there was an easier way, where you can have your capturing lambda be a coroutine?](https://devblogs.microsoft.com/oldnewthing/20211103-00/?p=105870#:~:text=but%20what%20if%20i%20told%20you%20there%20was%20an%20easier%20way%2C%20where%20you%20can%20have%20your%20capturing%20lambda%20be%20a%20coroutine%3F)

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/6633940b9cf962035a180ddddf3bb417c6e436b0..913f19d928f567dea442a98add5290f4bcd5329f)

* Add a smattering of `std::move`s to the `sub` captures.

## Release notes

### Improvements

* Schema Registry: Fix a crash when publishing multiple protobuf schema #3559 