### PR TITLE
Fix NodeJs issue when running rpk wasm generate in CI enviornment

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/wasm/generate_test.go
+++ b/src/go/rpk/pkg/cli/cmd/wasm/generate_test.go
@@ -17,10 +17,6 @@ import (
 	"github.com/vectorizedio/redpanda/src/go/rpk/pkg/testfs"
 )
 
-func init() {
-	inTests = true
-}
-
 func TestGetWasmApiVersion(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -98,7 +94,7 @@ func TestWasmCommand(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fs := testfs.FromMap(test.pre)
-			err := executeGenerate(fs, test.path)
+			err := executeGenerate(fs, test.path, true)
 			gotErr := err != nil
 			if gotErr != test.expErr {
 				t.Errorf("got err %v (%v) != exp err? %v", gotErr, err, test.expErr)

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -227,7 +227,9 @@ class RpkTool:
         return self._execute(cmd)
 
     def wasm_gen(self, directory):
-        cmd = [self._rpk_binary(), 'wasm', 'generate', directory]
+        cmd = [
+            self._rpk_binary(), 'wasm', 'generate', '--skip-version', directory
+        ]
         return self._execute(cmd)
 
     def _run_topic(self, cmd, stdin=None, timeout=None):


### PR DESCRIPTION
## Cover letter

When running `rpk wasm generate` in CI, a failure is observed, however CI continues without issue. This is because `rpk` is failing to invoke `npm search` as it uses that value to fill in a version for the `wasm-api` section in the programs `package.json` template file. `rpk` defaults to a hardcoded version in case of a failure, which CI doesn't need to use anyway because it builds coprocessors with the artifacts of `wasm-api` that it produces itself.

Link to observed error here: #3612 

## Release notes

* none

### Improvements

* Should no longer see any errors arising from `rpk wasm*` commands in our `wasm` test suite

### Force pushes
Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/4cb331adacf6e1c771efa01ee919a9009ab66c84..475a8626ed3605b3e4884b2d93886146a9179cb7)
- Formatted code
- Moved if check outside of `latestClientApiVersion` function 

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/475a8626ed3605b3e4884b2d93886146a9179cb7..f217514acfad0fc43e337047b52f2d39e8c4bb34)
- Fixed failing rpk test due to not updating it to reflect new changes

Changes in [force-push](https://github.com/vectorizedio/redpanda/compare/f217514acfad0fc43e337047b52f2d39e8c4bb34..a8cb5c475f69ab542836390aaa96029d28e12251)
- Realized the newly introduced feature could remove the necessity of having the `isTests` global, so just removed that