### PR TITLE
Fix incorrect assertion in wasm ducktape test that breaks CI

### DIFF
--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -191,9 +191,9 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         # Wait for all acked, output, significant because due to failure the number of
         # actual produced records may be less than expected
-        self._await_consumer(len(self.producer.acked), 90)
+        num_producer_acked = len(self.producer.acked)
+        self._await_consumer(num_producer_acked, 90)
 
         # GTE due to the fact that upon error, copro may re-processed already processed
         # data depending on when offsets were checkpointed
-        assert self.mconsumer.total_consumed() >= self.consumer.total_consumed(
-        )
+        assert self.mconsumer.total_consumed() >= num_producer_acked


### PR DESCRIPTION
## Cover letter

Similar to the fix implemented yesterday in PR #3599, an assert was checking an expected value against the total number of records produced instead of the total number of records acked. Looking in the failed tests logs:
```
[INFO  - 2022-01-25 21:30:09,387 - end_to_end - validate - lineno:169]: Number of acked records: 140642
[INFO  - 2022-01-25 21:30:09,387 - end_to_end - validate - lineno:171]: Number of consumed records: 151278
```
The number of acked records is less then the number of consumed. Looking at the failure...
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 135, in run
    data = self.run_test()
  File "/usr/local/lib/python3.9/dist-packages/ducktape/tests/runner_client.py", line 215, in run_test
    return self.test_context.function(self.test)
  File "/root/tests/rptest/tests/wasm_partition_movement_test.py", line 198, in test_dynamic_with_failure
    assert self.mconsumer.total_consumed() >= self.consumer.total_consumed(
AssertionError
```
And source code:
```
        self._await_consumer(len(self.producer.acked), 90)

        # GTE due to the fact that upon error, copro may re-processed already processed
        # data depending on when offsets were checkpointed
        assert self.mconsumer.total_consumed() >= self.consumer.total_consumed()
```

One can see the change in #3599 should have modified all conditions against number of records acked and it didn't. 

## solution
Modify the final assert in the test to compare against total acked instead of total the consumer has consumed. 

## Release notes
* none

### Improvements

* Fixes failing wasm partition movement ducktape test.
