### PR TITLE
cloud_storage: Improve SI memory layout

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -13,6 +13,7 @@
 #include "archival/types.h"
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
+#include "cloud_storage/manifest.h"
 #include "cluster/members_table.h"
 #include "random/generators.h"
 #include "s3/client.h"
@@ -467,5 +468,7 @@ archival::remote_segment_path get_segment_path(
   const cloud_storage::manifest& manifest, const archival::segment_name& name) {
     auto meta = manifest.get(name);
     BOOST_REQUIRE(meta);
-    return manifest.generate_segment_path(name, *meta);
+    auto key = cloud_storage::parse_segment_name(name);
+    BOOST_REQUIRE(key);
+    return manifest.generate_segment_path(*key, *meta);
 }

--- a/src/v/cloud_storage/manifest.cc
+++ b/src/v/cloud_storage/manifest.cc
@@ -269,6 +269,15 @@ const manifest::segment_meta* manifest::get(const segment_name& name) const {
     return get(key);
 }
 
+manifest::const_iterator manifest::find(model::offset o) const {
+    auto it = _segments.lower_bound(
+      {.base_offset = o, .term = model::term_id(0)});
+    if (it == _segments.end() || it->first.base_offset != o) {
+        return end();
+    }
+    return it;
+}
+
 std::insert_iterator<manifest::segment_map> manifest::get_insert_iterator() {
     return std::inserter(_segments, _segments.begin());
 }

--- a/src/v/cloud_storage/manifest.cc
+++ b/src/v/cloud_storage/manifest.cc
@@ -19,6 +19,7 @@
 #include "ssx/sformat.h"
 #include "storage/fs_utils.h"
 #include "storage/ntp_config.h"
+#include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
 
@@ -147,6 +148,10 @@ remote_segment_path generate_remote_segment_path(
     }
 }
 
+segment_name generate_segment_name(model::offset o, model::term_id t) {
+    return segment_name(ssx::sformat("{}-{}-v1.log", o(), t()));
+}
+
 manifest::manifest()
   : _ntp()
   , _rev()
@@ -194,8 +199,9 @@ model::initial_revision_id manifest::get_revision_id() const { return _rev; }
 
 remote_segment_path manifest::generate_segment_path(
   const manifest::key& key, const segment_meta& meta) const {
+    auto name = generate_segment_name(key.base_offset, key.term);
     return generate_remote_segment_path(
-      _ntp, meta.ntp_revision, key, meta.archiver_term);
+      _ntp, meta.ntp_revision, name, meta.archiver_term);
 }
 
 manifest::const_iterator manifest::begin() const { return _segments.begin(); }
@@ -216,6 +222,16 @@ bool manifest::contains(const manifest::key& key) const {
     return _segments.contains(key);
 }
 
