### PR TITLE
V21.11.x backport3511

### DIFF
--- a/src/v/cloud_storage/manifest.cc
+++ b/src/v/cloud_storage/manifest.cc
@@ -31,7 +31,6 @@
 #include <ctll/fixed_string.hpp>
 #include <ctre/functions.hpp>
 #include <fmt/ostream.h>
-#include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/ostreamwrapper.h>
 #include <rapidjson/rapidjson.h>
@@ -306,21 +305,19 @@ manifest manifest::difference(const manifest& remote_set) const {
 }
 
 ss::future<> manifest::update(ss::input_stream<char> is) {
-    using namespace rapidjson;
     iobuf result;
     auto os = make_iobuf_ref_output_stream(result);
     co_await ss::copy(is, os);
     iobuf_istreambuf ibuf(result);
     std::istream stream(&ibuf);
-    Document m;
-    IStreamWrapper wrapper(stream);
+    json::Document m;
+    rapidjson::IStreamWrapper wrapper(stream);
     m.ParseStream(wrapper);
     update(m);
     co_return;
 }
 
-void manifest::update(const rapidjson::Document& m) {
-    using namespace rapidjson;
+void manifest::update(const json::Document& m) {
     auto ver = model::partition_id(m["version"].GetInt());
     if (ver != static_cast<int>(manifest_version::v1)) {
         throw std::runtime_error("manifest version not supported");
@@ -400,9 +397,8 @@ serialized_json_stream manifest::serialize() const {
 }
 
 void manifest::serialize(std::ostream& out) const {
-    using namespace rapidjson;
-    OStreamWrapper wrapper(out);
-    Writer<OStreamWrapper> w(wrapper);
+    rapidjson::OStreamWrapper wrapper(out);
+    rapidjson::Writer<rapidjson::OStreamWrapper> w(wrapper);
     w.StartObject();
     w.Key("version");
     w.Int(static_cast<int>(manifest_version::v1));
@@ -486,21 +482,19 @@ topic_manifest::topic_manifest()
   : _topic_config(std::nullopt) {}
 
 ss::future<> topic_manifest::update(ss::input_stream<char> is) {
-    using namespace rapidjson;
     iobuf result;
     auto os = make_iobuf_ref_output_stream(result);
     co_await ss::copy(is, os);
     iobuf_istreambuf ibuf(result);
     std::istream stream(&ibuf);
-    Document m;
-    IStreamWrapper wrapper(stream);
+    json::Document m;
+    rapidjson::IStreamWrapper wrapper(stream);
     m.ParseStream(wrapper);
     update(m);
     co_return;
 }
 
-void topic_manifest::update(const rapidjson::Document& m) {
-    using namespace rapidjson;
+void topic_manifest::update(const json::Document& m) {
     auto ver = m["version"].GetInt();
     if (ver != static_cast<int>(topic_manifest_version::v1)) {
         throw std::runtime_error("topic manifest version not supported");
@@ -569,9 +563,8 @@ serialized_json_stream topic_manifest::serialize() const {
 }
 
 void topic_manifest::serialize(std::ostream& out) const {
-    using namespace rapidjson;
-    OStreamWrapper wrapper(out);
-    Writer<OStreamWrapper> w(wrapper);
+    rapidjson::OStreamWrapper wrapper(out);
+    rapidjson::Writer<rapidjson::OStreamWrapper> w(wrapper);
     w.StartObject();
     w.Key("version");
     w.Int(static_cast<int>(manifest_version::v1));

--- a/src/v/cloud_storage/manifest.cc
+++ b/src/v/cloud_storage/manifest.cc
@@ -10,14 +10,10 @@
 
 #include "cloud_storage/manifest.h"
 
-#include "bytes/iobuf.h"
 #include "bytes/iobuf_istreambuf.h"
 #include "bytes/iobuf_ostreambuf.h"
 #include "cloud_storage/types.h"
-#include "cluster/types.h"
 #include "hashing/xx.h"
-#include "model/fundamental.h"
-#include "model/metadata.h"
 #include "model/timestamp.h"
 #include "ssx/sformat.h"
 #include "storage/fs_utils.h"

--- a/src/v/cloud_storage/manifest.h
+++ b/src/v/cloud_storage/manifest.h
@@ -13,6 +13,7 @@
 #include "bytes/iobuf.h"
 #include "cloud_storage/types.h"
 #include "cluster/types.h"
+#include "json/document.h"
 #include "json/json.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -22,8 +23,6 @@
 #include "tristate.h"
 
 #include <seastar/util/bool_class.hh>
-
-#include <rapidjson/fwd.h>
 
 #include <compare>
 #include <iterator>
@@ -228,7 +227,7 @@ public:
 private:
     /// Update manifest content from json document that supposed to be generated
     /// from manifest.json file
-    void update(const rapidjson::Document& m);
+    void update(const json::Document& m);
 
     model::ntp _ntp;
     model::initial_revision_id _rev;
@@ -281,7 +280,7 @@ public:
 private:
     /// Update manifest content from json document that supposed to be generated
     /// from manifest.json file
-    void update(const rapidjson::Document& m);
+    void update(const json::Document& m);
 
     std::optional<cluster::topic_configuration> _topic_config;
     model::initial_revision_id _rev;

--- a/src/v/json/allocator.h
+++ b/src/v/json/allocator.h
@@ -1,0 +1,47 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "json/logger.h"
+#include "vlog.h"
+
+#include <fmt/format.h>
+#include <rapidjson/allocators.h>
+namespace json {
+class throwing_allocator {
+public:
+    void* Malloc(size_t size) {
+        void* res = _rp_allocator.Malloc(size);
+        if (!res && (0 != size)) {
+            vlog(json_log.error, "Could not allocate {} bytes", size);
+            throw std::bad_alloc{};
+        }
+        return res;
+    }
+
+    void* Realloc(void* originalPtr, size_t originalSize, size_t newSize) {
+        void* res = _rp_allocator.Realloc(originalPtr, originalSize, newSize);
+
+        if (!res && (0 != newSize)) {
+            vlog(
+              json_log.error,
+              "Could not reallocate memory: original size: {} bytes, new size: "
+              "{} bytes",
+              originalSize,
+              newSize);
+            throw std::bad_alloc{};
+        }
+        return res;
+    }
+
+    static void Free(void* ptr) { return rapidjson::CrtAllocator::Free(ptr); }
+
+private:
+    [[no_unique_address]] rapidjson::CrtAllocator _rp_allocator;
+};
+} // namespace json

--- a/src/v/json/document.h
+++ b/src/v/json/document.h
@@ -1,0 +1,20 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "json/allocator.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/encodings.h>
+
+namespace json {
+using Document = rapidjson::GenericDocument<
+  rapidjson::UTF8<>,
+  rapidjson::MemoryPoolAllocator<throwing_allocator>,
+  throwing_allocator>;
+}

--- a/src/v/json/logger.h
+++ b/src/v/json/logger.h
@@ -1,0 +1,18 @@
+// Copyright 2022 Vectorized, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace json {
+inline ss::logger json_log("json");
+} // namespace json


### PR DESCRIPTION
Backport of #3511 

## Cover letter

This PR add a wrapper around rapid_json memory allocator that throws bad_alloc if memory was requested, but wasn't allocated. cloud_storage manifests now use this allocator when parsing json document.

## Release notes
* none
