### PR TITLE
yapf: explicitly control class def blank lines

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,4 @@
 [style]
 based_on_style = pep8
 split_before_logical_operator = true
+blank_line_before_nested_class_or_def = false


### PR DESCRIPTION
## Cover letter

Recently yapf started reformatting every class and inserting blank line
after the class definition like this:

```diff
 class KafkaCliClientCompatTest(RedpandaTest):
+
     @cluster(num_nodes=3)
```

It's unknown why this occurred, but it could be that an upgrade changed
some default settings. In any case, this patch explicitly disables the
setting to help keep yapf behavior consistent across developer
environments and CI.

## Release notes

* None