### PR TITLE
test: expand usage of default kafka client in ducktape

### DIFF
--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -89,3 +89,7 @@ class DefaultClient:
     def describe_topic_configs(self, topic: str):
         rpk = RpkTool(self._redpanda)
         return rpk.describe_topic_configs(topic)
+
+    def delete_topic_config(self, topic: str, key: str):
+        rpk = RpkTool(self._redpanda)
+        rpk.delete_topic_config(topic, key)

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -9,6 +9,7 @@
 import typing
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
 from kafka import KafkaAdminClient
 
 
@@ -68,6 +69,14 @@ class DefaultClient:
     def alter_topic_partition_count(self, topic: str, count: int):
         client = KafkaCliTools(self._redpanda)
         client.create_topic_partitions(topic, count)
+
+    def alter_topic_config(self, topic: str, key: str,
+                           value: typing.Union[str, int]):
+        """
+        Alter a topic configuration property.
+        """
+        rpk = RpkTool(self._redpanda)
+        rpk.alter_topic_config(topic, key, value)
 
     def alter_topic_configs(self, topic: str,
                             props: dict[str, typing.Union[str, int]]):

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -85,3 +85,7 @@ class DefaultClient:
         """
         kafka_tools = KafkaCliTools(self._redpanda)
         kafka_tools.alter_topic_config(topic, props)
+
+    def describe_topic_configs(self, topic: str):
+        rpk = RpkTool(self._redpanda)
+        return rpk.describe_topic_configs(topic)

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -24,6 +24,17 @@ class TopicDescription(typing.NamedTuple):
     partitions: typing.List[PartitionDescription]
 
 
+class TopicConfigValue(typing.NamedTuple):
+    value: typing.Union[str, int]
+    source: str
+
+    def __eq__(self, other):
+        if isinstance(other, TopicConfigValue):
+            return self.value == other.value and self.source == other.source
+        assert isinstance(other, str) or isinstance(other, int)
+        return self.value == other
+
+
 class DefaultClient:
     def __init__(self, redpanda):
         self._redpanda = redpanda
@@ -88,7 +99,11 @@ class DefaultClient:
 
     def describe_topic_configs(self, topic: str):
         rpk = RpkTool(self._redpanda)
-        return rpk.describe_topic_configs(topic)
+        configs = rpk.describe_topic_configs(topic)
+        return {
+            key: TopicConfigValue(value=value[0], source=value[1])
+            for key, value in configs.items()
+        }
 
     def delete_topic_config(self, topic: str, key: str):
         rpk = RpkTool(self._redpanda)

--- a/tests/rptest/clients/default.py
+++ b/tests/rptest/clients/default.py
@@ -68,3 +68,11 @@ class DefaultClient:
     def alter_topic_partition_count(self, topic: str, count: int):
         client = KafkaCliTools(self._redpanda)
         client.create_topic_partitions(topic, count)
+
+    def alter_topic_configs(self, topic: str,
+                            props: dict[str, typing.Union[str, int]]):
+        """
+        Alter multiple topic configuration properties.
+        """
+        kafka_tools = KafkaCliTools(self._redpanda)
+        kafka_tools.alter_topic_config(topic, props)

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -94,51 +94,51 @@ class AlterTopicConfiguration(RedpandaTest):
         topic = self.topics[0].name
         original_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"original_output={original_output}")
-        assert original_output["redpanda.remote.read"][0] == "false"
-        assert original_output["redpanda.remote.write"][0] == "false"
+        assert original_output["redpanda.remote.read"] == "false"
+        assert original_output["redpanda.remote.write"] == "false"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "true"
-        assert altered_output["redpanda.remote.write"][0] == "false"
+        assert altered_output["redpanda.remote.read"] == "true"
+        assert altered_output["redpanda.remote.write"] == "false"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "false"
-        assert altered_output["redpanda.remote.write"][0] == "false"
+        assert altered_output["redpanda.remote.read"] == "false"
+        assert altered_output["redpanda.remote.write"] == "false"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
         self.client().alter_topic_config(topic, "redpanda.remote.write", "true")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "true"
-        assert altered_output["redpanda.remote.write"][0] == "true"
+        assert altered_output["redpanda.remote.read"] == "true"
+        assert altered_output["redpanda.remote.write"] == "true"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "false"
-        assert altered_output["redpanda.remote.write"][0] == "true"
+        assert altered_output["redpanda.remote.read"] == "false"
+        assert altered_output["redpanda.remote.write"] == "true"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "true"
-        assert altered_output["redpanda.remote.write"][0] == "true"
+        assert altered_output["redpanda.remote.read"] == "true"
+        assert altered_output["redpanda.remote.write"] == "true"
 
         self.client().alter_topic_config(topic, "redpanda.remote.write", "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "true"
-        assert altered_output["redpanda.remote.write"][0] == "false"
+        assert altered_output["redpanda.remote.read"] == "true"
+        assert altered_output["redpanda.remote.write"] == "false"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "false"
-        assert altered_output["redpanda.remote.write"][0] == "false"
+        assert altered_output["redpanda.remote.read"] == "false"
+        assert altered_output["redpanda.remote.write"] == "false"
 
 
 class ShadowIndexingGlobalConfig(RedpandaTest):
@@ -157,36 +157,36 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
         topic = self.topics[0].name
         original_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"original_output={original_output}")
-        assert original_output["redpanda.remote.read"][0] == "true"
-        assert original_output["redpanda.remote.write"][0] == "true"
+        assert original_output["redpanda.remote.read"] == "true"
+        assert original_output["redpanda.remote.write"] == "true"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "false"
-        assert altered_output["redpanda.remote.write"][0] == "false"
+        assert altered_output["redpanda.remote.read"] == "false"
+        assert altered_output["redpanda.remote.write"] == "false"
 
     @cluster(num_nodes=3)
     def test_overrides_remove(self):
         topic = self.topics[0].name
         original_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"original_output={original_output}")
-        assert original_output["redpanda.remote.read"][0] == "true"
-        assert original_output["redpanda.remote.write"][0] == "true"
+        assert original_output["redpanda.remote.read"] == "true"
+        assert original_output["redpanda.remote.write"] == "true"
 
         # disable shadow indexing for topic
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         self.client().alter_topic_config(topic, "redpanda.remote.write", "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "false"
-        assert altered_output["redpanda.remote.write"][0] == "false"
+        assert altered_output["redpanda.remote.read"] == "false"
+        assert altered_output["redpanda.remote.write"] == "false"
 
         # delete topic configs (value from configuration should be used)
         self.client().delete_topic_config(topic, "redpanda.remote.read")
         self.client().delete_topic_config(topic, "redpanda.remote.write")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
-        assert altered_output["redpanda.remote.read"][0] == "true"
-        assert altered_output["redpanda.remote.write"][0] == "true"
+        assert altered_output["redpanda.remote.read"] == "true"
+        assert altered_output["redpanda.remote.write"] == "true"

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -13,7 +13,6 @@ import string
 from rptest.services.cluster import cluster
 from ducktape.mark import parametrize
 from rptest.clients.kafka_cli_tools import KafkaCliTools
-from rptest.clients.rpk import RpkTool
 
 from rptest.clients.types import TopicSpec
 from rptest.tests.redpanda_test import RedpandaTest
@@ -171,7 +170,6 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
     @cluster(num_nodes=3)
     def test_overrides_remove(self):
         topic = self.topics[0].name
-        rpk = RpkTool(self.redpanda)
         original_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"original_output={original_output}")
         assert original_output["redpanda.remote.read"][0] == "true"
@@ -186,8 +184,8 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
         assert altered_output["redpanda.remote.write"][0] == "false"
 
         # delete topic configs (value from configuration should be used)
-        rpk.delete_topic_config(topic, "redpanda.remote.read")
-        rpk.delete_topic_config(topic, "redpanda.remote.write")
+        self.client().delete_topic_config(topic, "redpanda.remote.read")
+        self.client().delete_topic_config(topic, "redpanda.remote.write")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -103,20 +103,23 @@ class AlterTopicConfiguration(RedpandaTest):
         assert altered_output["redpanda.remote.read"] == "true"
         assert altered_output["redpanda.remote.write"] == "false"
 
-        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read",
+                                         "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"] == "false"
         assert altered_output["redpanda.remote.write"] == "false"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
-        self.client().alter_topic_config(topic, "redpanda.remote.write", "true")
+        self.client().alter_topic_config(topic, "redpanda.remote.write",
+                                         "true")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"] == "true"
         assert altered_output["redpanda.remote.write"] == "true"
 
-        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read",
+                                         "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"] == "false"
@@ -128,13 +131,15 @@ class AlterTopicConfiguration(RedpandaTest):
         assert altered_output["redpanda.remote.read"] == "true"
         assert altered_output["redpanda.remote.write"] == "true"
 
-        self.client().alter_topic_config(topic, "redpanda.remote.write", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.write",
+                                         "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"] == "true"
         assert altered_output["redpanda.remote.write"] == "false"
 
-        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read",
+                                         "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"] == "false"
@@ -160,8 +165,10 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
         assert original_output["redpanda.remote.read"] == "true"
         assert original_output["redpanda.remote.write"] == "true"
 
-        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
-        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read",
+                                         "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read",
+                                         "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"] == "false"
@@ -176,8 +183,10 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
         assert original_output["redpanda.remote.write"] == "true"
 
         # disable shadow indexing for topic
-        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
-        self.client().alter_topic_config(topic, "redpanda.remote.write", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read",
+                                         "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.write",
+                                         "false")
         altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"] == "false"

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -93,51 +93,50 @@ class AlterTopicConfiguration(RedpandaTest):
     @cluster(num_nodes=3)
     def test_shadow_indexing_config(self):
         topic = self.topics[0].name
-        rpk = RpkTool(self.redpanda)
-        original_output = rpk.describe_topic_configs(topic)
+        original_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"original_output={original_output}")
         assert original_output["redpanda.remote.read"][0] == "false"
         assert original_output["redpanda.remote.write"][0] == "false"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"
         assert altered_output["redpanda.remote.write"][0] == "false"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"
         assert altered_output["redpanda.remote.write"][0] == "false"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
         self.client().alter_topic_config(topic, "redpanda.remote.write", "true")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"
         assert altered_output["redpanda.remote.write"][0] == "true"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"
         assert altered_output["redpanda.remote.write"][0] == "true"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"
         assert altered_output["redpanda.remote.write"][0] == "true"
 
         self.client().alter_topic_config(topic, "redpanda.remote.write", "false")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"
         assert altered_output["redpanda.remote.write"][0] == "false"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"
         assert altered_output["redpanda.remote.write"][0] == "false"
@@ -157,15 +156,14 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
     @cluster(num_nodes=3)
     def test_overrides_set(self):
         topic = self.topics[0].name
-        rpk = RpkTool(self.redpanda)
-        original_output = rpk.describe_topic_configs(topic)
+        original_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"original_output={original_output}")
         assert original_output["redpanda.remote.read"][0] == "true"
         assert original_output["redpanda.remote.write"][0] == "true"
 
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"
         assert altered_output["redpanda.remote.write"][0] == "false"
@@ -174,7 +172,7 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
     def test_overrides_remove(self):
         topic = self.topics[0].name
         rpk = RpkTool(self.redpanda)
-        original_output = rpk.describe_topic_configs(topic)
+        original_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"original_output={original_output}")
         assert original_output["redpanda.remote.read"][0] == "true"
         assert original_output["redpanda.remote.write"][0] == "true"
@@ -182,7 +180,7 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
         # disable shadow indexing for topic
         self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         self.client().alter_topic_config(topic, "redpanda.remote.write", "false")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"
         assert altered_output["redpanda.remote.write"][0] == "false"
@@ -190,7 +188,7 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
         # delete topic configs (value from configuration should be used)
         rpk.delete_topic_config(topic, "redpanda.remote.read")
         rpk.delete_topic_config(topic, "redpanda.remote.write")
-        altered_output = rpk.describe_topic_configs(topic)
+        altered_output = self.client().describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"
         assert altered_output["redpanda.remote.write"][0] == "true"

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -42,8 +42,8 @@ class AlterTopicConfiguration(RedpandaTest):
                  value="LogAppendTime")
     def test_altering_topic_configuration(self, property, value):
         topic = self.topics[0].name
+        self.client().alter_topic_configs(topic, {property: value})
         kafka_tools = KafkaCliTools(self.redpanda)
-        kafka_tools.alter_topic_config(topic, {property: value})
         spec = kafka_tools.describe_topic(topic)
 
         # e.g. retention.ms is TopicSpec.retention_ms
@@ -54,7 +54,7 @@ class AlterTopicConfiguration(RedpandaTest):
     def test_altering_multiple_topic_configurations(self):
         topic = self.topics[0].name
         kafka_tools = KafkaCliTools(self.redpanda)
-        kafka_tools.alter_topic_config(
+        self.client().alter_topic_configs(
             topic, {
                 TopicSpec.PROPERTY_SEGMENT_SIZE: 1024,
                 TopicSpec.PROPERTY_RETENTION_TIME: 360000,
@@ -79,7 +79,7 @@ class AlterTopicConfiguration(RedpandaTest):
         for _ in range(0, 5):
             key = self.random_string(5)
             try:
-                kafka_tools.alter_topic_config(topic, {key: "123"})
+                self.client().alter_topic_configs(topic, {key: "123"})
             except Exception as inst:
                 self.logger.info(
                     "alter failed as expected: expected exception %s", inst)

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -99,44 +99,44 @@ class AlterTopicConfiguration(RedpandaTest):
         assert original_output["redpanda.remote.read"][0] == "false"
         assert original_output["redpanda.remote.write"][0] == "false"
 
-        rpk.alter_topic_config(topic, "redpanda.remote.read", "true")
+        self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
         altered_output = rpk.describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"
         assert altered_output["redpanda.remote.write"][0] == "false"
 
-        rpk.alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         altered_output = rpk.describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"
         assert altered_output["redpanda.remote.write"][0] == "false"
 
-        rpk.alter_topic_config(topic, "redpanda.remote.read", "true")
-        rpk.alter_topic_config(topic, "redpanda.remote.write", "true")
+        self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
+        self.client().alter_topic_config(topic, "redpanda.remote.write", "true")
         altered_output = rpk.describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"
         assert altered_output["redpanda.remote.write"][0] == "true"
 
-        rpk.alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         altered_output = rpk.describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"
         assert altered_output["redpanda.remote.write"][0] == "true"
 
-        rpk.alter_topic_config(topic, "redpanda.remote.read", "true")
+        self.client().alter_topic_config(topic, "redpanda.remote.read", "true")
         altered_output = rpk.describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"
         assert altered_output["redpanda.remote.write"][0] == "true"
 
-        rpk.alter_topic_config(topic, "redpanda.remote.write", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.write", "false")
         altered_output = rpk.describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "true"
         assert altered_output["redpanda.remote.write"][0] == "false"
 
-        rpk.alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         altered_output = rpk.describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"
@@ -163,8 +163,8 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
         assert original_output["redpanda.remote.read"][0] == "true"
         assert original_output["redpanda.remote.write"][0] == "true"
 
-        rpk.alter_topic_config(topic, "redpanda.remote.read", "false")
-        rpk.alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
         altered_output = rpk.describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"
@@ -180,8 +180,8 @@ class ShadowIndexingGlobalConfig(RedpandaTest):
         assert original_output["redpanda.remote.write"][0] == "true"
 
         # disable shadow indexing for topic
-        rpk.alter_topic_config(topic, "redpanda.remote.read", "false")
-        rpk.alter_topic_config(topic, "redpanda.remote.write", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.read", "false")
+        self.client().alter_topic_config(topic, "redpanda.remote.write", "false")
         altered_output = rpk.describe_topic_configs(topic)
         self.logger.info(f"altered_output={altered_output}")
         assert altered_output["redpanda.remote.read"][0] == "false"

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -46,8 +46,6 @@ class RetentionPolicyTest(RedpandaTest):
         appear, then it changes retention topic property and waits for
         segments to be removed
         """
