### PR TITLE
cluster: fix metrics reporter on single node clusters

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -237,7 +237,6 @@ ss::future<> metrics_reporter::try_initialize_cluster_info() {
 
     storage::log_reader_config reader_cfg(
       model::offset(0), model::offset(2), ss::default_priority_class());
-    reader_cfg.type_filter = model::record_batch_type::raft_configuration;
     auto reader = co_await _raft0->make_reader(reader_cfg);
 
     auto batches = co_await model::consume_reader_to_memory(


### PR DESCRIPTION
## Cover letter

```
 cluster: fix metrics_reporter for single node clusters

It is intentional that we only start reporting metrics
after at least two raft0 batches (either N raft_configuration
messages for a multi-node cluster, or 1 raft_configuration
plus first topic creation for a single node cluster).

However, we were filtering on raft_configuration as
the batch type, so this was only working reliably on the multi
node case.
```

## Release notes

### Improvements

* The cluster metrics reporter now works on single node redpanda clusters as well as multi-node redpanda clusters.