### PR TITLE
pandaproxy: Improve header validation

### DIFF
--- a/src/v/pandaproxy/api/api-doc/header.json
+++ b/src/v/pandaproxy/api/api-doc/header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy API",
-    "version": "0.0.1"
+    "version": "0.0.2"
   },
   "host": "{{Host}}",
   "basePath": "/",

--- a/src/v/pandaproxy/api/api-doc/rest.json
+++ b/src/v/pandaproxy/api/api-doc/rest.json
@@ -2,6 +2,7 @@
         "get": {
           "summary": "Get a list of brokers.",
           "operationId": "get_brokers",
+          "produces": ["application/vnd.kafka.v2+json"],
           "responses": {
             "200": {
               "description": "Array of topic names",
@@ -265,7 +266,6 @@
         "get": {
           "summary": "Fetch data for the consumer assignments",
           "operationId": "consumer_fetch",
-          "consumes": ["application/vnd.kafka.v2+json"],
           "parameters": [
             {
               "name": "group_name",
@@ -366,6 +366,7 @@
             }
           }
         ],
+        "produces": ["application/vnd.kafka.v2+json"],
         "responses": {
           "204": {
             "description": ""
@@ -383,6 +384,7 @@
       "get": {
         "summary": "Get a list of Kafka topics.",
         "operationId": "get_topics_names",
+        "produces": ["application/vnd.kafka.v2+json"],
         "responses": {
           "200": {
             "description": "Array of topic names",
@@ -469,7 +471,6 @@
       "get": {
         "summary": "Get records from a topic.",
         "operationId": "get_topics_records",
-        "consumes": ["application/vnd.kafka.v2+json"],
         "parameters": [
           {
             "name": "topic_name",

--- a/src/v/pandaproxy/rest/handlers.cc
+++ b/src/v/pandaproxy/rest/handlers.cc
@@ -69,9 +69,6 @@ ss::shard_id consumer_shard(const kafka::group_id& g_id) {
 
 ss::future<server::reply_t>
 get_brokers(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(
-      *rq.req,
-      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req,
       {json::serialization_format::v2, json::serialization_format::none});
@@ -108,9 +105,6 @@ get_brokers(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 get_topics_names(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(
-      *rq.req,
-      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req,
       {json::serialization_format::v2, json::serialization_format::none});
@@ -146,9 +140,6 @@ get_topics_names(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 get_topics_records(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(
-      *rq.req,
-      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req,
       {json::serialization_format::binary_v2,
@@ -387,9 +378,6 @@ subscribe_consumer(server::request_t rq, server::reply_t rp) {
 
 ss::future<server::reply_t>
 consumer_fetch(server::request_t rq, server::reply_t rp) {
-    parse::content_type_header(
-      *rq.req,
-      {json::serialization_format::v2, json::serialization_format::none});
     auto res_fmt = parse::accept_header(
       *rq.req,
       {json::serialization_format::binary_v2,

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -224,7 +224,6 @@ class PandaProxyTest(RedpandaTest):
         """
         Acceptable headers:
         * Accept: "", "*.*", "application/vnd.kafka.v2+json"
-        * Content-Type: "", "*.*", "application/vnd.kafka.v2+json"
 
         """
         self.logger.debug(f"List topics with no accept header")
@@ -258,11 +257,6 @@ class PandaProxyTest(RedpandaTest):
         self.logger.debug(f"List topics with invalid accept header")
         result_raw = self._get_topics({"Accept": "application/json"})
         assert result_raw.status_code == requests.codes.not_acceptable
-        assert result_raw.headers["Content-Type"] == "application/json"
-
-        self.logger.debug(f"List topics with invalid content-type header")
-        result_raw = self._get_topics({"Content-Type": "application/json"})
-        assert result_raw.status_code == requests.codes.unsupported_media_type
         assert result_raw.headers["Content-Type"] == "application/json"
 
     @cluster(num_nodes=3)


### PR DESCRIPTION
## Cover letter

Ensure consistency between request validation and Swagger UI command generation

* Requests without a body do not require `Content-Type` validation
* Swagger: Remove `consumes` for empty body requests
* Swagger: Ensure `produces` for all endpoints to prevent SwaggerUI generating `application/json`

Swagger documented on [SwaggerHub](https://app.swaggerhub.com/apis/BenPope/pandaproxy-rest/0.0.2)

Signed-off-by: Ben Pope <ben@vectorized.io>

## Release notes


### Improvements

* Pandaproxy REST: Improve header validation and Swagger API
