### PR TITLE
V21.11.x backport3570

### DIFF
--- a/src/v/cloud_storage/manifest.cc
+++ b/src/v/cloud_storage/manifest.cc
@@ -14,6 +14,7 @@
 #include "bytes/iobuf_ostreambuf.h"
 #include "cloud_storage/types.h"
 #include "hashing/xx.h"
+#include "json/writer.h"
 #include "model/timestamp.h"
 #include "ssx/sformat.h"
 #include "storage/fs_utils.h"
@@ -30,7 +31,6 @@
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/ostreamwrapper.h>
 #include <rapidjson/rapidjson.h>
-#include <rapidjson/writer.h>
 
 #include <algorithm>
 #include <array>
@@ -394,7 +394,7 @@ serialized_json_stream manifest::serialize() const {
 
 void manifest::serialize(std::ostream& out) const {
     rapidjson::OStreamWrapper wrapper(out);
-    rapidjson::Writer<rapidjson::OStreamWrapper> w(wrapper);
+    json::Writer<rapidjson::OStreamWrapper> w(wrapper);
     w.StartObject();
     w.Key("version");
     w.Int(static_cast<int>(manifest_version::v1));
@@ -560,7 +560,7 @@ serialized_json_stream topic_manifest::serialize() const {
 
 void topic_manifest::serialize(std::ostream& out) const {
     rapidjson::OStreamWrapper wrapper(out);
-    rapidjson::Writer<rapidjson::OStreamWrapper> w(wrapper);
+    json::Writer<rapidjson::OStreamWrapper> w(wrapper);
     w.StartObject();
     w.Key("version");
     w.Int(static_cast<int>(manifest_version::v1));

--- a/src/v/json/allocator.h
+++ b/src/v/json/allocator.h
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#pragma once
+
 #include "json/logger.h"
 #include "vlog.h"
 

--- a/src/v/json/writer.h
+++ b/src/v/json/writer.h
@@ -11,12 +11,19 @@
 
 #include "json/allocator.h"
 
-#include <rapidjson/document.h>
 #include <rapidjson/encodings.h>
+#include <rapidjson/writer.h>
 
 namespace json {
-using Document = rapidjson::GenericDocument<
-  rapidjson::UTF8<>,
-  rapidjson::MemoryPoolAllocator<throwing_allocator>,
-  throwing_allocator>;
+template<
+  typename OutputStream,
+  typename SourceEncoding = rapidjson::UTF8<>,
+  typename TargetEncoding = rapidjson::UTF8<>,
+  unsigned writeFlags = rapidjson::kWriteDefaultFlags>
+using Writer = rapidjson::Writer<
+  OutputStream,
+  SourceEncoding,
+  TargetEncoding,
+  throwing_allocator,
+  writeFlags>;
 }


### PR DESCRIPTION
Backport of #3570 

## Cover letter

Make `cloud_storage::manifest` use `json::Writer`, which uses `json::throwing_allocator`, which throws `std::bad_alloc` if memory allocation failed.