### PR TITLE
Fixed TLS setup in metrics reporter client

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -25,6 +25,7 @@
 #include "model/namespace.h"
 #include "model/record_batch_types.h"
 #include "model/timeout_clock.h"
+#include "net/tls.h"
 #include "net/unresolved_address.h"
 #include "reflection/adl.h"
 #include "rpc/types.h"
@@ -307,8 +308,8 @@ ss::future<http::client> metrics_reporter::make_http_client() {
 
         client_configuration.credentials
           = co_await builder.build_reloadable_certificate_credentials();
+        client_configuration.tls_sni_hostname = _address.host;
     }
-
     co_return http::client(client_configuration, _as.local());
 }
 

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -290,9 +290,23 @@ ss::future<http::client> metrics_reporter::make_http_client() {
     client_configuration.disable_metrics = net::metrics_disabled::yes;
 
     if (_address.protocol == "https") {
+        ss::tls::credentials_builder builder;
+        builder.set_client_auth(ss::tls::client_auth::NONE);
+        auto ca_file = co_await net::find_ca_file();
+        if (ca_file) {
+            vlog(
+              _logger.trace, "using {} as metrics reporter CA store", ca_file);
+            co_await builder.set_x509_trust_file(
+              ca_file.value(), ss::tls::x509_crt_format::PEM);
+        } else {
+            vlog(
+              _logger.trace,
+              "ca file not found, defaulting to system trust store");
+            co_await builder.set_system_trust();
+        }
+
         client_configuration.credentials
-          = ss::make_shared<ss::tls::certificate_credentials>();
-        co_await client_configuration.credentials->set_system_trust();
+          = co_await builder.build_reloadable_certificate_credentials();
     }
 
     co_return http::client(client_configuration, _as.local());

--- a/src/v/net/CMakeLists.txt
+++ b/src/v/net/CMakeLists.txt
@@ -7,6 +7,7 @@ v_cc_library(
     connection.cc
     server.cc
     probes.cc
+    tls.cc
   DEPS
     Seastar::seastar
   )

--- a/src/v/net/tls.cc
+++ b/src/v/net/tls.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "net/tls.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/seastar.hh>
+
+namespace net {
+ss::future<std::optional<ss::sstring>> find_ca_file() {
+    // list of all possible ca-cert file locations on different linux distros
+    static constexpr std::array<std::string_view, 6> ca_cert_locations = {{
+      "/etc/ssl/certs/ca-certificates.crt",
+      "/etc/pki/tls/certs/ca-bundle.crt",
+      "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+      "/etc/ssl/cert.pem",
+      "/etc/ssl/ca-bundle.pem",
+      "/etc/pki/tls/cacert.pem",
+    }};
+
+    for (auto ca_loc : ca_cert_locations) {
+        if (co_await ss::file_exists(ca_loc)) {
+            co_return ca_loc;
+        }
+    }
+    co_return std::nullopt;
+}
+} // namespace net

--- a/src/v/net/tls.h
+++ b/src/v/net/tls.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Vectorized, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+
+namespace net {
+
+/// Find CA trust file using the predefined set of locations
+///
+/// Historically, different linux distributions use different locations to
+/// store certificates for their private key infrastructure. This is just a
+/// convention and can't be queried by the application code. The application
+/// is required to 'know' where to find the certs. In case of GnuTLS the
+/// location is configured during build time. It depend on distribution on
+/// which GnuTLS is built. This approach doesn't work for Redpanda because
+/// single Redpanda binary can be executed on any linux distro. So the default
+/// option only work on some distributions. The rest require the location to
+/// be explicitly specified. This function does different thing. It probes
+/// the set of default locations for different distributions untill it finds
+/// the one that exists. This path is then passed to GnuTLS.
+ss::future<std::optional<ss::sstring>> find_ca_file();
+
+} // namespace net


### PR DESCRIPTION
## Cover letter

Using the same approach as the S3 client uses to find a Certificate Authority certificate chain location and enabled SNI extension which support is often required by servers. 


Fixes #3720

## Release notes

### Improvements
* metrics reporter will work with TLS secured endpoints requiring SNI extension 

