### PR TITLE
Backporting #3492 (Use stable paths in s3)

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -61,7 +61,7 @@ ntp_archiver::ntp_archiver(
       conf.time_limit,
       conf.upload_io_priority)
   , _bucket(conf.bucket_name)
-  , _manifest(_ntp, model::revision_id(_rev()))
+  , _manifest(_ntp, _rev)
   , _gate()
   , _initial_backoff(conf.initial_backoff)
   , _segment_upload_timeout(conf.segment_upload_timeout)
@@ -146,7 +146,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_segment(
     retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
 
     auto path = cloud_storage::generate_remote_segment_path(
-      _ntp, model::revision_id(_rev()), candidate.exposed_name, _start_term);
+      _ntp, _rev, candidate.exposed_name, _start_term);
 
     vlog(ctxlog.debug, "Uploading segment {} to {}", candidate, path);
 
@@ -263,7 +263,7 @@ ss::future<ntp_archiver::scheduled_upload> ntp_archiver::schedule_single_upload(
         .base_timestamp = upload.base_timestamp,
         .max_timestamp = upload.max_timestamp,
         .delta_offset = delta,
-        .ntp_revision = model::revision_id(_rev()),
+        .ntp_revision = _rev,
         .archiver_term = _start_term,
       },
       .name = upload.exposed_name, .delta = offset - base,

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -45,6 +45,12 @@ using namespace std::chrono_literals;
 /// The 'ntp_archiver' is responsible for manifest manitpulations and
 /// generation of per-ntp candidate set. The actual file uploads are
 /// handled by 'archiver_service'.
