### PR TITLE
fix ducktape test name typo

### DIFF
--- a/tests/rptest/tests/node_operations_fuzzy_test.py
+++ b/tests/rptest/tests/node_operations_fuzzy_test.py
@@ -115,7 +115,7 @@ class NodeOperationFuzzyTest(EndToEndTest):
     @cluster(num_nodes=7, log_allow_list=CHAOS_LOG_ALLOW_LIST)
     @parametrize(enable_failures=True)
     @parametrize(enable_failures=False)
-    def test_node_opeartions(self, enable_failures):
+    def test_node_operations(self, enable_failures):
         # allocate 5 nodes for the cluster
         self.redpanda = RedpandaService(
             self.test_context,


### PR DESCRIPTION
This PR could be merged after #3603 is fixed so people searching for the old test name still get a hit.

## Release notes

* none