-        kafka_tools = KafkaCliTools(self.redpanda)
-
         # produce until segments have been compacted
         produce_until_segments(
             self.redpanda,
@@ -57,7 +55,7 @@ class RetentionPolicyTest(RedpandaTest):
             acks=acks,
         )
         # change retention time
-        kafka_tools.alter_topic_config(self.topic, {
+        self.client().alter_topic_configs(self.topic, {
             property: 10000,
         })
         wait_for_segments_removal(self.redpanda,
@@ -92,7 +90,7 @@ class RetentionPolicyTest(RedpandaTest):
         kafka_tools.describe_topic(self.topic)
 
         # change retention bytes to preserve 15 segments
-        kafka_tools.alter_topic_config(
+        self.client().alter_topic_configs(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 15 * segment_size,
             })
@@ -102,7 +100,7 @@ class RetentionPolicyTest(RedpandaTest):
                                   count=16)
 
         # change retention bytes again to preserve 10 segments
-        kafka_tools.alter_topic_config(
+        self.client().alter_topic_configs(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 10 * segment_size,
             })
@@ -112,7 +110,7 @@ class RetentionPolicyTest(RedpandaTest):
                                   count=11)
 
         # change retention bytes again to preserve 5 segments
-        kafka_tools.alter_topic_config(
+        self.client().alter_topic_configs(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 4 * segment_size,
             })
@@ -146,7 +144,7 @@ class RetentionPolicyTest(RedpandaTest):
         kafka_tools.describe_topic(self.topic)
 
         # change retention bytes to preserve 15 segments
-        kafka_tools.alter_topic_config(
+        self.client().alter_topic_configs(
             self.topic, {
                 TopicSpec.PROPERTY_RETENTION_BYTES: 2 * segment_size,
             })


### PR DESCRIPTION
## Cover letter

Expands default kafka interface to include topic configuration operations and uses the new interface in tests.

## Release notes

* None