### PR TITLE
tree-wide: Copy lambda captures to coroutine frame.

### DIFF
--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -533,9 +533,11 @@ ss::future<> partition_downloader::download_segment_file(
         co_await ss::remove_file(localpath.string());
     }
 
-    auto stream = [this, part, remote_path, localpath, otl](
+    auto stream = [this, part, remote_path, _localpath{localpath}, _otl{otl}](
                     uint64_t len,
                     ss::input_stream<char> in) -> ss::future<uint64_t> {
+        auto localpath{_localpath};
+        auto otl{_otl};
         vlog(
           _ctxlog.info,
           "Copying s3 path {} to local location {}",

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -50,8 +50,9 @@ recursive_directory_walker::walk(ss::sstring start_dir) {
         try {
             ss::file target_dir = co_await open_directory(target);
             auto sub = target_dir.list_directory(
-              [&files, &current_cache_size, &dirlist, target](
+              [&files, &current_cache_size, &dirlist, _target{target}](
                 ss::directory_entry entry) -> ss::future<> {
+                  auto target{_target};
                   vlog(cst_log.debug, "Looking at directory {}", target);
 
                   auto entry_path = std::filesystem::path(target)

--- a/src/v/coproc/script_context_backend.cc
+++ b/src/v/coproc/script_context_backend.cc
@@ -339,7 +339,8 @@ write_materialized(output_write_inputs replies, output_write_args args) {
     grouping_t grs = group_replies(std::move(replies));
     bool err{false};
     co_await ss::parallel_for_each(
-      grs, [args, &err](grouping_t::value_type& vt) -> ss::future<> {
+      grs, [_args{args}, &err](grouping_t::value_type& vt) -> ss::future<> {
+          auto args{_args};
           try {
               co_await process_reply_group(
                 vt.first, std::move(vt.second), args);

--- a/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
+++ b/src/v/coproc/tests/fixtures/fiber_mock_fixture.cc
@@ -35,7 +35,8 @@ ss::future<> fiber_mock_fixture::init_test(test_parameters params) {
         auto shard = app.shard_table.local().shard_for(ntp);
         vassert(shard, "topic not up yet");
         co_await _state.invoke_on(
-          *shard, [this, ntp, params](state& s) -> ss::future<> {
+          *shard, [this, _ntp{ntp}, params](state& s) -> ss::future<> {
+              auto ntp{_ntp};
               auto src = co_await make_source(ntp, s, params);
               auto [_, success] = s.routes.emplace(ntp, src);
               vassert(success, "no double insert attempt should occur");

--- a/src/v/coproc/tests/pacemaker_tests.cc
+++ b/src/v/coproc/tests/pacemaker_tests.cc
@@ -87,8 +87,9 @@ FIXTURE_TEST(test_coproc_router_off_by_one, coproc_test_fixture) {
           .topics = {std::make_pair<>(
             src_topic, coproc::topic_ingestion_policy::stored)}}}})
       .get();
-    auto fn =
-      [this, input_ntp, output_ntp](model::offset start) -> ss::future<size_t> {
+    auto fn = [this, input_ntp, _output_ntp{output_ntp}](
+                model::offset start) -> ss::future<size_t> {
+        auto output_ntp{_output_ntp};
         co_await produce(input_ntp, make_random_batch(1));
         auto r = co_await consume(output_ntp, 1, start);
         co_return num_records(r);

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -254,13 +254,20 @@ create_consumer(server::request_t rq, server::reply_t rp) {
           parse::error_code::invalid_param, "auto.commit must be false");
     }
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       res_fmt,
-       req_data{std::move(req_data)},
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _res_fmt{res_fmt},
+       _req_data{std::move(req_data)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto res_fmt{_res_fmt};
+        auto req_data{std::move(_req_data)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
+
         vlog(
           plog.debug,
           "create_consumer: group_id: {}, name: {}, min_bytes: {}, timeout: "
@@ -283,7 +290,7 @@ create_consumer(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -298,9 +305,17 @@ remove_consumer(server::request_t rq, server::reply_t rp) {
     auto member_id = parse::request_param<kafka::member_id>(
       *rq.req, "instance");
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id, member_id, rq{std::move(rq)}, rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _member_id{std::move(member_id)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto member_id{std::move(_member_id)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "remove_consumer: group_id: {}, member_id: {}",
@@ -313,7 +328,7 @@ remove_consumer(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -331,14 +346,21 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
     auto req_data = ppj::rjson_parse(
       rq.req->content.data(), ppj::subscribe_consumer_request_handler());
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       member_id,
-       res_fmt,
-       req_data{std::move(req_data)},
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _member_id{std::move(member_id)},
+       _res_fmt{res_fmt},
+       _req_data{std::move(req_data)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto member_id{std::move(_member_id)};
+        auto res_fmt{_res_fmt};
+        auto req_data{std::move(_req_data)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "subscribe_consumer: group_id: {}, member_id: {}, topics: {}",
@@ -354,7 +376,7 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -374,15 +396,23 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
     auto max_bytes{
       parse::query_param<std::optional<int32_t>>(*rq.req, "max_bytes")};
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       name,
-       timeout,
-       max_bytes,
-       res_fmt,
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _name{std::move(name)},
+       _timeout{timeout},
+       _max_bytes{max_bytes},
+       _res_fmt{res_fmt},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto name{std::move(_name)};
+        auto timeout{_timeout};
+        auto max_bytes{_max_bytes};
+        auto res_fmt{_res_fmt};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "consumer_fetch: group_id: {}, name: {}, timeout: {}, max_bytes: {}",
@@ -406,7 +436,7 @@ consumer_fetch(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -422,14 +452,21 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
     auto req_data = ppj::partitions_request_to_offset_request(ppj::rjson_parse(
       rq.req->content.data(), ppj::partitions_request_handler()));
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       member_id,
-       req_data{std::move(req_data)},
-       res_fmt,
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _member_id{std::move(member_id)},
+       _res_fmt{res_fmt},
+       _req_data{std::move(req_data)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto member_id{std::move(_member_id)};
+        auto res_fmt{_res_fmt};
+        auto req_data{std::move(_req_data)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "get_consumer_offsets: group_id: {}, member_id: {}, offsets: {}",
@@ -449,7 +486,7 @@ get_consumer_offsets(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 ss::future<server::reply_t>
@@ -470,13 +507,19 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
                           rq.req->content.data(),
                           ppj::partition_offsets_request_handler()));
 
+    auto group_shard{consumer_shard(group_id)};
     auto handler =
-      [group_id,
-       member_id,
-       req_data{std::move(req_data)},
-       rq{std::move(rq)},
-       rp{std::move(rp)}](
+      [_group_id{std::move(group_id)},
+       _member_id{std::move(member_id)},
+       _req_data{std::move(req_data)},
+       _rq{std::move(rq)},
+       _rp{std::move(rp)}](
         kafka::client::client& client) mutable -> ss::future<server::reply_t> {
+        auto group_id{std::move(_group_id)};
+        auto member_id{std::move(_member_id)};
+        auto req_data{std::move(_req_data)};
+        auto rq{std::move(_rq)};
+        auto rp{std::move(_rp)};
         vlog(
           plog.debug,
           "post_consumer_offsets: group_id: {}, member_id: {}, offsets: {}",
@@ -491,7 +534,7 @@ post_consumer_offsets(server::request_t rq, server::reply_t rp) {
     };
 
     co_return co_await rq.service().client().invoke_on(
-      consumer_shard(group_id), rq.context().smp_sg, std::move(handler));
+      group_shard, rq.context().smp_sg, std::move(handler));
 }
 
 } // namespace pandaproxy::rest

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1332,9 +1332,11 @@ void admin_server::register_partition_routes() {
 
           co_return co_await _partition_manager.invoke_on(
             *shard,
-            [ntp = std::move(ntp), req = std::move(req), this](
+            [_ntp = std::move(ntp), _req = std::move(req), this](
               cluster::partition_manager& pm) mutable
             -> ss::future<ss::json::json_return_type> {
+                auto ntp = std::move(_ntp);
+                auto req = std::move(_req);
                 auto partition = pm.get(ntp);
                 if (!partition) {
                     throw ss::httpd::server_error_exception(fmt_with_ctx(
@@ -1443,9 +1445,11 @@ void admin_server::register_partition_routes() {
 
           co_return co_await _partition_manager.invoke_on(
             *shard,
-            [ntp = std::move(ntp), pid, req = std::move(req), this](
+            [_ntp = std::move(ntp), pid, _req = std::move(req), this](
               cluster::partition_manager& pm) mutable
             -> ss::future<ss::json::json_return_type> {
+                auto ntp = std::move(_ntp);
+                auto req = std::move(_req);
                 auto partition = pm.get(ntp);
                 if (!partition) {
                     throw ss::httpd::server_error_exception(fmt_with_ctx(

--- a/src/v/s3/tests/s3_client_test.cc
+++ b/src/v/s3/tests/s3_client_test.cc
@@ -407,8 +407,9 @@ void test_client_pool(s3::client_pool_overdraft_policy policy) {
     std::vector<ss::future<>> fut;
     for (size_t i = 0; i < 20; i++) {
         auto f = pool->acquire().then(
-          [server = server](
+          [_server = server](
             s3::client_pool::client_lease lease) -> ss::future<> {
+              auto server = _server;
               auto& [client, _] = lease;
               iobuf payload;
               auto payload_stream = make_iobuf_ref_output_stream(payload);
@@ -449,8 +450,9 @@ SEASTAR_TEST_CASE(test_client_pool_reconnect) {
         std::vector<ss::future<bool>> fut;
         for (size_t i = 0; i < 20; i++) {
             auto f = pool->acquire().then(
-              [server = server](
+              [_server = server](
                 s3::client_pool::client_lease lease) -> ss::future<bool> {
+                  auto server = _server;
                   co_await ss::sleep(100ms);
                   auto& [client, _] = lease;
                   iobuf payload;


### PR DESCRIPTION
## Cover letter

Address cpp core guideline CP.51:
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#cp51-do-not-use-capturing-lambdas-that-are-coroutines

This trick works because seastar awaitable are declared
`std::suspend_never initial_suspend() noexcept`.

Also see: https://devblogs.microsoft.com/oldnewthing/20211103-00

Signed-off-by: Ben Pope <ben@vectorized.io>


## Release notes

* none