+bool manifest::contains(const segment_name& name) const {
+    auto maybe_key = parse_segment_name(name);
+    if (!maybe_key) {
+        throw std::runtime_error(
+          fmt_with_ctx(fmt::format, "can't parse segment name \"{}\"", name));
+    }
+    key key = {.base_offset = maybe_key->base_offset, .term = maybe_key->term};
+    return _segments.contains(key);
+}
+
 bool manifest::add(const manifest::key& key, const segment_meta& meta) {
     auto [it, ok] = _segments.insert(std::make_pair(key, meta));
     if (ok && it->second.ntp_revision == model::initial_revision_id{}) {
@@ -225,12 +241,32 @@ bool manifest::add(const manifest::key& key, const segment_meta& meta) {
     return ok;
 }
 
+bool manifest::add(const segment_name& name, const segment_meta& meta) {
+    auto maybe_key = parse_segment_name(name);
+    if (!maybe_key) {
+        throw std::runtime_error(
+          fmt_with_ctx(fmt::format, "can't parse segment name \"{}\"", name));
+    }
+    key key = {.base_offset = maybe_key->base_offset, .term = maybe_key->term};
+    return add(key, meta);
+}
+
 const manifest::segment_meta* manifest::get(const manifest::key& key) const {
     auto it = _segments.find(key);
     if (it == _segments.end()) {
         return nullptr;
     }
     return &it->second;
+}
+
+const manifest::segment_meta* manifest::get(const segment_name& name) const {
+    auto maybe_key = parse_segment_name(name);
+    if (!maybe_key) {
+        throw std::runtime_error(
+          fmt_with_ctx(fmt::format, "can't parse segment name \"{}\"", name));
+    }
+    key key = {.base_offset = maybe_key->base_offset, .term = maybe_key->term};
+    return get(key);
 }
 
 std::insert_iterator<manifest::segment_map> manifest::get_insert_iterator() {
@@ -283,7 +319,14 @@ void manifest::update(const json::Document& m) {
     if (m.HasMember("segments")) {
         const auto& s = m["segments"].GetObject();
         for (auto it = s.MemberBegin(); it != s.MemberEnd(); it++) {
-            auto name = manifest::key{it->name.GetString()};
+            auto name = segment_name{it->name.GetString()};
+            auto parsed_key = parse_segment_name(name);
+            if (!parsed_key) {
+                throw std::runtime_error(fmt_with_ctx(
+                  fmt::format, "can't parse segment name \"{}\"", name));
+            }
+            key key = {
+              .base_offset = parsed_key->base_offset, .term = parsed_key->term};
             auto coffs = it->value["committed_offset"].GetInt64();
             auto boffs = it->value["base_offset"].GetInt64();
             auto size_bytes = it->value["size_bytes"].GetInt64();
@@ -323,7 +366,7 @@ void manifest::update(const json::Document& m) {
               .ntp_revision = ntp_revision,
               .archiver_term = archiver_term,
             };
-            tmp.insert(std::make_pair(name, meta));
+            tmp.insert(std::make_pair(key, meta));
         }
     }
     std::swap(tmp, _segments);
@@ -359,7 +402,8 @@ void manifest::serialize(std::ostream& out) const {
     if (!_segments.empty()) {
         w.Key("segments");
         w.StartObject();
-        for (const auto& [sn, meta] : _segments) {
+        for (const auto& [key, meta] : _segments) {
+            auto sn = generate_segment_name(key.base_offset, key.term);
             w.Key(sn());
             w.StartObject();
             w.Key("is_compacted");
@@ -409,6 +453,11 @@ bool manifest::delete_permanently(const manifest::key& key) {
         return true;
     }
     return false;
+}
+
+std::ostream& operator<<(std::ostream& o, const manifest::key& k) {
+    o << generate_segment_name(k.base_offset, k.term);
+    return o;
 }
 
 topic_manifest::topic_manifest(

--- a/src/v/cloud_storage/manifest.cc
+++ b/src/v/cloud_storage/manifest.cc
@@ -193,9 +193,9 @@ const model::offset manifest::get_last_offset() const { return _last_offset; }
 model::initial_revision_id manifest::get_revision_id() const { return _rev; }
 
 remote_segment_path manifest::generate_segment_path(
-  const segment_name& name, const segment_meta& meta) const {
+  const manifest::key& key, const segment_meta& meta) const {
     return generate_remote_segment_path(
-      _ntp, meta.ntp_revision, name, meta.archiver_term);
+      _ntp, meta.ntp_revision, key, meta.archiver_term);
 }
 
 manifest::const_iterator manifest::begin() const { return _segments.begin(); }
@@ -212,12 +212,12 @@ manifest::const_reverse_iterator manifest::rend() const {
 
 size_t manifest::size() const { return _segments.size(); }
 
-bool manifest::contains(const segment_name& name) const {
-    return _segments.contains(name);
+bool manifest::contains(const manifest::key& key) const {
+    return _segments.contains(key);
 }
 
-bool manifest::add(const segment_name& name, const segment_meta& meta) {
-    auto [it, ok] = _segments.insert(std::make_pair(name, meta));
+bool manifest::add(const manifest::key& key, const segment_meta& meta) {
+    auto [it, ok] = _segments.insert(std::make_pair(key, meta));
     if (ok && it->second.ntp_revision == model::initial_revision_id{}) {
         it->second.ntp_revision = _rev;
     }
@@ -225,8 +225,8 @@ bool manifest::add(const segment_name& name, const segment_meta& meta) {
     return ok;
 }
 
-const manifest::segment_meta* manifest::get(const segment_name& name) const {
-    auto it = _segments.find(name);
+const manifest::segment_meta* manifest::get(const manifest::key& key) const {
+    auto it = _segments.find(key);
     if (it == _segments.end()) {
         return nullptr;
     }
@@ -402,8 +402,8 @@ void manifest::serialize(std::ostream& out) const {
     w.EndObject();
 }
 
-bool manifest::delete_permanently(const segment_name& name) {
-    auto it = _segments.find(name);
+bool manifest::delete_permanently(const manifest::key& key) {
+    auto it = _segments.find(key);
     if (it != _segments.end()) {
         _segments.erase(it);
         return true;

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -185,6 +185,8 @@ public:
     /// Get segment if available or nullopt
     const segment_meta* get(const key& key) const;
     const segment_meta* get(const segment_name& name) const;
+    /// Find element of the manifest by offset
+    const_iterator find(model::offset o) const;
 
     /// Get insert iterator for segments set
     std::insert_iterator<segment_map> get_insert_iterator();

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -48,6 +48,8 @@ get_manifest_path_components(const std::filesystem::path& path);
 struct segment_name_components {
     model::offset base_offset;
     model::term_id term;
+
+    auto operator<=>(const segment_name_components&) const = default;
 };
 
 std::optional<segment_name_components>
@@ -59,6 +61,9 @@ remote_segment_path generate_remote_segment_path(
   model::initial_revision_id,
   const segment_name&,
   model::term_id archiver_term);
+
+/// Generate correct S3 segment name based on term and base offset
+segment_name generate_segment_name(model::offset o, model::term_id t);
 
 struct serialized_json_stream {
     ss::input_stream<char> stream;
@@ -134,9 +139,10 @@ public:
         auto operator<=>(const segment_meta&) const = default;
     };
 
-    using key = segment_name;
+    /// Segment key in the maifest
+    using key = segment_name_components;
     using value = segment_meta;
-    using segment_map = std::map<key, value>;
+    using segment_map = absl::btree_map<key, value>;
     using const_iterator = segment_map::const_iterator;
     using const_reverse_iterator = segment_map::const_reverse_iterator;
 
@@ -170,12 +176,15 @@ public:
 
     /// Check if the manifest contains particular segment
     bool contains(const key& key) const;
+    bool contains(const segment_name& name) const;
 
     /// Add new segment to the manifest
-    bool add(const key& name, const segment_meta& meta);
+    bool add(const key& key, const segment_meta& meta);
+    bool add(const segment_name& name, const segment_meta& meta);
 
     /// Get segment if available or nullopt
-    const segment_meta* get(const key& name) const;
+    const segment_meta* get(const key& key) const;
+    const segment_meta* get(const segment_name& name) const;
 
     /// Get insert iterator for segments set
     std::insert_iterator<segment_map> get_insert_iterator();
@@ -223,6 +232,8 @@ private:
     segment_map _segments;
     model::offset _last_offset;
 };
+
+std::ostream& operator<<(std::ostream& o, const manifest::key& k);
 
 class topic_manifest final : public base_manifest {
 public:

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -159,7 +159,7 @@ public:
     model::initial_revision_id get_revision_id() const;
 
     remote_segment_path
-    generate_segment_path(const segment_name&, const segment_meta&) const;
+    generate_segment_path(const key&, const segment_meta&) const;
 
     /// Return iterator to the begining(end) of the segments list
     const_iterator begin() const;
@@ -169,13 +169,13 @@ public:
     size_t size() const;
 
     /// Check if the manifest contains particular segment
-    bool contains(const segment_name& name) const;
+    bool contains(const key& key) const;
 
     /// Add new segment to the manifest
-    bool add(const segment_name& name, const segment_meta& meta);
+    bool add(const key& name, const segment_meta& meta);
 
     /// Get segment if available or nullopt
-    const segment_meta* get(const segment_name& name) const;
+    const segment_meta* get(const key& name) const;
 
     /// Get insert iterator for segments set
     std::insert_iterator<segment_map> get_insert_iterator();
@@ -207,7 +207,7 @@ public:
     ///
     /// \param name is a segment name
     /// \return true on success, false on failure (no such segment)
-    bool delete_permanently(const segment_name& name);
+    bool delete_permanently(const key& name);
 
     manifest_type get_manifest_type() const override {
         return manifest_type::partition;

--- a/src/v/cloud_storage/offset_translation_layer.cc
+++ b/src/v/cloud_storage/offset_translation_layer.cc
@@ -61,21 +61,19 @@ ss::future<uint64_t> offset_translator::copy_stream(
 }
 
 segment_name offset_translator::get_adjusted_segment_name(
-  const segment_name& name, retry_chain_node& fib) const {
+  const manifest::key& key, retry_chain_node& fib) const {
     retry_chain_logger ctxlog(cst_log, fib);
-    auto parsed_name = parse_segment_name(name);
-    vassert(parsed_name, "Can't parse segment name, name: {}", name);
-    auto base_offset = parsed_name->base_offset;
-    auto term_id = parsed_name->term;
-
+    auto base_offset = key.base_offset;
+    auto term_id = key.term;
     auto new_base = base_offset - _initial_delta;
     auto new_name = segment_name{
       ssx::sformat("{}-{}-v1.log", new_base(), term_id())};
     vlog(
       ctxlog.debug,
-      "Segment name: {}, base-offset: {}, term-id: {}, "
+      "Segment: {}-{}-v1.log, base-offset: {}, term-id: {}, "
       "adjusted-base-offset: {}, adjusted-name: {}",
-      name,
+      key.base_offset,
+      key.term,
       base_offset,
       term_id,
       new_base,

--- a/src/v/cloud_storage/offset_translation_layer.h
+++ b/src/v/cloud_storage/offset_translation_layer.h
@@ -42,7 +42,7 @@ public:
 
     /// Get segment name adjusted for all removed offsets
     segment_name get_adjusted_segment_name(
-      const segment_name& s, retry_chain_node& fib) const;
+      const manifest::key& s, retry_chain_node& fib) const;
 
 private:
     model::offset _initial_delta;

--- a/src/v/cloud_storage/partition_recovery_manager.h
+++ b/src/v/cloud_storage/partition_recovery_manager.h
@@ -114,7 +114,7 @@ private:
     };
 
     struct segment {
-        segment_name name;
+        manifest::key manifest_key;
         manifest::segment_meta meta;
     };
 

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -28,13 +28,108 @@
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/util/noncopyable_function.hh>
 
+#include <boost/iterator/iterator_categories.hpp>
+#include <boost/iterator/iterator_facade.hpp>
+
 #include <chrono>
+#include <functional>
 
 namespace cloud_storage {
 
 using namespace std::chrono_literals;
 
 class partition_record_batch_reader_impl;
+
+namespace details {
+
+/// Iterator adapter for absl::btree_map that privides
+/// iterator stability guarantee by caching the key and
+/// doing a lookup on every increment.
+/// This turns iterator increment into O(logN) operation
+/// but this is OK since the underlying btree_map has high
+/// fan-out ratio so the logarithm base is relatively large.
+template<class TKey, class TVal>
+class btree_map_stable_iterator
+  : public boost::iterator_facade<
+      btree_map_stable_iterator<TKey, TVal>,
+      typename absl::btree_map<TKey, TVal>::value_type,
+      boost::bidirectional_traversal_tag> {
+    using map_t = absl::btree_map<TKey, TVal>;
+    using self_t = btree_map_stable_iterator<TKey, TVal>;
+    using value_t = typename map_t::value_type;
+
+public:
+    /// Creates an iterator that points to the end of the sequence
+    explicit btree_map_stable_iterator(map_t& map)
+      : _key(std::nullopt)
+      , _map(std::ref(map)) {}
+
+    /// Create an iterator that points to the arbitrary element
+    explicit btree_map_stable_iterator(map_t& map, TKey o)
+      : _key(std::nullopt)
+      , _map(std::ref(map)) {
+        // Invariant: the iterator is pointing to end (_map is null) or
+        // _key is initialized using correct value.
+        if (map.empty()) {
+            set_end();
+        }
+        if (auto it = _map.get().find(o); it != _map.get().end()) {
+            _key = it->first;
+        } else {
+            // Same behaviour as map::find, if key can't be found setup
+            // iterator to point to end of key sequence.
+            set_end();
+        }
+    }
+
+private:
+    friend class boost::iterator_core_access;
+
+    // Increment iterator if possible.
+    // The _key will be set to next element key or nullopt.
+    void increment() {
+        vassert(
+          _key.has_value(), "btree_map_stable_iterator can't be incremented");
+        auto it = _map.get().find(*_key);
+        ++it;
+        if (it == _map.get().end()) {
+            set_end();
+        } else {
+            _key = it->first;
+        }
+    }
+
+    // Decrement iterator if possible.
+    // The _key will be set to prev element key.
+    void decrement() {
+        auto it = _key ? _map.get().find(*_key) : _map.get().end();
+        vassert(
+          it != _map.get().begin(),
+          "btree_map_stable_iterator can't be decremented");
+        --it;
+        _key = it->first;
+    }
+
+    bool equal(const self_t& other) const { return _key == other._key; }
+
+    value_t& dereference() const {
+        vassert(
+          _key.has_value(),
+          "btree_map_stable_iterator doesn't point to an element and can't be "
+          "dereferenced");
+        auto it = _map.get().find(*_key);
+        return *it;
+    }
+
+    void set_end() { _key = std::nullopt; }
+
+    /// Key of the current element, nullopt is iter == end
+    std::optional<TKey> _key;
+    /// Reference to the container
+    std::reference_wrapper<map_t> _map;
+};
+
+} // namespace details
 
 /// Remote partition manintains list of remote segments
 /// and list of active readers. Only one reader can be
@@ -159,6 +254,9 @@ private:
       sizeof(segment_state) == sizeof(std::variant<size_t>),
       "segment_state has unexpected size");
 
+    using iterator
+      = details::btree_map_stable_iterator<model::offset, segment_state>;
+
     /// Materialize segment if needed and create a reader
     ///
     /// \param config is a reader config
@@ -184,7 +282,12 @@ private:
         _cvar.signal();
     }
 
-    using segment_map_t = std::map<model::offset, segment_state>;
+    /// Iterators used by the partition_record_batch_reader_impl class
+    iterator begin();
+    iterator end();
+    iterator upper_bound(model::offset);
+
+    using segment_map_t = absl::btree_map<model::offset, segment_state>;
 
     using evicted_resource_t = std::variant<
       std::unique_ptr<remote_segment_batch_reader>,

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -101,16 +101,20 @@ private:
 
     /// State that have to be materialized before use
     struct offloaded_segment_state {
-        explicit offloaded_segment_state(manifest::key key);
+        explicit offloaded_segment_state(model::offset bo);
 
         std::unique_ptr<materialized_segment_state>
         materialize(remote_partition& p, model::offset offset_key);
 
         ss::future<> stop();
 
-        std::unique_ptr<offloaded_segment_state> offload(remote_partition*);
+        offloaded_segment_state offload(remote_partition*);
 
-        manifest::key manifest_key;
+        model::offset base_rp_offset;
+
+        offloaded_segment_state* operator->() { return this; }
+
+        const offloaded_segment_state* operator->() const { return this; }
     };
 
     /// State with materialized segment and cached reader
@@ -120,7 +124,7 @@ private:
     /// remote segment.
     struct materialized_segment_state {
         materialized_segment_state(
-          manifest::key mk, model::offset offk, remote_partition& p);
+          model::offset bo, model::offset offk, remote_partition& p);
 
         void return_reader(std::unique_ptr<remote_segment_batch_reader> reader);
 
@@ -131,11 +135,10 @@ private:
 
         ss::future<> stop();
 
-        std::unique_ptr<offloaded_segment_state>
-        offload(remote_partition* partition);
+        offloaded_segment_state offload(remote_partition* partition);
 
-        /// Key of the segment metatdata in the manifest
-        manifest::key manifest_key;
+        /// Base offsetof the segment
+        model::offset base_rp_offset;
         /// Key of the segment in _segments collection of the remote_partition
         model::offset offset_key;
         ss::lw_shared_ptr<remote_segment> segment;
@@ -147,11 +150,14 @@ private:
         intrusive_list_hook _hook;
     };
 
-    using offloaded_segment_ptr = std::unique_ptr<offloaded_segment_state>;
     using materialized_segment_ptr
       = std::unique_ptr<materialized_segment_state>;
     using segment_state
-      = std::variant<offloaded_segment_ptr, materialized_segment_ptr>;
+      = std::variant<offloaded_segment_state, materialized_segment_ptr>;
+
+    static_assert(
+      sizeof(segment_state) == sizeof(std::variant<size_t>),
+      "segment_state has unexpected size");
 
     /// Materialize segment if needed and create a reader
     ///

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -92,7 +92,8 @@ remote_segment::remote_segment(
 
     _path = m.generate_segment_path(name, *meta);
 
-    auto parsed_name = parse_segment_name(name);
+    auto parsed_name = parse_segment_name(
+      generate_segment_name(name.base_offset, name.term));
     vassert(parsed_name, "Can't parse segment name, name: {}", name);
     _term = parsed_name->term;
 

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -58,6 +58,14 @@ public:
       const manifest::key& name,
       retry_chain_node& parent);
 
+    remote_segment(
+      remote& r,
+      cache& cache,
+      s3::bucket_name bucket,
+      const manifest& m,
+      model::offset base_offset,
+      retry_chain_node& parent);
+
     remote_segment(const remote_segment&) = delete;
     remote_segment(remote_segment&&) = delete;
     remote_segment& operator=(const remote_segment&) = delete;

--- a/src/v/cloud_storage/tests/manifest_test.cc
+++ b/src/v/cloud_storage/tests/manifest_test.cc
@@ -134,7 +134,9 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
          model::timestamp(1234567890)}},
     };
     for (const auto& actual : m) {
-        auto it = expected.find(actual.first());
+        auto sn = generate_segment_name(
+          actual.first.base_offset, actual.first.term);
+        auto it = expected.find(sn());
         BOOST_REQUIRE(it != expected.end());
         BOOST_REQUIRE_EQUAL(it->second.base_offset, actual.second.base_offset);
         BOOST_REQUIRE_EQUAL(
@@ -193,11 +195,13 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_difference) {
         auto c = a.difference(b);
         BOOST_REQUIRE(c.size() == 1);
         auto res = *c.begin();
-        BOOST_REQUIRE(res.first == segment_name("3-3-v1.log"));
+        auto expected = manifest::key{
+          .base_offset = model::offset(3), .term = model::term_id(3)};
+        BOOST_REQUIRE(res.first == expected);
     }
     // check that set difference is not symmetrical
     b.add(segment_name("3-3-v1.log"), {});
-    b.add(segment_name("4-4-v2.log"), {});
+    b.add(segment_name("4-4-v1.log"), {});
     {
         auto c = a.difference(b);
         BOOST_REQUIRE(c.size() == 0);

--- a/src/v/cloud_storage/tests/offset_translation_layer_test.cc
+++ b/src/v/cloud_storage/tests/offset_translation_layer_test.cc
@@ -8,6 +8,7 @@
  * https://github.com/vectorizedio/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "cloud_storage/manifest.h"
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/types.h"
 #include "seastarx.h"
@@ -89,10 +90,10 @@ SEASTAR_THREAD_TEST_CASE(test_name_translation) {
 
     for (const auto& [orig, expected] : orig2expected) {
         segment_name orig_name{orig};
+        segment_name_components key = parse_segment_name(orig_name).value();
         auto meta = m.get(orig_name);
         BOOST_REQUIRE(meta);
         offset_translator otl(meta->delta_offset);
-        BOOST_REQUIRE_EQUAL(
-          otl.get_adjusted_segment_name(orig_name, fib), expected);
+        BOOST_REQUIRE_EQUAL(otl.get_adjusted_segment_name(key, fib), expected);
     }
 }

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -961,3 +961,31 @@ FIXTURE_TEST(
     }
     BOOST_REQUIRE_EQUAL(headers_read.size(), num_data_batches);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_btree_iterator_range_scan) {
+    using map_t = absl::btree_map<int, int>;
+    using iter_t = cloud_storage::details::btree_map_stable_iterator<int, int>;
+    static constexpr int N = 1000;
+    static constexpr int M = 500;
+    map_t map;
+    for (int i = 0; i < N; i++) {
+        map[i] = i * 2;
+    }
+    iter_t begin(map, 0);
+    iter_t end(map);
+    int cnt = 0;
+    for (auto i = begin; i != end; i++) {
+        BOOST_REQUIRE_EQUAL(i->first, cnt);
+        BOOST_REQUIRE_EQUAL(i->second, 2 * cnt);
+        cnt++;
+    }
+
+    cnt = M;
+    for (auto i = iter_t(map, M); i != end; i++) {
+        BOOST_REQUIRE_EQUAL(i->first, cnt);
+        BOOST_REQUIRE_EQUAL(i->second, 2 * cnt);
+        cnt++;
+    }
+
+    auto it = iter_t(map);
+}

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -211,8 +211,8 @@ make_imposter_expectations(
         m.add(s.sname, meta);
 
         delta = delta + model::offset(s.num_config_records);
-
-        auto url = m.generate_segment_path(s.sname, meta);
+        auto res = parse_segment_name(s.sname);
+        auto url = m.generate_segment_path(*res, meta);
         results.push_back(cloud_storage_fixture::expectation{
           .url = "/" + url().string(), .body = body});
     }

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -9,6 +9,7 @@
 
 #include "cluster/archival_metadata_stm.h"
 
+#include "cloud_storage/manifest.h"
 #include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -63,11 +64,12 @@ archival_metadata_stm::segments_from_manifest(
   const cloud_storage::manifest& manifest) {
     std::vector<segment> segments;
     segments.reserve(manifest.size());
-    for (auto [name, meta] : manifest) {
+    for (auto [key, meta] : manifest) {
         if (meta.ntp_revision == model::initial_revision_id{}) {
             meta.ntp_revision = manifest.get_revision_id();
         }
-
+        auto name = cloud_storage::generate_segment_name(
+          key.base_offset, key.term);
         segments.push_back(segment{
           .ntp_revision_deprecated = meta.ntp_revision,
           .name = std::move(name),


### PR DESCRIPTION
## Cover letter

This PR changes the data structure that shadow indexing uses. Previous version
was prone to memory fragmentation and allocated memory for every uploaded
segment.

The improved version doesn't allocate memory per segment and uses more efficient
memory layout and data structures:
- absl::bree_map in the `manifest` and `remote_partition`
- The key in the manifest is a struct (offset + term) instead of the segment nam (ss::sstring)
- The `model::offset` is used as a key inside the `remote_partition`
- The variant type inside the `remote_partition` which is created per segment stores
   the instance of the `offloaded_segment_state` instead of the pointer to it. This eliminates
  allocation in case if the segment is not touched by the reader.

The manual tests showed improvement.
I was running `si-verifier` to produce data multiple times `> si-verifier  --topic panda-topic --msg_size 128000 --produce_msgs 0 --rand_read_msgs 100 --seq_read=0 --parallel 64` until enough long segment names were used. The segment size was set to 10MiB.

I measured the memory fragmentation using `generate_memory_diagnostics_report` function by recording the size of the largest allocation that the allocator could provide. All testing was done in low-memory environment. Before the optimisation the longest memory span was 64KiB (average). And with optimisations the span size went up to 512KiB. 


<!-- Use the GitHub keyword `Fixes` to link to bug(s) this PR will fix. -->
Fixes #3548

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/4a61eaa63812bf940cc68a1a1317eb98913b74c7..c5b678370ebe2907c6643680bb7e0f87f420361c)
- Address some code review comments
- Fix iterator stability issue by introducing custom iterator 


Changes in [force push](https://github.com/vectorizedio/redpanda/compare/c5b678370ebe2907c6643680bb7e0f87f420361c..e671e7b2b153846393bd51951d4c7ea361191396)
- Rebase with dev, fix merge conflicts 

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/e671e7b2b153846393bd51951d4c7ea361191396..50a91722cd6518abeba73b07aeea718550c1c16a)
- Fix remaining code review issues

## Release notes

* Shadow indexing memory utilization was optimised
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
