### PR TITLE
Fix assertion in wasm partition movement ducktape test

### DIFF
--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -189,8 +189,9 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                             enable_idempotence=False,
                             consumer_timeout_sec=90)
 
-        # Wait for all output
-        self._await_consumer(self.consumer.total_consumed(), 90)
+        # Wait for all acked, output, significant because due to failure the number of
+        # actual produced records may be less than expected
+        self._await_consumer(len(self.producer.acked), 90)
 
         # GTE due to the fact that upon error, copro may re-processed already processed
         # data depending on when offsets were checkpointed


### PR DESCRIPTION
## cause
Small write-up for root cause here: https://github.com/vectorizedio/redpanda/issues/3595#issuecomment-1020529744

## solution
Fix the assertion to compare number of expected records with number of produced & acked records. This is only necessary in the test that had failed since a crash node failure is injected during the test.

## release notes
none

## linked fixes
- Fixes: #3595