### PR TITLE
tests: extend RESTART_LOG_ALLOW_LIST

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -53,6 +53,10 @@ RESTART_LOG_ALLOW_LIST = [
     re.compile(
         "(raft|rpc) - .*(disconnected_endpoint|Broken pipe|Connection reset by peer)"
     ),
+    # cluster - members_manager.cc:118 - Unable to update node configuration - seastar::sleep_aborted (Sleep is aborted)
+    re.compile("members_manager.*sleep_aborted"),
+    # cluster - members_backend.cc:91 - error waiting for members updates - seastar::abort_requested_exception (abort requested)
+    re.compile("members_backend.*abort_requested_exception"),
     re.compile(
         "raft - .*recovery append entries error.*client_request_timeout"),
 ]


### PR DESCRIPTION
## Cover letter

Certain members* shutdown log messages were
rare until node_resize_test was added, which
triggers shutdowns early during startup.

Example failure: https://buildkite.com/vectorized/redpanda/builds/6797#7649610d-0da4-462f-9e1a-aac114f41f28

## Release notes


* none
