### PR TITLE
ducktape: expand use of default kafka client

### DIFF
--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -24,7 +24,6 @@ class TopicDescription(typing.NamedTuple):
 
 
 class DefaultClient:
-
     def __init__(self, redpanda):
         self._redpanda = redpanda
 
@@ -44,11 +43,10 @@ class DefaultClient:
         Describe topics. Pass topics=None to describe all topics, or a pass a
         list of topic names to restrict the call to a set of specific topics.
         """
-
         def make_partition_desc(d):
             return PartitionDescription(id=d['partition'],
-                                 leader=d['leader'],
-                                 replicas=d['replicas'])
+                                        leader=d['leader'],
+                                        replicas=d['replicas'])
 
         def make_topic_desc(d):
             partitions = [make_partition_desc(d) for d in d['partitions']]
@@ -63,7 +61,8 @@ class DefaultClient:
     def describe_topic(self, topic: str):
         td = self.describe_topics([topic])
         assert len(td) == 1, f"Received {len(td)} topics expected 1: {td}"
-        assert td[0].name == topic, f"Received topic {td[0].name} expected {topic}: {td}"
+        assert td[
+            0].name == topic, f"Received topic {td[0].name} expected {topic}: {td}"
         return td[0]
 
     def alter_topic_partition_count(self, topic: str, count: int):

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -59,3 +59,9 @@ class DefaultClient:
             **self._redpanda.security_config())
         res = client.describe_topics(topics)
         return [make_topic_desc(d) for d in res]
+
+    def describe_topic(self, topic: str):
+        td = self.describe_topics([topic])
+        assert len(td) == 1, f"Received {len(td)} topics expected 1: {td}"
+        assert td[0].name == topic, f"Received topic {td[0].name} expected {topic}: {td}"
+        return td[0]

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -65,3 +65,7 @@ class DefaultClient:
         assert len(td) == 1, f"Received {len(td)} topics expected 1: {td}"
         assert td[0].name == topic, f"Received topic {td[0].name} expected {topic}: {td}"
         return td[0]
+
+    def alter_topic_partition_count(self, topic: str, count: int):
+        client = KafkaCliTools(self._redpanda)
+        client.create_topic_partitions(topic, count)

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -6,13 +6,25 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-
+import typing
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from kafka import KafkaAdminClient
 
 
+class PartitionDescription(typing.NamedTuple):
+    id: int
+    leader: int
+    replicas: typing.List[int]
+
+
+class TopicDescription(typing.NamedTuple):
+    name: str
+    partitions: typing.List[PartitionDescription]
+
+
 class DefaultClient:
+
     def __init__(self, redpanda):
         self._redpanda = redpanda
 
@@ -31,23 +43,19 @@ class DefaultClient:
         """
         Describe topics. Pass topics=None to describe all topics, or a pass a
         list of topic names to restrict the call to a set of specific topics.
