### PR TITLE
c/members_backend: refresh not requested reallocations on leader change

### DIFF
--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -83,6 +83,7 @@ private:
     ss::sharded<ss::abort_source>& _as;
     ss::gate _bg;
     mutex _lock;
+    model::term_id _last_term;
 
     // replicas reallocations in progress
     std::vector<update_meta> _updates;


### PR DESCRIPTION
## Cover letter
Members backend performs partition reassignments based on the current
cluster state stored in `members_table` and `topics_table`. Partition
reassignments are stored in `members_backend` internal state and
executed in reconciliation loop. Reconciliation loop is executed only on
the node that is currently being a controller leader. In the
reconciliation loop partitions that required to be reassigned as a
result of cluster membership update are first being reassigned then its
configuration is being update and only after that the reassignment is
claimed as being successful. When controller leadership changes during
the reassignment process it may happen that members_backend, that
previously has been a leader and regained a leadership, pending
partition reassignments are based on the stale cluster information. f.e.
reallocation to not existing node may have been stored in pending
operations.

Implementing tracking raft0 term in `members_backend` to make it
possible to refresh stale state stored in pending operations whenever
raft0 leadership changes. This way the new partition reassignments will
account newly created topics and nodes that were added or decommissioned
by other raft0 leader

Fixes #3603