+///
+/// Note that archiver uses initial revision of the partition, not the
+/// current one. The revision of the partition can change when the partition
+/// is moved between the nodes. To make all object names stable inside
+/// the S3 bucket we're using initial revision. The revision that the
+/// topic was assigned when it was just created.
 class ntp_archiver {
 public:
     /// Iterator type used to retrieve candidates for upload
@@ -74,7 +80,7 @@ public:
     const model::ntp& get_ntp() const;
 
     /// Get revision id
-    model::revision_id get_revision_id() const;
+    model::initial_revision_id get_revision_id() const;
 
     /// Get timestamp
     const ss::lowres_clock::time_point get_last_upload_time() const;
@@ -163,7 +169,7 @@ private:
     service_probe& _svc_probe;
     ntp_level_probe _probe;
     model::ntp _ntp;
-    model::revision_id _rev;
+    model::initial_revision_id _rev;
     cloud_storage::remote& _remote;
     ss::lw_shared_ptr<cluster::partition> _partition;
     model::term_id _start_term;

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -249,7 +249,7 @@ ss::future<> scheduler_service_impl::upload_topic_manifest(
               _topic_manifest_upload_timeout, _initial_backoff, &_rtcnode);
             retry_chain_logger ctxlog(archival_log, fib);
             vlog(ctxlog.info, "Uploading topic manifest {}", topic_ns);
-            cloud_storage::topic_manifest tm(*cfg, model::revision_id(rev()));
+            cloud_storage::topic_manifest tm(*cfg, rev);
             auto key = tm.get_manifest_path();
             vlog(ctxlog.debug, "Topic manifest object key is '{}'", key);
             auto res = co_await _remote.local().upload_manifest(

--- a/src/v/archival/service.cc
+++ b/src/v/archival/service.cc
@@ -235,7 +235,7 @@ ss::lw_shared_ptr<ntp_archiver> scheduler_service_impl::get_upload_candidate() {
 }
 
 ss::future<> scheduler_service_impl::upload_topic_manifest(
-  model::topic_namespace topic_ns, model::revision_id rev) {
+  model::topic_namespace topic_ns, model::initial_revision_id rev) {
     gate_guard gg(_gate);
     auto cfg = _topic_table.local().get_topic_cfg(topic_ns);
     if (!cfg) {
@@ -249,7 +249,7 @@ ss::future<> scheduler_service_impl::upload_topic_manifest(
               _topic_manifest_upload_timeout, _initial_backoff, &_rtcnode);
             retry_chain_logger ctxlog(archival_log, fib);
             vlog(ctxlog.info, "Uploading topic manifest {}", topic_ns);
-            cloud_storage::topic_manifest tm(*cfg, rev);
+            cloud_storage::topic_manifest tm(*cfg, model::revision_id(rev()));
             auto key = tm.get_manifest_path();
             vlog(ctxlog.debug, "Topic manifest object key is '{}'", key);
             auto res = co_await _remote.local().upload_manifest(

--- a/src/v/archival/service.h
+++ b/src/v/archival/service.h
@@ -170,7 +170,7 @@ private:
     ss::future<> remove_archivers(std::vector<model::ntp> to_remove);
     ss::future<> create_archivers(std::vector<model::ntp> to_create);
     ss::future<> upload_topic_manifest(
-      model::topic_namespace topic_ns, model::revision_id rev);
+      model::topic_namespace topic_ns, model::initial_revision_id rev);
     /// Adds archiver to the reconciliation loop after fetching its manifest.
     ss::future<ss::stop_iteration>
     add_ntp_archiver(ss::lw_shared_ptr<ntp_archiver> archiver);

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -44,8 +44,8 @@ static const auto manifest_ntp = model::ntp(                    // NOLINT
   manifest_namespace,
   manifest_topic,
   manifest_partition);
-static const auto manifest_revision = model::revision_id(0); // NOLINT
-static const ss::sstring manifest_url = ssx::sformat(        // NOLINT
+static const auto manifest_revision = model::initial_revision_id(0); // NOLINT
+static const ss::sstring manifest_url = ssx::sformat(                // NOLINT
   "/10000000/meta/{}_{}/manifest.json",
   manifest_ntp.path(),
   manifest_revision());

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -37,7 +37,7 @@ struct manifest_path_components {
     model::ns _ns;
     model::topic _topic;
     model::partition_id _part;
-    model::revision_id _rev;
+    model::initial_revision_id _rev;
 };
 
 std::ostream& operator<<(std::ostream& s, const manifest_path_components& c);
@@ -57,7 +57,7 @@ parse_segment_name(const segment_name& name);
 /// Segment file name in S3
 remote_segment_path generate_remote_segment_path(
   const model::ntp&,
-  model::revision_id,
+  model::initial_revision_id,
   const segment_name&,
   model::term_id archiver_term);
 
@@ -129,7 +129,7 @@ public:
         model::timestamp max_timestamp;
         model::offset delta_offset;
 
-        model::revision_id ntp_revision;
+        model::initial_revision_id ntp_revision;
         model::term_id archiver_term;
 
         auto operator<=>(const segment_meta&) const = default;
@@ -145,7 +145,7 @@ public:
     manifest();
 
     /// Create manifest for specific ntp
-    explicit manifest(model::ntp ntp, model::revision_id rev);
+    explicit manifest(model::ntp ntp, model::initial_revision_id rev);
 
     /// Manifest object name in S3
     remote_manifest_path get_manifest_path() const override;
@@ -157,7 +157,7 @@ public:
     const model::offset get_last_offset() const;
 
     /// Get revision
-    model::revision_id get_revision_id() const;
+    model::initial_revision_id get_revision_id() const;
 
     remote_segment_path
     generate_segment_path(const segment_name&, const segment_meta&) const;
@@ -220,7 +220,7 @@ private:
     void update(const rapidjson::Document& m);
 
     model::ntp _ntp;
-    model::revision_id _rev;
+    model::initial_revision_id _rev;
     segment_map _segments;
     model::offset _last_offset;
 };
@@ -229,7 +229,7 @@ class topic_manifest final : public base_manifest {
 public:
     /// Create manifest for specific ntp
     explicit topic_manifest(
-      const cluster::topic_configuration& cfg, model::revision_id rev);
+      const cluster::topic_configuration& cfg, model::initial_revision_id rev);
 
     /// Create empty manifest that supposed to be updated later
     topic_manifest();
@@ -260,10 +260,10 @@ public:
         return manifest_type::partition;
     };
 
-    model::revision_id get_revision() const noexcept { return _rev; }
+    model::initial_revision_id get_revision() const noexcept { return _rev; }
 
     /// Change topic-manifest revision
-    void set_revision(model::revision_id id) noexcept { _rev = id; }
+    void set_revision(model::initial_revision_id id) noexcept { _rev = id; }
 
 private:
     /// Update manifest content from json document that supposed to be generated
@@ -271,7 +271,7 @@ private:
     void update(const rapidjson::Document& m);
 
     std::optional<cluster::topic_configuration> _topic_config;
-    model::revision_id _rev;
+    model::initial_revision_id _rev;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_recovery_manager.cc
+++ b/src/v/cloud_storage/partition_recovery_manager.cc
@@ -249,7 +249,7 @@ partition_downloader::download_log(const remote_manifest_path& manifest_key) {
       retention);
     auto mat = co_await find_recovery_material(manifest_key);
     auto offset_map = co_await build_offset_map(mat);
-    manifest target(_ntpc.ntp(), _ntpc.get_revision());
+    manifest target(_ntpc.ntp(), _ntpc.get_initial_revision());
     for (const auto& kv : offset_map) {
         target.add(kv.second.name, kv.second.meta);
     }
@@ -314,8 +314,8 @@ partition_downloader::download_log(const remote_manifest_path& manifest_key) {
     // Upload topic manifest for re-created topic (here we don't prevent
     // other partitions of the same topic to read old topic manifest if the
     // revision is different).
-    if (mat.topic_manifest.get_revision() != _ntpc.get_revision()) {
-        mat.topic_manifest.set_revision(_ntpc.get_revision());
+    if (mat.topic_manifest.get_revision() != _ntpc.get_initial_revision()) {
+        mat.topic_manifest.set_revision(_ntpc.get_initial_revision());
         upl_result = co_await _remote->upload_manifest(
           _bucket, mat.topic_manifest, _rtcnode);
         if (upl_result != upload_result::success) {
@@ -433,7 +433,7 @@ partition_downloader::download_log_with_capped_time(
 ss::future<manifest>
 partition_downloader::download_manifest(const remote_manifest_path& key) {
     vlog(_ctxlog.info, "Downloading manifest {}", key);
-    manifest manifest(_ntpc.ntp(), _ntpc.get_revision());
+    manifest manifest(_ntpc.ntp(), _ntpc.get_initial_revision());
     auto result = co_await _remote->download_manifest(
       _bucket, key, manifest, _rtcnode);
     if (result != download_result::success) {

--- a/src/v/cloud_storage/tests/common_def.h
+++ b/src/v/cloud_storage/tests/common_def.h
@@ -18,7 +18,7 @@ static const auto manifest_ntp = model::ntp(                    // NOLINT
   manifest_namespace,
   manifest_topic,
   manifest_partition);
-static const auto manifest_revision = model::revision_id(0); // NOLINT
+static const auto manifest_revision = model::initial_revision_id(0); // NOLINT
 static const auto archiver_term = model::term_id{123};
 static const ss::sstring manifest_url = ssx::sformat( // NOLINT
   "20000000/meta/{}_{}/manifest.json",

--- a/src/v/cloud_storage/tests/manifest_test.cc
+++ b/src/v/cloud_storage/tests/manifest_test.cc
@@ -80,7 +80,7 @@ inline ss::input_stream<char> make_manifest_stream(std::string_view json) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_manifest_path) {
-    manifest m(manifest_ntp, model::revision_id(0));
+    manifest m(manifest_ntp, model::initial_revision_id(0));
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
       path, "20000000/meta/test-ns/test-topic/42_0/manifest.json");
@@ -89,7 +89,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_path) {
 SEASTAR_THREAD_TEST_CASE(test_segment_path) {
     auto path = generate_remote_segment_path(
       manifest_ntp,
-      model::revision_id(0),
+      model::initial_revision_id(0),
       segment_name("22-11-v1.log"),
       model::term_id{123});
     // use pre-calculated murmur hash value from full ntp path + file name
@@ -148,7 +148,7 @@ SEASTAR_THREAD_TEST_CASE(test_complete_manifest_update) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
-    manifest m(manifest_ntp, model::revision_id(0));
+    manifest m(manifest_ntp, model::initial_revision_id(0));
     m.add(
       segment_name("10-1-v1.log"),
       {
@@ -157,7 +157,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
         .base_offset = model::offset(10),
         .committed_offset = model::offset(19),
         .max_timestamp = model::timestamp::missing(),
-        .ntp_revision = model::revision_id(0),
+        .ntp_revision = model::initial_revision_id(0),
       });
     m.add(
       segment_name("20-1-v1.log"),
@@ -167,7 +167,7 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
         .base_offset = model::offset(20),
         .committed_offset = model::offset(29),
         .max_timestamp = model::timestamp::missing(),
-        .ntp_revision = model::revision_id(3),
+        .ntp_revision = model::initial_revision_id(3),
       });
     auto [is, size] = m.serialize();
     iobuf buf;
@@ -182,11 +182,11 @@ SEASTAR_THREAD_TEST_CASE(test_manifest_serialization) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_manifest_difference) {
-    manifest a(manifest_ntp, model::revision_id(0));
+    manifest a(manifest_ntp, model::initial_revision_id(0));
     a.add(segment_name("1-1-v1.log"), {});
     a.add(segment_name("2-2-v1.log"), {});
     a.add(segment_name("3-3-v1.log"), {});
-    manifest b(manifest_ntp, model::revision_id(0));
+    manifest b(manifest_ntp, model::initial_revision_id(0));
     b.add(segment_name("1-1-v1.log"), {});
     b.add(segment_name("2-2-v1.log"), {});
     {
@@ -316,12 +316,12 @@ SEASTAR_THREAD_TEST_CASE(test_segment_meta_serde_compat) {
       .base_timestamp = timestamp,
       .max_timestamp = timestamp,
       .delta_offset = model::offset{7},
-      .ntp_revision = model::revision_id{42},
+      .ntp_revision = model::initial_revision_id{42},
       .archiver_term = model::term_id{123},
     };
 
     cloud_storage::manifest::segment_meta meta_wo_new_fields = meta_new;
-    meta_wo_new_fields.ntp_revision = model::revision_id{};
+    meta_wo_new_fields.ntp_revision = model::initial_revision_id{};
     meta_wo_new_fields.archiver_term = model::term_id{};
 
     old::segment_meta_v0 meta_old{

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -62,7 +62,7 @@ FIXTURE_TEST(
     remote remote(s3_connection_limit(10), conf);
     manifest m(manifest_ntp, manifest_revision);
     auto name = segment_name("1-2-v1.log");
-    model::revision_id segment_ntp_revision{777};
+    model::initial_revision_id segment_ntp_revision{777};
     iobuf segment_bytes = generate_segment(model::offset(1), 20);
     uint64_t clen = segment_bytes.size_bytes();
     auto action = ss::defer([&remote] { remote.stop().get(); });

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -14,6 +14,7 @@
 #include "cloud_storage/manifest.h"
 #include "cloud_storage/remote.h"
 #include "cluster/persisted_stm.h"
+#include "model/metadata.h"
 #include "utils/mutex.h"
 #include "utils/prefix_logger.h"
 #include "utils/retry_chain_node.h"

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -12,9 +12,11 @@
 #pragma once
 
 #include "cluster/commands.h"
+#include "cluster/non_replicable_topics_frontend.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/limits.h"
+#include "model/metadata.h"
 #include "utils/expiring_promise.h"
 
 #include <absl/container/flat_hash_map.h>
@@ -35,11 +37,15 @@ namespace cluster {
 class topic_table {
 public:
     using delta = topic_table_delta;
+
     class topic_metadata {
     public:
         topic_metadata(
           topic_configuration_assignment, model::revision_id) noexcept;
-        topic_metadata(topic_configuration_assignment, model::topic) noexcept;
+        topic_metadata(
+          topic_configuration_assignment,
+          model::revision_id,
+          model::topic) noexcept;
 
         bool is_topic_replicable() const;
         model::revision_id get_revision() const;
@@ -49,7 +55,8 @@ public:
     private:
         friend class topic_table;
         topic_configuration_assignment configuration;
-        std::variant<model::revision_id, model::topic> _id_or_topic;
+        std::optional<model::topic> _source_topic;
+        model::revision_id _revision;
     };
     using underlying_t = absl::flat_hash_map<
       model::topic_namespace,
@@ -159,6 +166,14 @@ public:
     bool has_updates_in_progress() const {
         return !_update_in_progress.empty();
     }
+
+    ///\brief Returns initial revision id of the topic
+    std::optional<model::initial_revision_id>
+    get_initial_revision(model::topic_namespace_view tp) const;
+
+    ///\brief Returns initial revision id of the partition
+    std::optional<model::initial_revision_id>
+    get_initial_revision(const model::ntp& ntp) const;
 
 private:
     struct waiter {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -68,7 +68,8 @@ topic_configuration::topic_configuration(
 storage::ntp_config topic_configuration::make_ntp_config(
   const ss::sstring& work_dir,
   model::partition_id p_id,
-  model::revision_id rev) const {
+  model::revision_id rev,
+  model::initial_revision_id init_rev) const {
     auto has_overrides = properties.has_overrides() || is_internal();
     std::unique_ptr<storage::ntp_config::default_overrides> overrides = nullptr;
 
@@ -89,11 +90,12 @@ storage::ntp_config topic_configuration::make_ntp_config(
                                       ? *properties.shadow_indexing
                                       : model::shadow_indexing_mode::disabled});
     }
-    return storage::ntp_config(
+    return {
       model::ntp(tp_ns.ns, tp_ns.tp, p_id),
       work_dir,
       std::move(overrides),
-      rev);
+      rev,
+      init_rev};
 }
 
 model::topic_metadata topic_configuration_assignment::get_metadata() const {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -408,7 +408,10 @@ struct topic_configuration {
       int16_t replication_factor);
 
     storage::ntp_config make_ntp_config(
-      const ss::sstring&, model::partition_id, model::revision_id) const;
+      const ss::sstring&,
+      model::partition_id,
+      model::revision_id,
+      model::initial_revision_id) const;
 
     bool is_internal() const {
         return tp_ns.ns == model::kafka_internal_namespace;

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -35,6 +35,15 @@ using node_id = named_type<int32_t, struct node_id_model_type>;
  * first created and then removed, raft configuration
  */
 using revision_id = named_type<int64_t, struct revision_id_model_type>;
+
+/**
+ * Revision id that the partition had when the topic was just created.
+ * The revision_id of the partition might change when the partition is moved
+ * between the nodes.
+ */
+using initial_revision_id
+  = named_type<int64_t, struct initial_revision_id_model_type>;
+
 struct broker_properties {
     uint32_t cores;
     uint32_t available_memory;

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -75,10 +75,26 @@ public:
       , _overrides(std::move(overrides))
       , _revision_id(id) {}
 
+    ntp_config(
+      model::ntp n,
+      ss::sstring base_dir,
+      std::unique_ptr<default_overrides> overrides,
+      model::revision_id id,
+      model::initial_revision_id initial_id) noexcept
+      : _ntp(std::move(n))
+      , _base_dir(std::move(base_dir))
+      , _overrides(std::move(overrides))
+      , _revision_id(id)
+      , _initial_rev(initial_id) {}
+
     const model::ntp& ntp() const { return _ntp; }
     model::ntp& ntp() { return _ntp; }
 
     model::revision_id get_revision() const { return _revision_id; }
+
+    model::initial_revision_id get_initial_revision() const {
+        return _initial_rev;
+    }
 
     const ss::sstring& base_directory() const { return _base_dir; }
     ss::sstring& base_directory() { return _base_dir; }
@@ -148,6 +164,14 @@ private:
      * than once (i.e. created, deleted and then created again)
      */
     model::revision_id _revision_id{0};
+
+    /**
+     * A number indicating an initial revision of the NTP. The revision
+     * of the NTP might change when the partition is moved between the
+     * nodes. The initial revision is the revision_id that was assigned
+     * to the topic when it was created.
+     */
+    model::initial_revision_id _initial_rev{0};
 
     // in storage/types.cc
     friend std::ostream& operator<<(std::ostream&, const ntp_config&);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -68,14 +68,27 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
 }
 
 std::ostream& operator<<(std::ostream& o, const ntp_config& v) {
-    o << "{ntp:" << v.ntp() << ", base_dir:" << v.base_directory()
-      << ", overrides:";
     if (v.has_overrides()) {
-        o << v.get_overrides();
+        fmt::print(
+          o,
+          "{{ntp: {}, base_dir: {}, overrides: {}, revision: {}, "
+          "initial_revision: {}}}",
+          v.ntp(),
+          v.base_directory(),
+          v.get_overrides(),
+          v.get_revision(),
+          v.get_initial_revision());
     } else {
-        o << "nullptr";
+        fmt::print(
+          o,
+          "{{ntp: {}, base_dir: {}, overrides: nullptr, revision: {}, "
+          "initial_revision: {}}}",
+          v.ntp(),
+          v.base_directory(),
+          v.get_revision(),
+          v.get_initial_revision());
     }
-    return o << "}";
+    return o;
 }
 
 std::ostream& operator<<(std::ostream& o, const truncate_config& cfg) {


### PR DESCRIPTION
## Cover letter

Currently, the revision-id is used as part of the segment path and manifest path in S3. This creates the following issue: if the partition was moved, the revision id increases. So the archiver for the subsystem can't find the original manifest in the S3 and some subset of the data can be re-uploaded. Also, shadow indexing can't 'see' some segments.

The issue in #3316 was also caused by this. During the raft bootstrap the moved raft group the initial revision id is assigned first. But after the partition assignment is applied the revision id increases and this can cause inconsistency in manifest versions during archival_metadata_stm sync.

The solution is to always use initial revision id in the archival/SI. The initial revision id is assigned during topic creation and never changes. It's obtained via the `topic_table` the manifest and all paths has this value instead of revision id (which could change).

#3492

Changes in [force push](https://github.com/vectorizedio/redpanda/compare/ec0da62a8b74567aa6eeb53d5858c4ba5d6acc57..b3c4b39872a75119959f602d47feddbb53ccc439)
- Fixed merge conflict 

## Release notes

* Fix shadow indexing error that occurred when the partition was moved between the nodes
<!--

If this PR does not need to be included in the release notes, then
simply have a bullet point for `none` directly under the `Release notes`
section, e.g.

* none

Otherwise, add one or more of the following sections. A section must have
at least 1 bullet point. You can add multiple sections with multiple
bullet points if this PR represents multiple release note items. See
the CONTRIBUTING.md guidelines for more details.

### Features

* Short description of the feature. Explain how to configure the new feature if applicable.

### Improvements

* Short description of how this PR improves redpanda.

-->