-
-        Sample return value:
-            [
-              {'error_code': 0,
-               'topic': 'topic-kabn',
-               'is_internal': False,
-               'partitions': [
-                 {'error_code': 0,
-                  'partition': 0,
-                  'leader': 1,
-                  'replicas': [1],
-                  'isr': [1],
-                  'offline_replicas': []}
-               }
-            ]
         """
+
+        def make_partition_desc(d):
+            return PartitionDescription(id=d['partition'],
+                                 leader=d['leader'],
+                                 replicas=d['replicas'])
+
+        def make_topic_desc(d):
+            partitions = [make_partition_desc(d) for d in d['partitions']]
+            return TopicDescription(name=d['topic'], partitions=partitions)
+
         client = KafkaAdminClient(
             bootstrap_servers=self._redpanda.brokers_list(),
             **self._redpanda.security_config())
-        return client.describe_topics(topics)
+        res = client.describe_topics(topics)
+        return [make_topic_desc(d) for d in res]

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -313,7 +313,6 @@ class RpkTool:
         ])
 
     def cluster_config_export(self, file, all):
-        node = self._redpanda.nodes[0]
         cmd = [
             self._rpk_binary(), '--api-urls',
             self._admin_host(), "cluster", "config", "export", "--filename",

--- a/tests/rptest/services/kaf_consumer.py
+++ b/tests/rptest/services/kaf_consumer.py
@@ -22,7 +22,7 @@ class KafConsumer(BackgroundThreadService):
         self.done = False
         self.offset = dict()
 
-    def _worker(self, idx, node):
+    def _worker(self, _, node):
         self._stopping.clear()
         try:
             partition = None

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -276,7 +276,7 @@ class RedpandaService(Service):
                 else:
                     self.logger.debug("%s: skip cleaning node" %
                                       self.who_am_i(node))
-            except Exception as e:
+            except Exception:
                 self.logger.exception(
                     f"Error cleaning data files on {node.account.hostname}:")
                 raise

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -735,7 +735,7 @@ class RedpandaService(Service):
                 shutil.move(os.path.join(data_dir, fn), dest)
 
     def data_checksum(self, node):
-        """Run command that computes MD5 hash of every file in redpanda data 
+        """Run command that computes MD5 hash of every file in redpanda data
         directory. The results of the command are turned into a map from path
         to hash-size tuples."""
         cmd = f"find {RedpandaService.DATA_DIR} -type f -exec md5sum -z '{{}}' \; -exec stat -c ' %s' '{{}}' \;"

--- a/tests/rptest/tests/cluster_view_test.py
+++ b/tests/rptest/tests/cluster_view_test.py
@@ -7,16 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import random
-import time
-
 import requests
 import json
-from ducktape.mark import ignore
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
-from rptest.clients.kafka_cat import KafkaCat
-from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.redpanda import RedpandaService
 from rptest.tests.end_to_end import EndToEndTest

--- a/tests/rptest/tests/create_partitions_test.py
+++ b/tests/rptest/tests/create_partitions_test.py
@@ -18,9 +18,8 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 class CreatePartitionsTest(RedpandaTest):
     def _partition_count(self, topic):
-        client = KafkaCliTools(self.redpanda)
-        meta = client.describe_topic(topic)
-        return meta.partition_count
+        meta = self.client().describe_topic(topic)
+        return len(meta.partitions)
 
     def _create_topic_partitions(self, topic, count):
         client = KafkaCliTools(self.redpanda)

--- a/tests/rptest/tests/create_partitions_test.py
+++ b/tests/rptest/tests/create_partitions_test.py
@@ -25,10 +25,6 @@ class CreatePartitionsTest(RedpandaTest):
         client = KafkaCliTools(self.redpanda)
         client.create_topic_partitions(topic, count)
 
-    def _delete_topic(self, topic_name):
-        client = KafkaCliTools(self.redpanda)
-        client.delete_topic(topic_name)
-
     def _create_add_verify(self, topic, new_parts):
         self.logger.info(
             f"Testing topic {topic.name} with partitions {topic.partition_count} replicas {topic.replication_factor} expected partitions {new_parts}"
@@ -66,6 +62,6 @@ class CreatePartitionsTest(RedpandaTest):
             topic = TopicSpec(partition_count=partition_count,
                               replication_factor=random.choice((1, 3)))
             self._create_add_verify(topic, new_partition_count)
-            self._delete_topic(topic.name)
+            self.client().delete_topic(topic.name)
 
             # todo delete the topic to avoid running out of file handles

--- a/tests/rptest/tests/create_partitions_test.py
+++ b/tests/rptest/tests/create_partitions_test.py
@@ -13,17 +13,12 @@ from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
 
 from rptest.clients.types import TopicSpec
-from rptest.clients.kafka_cli_tools import KafkaCliTools
 
 
 class CreatePartitionsTest(RedpandaTest):
     def _partition_count(self, topic):
         meta = self.client().describe_topic(topic)
         return len(meta.partitions)
-
-    def _create_topic_partitions(self, topic, count):
-        client = KafkaCliTools(self.redpanda)
-        client.create_topic_partitions(topic, count)
 
     def _create_add_verify(self, topic, new_parts):
         self.logger.info(
@@ -40,7 +35,7 @@ class CreatePartitionsTest(RedpandaTest):
             f"Initial topic doesn't have expected {topic.partition_count} partitions, found {self._partition_count(topic.name)}"
         )
 
-        self._create_topic_partitions(topic.name, new_parts)
+        self.client().alter_topic_partition_count(topic.name, new_parts)
 
         expected_parts = new_parts
         wait_until(

--- a/tests/rptest/tests/multi_restarts_with_archival_test.py
+++ b/tests/rptest/tests/multi_restarts_with_archival_test.py
@@ -7,22 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import random
-from time import sleep
 import uuid
-import sys
 
 from ducktape.mark.resource import cluster
-from ducktape.mark import matrix
 from rptest.archival.s3_client import S3Client
 from ducktape.utils.util import wait_until
 from rptest.clients.types import TopicSpec
 from rptest.clients.default import DefaultClient
 from rptest.clients.rpk import RpkTool
 from rptest.tests.end_to_end import EndToEndTest
-
-from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.rpk_producer import RpkProducer
 
 
 class MultiRestartTest(EndToEndTest):

--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -108,7 +108,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
         return topics
 
     """
-    Adding nodes to the cluster should result in partition reallocations to new 
+    Adding nodes to the cluster should result in partition reallocations to new
     nodes
     """
 

--- a/tests/rptest/tests/partition_movement.py
+++ b/tests/rptest/tests/partition_movement.py
@@ -16,8 +16,8 @@ class PartitionMovementMixin():
     @staticmethod
     def _random_partition(metadata):
         topic = random.choice(metadata)
-        partition = random.choice(topic["partitions"])
-        return topic["topic"], partition["partition"]
+        partition = random.choice(topic.partitions)
+        return topic.name, partition.id
 
     @staticmethod
     def _choose_replacement(admin, assignments):

--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -86,10 +86,10 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
     def _grab_input(self, topic):
         metadata = self.client().describe_topics()
-        selected = [x for x in metadata if x['topic'] == topic]
+        selected = [x for x in metadata if x.name == topic]
         assert len(selected) == 1
-        partition = random.choice(selected[0]["partitions"])
-        return selected[0]["topic"], partition["partition"]
+        partition = random.choice(selected[0].partitions)
+        return selected[0].name, partition.id
 
     def _on_data_consumed(self, record, node):
         self.result_data.append(record["value"])
@@ -131,7 +131,7 @@ class WasmPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         def topic_created():
             metadata = self.client().describe_topics()
             self.logger.info(f"metadata: {metadata}")
-            return any([x['topic'] == materialized_topic for x in metadata])
+            return any([x.name == materialized_topic for x in metadata])
 
         wait_until(topic_created, timeout_sec=30, backoff_sec=2)
 

--- a/tests/rptest/tests/wasm_partition_movement_test.py
+++ b/tests/rptest/tests/wasm_partition_movement_test.py
@@ -7,15 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import time
 import random
-from functools import partial
 
 from rptest.services.admin import Admin
 from rptest.services.verifiable_consumer import VerifiableConsumer
 
 from ducktape.mark.resource import cluster
-from ducktape.mark import ignore
 from ducktape.utils.util import wait_until
 
 from rptest.tests.end_to_end import EndToEndTest

--- a/tests/rptest/tests/wasm_topics_test.py
+++ b/tests/rptest/tests/wasm_topics_test.py
@@ -66,7 +66,7 @@ class WasmDeleteTopicsTest(WasmIdentityTest):
             if topic in topics:
                 raise Exception(
                     'Failed to delete materialized topic %s - topics: %s' %
-                    (topic, itopics))
+                    (topic, topics))
 
         if itopic in topics:
             raise Exception('Failed to delete source topic: %s - topics: %s' %

--- a/tests/rptest/wasm/wasm_test.py
+++ b/tests/rptest/wasm/wasm_test.py
@@ -12,7 +12,6 @@ from kafka import TopicPartition
 from rptest.wasm.topic import get_source_topic
 from rptest.wasm.native_kafka_consumer import NativeKafkaConsumer
 from rptest.wasm.cli_kafka_producer import CliKafkaProducer
-from rptest.wasm.wasm_script import WasmScript
 
 from rptest.wasm.topic import construct_materialized_topic
 from rptest.wasm.wasm_build_tool import WasmBuildTool


### PR DESCRIPTION
## Cover letter

* Adds a data model to the default client for describing topics so that users can avoid indexing into a python dictionary.
* Expands use of default client to new tests
* Fixes some pyright warnings/errors

## Release notes

* None